### PR TITLE
feat(observ): wire initObserv into astro-kbve global head

### DIFF
--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -184,3 +184,13 @@ if (isArticle) {
 <link rel="preconnect" href="https://i.ytimg.com" crossorigin />
 <link rel="preconnect" href="https://yt3.ggpht.com" crossorigin />
 <link rel="dns-prefetch" href="https://www.youtube-nocookie.com" />
+
+<script>
+	import { initObserv } from '@kbve/observ';
+	initObserv({
+		endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+		project: 'astro-kbve',
+		platform: 'web',
+		environment: import.meta.env.MODE,
+	});
+</script>

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -26,6 +26,7 @@
 			],
 			"@kbve/proto/*": ["../../../packages/data/codegen/generated/*"],
 			"@kbve/core": ["../../../packages/npm/core/src/index.ts"],
+			"@kbve/observ": ["../../../packages/npm/observ/src/index.ts"],
 			"@kbve/rn": ["../../../packages/npm/rn/src/index.web.ts"],
 			"@kbve/rn/ui": ["../../../packages/npm/rn/src/ui/index.web.ts"],
 			"@kbve/rn-astro": ["../../../packages/npm/rn-astro/src/index.ts"],


### PR DESCRIPTION
## What

Installs the `@kbve/observ` browser SDK from the Starlight `Head.astro` override so client-side `error` + `unhandledrejection` events on kbve.com flow into the metrics ingest (`telemetry.errors`).

## Config

```ts
initObserv({
  endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
  project: 'astro-kbve',
  platform: 'web',
  environment: import.meta.env.MODE,
});
```

- **project / url dual axis** — each event auto-carries `url = location.href`, so errors group by stack fingerprint (Sentry-correct: same bug across pages = one group) while staying filterable by page. Downstream game clients reuse the same table with their own `project` + `platform` and a logical `url` (scene/level).
- **All environments** — `environment` field tags prod vs dev rather than gating install.

## tsconfig path

astro-kbve resolves `@kbve/*` via its **own** `tsconfig.json` paths (not `tsconfig.base.json`). The client-script rollup pass couldn't resolve `@kbve/observ` without an entry, so added one next to `@kbve/core`.

## Safety

Transport swallows fetch failures (`.catch(() => undefined)`), so this is **inert until** `ghcr.io/kbve/metrics` publishes and `metrics.kbve.com` goes live (gated on #12898 → dev→main release). No user-facing impact before then.

## Verification

Full `astro-kbve:build` green (7772 pages). Singleton + `installed` guard handle SPA re-runs under ClientRouter.