### PR TITLE
fix(edge): drop error detail from edge function responses (#12941)

### DIFF
--- a/apps/kbve/edge/functions/discord-bot/index.ts
+++ b/apps/kbve/edge/functions/discord-bot/index.ts
@@ -307,12 +307,6 @@ serve(async (req) => {
   }
   } catch (e) {
     console.error("discord-bot: unhandled error:", e);
-    return jsonResponse(
-      {
-        error: "Internal error",
-        detail: e instanceof Error ? e.message : String(e),
-      },
-      500,
-    );
+    return jsonResponse({ error: "Internal error" }, 500);
   }
 });

--- a/apps/kbve/edge/functions/gh-admin/index.ts
+++ b/apps/kbve/edge/functions/gh-admin/index.ts
@@ -1064,12 +1064,6 @@ serve(async (req) => {
   }
   } catch (e) {
     console.error("gh-admin: unhandled error:", e);
-    return jsonResponse(
-      {
-        error: "Internal error",
-        detail: e instanceof Error ? e.message : String(e),
-      },
-      500,
-    );
+    return jsonResponse({ error: "Internal error" }, 500);
   }
 });

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -296,7 +296,7 @@ serve(async (req) => {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error("gh-backfill fetch error:", msg);
-      return jsonResponse({ error: "GitHub fetch failed", detail: msg }, 502);
+      return jsonResponse({ error: "GitHub fetch failed" }, 502);
     }
 
     lastRateLimitRemaining = result.rateLimitRemaining;
@@ -353,12 +353,6 @@ serve(async (req) => {
   );
   } catch (e) {
     console.error("gh-backfill: unhandled error:", e);
-    return jsonResponse(
-      {
-        error: "Internal error",
-        detail: e instanceof Error ? e.message : String(e),
-      },
-      500,
-    );
+    return jsonResponse({ error: "Internal error" }, 500);
   }
 });


### PR DESCRIPTION
## Summary

Closes #12941 — CodeQL alert #501 `js/stack-trace-exposure`.

Drops the `detail` field (raw error message) from user-facing error responses in the Supabase edge functions. Server-side `console.error` logging retained at every site.

## Sites fixed
- discord-bot/index.ts:313 — unhandled-error 500
- gh-backfill/index.ts:299 — fetch-error 502
- gh-backfill/index.ts:359 — unhandled-error 500
- gh-admin/index.ts:1069 — unhandled-error 500

## Acceptance
- [x] No error message/stack content returned to clients
- [x] Server-side `console.error` logging retained
- [ ] CodeQL alert #501 resolves on next scan