### PR TITLE
chore(release): bump jobboard 0.1.9 + metrics 0.1.1

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -299,7 +299,7 @@
 		{
 			"key": "jobboard",
 			"app_name": "jobboard",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/jobboard/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx",
 			"version_target": "apps/jobboard/Cargo.toml",
@@ -435,7 +435,7 @@
 		{
 			"key": "metrics",
 			"app_name": "metrics",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/metrics/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx",
 			"version_target": "apps/metrics/Cargo.toml",
@@ -1177,7 +1177,7 @@
 			"key": "unreal_chuck_beta",
 			"app_name": "chuck",
 			"engine": {
-				"version": "5.8.0",
+				"version": "5.7.4",
 				"project_path": "chuck",
 				"build_targets": [
 					"Win64",
@@ -1197,7 +1197,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.28",
+			"version": "0.3.29",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",
@@ -1210,7 +1210,7 @@
 			"key": "unreal_chuck_dev",
 			"app_name": "chuck-dev",
 			"engine": {
-				"version": "5.8.0",
+				"version": "5.7.4",
 				"project_path": "chuck",
 				"build_targets": [
 					"Win64",
@@ -1244,7 +1244,7 @@
 			"key": "unreal_rentearth",
 			"app_name": "rentearth",
 			"engine": {
-				"version": "5.8.0",
+				"version": "5.7.4",
 				"project_path": "apps/rentearth/unreal-rentearth",
 				"build_targets": [
 					"Win64",

--- a/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
@@ -24,7 +24,7 @@ tags:
 key: jobboard
 pipeline: docker
 app_name: jobboard
-version: "0.1.8"
+version: "0.1.9"
 source_path: apps/jobboard
 version_toml: apps/jobboard/version.toml
 version_target: apps/jobboard/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -24,7 +24,7 @@ tags:
 key: metrics
 pipeline: docker
 app_name: metrics
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/metrics
 version_toml: apps/metrics/version.toml
 version_target: apps/metrics/Cargo.toml


### PR DESCRIPTION
## What

Version bumps to publish two pending docker images.

- **jobboard 0.1.8 → 0.1.9** — republishes the merged `jsonwebtoken` `rust_crypto` 503 fix. The deployed `jobboard:0.1.8` image predates the fix (it landed at 0.1.8 without a bump, so the version gate skipped a rebuild). 0.1.9 forces the corrected image.
- **metrics 0.1.0 → 0.1.1** — `ghcr.io/kbve/metrics` is **unpublished** (GHCR 404); 0.1.0 was registered (#12898) but never built. 0.1.1 triggers the first publish so the ingest + read-path services can deploy.

## Manifest

Regenerated `.github/ci-dispatch-manifest.json` via full `astro-kbve:build` → `sync:ci-manifest` (no surgical edit). The diff also catches up **chuck**'s stale manifest entry (`0.3.28 → 0.3.29`, engine `5.8.0 → 5.7.4`) so it matches the current `unreal-chuck-beta.mdx` on dev — the manifest hadn't been regenerated since that MDX changed.

Only MDX `version:` fields edited; `version.toml` + k8s image tags auto-sync via the post-publish atom PR.