### PR TITLE
feat(argo-dashboard): live-vs-target diff + one-click rollback

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.ApplicationRow.unit.test.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.ApplicationRow.unit.test.tsx
@@ -39,8 +39,8 @@ function renderRow(
 		app?: ArgoApplication;
 		expanded?: boolean;
 		onToggle?: () => void;
-		tab?: 'resources' | 'events' | 'history';
-		onTabChange?: (t: 'resources' | 'events' | 'history') => void;
+		tab?: 'resources' | 'diff' | 'events' | 'history';
+		onTabChange?: (t: 'resources' | 'diff' | 'events' | 'history') => void;
 		selectedResource?: ResourceSelector | null;
 		onSelectResource?: (sel: ResourceSelector) => void;
 	} = {},

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -6,11 +6,16 @@ import {
 	syncColor,
 	fetchResourceTree,
 	fetchAppEvents,
+	fetchManagedResources,
 	detectAppStall,
 	detectResourceStall,
 	formatAge,
+	diffLines,
+	prettyManifest,
 	type AppEvent,
+	type AppTab,
 	type ArgoApplication,
+	type ManagedResource,
 	type ResourceTree,
 	type ResourceNode,
 	type ResourceSelector,
@@ -27,6 +32,8 @@ import {
 	ChevronRight,
 	Box,
 	Clock,
+	FileDiff,
+	Undo2,
 } from 'lucide-react';
 
 function StallBadge({
@@ -626,6 +633,10 @@ function AppEventsPanel({
 }
 
 function AppHistoryPanel({ app }: { app: ArgoApplication }) {
+	const busy = useStore(argoService.$actionBusy);
+	const name = app.metadata.name;
+	const rolling = busy === `${name}:rollback`;
+	const anyBusy = busy !== null;
 	const history = (app.status as Record<string, unknown>)?.history as
 		| Array<Record<string, unknown>>
 		| undefined;
@@ -705,6 +716,68 @@ function AppHistoryPanel({ app }: { app: ArgoApplication }) {
 									? new Date(deployedAt).toLocaleString()
 									: ''}
 							</span>
+							{i === 0 ? (
+								<span
+									style={{
+										padding: '1px 6px',
+										borderRadius: 4,
+										background: 'rgba(34, 197, 94, 0.12)',
+										border: '1px solid rgba(34, 197, 94, 0.35)',
+										color: '#4ade80',
+										fontSize: '0.65rem',
+										fontWeight: 600,
+										textTransform: 'uppercase',
+									}}>
+									Current
+								</span>
+							) : (
+								id != null && (
+									<button
+										type="button"
+										disabled={anyBusy}
+										title={`Roll back to revision #${id}`}
+										onClick={() => {
+											if (
+												window.confirm(
+													`Roll back ${name} to revision #${id}? This deploys the older manifests.`,
+												)
+											)
+												void argoService.rollbackApp(
+													name,
+													id,
+												);
+										}}
+										style={{
+											display: 'inline-flex',
+											alignItems: 'center',
+											gap: 4,
+											padding: '0.2rem 0.5rem',
+											borderRadius: 5,
+											border: '1px solid var(--sl-color-gray-5, #262626)',
+											background:
+												'var(--sl-color-bg-nav, #111)',
+											color: 'var(--sl-color-gray-2, #c9d1d9)',
+											fontSize: '0.7rem',
+											fontWeight: 500,
+											cursor: anyBusy
+												? 'wait'
+												: 'pointer',
+										}}>
+										{rolling ? (
+											<Loader2
+												size={11}
+												style={{
+													animation:
+														'spin 1s linear infinite',
+												}}
+											/>
+										) : (
+											<Undo2 size={11} />
+										)}
+										Rollback
+									</button>
+								)
+							)}
 						</div>
 						{source && (
 							<div
@@ -726,6 +799,159 @@ function AppHistoryPanel({ app }: { app: ArgoApplication }) {
 	);
 }
 
+function resourceLabel(r: ManagedResource): string {
+	const g = r.group ? `${r.group}/` : '';
+	const ns = r.namespace ? `${r.namespace}/` : '';
+	return `${g}${r.kind} · ${ns}${r.name}`;
+}
+
+function isOutOfSync(r: ManagedResource): boolean {
+	const live = prettyManifest(r.normalizedLiveState ?? r.liveState);
+	const target = prettyManifest(r.predictedLiveState ?? r.targetState);
+	return live !== target;
+}
+
+function DiffView({ before, after }: { before: string; after: string }) {
+	const lines = diffLines(before, after);
+	return (
+		<pre
+			style={{
+				margin: 0,
+				padding: '0.5rem 0.75rem',
+				overflowX: 'auto',
+				fontSize: '0.72rem',
+				lineHeight: 1.55,
+				fontFamily: 'var(--sl-font-mono, monospace)',
+				background: 'var(--sl-color-bg, #0d1117)',
+				borderRadius: 6,
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+			}}>
+			{lines.map((l, i) => {
+				const sign =
+					l.op === 'add' ? '+' : l.op === 'remove' ? '-' : ' ';
+				const color =
+					l.op === 'add'
+						? '#22c55e'
+						: l.op === 'remove'
+							? '#ef4444'
+							: 'var(--sl-color-gray-3, #8b949e)';
+				const bg =
+					l.op === 'add'
+						? 'rgba(34, 197, 94, 0.08)'
+						: l.op === 'remove'
+							? 'rgba(239, 68, 68, 0.08)'
+							: 'transparent';
+				return (
+					<div key={i} style={{ color, background: bg }}>
+						{sign} {l.text}
+					</div>
+				);
+			})}
+		</pre>
+	);
+}
+
+function AppDiffPanel({ token, appName }: { token: string; appName: string }) {
+	const [resources, setResources] = useState<ManagedResource[] | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				setLoading(true);
+				const data = await fetchManagedResources(token, appName);
+				if (!cancelled) setResources(data);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setError(e instanceof Error ? e.message : 'Failed to load');
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [token, appName]);
+
+	if (loading) return <LoadingBlock label="Computing diff..." />;
+	if (error) return <ErrorBlock message={error} />;
+
+	const drifted = (resources ?? []).filter(isOutOfSync);
+	if (drifted.length === 0) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: '#22c55e',
+					fontSize: '0.85rem',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+				}}>
+				<CheckCircle2 size={14} />
+				All managed resources match the desired state
+			</div>
+		);
+	}
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+			<div
+				style={{
+					fontSize: '0.75rem',
+					color: 'var(--sl-color-gray-4, #6b7280)',
+				}}>
+				{drifted.length} resource{drifted.length === 1 ? '' : 's'}{' '}
+				differ from target —{' '}
+				<span style={{ color: '#ef4444' }}>red</span> is live,{' '}
+				<span style={{ color: '#22c55e' }}>green</span> is target.
+			</div>
+			{drifted.map((r, i) => (
+				<div key={`${r.kind}-${r.namespace}-${r.name}-${i}`}>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+							marginBottom: 4,
+							fontSize: '0.78rem',
+							fontWeight: 600,
+							color: 'var(--sl-color-text, #e6edf3)',
+						}}>
+						<FileDiff size={13} style={{ color: '#8b5cf6' }} />
+						{resourceLabel(r)}
+						{r.requiresPruning && (
+							<span
+								style={{
+									padding: '0 6px',
+									borderRadius: 4,
+									background: 'rgba(239, 68, 68, 0.12)',
+									border: '1px solid rgba(239, 68, 68, 0.35)',
+									color: '#fca5a5',
+									fontSize: '0.65rem',
+									fontWeight: 600,
+									textTransform: 'uppercase',
+								}}>
+								Prune
+							</span>
+						)}
+					</div>
+					<DiffView
+						before={prettyManifest(
+							r.normalizedLiveState ?? r.liveState,
+						)}
+						after={prettyManifest(
+							r.predictedLiveState ?? r.targetState,
+						)}
+					/>
+				</div>
+			))}
+		</div>
+	);
+}
+
 export function AppExpandedPanel({
 	app,
 	token,
@@ -736,13 +962,15 @@ export function AppExpandedPanel({
 }: {
 	app: ArgoApplication;
 	token: string;
-	tab: 'resources' | 'events' | 'history';
-	onTabChange: (t: 'resources' | 'events' | 'history') => void;
+	tab: AppTab;
+	onTabChange: (t: AppTab) => void;
 	selectedResource: ResourceSelector | null;
 	onSelectResource: (sel: ResourceSelector) => void;
 }) {
-	const tabs: { id: 'resources' | 'events' | 'history'; label: string }[] = [
+	const outOfSync = app.status.sync.status === 'OutOfSync';
+	const tabs: { id: AppTab; label: string }[] = [
 		{ id: 'resources', label: 'Resources' },
+		{ id: 'diff', label: outOfSync ? 'Diff •' : 'Diff' },
 		{ id: 'events', label: 'Events' },
 		{ id: 'history', label: 'Sync History' },
 	];
@@ -791,6 +1019,9 @@ export function AppExpandedPanel({
 					onSelectResource={onSelectResource}
 				/>
 			)}
+			{tab === 'diff' && (
+				<AppDiffPanel token={token} appName={app.metadata.name} />
+			)}
 			{tab === 'events' && (
 				<AppEventsPanel token={token} appName={app.metadata.name} />
 			)}
@@ -817,8 +1048,8 @@ export function ApplicationRow({
 	token: string;
 	expanded: boolean;
 	onToggle: () => void;
-	tab: 'resources' | 'events' | 'history';
-	onTabChange: (t: 'resources' | 'events' | 'history') => void;
+	tab: AppTab;
+	onTabChange: (t: AppTab) => void;
 	selectedResource: ResourceSelector | null;
 	onSelectResource: (sel: ResourceSelector) => void;
 }) {

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -408,6 +408,108 @@ export async function hardRefreshApplication(
 	if (!resp.ok) throw new Error(`Refresh failed: ${resp.status}`);
 }
 
+export async function rollbackApplication(
+	token: string,
+	appName: string,
+	id: number,
+): Promise<void> {
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}/rollback`,
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ id, prune: false, dryRun: false }),
+			signal: AbortSignal.timeout(30000),
+		},
+	);
+	if (resp.status === 403) throw new ManageForbiddenError();
+	if (!resp.ok) throw new Error(`Rollback failed: ${resp.status}`);
+}
+
+// ---------------------------------------------------------------------------
+// Diff helpers — readable live-vs-target comparison for OutOfSync resources.
+// ArgoCD's managed-resources endpoint returns JSON manifests as strings; we
+// pretty-print with stable key ordering, then run a line LCS to mark changes.
+// ---------------------------------------------------------------------------
+
+export type AppTab = 'resources' | 'diff' | 'events' | 'history';
+
+export type DiffLineOp = 'context' | 'add' | 'remove';
+
+export interface DiffLine {
+	op: DiffLineOp;
+	text: string;
+}
+
+function stableStringify(value: unknown): string {
+	const seen = new WeakSet();
+	const sort = (v: unknown): unknown => {
+		if (v === null || typeof v !== 'object') return v;
+		if (seen.has(v as object)) return undefined;
+		seen.add(v as object);
+		if (Array.isArray(v)) return v.map(sort);
+		const out: Record<string, unknown> = {};
+		for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+			out[k] = sort((v as Record<string, unknown>)[k]);
+		}
+		return out;
+	};
+	return JSON.stringify(sort(value), null, 2);
+}
+
+export function prettyManifest(raw: string | undefined): string {
+	if (!raw) return '';
+	try {
+		return stableStringify(JSON.parse(raw));
+	} catch {
+		return raw;
+	}
+}
+
+/**
+ * Minimal line diff via longest-common-subsequence. Manifests are small
+ * (typically <500 lines) so the O(n·m) DP table is fine.
+ */
+export function diffLines(before: string, after: string): DiffLine[] {
+	const a = before ? before.split('\n') : [];
+	const b = after ? after.split('\n') : [];
+	const n = a.length;
+	const m = b.length;
+	const lcs: number[][] = Array.from({ length: n + 1 }, () =>
+		new Array<number>(m + 1).fill(0),
+	);
+	for (let i = n - 1; i >= 0; i--) {
+		for (let j = m - 1; j >= 0; j--) {
+			lcs[i][j] =
+				a[i] === b[j]
+					? lcs[i + 1][j + 1] + 1
+					: Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+		}
+	}
+	const out: DiffLine[] = [];
+	let i = 0;
+	let j = 0;
+	while (i < n && j < m) {
+		if (a[i] === b[j]) {
+			out.push({ op: 'context', text: a[i] });
+			i++;
+			j++;
+		} else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+			out.push({ op: 'remove', text: a[i] });
+			i++;
+		} else {
+			out.push({ op: 'add', text: b[j] });
+			j++;
+		}
+	}
+	while (i < n) out.push({ op: 'remove', text: a[i++] });
+	while (j < m) out.push({ op: 'add', text: b[j++] });
+	return out;
+}
+
 // ---------------------------------------------------------------------------
 // Cache helpers — IndexedDB-backed (SharedWorker → Dexie → localStorage →
 // memory) via the shared idb-cache layer. Render from here first, then pull.
@@ -645,9 +747,7 @@ class ArgoService {
 	public readonly $lastUpdated = atom<Date | null>(null);
 	public readonly $expandedApp = atom<string | null>(null);
 	public readonly $selectedResource = atom<ResourceSelector | null>(null);
-	public readonly $appTab = atom<'resources' | 'events' | 'history'>(
-		'resources',
-	);
+	public readonly $appTab = atom<AppTab>('resources');
 
 	// Per-app action state: $actionBusy holds `${name}:sync` | `${name}:refresh`
 	// while the request is in flight; messages are transient banners.
@@ -865,6 +965,30 @@ class ArgoService {
 		}
 	}
 
+	public async rollbackApp(name: string, id: number): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$actionBusy.get()) return;
+		this.$actionBusy.set(`${name}:rollback`);
+		this.$actionError.set(null);
+		this.$actionMsg.set(null);
+		try {
+			await rollbackApplication(token, name, id);
+			this.$actionMsg.set(`Rollback to revision #${id} triggered`);
+			await this.invalidateCache();
+			this._scheduleRefresh(true);
+		} catch (e: unknown) {
+			this.$actionError.set(
+				e instanceof ManageForbiddenError
+					? 'Rollback needs DASHBOARD_MANAGE permission'
+					: e instanceof Error
+						? e.message
+						: 'Rollback failed',
+			);
+		} finally {
+			this.$actionBusy.set(null);
+		}
+	}
+
 	private _scheduleRefresh(immediate = false): void {
 		if (this._refreshTimer) clearTimeout(this._refreshTimer);
 		this._refreshTimer = setTimeout(
@@ -934,7 +1058,7 @@ class ArgoService {
 		}
 	}
 
-	public setAppTab(tab: 'resources' | 'events' | 'history'): void {
+	public setAppTab(tab: AppTab): void {
 		this.$appTab.set(tab);
 	}
 


### PR DESCRIPTION
## Summary
Closes the triage loop on the ArgoCD dashboard — from *see drift* to *fix it*.

### Diff tab
- New **Diff** tab in the expanded app panel. Fetches `managed-resources`, filters to resources whose live state differs from target, and renders a readable line diff (live in red, target in green).
- Diff engine in `argoService`: `prettyManifest` (stable-key JSON pretty-print) + `diffLines` (LCS line diff, pure/testable). No new deps.
- Tab is flagged (`Diff •`) when the app is `OutOfSync`; shows an all-clear when nothing drifts.

### Rollback
- Per-revision **Rollback** button in the Sync History tab → `rollbackApplication` POSTs to ArgoCD's `/rollback`. Mutation is **DASHBOARD_MANAGE**-gated by the existing method-aware proxy, guarded by a confirm dialog, and reuses the `$actionBusy/$actionMsg/$actionError` plumbing.
- The currently-deployed revision is tagged **Current** instead of offering rollback.

### Notes
- `AppTab` union centralized in `argoService` and extended with `diff`; ApplicationRow + unit test updated.
- `astro-kbve:check` clean on touched files (lone remaining error `RnWebDemo.tsx:37` is pre-existing/unrelated).
- No proxy/Rust changes.