### PR TITLE
fix(astro): allow workspace-root fs access in vitest for droid worker imports

### DIFF
--- a/packages/npm/astro/vite.config.ts
+++ b/packages/npm/astro/vite.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
 	root: __dirname,
 	cacheDir: '../../../node_modules/.vite/npm/astro',
 
+	server: {
+		fs: {
+			allow: [path.resolve(__dirname, '../../..')],
+		},
+	},
+
 	plugins: [
 		react(),
 		nxViteTsPaths(),


### PR DESCRIPTION
## Problem

`nx run astro:test` failed in CI ([run](https://github.com/KBVE/kbve/actions/runs/27901825858/job/82563365582)):

```
Error: Denied ID .../packages/npm/droid/src/lib/workers/supabase-shared-worker.ts?worker&url
```

`SiteGraph.spec.tsx` renders `SiteGraph`, which value-imports `openTooltip`/`closeTooltip` from the `@kbve/droid` barrel. The barrel top-level imports worker bundles via `?worker&url`. vitest's nested vite (7.3.2) ran `isServerAccessDeniedForTransform` and rejected the droid worker file because workspace-root detection didn't cover the droid package — only the `SiteGraph` suite failed to load (33/37 still passed).

## Fix

Set explicit `server.fs.allow` to the monorepo root in `packages/npm/astro/vite.config.ts`, so the droid worker file is always within the serve allow-list regardless of CI vs local root detection.

## Verify

`nx run astro:test --skip-nx-cache` → 6 suites / 37 tests pass.