### PR TITLE
feat(forgejo): wire file browser, git tags + release assets into dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -10,6 +10,7 @@ import ReactForgejoOrgPanel from './ReactForgejoOrgPanel';
 import ReactForgejoRepoAdmin from './ReactForgejoRepoAdmin';
 import ReactForgejoIssues from './ReactForgejoIssues';
 import ReactForgejoPackages from './ReactForgejoPackages';
+import ReactForgejoFiles from './ReactForgejoFiles';
 import ReactForgejoRunners from './ReactForgejoRunners';
 import ReactForgejoSystemPanel from './ReactForgejoSystemPanel';
 import ReactForgejoToast from './ReactForgejoToast';
@@ -50,6 +51,9 @@ import ReactForgejoToast from './ReactForgejoToast';
 				</div>
 				<div id="forgejo-packages">
 					<ReactForgejoPackages client:only="react" />
+				</div>
+				<div id="forgejo-files">
+					<ReactForgejoFiles client:only="react" />
 				</div>
 				<div id="forgejo-runners">
 					<ReactForgejoRunners client:only="react" />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoFiles.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoFiles.tsx
@@ -1,0 +1,525 @@
+import { useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	forgejoService,
+	formatBytes,
+	type ForgejoContentEntry,
+} from './forgejoService';
+import {
+	ActionButton,
+	Modal,
+	ConfirmDialog,
+	SelectField,
+	TextField,
+	useForm,
+	useTabActive,
+	uiTokens,
+	ForgejoNotice,
+} from './forgejoUi';
+import {
+	Folder,
+	FileText,
+	FileLock2,
+	ChevronRight,
+	Home,
+	Save,
+	Trash2,
+	Plus,
+	Download,
+	Loader2,
+	X,
+} from 'lucide-react';
+
+const { textColor, subText, border, panelBg } = uiTokens;
+
+function Breadcrumb({ path }: { path: string }) {
+	const segments = path ? path.split('/') : [];
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 4,
+				flexWrap: 'wrap',
+				fontSize: '0.8rem',
+				marginBottom: '0.75rem',
+			}}>
+			<button
+				type="button"
+				onClick={() => forgejoService.navigateDir('')}
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: 4,
+					background: 'transparent',
+					border: 'none',
+					color: segments.length
+						? 'var(--sl-color-accent, #06b6d4)'
+						: subText,
+					cursor: 'pointer',
+					padding: 0,
+				}}>
+				<Home size={13} /> root
+			</button>
+			{segments.map((seg, i) => {
+				const sub = segments.slice(0, i + 1).join('/');
+				const last = i === segments.length - 1;
+				return (
+					<span
+						key={sub}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 4,
+						}}>
+						<ChevronRight size={12} style={{ color: subText }} />
+						<button
+							type="button"
+							disabled={last}
+							onClick={() => forgejoService.navigateDir(sub)}
+							style={{
+								background: 'transparent',
+								border: 'none',
+								color: last
+									? textColor
+									: 'var(--sl-color-accent, #06b6d4)',
+								cursor: last ? 'default' : 'pointer',
+								padding: 0,
+								fontWeight: last ? 600 : 400,
+							}}>
+							{seg}
+						</button>
+					</span>
+				);
+			})}
+		</div>
+	);
+}
+
+function NewFileModal({ onClose }: { onClose: () => void }) {
+	const busy = useStore(forgejoService.$busy);
+	const dir = useStore(forgejoService.$filesPath);
+	const { state, set } = useForm({ name: '', content: '', message: '' });
+	const path = dir ? `${dir}/${state.name}` : state.name;
+	return (
+		<Modal
+			title="New file"
+			onClose={onClose}
+			width={620}
+			footer={
+				<>
+					<ActionButton variant="ghost" onClick={onClose}>
+						Cancel
+					</ActionButton>
+					<ActionButton
+						variant="primary"
+						disabled={!state.name}
+						loading={busy === `file-create-${path}`}
+						onClick={async () => {
+							const ok = await forgejoService.createFile(
+								state.name,
+								state.content,
+								state.message,
+							);
+							if (ok) onClose();
+						}}>
+						Create
+					</ActionButton>
+				</>
+			}>
+			<TextField
+				label={`Path (under ${dir || 'root'})`}
+				value={state.name}
+				onChange={(v) => set('name', v)}
+				placeholder="docs/notes.md"
+			/>
+			<label style={{ display: 'block', marginBottom: '0.75rem' }}>
+				<span
+					style={{
+						display: 'block',
+						fontSize: '0.72rem',
+						fontWeight: 600,
+						color: subText,
+						marginBottom: 4,
+						textTransform: 'uppercase',
+						letterSpacing: '0.04em',
+					}}>
+					Content
+				</span>
+				<textarea
+					value={state.content}
+					onChange={(e) => set('content', e.target.value)}
+					rows={10}
+					spellCheck={false}
+					style={{
+						width: '100%',
+						padding: '0.5rem 0.6rem',
+						borderRadius: 7,
+						border,
+						background: 'var(--sl-color-bg, #0d1117)',
+						color: textColor,
+						fontSize: '0.78rem',
+						fontFamily: 'monospace',
+						boxSizing: 'border-box',
+						resize: 'vertical',
+					}}
+				/>
+			</label>
+			<TextField
+				label="Commit message"
+				value={state.message}
+				onChange={(v) => set('message', v)}
+				placeholder={`Create ${state.name || 'file'}`}
+			/>
+		</Modal>
+	);
+}
+
+function FileEditor() {
+	const file = useStore(forgejoService.$openFile);
+	const busy = useStore(forgejoService.$busy);
+	const [text, setText] = useState('');
+	const [message, setMessage] = useState('');
+
+	useEffect(() => {
+		setText(file?.text ?? '');
+		setMessage('');
+	}, [file?.path, file?.sha]);
+
+	if (!file) return null;
+
+	const editable = !file.binary && !file.tooLarge;
+	const dirty = editable && text !== file.text;
+
+	return (
+		<div
+			style={{
+				border,
+				borderRadius: 10,
+				background: panelBg,
+				marginTop: '1rem',
+				overflow: 'hidden',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					padding: '0.6rem 0.8rem',
+					borderBottom: border,
+				}}>
+				<FileText size={14} style={{ color: subText }} />
+				<span
+					style={{
+						flex: 1,
+						color: textColor,
+						fontSize: '0.82rem',
+						fontFamily: 'monospace',
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					}}>
+					{file.path}
+				</span>
+				<ActionButton
+					size="sm"
+					title="Close"
+					onClick={() => forgejoService.closeFile()}>
+					<X size={12} />
+				</ActionButton>
+			</div>
+
+			{!editable ? (
+				<div
+					style={{
+						padding: '1rem',
+						color: subText,
+						fontSize: '0.82rem',
+					}}>
+					{file.binary
+						? 'Binary file — not editable here.'
+						: 'File too large to edit in the dashboard.'}
+				</div>
+			) : (
+				<div style={{ padding: '0.8rem' }}>
+					<textarea
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+						spellCheck={false}
+						rows={20}
+						style={{
+							width: '100%',
+							padding: '0.6rem',
+							borderRadius: 7,
+							border,
+							background: 'var(--sl-color-bg, #0d1117)',
+							color: textColor,
+							fontSize: '0.78rem',
+							fontFamily: 'monospace',
+							boxSizing: 'border-box',
+							resize: 'vertical',
+						}}
+					/>
+					<div
+						style={{
+							display: 'flex',
+							gap: 8,
+							alignItems: 'center',
+							marginTop: 8,
+							flexWrap: 'wrap',
+						}}>
+						<input
+							value={message}
+							onChange={(e) => setMessage(e.target.value)}
+							placeholder={`Update ${file.path}`}
+							style={{
+								flex: '1 1 220px',
+								padding: '0.45rem 0.6rem',
+								borderRadius: 7,
+								border,
+								background: 'var(--sl-color-bg, #0d1117)',
+								color: textColor,
+								fontSize: '0.8rem',
+							}}
+						/>
+						<ActionButton
+							variant="primary"
+							disabled={!dirty}
+							loading={busy === `file-save-${file.path}`}
+							onClick={() =>
+								forgejoService.saveFile(
+									file.path,
+									file.sha,
+									text,
+									message,
+								)
+							}>
+							<Save size={13} /> Commit
+						</ActionButton>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default function ReactForgejoFiles() {
+	const active = useTabActive('files');
+	const repos = useStore(forgejoService.$repos);
+	const repo = useStore(forgejoService.$filesRepo);
+	const path = useStore(forgejoService.$filesPath);
+	const entries = useStore(forgejoService.$filesEntries);
+	const loading = useStore(forgejoService.$filesLoading);
+	const openFile = useStore(forgejoService.$openFile);
+	const busy = useStore(forgejoService.$busy);
+	const [newOpen, setNewOpen] = useState(false);
+	const [delTarget, setDelTarget] = useState<ForgejoContentEntry | null>(
+		null,
+	);
+
+	if (!active) return null;
+
+	return (
+		<div className="not-content">
+			<ForgejoNotice
+				ctx="files"
+				onRetry={() => forgejoService.navigateDir(path)}
+			/>
+			<div
+				style={{
+					display: 'flex',
+					gap: 12,
+					alignItems: 'flex-end',
+					flexWrap: 'wrap',
+					marginBottom: '1.25rem',
+				}}>
+				<div style={{ flex: '1 1 280px', maxWidth: 420 }}>
+					<SelectField
+						label="Repository"
+						value={repo ?? ''}
+						onChange={(v) => v && forgejoService.selectFilesRepo(v)}
+						options={[
+							{ value: '', label: 'Select a repository…' },
+							...repos.map((r) => ({
+								value: r.full_name,
+								label: r.full_name,
+							})),
+						]}
+					/>
+				</div>
+				{repo && (
+					<div style={{ marginBottom: '0.75rem' }}>
+						<ActionButton
+							variant="primary"
+							onClick={() => setNewOpen(true)}>
+							<Plus size={13} /> New file
+						</ActionButton>
+					</div>
+				)}
+			</div>
+
+			{!repo && (
+				<span style={{ color: subText, fontSize: '0.85rem' }}>
+					Choose a repository to browse and edit its files.
+				</span>
+			)}
+
+			{repo && (
+				<>
+					<Breadcrumb path={path} />
+
+					{loading && entries.length === 0 ? (
+						<div
+							style={{
+								display: 'flex',
+								justifyContent: 'center',
+								padding: '2rem',
+							}}>
+							<Loader2
+								size={22}
+								style={{
+									animation: 'spin 1s linear infinite',
+									color: 'var(--sl-color-accent, #06b6d4)',
+								}}
+							/>
+						</div>
+					) : (
+						<div
+							style={{
+								borderRadius: 10,
+								border,
+								overflow: 'hidden',
+							}}>
+							{entries.map((e) => {
+								const isDir = e.type === 'dir';
+								const isFile = e.type === 'file';
+								return (
+									<div
+										key={e.path}
+										style={{
+											display: 'flex',
+											alignItems: 'center',
+											gap: 10,
+											padding: '0.5rem 0.75rem',
+											borderBottom: border,
+											background: panelBg,
+										}}>
+										{isDir ? (
+											<Folder
+												size={14}
+												style={{ color: '#06b6d4' }}
+											/>
+										) : isFile ? (
+											<FileText
+												size={14}
+												style={{ color: subText }}
+											/>
+										) : (
+											<FileLock2
+												size={14}
+												style={{ color: subText }}
+											/>
+										)}
+										<button
+											type="button"
+											onClick={() =>
+												isDir
+													? forgejoService.navigateDir(
+															e.path,
+														)
+													: isFile
+														? forgejoService.openFile(
+																e,
+															)
+														: undefined
+											}
+											style={{
+												flex: 1,
+												textAlign: 'left',
+												background: 'transparent',
+												border: 'none',
+												color: textColor,
+												fontSize: '0.82rem',
+												cursor:
+													isDir || isFile
+														? 'pointer'
+														: 'default',
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+											}}>
+											{e.name}
+										</button>
+										{isFile && (
+											<span
+												style={{
+													color: subText,
+													fontSize: '0.7rem',
+												}}>
+												{formatBytes(e.size)}
+											</span>
+										)}
+										{e.download_url && (
+											<a
+												href={e.download_url}
+												target="_blank"
+												rel="noreferrer"
+												style={{
+													color: subText,
+													display: 'flex',
+												}}
+												title="Download">
+												<Download size={12} />
+											</a>
+										)}
+										{isFile && (
+											<ActionButton
+												size="sm"
+												variant="danger"
+												title="Delete file"
+												onClick={() => setDelTarget(e)}>
+												<Trash2 size={11} />
+											</ActionButton>
+										)}
+									</div>
+								);
+							})}
+							{entries.length === 0 && (
+								<div
+									style={{
+										padding: '0.75rem',
+										color: subText,
+										fontSize: '0.8rem',
+										background: panelBg,
+									}}>
+									Empty directory.
+								</div>
+							)}
+						</div>
+					)}
+
+					{openFile && <FileEditor />}
+				</>
+			)}
+
+			{newOpen && <NewFileModal onClose={() => setNewOpen(false)} />}
+			{delTarget && (
+				<ConfirmDialog
+					title="Delete file"
+					message={`Delete ${delTarget.path}? This commits a deletion to the default branch.`}
+					confirmLabel="Delete"
+					danger
+					loading={busy === `file-delete-${delTarget.path}`}
+					onCancel={() => setDelTarget(null)}
+					onConfirm={async () => {
+						const ok = await forgejoService.deleteFile(
+							delTarget,
+							'',
+						);
+						if (ok) setDelTarget(null);
+					}}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useStore } from '@nanostores/react';
-import { forgejoService, timeAgo } from './forgejoService';
+import { forgejoService, timeAgo, formatBytes } from './forgejoService';
 import {
 	ActionButton,
 	Modal,
@@ -19,10 +19,12 @@ import {
 	Send,
 	Webhook,
 	Tag,
+	Tags,
 	CheckCircle2,
 	XCircle,
 	ShieldCheck,
 	KeyRound,
+	Download,
 } from 'lucide-react';
 
 const { textColor, subText, border, panelBg } = uiTokens;
@@ -323,6 +325,62 @@ function CreateProtectionModal({
 	);
 }
 
+function CreateTagModal({
+	repo,
+	onClose,
+}: {
+	repo: string;
+	onClose: () => void;
+}) {
+	const busy = useStore(forgejoService.$busy);
+	const { state, set } = useForm({
+		tag_name: '',
+		target: 'main',
+		message: '',
+	});
+	const submit = async () => {
+		const ok = await forgejoService.createTag(repo, state);
+		if (ok) onClose();
+	};
+	return (
+		<Modal
+			title={`New tag · ${repo}`}
+			onClose={onClose}
+			footer={
+				<>
+					<ActionButton variant="ghost" onClick={onClose}>
+						Cancel
+					</ActionButton>
+					<ActionButton
+						variant="primary"
+						onClick={submit}
+						loading={busy === `tag-create-${repo}`}
+						disabled={!state.tag_name}>
+						Create
+					</ActionButton>
+				</>
+			}>
+			<TextField
+				label="Tag name"
+				value={state.tag_name}
+				onChange={(v) => set('tag_name', v)}
+				placeholder="v1.0.0"
+			/>
+			<TextField
+				label="Target branch / commit"
+				value={state.target}
+				onChange={(v) => set('target', v)}
+			/>
+			<TextField
+				label="Message (optional, annotated tag)"
+				value={state.message}
+				onChange={(v) => set('message', v)}
+				textarea
+			/>
+		</Modal>
+	);
+}
+
 function AddSecretVarModal({
 	repo,
 	mode,
@@ -385,9 +443,10 @@ export default function ReactForgejoRepoAdmin() {
 	const protectionsMap = useStore(forgejoService.$repoProtections);
 	const secretsMap = useStore(forgejoService.$repoSecrets);
 	const variablesMap = useStore(forgejoService.$repoVariables);
+	const tagsMap = useStore(forgejoService.$repoTags);
 	const busy = useStore(forgejoService.$busy);
 	const [modal, setModal] = useState<
-		'hook' | 'release' | 'protection' | 'secret' | 'variable' | null
+		'hook' | 'release' | 'protection' | 'secret' | 'variable' | 'tag' | null
 	>(null);
 	const [confirm, setConfirm] = useState<{
 		kind: 'hook' | 'release';
@@ -398,6 +457,12 @@ export default function ReactForgejoRepoAdmin() {
 		kind: 'secret' | 'variable';
 		name: string;
 	} | null>(null);
+	const [tagConfirm, setTagConfirm] = useState<string | null>(null);
+	const [assetConfirm, setAssetConfirm] = useState<{
+		releaseId: number;
+		assetId: number;
+		name: string;
+	} | null>(null);
 
 	if (!active) return null;
 
@@ -406,6 +471,7 @@ export default function ReactForgejoRepoAdmin() {
 	const protections = selected ? protectionsMap[selected] : undefined;
 	const secrets = selected ? secretsMap[selected] : undefined;
 	const variables = selected ? variablesMap[selected] : undefined;
+	const tags = selected ? tagsMap[selected] : undefined;
 
 	return (
 		<div className="not-content">
@@ -583,61 +649,129 @@ export default function ReactForgejoRepoAdmin() {
 								<div
 									key={r.id}
 									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 8,
 										padding: '0.6rem 0.7rem',
 										borderRadius: 8,
 										border,
 										background: panelBg,
 									}}>
-									<span
+									<div
 										style={{
-											color: textColor,
-											fontWeight: 600,
-											fontSize: '0.8rem',
+											display: 'flex',
+											alignItems: 'center',
+											gap: 8,
 										}}>
-										{r.tag_name}
-									</span>
-									{r.draft && (
 										<span
 											style={{
-												color: '#6b7280',
-												fontSize: '0.68rem',
+												color: textColor,
+												fontWeight: 600,
+												fontSize: '0.8rem',
 											}}>
-											draft
+											{r.tag_name}
 										</span>
-									)}
-									{r.prerelease && (
-										<span
-											style={{
-												color: '#f59e0b',
-												fontSize: '0.68rem',
-											}}>
-											pre
-										</span>
-									)}
-									<span
-										style={{
-											marginLeft: 'auto',
-											color: subText,
-											fontSize: '0.68rem',
-										}}>
-										{timeAgo(
-											r.published_at || r.created_at,
+										{r.draft && (
+											<span
+												style={{
+													color: '#6b7280',
+													fontSize: '0.68rem',
+												}}>
+												draft
+											</span>
 										)}
-									</span>
-									<ActionButton
-										size="sm"
-										variant="danger"
-										onClick={() =>
-											setConfirm({
-												kind: 'release',
-												id: r.id,
-											})
-										}>
-										<Trash2 size={11} />
-									</ActionButton>
+										{r.prerelease && (
+											<span
+												style={{
+													color: '#f59e0b',
+													fontSize: '0.68rem',
+												}}>
+												pre
+											</span>
+										)}
+										<span
+											style={{
+												marginLeft: 'auto',
+												color: subText,
+												fontSize: '0.68rem',
+											}}>
+											{timeAgo(
+												r.published_at || r.created_at,
+											)}
+										</span>
+										<ActionButton
+											size="sm"
+											variant="danger"
+											onClick={() =>
+												setConfirm({
+													kind: 'release',
+													id: r.id,
+												})
+											}>
+											<Trash2 size={11} />
+										</ActionButton>
+									</div>
+									{(r.assets ?? []).length > 0 && (
+										<div
+											style={{
+												display: 'flex',
+												flexDirection: 'column',
+												gap: 4,
+												marginTop: 6,
+												paddingLeft: 4,
+											}}>
+											{r.assets.map((a) => (
+												<div
+													key={a.id}
+													style={{
+														display: 'flex',
+														alignItems: 'center',
+														gap: 6,
+														fontSize: '0.72rem',
+														color: subText,
+													}}>
+													<Download size={11} />
+													<a
+														href={
+															a.browser_download_url
+														}
+														target="_blank"
+														rel="noreferrer"
+														style={{
+															color: textColor,
+															flex: 1,
+															overflow: 'hidden',
+															textOverflow:
+																'ellipsis',
+															whiteSpace:
+																'nowrap',
+														}}>
+														{a.name}
+													</a>
+													<span>
+														{formatBytes(a.size)}
+													</span>
+													<span>
+														↓{a.download_count}
+													</span>
+													<ActionButton
+														size="sm"
+														variant="danger"
+														title="Delete asset"
+														loading={
+															busy ===
+															`asset-delete-${selected}-${r.id}-${a.id}`
+														}
+														onClick={() =>
+															setAssetConfirm({
+																releaseId: r.id,
+																assetId: a.id,
+																name: a.name,
+															})
+														}>
+														<Trash2 size={10} />
+													</ActionButton>
+												</div>
+											))}
+										</div>
+									)}
 								</div>
 							))}
 							{releases && releases.length === 0 && (
@@ -647,6 +781,89 @@ export default function ReactForgejoRepoAdmin() {
 										fontSize: '0.8rem',
 									}}>
 									No releases.
+								</span>
+							)}
+						</div>
+					</div>
+
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								marginBottom: '0.75rem',
+							}}>
+							<h3 style={{ ...sectionTitle, margin: 0, flex: 1 }}>
+								<Tags size={14} /> Tags
+							</h3>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								onClick={() => setModal('tag')}>
+								<Plus size={12} /> Add
+							</ActionButton>
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 8,
+							}}>
+							{(tags ?? []).map((t) => (
+								<div
+									key={t.name}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										padding: '0.5rem 0.7rem',
+										borderRadius: 8,
+										border,
+										background: panelBg,
+									}}>
+									<Tag
+										size={12}
+										style={{ color: '#06b6d4' }}
+									/>
+									<span
+										style={{
+											color: textColor,
+											fontWeight: 600,
+											fontSize: '0.78rem',
+											fontFamily: 'monospace',
+										}}>
+										{t.name}
+									</span>
+									{t.commit?.sha && (
+										<span
+											style={{
+												color: subText,
+												fontSize: '0.66rem',
+												fontFamily: 'monospace',
+											}}>
+											{t.commit.sha.slice(0, 7)}
+										</span>
+									)}
+									<span style={{ flex: 1 }} />
+									<ActionButton
+										size="sm"
+										variant="danger"
+										loading={
+											busy ===
+											`tag-delete-${selected}-${t.name}`
+										}
+										onClick={() => setTagConfirm(t.name)}>
+										<Trash2 size={11} />
+									</ActionButton>
+								</div>
+							))}
+							{tags && tags.length === 0 && (
+								<span
+									style={{
+										color: subText,
+										fontSize: '0.8rem',
+									}}>
+									No tags.
 								</span>
 							)}
 						</div>
@@ -902,6 +1119,50 @@ export default function ReactForgejoRepoAdmin() {
 					repo={selected}
 					mode={modal}
 					onClose={() => setModal(null)}
+				/>
+			)}
+			{modal === 'tag' && selected && (
+				<CreateTagModal
+					repo={selected}
+					onClose={() => setModal(null)}
+				/>
+			)}
+			{tagConfirm && selected && (
+				<ConfirmDialog
+					title="Delete tag"
+					message={`Delete tag "${tagConfirm}"? This cannot be undone.`}
+					confirmLabel="Delete"
+					danger
+					loading={busy === `tag-delete-${selected}-${tagConfirm}`}
+					onCancel={() => setTagConfirm(null)}
+					onConfirm={async () => {
+						const ok = await forgejoService.deleteTag(
+							selected,
+							tagConfirm,
+						);
+						if (ok) setTagConfirm(null);
+					}}
+				/>
+			)}
+			{assetConfirm && selected && (
+				<ConfirmDialog
+					title="Delete asset"
+					message={`Delete release asset "${assetConfirm.name}"?`}
+					confirmLabel="Delete"
+					danger
+					loading={
+						busy ===
+						`asset-delete-${selected}-${assetConfirm.releaseId}-${assetConfirm.assetId}`
+					}
+					onCancel={() => setAssetConfirm(null)}
+					onConfirm={async () => {
+						const ok = await forgejoService.deleteReleaseAsset(
+							selected,
+							assetConfirm.releaseId,
+							assetConfirm.assetId,
+						);
+						if (ok) setAssetConfirm(null);
+					}}
 				/>
 			)}
 			{svConfirm && selected && (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
@@ -8,6 +8,7 @@ import {
 	Webhook,
 	CircleDot,
 	Package,
+	FolderTree,
 	Cpu,
 	ServerCog,
 } from 'lucide-react';
@@ -24,6 +25,7 @@ const TABS: { id: ForgejoTab; label: string; icon: React.ReactNode }[] = [
 	},
 	{ id: 'issues', label: 'Issues & PRs', icon: <CircleDot size={14} /> },
 	{ id: 'packages', label: 'Packages', icon: <Package size={14} /> },
+	{ id: 'files', label: 'Files', icon: <FolderTree size={14} /> },
 	{ id: 'runners', label: 'Runners', icon: <Cpu size={14} /> },
 	{ id: 'system', label: 'System', icon: <ServerCog size={14} /> },
 ];

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -45,6 +45,7 @@ import type {
 	ForgejoPublicKey,
 	ForgejoGpgKey,
 	ForgejoPull,
+	ForgejoTag,
 } from '@/data/schema/forgejo';
 
 export type {
@@ -76,7 +77,28 @@ export type {
 	ForgejoPublicKey,
 	ForgejoGpgKey,
 	ForgejoPull,
+	ForgejoTag,
 };
+
+export interface ForgejoContentEntry {
+	name: string;
+	path: string;
+	type: string;
+	size: number;
+	sha: string;
+	encoding?: string;
+	content?: string;
+	download_url?: string | null;
+	html_url?: string | null;
+}
+
+export interface OpenFile {
+	path: string;
+	sha: string;
+	text: string;
+	tooLarge: boolean;
+	binary: boolean;
+}
 
 export interface RepoDetail {
 	branches: ForgejoBranch[];
@@ -111,8 +133,15 @@ export type ForgejoTab =
 	| 'webhooks'
 	| 'issues'
 	| 'packages'
+	| 'files'
 	| 'runners'
 	| 'system';
+
+export interface CreateTagInput {
+	tag_name: string;
+	target: string;
+	message: string;
+}
 
 export interface CreateUserKeyInput {
 	title: string;
@@ -596,6 +625,39 @@ export function formatSize(bytes: number): string {
 	return `${(mb / 1024).toFixed(2)} GB`;
 }
 
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const kb = bytes / 1024;
+	if (kb < 1024) return `${kb.toFixed(1)} KB`;
+	const mb = kb / 1024;
+	if (mb < 1024) return `${mb.toFixed(1)} MB`;
+	return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+const MAX_EDIT_BYTES = 512 * 1024;
+
+function decodeBase64ToText(b64: string): { text: string; binary: boolean } {
+	try {
+		const bin = atob(b64.replace(/\s/g, ''));
+		const bytes = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+		if (bytes.includes(0)) return { text: '', binary: true };
+		return {
+			text: new TextDecoder('utf-8', { fatal: false }).decode(bytes),
+			binary: false,
+		};
+	} catch {
+		return { text: '', binary: true };
+	}
+}
+
+function encodeTextToBase64(text: string): string {
+	const bytes = new TextEncoder().encode(text);
+	let bin = '';
+	for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+	return btoa(bin);
+}
+
 export function timeAgo(dateStr: string): string {
 	const diff = Date.now() - new Date(dateStr).getTime();
 	const mins = Math.floor(diff / 60000);
@@ -698,6 +760,14 @@ class ForgejoService {
 	public readonly $repoVariables = atom<Record<string, ForgejoVariable[]>>(
 		{},
 	);
+	public readonly $repoTags = atom<Record<string, ForgejoTag[]>>({});
+
+	// File browser
+	public readonly $filesRepo = atom<string | null>(null);
+	public readonly $filesPath = atom<string>('');
+	public readonly $filesEntries = atom<ForgejoContentEntry[]>([]);
+	public readonly $filesLoading = atom<boolean>(false);
+	public readonly $openFile = atom<OpenFile | null>(null);
 
 	public readonly $version = atom<string | null>(null);
 	public readonly $cronTasks = atom<ForgejoCronTask[]>([]);
@@ -1831,6 +1901,79 @@ class ForgejoService {
 		);
 	}
 
+	public deleteReleaseAsset(
+		fullName: string,
+		releaseId: number,
+		assetId: number,
+	): Promise<boolean> {
+		return this._run(
+			`asset-delete-${fullName}-${releaseId}-${assetId}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${fullName}/releases/${releaseId}/assets/${assetId}`,
+				);
+				await this.loadRepoReleases(fullName);
+			},
+			`Asset deleted`,
+		);
+	}
+
+	// --- Tag actions ---
+
+	public async loadRepoTags(fullName: string): Promise<void> {
+		await this._loadResource<ForgejoTag[]>(
+			'repoAdmin',
+			`forgejo:tags:${fullName}`,
+			`/api/v1/repos/${fullName}/tags?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$repoTags.set({
+					...this.$repoTags.get(),
+					[fullName]: d,
+				}),
+		);
+	}
+
+	public createTag(
+		fullName: string,
+		input: CreateTagInput,
+	): Promise<boolean> {
+		return this._run(
+			`tag-create-${fullName}`,
+			async (t) => {
+				const body: Record<string, unknown> = {
+					tag_name: input.tag_name,
+				};
+				if (input.target) body.target = input.target;
+				if (input.message) body.message = input.message;
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${fullName}/tags`,
+					body,
+				);
+				await this.loadRepoTags(fullName);
+			},
+			`Tag ${input.tag_name} created`,
+		);
+	}
+
+	public deleteTag(fullName: string, tag: string): Promise<boolean> {
+		return this._run(
+			`tag-delete-${fullName}-${tag}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${fullName}/tags/${encodeURIComponent(tag)}`,
+				);
+				await this.loadRepoTags(fullName);
+			},
+			`Tag ${tag} deleted`,
+		);
+	}
+
 	// --- Branch protection actions ---
 
 	public async loadRepoProtections(fullName: string): Promise<void> {
@@ -1988,6 +2131,7 @@ class ForgejoService {
 		this.loadRepoProtections(fullName);
 		this.loadRepoSecrets(fullName);
 		this.loadRepoVariables(fullName);
+		this.loadRepoTags(fullName);
 	}
 
 	// --- Issue & PR moderation actions ---
@@ -2534,6 +2678,154 @@ class ForgejoService {
 				await this.loadPackages(owner);
 			},
 			`Package ${pkg.name}@${pkg.version} deleted`,
+		);
+	}
+
+	// --- File browser actions ---
+
+	public selectFilesRepo(fullName: string): void {
+		this.$filesRepo.set(fullName);
+		this.$openFile.set(null);
+		void this.navigateDir('');
+	}
+
+	public async navigateDir(path: string): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$filesRepo.get();
+		if (!token || !repo) return;
+		this.$openFile.set(null);
+		this.$filesPath.set(path);
+		this.$filesLoading.set(true);
+		try {
+			const data = await apiFetch<
+				ForgejoContentEntry[] | ForgejoContentEntry
+			>(token, `/api/v1/repos/${repo}/contents/${path}`);
+			const entries = Array.isArray(data) ? data : data ? [data] : [];
+			entries.sort((a, b) => {
+				if (a.type !== b.type) return a.type === 'dir' ? -1 : 1;
+				return a.name.localeCompare(b.name);
+			});
+			this.$filesEntries.set(entries);
+			this.clearNotice('files');
+		} catch (e) {
+			this.$filesEntries.set([]);
+			this.setNotice('files', this._noticeFor(e));
+		} finally {
+			this.$filesLoading.set(false);
+		}
+	}
+
+	public async openFile(entry: ForgejoContentEntry): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$filesRepo.get();
+		if (!token || !repo) return;
+		this.$filesLoading.set(true);
+		try {
+			const data = await apiFetch<ForgejoContentEntry>(
+				token,
+				`/api/v1/repos/${repo}/contents/${entry.path}`,
+			);
+			const tooLarge = (data.size ?? 0) > MAX_EDIT_BYTES;
+			let text = '';
+			let binary = false;
+			if (!tooLarge && data.content) {
+				const decoded = decodeBase64ToText(data.content);
+				text = decoded.text;
+				binary = decoded.binary;
+			}
+			this.$openFile.set({
+				path: data.path,
+				sha: data.sha,
+				text,
+				tooLarge,
+				binary,
+			});
+		} catch (e) {
+			this.setNotice('files', this._noticeFor(e));
+		} finally {
+			this.$filesLoading.set(false);
+		}
+	}
+
+	public closeFile(): void {
+		this.$openFile.set(null);
+	}
+
+	public saveFile(
+		path: string,
+		sha: string,
+		text: string,
+		message: string,
+	): Promise<boolean> {
+		const repo = this.$filesRepo.get();
+		return this._run(
+			`file-save-${path}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'PUT',
+					`/api/v1/repos/${repo}/contents/${path}`,
+					{
+						content: encodeTextToBase64(text),
+						message: message || `Update ${path}`,
+						sha,
+					},
+				);
+				await this.navigateDir(this.$filesPath.get());
+			},
+			`Saved ${path}`,
+		);
+	}
+
+	public createFile(
+		name: string,
+		text: string,
+		message: string,
+	): Promise<boolean> {
+		const repo = this.$filesRepo.get();
+		const dir = this.$filesPath.get();
+		const path = dir ? `${dir}/${name}` : name;
+		return this._run(
+			`file-create-${path}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${repo}/contents/${path}`,
+					{
+						content: encodeTextToBase64(text),
+						message: message || `Create ${path}`,
+					},
+				);
+				await this.navigateDir(dir);
+			},
+			`Created ${path}`,
+		);
+	}
+
+	public deleteFile(
+		entry: ForgejoContentEntry,
+		message: string,
+	): Promise<boolean> {
+		const repo = this.$filesRepo.get();
+		return this._run(
+			`file-delete-${entry.path}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${repo}/contents/${entry.path}`,
+					{
+						message: message || `Delete ${entry.path}`,
+						sha: entry.sha,
+					},
+				);
+				await this.navigateDir(this.$filesPath.get());
+			},
+			`Deleted ${entry.path}`,
 		);
 	}
 }


### PR DESCRIPTION
Surfaces the last three Forgejo backend proxy areas that had typed routes but no dashboard UI. Pure frontend wiring against `/dashboard/forgejo/api/*` — **no backend changes**.

## What's new
**File browser** (new Files tab)
- Repo picker + breadcrumb path navigation over the `contents` endpoint
- Click a directory to descend, a file to open
- In-dash editor: base64 → UTF-8 decode, commit edits (`PUT contents`), create new files (`POST`), delete files (`DELETE`) — each with a commit message
- Binary / >512 KB files flagged read-only (download link still offered)

**Git tags** (Repo Admin → Tags section)
- List (name + short sha), create (target branch/commit, optional annotation message), delete

**Release assets** (Repo Admin → under each release)
- Each release lists its download assets (name, size, download count) with per-asset delete

## Notes
- Release assets come from the release object's inline `assets[]`; delete hits `releases/{id}/assets/{asset_id}`.
- Adds `formatBytes` + base64↔UTF-8 helpers; `ForgejoTag` / `ForgejoContentEntry` types.
- Verified with a targeted `tsc` over touched + new files (inherited tsconfig paths): zero errors. Standalone nx `astro-kbve:check` remains blocked by the unrelated `@monodon/rust` graph flake.