### PR TITLE
feat(edge): edge functions hardening phase 2 (#8246)

### DIFF
--- a/apps/kbve/edge-e2e/e2e/argo.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/argo.spec.ts
@@ -18,9 +18,14 @@ describe('Argo — Smoke Tests', () => {
 	// -- CORS --
 
 	it('should return 200 for OPTIONS preflight without JWT', async () => {
-		const res = await fetch(`${BASE_URL}/argo`, { method: 'OPTIONS' });
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'OPTIONS',
+			headers: { Origin: 'https://kbve.com' },
+		});
 		expect(res.status).toBe(200);
-		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-origin')).toBe(
+			'https://kbve.com',
+		);
 	});
 
 	// -- Method --

--- a/apps/kbve/edge-e2e/e2e/cors.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/cors.spec.ts
@@ -18,7 +18,22 @@ describe('CORS Preflight Handling', () => {
 		expect(res.ok).toBe(true);
 	});
 
-	it('should include CORS headers in the OPTIONS response', async () => {
+	it('should echo an allowlisted origin in the OPTIONS response', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://kbve.com',
+				'Access-Control-Request-Method': 'POST',
+			},
+		});
+		const allowOrigin = res.headers.get('access-control-allow-origin');
+		const allowHeaders = res.headers.get('access-control-allow-headers');
+		expect(allowOrigin).toBe('https://kbve.com');
+		expect(allowHeaders).toContain('authorization');
+		expect(allowHeaders).toContain('content-type');
+	});
+
+	it('should not echo a non-allowlisted origin', async () => {
 		const res = await fetch(`${BASE_URL}/vault-reader`, {
 			method: 'OPTIONS',
 			headers: {
@@ -26,10 +41,6 @@ describe('CORS Preflight Handling', () => {
 				'Access-Control-Request-Method': 'POST',
 			},
 		});
-		const allowOrigin = res.headers.get('access-control-allow-origin');
-		const allowHeaders = res.headers.get('access-control-allow-headers');
-		expect(allowOrigin).toBe('*');
-		expect(allowHeaders).toContain('authorization');
-		expect(allowHeaders).toContain('content-type');
+		expect(res.headers.get('access-control-allow-origin')).toBeNull();
 	});
 });

--- a/apps/kbve/edge-e2e/e2e/discordsh.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/discordsh.spec.ts
@@ -20,9 +20,12 @@ describe('Discordsh — Smoke Tests', () => {
 	it('should return 200 for OPTIONS preflight without JWT', async () => {
 		const res = await fetch(`${BASE_URL}/discordsh`, {
 			method: 'OPTIONS',
+			headers: { Origin: 'https://kbve.com' },
 		});
 		expect(res.status).toBe(200);
-		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-origin')).toBe(
+			'https://kbve.com',
+		);
 	});
 
 	// -- Method --

--- a/apps/kbve/edge-e2e/e2e/forum.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/forum.spec.ts
@@ -28,9 +28,14 @@ describe('Forum — Smoke Tests', () => {
 	// -- CORS / method --
 
 	it('returns 200 for OPTIONS preflight without JWT', async () => {
-		const res = await fetch(`${BASE_URL}/forum`, { method: 'OPTIONS' });
+		const res = await fetch(`${BASE_URL}/forum`, {
+			method: 'OPTIONS',
+			headers: { Origin: 'https://kbve.com' },
+		});
 		expect(res.status).toBe(200);
-		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-origin')).toBe(
+			'https://kbve.com',
+		);
 	});
 
 	it('returns 405 for GET', async () => {

--- a/apps/kbve/edge-e2e/e2e/helpers/jwt.ts
+++ b/apps/kbve/edge-e2e/e2e/helpers/jwt.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto';
 
-const JWT_SECRET = 'super-secret-jwt-token-for-dev';
+const JWT_SECRET = 'super-secret-jwt-token-with-at-least-32-characters-long';
 
 export type JwtRole = 'service_role' | 'anon' | 'authenticated';
 

--- a/apps/kbve/edge-e2e/e2e/meme.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/meme.spec.ts
@@ -18,9 +18,14 @@ describe('Meme — Smoke Tests', () => {
 	// -- CORS --
 
 	it('should return 200 for OPTIONS preflight without JWT', async () => {
-		const res = await fetch(`${BASE_URL}/meme`, { method: 'OPTIONS' });
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'OPTIONS',
+			headers: { Origin: 'https://kbve.com' },
+		});
 		expect(res.status).toBe(200);
-		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-origin')).toBe(
+			'https://kbve.com',
+		);
 	});
 
 	// -- Method --
@@ -137,14 +142,20 @@ describe('Meme — Smoke Tests', () => {
 	// -- Admin module (service_role only) --
 
 	it('should reject admin.create without service_role', async () => {
-		const anonToken = createJwt({ role: 'authenticated', extraClaims: { sub: '00000000-0000-0000-0000-000000000001' } });
+		const anonToken = createJwt({
+			role: 'authenticated',
+			extraClaims: { sub: '00000000-0000-0000-0000-000000000001' },
+		});
 		const res = await fetch(`${BASE_URL}/meme`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
 				Authorization: `Bearer ${anonToken}`,
 			},
-			body: JSON.stringify({ command: 'admin.create', asset_url: 'https://example.com/meme.png' }),
+			body: JSON.stringify({
+				command: 'admin.create',
+				asset_url: 'https://example.com/meme.png',
+			}),
 		});
 		expect(res.status).toBe(403);
 		const body = await res.json();

--- a/apps/kbve/edge-e2e/e2e/user-vault.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/user-vault.spec.ts
@@ -34,9 +34,12 @@ describe('User Vault — Auth & Routing', () => {
 	it('should return 200 for OPTIONS preflight without JWT', async () => {
 		const res = await fetch(`${BASE_URL}/user-vault`, {
 			method: 'OPTIONS',
+			headers: { Origin: 'https://kbve.com' },
 		});
 		expect(res.status).toBe(200);
-		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-origin')).toBe(
+			'https://kbve.com',
+		);
 	});
 
 	// -- Method --

--- a/apps/kbve/edge-e2e/project.json
+++ b/apps/kbve/edge-e2e/project.json
@@ -15,7 +15,7 @@
 			"options": {
 				"commands": [
 					"docker rm -f edge-e2e-test 2>/dev/null || true",
-					"docker run -d --name edge-e2e-test -p 9100:9000 -e JWT_SECRET=super-secret-jwt-token-for-dev -e VERIFY_JWT=true -e SUPABASE_URL=http://localhost:54321 -e SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key kbve/edge:latest start --main-service /home/deno/functions/main",
+					"docker run -d --name edge-e2e-test -p 9100:9000 -e JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long -e VERIFY_JWT=true -e SUPABASE_URL=http://localhost:54321 -e SUPABASE_ANON_KEY=dummy-anon-key -e SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key -e CLICKHOUSE_ENDPOINT=http://localhost:8123 -e CLICKHOUSE_USER=default -e CLICKHOUSE_PASSWORD=dummy kbve/edge:latest start --main-service /home/deno/functions/main",
 					"npx vitest run; EC=$?; if [ $EC -ne 0 ]; then echo '--- edge-e2e-test container state ---'; docker ps -a --filter name=edge-e2e-test --format 'table {{.Names}}\\t{{.Status}}\\t{{.Ports}}' || true; echo '--- edge-e2e-test logs (last 200 lines) ---'; docker logs --tail 200 edge-e2e-test 2>&1 || true; echo '--- end edge-e2e-test logs ---'; fi; docker rm -f edge-e2e-test 2>/dev/null || true; exit $EC"
 				],
 				"parallel": false,

--- a/apps/kbve/edge/functions/_shared/constants.ts
+++ b/apps/kbve/edge/functions/_shared/constants.ts
@@ -1,0 +1,73 @@
+/**
+ * Centralized numeric constants and enumerations for edge functions.
+ *
+ * Single source of truth for pagination limits, container/skill enum ranges,
+ * and validation bounds that were previously scattered as magic numbers across
+ * individual modules.
+ */
+
+/** Request body size cap shared by every router (1 MB). */
+export const MAX_BODY_BYTES = 1_048_576;
+
+/**
+ * Per-module pagination limits. Each entry is the maximum page size a caller
+ * may request; requests above the max are clamped, not rejected.
+ */
+export const PAGINATION = {
+  meme: { defaultLimit: 20, maxLimit: 50 },
+  logs: { defaultLimit: 100, maxLimit: 500 },
+  transfer: { defaultLimit: 50, maxLimit: 500, maxBatch: 1000 },
+  discordsh: { defaultLimit: 24, maxLimit: 50, maxPage: 10000 },
+  forum: { defaultLimit: 25, maxLimit: 100 },
+} as const;
+
+/** Upper bound on any page number to prevent unbounded DB offsets. */
+export const MAX_PAGE = 10000;
+
+/**
+ * Minecraft container types persisted by mc/container.ts. The numeric range
+ * mirrors the `mc.container_type` CHECK constraint in SQL.
+ */
+export enum ContainerType {
+  Chest = 0,
+  TrappedChest = 1,
+  Barrel = 2,
+  ShulkerBox = 3,
+  Furnace = 4,
+  BlastFurnace = 5,
+  Smoker = 6,
+  Dispenser = 7,
+  Dropper = 8,
+  Hopper = 9,
+  BrewingStand = 10,
+  Beacon = 11,
+  EnderChest = 12,
+  Other = 13,
+}
+
+export const CONTAINER_TYPE_MIN = ContainerType.Chest;
+export const CONTAINER_TYPE_MAX = ContainerType.Other;
+
+/**
+ * Minecraft skill categories used by mc/skill.ts. Mirrors the
+ * `mc.skill_category` enum on the server.
+ */
+export enum SkillCategory {
+  General = 0,
+  Combat = 1,
+  Gathering = 2,
+  Crafting = 3,
+  Magic = 4,
+}
+
+export const VALID_SKILL_CATEGORIES: readonly number[] = Object.values(
+  SkillCategory,
+).filter((v): v is number => typeof v === "number");
+
+/** Meme reaction type range (matches meme_reactions CHECK constraint). */
+export const REACTION_MIN = 1;
+export const REACTION_MAX = 6;
+
+/** Meme report reason range (matches meme_reports CHECK constraint). */
+export const REPORT_REASON_MIN = 1;
+export const REPORT_REASON_MAX = 7;

--- a/apps/kbve/edge/functions/_shared/cors.ts
+++ b/apps/kbve/edge/functions/_shared/cors.ts
@@ -15,6 +15,13 @@ const ALLOWED_ORIGINS = new Set([
   "https://localhost:3080",
 ]);
 
+const BASE_CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-idempotency-key",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Vary": "Origin",
+};
+
 /**
  * Build CORS headers for a given request origin.
  * Returns the origin if it's in the allowlist, otherwise omits the header
@@ -24,16 +31,37 @@ export function getCorsHeaders(req?: Request): Record<string, string> {
   const origin = req?.headers.get("origin") ?? "";
   const allowedOrigin = ALLOWED_ORIGINS.has(origin) ? origin : "";
   return {
+    ...BASE_CORS_HEADERS,
     ...(allowedOrigin ? { "Access-Control-Allow-Origin": allowedOrigin } : {}),
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
-    "Vary": "Origin",
   };
 }
 
-/** Legacy export for routers that don't pass the request object yet. */
-export const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
-};
+/**
+ * Default CORS headers with NO `Access-Control-Allow-Origin`. Cross-origin
+ * browser reads are blocked unless the response is passed through `withCors`
+ * with the originating request. Used by `jsonResponse` as a safe baseline.
+ */
+export const corsHeaders = BASE_CORS_HEADERS;
+
+/**
+ * Merge origin-aware CORS headers onto an existing Response at the router
+ * boundary, so allowlisted browser origins receive a matching
+ * `Access-Control-Allow-Origin` without threading the request through every
+ * handler.
+ */
+export function withCors(res: Response, req: Request): Response {
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(getCorsHeaders(req))) {
+    headers.set(k, v);
+  }
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}
+
+/** Standard preflight response for OPTIONS requests. */
+export function preflight(req: Request): Response {
+  return new Response("ok", { headers: getCorsHeaders(req) });
+}

--- a/apps/kbve/edge/functions/_shared/env.ts
+++ b/apps/kbve/edge/functions/_shared/env.ts
@@ -1,0 +1,51 @@
+/**
+ * Environment variable loading and validation.
+ *
+ * Fails fast at worker boot with a clear message listing every missing variable
+ * instead of surfacing a cryptic `undefined` deep inside a handler. Also
+ * validates JWT secret strength so a weak/short secret is caught at startup.
+ */
+
+/** Minimum acceptable JWT secret length (HS256 keys should be >= 32 bytes). */
+export const MIN_JWT_SECRET_LENGTH = 32;
+
+/**
+ * Read and validate all required env vars at startup.
+ * Throws a single error naming every missing variable.
+ */
+export function loadEnv<K extends string>(
+  required: readonly K[],
+): Record<K, string> {
+  const out = {} as Record<K, string>;
+  const missing: string[] = [];
+  for (const key of required) {
+    const value = Deno.env.get(key);
+    if (value === undefined || value === "") {
+      missing.push(key);
+    } else {
+      out[key] = value;
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Validate a JWT secret for minimum strength. Throws when the secret is missing
+ * or shorter than MIN_JWT_SECRET_LENGTH.
+ */
+export function validateJwtSecret(secret: string | undefined): string {
+  if (!secret) {
+    throw new Error("JWT_SECRET is not configured");
+  }
+  if (secret.length < MIN_JWT_SECRET_LENGTH) {
+    throw new Error(
+      `JWT_SECRET is too weak: must be at least ${MIN_JWT_SECRET_LENGTH} characters`,
+    );
+  }
+  return secret;
+}

--- a/apps/kbve/edge/functions/_shared/idempotency.ts
+++ b/apps/kbve/edge/functions/_shared/idempotency.ts
@@ -1,0 +1,58 @@
+/**
+ * In-memory idempotency guard for write actions (vote.cast, server.submit).
+ *
+ * Per-worker only — collapses duplicate submissions that arrive in quick
+ * succession with the same idempotency key. Not a durable exactly-once
+ * guarantee; the DB RPCs remain the source of truth for true uniqueness.
+ */
+
+interface Entry {
+  expiresAt: number;
+}
+
+const seen = new Map<string, Entry>();
+let lastSweep = 0;
+
+function sweep(now: number): void {
+  if (now - lastSweep < 60_000) return;
+  lastSweep = now;
+  for (const [key, entry] of seen) {
+    if (entry.expiresAt <= now) seen.delete(key);
+  }
+}
+
+/** Default idempotency window (60s). */
+export const DEFAULT_IDEMPOTENCY_TTL_MS = 60_000;
+
+/**
+ * Read an idempotency key from the request header or body. Returns null when no
+ * key is supplied (idempotency is opt-in).
+ */
+export function readIdempotencyKey(
+  req: Request,
+  body: Record<string, unknown>,
+): string | null {
+  const header = req.headers.get("x-idempotency-key");
+  if (header && header.length > 0) return header;
+  const fromBody = body.idempotency_key;
+  return typeof fromBody === "string" && fromBody.length > 0 ? fromBody : null;
+}
+
+/**
+ * Mark `key` as in-flight for `scope`. Returns true if this is the first time
+ * the key has been seen within the TTL (caller should proceed), false if it is
+ * a duplicate (caller should reject).
+ */
+export function claimIdempotencyKey(
+  scope: string,
+  key: string,
+  ttlMs: number = DEFAULT_IDEMPOTENCY_TTL_MS,
+): boolean {
+  const now = Date.now();
+  sweep(now);
+  const composite = `${scope}:${key}`;
+  const existing = seen.get(composite);
+  if (existing && existing.expiresAt > now) return false;
+  seen.set(composite, { expiresAt: now + ttlMs });
+  return true;
+}

--- a/apps/kbve/edge/functions/_shared/logging.ts
+++ b/apps/kbve/edge/functions/_shared/logging.ts
@@ -1,0 +1,49 @@
+/**
+ * Structured JSON logging for the Vector → ClickHouse pipeline.
+ *
+ * Replaces ad-hoc `console.error("foo:", err)` calls with single-line JSON
+ * records that Vector can parse without regex. Levels map to stderr (error,
+ * warn) and stdout (info, debug).
+ */
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+interface LogFields {
+  [key: string]: unknown;
+}
+
+function emit(level: LogLevel, context: string, fields: LogFields): void {
+  const record = { level, context, ...fields };
+  const line = JSON.stringify(record);
+  if (level === "error" || level === "warn") {
+    console.error(line);
+  } else {
+    console.log(line);
+  }
+}
+
+function serializeError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message, stack: err.stack };
+  }
+  return { message: String(err) };
+}
+
+/** Log an error with serialized exception details. */
+export function logError(
+  context: string,
+  err: unknown,
+  fields: LogFields = {},
+): void {
+  emit("error", context, { ...fields, error: serializeError(err) });
+}
+
+/** Log a warning. */
+export function logWarn(context: string, fields: LogFields = {}): void {
+  emit("warn", context, fields);
+}
+
+/** Log an informational event. */
+export function logInfo(context: string, fields: LogFields = {}): void {
+  emit("info", context, fields);
+}

--- a/apps/kbve/edge/functions/_shared/middleware.ts
+++ b/apps/kbve/edge/functions/_shared/middleware.ts
@@ -1,0 +1,49 @@
+/**
+ * Auth guard middleware.
+ *
+ * Wraps an action handler with a role check so individual handlers no longer
+ * repeat `requireServiceRole(claims)` / `requireUserToken(claims)` boilerplate.
+ */
+
+import type { JwtClaims } from "./supabase.ts";
+import {
+  requireServiceRole,
+  requireStaffOrServiceRole,
+  requireUserToken,
+} from "./supabase.ts";
+
+/** Minimal shape every module request context shares. */
+export interface AuthedRequest {
+  token: string;
+  claims: JwtClaims;
+}
+
+export type Role = "user" | "service_role" | "staff";
+
+/**
+ * Wrap a handler so the given role is enforced before it runs. Returns a 403
+ * Response when the caller's role is insufficient.
+ *
+ *   const cast = withAuth("user", async (req) => { ... });
+ */
+export function withAuth<R extends AuthedRequest>(
+  role: Role,
+  handler: (req: R) => Promise<Response>,
+): (req: R) => Promise<Response> {
+  return async (req: R): Promise<Response> => {
+    let denied: Response | null = null;
+    switch (role) {
+      case "user":
+        denied = requireUserToken(req.claims);
+        break;
+      case "service_role":
+        denied = requireServiceRole(req.claims);
+        break;
+      case "staff":
+        denied = await requireStaffOrServiceRole(req.token, req.claims);
+        break;
+    }
+    if (denied) return denied;
+    return handler(req);
+  };
+}

--- a/apps/kbve/edge/functions/_shared/pagination.ts
+++ b/apps/kbve/edge/functions/_shared/pagination.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared pagination validation.
+ *
+ * Replaces the per-module limit/cursor/offset/page clamping repeated across
+ * meme, mc, discordsh, forum. Two styles are supported:
+ *   - validateLimit(): strict integer validation, returns an error Response on
+ *     out-of-range input (used by meme, which rejects bad input).
+ *   - clampLimit()/clampPage()/clampOffset(): silent clamping, used by modules
+ *     that prefer to coerce rather than reject (mc, discordsh).
+ */
+
+import { jsonResponse } from "./supabase.ts";
+import { MAX_PAGE } from "./constants.ts";
+
+export interface LimitResult {
+  value: number;
+  error: Response | null;
+}
+
+/**
+ * Strict pagination limit: must be an integer in [1, max].
+ * Returns the default when the value is omitted, an error Response otherwise.
+ */
+export function validateLimit(
+  limit: unknown,
+  { def = 20, max = 50 }: { def?: number; max?: number } = {},
+): LimitResult {
+  if (limit === undefined || limit === null) {
+    return { value: def, error: null };
+  }
+  const num = Number(limit);
+  if (!Number.isInteger(num) || num < 1 || num > max) {
+    return {
+      value: def,
+      error: jsonResponse(
+        { error: `limit must be an integer between 1 and ${max}` },
+        400,
+      ),
+    };
+  }
+  return { value: num, error: null };
+}
+
+/** Silently clamp a limit into [1, max], falling back to `def`. */
+export function clampLimit(
+  limit: unknown,
+  { def, max }: { def: number; max: number },
+): number {
+  return Math.min(Math.max(Number(limit) || def, 1), max);
+}
+
+/** Silently clamp a 1-based page into [1, maxPage]. */
+export function clampPage(page: unknown, maxPage: number = MAX_PAGE): number {
+  return Math.min(Math.max(Number(page) || 1, 1), maxPage);
+}
+
+/** Silently clamp a non-negative offset, capped to avoid unbounded scans. */
+export function clampOffset(
+  offset: unknown,
+  maxOffset = MAX_PAGE * 1000,
+): number {
+  return Math.min(Math.max(Number(offset) || 0, 0), maxOffset);
+}

--- a/apps/kbve/edge/functions/_shared/ratelimit.ts
+++ b/apps/kbve/edge/functions/_shared/ratelimit.ts
@@ -1,0 +1,77 @@
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Per-worker only — state does not persist across worker restarts or span
+ * multiple worker instances. This mirrors the existing in-memory ownership
+ * cache in guild-vault and is sufficient to blunt single-worker abuse; a
+ * durable limiter (Valkey) is a future upgrade.
+ */
+
+import { jsonResponse } from "./supabase.ts";
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Window>();
+let lastSweep = 0;
+
+function sweep(now: number): void {
+  if (now - lastSweep < 60_000) return;
+  lastSweep = now;
+  for (const [key, win] of buckets) {
+    if (win.resetAt <= now) buckets.delete(key);
+  }
+}
+
+export interface RateLimitOptions {
+  /** Max requests allowed per window. */
+  limit: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+/**
+ * Register a request against `key`. Returns a 429 Response when the caller has
+ * exceeded `limit` within `windowMs`, otherwise null.
+ */
+export function rateLimit(
+  key: string,
+  { limit, windowMs }: RateLimitOptions,
+): Response | null {
+  const now = Date.now();
+  sweep(now);
+
+  const win = buckets.get(key);
+  if (!win || win.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+
+  win.count++;
+  if (win.count > limit) {
+    const retryAfter = Math.ceil((win.resetAt - now) / 1000);
+    return jsonResponse(
+      { error: "Rate limit exceeded. Try again later." },
+      429,
+    );
+  }
+  return null;
+}
+
+/**
+ * Derive a stable rate-limit key from a request, preferring the authenticated
+ * user id, then a forwarded client IP, then a constant fallback.
+ */
+export function rateLimitKey(
+  scope: string,
+  req: Request,
+  userId?: string,
+): string {
+  if (userId) return `${scope}:user:${userId}`;
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown";
+  return `${scope}:ip:${ip}`;
+}

--- a/apps/kbve/edge/functions/_shared/responses.ts
+++ b/apps/kbve/edge/functions/_shared/responses.ts
@@ -1,0 +1,20 @@
+/**
+ * Standard success/error response envelopes.
+ *
+ * Convention for new handlers: `{ success: true, data: <payload> }` for
+ * success and `{ success: false, error: <message> }` for failures. Existing
+ * handlers keep their wire shapes for client compatibility; adopt these helpers
+ * for any new endpoint.
+ */
+
+import { jsonResponse } from "./supabase.ts";
+
+/** `{ success: true, data }` envelope. */
+export function successResponse(data: unknown, status = 200): Response {
+  return jsonResponse({ success: true, data }, status);
+}
+
+/** `{ success: false, error }` envelope. */
+export function errorResponse(message: string, status = 400): Response {
+  return jsonResponse({ success: false, error: message }, status);
+}

--- a/apps/kbve/edge/functions/_shared/routing.ts
+++ b/apps/kbve/edge/functions/_shared/routing.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared command routing for "module.action" dispatch.
+ *
+ * Replaces the duplicated `command.indexOf(".")` / `command.slice(...)` blocks
+ * that every module router previously reimplemented.
+ */
+
+import { jsonResponse } from "./supabase.ts";
+
+export interface ParsedCommand {
+  module: string;
+  action: string;
+}
+
+/**
+ * Parse a "module.action" command string.
+ *
+ * Returns a ParsedCommand on success, or a 400 Response describing the error.
+ * `help` is appended to error messages to list the available commands.
+ */
+export function parseCommand(
+  command: unknown,
+  help: string,
+): ParsedCommand | Response {
+  if (!command || typeof command !== "string") {
+    return jsonResponse(
+      {
+        error:
+          `command is required (format: "module.action"). Available: ${help}`,
+      },
+      400,
+    );
+  }
+
+  const dotIndex = command.indexOf(".");
+  if (dotIndex <= 0 || dotIndex === command.length - 1) {
+    return jsonResponse(
+      {
+        error:
+          `invalid command format. Use "module.action". Available: ${help}`,
+      },
+      400,
+    );
+  }
+
+  return {
+    module: command.slice(0, dotIndex),
+    action: command.slice(dotIndex + 1),
+  };
+}
+
+/**
+ * Build a "module.action, module.action, ..." help string from a registry of
+ * modules keyed by name with an `actions` string array.
+ */
+export function buildHelpText(
+  modules: Record<string, { actions: string[] }>,
+): string {
+  const commands: string[] = [];
+  for (const [mod, { actions }] of Object.entries(modules)) {
+    for (const action of actions) {
+      commands.push(`${mod}.${action}`);
+    }
+  }
+  return commands.join(", ");
+}

--- a/apps/kbve/edge/functions/argo/index.ts
+++ b/apps/kbve/edge/functions/argo/index.ts
@@ -1,5 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv } from "../_shared/env.ts";
 import { enforceBodySizeLimit } from "../_shared/validators.ts";
 import {
   extractToken,
@@ -19,8 +22,9 @@ import {
 //   health        — ArgoCD server health check
 // ---------------------------------------------------------------------------
 
-const ARGOCD_URL = Deno.env.get("ARGOCD_UPSTREAM_URL") ?? "";
-const ARGOCD_TOKEN = Deno.env.get("ARGOCD_AUTH_TOKEN") ?? "";
+const env = loadEnv(["ARGOCD_UPSTREAM_URL", "ARGOCD_AUTH_TOKEN"]);
+const ARGOCD_URL = env.ARGOCD_UPSTREAM_URL;
+const ARGOCD_TOKEN = env.ARGOCD_AUTH_TOKEN;
 
 async function argoFetch(
   path: string,
@@ -51,11 +55,11 @@ async function argoFetch(
 
     return { status: resp.status, body, elapsed, size: text.length };
   } catch (err) {
+    logError("argo", err);
     const elapsed = Math.round(performance.now() - start);
-    const message = err instanceof Error ? err.message : String(err);
     return {
       status: 0,
-      body: { error: message },
+      body: { error: "Upstream request failed" },
       elapsed,
       size: 0,
     };
@@ -64,7 +68,7 @@ async function argoFetch(
   }
 }
 
-async function handleApplications() {
+async function handleApplications(): Promise<Record<string, unknown>> {
   const result = await argoFetch("/api/v1/applications");
   const apps =
     result.status === 200 && typeof result.body === "object" && result.body
@@ -93,7 +97,7 @@ async function handleApplications() {
   };
 }
 
-async function handleAppStatus(name: string) {
+async function handleAppStatus(name: string): Promise<Record<string, unknown>> {
   const result = await argoFetch(`/api/v1/applications/${encodeURIComponent(name)}`);
   return {
     upstream_status: result.status,
@@ -103,7 +107,7 @@ async function handleAppStatus(name: string) {
   };
 }
 
-async function handleHealth() {
+async function handleHealth(): Promise<Record<string, unknown>> {
   const result = await argoFetch("/healthz", 10000);
   return {
     argocd_reachable: result.status === 200,
@@ -114,25 +118,20 @@ async function handleHealth() {
   };
 }
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
+async function handle(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return jsonResponse({ error: "Only POST method is allowed" }, 405);
-  }
-
-  if (!ARGOCD_URL || !ARGOCD_TOKEN) {
-    return jsonResponse(
-      { error: "Service unavailable" },
-      503,
-    );
   }
 
   try {
     const token = extractToken(req);
     const claims = await parseJwt(token);
+
+    const rl = rateLimit(
+      rateLimitKey("argo", req, claims?.sub as string | undefined),
+      { limit: 30, windowMs: 60_000 },
+    );
+    if (rl) return rl;
 
     const denied = await requireStaffOrServiceRole(token, claims);
     if (denied) return denied;
@@ -176,10 +175,20 @@ serve(async (req) => {
 
     return jsonResponse(result);
   } catch (err) {
-    console.error("argo error:", err);
+    logError("argo", err);
     const message = err instanceof Error ? err.message : "Internal server error";
     const status =
       message.includes("authorization") || message.includes("JWT") ? 401 : 500;
-    return jsonResponse({ error: message }, status);
+    return jsonResponse(
+      { error: status === 401 ? "Unauthorized" : "Internal server error" },
+      status,
+    );
   }
+}
+
+serve(async (req): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return preflight(req);
+  }
+  return withCors(await handle(req), req);
 });

--- a/apps/kbve/edge/functions/argo/index.ts
+++ b/apps/kbve/edge/functions/argo/index.ts
@@ -2,7 +2,6 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { preflight, withCors } from "../_shared/cors.ts";
 import { logError } from "../_shared/logging.ts";
 import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
-import { loadEnv } from "../_shared/env.ts";
 import { enforceBodySizeLimit } from "../_shared/validators.ts";
 import {
   extractToken,
@@ -22,9 +21,8 @@ import {
 //   health        — ArgoCD server health check
 // ---------------------------------------------------------------------------
 
-const env = loadEnv(["ARGOCD_UPSTREAM_URL", "ARGOCD_AUTH_TOKEN"]);
-const ARGOCD_URL = env.ARGOCD_UPSTREAM_URL;
-const ARGOCD_TOKEN = env.ARGOCD_AUTH_TOKEN;
+const ARGOCD_URL = Deno.env.get("ARGOCD_UPSTREAM_URL") ?? "";
+const ARGOCD_TOKEN = Deno.env.get("ARGOCD_AUTH_TOKEN") ?? "";
 
 async function argoFetch(
   path: string,
@@ -135,6 +133,13 @@ async function handle(req: Request): Promise<Response> {
 
     const denied = await requireStaffOrServiceRole(token, claims);
     if (denied) return denied;
+
+    if (!ARGOCD_URL || !ARGOCD_TOKEN) {
+      return jsonResponse(
+        { error: "Service unavailable: ArgoCD upstream not configured" },
+        503,
+      );
+    }
 
     const sizeErr = enforceBodySizeLimit(req);
     if (sizeErr) return sizeErr;

--- a/apps/kbve/edge/functions/discordsh/_shared.ts
+++ b/apps/kbve/edge/functions/discordsh/_shared.ts
@@ -11,6 +11,7 @@ export {
 } from "../_shared/supabase.ts";
 
 import { jsonResponse } from "../_shared/supabase.ts";
+import { logError, logWarn } from "../_shared/logging.ts";
 
 // ---------------------------------------------------------------------------
 // Discordsh-specific request type
@@ -21,6 +22,7 @@ export interface DiscordshRequest {
   claims: import("../_shared/supabase.ts").JwtClaims;
   body: Record<string, unknown>;
   action: string;
+  req: Request;
 }
 
 // ---------------------------------------------------------------------------
@@ -79,7 +81,7 @@ export async function verifyCaptcha(
   captchaToken: unknown,
 ): Promise<Response | null> {
   if (!HCAPTCHA_SECRET) {
-    console.error("HCAPTCHA_SECRET not configured");
+    logError("discordsh.captcha", new Error("HCAPTCHA_SECRET not configured"));
     return jsonResponse(
       { error: "Captcha verification is not configured" },
       500,
@@ -106,7 +108,9 @@ export async function verifyCaptcha(
     });
 
     if (!res.ok) {
-      console.error("hCaptcha API error:", res.status);
+      logError("discordsh.captcha", new Error("hCaptcha API error"), {
+        status: res.status,
+      });
       return jsonResponse(
         { error: "Captcha verification service unavailable" },
         502,
@@ -116,10 +120,10 @@ export async function verifyCaptcha(
     const result: HCaptchaResult = await res.json();
 
     if (!result.success) {
-      console.warn(
-        "hCaptcha verification failed:",
-        result["error-codes"],
-      );
+      logWarn("discordsh.captcha", {
+        message: "hCaptcha verification failed",
+        errorCodes: result["error-codes"],
+      });
       return jsonResponse(
         { error: "Captcha verification failed. Please try again." },
         400,
@@ -128,7 +132,7 @@ export async function verifyCaptcha(
 
     return null;
   } catch (err) {
-    console.error("hCaptcha verification error:", err);
+    logError("discordsh.captcha", err);
     return jsonResponse(
       { error: "Captcha verification failed unexpectedly" },
       500,

--- a/apps/kbve/edge/functions/discordsh/index.ts
+++ b/apps/kbve/edge/functions/discordsh/index.ts
@@ -1,5 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { buildHelpText, parseCommand } from "../_shared/routing.ts";
+import { logError } from "../_shared/logging.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
 import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
 import { handleVote, VOTE_ACTIONS } from "./vote.ts";
@@ -30,89 +32,63 @@ const MODULES: Record<
   list: { handler: handleList, actions: LIST_ACTIONS, public: true },
 };
 
-function buildHelpText(): string {
-  const commands: string[] = [];
-  for (const [mod, { actions }] of Object.entries(MODULES)) {
-    for (const action of actions) {
-      commands.push(`${mod}.${action}`);
-    }
-  }
-  return commands.join(", ");
-}
-
 serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return preflight(req);
   }
 
   if (req.method !== "POST") {
-    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+    return withCors(jsonResponse({ error: "Only POST method is allowed" }, 405), req);
   }
 
   const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
+  if (ctErr) return withCors(ctErr, req);
   const sizeErr = enforceBodySizeLimit(req);
-  if (sizeErr) return sizeErr;
+  if (sizeErr) return withCors(sizeErr, req);
 
   try {
     const body = await req.json();
     const { command } = body;
 
-    if (!command || typeof command !== "string") {
-      return jsonResponse(
-        {
-          error:
-            `command is required (format: "module.action"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
+    const parsed = parseCommand(command, buildHelpText(MODULES));
+    if (parsed instanceof Response) return withCors(parsed, req);
 
-    const dotIndex = command.indexOf(".");
-    if (dotIndex === -1) {
-      return jsonResponse(
-        {
-          error:
-            `Invalid command format. Use "module.action" (e.g. "vote.cast"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
-
-    const moduleName = command.slice(0, dotIndex);
-    const action = command.slice(dotIndex + 1);
+    const { module: moduleName, action } = parsed;
 
     const mod = MODULES[moduleName];
     if (!mod) {
-      return jsonResponse(
-        {
-          error: `Unknown module: ${moduleName}. Available modules: ${
-            Object.keys(MODULES).join(", ")
-          }`,
-        },
-        400,
+      return withCors(
+        jsonResponse(
+          {
+            error: `Unknown module: ${moduleName}. Available modules: ${
+              Object.keys(MODULES).join(", ")
+            }`,
+          },
+          400,
+        ),
+        req,
       );
     }
 
-    // Public modules skip authentication
     let token = "";
-    let claims = {} as import("./_shared.ts").JwtClaims;
+    let claims = { role: "anon" } as import("./_shared.ts").JwtClaims;
     if (!mod.public) {
       token = extractToken(req);
       claims = await parseJwt(token);
     }
 
-    return mod.handler({ token, claims, body, action });
+    const res = await mod.handler({ token, claims, body, action, req });
+    return withCors(res, req);
   } catch (err) {
-    console.error("discordsh error:", err);
+    logError("discordsh", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: "Unauthorized" }, 401);
+      return withCors(jsonResponse({ error: "Unauthorized" }, 401), req);
     }
-    return jsonResponse({ error: "Internal server error" }, 500);
+    return withCors(jsonResponse({ error: "Internal server error" }, 500), req);
   }
 });

--- a/apps/kbve/edge/functions/discordsh/list.ts
+++ b/apps/kbve/edge/functions/discordsh/list.ts
@@ -4,6 +4,9 @@ import {
   jsonResponse,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import { clampLimit, clampPage } from "../_shared/pagination.ts";
+import { PAGINATION } from "../_shared/constants.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
 
 // ---------------------------------------------------------------------------
 // Discordsh List Module
@@ -17,9 +20,18 @@ type Handler = (req: DiscordshRequest) => Promise<Response>;
 const VALID_SORTS = new Set(["votes", "members", "newest", "bumped"]);
 
 const handlers: Record<string, Handler> = {
-  async servers({ body }) {
-    const limit = Math.min(Math.max(Number(body.limit) || 24, 1), 50);
-    const page = Math.min(Math.max(Number(body.page) || 1, 1), 10000);
+  async servers({ body, req }) {
+    const rl = rateLimit(rateLimitKey("discordsh.list", req), {
+      limit: 60,
+      windowMs: 60_000,
+    });
+    if (rl) return rl;
+
+    const limit = clampLimit(body.limit, {
+      def: PAGINATION.discordsh.defaultLimit,
+      max: PAGINATION.discordsh.maxLimit,
+    });
+    const page = clampPage(body.page, PAGINATION.discordsh.maxPage);
     const sort = typeof body.sort === "string" && VALID_SORTS.has(body.sort)
       ? body.sort
       : "votes";
@@ -42,9 +54,14 @@ const handlers: Record<string, Handler> = {
     }
 
     const rows = Array.isArray(data) ? data : [];
+    /**
+     * `total` is a snapshot of the count returned alongside this page of rows.
+     * Because the count and the page data are read together (not in a single
+     * serializable transaction), concurrent writes can shift it, so `has_more`
+     * is best-effort rather than exact.
+     */
     const total = rows.length > 0 ? Number(rows[0].total_count) : 0;
 
-    // Strip total_count from each row before sending to client
     const servers = rows.map(
       ({ total_count: _, ...rest }: Record<string, unknown>) => rest,
     );

--- a/apps/kbve/edge/functions/discordsh/server.ts
+++ b/apps/kbve/edge/functions/discordsh/server.ts
@@ -7,6 +7,10 @@ import {
 } from "./_shared.ts";
 import { SubmitServerRequestSchema } from "./validate.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import {
+  claimIdempotencyKey,
+  readIdempotencyKey,
+} from "../_shared/idempotency.ts";
 
 // ---------------------------------------------------------------------------
 // Discordsh Server Module
@@ -18,9 +22,14 @@ import { safeRpcError } from "../_shared/validators.ts";
 type Handler = (req: DiscordshRequest) => Promise<Response>;
 
 const handlers: Record<string, Handler> = {
-  async submit({ claims, token, body }) {
+  async submit({ claims, token, body, req }) {
     const denied = requireUserToken(claims);
     if (denied) return denied;
+
+    const idkey = readIdempotencyKey(req, body);
+    if (idkey && !claimIdempotencyKey("discordsh.server", idkey)) {
+      return jsonResponse({ success: false, error: "duplicate request" }, 409);
+    }
 
     // --- Zod validation (mirrors client-side SubmitServerRequestSchema) ---
     const parsed = SubmitServerRequestSchema.omit({

--- a/apps/kbve/edge/functions/discordsh/vote.ts
+++ b/apps/kbve/edge/functions/discordsh/vote.ts
@@ -7,6 +7,10 @@ import {
   verifyCaptcha,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import {
+  claimIdempotencyKey,
+  readIdempotencyKey,
+} from "../_shared/idempotency.ts";
 
 // ---------------------------------------------------------------------------
 // Discordsh Vote Module
@@ -18,9 +22,14 @@ import { safeRpcError } from "../_shared/validators.ts";
 type Handler = (req: DiscordshRequest) => Promise<Response>;
 
 const handlers: Record<string, Handler> = {
-  async cast({ claims, token, body }) {
+  async cast({ claims, token, body, req }) {
     const denied = requireUserToken(claims);
     if (denied) return denied;
+
+    const idkey = readIdempotencyKey(req, body);
+    if (idkey && !claimIdempotencyKey("discordsh.vote", idkey)) {
+      return jsonResponse({ success: false, error: "duplicate request" }, 409);
+    }
 
     const { server_id, captcha_token } = body;
 

--- a/apps/kbve/edge/functions/forum/index.ts
+++ b/apps/kbve/edge/functions/forum/index.ts
@@ -21,7 +21,6 @@ import { handleThread, THREAD_ACTIONS } from "./threads.ts";
 
 loadEnv([
   "SUPABASE_URL",
-  "SUPABASE_ANON_KEY",
   "SUPABASE_SERVICE_ROLE_KEY",
   "JWT_SECRET",
 ]);

--- a/apps/kbve/edge/functions/forum/index.ts
+++ b/apps/kbve/edge/functions/forum/index.ts
@@ -1,5 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { buildHelpText, parseCommand } from "../_shared/routing.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv } from "../_shared/env.ts";
 import {
   enforceBodySizeLimit,
   requireJsonContentType,
@@ -14,6 +18,13 @@ import {
 import { handleSpace, SPACE_ACTIONS } from "./spaces.ts";
 import { handleTag, TAG_ACTIONS } from "./tags.ts";
 import { handleThread, THREAD_ACTIONS } from "./threads.ts";
+
+loadEnv([
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+]);
 
 // ---------------------------------------------------------------------------
 // Forum Edge Function — Read-only public router
@@ -37,77 +48,68 @@ const MODULES: Record<
   thread: { handler: handleThread, actions: THREAD_ACTIONS },
 };
 
-function buildHelpText(): string {
-  const out: string[] = [];
-  for (const [mod, { actions }] of Object.entries(MODULES)) {
-    for (const action of actions) out.push(`${mod}.${action}`);
-  }
-  return out.join(", ");
-}
+const HELP = buildHelpText(MODULES);
 
-serve(async (req) => {
+serve(async (req): Promise<Response> => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return preflight(req);
   }
   if (req.method !== "POST") {
-    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+    return withCors(jsonResponse({ error: "Only POST method is allowed" }, 405), req);
   }
 
-  const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
+  const rl = rateLimit(rateLimitKey("forum", req), {
+    limit: 120,
+    windowMs: 60_000,
+  });
+  if (rl) return withCors(rl, req);
 
-  // Verify the JWT but do NOT gate on role — anon, authenticated, and
-  // service_role all may read. The service-role RPC calls happen
-  // internally below.
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return withCors(ctErr, req);
+
   let claims: JwtClaims;
   try {
     const token = extractToken(req);
     claims = await parseJwt(token);
   } catch {
-    return jsonResponse({ error: "Authentication required" }, 401);
+    return withCors(jsonResponse({ error: "Authentication required" }, 401), req);
   }
 
   const sizeErr = enforceBodySizeLimit(req);
-  if (sizeErr) return sizeErr;
+  if (sizeErr) return withCors(sizeErr, req);
 
   let body: Record<string, unknown>;
   try {
     body = await req.json();
   } catch {
-    return jsonResponse({ error: "Invalid JSON body" }, 400);
+    return withCors(jsonResponse({ error: "Invalid JSON body" }, 400), req);
   }
 
-  const command = body.command;
-  if (typeof command !== "string" || !command.includes(".")) {
-    return jsonResponse(
-      {
-        error:
-          `command is required (format: "module.action"). Available: ${buildHelpText()}`,
-      },
-      400,
-    );
-  }
+  const parsed = parseCommand(body.command, HELP);
+  if (parsed instanceof Response) return withCors(parsed, req);
 
-  const dotIndex = command.indexOf(".");
-  const moduleName = command.slice(0, dotIndex);
-  const action = command.slice(dotIndex + 1);
-
-  const mod = MODULES[moduleName];
+  const mod = MODULES[parsed.module];
   if (!mod) {
-    return jsonResponse(
-      {
-        error: `Unknown module: ${moduleName}. Available: ${
-          Object.keys(MODULES).join(", ")
-        }`,
-      },
-      400,
+    return withCors(
+      jsonResponse(
+        {
+          error: `Unknown module: ${parsed.module}. Available: ${
+            Object.keys(MODULES).join(", ")
+          }`,
+        },
+        400,
+      ),
+      req,
     );
   }
 
   try {
-    return await mod.handler({ claims, body, action });
+    return withCors(
+      await mod.handler({ claims, body, action: parsed.action }),
+      req,
+    );
   } catch (err) {
-    console.error("forum error:", err);
-    return jsonResponse({ error: "Internal server error" }, 500);
+    logError("forum", err);
+    return withCors(jsonResponse({ error: "Internal server error" }, 500), req);
   }
 });

--- a/apps/kbve/edge/functions/forum/spaces.ts
+++ b/apps/kbve/edge/functions/forum/spaces.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import {
   createServiceClient,
   type ForumRequest,
@@ -25,7 +26,7 @@ const handlers: Record<string, Handler> = {
       .order("slug", { ascending: true })
       .limit(200);
     if (error) {
-      console.error("forum.space.list error:", error);
+      logError("forum", error, { action: "space.list" });
       return jsonResponse({ error: "spaces lookup failed" }, 502);
     }
     return jsonResponse({ spaces: data ?? [] });
@@ -44,7 +45,7 @@ const handlers: Record<string, Handler> = {
       .eq("status", "active")
       .maybeSingle();
     if (error) {
-      console.error("forum.space.get error:", error);
+      logError("forum", error, { action: "space.get" });
       return jsonResponse({ error: "space lookup failed" }, 502);
     }
     if (!data) return jsonResponse({ error: "space not found" }, 404);

--- a/apps/kbve/edge/functions/forum/tags.ts
+++ b/apps/kbve/edge/functions/forum/tags.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import {
   clampLimit,
   createServiceClient,
@@ -18,7 +19,7 @@ const handlers: Record<string, Handler> = {
       p_limit: limit,
     });
     if (error) {
-      console.error("forum.tag.list error:", error);
+      logError("forum", error, { action: "tag.list" });
       return jsonResponse({ error: "tag list failed" }, 502);
     }
     return jsonResponse({ tags: data ?? [] });
@@ -33,7 +34,7 @@ const handlers: Record<string, Handler> = {
       .schema("forum")
       .rpc("service_get_tag_by_slug", { p_slug: slug as string });
     if (error) {
-      console.error("forum.tag.get error:", error);
+      logError("forum", error, { action: "tag.get" });
       return jsonResponse({ error: "tag lookup failed" }, 502);
     }
     const row = Array.isArray(data) ? data[0] : data;

--- a/apps/kbve/edge/functions/forum/threads.ts
+++ b/apps/kbve/edge/functions/forum/threads.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import {
   clampLimit,
   createServiceClient,
@@ -42,7 +43,7 @@ const handlers: Record<string, Handler> = {
         .eq("status", "active")
         .maybeSingle();
       if (spaceErr) {
-        console.error("forum.thread.list space resolve error:", spaceErr);
+        logError("forum", spaceErr, { action: "thread.list", step: "space resolve" });
         return jsonResponse({ error: "space resolve failed" }, 502);
       }
       if (!spaceRow) return jsonResponse({ error: "space not found" }, 404);
@@ -61,7 +62,7 @@ const handlers: Record<string, Handler> = {
         p_include_nsfw: false,
       });
     if (error) {
-      console.error("forum.thread.list error:", error);
+      logError("forum", error, { action: "thread.list" });
       return jsonResponse({ error: "feed fetch failed" }, 502);
     }
     return jsonResponse({ threads: data ?? [], sort, limit });
@@ -91,7 +92,7 @@ const handlers: Record<string, Handler> = {
       : query.eq("slug", slugOrId)
     ).maybeSingle();
     if (error) {
-      console.error("forum.thread.get error:", error);
+      logError("forum", error, { action: "thread.get" });
       return jsonResponse({ error: "thread lookup failed" }, 502);
     }
     if (!data) return jsonResponse({ error: "thread not found" }, 404);
@@ -109,7 +110,7 @@ const handlers: Record<string, Handler> = {
       .schema("forum")
       .rpc("service_get_thread_tags", { p_thread_id: threadId });
     if (error) {
-      console.error("forum.thread.tags error:", error);
+      logError("forum", error, { action: "thread.tags" });
       return jsonResponse({ error: "thread tags failed" }, 502);
     }
     return jsonResponse({ tags: data ?? [] });

--- a/apps/kbve/edge/functions/guild-vault/_shared.ts
+++ b/apps/kbve/edge/functions/guild-vault/_shared.ts
@@ -9,6 +9,12 @@ export {
 } from "../_shared/supabase.ts";
 
 import { jsonResponse } from "../_shared/supabase.ts";
+import {
+  SERVICE_RE,
+  SNOWFLAKE_RE,
+  TOKEN_NAME_RE,
+  UUID_RE,
+} from "../_shared/formats.ts";
 
 // ---------------------------------------------------------------------------
 // Guild-vault-specific request type
@@ -25,12 +31,6 @@ export interface GuildVaultRequest {
 // ---------------------------------------------------------------------------
 // Validators (guard pattern: return Response on failure, null on success)
 // ---------------------------------------------------------------------------
-
-const SNOWFLAKE_RE = /^\d{17,20}$/;
-const TOKEN_NAME_RE = /^[a-z0-9_-]{3,64}$/;
-const SERVICE_RE = /^[a-z0-9_]{2,32}$/;
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function validateSnowflake(
   id: unknown,

--- a/apps/kbve/edge/functions/guild-vault/index.ts
+++ b/apps/kbve/edge/functions/guild-vault/index.ts
@@ -1,6 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv, validateJwtSecret } from "../_shared/env.ts";
 import {
   extractToken,
   type GuildVaultRequest,
@@ -9,6 +12,14 @@ import {
   requireUserToken,
 } from "./_shared.ts";
 import { handleTokens, TOKEN_ACTIONS } from "./tokens.ts";
+
+loadEnv([
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+]);
+validateJwtSecret(Deno.env.get("JWT_SECRET"));
 
 // ---------------------------------------------------------------------------
 // Guild Vault Edge Function — Router
@@ -42,11 +53,7 @@ function buildHelpText(): string {
   return commands.join(", ");
 }
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
+async function handleRequest(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return jsonResponse({ error: "Only POST method is allowed" }, 405);
   }
@@ -58,7 +65,6 @@ serve(async (req) => {
     const token = extractToken(req);
     const claims = await parseJwt(token);
 
-    // Guild vault: authenticated users only (no service_role)
     const denied = requireUserToken(claims);
     if (denied) return denied;
 
@@ -66,6 +72,12 @@ serve(async (req) => {
     if (!sub || typeof sub !== "string") {
       return jsonResponse({ error: "JWT is missing sub claim" }, 401);
     }
+
+    const rl = rateLimit(
+      rateLimitKey("guild-vault", req, sub),
+      { limit: 60, windowMs: 60_000 },
+    );
+    if (rl) return rl;
 
     const sizeErr = enforceBodySizeLimit(req);
     if (sizeErr) return sizeErr;
@@ -117,7 +129,7 @@ serve(async (req) => {
       userId: sub,
     });
   } catch (err) {
-    console.error("guild-vault error:", err);
+    logError("guild-vault", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
@@ -128,4 +140,11 @@ serve(async (req) => {
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }
+}
+
+serve(async (req): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return preflight(req);
+  }
+  return withCors(await handleRequest(req), req);
 });

--- a/apps/kbve/edge/functions/guild-vault/index.ts
+++ b/apps/kbve/edge/functions/guild-vault/index.ts
@@ -13,13 +13,12 @@ import {
 } from "./_shared.ts";
 import { handleTokens, TOKEN_ACTIONS } from "./tokens.ts";
 
-loadEnv([
+const env = loadEnv([
   "SUPABASE_URL",
-  "SUPABASE_ANON_KEY",
   "SUPABASE_SERVICE_ROLE_KEY",
   "JWT_SECRET",
 ]);
-validateJwtSecret(Deno.env.get("JWT_SECRET"));
+validateJwtSecret(env.JWT_SECRET);
 
 // ---------------------------------------------------------------------------
 // Guild Vault Edge Function — Router

--- a/apps/kbve/edge/functions/irc/_shared.ts
+++ b/apps/kbve/edge/functions/irc/_shared.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import {
   extractToken,
   jsonResponse,
@@ -42,7 +43,7 @@ export async function requireStaffOrAdmin(
     // staff_permissions returns an integer bitmask; non-zero = staff
     if (typeof data === "number" && data > 0) return null;
   } catch (err) {
-    console.error("staff check failed:", err);
+    logError("irc", err, { step: "staff check" });
   }
 
   return jsonResponse({ error: "Access denied: staff or service_role required" }, 403);

--- a/apps/kbve/edge/functions/irc/channel.ts
+++ b/apps/kbve/edge/functions/irc/channel.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import { jsonResponse, withIrcConnection } from "./_shared.ts";
 import type { IrcRequest } from "./_shared.ts";
 
@@ -32,7 +33,7 @@ export async function handleChannel(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ channels });
       } catch (err) {
-        console.error("irc channel.list error:", err);
+        logError("irc", err, { action: "channel.list" });
         return jsonResponse(
           { error: "Failed to list channels — Ergo unreachable" },
           503,
@@ -71,7 +72,7 @@ export async function handleChannel(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ channel: safeChan, topic: topic ?? "(no topic set)" });
       } catch (err) {
-        console.error("irc channel.topic error:", err);
+        logError("irc", err, { action: "channel.topic" });
         return jsonResponse(
           { error: "Failed to get topic — Ergo unreachable" },
           503,
@@ -112,7 +113,7 @@ export async function handleChannel(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ channel: safeChan, names });
       } catch (err) {
-        console.error("irc channel.names error:", err);
+        logError("irc", err, { action: "channel.names" });
         return jsonResponse(
           { error: "Failed to get names — Ergo unreachable" },
           503,

--- a/apps/kbve/edge/functions/irc/index.ts
+++ b/apps/kbve/edge/functions/irc/index.ts
@@ -1,5 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { buildHelpText, parseCommand } from "../_shared/routing.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv } from "../_shared/env.ts";
 import {
   requireJsonContentType,
   enforceBodySizeLimit,
@@ -14,6 +18,12 @@ import {
 import { CHANNEL_ACTIONS, handleChannel } from "./channel.ts";
 import { MESSAGE_ACTIONS, handleMessage } from "./message.ts";
 import { SERVER_ACTIONS, handleServer } from "./server.ts";
+
+loadEnv([
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+]);
 
 // ---------------------------------------------------------------------------
 // IRC Edge Function — Admin Router
@@ -39,85 +49,68 @@ const MODULES: Record<
   message: { handler: handleMessage, actions: MESSAGE_ACTIONS },
 };
 
-function buildHelpText(): string {
-  const commands: string[] = [];
-  for (const [mod, { actions }] of Object.entries(MODULES)) {
-    for (const action of actions) {
-      commands.push(`${mod}.${action}`);
-    }
-  }
-  return commands.join(", ");
-}
+const HELP = buildHelpText(MODULES);
 
-serve(async (req) => {
+serve(async (req): Promise<Response> => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return preflight(req);
   }
 
   if (req.method !== "POST") {
-    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+    return withCors(jsonResponse({ error: "Only POST method is allowed" }, 405), req);
   }
 
+  const rl = rateLimit(rateLimitKey("irc", req), {
+    limit: 120,
+    windowMs: 60_000,
+  });
+  if (rl) return withCors(rl, req);
+
   const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
+  if (ctErr) return withCors(ctErr, req);
 
   try {
     const token = extractToken(req);
     const claims = await parseJwt(token);
 
-    // Gate: service_role or staff only
     const accessErr = await requireStaffOrAdmin(claims, token);
-    if (accessErr) return accessErr;
+    if (accessErr) return withCors(accessErr, req);
 
     const sizeErr = enforceBodySizeLimit(req);
-    if (sizeErr) return sizeErr;
+    if (sizeErr) return withCors(sizeErr, req);
 
     const body = await req.json();
-    const { command } = body;
 
-    if (!command || typeof command !== "string") {
-      return jsonResponse(
-        {
-          error: `command is required (format: "module.action"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
+    const parsed = parseCommand(body.command, HELP);
+    if (parsed instanceof Response) return withCors(parsed, req);
 
-    const dotIndex = command.indexOf(".");
-    if (dotIndex === -1) {
-      return jsonResponse(
-        {
-          error: `Invalid command format. Use "module.action". Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
-
-    const moduleName = command.slice(0, dotIndex);
-    const action = command.slice(dotIndex + 1);
-
-    const mod = MODULES[moduleName];
+    const mod = MODULES[parsed.module];
     if (!mod) {
-      return jsonResponse(
-        {
-          error: `Unknown module: ${moduleName}. Available: ${Object.keys(MODULES).join(", ")}`,
-        },
-        400,
+      return withCors(
+        jsonResponse(
+          {
+            error: `Unknown module: ${parsed.module}. Available: ${Object.keys(MODULES).join(", ")}`,
+          },
+          400,
+        ),
+        req,
       );
     }
 
-    return mod.handler({ token, claims, body, action });
+    return withCors(
+      await mod.handler({ token, claims, body, action: parsed.action }),
+      req,
+    );
   } catch (err) {
-    console.error("irc error:", err);
+    logError("irc", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: "Unauthorized" }, 401);
+      return withCors(jsonResponse({ error: "Unauthorized" }, 401), req);
     }
-    return jsonResponse({ error: "Internal server error" }, 500);
+    return withCors(jsonResponse({ error: "Internal server error" }, 500), req);
   }
 });

--- a/apps/kbve/edge/functions/irc/message.ts
+++ b/apps/kbve/edge/functions/irc/message.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import { jsonResponse, withIrcConnection } from "./_shared.ts";
 import type { IrcRequest } from "./_shared.ts";
 
@@ -53,7 +54,7 @@ export async function handleMessage(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ ok: true, channel: safeChan });
       } catch (err) {
-        console.error("irc message.send error:", err);
+        logError("irc", err, { action: "message.send" });
         return jsonResponse(
           { error: "Failed to send message — Ergo unreachable" },
           503,
@@ -113,7 +114,7 @@ export async function handleMessage(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ channel: safeChan, messages });
       } catch (err) {
-        console.error("irc message.history error:", err);
+        logError("irc", err, { action: "message.history" });
         return jsonResponse(
           { error: "Failed to get history — Ergo unreachable" },
           503,

--- a/apps/kbve/edge/functions/irc/server.ts
+++ b/apps/kbve/edge/functions/irc/server.ts
@@ -1,3 +1,4 @@
+import { logError } from "../_shared/logging.ts";
 import { jsonResponse, withIrcConnection } from "./_shared.ts";
 import type { IrcRequest } from "./_shared.ts";
 
@@ -28,7 +29,7 @@ export async function handleServer(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ status: "connected", info });
       } catch (err) {
-        console.error("irc server.status error:", err);
+        logError("irc", err, { action: "server.status" });
         return jsonResponse(
           { status: "unreachable", error: "Ergo IRC server is not reachable" },
           503,
@@ -52,7 +53,7 @@ export async function handleServer(req: IrcRequest): Promise<Response> {
         });
         return jsonResponse({ motd });
       } catch (err) {
-        console.error("irc server.motd error:", err);
+        logError("irc", err, { action: "server.motd" });
         return jsonResponse(
           { error: "Failed to retrieve MOTD — Ergo unreachable" },
           503,

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -6,7 +6,11 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 // `npm:` resolves through Deno's own npm cache, no third-party CDN in the
 // boot path.
 import { createClient } from "@clickhouse/client-web";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv } from "../_shared/env.ts";
+import { PAGINATION } from "../_shared/constants.ts";
 import {
   extractToken,
   jsonResponse,
@@ -25,15 +29,19 @@ import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validat
 //   stats   — namespace/service counts
 // ---------------------------------------------------------------------------
 
-const MAX_LIMIT = 500;
-const DEFAULT_LIMIT = 100;
 const MAX_MINUTES = 10080; // 7 days
 const MAX_SEARCH_LENGTH = 100;
 
+const env = loadEnv([
+  "CLICKHOUSE_ENDPOINT",
+  "CLICKHOUSE_USER",
+  "CLICKHOUSE_PASSWORD",
+]);
+
 const ch = createClient({
-  url: Deno.env.get("CLICKHOUSE_ENDPOINT") ?? "",
-  username: Deno.env.get("CLICKHOUSE_USER") ?? "",
-  password: Deno.env.get("CLICKHOUSE_PASSWORD") ?? "",
+  url: env.CLICKHOUSE_ENDPOINT,
+  username: env.CLICKHOUSE_USER,
+  password: env.CLICKHOUSE_PASSWORD,
   database: "observability",
 });
 
@@ -47,7 +55,7 @@ interface QueryParams {
   limit?: number;
 }
 
-async function handleQuery(params: QueryParams) {
+async function handleQuery(params: QueryParams): Promise<{ rows: unknown[]; count: number }> {
   const conditions: string[] = [];
   const queryParams: Record<string, unknown> = {};
 
@@ -83,8 +91,8 @@ async function handleQuery(params: QueryParams) {
   }
 
   const limit = Math.min(
-    Math.max(params.limit ?? DEFAULT_LIMIT, 1),
-    MAX_LIMIT,
+    Math.max(params.limit ?? PAGINATION.logs.defaultLimit, 1),
+    PAGINATION.logs.maxLimit,
   );
 
   const where =
@@ -107,7 +115,7 @@ async function handleQuery(params: QueryParams) {
   return { rows, count: rows.length };
 }
 
-async function handleStats(params: { minutes?: number }) {
+async function handleStats(params: { minutes?: number }): Promise<{ rows: unknown[]; count: number }> {
   const minutes = Math.min(Math.max(params.minutes ?? 60, 1), MAX_MINUTES);
 
   const resultSet = await ch.query({
@@ -127,11 +135,7 @@ async function handleStats(params: { minutes?: number }) {
   return { rows, count: rows.length };
 }
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
+async function handle(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return jsonResponse({ error: "Only POST method is allowed" }, 405);
   }
@@ -145,6 +149,12 @@ serve(async (req) => {
 
     const denied = requireServiceRole(claims);
     if (denied) return denied;
+
+    const rl = rateLimit(
+      rateLimitKey("logs", req, claims.sub as string | undefined),
+      { limit: 60, windowMs: 60_000 },
+    );
+    if (rl) return rl;
 
     const sizeErr = enforceBodySizeLimit(req);
     if (sizeErr) return sizeErr;
@@ -177,7 +187,7 @@ serve(async (req) => {
 
     return jsonResponse(result);
   } catch (err) {
-    console.error("logs error:", err);
+    logError("logs", err);
     const rawMessage =
       err instanceof Error ? err.message : "Internal server error";
     const isAuthError =
@@ -187,4 +197,11 @@ serve(async (req) => {
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }
+}
+
+serve(async (req): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return preflight(req);
+  }
+  return withCors(await handle(req), req);
 });

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -1,11 +1,17 @@
 /// <reference path="../types.d.ts" />
 import { serve } from "https://deno.land/std@0.131.0/http/server.ts";
 import * as jose from "https://deno.land/x/jose@v4.14.4/index.ts";
+import { validateJwtSecret } from "../_shared/env.ts";
+import { logError, logInfo } from "../_shared/logging.ts";
 
-console.log("main function started");
+logInfo("main", { event: "function_started" });
 
-const JWT_SECRET = Deno.env.get("JWT_SECRET");
 const VERIFY_JWT = Deno.env.get("VERIFY_JWT") === "true";
+// Validate JWT secret strength at boot when verification is enabled, so a
+// weak/missing secret fails fast instead of surfacing as a runtime 401.
+const JWT_SECRET = VERIFY_JWT
+  ? validateJwtSecret(Deno.env.get("JWT_SECRET"))
+  : Deno.env.get("JWT_SECRET");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const PUBLIC_ROUTES = new Set(["health", "gh-webhook"]);
@@ -50,7 +56,7 @@ async function verifyJWT(jwt: string): Promise<boolean> {
   try {
     await jose.jwtVerify(jwt, secretKey);
   } catch (err) {
-    console.error(err);
+    logError("main.verifyJWT", err);
     return false;
   }
   return true;
@@ -74,7 +80,7 @@ serve(async (req: Request) => {
         });
       }
     } catch (e) {
-      console.error(e);
+      logError("main.auth", e);
       return new Response(
         JSON.stringify({ msg: "Authentication failed" }),
         {
@@ -129,7 +135,7 @@ serve(async (req: Request) => {
         }
       }
     } catch (e) {
-      console.error("Staff gate error:", e);
+      logError("main.staffGate", e);
       return new Response(
         JSON.stringify({ msg: "Access denied" }),
         {
@@ -141,7 +147,7 @@ serve(async (req: Request) => {
   }
 
   const servicePath = `/home/deno/functions/${service_name}`;
-  console.error(`serving the request with ${servicePath}`);
+  logInfo("main.dispatch", { service: service_name });
 
   const memoryLimitMb = 150;
   const workerTimeoutMs = 1 * 60 * 1000;
@@ -192,7 +198,7 @@ serve(async (req: Request) => {
     });
     return await worker.fetch(req);
   } catch (e) {
-    console.error("Worker error:", e);
+    logError("main.worker", e, { service: service_name });
     return new Response(
       JSON.stringify({ msg: "Internal server error" }),
       {

--- a/apps/kbve/edge/functions/mc/_shared.ts
+++ b/apps/kbve/edge/functions/mc/_shared.ts
@@ -14,6 +14,7 @@ export {
 } from "../_shared/supabase.ts";
 
 import { jsonResponse } from "../_shared/supabase.ts";
+import { MC_UUID_RE } from "../_shared/formats.ts";
 
 // MC-specific request type
 export interface McRequest {
@@ -22,9 +23,6 @@ export interface McRequest {
   body: Record<string, unknown>;
   action: string;
 }
-
-// MC UUID format: 32 lowercase hex characters (no dashes), matches SQL CHECK
-const MC_UUID_RE = /^[a-f0-9]{32}$/;
 
 export function isValidMcUuid(uuid: unknown): boolean {
   return typeof uuid === "string" && MC_UUID_RE.test(uuid);

--- a/apps/kbve/edge/functions/mc/admin.ts
+++ b/apps/kbve/edge/functions/mc/admin.ts
@@ -6,6 +6,7 @@ import {
   requireStaffOrServiceRole,
   staffPerm,
 } from "./_shared.ts";
+import { logError } from "../_shared/logging.ts";
 
 // ---------------------------------------------------------------------------
 // MC Admin Module — Staff-gated RCON execution
@@ -267,7 +268,7 @@ const handlers: Record<string, Handler> = {
         response: response || "(no output)",
       });
     } catch (err) {
-      console.error("RCON error:", err);
+      logError("mc.admin", err);
       const msg = err instanceof Error ? err.message : "RCON connection failed";
       return jsonResponse({ error: msg }, 502);
     }
@@ -316,7 +317,7 @@ const handlers: Record<string, Handler> = {
       const response = await rconExecute(config, mcCommand);
       return jsonResponse({ success: true, server, command: mcCommand, response: response || "(no output)" });
     } catch (err) {
-      console.error("RCON error:", err);
+      logError("mc.admin", err);
       const msg = err instanceof Error ? err.message : "RCON connection failed";
       return jsonResponse({ error: msg }, 502);
     }
@@ -371,7 +372,7 @@ const handlers: Record<string, Handler> = {
       const response = await rconExecute(config, mcCommand);
       return jsonResponse({ success: true, server, command: mcCommand, response: response || "(no output)" });
     } catch (err) {
-      console.error("RCON error:", err);
+      logError("mc.admin", err);
       const msg = err instanceof Error ? err.message : "RCON connection failed";
       return jsonResponse({ error: msg }, 502);
     }
@@ -411,7 +412,7 @@ const handlers: Record<string, Handler> = {
       const response = await rconExecute(config, mcCommand);
       return jsonResponse({ success: true, server, command: mcCommand, response: response || "(no output)" });
     } catch (err) {
-      console.error("RCON error:", err);
+      logError("mc.admin", err);
       const msg = err instanceof Error ? err.message : "RCON connection failed";
       return jsonResponse({ error: msg }, 502);
     }

--- a/apps/kbve/edge/functions/mc/container.ts
+++ b/apps/kbve/edge/functions/mc/container.ts
@@ -6,6 +6,11 @@ import {
   requireServiceRole,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import {
+  CONTAINER_TYPE_MAX,
+  CONTAINER_TYPE_MIN,
+  ContainerType,
+} from "../_shared/constants.ts";
 
 // ---------------------------------------------------------------------------
 // MC Container Module
@@ -13,6 +18,10 @@ import { safeRpcError } from "../_shared/validators.ts";
 // Actions:
 //   save  — MC server persists container state (chests, barrels, etc.)
 //   load  — MC server loads container state by ID + server
+//
+// Container `type` is a ContainerType enum value
+// (Chest=0 … Other=13); inputs outside [CONTAINER_TYPE_MIN, CONTAINER_TYPE_MAX]
+// are rejected.
 // ---------------------------------------------------------------------------
 
 type Handler = (mcReq: McRequest) => Promise<Response>;
@@ -34,12 +43,20 @@ const handlers: Record<string, Handler> = {
     const cidErr = requireNonEmpty(c.container_id, "container_id");
     if (cidErr) return cidErr;
 
-    // Validate container_type range if provided
     if (c.type !== undefined) {
       const t = Number(c.type);
-      if (!Number.isInteger(t) || t < 0 || t > 13) {
+      if (
+        !Number.isInteger(t) ||
+        t < CONTAINER_TYPE_MIN ||
+        t > CONTAINER_TYPE_MAX
+      ) {
         return jsonResponse(
-          { error: "container type must be 0-13" },
+          {
+            error:
+              `container type must be a ContainerType value ${CONTAINER_TYPE_MIN}-${CONTAINER_TYPE_MAX} (${
+                ContainerType[CONTAINER_TYPE_MIN]
+              }..${ContainerType[CONTAINER_TYPE_MAX]})`,
+          },
           400,
         );
       }

--- a/apps/kbve/edge/functions/mc/index.ts
+++ b/apps/kbve/edge/functions/mc/index.ts
@@ -1,5 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
+import { buildHelpText, parseCommand } from "../_shared/routing.ts";
+import { logError } from "../_shared/logging.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
 import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
 import { AUTH_ACTIONS, handleAuth } from "./auth.ts";
@@ -42,84 +44,62 @@ const MODULES: Record<
   mojang: { handler: handleMojang, actions: MOJANG_ACTIONS },
 };
 
-function buildHelpText(): string {
-  const commands: string[] = [];
-  for (const [mod, { actions }] of Object.entries(MODULES)) {
-    for (const action of actions) {
-      commands.push(`${mod}.${action}`);
-    }
-  }
-  return commands.join(", ");
-}
-
 serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return preflight(req);
   }
 
   if (req.method !== "POST") {
-    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+    return withCors(jsonResponse({ error: "Only POST method is allowed" }, 405), req);
   }
 
   const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
+  if (ctErr) return withCors(ctErr, req);
 
   try {
     const token = extractToken(req);
     const claims = await parseJwt(token);
     const sizeErr = enforceBodySizeLimit(req);
-    if (sizeErr) return sizeErr;
+    if (sizeErr) return withCors(sizeErr, req);
 
     const body = await req.json();
     const { command } = body;
 
-    if (!command || typeof command !== "string") {
-      return jsonResponse(
-        {
-          error:
-            `command is required (format: "module.action"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
+    const parsed = parseCommand(command, buildHelpText(MODULES));
+    if (parsed instanceof Response) return withCors(parsed, req);
 
-    const dotIndex = command.indexOf(".");
-    if (dotIndex === -1) {
-      return jsonResponse(
-        {
-          error:
-            `Invalid command format. Use "module.action" (e.g. "auth.request_link"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
-
-    const moduleName = command.slice(0, dotIndex);
-    const action = command.slice(dotIndex + 1);
-
-    const mod = MODULES[moduleName];
+    const mod = MODULES[parsed.module];
     if (!mod) {
-      return jsonResponse(
-        {
-          error: `Unknown module: ${moduleName}. Available modules: ${
-            Object.keys(MODULES).join(", ")
-          }`,
-        },
-        400,
+      return withCors(
+        jsonResponse(
+          {
+            error: `Unknown module: ${parsed.module}. Available modules: ${
+              Object.keys(MODULES).join(", ")
+            }`,
+          },
+          400,
+        ),
+        req,
       );
     }
 
-    return mod.handler({ token, claims, body, action });
+    const res = await mod.handler({
+      token,
+      claims,
+      body,
+      action: parsed.action,
+    });
+    return withCors(res, req);
   } catch (err) {
-    console.error("mc error:", err);
+    logError("mc", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: "Unauthorized" }, 401);
+      return withCors(jsonResponse({ error: "Unauthorized" }, 401), req);
     }
-    return jsonResponse({ error: "Internal server error" }, 500);
+    return withCors(jsonResponse({ error: "Internal server error" }, 500), req);
   }
 });

--- a/apps/kbve/edge/functions/mc/skill.ts
+++ b/apps/kbve/edge/functions/mc/skill.ts
@@ -7,6 +7,7 @@ import {
   validateMcUuid,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import { VALID_SKILL_CATEGORIES } from "../_shared/constants.ts";
 
 // ---------------------------------------------------------------------------
 // MC Skill Module — Per-skill progression (skill tree)
@@ -15,12 +16,13 @@ import { safeRpcError } from "../_shared/validators.ts";
 //   save    — MC server persists a full skill tree (bulk upsert)
 //   load    — MC server loads all skills for a player on a server
 //   add_xp  — MC server atomically adds XP to a specific skill
+//
+// `category` is a SkillCategory enum value
+// (General=0, Combat=1, Gathering=2, Crafting=3, Magic=4); only the values in
+// VALID_SKILL_CATEGORIES are accepted.
 // ---------------------------------------------------------------------------
 
 type Handler = (mcReq: McRequest) => Promise<Response>;
-
-// Valid skill categories (McSkillCategory enum)
-const VALID_CATEGORIES = [0, 1, 2, 3, 4];
 
 // Edge-level skill_id format validation
 function isValidSkillId(id: unknown): boolean {
@@ -78,7 +80,7 @@ const handlers: Record<string, Handler> = {
       }
       if (
         s.category !== undefined &&
-        !VALID_CATEGORIES.includes(Number(s.category))
+        !VALID_SKILL_CATEGORIES.includes(Number(s.category))
       ) {
         return jsonResponse(
           {
@@ -165,7 +167,7 @@ const handlers: Record<string, Handler> = {
 
     if (
       category !== undefined &&
-      !VALID_CATEGORIES.includes(Number(category))
+      !VALID_SKILL_CATEGORIES.includes(Number(category))
     ) {
       return jsonResponse({ error: "category must be 0-4" }, 400);
     }

--- a/apps/kbve/edge/functions/mc/transfer.ts
+++ b/apps/kbve/edge/functions/mc/transfer.ts
@@ -6,6 +6,8 @@ import {
   validateMcUuid,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
+import { PAGINATION } from "../_shared/constants.ts";
+import { clampLimit, clampOffset } from "../_shared/pagination.ts";
 
 // ---------------------------------------------------------------------------
 // MC Transfer Module
@@ -28,12 +30,18 @@ const handlers: Record<string, Handler> = {
     }
 
     if (batch.length === 0) {
-      return jsonResponse({ success: true, recorded_count: 0 });
+      return jsonResponse(
+        { success: false, error: "batch must not be empty", recorded_count: 0 },
+        400,
+      );
     }
 
-    if (batch.length > 1000) {
+    if (batch.length > PAGINATION.transfer.maxBatch) {
       return jsonResponse(
-        { error: "Batch size exceeds limit of 1000 transfers" },
+        {
+          error:
+            `Batch size exceeds limit of ${PAGINATION.transfer.maxBatch} transfers`,
+        },
         400,
       );
     }
@@ -58,12 +66,11 @@ const handlers: Record<string, Handler> = {
     const uuidErr = validateMcUuid(player_uuid, "player_uuid");
     if (uuidErr) return uuidErr;
 
-    // Clamp pagination parameters at edge (mirrors SQL clamping)
-    const rawLimit = Number(body.limit) || 50;
-    const limit = Math.min(Math.max(rawLimit, 1), 500);
-
-    const rawOffset = Number(body.offset) || 0;
-    const offset = Math.max(rawOffset, 0);
+    const limit = clampLimit(body.limit, {
+      def: PAGINATION.transfer.defaultLimit,
+      max: PAGINATION.transfer.maxLimit,
+    });
+    const offset = clampOffset(body.offset);
 
     const supabase = createServiceClient();
     const { data, error } = await supabase.schema("mc").rpc(

--- a/apps/kbve/edge/functions/meme/_shared.ts
+++ b/apps/kbve/edge/functions/meme/_shared.ts
@@ -13,6 +13,15 @@ export {
 import { jsonResponse } from "../_shared/supabase.ts";
 import type { JwtClaims } from "../_shared/supabase.ts";
 import { rejectIllegalChars } from "../_shared/validators.ts";
+import { TAG_RE, ULID_RE, UUID_RE } from "../_shared/formats.ts";
+import { validateLimit as sharedValidateLimit } from "../_shared/pagination.ts";
+import {
+  PAGINATION,
+  REACTION_MAX,
+  REACTION_MIN,
+  REPORT_REASON_MAX,
+  REPORT_REASON_MIN,
+} from "../_shared/constants.ts";
 
 // Meme-specific request type
 export interface MemeRequest {
@@ -21,9 +30,6 @@ export interface MemeRequest {
   body: Record<string, unknown>;
   action: string;
 }
-
-// ULID format: 26 Crockford Base32 characters
-const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
 export function validateMemeId(
   id: unknown,
@@ -51,11 +57,14 @@ export function validateReaction(reaction: unknown): Response | null {
     reaction === null ||
     !Number.isFinite(num) ||
     !Number.isInteger(num) ||
-    num < 1 ||
-    num > 6
+    num < REACTION_MIN ||
+    num > REACTION_MAX
   ) {
     return jsonResponse(
-      { error: "reaction must be an integer between 1 and 6" },
+      {
+        error:
+          `reaction must be an integer between ${REACTION_MIN} and ${REACTION_MAX}`,
+      },
       400,
     );
   }
@@ -63,8 +72,6 @@ export function validateReaction(reaction: unknown): Response | null {
 }
 
 // Tag validation: lowercase slug-safe, 1-50 chars
-const TAG_RE = /^[a-z0-9][a-z0-9_-]*$/;
-
 export function validateTag(tag: unknown): Response | null {
   if (tag === undefined || tag === null) return null;
   if (typeof tag !== "string" || tag.length < 1 || tag.length > 50) {
@@ -134,9 +141,6 @@ export function extractUserId(
 }
 
 // UUID format validation
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 export function validateUserId(
   id: unknown,
   field = "user_id",
@@ -175,11 +179,14 @@ export function validateReportReason(reason: unknown): Response | null {
     reason === null ||
     !Number.isFinite(num) ||
     !Number.isInteger(num) ||
-    num < 1 ||
-    num > 7
+    num < REPORT_REASON_MIN ||
+    num > REPORT_REASON_MAX
   ) {
     return jsonResponse(
-      { error: "reason must be an integer between 1 and 7" },
+      {
+        error:
+          `reason must be an integer between ${REPORT_REASON_MIN} and ${REPORT_REASON_MAX}`,
+      },
       400,
     );
   }
@@ -205,20 +212,10 @@ export function validateLimit(limit: unknown): {
   value: number;
   error: Response | null;
 } {
-  if (limit === undefined || limit === null) {
-    return { value: 20, error: null };
-  }
-  const num = Number(limit);
-  if (!Number.isInteger(num) || num < 1 || num > 50) {
-    return {
-      value: 20,
-      error: jsonResponse(
-        { error: "limit must be an integer between 1 and 50" },
-        400,
-      ),
-    };
-  }
-  return { value: num, error: null };
+  return sharedValidateLimit(limit, {
+    def: PAGINATION.meme.defaultLimit,
+    max: PAGINATION.meme.maxLimit,
+  });
 }
 
 // Pagination cursor: optional ULID

--- a/apps/kbve/edge/functions/meme/feed.ts
+++ b/apps/kbve/edge/functions/meme/feed.ts
@@ -2,6 +2,7 @@ import {
   createServiceClient,
   jsonResponse,
   type MemeRequest,
+  validateLimit,
   validateMemeId,
   validateTag,
 } from "./_shared.ts";
@@ -24,18 +25,8 @@ const handlers: Record<string, Handler> = {
 
     const { limit, cursor, tag } = body;
 
-    // Validate limit
-    let safeLimit = 20;
-    if (limit !== undefined) {
-      const num = Number(limit);
-      if (!Number.isInteger(num) || num < 1 || num > 50) {
-        return jsonResponse(
-          { error: "limit must be an integer between 1 and 50" },
-          400,
-        );
-      }
-      safeLimit = num;
-    }
+    const { value: safeLimit, error: limitErr } = validateLimit(limit);
+    if (limitErr) return limitErr;
 
     // Validate cursor (optional ULID)
     if (cursor !== undefined && cursor !== null) {

--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
+import { buildHelpText, parseCommand } from "../_shared/routing.ts";
+import { logError } from "../_shared/logging.ts";
 import {
   extractToken,
   jsonResponse,
@@ -51,27 +53,20 @@ const MODULES: Record<
   admin: { handler: handleAdmin, actions: ADMIN_ACTIONS },
 };
 
-function buildHelpText(): string {
-  const commands: string[] = [];
-  for (const [mod, { actions }] of Object.entries(MODULES)) {
-    for (const action of actions) {
-      commands.push(`${mod}.${action}`);
-    }
-  }
-  return commands.join(", ");
-}
-
 serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return preflight(req);
   }
 
   if (req.method !== "POST") {
-    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+    return withCors(
+      jsonResponse({ error: "Only POST method is allowed" }, 405),
+      req,
+    );
   }
 
   const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
+  if (ctErr) return withCors(ctErr, req);
 
   try {
     // All access requires service_role — axum gateway handles user auth
@@ -82,69 +77,63 @@ serve(async (req) => {
       token = extractToken(req);
       claims = await parseJwt(token);
     } catch {
-      return jsonResponse({ error: "Authentication required" }, 401);
+      return withCors(
+        jsonResponse({ error: "Authentication required" }, 401),
+        req,
+      );
     }
 
     if (claims.role !== "service_role") {
-      return jsonResponse(
-        { error: "Forbidden: service_role required. Use the API gateway." },
-        403,
+      return withCors(
+        jsonResponse(
+          { error: "Forbidden: service_role required. Use the API gateway." },
+          403,
+        ),
+        req,
       );
     }
 
     const sizeErr = enforceBodySizeLimit(req);
-    if (sizeErr) return sizeErr;
+    if (sizeErr) return withCors(sizeErr, req);
 
     const body = await req.json();
     const { command } = body;
 
-    if (!command || typeof command !== "string") {
-      return jsonResponse(
-        {
-          error:
-            `command is required (format: "module.action"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
+    const help = buildHelpText(MODULES);
+    const parsed = parseCommand(command, help);
+    if (parsed instanceof Response) return withCors(parsed, req);
 
-    const dotIndex = command.indexOf(".");
-    if (dotIndex === -1) {
-      return jsonResponse(
-        {
-          error:
-            `Invalid command format. Use "module.action" (e.g. "feed.list"). Available: ${buildHelpText()}`,
-        },
-        400,
-      );
-    }
-
-    const moduleName = command.slice(0, dotIndex);
-    const action = command.slice(dotIndex + 1);
+    const { module: moduleName, action } = parsed;
 
     const mod = MODULES[moduleName];
     if (!mod) {
-      return jsonResponse(
-        {
-          error: `Unknown module: ${moduleName}. Available modules: ${
-            Object.keys(MODULES).join(", ")
-          }`,
-        },
-        400,
+      return withCors(
+        jsonResponse(
+          {
+            error: `Unknown module: ${moduleName}. Available modules: ${
+              Object.keys(MODULES).join(", ")
+            }`,
+          },
+          400,
+        ),
+        req,
       );
     }
 
-    return mod.handler({ token, claims, body, action });
+    return withCors(await mod.handler({ token, claims, body, action }), req);
   } catch (err) {
-    console.error("meme error:", err);
+    logError("meme", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: "Unauthorized" }, 401);
+      return withCors(jsonResponse({ error: "Unauthorized" }, 401), req);
     }
-    return jsonResponse({ error: "Internal server error" }, 500);
+    return withCors(
+      jsonResponse({ error: "Internal server error" }, 500),
+      req,
+    );
   }
 });

--- a/apps/kbve/edge/functions/user-vault/index.ts
+++ b/apps/kbve/edge/functions/user-vault/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { preflight, withCors } from "../_shared/cors.ts";
 import {
   extractToken,
   jsonResponse,
@@ -7,7 +7,19 @@ import {
   parseJwt,
 } from "../_shared/supabase.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
+import { UUID_RE } from "../_shared/formats.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv, validateJwtSecret } from "../_shared/env.ts";
 import { handleTokens, TOKEN_ACTIONS } from "./tokens.ts";
+
+loadEnv([
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+]);
+validateJwtSecret(Deno.env.get("JWT_SECRET"));
 
 // ---------------------------------------------------------------------------
 // User Vault Edge Function — Unified Router
@@ -46,9 +58,6 @@ function buildHelpText(): string {
   return commands.join(", ");
 }
 
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 function resolveUserId(
   claims: JwtClaims,
   body: Record<string, unknown>,
@@ -81,11 +90,7 @@ function resolveUserId(
   );
 }
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
+async function handleRequest(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return jsonResponse({ error: "Only POST method is allowed" }, 405);
   }
@@ -96,6 +101,13 @@ serve(async (req) => {
   try {
     const token = extractToken(req);
     const claims = await parseJwt(token);
+
+    const rl = rateLimit(
+      rateLimitKey("user-vault", req, claims.sub as string | undefined),
+      { limit: 60, windowMs: 60_000 },
+    );
+    if (rl) return rl;
+
     const sizeErr = enforceBodySizeLimit(req);
     if (sizeErr) return sizeErr;
 
@@ -151,7 +163,7 @@ serve(async (req) => {
       userId: userIdOrError,
     });
   } catch (err) {
-    console.error("user-vault error:", err);
+    logError("user-vault", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";
@@ -162,4 +174,11 @@ serve(async (req) => {
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }
+}
+
+serve(async (req): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return preflight(req);
+  }
+  return withCors(await handleRequest(req), req);
 });

--- a/apps/kbve/edge/functions/user-vault/index.ts
+++ b/apps/kbve/edge/functions/user-vault/index.ts
@@ -13,13 +13,12 @@ import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
 import { loadEnv, validateJwtSecret } from "../_shared/env.ts";
 import { handleTokens, TOKEN_ACTIONS } from "./tokens.ts";
 
-loadEnv([
+const env = loadEnv([
   "SUPABASE_URL",
-  "SUPABASE_ANON_KEY",
   "SUPABASE_SERVICE_ROLE_KEY",
   "JWT_SECRET",
 ]);
-validateJwtSecret(Deno.env.get("JWT_SECRET"));
+validateJwtSecret(env.JWT_SECRET);
 
 // ---------------------------------------------------------------------------
 // User Vault Edge Function — Unified Router

--- a/apps/kbve/edge/functions/vault-reader/index.ts
+++ b/apps/kbve/edge/functions/vault-reader/index.ts
@@ -1,7 +1,10 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { jwtVerify } from "https://deno.land/x/jose@v4.14.4/index.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders, preflight, withCors } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
+import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";
+import { loadEnv, validateJwtSecret } from "../_shared/env.ts";
 import {
   SECRET_NAME_RE,
   MAX_SECRET_VALUE_LENGTH,
@@ -13,20 +16,43 @@ import {
   requireJsonContentType,
 } from "../_shared/validators.ts";
 
-serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
+// ---------------------------------------------------------------------------
+// Vault Reader Edge Function — read/write Supabase Vault secrets
+//
+// Auth: service_role only (verified against JWT_SECRET)
+//
+// POST /vault-reader  { command, ... }
+//   get           — fetch a decrypted secret by UUID
+//   set           — create/update a secret
+//   get_by_guild  — bot-facing guild token lookup
+//   get_by_tag    — alias for get_by_guild, parses "service:server_id" tag
+// ---------------------------------------------------------------------------
 
-  // Only allow POST requests
+const env = loadEnv([
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+]);
+const JWT_SECRET = validateJwtSecret(env.JWT_SECRET);
+
+const supabase = createClient(
+  env.SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  },
+);
+
+const JSON_HEADERS = { ...corsHeaders, "Content-Type": "application/json" };
+
+async function handle(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return new Response(
       JSON.stringify({ error: "Only POST method is allowed" }),
-      {
-        status: 405,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      },
+      { status: 405, headers: JSON_HEADERS },
     );
   }
 
@@ -43,168 +69,85 @@ serve(async (req) => {
     if (!command) {
       return new Response(
         JSON.stringify({ error: "command is required (get or set)" }),
-        {
-          status: 400,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { status: 400, headers: JSON_HEADERS },
       );
     }
 
-    // Create Supabase client with service role key
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey, {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false,
-      },
-    });
-
-    // Security check: Verify JWT token and role
     const authHeader = req.headers.get("authorization");
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return new Response(
         JSON.stringify({ error: "Authorization header required" }),
-        {
-          status: 401,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { status: 401, headers: JSON_HEADERS },
       );
     }
 
     const token = authHeader.replace("Bearer ", "");
 
-    // Get JWT secret from environment
-    const jwtSecret = Deno.env.get("JWT_SECRET");
-    if (!jwtSecret) {
-      console.error("JWT_SECRET not found in environment");
-      return new Response(
-        JSON.stringify({ error: "Server configuration error" }),
-        {
-          status: 500,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
-      );
-    }
-
+    let claims: { role?: string; sub?: string };
     try {
-      // Convert the secret to a proper key format
-      const key = new TextEncoder().encode(jwtSecret);
-
-      // Verify the JWT token
+      const key = new TextEncoder().encode(JWT_SECRET);
       const { payload } = await jwtVerify(token, key, {
         algorithms: ["HS256"],
       });
+      claims = payload as { role?: string; sub?: string };
 
-      // Check if it's a service_role token
-      if (payload.role !== "service_role") {
+      if (claims.role !== "service_role") {
         return new Response(
-          JSON.stringify({
-            error: "Access denied: Service role required",
-          }),
-          {
-            status: 403,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          JSON.stringify({ error: "Access denied: Service role required" }),
+          { status: 403, headers: JSON_HEADERS },
         );
       }
     } catch (jwtError) {
-      console.error("JWT verification error:", jwtError);
+      logError("vault-reader", jwtError);
       return new Response(
         JSON.stringify({ error: "Invalid or expired token" }),
-        {
-          status: 401,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { status: 401, headers: JSON_HEADERS },
       );
     }
 
-    // Handle GET command (retrieve secret)
+    const rl = rateLimit(
+      rateLimitKey("vault-reader", req, claims.sub as string | undefined),
+      { limit: 60, windowMs: 60_000 },
+    );
+    if (rl) return rl;
+
     if (command === "get") {
       const { secret_id } = body;
 
       if (!secret_id || typeof secret_id !== "string") {
         return new Response(
-          JSON.stringify({
-            error: "secret_id is required for get command",
-          }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          JSON.stringify({ error: "secret_id is required for get command" }),
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
       if (!UUID_RE.test(secret_id)) {
         return new Response(
-          JSON.stringify({
-            error: "secret_id must be a valid UUID",
-          }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          JSON.stringify({ error: "secret_id must be a valid UUID" }),
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
-      // Call our RPC function to get the decrypted secret from vault
       const { data, error } = await supabase.rpc(
         "get_vault_secret_by_id",
-        {
-          secret_id: secret_id,
-        },
+        { secret_id: secret_id },
       );
 
       if (error) {
-        console.error("Error fetching secret via RPC:", error.message);
+        logError("vault-reader", error);
         return new Response(
           JSON.stringify({ error: "Failed to retrieve secret" }),
-          {
-            status: 500,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 500, headers: JSON_HEADERS },
         );
       }
 
       if (!data || !Array.isArray(data) || data.length === 0) {
         return new Response(
           JSON.stringify({ error: "Secret not found" }),
-          {
-            status: 404,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 404, headers: JSON_HEADERS },
         );
       }
 
-      // RPC returns an array, get the first result
       const secret = data[0];
 
       return new Response(
@@ -216,16 +159,10 @@ serve(async (req) => {
           created_at: secret.created_at,
           updated_at: secret.updated_at,
         }),
-        {
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { headers: JSON_HEADERS },
       );
     }
 
-    // Handle SET command (create/update secret)
     if (command === "set") {
       const { secret_name, secret_value, secret_description } = body;
 
@@ -234,37 +171,23 @@ serve(async (req) => {
           JSON.stringify({
             error: "secret_name and secret_value are required for set command",
           }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
-      // Validate secret_name format
       if (typeof secret_name !== "string" || !SECRET_NAME_RE.test(secret_name)) {
         return new Response(
           JSON.stringify({
             error:
               "secret_name must be 1-100 chars: alphanumeric, underscore, or dash",
           }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
       const illegalName = rejectIllegalChars(secret_name, "secret_name");
       if (illegalName) return illegalName;
 
-      // Validate secret_value length
       if (
         typeof secret_value !== "string" ||
         secret_value.length > MAX_SECRET_VALUE_LENGTH
@@ -273,17 +196,10 @@ serve(async (req) => {
           JSON.stringify({
             error: `secret_value must be a string of at most ${MAX_SECRET_VALUE_LENGTH} characters`,
           }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
-      // Call our RPC function to set the secret in vault
       const { data, error } = await supabase.rpc("set_vault_secret", {
         secret_name: secret_name,
         secret_value: secret_value,
@@ -291,16 +207,10 @@ serve(async (req) => {
       });
 
       if (error) {
-        console.error("Error setting secret via RPC:", error.message);
+        logError("vault-reader", error);
         return new Response(
           JSON.stringify({ error: "Failed to store secret" }),
-          {
-            status: 500,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 500, headers: JSON_HEADERS },
         );
       }
 
@@ -310,16 +220,10 @@ serve(async (req) => {
           secret_id: data,
           message: "Secret created/updated successfully",
         }),
-        {
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { headers: JSON_HEADERS },
       );
     }
 
-    // Handle GET_BY_GUILD command (bot-facing guild token lookup)
     if (command === "get_by_guild") {
       const { server_id, service } = body;
 
@@ -329,13 +233,7 @@ serve(async (req) => {
             error:
               "server_id and service are required for get_by_guild command",
           }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
@@ -345,16 +243,10 @@ serve(async (req) => {
       });
 
       if (error) {
-        console.error("Error fetching guild token via RPC:", error.message);
+        logError("vault-reader", error);
         return new Response(
           JSON.stringify({ error: "Failed to retrieve guild token" }),
-          {
-            status: 500,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 500, headers: JSON_HEADERS },
         );
       }
 
@@ -363,13 +255,7 @@ serve(async (req) => {
           JSON.stringify({
             error: "No active token found for this guild and service",
           }),
-          {
-            status: 404,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 404, headers: JSON_HEADERS },
         );
       }
 
@@ -382,48 +268,27 @@ serve(async (req) => {
           created_at: "",
           updated_at: "",
         }),
-        {
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { headers: JSON_HEADERS },
       );
     }
 
-    // Handle GET_BY_TAG command (alias for get_by_guild, parses tag format)
     if (command === "get_by_tag") {
       const { tag } = body;
 
       if (!tag || typeof tag !== "string") {
         return new Response(
-          JSON.stringify({
-            error: "tag is required for get_by_tag command",
-          }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          JSON.stringify({ error: "tag is required for get_by_tag command" }),
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
-      // Parse tag format: "github_pat:1234567890" -> service=github, server_id=1234567890
       const colonIdx = tag.indexOf(":");
       if (colonIdx === -1) {
         return new Response(
           JSON.stringify({
             error: 'Invalid tag format. Expected "service_name:server_id"',
           }),
-          {
-            status: 400,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 400, headers: JSON_HEADERS },
         );
       }
 
@@ -436,29 +301,17 @@ serve(async (req) => {
       });
 
       if (error) {
-        console.error("Error fetching guild token via tag RPC:", error.message);
+        logError("vault-reader", error);
         return new Response(
           JSON.stringify({ error: "Failed to retrieve guild token" }),
-          {
-            status: 500,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 500, headers: JSON_HEADERS },
         );
       }
 
       if (!data) {
         return new Response(
           JSON.stringify({ error: "No active token found for tag" }),
-          {
-            status: 404,
-            headers: {
-              ...corsHeaders,
-              "Content-Type": "application/json",
-            },
-          },
+          { status: 404, headers: JSON_HEADERS },
         );
       }
 
@@ -471,34 +324,29 @@ serve(async (req) => {
           created_at: "",
           updated_at: "",
         }),
-        {
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        },
+        { headers: JSON_HEADERS },
       );
     }
 
-    // Invalid command
     return new Response(
       JSON.stringify({
         error:
           'Invalid command. Use "get", "set", "get_by_guild", or "get_by_tag"',
       }),
-      {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      },
+      { status: 400, headers: JSON_HEADERS },
     );
   } catch (err) {
-    console.error("Unexpected error:", err);
+    logError("vault-reader", err);
     return new Response(
       JSON.stringify({ error: "Internal server error" }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      },
+      { status: 500, headers: JSON_HEADERS },
     );
   }
+}
+
+serve(async (req): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return preflight(req);
+  }
+  return withCors(await handle(req), req);
 });


### PR DESCRIPTION
Resolves the remaining deferred + phase-2 audit items from #8246. Most critical/high items (env-var allowlisting, body-size limits, page bounds, ArgoCD URL disclosure, char filtering, ownership-cache invalidation) already shipped in earlier phases; this PR fills the rest.

## Shared utilities (`apps/kbve/edge/functions/_shared/`)
- **routing.ts** — `parseCommand()` replaces duplicated `command.indexOf(".")`/`slice` blocks in every router.
- **pagination.ts** — `validateLimit` / `clampLimit` / `clampPage` / `clampOffset`; consolidates per-module clamping.
- **constants.ts** — `ContainerType` / `SkillCategory` enums (kills magic numbers), centralized `PAGINATION` limits.
- **middleware.ts** — `withAuth(role, handler)` role-guard wrapper.
- **logging.ts** — structured JSON logging for the Vector → ClickHouse pipeline.
- **env.ts** — `loadEnv()` fail-fast boot validation + `validateJwtSecret()` strength check.
- **ratelimit.ts** — in-memory sliding-window limiter (per-worker, mirrors existing ownership cache).
- **idempotency.ts** — in-memory dedup for write actions.
- **responses.ts** — standard success/error envelopes for new handlers.

## CORS
`cors.ts` no longer emits `Access-Control-Allow-Origin: *`. `getCorsHeaders` echoes only allowlisted origins; `withCors` applies them at the router boundary so allowlisted browser origins keep working without threading the request through every handler.

## Module refactors
meme, mc, discordsh, forum, irc, argo, logs, vault-reader, user-vault, guild-vault, main:
- adopt `parseCommand` / `preflight` / `withCors` / `logError`
- dedup UUID/ULID/MC_UUID/snowflake regexes onto `_shared/formats.ts`
- rate limiting on logs, vault-reader, argo, and public discordsh/forum/irc reads
- idempotency on `discordsh` `vote.cast` + `server.submit`
- `mc` container-type / skill-category magic numbers → enums
- `mc` transfer empty batch now returns 400 instead of silent success
- `loadEnv` + JWT strength validation at boot (main, vault-reader, forum, irc)
- argo error responses no longer echo the upstream URL/host
- discordsh public-module claims init `{ role: "anon" }`

## Verification
`deno check` passes on all refactored files. Remaining type errors (irc `setReadDeadline`, mc/admin RCON buffer concat, health `manifest.ts`, gh-* PATCH method) are pre-existing and untouched by this PR.

## Wire compatibility
Existing JSON response shapes + status codes preserved. New status codes are additive only: 429 (rate limit), 409 (idempotency duplicate), and 400 on empty mc transfer batch.

Credit: original audit by @fudster in #8178.