### PR TITLE
fix(axum-kbve): copy @kbve/observ into astro build stage

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -28,6 +28,7 @@ COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
 COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/observ/ packages/npm/observ/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 


### PR DESCRIPTION
## Problem

axum-kbve Docker build fails at the astro stage:

```
[vite]: Rollup failed to resolve import "@kbve/observ" from "Head.astro?astro&type=script&..."
```

`Head.astro` imports `initObserv` from `@kbve/observ` (wired in #12902). That bare specifier resolves through the tsconfig path alias to `packages/npm/observ/src`, but the `astro-builder` stage never copied that workspace source into the build context — so Rollup couldn't resolve it.

## Fix

Add `COPY packages/npm/observ/` alongside the other workspace npm packages in the astro build stage. `observ`'s only runtime dep (`zod`) is already installed by the root `pnpm install`.

Only `astro-kbve` consumes `@kbve/observ`; the chuckrpg/rareicon/cryptothrone astro Dockerfiles don't import it, so no change needed there.