### PR TITLE
feat(argo-dashboard): card filter chips, search + grouping

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoCards.tsx
@@ -8,6 +8,8 @@ import {
 	type AppSummary,
 	type ResourceTally,
 	type ArgoApplication,
+	type CardFilter,
+	type CardGroupBy,
 } from './argoService';
 import {
 	AppExpandedPanel,
@@ -23,6 +25,7 @@ import {
 	RotateCw,
 	Loader2,
 	AlertTriangle,
+	Search,
 } from 'lucide-react';
 
 function ResourceBar({ tally }: { tally: ResourceTally }) {
@@ -377,8 +380,204 @@ const emptyTally: ResourceTally = {
 	out_of_sync: 0,
 };
 
+function FilterChip({
+	label,
+	count,
+	active,
+	tone,
+	onClick,
+}: {
+	label: string;
+	count: number;
+	active: boolean;
+	tone: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-pressed={active}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: 5,
+				padding: '3px 10px',
+				borderRadius: 999,
+				fontSize: '0.73rem',
+				fontWeight: 600,
+				cursor: 'pointer',
+				color: active ? '#0d0d0d' : tone,
+				background: active ? tone : 'transparent',
+				border: `1px solid ${active ? tone : 'var(--sl-color-gray-5, #262626)'}`,
+			}}>
+			{label}
+			<span
+				style={{
+					fontVariantNumeric: 'tabular-nums',
+					opacity: 0.85,
+					fontSize: '0.68rem',
+				}}>
+				{count}
+			</span>
+		</button>
+	);
+}
+
+function CardFilterBar({
+	filter,
+	search,
+	groupBy,
+	counts,
+}: {
+	filter: CardFilter;
+	search: string;
+	groupBy: CardGroupBy;
+	counts: {
+		all: number;
+		degraded: number;
+		outofsync: number;
+		stalled: number;
+	};
+}) {
+	const set = (f: CardFilter) =>
+		argoService.setCardFilter(filter === f ? 'all' : f);
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexWrap: 'wrap',
+				alignItems: 'center',
+				gap: 8,
+				marginBottom: '0.75rem',
+			}}>
+			<FilterChip
+				label="All"
+				count={counts.all}
+				active={filter === 'all'}
+				tone="#8b5cf6"
+				onClick={() => argoService.setCardFilter('all')}
+			/>
+			<FilterChip
+				label="Degraded"
+				count={counts.degraded}
+				active={filter === 'degraded'}
+				tone="#ef4444"
+				onClick={() => set('degraded')}
+			/>
+			<FilterChip
+				label="OutOfSync"
+				count={counts.outofsync}
+				active={filter === 'outofsync'}
+				tone="#f59e0b"
+				onClick={() => set('outofsync')}
+			/>
+			<FilterChip
+				label="Stalled"
+				count={counts.stalled}
+				active={filter === 'stalled'}
+				tone="#fbbf24"
+				onClick={() => set('stalled')}
+			/>
+
+			<div
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: 5,
+					marginLeft: 'auto',
+					padding: '3px 8px',
+					borderRadius: 6,
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					background: 'var(--sl-color-bg, #0d0d0d)',
+				}}>
+				<Search
+					size={13}
+					style={{ color: 'var(--sl-color-gray-4, #6b7280)' }}
+				/>
+				<input
+					value={search}
+					onChange={(e) => argoService.setCardSearch(e.target.value)}
+					placeholder="filter by name / namespace / project"
+					style={{
+						background: 'transparent',
+						border: 'none',
+						outline: 'none',
+						color: 'var(--sl-color-text, #e6edf3)',
+						fontSize: '0.75rem',
+						width: 220,
+						maxWidth: '50vw',
+					}}
+				/>
+			</div>
+
+			<select
+				value={groupBy}
+				onChange={(e) =>
+					argoService.setCardGroupBy(e.target.value as CardGroupBy)
+				}
+				title="Group cards"
+				style={{
+					background: 'var(--sl-color-bg-nav, #111)',
+					color: 'var(--sl-color-text, #e6edf3)',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					borderRadius: 6,
+					padding: '4px 8px',
+					fontSize: '0.75rem',
+				}}>
+				<option value="none">No grouping</option>
+				<option value="project">By project</option>
+				<option value="namespace">By namespace</option>
+			</select>
+		</div>
+	);
+}
+
+function CardGrid({
+	summaries,
+	expandedApp,
+}: {
+	summaries: AppSummary[];
+	expandedApp: string | null;
+}) {
+	return (
+		<div
+			style={{
+				display: 'grid',
+				gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+				gap: '0.75rem',
+			}}>
+			{summaries.map((s) => (
+				<AppCard
+					key={s.name}
+					summary={s}
+					expanded={expandedApp === s.name}
+					onToggle={() => argoService.toggleExpandedApp(s.name)}
+				/>
+			))}
+		</div>
+	);
+}
+
+function groupSummaries(
+	summaries: AppSummary[],
+	groupBy: CardGroupBy,
+): { key: string; items: AppSummary[] }[] {
+	if (groupBy === 'none') return [{ key: '', items: summaries }];
+	const map = new Map<string, AppSummary[]>();
+	for (const s of summaries) {
+		const k = (groupBy === 'project' ? s.project : s.namespace) || '—';
+		const arr = map.get(k) ?? [];
+		arr.push(s);
+		map.set(k, arr);
+	}
+	return Array.from(map.entries())
+		.sort((a, b) => a[0].localeCompare(b[0]))
+		.map(([key, items]) => ({ key, items }));
+}
+
 export default function ReactArgoCards() {
-	const summaries = useStore(argoService.$appSummaries);
+	const summaries = useStore(argoService.$filteredSummaries);
 	const applications = useStore(argoService.$applications);
 	const expandedApp = useStore(argoService.$expandedApp);
 	const accessToken = useStore(argoService.$accessToken);
@@ -386,31 +585,78 @@ export default function ReactArgoCards() {
 	const selectedResource = useStore(argoService.$selectedResource);
 	const actionError = useStore(argoService.$actionError);
 	const actionMsg = useStore(argoService.$actionMsg);
+	const filter = useStore(argoService.$cardFilter);
+	const search = useStore(argoService.$cardSearch);
+	const groupBy = useStore(argoService.$cardGroupBy);
+	const totalApps = useStore(argoService.$totalApps);
+	const degradedCount = useStore(argoService.$degradedCount);
+	const outOfSyncCount = useStore(argoService.$outOfSyncCount);
+	const stalledCount = useStore(argoService.$stalledCount);
 
-	if (!summaries.length) return null;
+	if (!applications.length) return null;
 
 	const expandedRaw: ArgoApplication | undefined = expandedApp
 		? applications.find((a) => a.metadata.name === expandedApp)
 		: undefined;
 
+	const groups = groupSummaries(summaries, groupBy);
+
 	return (
 		<>
-			<div
-				style={{
-					display: 'grid',
-					gridTemplateColumns:
-						'repeat(auto-fill, minmax(280px, 1fr))',
-					gap: '0.75rem',
-				}}>
-				{summaries.map((s) => (
-					<AppCard
-						key={s.name}
-						summary={s}
-						expanded={expandedApp === s.name}
-						onToggle={() => argoService.toggleExpandedApp(s.name)}
-					/>
-				))}
-			</div>
+			<CardFilterBar
+				filter={filter}
+				search={search}
+				groupBy={groupBy}
+				counts={{
+					all: totalApps,
+					degraded: degradedCount,
+					outofsync: outOfSyncCount,
+					stalled: stalledCount,
+				}}
+			/>
+
+			{summaries.length === 0 ? (
+				<div
+					style={{
+						padding: '1.5rem',
+						textAlign: 'center',
+						color: 'var(--sl-color-gray-4, #6b7280)',
+						fontSize: '0.85rem',
+					}}>
+					No applications match the current filter
+				</div>
+			) : (
+				groups.map((g) => (
+					<div key={g.key || 'all'} style={{ marginBottom: '1rem' }}>
+						{g.key && (
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 6,
+									margin: '0 0 0.5rem',
+									fontSize: '0.72rem',
+									fontWeight: 700,
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+								}}>
+								{g.key}
+								<span
+									style={{
+										color: 'var(--sl-color-gray-4, #6b7280)',
+									}}>
+									({g.items.length})
+								</span>
+							</div>
+						)}
+						<CardGrid
+							summaries={g.items}
+							expandedApp={expandedApp}
+						/>
+					</div>
+				))
+			)}
 
 			{expandedRaw && accessToken && (
 				<div

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -437,6 +437,10 @@ export async function rollbackApplication(
 
 export type AppTab = 'resources' | 'diff' | 'events' | 'history';
 
+export type CardFilter = 'all' | 'degraded' | 'outofsync' | 'stalled';
+
+export type CardGroupBy = 'none' | 'project' | 'namespace';
+
 export type DiffLineOp = 'context' | 'add' | 'remove';
 
 export interface DiffLine {
@@ -731,6 +735,36 @@ export function normalizeApp(app: ArgoApplication): AppSummary {
 }
 
 // ---------------------------------------------------------------------------
+// UI preference persistence (view mode + grouping survive reloads)
+// ---------------------------------------------------------------------------
+
+const PREF_VIEW = 'argo:pref:view';
+const PREF_GROUP = 'argo:pref:group';
+
+function loadPref<T extends string>(
+	key: string,
+	allowed: readonly T[],
+	fallback: T,
+): T {
+	try {
+		const v = localStorage.getItem(key);
+		return v && (allowed as readonly string[]).includes(v)
+			? (v as T)
+			: fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+function savePref(key: string, value: string): void {
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		/* ignore quota / unavailable */
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
@@ -838,8 +872,43 @@ class ArgoService {
 			);
 	});
 
-	// View toggle: rich card grid (default) vs dense table rows.
-	public readonly $viewMode = atom<'grid' | 'table'>('grid');
+	// View toggle: rich card grid (default) vs dense table rows. Persisted.
+	public readonly $viewMode = atom<'grid' | 'table'>(
+		loadPref(PREF_VIEW, ['grid', 'table'] as const, 'grid'),
+	);
+
+	// Card grid filtering: chip filter + free-text search + grouping.
+	public readonly $cardFilter = atom<CardFilter>('all');
+	public readonly $cardSearch = atom<string>('');
+	public readonly $cardGroupBy = atom<CardGroupBy>(
+		loadPref(PREF_GROUP, ['none', 'project', 'namespace'] as const, 'none'),
+	);
+
+	public readonly $filteredSummaries = computed(
+		[this.$appSummaries, this.$cardFilter, this.$cardSearch],
+		(summaries, filter, search) => {
+			const q = search.trim().toLowerCase();
+			return summaries.filter((s) => {
+				const health = s.health?.status ?? 'Unknown';
+				if (
+					filter === 'degraded' &&
+					!(health === 'Degraded' || health === 'Missing')
+				)
+					return false;
+				if (filter === 'outofsync' && s.sync?.status !== 'OutOfSync')
+					return false;
+				if (filter === 'stalled' && !s.stalled) return false;
+				if (
+					q &&
+					!`${s.name} ${s.namespace} ${s.project}`
+						.toLowerCase()
+						.includes(q)
+				)
+					return false;
+				return true;
+			});
+		},
+	);
 
 	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
 	private _refreshTimer: ReturnType<typeof setTimeout> | undefined;
@@ -1064,6 +1133,20 @@ class ArgoService {
 
 	public setViewMode(mode: 'grid' | 'table'): void {
 		this.$viewMode.set(mode);
+		savePref(PREF_VIEW, mode);
+	}
+
+	public setCardFilter(filter: CardFilter): void {
+		this.$cardFilter.set(filter);
+	}
+
+	public setCardSearch(query: string): void {
+		this.$cardSearch.set(query);
+	}
+
+	public setCardGroupBy(group: CardGroupBy): void {
+		this.$cardGroupBy.set(group);
+		savePref(PREF_GROUP, group);
 	}
 
 	private _startAutoRefresh(): void {


### PR DESCRIPTION
## Summary
Makes drift visible at a glance on the ArgoCD card grid, so a broken app is one filter + one click from its diff/rollback (#12901).

### Filter chips
- **All / Degraded / OutOfSync / Stalled** chips with live counts ($cardFilter). Clicking the active chip toggles back to All.

### Search + grouping
- Free-text search over name / namespace / project ($cardSearch).
- **Group by** project or namespace, rendered as titled sections with counts ($cardGroupBy); 'No grouping' keeps the flat worst-health-first sort.
- $filteredSummaries derives the visible set from $appSummaries; empty result shows a clear message.

### Persistence
- View mode (Cards/Table) and grouping survive reloads via localStorage.

### Notes
- `astro-kbve:check` clean on touched files (lone `RnWebDemo.tsx:37` error is pre-existing/unrelated).
- Cards-only change + additive argoService state; table view + diff/rollback untouched.