### PR TITLE
fix(bevy_skills): enable bevy_log for warn! macro

### DIFF
--- a/packages/rust/bevy/bevy_skills/Cargo.toml
+++ b/packages/rust/bevy/bevy_skills/Cargo.toml
@@ -31,4 +31,5 @@ serde_json = "1"
 # Bevy — only pulled in under the `bevy` feature.
 bevy = { version = "0.18", default-features = false, features = [
     "bevy_state",
+    "bevy_log",
 ], optional = true }


### PR DESCRIPTION
## Problem

`bevy_skills:lint` fails CI (issue #12914) with:

```
error: cannot find macro `warn` in this scope
  --> packages/rust/bevy/bevy_skills/src/systems.rs:22:13
   = note: `warn` is in scope, but it is an attribute: `#[warn]`
```

## Cause

`bevy_skills` pulls bevy with `default-features = false, features = ["bevy_state"]`. The log macros (`warn!`/`info!`/`error!`) are gated behind the `bevy_log` feature, which was not enabled — so `bevy::prelude::*` never exported `warn!` and it resolved to the built-in `#[warn]` lint attribute.

## Fix

Add `bevy_log` to the bevy feature list. Stays gated under the optional `bevy` feature, so FFI / headless builds (`default-features = false`) are unaffected.

Verified: `cargo clippy -p bevy_skills -- -D warnings` exits 0.

Closes #12914