### PR TITLE
feat(arpg): env object foundation — campfire (block + heal aura + burn)

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -1,9 +1,9 @@
-use bevy::prelude::{Commands, Local, Res};
+use bevy::prelude::{Commands, Local, Res, ResMut};
 use simgrid::arpg_dungeon;
 use simgrid::proto::Tile;
 use simgrid::{
-    AggroSpec, KindRegistry, NpcSpec, SIM_TICK_HZ, SimConfig, Stairs, WalkableMap,
-    ground_item_bundle, spawn_npc_from_spec,
+    AggroSpec, EnvOpts, HazardZone, HealAura, KindRegistry, NpcSpec, SIM_TICK_HZ, SimConfig,
+    Stairs, WalkableMap, ground_item_bundle, spawn_env_object, spawn_npc_from_spec,
 };
 
 pub const MAX_PLAYERS: usize = 32;
@@ -39,6 +39,15 @@ pub const GOBLIN_DEFENSE: i32 = 0;
 pub const GOBLIN_TICKS_PER_TILE: u8 = 6;
 pub const HOSTILE_AGGRO_RANGE: i32 = 6;
 
+// Campfire: a placed env object near spawn. Blocks its tile, heals players in the
+// adjacent ring, and burns anything forced onto the tile. Tuning is hardcoded
+// here for the MVP; #12972 will read it from the `campfire` itemdb entry.
+pub const CAMPFIRE_REF: &str = "campfire";
+pub const CAMPFIRE_HEAL_RANGE: i32 = 2;
+pub const CAMPFIRE_HEAL_AMOUNT: i32 = 3;
+pub const CAMPFIRE_BURN_AMOUNT: i32 = 8;
+pub const CAMPFIRE_PERIOD_TICKS: u32 = SIM_TICK_HZ;
+
 /// Ground floor — players spawn here; stairs descend to deeper floors.
 pub const SPAWN_FLOOR: i32 = 0;
 
@@ -71,6 +80,7 @@ pub fn registry() -> KindRegistry {
     reg.register_npc(GOBLIN_REF);
     reg.register_item(GOBLIN_LOOT_REF);
     reg.register_item(STAIR_KEY_REF);
+    reg.register_env(CAMPFIRE_REF);
     reg
 }
 
@@ -130,7 +140,12 @@ fn goblin_spec(registry: &KindRegistry, origin: Tile) -> Option<NpcSpec> {
     })
 }
 
-pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut commands: Commands) {
+pub fn spawn_world(
+    mut done: Local<bool>,
+    registry: Res<KindRegistry>,
+    mut walkable: ResMut<WalkableMap>,
+    mut commands: Commands,
+) {
     if *done {
         return;
     }
@@ -159,6 +174,35 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
     let key_tile = floor_near(Tile::new(spawn.x - 2, spawn.y + 2));
     if let Some(bundle) = ground_item_bundle(&registry, STAIR_KEY_REF, 1, key_tile) {
         commands.spawn(bundle);
+    }
+
+    // A campfire near spawn: blocks its tile, heals the adjacent ring, burns
+    // anything forced onto it. Snap to a floor tile distinct from the player
+    // spawn so no one starts trapped on it.
+    let fire = floor_near(Tile::new(spawn.x + 3, spawn.y - 1));
+    if fire != spawn
+        && spawn_env_object(
+            &mut commands,
+            &registry,
+            CAMPFIRE_REF,
+            fire,
+            EnvOpts {
+                blocker: true,
+                heal_aura: Some(HealAura {
+                    range: CAMPFIRE_HEAL_RANGE,
+                    magnitude: CAMPFIRE_HEAL_AMOUNT,
+                    period_ticks: CAMPFIRE_PERIOD_TICKS,
+                }),
+                hazard: Some(HazardZone {
+                    magnitude: CAMPFIRE_BURN_AMOUNT,
+                    period_ticks: CAMPFIRE_PERIOD_TICKS,
+                }),
+                floor: SPAWN_FLOOR,
+            },
+        )
+        .is_some()
+    {
+        walkable.block_tile_z(SPAWN_FLOOR, fire);
     }
 }
 

--- a/packages/rust/simgrid/src/data.rs
+++ b/packages/rust/simgrid/src/data.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bevy::prelude::Resource;
 use serde::Deserialize;
 
-use crate::proto::{KIND_CAT_ITEM, KIND_CAT_NPC, KIND_CAT_PLAYER, KindEntry};
+use crate::proto::{KIND_CAT_ENV, KIND_CAT_ITEM, KIND_CAT_NPC, KIND_CAT_PLAYER, KindEntry};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct NpcDb {
@@ -147,6 +147,10 @@ impl KindRegistry {
 
     pub fn register_item(&mut self, ref_id: &str) -> u16 {
         self.insert(ref_id, KIND_CAT_ITEM)
+    }
+
+    pub fn register_env(&mut self, ref_id: &str) -> u16 {
+        self.insert(ref_id, KIND_CAT_ENV)
     }
 
     pub fn kind_of(&self, ref_id: &str) -> Option<u16> {

--- a/packages/rust/simgrid/src/grid.rs
+++ b/packages/rust/simgrid/src/grid.rs
@@ -76,6 +76,10 @@ pub struct WalkableMap {
     pub width: i32,
     pub height: i32,
     collision: Collision,
+    /// Dynamically blocked tiles, keyed by `(floor_z, tile)`. Placed env objects
+    /// (campfires, walls) occupy a tile without touching the seed-derived layout,
+    /// so the endless dungeon stays stateless except for what players build.
+    blocked: HashSet<(i32, Tile)>,
 }
 
 impl WalkableMap {
@@ -86,6 +90,7 @@ impl WalkableMap {
             width: w,
             height: h,
             collision: Collision::Bitset(vec![false; (w * h) as usize]),
+            blocked: HashSet::new(),
         }
     }
 
@@ -100,6 +105,7 @@ impl WalkableMap {
             width: w,
             height: w,
             collision: Collision::Dungeon { seed },
+            blocked: HashSet::new(),
         }
     }
 
@@ -112,6 +118,7 @@ impl WalkableMap {
             width: w,
             height: h,
             collision: Collision::Bitset(cells),
+            blocked: HashSet::new(),
         }
     }
 
@@ -200,6 +207,26 @@ impl WalkableMap {
         }
     }
 
+    /// Mark a tile on floor `z` impassable (placed env object). Checked by every
+    /// collision query via `is_walkable_z`, so movement and pathfinding both
+    /// route around it without touching the seed-derived layout.
+    pub fn block_tile_z(&mut self, z: i32, tile: Tile) {
+        self.blocked.insert((z, tile));
+    }
+
+    pub fn unblock_tile_z(&mut self, z: i32, tile: Tile) {
+        self.blocked.remove(&(z, tile));
+    }
+
+    /// Ground-floor convenience for single-floor callers.
+    pub fn block_tile(&mut self, tile: Tile) {
+        self.block_tile_z(0, tile);
+    }
+
+    pub fn unblock_tile(&mut self, tile: Tile) {
+        self.unblock_tile_z(0, tile);
+    }
+
     /// Walkability on the ground floor (z = 0). Single-floor games call this.
     pub fn is_walkable(&self, tile: Tile) -> bool {
         self.is_walkable_z(0, tile)
@@ -208,6 +235,9 @@ impl WalkableMap {
     /// Walkability on dungeon floor `z`. A bitset map is one fixed floor and
     /// ignores `z`; the endless dungeon derives the per-floor layout from `z`.
     pub fn is_walkable_z(&self, z: i32, tile: Tile) -> bool {
+        if self.blocked.contains(&(z, tile)) {
+            return false;
+        }
         match &self.collision {
             Collision::Bitset(cells) => self.index(tile).map(|i| !cells[i]).unwrap_or(false),
             Collision::Dungeon { seed } => crate::arpg_dungeon::is_floor(*seed, z, tile.x, tile.y),
@@ -524,6 +554,19 @@ mod tests {
             m.set_blocked(Tile::new(1, y), true);
         }
         assert!(m.find_path(Tile::new(0, 0), Tile::new(2, 0), 64).is_none());
+    }
+
+    #[test]
+    fn dynamic_block_tile_overlay() {
+        let mut m = WalkableMap::open(5, 5);
+        let t = Tile::new(2, 2);
+        assert!(m.is_walkable_z(0, t));
+        m.block_tile_z(0, t);
+        assert!(!m.is_walkable_z(0, t), "blocked tile impassable");
+        assert!(m.is_walkable_z(1, t), "overlay is per-floor");
+        assert!(m.is_walkable_z(0, Tile::new(2, 1)), "neighbor unaffected");
+        m.unblock_tile_z(0, t);
+        assert!(m.is_walkable_z(0, t), "unblock restores");
     }
 
     #[test]

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -16,9 +16,10 @@ pub use data::{ItemDb, ItemDef, KindRegistry, NpcDb, NpcDef};
 pub use grid::{Floor, GridPos, MoveSpeed, MoveTarget, StairLink, Stairs, WalkableMap};
 pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
-    Aggro, AggroSpec, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense, EntityKind,
-    EquipBonus, EquipmentEffects, Equipped, Health, Inventory, ItemPrices, Loot, NpcLevel, NpcSpec,
-    Path, PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimConfig, SimSet,
-    StatusEffect, StatusEffects, StepBuffer, TableDef, Tables, Wander, XpState, build_app,
-    ground_item_bundle, level_attack, level_max_hp, run_sim_loop, spawn_npc_from_spec, xp_to_next,
+    Aggro, AggroSpec, Blocker, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense,
+    EntityKind, EnvObject, EnvOpts, EquipBonus, EquipmentEffects, Equipped, HazardZone, HealAura,
+    Health, Inventory, ItemPrices, Loot, NpcLevel, NpcSpec, Path, PlayerSlotTag, PlayerStore,
+    RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimConfig, SimSet, StatusEffect, StatusEffects,
+    StepBuffer, TableDef, Tables, Wander, XpState, build_app, ground_item_bundle, level_attack,
+    level_max_hp, run_sim_loop, spawn_env_object, spawn_npc_from_spec, xp_to_next,
 };

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -23,6 +23,7 @@ pub const EPHEMERAL_FLOOR: u16 = 13;
 pub const KIND_CAT_PLAYER: u8 = 0;
 pub const KIND_CAT_NPC: u8 = 1;
 pub const KIND_CAT_ITEM: u8 = 2;
+pub const KIND_CAT_ENV: u8 = 3;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct EntityId(pub u32);

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -709,6 +709,124 @@ pub fn spawn_npc_from_spec(commands: &mut Commands, spec: &NpcSpec) {
     }
 }
 
+/// A placed environment object (campfire, wall, …). `def_ref` is its itemdb ref
+/// so systems can resolve data-driven behavior later (#12972); for now the
+/// behavior components are attached from spawn-time `EnvOpts`.
+#[derive(Component, Clone)]
+pub struct EnvObject {
+    pub def_ref: String,
+}
+
+/// Occupies its tile — paired with `WalkableMap::block_tile_z` so movement and
+/// pathfinding route around it.
+#[derive(Component, Clone, Copy)]
+pub struct Blocker;
+
+/// Periodic heal for players within `range` (Chebyshev) of this tile, excluding
+/// the unstandable center. `range >= 1` keeps it disjoint from a `HazardZone`.
+#[derive(Component, Clone, Copy)]
+pub struct HealAura {
+    pub range: i32,
+    pub magnitude: i32,
+    pub period_ticks: u32,
+}
+
+/// Periodic burn for any entity standing ON this tile (player or NPC — reached by
+/// knockback / forced move since the tile is usually a `Blocker`).
+#[derive(Component, Clone, Copy)]
+pub struct HazardZone {
+    pub magnitude: i32,
+    pub period_ticks: u32,
+}
+
+/// Spawn-time behavior for an env object. Hardcoded by the caller today; #12972
+/// will populate these from the itemdb item def.
+#[derive(Clone, Default)]
+pub struct EnvOpts {
+    pub blocker: bool,
+    pub heal_aura: Option<HealAura>,
+    pub hazard: Option<HazardZone>,
+    pub floor: i32,
+}
+
+/// Spawn a placed env object with the mandatory snapshot trio
+/// (`EntityKind + GridPos + MoveTarget`) plus opted-in behavior components. The
+/// caller blocks the tile via `WalkableMap::block_tile_z` when `opts.blocker`.
+pub fn spawn_env_object(
+    commands: &mut Commands,
+    registry: &KindRegistry,
+    item_ref: &str,
+    tile: Tile,
+    opts: EnvOpts,
+) -> Option<Entity> {
+    let kind = registry.kind_of(item_ref)?;
+    let mut e = commands.spawn((
+        EntityKind(kind),
+        GridPos::at(tile),
+        MoveTarget::default(),
+        EnvObject {
+            def_ref: item_ref.to_string(),
+        },
+    ));
+    if opts.floor != 0 {
+        e.insert(Floor(opts.floor));
+    }
+    if opts.blocker {
+        e.insert(Blocker);
+    }
+    if let Some(a) = opts.heal_aura {
+        e.insert(a);
+    }
+    if let Some(h) = opts.hazard {
+        e.insert(h);
+    }
+    Some(e.id())
+}
+
+/// Heal players standing in a campfire's aura ring (range >= 1, same floor).
+#[allow(clippy::type_complexity)]
+fn env_heal_aura(
+    clock: Res<SimClock>,
+    auras: Query<(&HealAura, &GridPos, Option<&Floor>)>,
+    mut players: Query<(&mut Health, &GridPos, Option<&Floor>), With<PlayerSlotTag>>,
+) {
+    for (aura, apos, afloor) in auras.iter() {
+        if aura.period_ticks == 0 || !clock.tick.is_multiple_of(aura.period_ticks) {
+            continue;
+        }
+        let az = afloor.map(|f| f.0).unwrap_or(0);
+        for (mut hp, ppos, pfloor) in players.iter_mut() {
+            if pfloor.map(|f| f.0).unwrap_or(0) != az || hp.hp <= 0 || hp.hp >= hp.max_hp {
+                continue;
+            }
+            let d = ppos.tile.chebyshev(apos.tile);
+            if d >= 1 && d <= aura.range {
+                hp.hp = (hp.hp + aura.magnitude).min(hp.max_hp);
+            }
+        }
+    }
+}
+
+/// Burn any entity (player or NPC) standing on a hazard tile (same floor).
+#[allow(clippy::type_complexity)]
+fn env_hazard_burn(
+    clock: Res<SimClock>,
+    hazards: Query<(&HazardZone, &GridPos, Option<&Floor>)>,
+    mut victims: Query<(&mut Health, &GridPos, Option<&Floor>)>,
+) {
+    for (hz, hpos, hfloor) in hazards.iter() {
+        if hz.period_ticks == 0 || !clock.tick.is_multiple_of(hz.period_ticks) {
+            continue;
+        }
+        let hz_z = hfloor.map(|f| f.0).unwrap_or(0);
+        for (mut hp, vpos, vfloor) in victims.iter_mut() {
+            if vfloor.map(|f| f.0).unwrap_or(0) == hz_z && vpos.tile == hpos.tile {
+                hp.hp -= hz.magnitude;
+            }
+        }
+    }
+}
+
 pub fn build_app(
     tx: mpsc::UnboundedSender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -790,6 +908,8 @@ pub fn build_app(
                 advance_movement,
                 chain_steps,
                 stair_system,
+                env_hazard_burn,
+                env_heal_aura,
                 tick_status_effects,
                 respawn_players,
                 regen_players,
@@ -3224,6 +3344,74 @@ mod tests {
             .unwrap()
             .claim(name.to_string(), test_ulid(name))
             .expect("slot available")
+    }
+
+    #[test]
+    fn env_hazard_burns_entity_on_tile() {
+        let (mut app, _rx, _tx, _roster) = harness(0x111);
+        let t = Tile::new(10, 10);
+        // Plain Health entity (no PlayerSlotTag → regen/status systems ignore it).
+        let victim = app
+            .world_mut()
+            .spawn((
+                EntityKind(1),
+                GridPos::at(t),
+                MoveTarget::default(),
+                Health {
+                    hp: 100,
+                    max_hp: 100,
+                },
+            ))
+            .id();
+        app.world_mut().spawn((
+            HazardZone {
+                magnitude: 8,
+                period_ticks: 1,
+            },
+            GridPos::at(t),
+        ));
+        for _ in 0..3 {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(victim).unwrap().hp;
+        assert_eq!(hp, 100 - 8 * 3, "burned 8/tick for 3 ticks");
+    }
+
+    #[test]
+    fn env_heal_aura_heals_adjacent_player() {
+        let (mut app, _rx, _tx, _roster) = harness(0x222);
+        let center = Tile::new(10, 10);
+        let adj = Tile::new(11, 10); // Chebyshev distance 1 from center.
+        let player = app
+            .world_mut()
+            .spawn((
+                EntityKind(PLAYER_KIND),
+                GridPos::at(adj),
+                MoveTarget::default(),
+                MoveSpeed { ticks_per_tile: 4 },
+                Health {
+                    hp: 10,
+                    max_hp: 100,
+                },
+                StatusEffects::default(),
+                PlayerSlotTag(proto::PlayerSlot(0)),
+            ))
+            .id();
+        app.world_mut().spawn((
+            HealAura {
+                range: 2,
+                magnitude: 3,
+                period_ticks: 1,
+            },
+            GridPos::at(center),
+        ));
+        // Fewer ticks than REGEN_PERIOD_TICKS (40) so regen_players never fires —
+        // any healing is purely the aura.
+        for _ in 0..5 {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(player).unwrap().hp;
+        assert_eq!(hp, 10 + 3 * 5, "aura healed 3/tick for 5 ticks");
     }
 
     #[test]


### PR DESCRIPTION
## ARPG environment objects — generic placeable foundation + campfire

First slice of epic #12955. Adds a generic placeable-object system to the isometric ARPG and ships the campfire as its first instance. Endless dungeon was seed-only (zero dynamic world state); placed objects are the first dynamic state.

### simgrid
- **`KIND_CAT_ENV` + `KindRegistry::register_env`** — new entity category. Rides the existing wire (`EntityDelta.kind` + `KindEntry.cat`), **no `PROTOCOL_VERSION` bump**.
- **`WalkableMap` blocked-tile overlay** — `(floor_z, tile)` `HashSet`, checked in `is_walkable_z` so movement *and* pathfinding route around placed objects without touching the seed-derived layout. `block_tile_z` / `unblock_tile_z` (+ ground-floor convenience).
- **Components + bundle** — `EnvObject` / `Blocker` / `HealAura` / `HazardZone`; `spawn_env_object` carries the mandatory snapshot trio (`EntityKind + GridPos + MoveTarget`) plus opted-in behavior.
- **Systems (Movement set, floor-aware)** — `env_heal_aura` heals players in the adjacent ring (range ≥ 1, excludes the unstandable center); `env_hazard_burn` burns any entity forced onto the tile (player **or** NPC).

### arpg-server
- Registers + spawns a campfire near world spawn: blocks its tile, heals the ring, burns on-tile. Tuning hardcoded for MVP (data-driven from itemdb deferred to #12972).

### Non-breaking by design
Burn is **direct HP damage** — no `StatusKind::Burn` on the wire yet — so live clients keep working. Heal is direct HP too. Client-side Burn VFX + status is a coordinated follow-up (#12965).

### Tests
- `dynamic_block_tile_overlay` (per-floor blocking)
- `env_hazard_burns_entity_on_tile` (burn DoT)
- `env_heal_aura_heals_adjacent_player` (isolated from `regen_players`)
- 102 simgrid tests pass, clippy clean (`-D warnings`).

### Tickets
Closes #12957 #12958 #12959 #12960 #12962 · Advances #12961 (client VFX #12965) #12972

### Not in this PR (tracked)
Client work — env category plumbing (#12963), `EnvironmentDef` + sprite (#12964), prediction + burn/heal feedback (#12965); `campfire` itemdb entry + deploy flow (#12966); data-driven effect mapping (#12972).
