### PR TITLE
feat(forgejo): automate LFS GC + Longhorn space reclaim

### DIFF
--- a/apps/kube/forgejo/README.md
+++ b/apps/kube/forgejo/README.md
@@ -74,6 +74,64 @@ Forgejo Actions runner (builds with code + assets)
 - **Database**: `forgejo` schema in kilobase CNPG cluster (shared Postgres)
 - **SSH**: NodePort 30022 → `forgejo.kbve.com:30022`
 
+## LFS space reclaim (GC + trim)
+
+Reclaiming disk after stale LFS objects accumulate is a **two-layer** problem
+(see issues #11930 and #12793). Doing only one layer makes GC "succeed" while
+disk usage stays flat:
+
+1. **Forgejo LFS GC** — deletes unreferenced LFS objects from the store
+   (`/data/lfs`). Frees ext4 files/inodes only.
+2. **Longhorn filesystem trim** — unmaps the freed blocks from the volume so
+   `volume.status.actualSize` actually drops. ext4 deletes do not UNMAP blocks,
+   so without a trim the space stays pinned in the Longhorn volume/snapshot
+   chain.
+
+### Automation (current state)
+
+- **GC**: `[cron.gc_lfs]` runs weekly (`@every 168h`, `OLDER_THAN = 168h`),
+  configured in `apps/kube/forgejo/application.yaml`.
+- **Trim**: Longhorn `RecurringJob forgejo-filesystem-trim-weekly` (Sun 03:00) in
+  `apps/kube/storage/manifests/recurring-jobs.yaml`, with
+  `removeSnapshotsDuringFilesystemTrim: true` (values.yaml) so snapshot-chain
+  space is reclaimed too. A `forgejo-snapshot-weekly` job (Sat 02:00, retain 2)
+  provides a safety point before the trim.
+- **Scoping**: both jobs target the `forgejo-reclaim` group, **not** Longhorn's
+  cluster-wide `default` group, so they only touch the LFS volume. Binding is via
+  a label on the CSI-created Volume CR (not in git) — re-apply it if the PVC is
+  ever recreated:
+
+  ```bash
+  kubectl -n longhorn-system label volume \
+    $(kubectl -n forgejo get pvc gitea-shared-storage -o jsonpath='{.spec.volumeName}') \
+    recurring-job-group.longhorn.io/forgejo-reclaim=enabled --overwrite
+  ```
+
+### Manual runbook (on-demand reclaim / verification)
+
+```bash
+# 1. Run LFS GC now (instead of waiting for the weekly cron).
+#    Forgejo admin API — token must have admin scope.
+curl -X POST -H "Authorization: token <ADMIN_TOKEN>" \
+  https://git.kbve.com/api/v1/admin/cron/gc_lfs
+
+# 2. Confirm the store shrank inside the pod.
+kubectl exec -n forgejo deploy/forgejo -- du -sh /data/lfs
+
+# 3. Trigger the Longhorn filesystem trim for the volume (or run the
+#    RecurringJob ad-hoc). Easiest via the Longhorn UI:
+#    Volume → gitea-shared-storage → "Trim Filesystem".
+#    API equivalent:
+#    POST /v1/volumes/<vol>?action=trimFilesystem
+
+# 4. Verify reclaim — actualSize should track the live filesystem size.
+kubectl get volumes.longhorn.io -n longhorn-system \
+  -o custom-columns=NAME:.metadata.name,SIZE:.spec.size,ACTUAL:.status.actualSize
+
+# 5. Storage-layer health.
+kubectl exec -n forgejo deploy/forgejo -- forgejo doctor check --run storage-lfs
+```
+
 ## DNS
 
 Add `forgejo.kbve.com` A record pointing to `142.132.206.74` in Cloudflare.

--- a/apps/kube/forgejo/README.md
+++ b/apps/kube/forgejo/README.md
@@ -89,8 +89,9 @@ disk usage stays flat:
 
 ### Automation (current state)
 
-- **GC**: `[cron.gc_lfs]` runs weekly (`@every 168h`, `OLDER_THAN = 168h`),
-  configured in `apps/kube/forgejo/application.yaml`.
+- **GC**: `[cron.gc_lfs]` (`SCHEDULE = '0 1 * * 0'`, `OLDER_THAN = 168h`),
+  configured in `apps/kube/forgejo/application.yaml`. Pinned to Sunday 01:00
+  (cron, not `@every 168h`) so it deterministically runs before the trim.
 - **Trim**: Longhorn `RecurringJob forgejo-filesystem-trim-weekly` (Sun 03:00) in
   `apps/kube/storage/manifests/recurring-jobs.yaml`, with
   `removeSnapshotsDuringFilesystemTrim: true` (values.yaml) so snapshot-chain
@@ -101,11 +102,11 @@ disk usage stays flat:
   a label on the CSI-created Volume CR (not in git) — re-apply it if the PVC is
   ever recreated:
 
-  ```bash
-  kubectl -n longhorn-system label volume \
-    $(kubectl -n forgejo get pvc gitea-shared-storage -o jsonpath='{.spec.volumeName}') \
-    recurring-job-group.longhorn.io/forgejo-reclaim=enabled --overwrite
-  ```
+    ```bash
+    kubectl -n longhorn-system label volume \
+      $(kubectl -n forgejo get pvc gitea-shared-storage -o jsonpath='{.spec.volumeName}') \
+      recurring-job-group.longhorn.io/forgejo-reclaim=enabled --overwrite
+    ```
 
 ### Manual runbook (on-demand reclaim / verification)
 

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -40,11 +40,12 @@ spec:
                       accessModes:
                           - ReadWriteOnce
 
-                  deployment:
-                      annotations:
-                          # Bump this value to force a pod rollout when config/secrets change.
-                          # ArgoCD detects the annotation change → new ReplicaSet → pod restart.
-                          kbve.com/config-revision: '2026-06-21-gc-lfs-cron'
+                  # Pod-template annotation (NOT deployment.annotations, which is
+                  # Deployment metadata and does not change the pod hash). Bumping
+                  # this value changes the pod template → new ReplicaSet → rollout,
+                  # so the new [cron.gc_lfs] config is actually loaded.
+                  podAnnotations:
+                      kbve.com/config-revision: '2026-06-21-gc-lfs-cron'
 
                   gitea:
                       admin:
@@ -117,10 +118,16 @@ spec:
                               # trim runs (see the Longhorn RecurringJob in
                               # apps/kube/storage/manifests). GC + trim together
                               # are what actually reclaim disk. See issue #12793.
+                              #
+                              # Pinned to Sunday 01:00 (cron, not '@every 168h')
+                              # so it deterministically precedes the Longhorn
+                              # forgejo-filesystem-trim-weekly job at Sunday 03:00.
+                              # '@every' anchors to pod start, which would not
+                              # guarantee that ordering.
                               gc_lfs:
                                   ENABLED: true
                                   RUN_AT_START: false
-                                  SCHEDULE: '@every 168h'
+                                  SCHEDULE: '0 1 * * 0'
                                   OLDER_THAN: 168h
                       additionalConfigFromEnvs:
                           - name: FORGEJO__SERVER__LFS_JWT_SECRET

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -44,7 +44,7 @@ spec:
                       annotations:
                           # Bump this value to force a pod rollout when config/secrets change.
                           # ArgoCD detects the annotation change → new ReplicaSet → pod restart.
-                          kbve.com/config-revision: '2026-06-20-gc-cron'
+                          kbve.com/config-revision: '2026-06-21-gc-lfs-cron'
 
                   gitea:
                       admin:
@@ -109,6 +109,19 @@ spec:
                                   RUN_AT_START: false
                                   SCHEDULE: '@every 24h'
                                   TIMEOUT: 120s
+                              # Prune unreferenced LFS objects from the store so
+                              # stale assets (e.g. deleted branches) stop pinning
+                              # space on the 50Gi Longhorn PVC. This frees ext4
+                              # inodes only — the freed blocks stay trapped in the
+                              # Longhorn volume/snapshot chain until a filesystem
+                              # trim runs (see the Longhorn RecurringJob in
+                              # apps/kube/storage/manifests). GC + trim together
+                              # are what actually reclaim disk. See issue #12793.
+                              gc_lfs:
+                                  ENABLED: true
+                                  RUN_AT_START: false
+                                  SCHEDULE: '@every 168h'
+                                  OLDER_THAN: 168h
                       additionalConfigFromEnvs:
                           - name: FORGEJO__SERVER__LFS_JWT_SECRET
                             valueFrom:

--- a/apps/kube/storage/manifests/kustomization.yaml
+++ b/apps/kube/storage/manifests/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+resources:
+    - recurring-jobs.yaml
+
 configMapGenerator:
     - name: longhorn-values
       files:

--- a/apps/kube/storage/manifests/recurring-jobs.yaml
+++ b/apps/kube/storage/manifests/recurring-jobs.yaml
@@ -1,0 +1,61 @@
+# Longhorn RecurringJobs — automated block-level space reclaim for Forgejo LFS.
+#
+# Context (issue #12793, follow-up from #11930): deleting LFS objects in ext4
+# does NOT unmap the underlying blocks, so freed space stays pinned in the
+# Longhorn volume/snapshot chain until a filesystem trim runs. Forgejo's
+# scheduled gc_lfs cron (apps/kube/forgejo/application.yaml) frees the files;
+# these jobs return the actual disk.
+#
+# SCOPING — these jobs run ONLY on volumes labeled into the "forgejo-reclaim"
+# group, NOT the built-in "default" group. The default group is auto-applied by
+# Longhorn to every volume in the cluster (~46 here, incl. 200-322Gi database
+# volumes), so a default-group snapshot/trim would fan out cluster-wide. We bind
+# only the Forgejo LFS volume (PVC gitea-shared-storage /
+# pvc-0d5edbf3-53e5-4b1f-8cf2-b28359844f73) with:
+#
+#   kubectl -n longhorn-system label volume \
+#     pvc-0d5edbf3-53e5-4b1f-8cf2-b28359844f73 \
+#     recurring-job-group.longhorn.io/forgejo-reclaim=enabled
+#
+# That label lives on the CSI-created Volume CR (not in git). It must be
+# re-applied if the PVC is ever recreated — see the runbook in
+# apps/kube/forgejo/README.md.
+#
+# trim relies on defaultSettings.removeSnapshotsDuringFilesystemTrim=true
+# (values.yaml) to also reclaim space trapped in the snapshot chain. That global
+# setting only has an effect while a volume is being trimmed, and forgejo-reclaim
+# is the only scheduled trim, so its practical blast radius is the LFS volume.
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+    name: forgejo-filesystem-trim-weekly
+    namespace: longhorn-system
+spec:
+    # Sunday 03:00 — after the weekly Forgejo gc_lfs run has freed the files.
+    cron: "0 3 * * 0"
+    task: filesystem-trim
+    groups:
+        - forgejo-reclaim
+    concurrency: 1
+    # filesystem-trim produces no snapshots/backups, so retain is irrelevant; 0.
+    retain: 0
+    labels:
+        kbve.com/managed-by: argocd
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+    name: forgejo-snapshot-weekly
+    namespace: longhorn-system
+spec:
+    # Saturday 02:00 — a safety point before the Sunday trim so cleanups are
+    # recoverable without taking manual snapshots (issue #12793, optional item).
+    cron: "0 2 * * 6"
+    task: snapshot
+    groups:
+        - forgejo-reclaim
+    concurrency: 1
+    retain: 2
+    labels:
+        kbve.com/managed-by: argocd

--- a/apps/kube/storage/manifests/values.yaml
+++ b/apps/kube/storage/manifests/values.yaml
@@ -29,6 +29,13 @@ defaultSettings:
   allowNodeDrainWithLastHealthyReplica: false
   mkfsExt4Parameters: "-O ^metadata_csum,^64bit"
   disableSnapshotPurge: false
+  # Let a filesystem-trim mark snapshots in the chain as removed so freed
+  # blocks are actually unmapped from the volume's actualSize. Without this,
+  # trimming the live filesystem leaves reclaimed space pinned in older
+  # snapshots (the ~18.5 GiB stuck case in #11930). Global equivalent of the
+  # per-volume unmapMarkSnapChainRemoved=enabled. Paired with the
+  # filesystem-trim RecurringJob (recurring-jobs.yaml). See issue #12793.
+  removeSnapshotsDuringFilesystemTrim: true
 
 longhornManager:
   tolerations:


### PR DESCRIPTION
Closes #12793. Follow-up from #11930.

Stale Forgejo LFS objects accumulate on the 50Gi Longhorn PVC, and reclaiming disk needs **two layers** — deleting LFS objects (ext4 frees inodes only) and then a filesystem trim to unmap the freed blocks from the volume. Without both, GC "succeeds" while disk usage stays flat. PR #12892's `git_gc_repos` cron is git repo GC, not LFS, and does nothing for the block-reclaim layer.

## Changes

**Forgejo** (`apps/kube/forgejo/application.yaml`)
- Add scheduled `[cron.gc_lfs]` (`@every 168h`, `OLDER_THAN = 168h`) alongside the existing `git_gc_repos`; bump `config-revision`.

**Longhorn** (`apps/kube/storage/manifests/`)
- New `recurring-jobs.yaml`: `forgejo-filesystem-trim-weekly` (Sun 03:00) + `forgejo-snapshot-weekly` (Sat 02:00, retain 2), scoped to a dedicated **`forgejo-reclaim` group**.
- `removeSnapshotsDuringFilesystemTrim: true` in `values.yaml` — global equivalent of per-volume `unmapMarkSnapChainRemoved=enabled`, so trim also reclaims space trapped in the snapshot chain (the ~18.5 GiB stuck case in #11930).
- Wire `recurring-jobs.yaml` into the kustomization.

**Docs** (`apps/kube/forgejo/README.md`)
- GC → trim → verify `actualSize` runbook + the volume-label binding step.

## Verified against the live cluster (`admin@kbve`, Longhorn v1.9.1)
- RecurringJob CRD **v1beta2** is the served/storage version → manifest uses it.
- Setting key **`remove-snapshots-during-filesystem-trim` exists** (was `false`) → `values.yaml` key is valid.
- PVC `gitea-shared-storage` → volume `pvc-0d5edbf3-…` (matches the issue), actualSize ~9.2 GiB.
- `kubectl kustomize apps/kube/storage/manifests` renders both RecurringJobs.
- **Scoping label applied** to the forgejo volume: `recurring-job-group.longhorn.io/forgejo-reclaim=enabled`.

## Design call — scoped, not cluster-wide
Longhorn auto-labels **every** volume into the built-in `default` group (confirmed: ~46 volumes, incl. 200–322 GiB DB volumes, several near capacity). A `default`-group snapshot/trim would fan out cluster-wide — a weekly snapshot of all DB volumes is real overhead and risk, counterproductive for a space-reclaim ticket. So the jobs target a dedicated `forgejo-reclaim` group bound only to the LFS volume.

**Trade-off (hidden state):** the group binding is a label on the CSI-created Volume CR, so it lives outside git and must be re-applied if the PVC is recreated. There's no clean GitOps-native way to scope a recurring job to one dynamically-named volume without minting a dedicated StorageClass (which would require recreating the 50Gi PVC). Documented in `recurring-jobs.yaml` + the README runbook; the label is already applied on the live cluster.


## Deferred scope

Cluster-wide `filesystem-trim` (other ~45 volumes incl 200–322Gi DBs) is intentionally **out of scope** here — tracked in #12915. This PR proves the GC→trim→reclaim loop on the single Forgejo LFS volume first to avoid I/O risk on database volumes.
