### PR TITLE
ci(docker): pull Forgejo LFS before build when app has LFS assets

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -217,6 +217,9 @@ jobs:
             source_path: ${{ needs.config.outputs.source_path }}
             version_source: ${{ needs.config.outputs.version_source }}
             version_target: ${{ needs.config.outputs.version_target }}
+        secrets:
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     # ---------------------------------------------------------------------------
     # Publish — promotes the ci-{sha} tag built in test to the release tag.
@@ -243,8 +246,11 @@ jobs:
             cargo_toml: ${{ needs.config.outputs.cargo_toml }}
             version_source: ${{ needs.config.outputs.version_source }}
             version_target: ${{ needs.config.outputs.version_target }}
+            source_path: ${{ needs.config.outputs.source_path }}
         secrets:
             MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     # ---------------------------------------------------------------------------
     # Post-publish — single atomic PR: version.toml + Cargo.toml + kube manifest.

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -36,6 +36,11 @@ on:
                 required: false
                 type: string
                 default: ''
+        secrets:
+            FORGEJO_USER:
+                required: false
+            FORGEJO_TOKEN:
+                required: false
 
 jobs:
     test:
@@ -80,6 +85,33 @@ jobs:
             - name: Checkout the monorepo
               uses: actions/checkout@v6
               continue-on-error: true
+
+            - name: Detect Forgejo LFS assets
+              id: lfs_detect
+              run: |
+                  SCOPE="${{ inputs.source_path }}"
+                  if [ -n "$SCOPE" ] && git lfs ls-files -- "$SCOPE" 2>/dev/null | grep -q .; then
+                    echo "uses_lfs=true" >> "$GITHUB_OUTPUT"
+                    echo "Forgejo LFS assets present under $SCOPE"
+                  else
+                    echo "uses_lfs=false" >> "$GITHUB_OUTPUT"
+                    echo "No LFS assets under '${SCOPE:-<unset>}' — skipping Forgejo credential setup"
+                  fi
+
+            - name: Configure Forgejo LFS credentials
+              if: ${{ steps.lfs_detect.outputs.uses_lfs == 'true' }}
+              env:
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+              run: |
+                  if [ -z "$FORGEJO_USER" ] || [ -z "$FORGEJO_TOKEN" ]; then
+                    echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing — cannot pull LFS from git.kbve.com (assets would ship as pointer stubs)"
+                    exit 1
+                  fi
+                  printf 'machine git.kbve.com\nlogin %s\npassword %s\n' \
+                    "$FORGEJO_USER" "$FORGEJO_TOKEN" > "$HOME/.netrc"
+                  chmod 600 "$HOME/.netrc"
+                  echo "Forgejo LFS credentials configured for git.kbve.com"
 
             - name: Sync version from MDX to build manifest
               if: ${{ inputs.version_source != '' && inputs.version_target != '' }}

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -32,9 +32,18 @@ on:
                 required: false
                 type: string
                 default: ''
+            source_path:
+                description: 'Project source path (e.g. apps/cryptothrone). Used to detect Forgejo LFS assets for the rebuild fallback.'
+                required: false
+                type: string
+                default: ''
         secrets:
             MY_GITHUB_TOKEN:
                 required: true
+            FORGEJO_USER:
+                required: false
+            FORGEJO_TOKEN:
+                required: false
 
 jobs:
     publish:
@@ -185,6 +194,34 @@ jobs:
                     sed -i "s/^version = .*/version = \"${VER}\"/" "$TGT"
                     echo "Synced version ${VER} → ${TGT}"
                   fi
+
+            - name: Detect Forgejo LFS assets
+              id: lfs_detect
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              run: |
+                  SCOPE="${{ inputs.source_path }}"
+                  if [ -n "$SCOPE" ] && git lfs ls-files -- "$SCOPE" 2>/dev/null | grep -q .; then
+                    echo "uses_lfs=true" >> "$GITHUB_OUTPUT"
+                    echo "Forgejo LFS assets present under $SCOPE"
+                  else
+                    echo "uses_lfs=false" >> "$GITHUB_OUTPUT"
+                    echo "No LFS assets under '${SCOPE:-<unset>}' — skipping Forgejo credential setup"
+                  fi
+
+            - name: Configure Forgejo LFS credentials
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' && steps.lfs_detect.outputs.uses_lfs == 'true' }}
+              env:
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+              run: |
+                  if [ -z "$FORGEJO_USER" ] || [ -z "$FORGEJO_TOKEN" ]; then
+                    echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing — cannot pull LFS from git.kbve.com (assets would ship as pointer stubs)"
+                    exit 1
+                  fi
+                  printf 'machine git.kbve.com\nlogin %s\npassword %s\n' \
+                    "$FORGEJO_USER" "$FORGEJO_TOKEN" > "$HOME/.netrc"
+                  chmod 600 "$HOME/.netrc"
+                  echo "Forgejo LFS credentials configured for git.kbve.com"
 
             - name: Build Docker Image with Nx
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}


### PR DESCRIPTION
## What
Make the shared docker pipeline hydrate Git LFS blobs from the private Forgejo (git.kbve.com) before the image build, so apps like cryptothrone ship real assets instead of pointer stubs.

Follow-up to #12897 (cryptothrone LFS migration), which landed the pointers but not the CI pull path.

## Why it's needed
cryptothrone's Dockerfile builds the Astro site **inside** the image (Stage A `COPY apps/cryptothrone/astro-cryptothrone/`), so the assets must be real blobs in the runner working tree **before** `docker build`. Docker cannot authenticate to Forgejo. The nx build already runs `./kbve.sh -lfs cryptothrone pull`, but it needs `~/.netrc` creds on the runner.

## How
- **Auto-detect** per app: `git lfs ls-files -- <source_path>`. Only apps with tracked LFS blobs under their path get the Forgejo credential bootstrap — non-LFS docker apps are completely untouched (proper `if` gate, no per-app manifest flag, self-maintaining).
- When detected, write `~/.netrc` from `FORGEJO_USER`/`FORGEJO_TOKEN` (repo secrets, same as ci-unity); **hard error** if missing (no silent stubs).
- Wired into both build paths: `docker-test-app.yml` (test job, primary build-once) and `utils-publish-docker-image.yml` (rebuild fallback; gains a `source_path` input).
- `ci-docker.yml` passes the secrets + `source_path` to both reusable workflows.