### PR TITLE
fix(kilobase): guard CNPG cluster against recovery-bootstrap rollback

### DIFF
--- a/apps/kube/kilobase/manifests/postgres-cluster.yaml
+++ b/apps/kube/kilobase/manifests/postgres-cluster.yaml
@@ -21,6 +21,15 @@ kind: Cluster
 metadata:
     name: supabase-cluster
     namespace: kilobase
+    annotations:
+        # GUARDRAIL: bootstrap.recovery (below) re-bootstraps from the S3 base
+        # backup on any fresh creation of this Cluster. Argo prune/selfHeal
+        # could delete + recreate it, silently rolling production back to the
+        # last backup. Prune=false stops Argo from ever deleting the live
+        # Cluster; Delete=false blocks cascade deletes during app removal.
+        # Recovery stays available for an INTENTIONAL DR rebuild. Never delete
+        # this Cluster without a verified plan to restore current data.
+        argocd.argoproj.io/sync-options: Prune=false,Delete=false
 spec:
     instances: 3
     #primaryUpdateStrategy: unsupervised
@@ -190,6 +199,11 @@ spec:
               barmanObjectName: kilobase-backup-store
               serverName: kilobase-postgres-backup
 
+    # DR-ONLY: runs solely on first creation of this Cluster. The live
+    # cluster ignores it. Protected by Prune=false,Delete=false on metadata
+    # so Argo cannot delete + recreate the Cluster and silently trigger a
+    # recovery rollback to the last S3 base backup. Keep for intentional
+    # disaster recovery; do not delete the Cluster expecting in-place data.
     bootstrap:
         recovery:
             source: kilobase-postgres-backup


### PR DESCRIPTION
## Problem

`kilobase/manifests/postgres-cluster.yaml` keeps `bootstrap.recovery.source: kilobase-postgres-backup` on the live `supabase-cluster`, while the Argo Application runs `prune: true` + `selfHeal: true`.

CNPG `bootstrap` runs only at **initial Cluster creation** — but if the `Cluster` resource is ever deleted and recreated (Argo prune, namespace recreate, manual delete, accidental git removal), Argo auto-recreates it → CNPG sees a fresh Cluster → re-runs `bootstrap.recovery` → restores the S3 base backup → **silent production Postgres rollback** to the last backup point.

## Fix

Per-resource guardrail on the Cluster (not app-wide), so drift-prune stays on for every other kilobase resource:

```yaml
annotations:
    argocd.argoproj.io/sync-options: Prune=false,Delete=false
```

- `Prune=false` — Argo never deletes the live Cluster, so it can never trigger the recovery-bootstrap path.
- `Delete=false` — blocks cascade delete during app removal.
- `bootstrap.recovery` is **kept** for an intentional DR rebuild, with a doc comment marking it DR-only.

## Why not the alternatives

- `bootstrap.initdb` — on recreate yields an *empty* cluster (loud, but still catastrophic; doesn't protect data).
- `prune: false` app-wide — loses drift cleanup for all other kilobase resources.

Resolves the CNPG item in #12973.