### PR TITLE
perf(astro-kbve): defer below-fold osrs + mc panel islands

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
@@ -249,7 +249,7 @@ const item = MCItemSchema.parse(data);
 												)}
 												{cell.ref ? (
 													<MCTextureImage
-														client:load
+														client:visible
 														ref={cell.ref}
 														alt={cell.ref}
 														size={56}
@@ -272,7 +272,7 @@ const item = MCItemSchema.parse(data);
 											<li>
 												{ing.ref && (
 													<MCTextureImage
-														client:load
+														client:visible
 														ref={ing.ref}
 														alt={ing.ref}
 														size={28}

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
@@ -213,11 +213,11 @@ const showUsedIn = (usedInEntries?.length ?? 0) > 0;
 				<span class="osrs-section__dot"></span>
 				<h4 class="osrs-section__title">Live GE Prices</h4>
 			</div>
-			<OSRSPriceWidget itemId={item.id} client:load />
+			<OSRSPriceWidget itemId={item.id} client:visible />
 		</div>
 
 		<!-- Price History Chart — full width -->
-		<OSRSCharts itemId={item.id} client:load />
+		<OSRSCharts itemId={item.id} client:visible />
 
 		<OSRSAdsenseSlot />
 


### PR DESCRIPTION
## What

Flip below-fold islands from `client:load` to `client:visible` so they hydrate on scroll instead of eagerly at load:

- `OSRSPriceWidget` + `OSRSCharts` — sit below the stat quad on OSRS item panels (charts especially heavy)
- `MCItemPanel` recipe-grid + recipe-ingredient `MCTextureImage` icons — deep in the panel's crafting section

## Left on client:load (intentional)

- Header item/block icons (`MCItemPanel:17`, `MCBlockPanel:13`) — above-fold, LCP-critical
- `ReactMainHero` / `ReactSubHero` — hero, top of page
- `SupaProvider` (context infra), `MCLinkTooltip` (hover-ready), `McPlayerList` (above-fold)

## Why

Part 2 of #12936, follow-up to #12954 (mcdb browsers). Targets clearly off-viewport islands only.

## Safety

- Were `client:load` → SSR HTML proven and **unchanged**; only hydration trigger moves. No blank-flash risk.
- No component logic touched.
- `astro-kbve:build` passes clean (0 errors).

Refs #12936.