### PR TITLE
feat(metrics): staff-gated telemetry read API + errors dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10459,6 +10459,7 @@ dependencies = [
  "dotenvy",
  "hex",
  "jedi",
+ "kbve",
  "parking_lot",
  "serde",
  "serde_json",

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactTelemetryDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactTelemetryDashboard.tsx
@@ -1,0 +1,142 @@
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { Loader2, RefreshCw, X } from 'lucide-react';
+import { groupEventCount, groupSessionCount } from '@kbve/devops/telemetry';
+import { telemetryService } from './telemetryService';
+import { AuthGate } from './dashboard-ui';
+
+function GroupsPanel() {
+	const groups = useStore(telemetryService.$groups);
+	const loading = useStore(telemetryService.$groupsLoading);
+	const error = useStore(telemetryService.$error);
+	const project = useStore(telemetryService.$project);
+	const selected = useStore(telemetryService.$selected);
+
+	return (
+		<div className="telemetry-groups">
+			<div className="telemetry-toolbar">
+				<input
+					type="text"
+					placeholder="Filter by project (e.g. astro-kbve)"
+					value={project}
+					onChange={(e) =>
+						telemetryService.setProject(e.target.value)
+					}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter')
+							void telemetryService.loadGroups();
+					}}
+				/>
+				<button
+					type="button"
+					onClick={() => void telemetryService.loadGroups()}
+					disabled={loading}>
+					{loading ? (
+						<Loader2 size={14} className="telemetry-spin" />
+					) : (
+						<RefreshCw size={14} />
+					)}
+					<span>Refresh</span>
+				</button>
+			</div>
+
+			{error && <div className="telemetry-error">{error}</div>}
+
+			<table className="telemetry-table">
+				<thead>
+					<tr>
+						<th>Project</th>
+						<th>Type</th>
+						<th>Message</th>
+						<th>Events</th>
+						<th>Sessions</th>
+						<th>Last seen</th>
+					</tr>
+				</thead>
+				<tbody>
+					{groups.map((g) => (
+						<tr
+							key={g.fingerprint}
+							className={
+								selected === g.fingerprint ? 'is-selected' : ''
+							}
+							onClick={() =>
+								void telemetryService.drill(g.fingerprint)
+							}>
+							<td>{g.project}</td>
+							<td>{g.error_type}</td>
+							<td className="telemetry-msg">
+								{g.sample_message}
+							</td>
+							<td>{groupEventCount(g)}</td>
+							<td>{groupSessionCount(g)}</td>
+							<td>{g.last_seen}</td>
+						</tr>
+					))}
+					{!loading && groups.length === 0 && (
+						<tr>
+							<td colSpan={6} className="telemetry-empty">
+								No error groups.
+							</td>
+						</tr>
+					)}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+function EventsPanel() {
+	const selected = useStore(telemetryService.$selected);
+	const events = useStore(telemetryService.$events);
+	const loading = useStore(telemetryService.$eventsLoading);
+
+	if (!selected) return null;
+
+	return (
+		<div className="telemetry-events">
+			<div className="telemetry-events-head">
+				<h3>{selected.slice(0, 12)}</h3>
+				<button
+					type="button"
+					onClick={() => telemetryService.clearSelection()}
+					aria-label="Close">
+					<X size={14} />
+				</button>
+			</div>
+			{loading ? (
+				<Loader2 size={16} className="telemetry-spin" />
+			) : (
+				<ul className="telemetry-event-list">
+					{events.map((e, i) => (
+						<li key={`${e.session_id}-${i}`}>
+							<div className="telemetry-event-msg">
+								{e.message}
+							</div>
+							<div className="telemetry-event-meta">
+								{e.platform} · {e.environment || 'n/a'} ·{' '}
+								{e.url}
+							</div>
+							{e.stack && <pre>{e.stack}</pre>}
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+export default function ReactTelemetryDashboard() {
+	const initAuth = useCallback(() => telemetryService.initAuth(), []);
+	return (
+		<AuthGate
+			$authState={telemetryService.$authState}
+			initAuth={initAuth}
+			serviceName="Telemetry errors dashboard">
+			<div className="telemetry-dashboard">
+				<GroupsPanel />
+				<EventsPanel />
+			</div>
+		</AuthGate>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/telemetryService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/telemetryService.ts
@@ -1,0 +1,131 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+import {
+	parseErrorGroups,
+	parseErrorEvents,
+	type ErrorGroup,
+	type ErrorEvent,
+} from '@kbve/devops/telemetry';
+
+export type AuthState =
+	| 'loading'
+	| 'authenticated'
+	| 'unauthenticated'
+	| 'forbidden';
+
+const METRICS_BASE = 'https://metrics.kbve.com';
+const REQUEST_TIMEOUT_MS = 15000;
+
+class TelemetryService {
+	public readonly $authState = atom<AuthState>('loading');
+	private readonly $accessToken = atom<string | null>(null);
+
+	public readonly $groups = atom<ErrorGroup[]>([]);
+	public readonly $groupsLoading = atom<boolean>(false);
+	public readonly $error = atom<string | null>(null);
+	public readonly $project = atom<string>('');
+
+	public readonly $selected = atom<string | null>(null);
+	public readonly $events = atom<ErrorEvent[]>([]);
+	public readonly $eventsLoading = atom<boolean>(false);
+
+	public async initAuth(): Promise<void> {
+		try {
+			await initSupa();
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+			if (!session?.access_token) {
+				this.$authState.set('unauthenticated');
+				return;
+			}
+			this.$accessToken.set(session.access_token as string);
+			this.$authState.set('authenticated');
+			void this.loadGroups();
+		} catch {
+			this.$authState.set('unauthenticated');
+		}
+	}
+
+	private authHeaders(): Record<string, string> | null {
+		const token = this.$accessToken.get();
+		if (!token) return null;
+		return { Authorization: `Bearer ${token}` };
+	}
+
+	public async loadGroups(): Promise<void> {
+		const headers = this.authHeaders();
+		if (!headers) return;
+		this.$groupsLoading.set(true);
+		this.$error.set(null);
+		try {
+			const qs = new URLSearchParams({ limit: '100' });
+			const project = this.$project.get().trim();
+			if (project) qs.set('project', project);
+			const resp = await fetch(`${METRICS_BASE}/api/v1/groups?${qs}`, {
+				headers,
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+			});
+			if (resp.status === 403) {
+				this.$authState.set('forbidden');
+				return;
+			}
+			if (!resp.ok) {
+				this.$error.set(`groups request failed (${resp.status})`);
+				return;
+			}
+			const data = await resp.json();
+			this.$groups.set(parseErrorGroups(data.groups ?? []));
+		} catch (err) {
+			this.$error.set(
+				err instanceof Error ? err.message : 'network error',
+			);
+		} finally {
+			this.$groupsLoading.set(false);
+		}
+	}
+
+	public async drill(fingerprint: string): Promise<void> {
+		this.$selected.set(fingerprint);
+		const headers = this.authHeaders();
+		if (!headers) return;
+		this.$eventsLoading.set(true);
+		this.$error.set(null);
+		try {
+			const qs = new URLSearchParams({ fingerprint, limit: '50' });
+			const project = this.$project.get().trim();
+			if (project) qs.set('project', project);
+			const resp = await fetch(`${METRICS_BASE}/api/v1/events?${qs}`, {
+				headers,
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+			});
+			if (resp.status === 403) {
+				this.$authState.set('forbidden');
+				return;
+			}
+			if (!resp.ok) {
+				this.$error.set(`events request failed (${resp.status})`);
+				return;
+			}
+			const data = await resp.json();
+			this.$events.set(parseErrorEvents(data.events ?? []));
+		} catch (err) {
+			this.$error.set(
+				err instanceof Error ? err.message : 'network error',
+			);
+		} finally {
+			this.$eventsLoading.set(false);
+		}
+	}
+
+	public setProject(project: string): void {
+		this.$project.set(project);
+	}
+
+	public clearSelection(): void {
+		this.$selected.set(null);
+		this.$events.set([]);
+	}
+}
+
+export const telemetryService = new TelemetryService();

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/telemetry/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/telemetry/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Telemetry Errors
+description: KBVE in-house client error telemetry dashboard
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Telemetry
+    order: 5
+unsplash: 1551288049-bebda4e38f71
+img: https://images.unsplash.com/photo-1551288049-bebda4e38f71?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - observability
+    - telemetry
+---
+
+import ReactTelemetryDashboard from '@/components/dashboard/ReactTelemetryDashboard.tsx';
+
+<ReactTelemetryDashboard client:only="react" />

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -17,6 +17,9 @@
 			"@kbve/astro/utils/*": ["../../../packages/npm/astro/src/utils/*"],
 			"@kbve/astro/data/*": ["../../../packages/npm/astro/src/data/*"],
 			"@kbve/devops": ["../../../packages/npm/devops/src/index.ts"],
+			"@kbve/devops/telemetry": [
+				"../../../packages/npm/devops/src/lib/telemetry/index.ts"
+			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
 			"@kbve/chat": ["../../../packages/npm/chat/src/index.ts"],

--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
         app: metrics
     annotations:
         reloader.stakater.com/auto: 'true'
-        secret.reloader.stakater.com/reload: 'clickhouse-credentials'
+        secret.reloader.stakater.com/reload: 'clickhouse-credentials,supabase-shared'
 spec:
     replicas: 1
     selector:
@@ -70,6 +70,13 @@ spec:
                             secretKeyRef:
                                 name: clickhouse-credentials
                                 key: password
+                      - name: SUPABASE_URL
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: jwt-secret
                   livenessProbe:
                       httpGet:
                           path: /health

--- a/apps/metrics/Cargo.toml
+++ b/apps/metrics/Cargo.toml
@@ -29,3 +29,4 @@ thiserror = "2"
 dotenvy = "0.15"
 
 jedi = { path = "../../packages/rust/jedi", features = ["clickhouse"] }
+kbve = { path = "../../packages/rust/kbve", default-features = false, features = ["gate-auth"] }

--- a/apps/metrics/src/auth.rs
+++ b/apps/metrics/src/auth.rs
@@ -1,0 +1,56 @@
+use axum::http::HeaderMap;
+use kbve::gate::{AuthError, Claims, StaffGate, extract_token, validate_token};
+
+pub struct StaffAuth {
+    jwt_secret: String,
+    staff: Option<StaffGate>,
+}
+
+impl StaffAuth {
+    pub fn from_env() -> Option<Self> {
+        let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+
+        let staff = match std::env::var("SUPABASE_URL").ok().filter(|s| !s.is_empty()) {
+            Some(url) => {
+                let apikey = std::env::var("SUPABASE_ANON_KEY")
+                    .ok()
+                    .filter(|s| !s.is_empty());
+                let schema =
+                    std::env::var("METRICS_STAFF_SCHEMA").unwrap_or_else(|_| "forum".into());
+                let ttl = std::env::var("METRICS_STAFF_TTL_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30);
+                Some(StaffGate::new(
+                    &url,
+                    jwt_secret.clone(),
+                    apikey,
+                    schema,
+                    ttl,
+                ))
+            }
+            None => None,
+        };
+
+        Some(Self { jwt_secret, staff })
+    }
+
+    pub async fn require_staff(&self, headers: &HeaderMap) -> Result<Claims, AuthError> {
+        let auth = headers.get("authorization").and_then(|v| v.to_str().ok());
+        let cookie = headers.get("cookie").and_then(|v| v.to_str().ok());
+        let token = extract_token(auth, cookie, None).ok_or(AuthError::MissingToken)?;
+
+        let claims = validate_token(&token, &self.jwt_secret)?.claims;
+
+        if matches!(claims.role.as_str(), "service_role" | "supabase_admin") {
+            return Ok(claims);
+        }
+
+        match &self.staff {
+            Some(gate) if gate.is_staff(&claims.sub).await? => Ok(claims),
+            _ => Err(AuthError::NotStaff),
+        }
+    }
+}

--- a/apps/metrics/src/main.rs
+++ b/apps/metrics/src/main.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod config;
 mod error;
 mod rest;
@@ -13,6 +14,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
+use crate::auth::StaffAuth;
 use crate::config::Config;
 use crate::state::{AppState, spawn_flusher};
 
@@ -30,7 +32,7 @@ fn cors_layer(cfg: &Config) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(allow)
         .allow_methods([Method::GET, Method::POST])
-        .allow_headers([header::CONTENT_TYPE])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
 }
 
 #[tokio::main]
@@ -45,12 +47,15 @@ async fn main() -> anyhow::Result<()> {
     let ch = jedi::state::sidecar::ClickHouseConfig::from_env();
     tracing::info!(database = %ch.database, url = %ch.url, "clickhouse configured");
 
+    let auth = StaffAuth::from_env();
+    tracing::info!(read_api = auth.is_some(), "staff read api");
+
     let (tx, rx) = mpsc::channel(cfg.channel_capacity);
     let max_body = cfg.max_body_bytes;
     let cors = cors_layer(&cfg);
     let addr = format!("{}:{}", cfg.host, cfg.port);
 
-    let state = Arc::new(AppState::new(cfg, ch, tx));
+    let state = Arc::new(AppState::new(cfg, ch, tx, auth));
     spawn_flusher(state.clone(), rx);
 
     let app = rest::router(state)

--- a/apps/metrics/src/rest/groups.rs
+++ b/apps/metrics/src/rest/groups.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use kbve::gate::AuthError;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+pub struct GroupsParams {
+    project: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Deserialize)]
+pub struct EventsParams {
+    fingerprint: String,
+    project: Option<String>,
+    limit: Option<u32>,
+}
+
+fn quote(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+fn clamp(limit: Option<u32>, fallback: u32) -> u32 {
+    limit.unwrap_or(fallback).clamp(1, 1000)
+}
+
+fn auth_status(err: &AuthError) -> StatusCode {
+    match err {
+        AuthError::MissingToken | AuthError::InvalidToken(_) | AuthError::TokenExpired => {
+            StatusCode::UNAUTHORIZED
+        }
+        AuthError::NotStaff => StatusCode::FORBIDDEN,
+        AuthError::Upstream(_) => StatusCode::BAD_GATEWAY,
+    }
+}
+
+async fn authorize(app: &AppState, headers: &HeaderMap) -> Result<(), Response> {
+    match &app.auth {
+        Some(auth) => auth.require_staff(headers).await.map(|_| ()).map_err(|e| {
+            (auth_status(&e), Json(json!({ "error": e.to_string() }))).into_response()
+        }),
+        None => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "auth not configured" })),
+        )
+            .into_response()),
+    }
+}
+
+async fn query(app: &AppState, sql: String, key: &str) -> Response {
+    match app.ch.execute_select(&sql).await {
+        Ok(rows) => {
+            let mut body = serde_json::Map::new();
+            body.insert(key.to_string(), json!(rows));
+            (StatusCode::OK, Json(serde_json::Value::Object(body))).into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "telemetry query failed");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": "query failed" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn groups(
+    State(app): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(p): Query<GroupsParams>,
+) -> Response {
+    if let Err(resp) = authorize(&app, &headers).await {
+        return resp;
+    }
+    let where_clause = p
+        .project
+        .as_deref()
+        .map(|pr| format!("WHERE project = {}", quote(pr)))
+        .unwrap_or_default();
+    let sql = format!(
+        "SELECT project, fingerprint, error_type, sample_message, \
+         toString(events) AS events, toString(sessions) AS sessions, \
+         toString(first_seen) AS first_seen, toString(last_seen) AS last_seen \
+         FROM error_groups {} ORDER BY last_seen DESC LIMIT {}",
+        where_clause,
+        clamp(p.limit, 100)
+    );
+    query(&app, sql, "groups").await
+}
+
+pub async fn events(
+    State(app): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(p): Query<EventsParams>,
+) -> Response {
+    if let Err(resp) = authorize(&app, &headers).await {
+        return resp;
+    }
+    let mut conds = vec![format!("fingerprint = {}", quote(&p.fingerprint))];
+    if let Some(pr) = p.project.as_deref() {
+        conds.push(format!("project = {}", quote(pr)));
+    }
+    let sql = format!(
+        "SELECT project, platform, release, environment, error_type, message, \
+         stack, url, user_id, session_id, handled, extra \
+         FROM errors_distributed WHERE {} ORDER BY timestamp DESC LIMIT {}",
+        conds.join(" AND "),
+        clamp(p.limit, 50)
+    );
+    query(&app, sql, "events").await
+}

--- a/apps/metrics/src/rest/mod.rs
+++ b/apps/metrics/src/rest/mod.rs
@@ -1,3 +1,4 @@
+pub mod groups;
 pub mod ingest;
 pub mod system;
 
@@ -13,5 +14,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/health", get(system::health))
         .route("/readiness", get(system::readiness))
         .route("/api/v1/ingest/errors", post(ingest::ingest_errors))
+        .route("/api/v1/groups", get(groups::groups))
+        .route("/api/v1/events", get(groups::events))
         .with_state(state)
 }

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -7,12 +7,14 @@ use parking_lot::Mutex;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
+use crate::auth::StaffAuth;
 use crate::config::Config;
 
 pub struct AppState {
     pub cfg: Config,
     pub ch: ClickHouseConfig,
     pub tx: mpsc::Sender<Value>,
+    pub auth: Option<StaffAuth>,
     pub started_at: Instant,
     limiter: Mutex<AHashMap<String, Bucket>>,
 }
@@ -23,11 +25,17 @@ struct Bucket {
 }
 
 impl AppState {
-    pub fn new(cfg: Config, ch: ClickHouseConfig, tx: mpsc::Sender<Value>) -> Self {
+    pub fn new(
+        cfg: Config,
+        ch: ClickHouseConfig,
+        tx: mpsc::Sender<Value>,
+        auth: Option<StaffAuth>,
+    ) -> Self {
         Self {
             cfg,
             ch,
             tx,
+            auth,
             started_at: Instant::now(),
             limiter: Mutex::new(AHashMap::new()),
         }

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -16,7 +16,8 @@ supabase = ["dep:lru", "dep:uuid"]
 image-gen = ["dep:resvg"]
 wallet = ["dep:uuid"]
 legacy-sync-db = ["diesel/postgres", "diesel/r2d2", "dep:r2d2"]
-gate = ["axum/ws", "reqwest/stream", "dep:tokio-tungstenite", "dep:lru", "dep:metrics", "jedi/prometheus"]
+gate-auth = ["dep:lru"]
+gate = ["gate-auth", "axum/ws", "reqwest/stream", "dep:tokio-tungstenite", "dep:metrics", "jedi/prometheus"]
 
 [dependencies]
 anyhow = "1.0"

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -7,11 +7,14 @@
 //! axum-kbve can adopt the same module later.
 
 mod auth;
+#[cfg(feature = "gate")]
 mod proxy;
 
-pub use auth::{AuthError, Authz, Claims, StaffGate, validate_token};
+pub use auth::{AuthError, Authz, Claims, StaffGate, extract_token, validate_token};
+#[cfg(feature = "gate")]
 pub use proxy::{GateConfig, GateState};
 
+#[cfg(feature = "gate")]
 use std::net::SocketAddr;
 
 /// Build a [`GateConfig`] from environment variables.
@@ -29,6 +32,7 @@ use std::net::SocketAddr;
 /// - `SUPABASE_ANON_KEY`    optional PostgREST apikey when authz=is_staff
 ///   (falls back to the minted service_role bearer)
 /// - `SUPABASE_JWT_ISSUER`  optional; pins the accepted token issuer when set
+#[cfg(feature = "gate")]
 pub fn config_from_env() -> Result<GateConfig, String> {
     let upstream =
         std::env::var("GATE_UPSTREAM").unwrap_or_else(|_| "http://127.0.0.1:5679".to_string());
@@ -90,6 +94,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
 ///
 /// A Prometheus `/metrics` endpoint is served on `GATE_METRICS_PORT`
 /// (default `9090`) with the gate's low-cardinality counters.
+#[cfg(feature = "gate")]
 pub async fn serve(cfg: GateConfig) -> Result<(), String> {
     let listen: SocketAddr = std::env::var("GATE_LISTEN")
         .unwrap_or_else(|_| "0.0.0.0:5678".to_string())

--- a/packages/rust/kbve/src/lib.rs
+++ b/packages/rust/kbve/src/lib.rs
@@ -19,7 +19,7 @@ pub mod utility;
 
 pub mod entity;
 
-#[cfg(feature = "gate")]
+#[cfg(any(feature = "gate", feature = "gate-auth"))]
 pub mod gate;
 
 #[cfg(feature = "legacy-sync-db")]


### PR DESCRIPTION
## What

Gives the in-house telemetry platform a **live read path**: a staff-gated read API on the metrics service, plus an errors dashboard that consumes it. Closes the loop the `@kbve/devops` telemetry module (#12893) was built for — its SQL builders/parsers finally get a transport.

## Backend — `apps/metrics`

- `GET /api/v1/groups` (telemetry `error_groups` view) and `GET /api/v1/events` (`errors_distributed` by fingerprint), both staff-gated.
- Queries via jedi `execute_select` against the telemetry DB; SQL is escaped + limit-clamped server-side.
- **Auth reuses `kbve::gate`** — `validate_token` + `StaffGate.is_staff` (Supabase RPC, cached). `service_role`/`supabase_admin` short-circuit; human staff go through the `is_staff` RPC — the same gate the ClickHouse logs dashboard uses, so login behaves identically (401 / 403-forbidden states).
- **Secrets: zero new plumbing.** References the existing kbve-ns `supabase-shared` secret (`jwt-secret`, already synced from `supabase-jwt`) + the internal kong URL. No new ExternalSecret/SA/RBAC.

## kbve crate — lean `gate-auth` feature

`gate::auth` (Claims, `validate_token`, `StaffGate`) is split behind a new `gate-auth` feature so consumers get the auth primitives **without** the proxy's `axum/ws` + `tokio-tungstenite` deps. `gate` now includes `gate-auth`; the full kbve-gate proxy is unchanged (verified `cargo check -p kbve --features gate`).

## Frontend — `astro-kbve`

- `telemetryService` (nanostores) + `ReactTelemetryDashboard` behind the shared `AuthGate`; error-groups table drills into recent events.
- Consumes `@kbve/devops/telemetry` (`parseErrorGroups`/`parseErrorEvents`) via a new **deep tsconfig path** so the devops barrel stays out of the browser bundle.
- New `/dashboard/telemetry` doc page mounts the panel.

## Safety

Read API is **inert until** the metrics image publishes and `metrics.kbve.com` is live (gated on the dev→main release). Dashboard fetch fails closed; no user impact before then.

## Verification

- `met:build` green; `cargo check -p kbve --features gate` green (full proxy intact).
- `astro-kbve:build` green — 7773 pages, `/dashboard/telemetry` built, deep devops import resolves.

## Follow-ups

- Panel CSS polish (functional, minimally styled now).
- perf / product lenses; source-map symbolication.