### PR TITLE
chore(edge): bump 0.1.45 + raise functions memory limit to 1Gi

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.44"
+version: "0.1.45"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -99,8 +99,8 @@ spec:
                                 key: rcon-password
                   resources:
                       requests:
-                          memory: '256Mi'
+                          memory: '384Mi'
                           cpu: '100m'
                       limits:
-                          memory: '512Mi'
+                          memory: '1Gi'
                           cpu: '500m'


### PR DESCRIPTION
## Version bump
Edge release `0.1.44` → `0.1.45` (MDX `version:` only; version.toml / deno.json / deployment image tag auto-sync via the post-publish atom PR). Ships the hardening work from #8246 (PR #12992).

## OOM fix — raise functions memory ceiling
The `functions` Deployment (ns `kilobase`) was OOMKilled (exit 137) once in the last 35h. Root cause: the pod runs `edge-runtime` plus ephemeral per-request user workers (each capped at `memoryLimitMb=150`, 60s timeout) with no worker-pool cap, so a burst of 3+ concurrent workers exceeds the old `512Mi` limit.

- requests memory `256Mi` → `384Mi`
- limits memory `512Mi` → `1Gi`
- CPU left unchanged (`100m` / `500m`)

The node (`talos-4bn-whr`) has ample memory headroom (18% requested / 55% limits of 593Gi allocatable), so the larger ceiling is cheap. CPU is deliberately untouched — that node is already CPU-overcommitted (89% requests / 276% limits), and the OOM was a memory event, not CPU.

Burstable QoS preserved (limits > requests). Existing `rollout-restart` annotation kept.