### PR TITLE
fix(agents): persist ChannelPicker selections in bot config

### DIFF
--- a/packages/npm/astro/src/agents/ReactAgentBotConfig.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentBotConfig.tsx
@@ -199,6 +199,21 @@ export default function ReactAgentBotConfig() {
 		};
 	}
 
+	function onChannelCommit(k: TextFieldKey) {
+		return (value: string) => {
+			if (!guildId) return;
+			if (refs.current[k]) refs.current[k]!.value = value;
+			const err = validateField(k, value);
+			setErrors((prev) => {
+				const next = { ...prev };
+				if (err) next[k] = err;
+				else delete next[k];
+				return next;
+			});
+			agents.patchBotConfigDraft(guildId, { [k]: value });
+		};
+	}
+
 	function onBoolChange(k: BoolFieldKey, v: boolean) {
 		if (k === 'mirror_pr_events') mirrorRef.current = v;
 		else activeRef.current = v;
@@ -349,7 +364,7 @@ export default function ReactAgentBotConfig() {
 					error={errors.claim_channel_id}
 					sourceError={channelsError}
 					inputRef={(el) => (refs.current.claim_channel_id = el)}
-					onBlur={onFieldBlur('claim_channel_id')}
+					onCommit={onChannelCommit('claim_channel_id')}
 				/>
 				<ChannelPicker
 					label="Forum channel"
@@ -362,7 +377,7 @@ export default function ReactAgentBotConfig() {
 					error={errors.forum_channel_id}
 					sourceError={channelsError}
 					inputRef={(el) => (refs.current.forum_channel_id = el)}
-					onBlur={onFieldBlur('forum_channel_id')}
+					onCommit={onChannelCommit('forum_channel_id')}
 				/>
 				<ChannelPicker
 					label="Notice board channel"
@@ -377,7 +392,7 @@ export default function ReactAgentBotConfig() {
 					inputRef={(el) =>
 						(refs.current.noticeboard_channel_id = el)
 					}
-					onBlur={onFieldBlur('noticeboard_channel_id')}
+					onCommit={onChannelCommit('noticeboard_channel_id')}
 				/>
 				<ChannelPicker
 					label="Task board channel"
@@ -390,7 +405,7 @@ export default function ReactAgentBotConfig() {
 					error={errors.taskboard_channel_id}
 					sourceError={channelsError}
 					inputRef={(el) => (refs.current.taskboard_channel_id = el)}
-					onBlur={onFieldBlur('taskboard_channel_id')}
+					onCommit={onChannelCommit('taskboard_channel_id')}
 				/>
 				<TextField
 					label="Max assignees per claim"
@@ -556,7 +571,7 @@ interface ChannelPickerProps {
 	sourceError: string | null;
 	error?: string;
 	inputRef: (el: HTMLInputElement | null) => void;
-	onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+	onCommit: (value: string) => void;
 }
 
 function ChannelPicker(props: ChannelPickerProps) {
@@ -571,9 +586,8 @@ function ChannelPicker(props: ChannelPickerProps) {
 		sourceError,
 		error,
 		inputRef,
-		onBlur,
+		onCommit,
 	} = props;
-	const hiddenRef = useRef<HTMLInputElement | null>(null);
 	const [showManual, setShowManual] = useState(false);
 	const [currentValue, setCurrentValue] = useState<string>(defaultValue);
 
@@ -581,23 +595,9 @@ function ChannelPicker(props: ChannelPickerProps) {
 		setCurrentValue(defaultValue);
 	}, [defaultValue]);
 
-	const setInputRef = useCallback(
-		(el: HTMLInputElement | null) => {
-			hiddenRef.current = el;
-			inputRef(el);
-		},
-		[inputRef],
-	);
-
 	function commitValue(v: string) {
 		setCurrentValue(v);
-		if (hiddenRef.current) {
-			hiddenRef.current.value = v;
-			const ev = new FocusEvent('blur', {
-				bubbles: true,
-			}) as unknown as FocusEvent<HTMLInputElement>;
-			onBlur(ev);
-		}
+		onCommit(v);
 	}
 
 	const list = channels ?? [];
@@ -610,10 +610,11 @@ function ChannelPicker(props: ChannelPickerProps) {
 			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
 			<span style={fieldLabel}>{label}</span>
 			<input
-				ref={setInputRef}
+				ref={inputRef}
 				name={name}
 				type="hidden"
-				defaultValue={defaultValue}
+				value={currentValue}
+				readOnly
 			/>
 			{loading && (
 				<span style={subtle}>


### PR DESCRIPTION
## Problem

The GitHub agent **Bot config** form (`/dashboard/agents/github`) never persisted `forum_channel_id` — or any channel/repo field. Saving wrote a vault config containing only the always-serialized booleans + `max_assignees` default. Confirmed against the live vault row: stored JSON was `{"active":true,"max_assignees":2,"mirror_pr_events":true}` despite the user selecting a forum channel.

Downstream impact: no `forum_channel_id` → `gh_sync` worker builds no route → issue events stall `pending` in the queue → nothing delivered to Discord.

Ruled out first: not the 502 (transient gateway blip), not a schema/`bot_get_guild_token` mismatch (public proxy → discordsh is correct; gh-webhook uses the same read), not vault corruption (secret decrypts fine), migration `20260614120000` already applied.

## Root cause

`ChannelPicker` captured its value through a fragile chain:
- imperative `hiddenRef.current.value = v` write,
- a synthetic `blur` event to trigger the commit,
- `setInputRef` whose `useCallback` dep was a fresh `inputRef` each render → ref detached/reattached every render.

Any of these racing dropped the picked value before submit, so `readForm` read an empty hidden input.

## Fix

`packages/npm/astro/src/agents/ReactAgentBotConfig.tsx`, ChannelPicker only:
- Hidden input is now **controlled** (`value={currentValue} readOnly`) → `readForm` always reads the picked value at submit.
- Selections commit **straight to the draft** via `onChannelCommit(key)(value)` → `patchBotConfigDraft({[key]: value})`, no DOM read-back.
- Removed `hiddenRef`, the synthetic blur, and the `setInputRef` churn.

## Test

- Pick forum/claim/notice/task channel → Save → reload → values persist.
- Typecheck: no new errors from the change (only pre-existing repo-wide `@kbve/droid` ambient resolution + `noImplicitAny` cascade).

## Notes

- Related feature work tracked in #12984 (bidirectional Discord→GitHub sync).
- Follow-up gap (not in this PR): manual-paste is gated behind `list.length > 0`, so a guild with zero forum channels has no way to enter a raw ID.