### PR TITLE
fix(kube): point kbve-gate SUPABASE_URL at kong gateway

### DIFF
--- a/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
+++ b/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
@@ -49,7 +49,7 @@ spec:
                       - name: GATE_COOKIE_DOMAIN
                         value: '.kbve.com'
                       - name: SUPABASE_URL
-                        value: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
                       - name: SUPABASE_JWT_SECRET
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -211,7 +211,7 @@ spec:
                       - name: GATE_COOKIE_DOMAIN
                         value: '.kbve.com'
                       - name: SUPABASE_URL
-                        value: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
                       - name: SUPABASE_JWT_SECRET
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Problem
`https://n8n.kbve.com` and `https://grafana.kbve.com` returned **502 Bad Gateway** after OAuth login.

## Root cause
Both kbve-gate deployments set:
```
SUPABASE_URL=http://supabase-postgrest.kilobase.svc.cluster.local:3000
```
No such service exists — PostgREST is exposed as `rest`, and the gate's `/rest/v1/rpc/is_staff` path is a **Kong** route. On a valid token the gate passed auth, then the `is_staff` RPC failed with a DNS/network error:
```
authz backend: is_staff network: error sending request for url (http://supabase-postgrest.kilobase.svc.cluster.local:3000/rest/v1/rpc/is_staff)
```
Bad/missing tokens still returned 401, so bare page loads masked the break.

## Fix
Point both gates at `http://kong.kilobase.svc.cluster.local:8000`, matching the already-working cryptothrone gate.

- `apps/kube/n8n/manifest/n8n-deployment.yaml`
- `apps/kube/monitoring/manifests/grafana-gate-deployment.yaml`

Reaches cluster after the dev→main release sync.