### PR TITLE
perf(astro-kbve): defer mcdb browser hydration with client:visible

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlockCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlockCategoryShell.astro
@@ -21,5 +21,5 @@ const { material, title, description } = Astro.props;
 		</div>
 	</header>
 
-	<MCBlocksBrowser client:load lockedMaterial={material} />
+	<MCBlocksBrowser client:visible lockedMaterial={material} />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksIndex.astro
@@ -17,5 +17,5 @@ import MCTooltipMount from './MCTooltipMount.astro';
 		</div>
 	</header>
 
-	<MCBlocksBrowser client:load />
+	<MCBlocksBrowser client:visible />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCCategoryShell.astro
@@ -21,5 +21,5 @@ const { category, title, description } = Astro.props;
 		</div>
 	</header>
 
-	<MCItemsBrowser client:load lockedCategory={category} />
+	<MCItemsBrowser client:visible lockedCategory={category} />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantCategoryShell.astro
@@ -28,5 +28,5 @@ const { group, title, description } = Astro.props;
 		</div>
 	</header>
 
-	<MCEnchantsBrowser client:load lockedGroup={group} />
+	<MCEnchantsBrowser client:visible lockedGroup={group} />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsIndex.astro
@@ -19,5 +19,5 @@ import MCTooltipMount from './MCTooltipMount.astro';
 		</div>
 	</header>
 
-	<MCEnchantsBrowser client:load />
+	<MCEnchantsBrowser client:visible />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
@@ -44,7 +44,7 @@ import MCTooltipMount from './MCTooltipMount.astro';
 		</button>
 	</header>
 
-	<MCItemsBrowser client:load />
+	<MCItemsBrowser client:visible />
 </section>
 
 <style is:global>


### PR DESCRIPTION
## What

Flip the mcdb browser islands from `client:load` to `client:visible` so they hydrate on scroll-into-view instead of immediately on load.

- `MCItemsBrowser` — index + category shell
- `MCBlocksBrowser` — index + category shell
- `MCEnchantsBrowser` — index + category shell

6 mount sites total.

## Why

Part 2 of #12936 (island hydration audit). These browsers render below the fold on their pages but were hydrating eagerly on `client:load`, blocking the main thread during initial paint.

## Safety

- Were already `client:load` → SSR HTML is proven and **unchanged**; only the hydration trigger moves. No blank-flash risk (unlike `client:only`).
- No component logic touched.
- `astro-kbve:build` passes clean (3m48s, pagefind index built, 0 errors).

Refs #12936.