### PR TITLE
fix(guacamole): require DASHBOARD_MANAGE + drop committed guacadmin hash

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -2385,14 +2385,27 @@ pub fn init_guacamole_proxy() -> bool {
 }
 
 pub async fn guacamole_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
-    match GUACAMOLE.get() {
-        Some(proxy) => proxy.handle(path, req).await,
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(json!({"error": "Guacamole proxy not configured"})),
-        )
-            .into_response(),
+    let proxy = match GUACAMOLE.get() {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "Guacamole proxy not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) =
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Guacamole").await
+    {
+        return resp;
     }
+
+    proxy.handle_preauthorized(path, req).await
 }
 
 /// Bridges the browser WebSocket to `/guacamole/websocket-tunnel`. The
@@ -2407,7 +2420,7 @@ pub async fn guacamole_ws_handler(
     let query = req.uri().query().map(|q| q.to_string());
 
     if let Err(resp) =
-        require_dashboard_view_with_query(&headers, query.as_deref(), "Guacamole-WS").await
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Guacamole-WS").await
     {
         return resp;
     }

--- a/apps/kube/kubevirt/guacamole/deployment.yaml
+++ b/apps/kube/kubevirt/guacamole/deployment.yaml
@@ -78,7 +78,9 @@ spec:
                   args:
                       - |
                           PASSWORD=$(cat /secrets/password)
-                          sed "s|</connection>|<param name=\"password\">${PASSWORD}</param>\n</connection>|" \
+                          GUAC_HASH=$(printf '%s' "$PASSWORD" | sha256sum | cut -d' ' -f1)
+                          sed -e "s|__GUACADMIN_SHA256__|${GUAC_HASH}|" \
+                              -e "s|</connection>|<param name=\"password\">${PASSWORD}</param>\n</connection>|" \
                             /template/user-mapping.xml > /config/user-mapping.xml
                   volumeMounts:
                       - name: user-mapping-template

--- a/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
+++ b/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
@@ -10,7 +10,7 @@ data:
     user-mapping.xml: |
         <user-mapping>
             <authorize username="guacadmin"
-                       password="f3293a1a94713ed45a8f23d84f41b41c670a7ae6fef7b05a2b0ba47a06061f43"
+                       password="__GUACADMIN_SHA256__"
                        encoding="sha256">
                 <connection name="Windows Builder">
                     <protocol>rdp</protocol>


### PR DESCRIPTION
Hardens the Guacamole RDP gateway (HIGH item from #12973). The gateway fronts a Windows VM running CI as **LocalSystem** with an `admin:org` PAT mounted, so a takeover is high impact.

## Context — guacamole is already proxy-gated

The original audit claimed guac was "protected only by a committed default credential." That misses the forward-auth layer:
- Guacamole `Service` is **ClusterIP only** — no LB/ingress.
- Only ingress is the axum proxy; both routes were already auth-gated (WS tunnel via `require_dashboard_view_with_query`, HTTP passthrough via `ServiceProxy.handle`).

So this PR is **defense-in-depth on top of an existing gate**, not a fix for an open door.

## Changes

**1. Raise the gate `DASHBOARD_VIEW` → `DASHBOARD_MANAGE`** (`apps/kbve/axum-kbve/src/transport/proxy.rs`)
- `guacamole_ws_handler` and `guacamole_proxy_handler` now require `DASHBOARD_MANAGE`. RDP-to-LocalSystem is more sensitive than read-only dashboard access, which the broad `DASHBOARD_VIEW` tier grants.
- `guacamole_proxy_handler` now gates explicitly then forwards via `handle_preauthorized` (was relying on `ServiceProxy.handle`'s VIEW gate).

**2. Drop the committed `guacadmin` sha256** (`apps/kube/kubevirt/guacamole/`)
- `user-mapping-configmap.yaml`: hardcoded hash → `__GUACADMIN_SHA256__` placeholder.
- `deployment.yaml`: the existing `inject-rdp-password` init container now also derives the guacadmin hash at startup (`sha256sum`) from the per-deploy `windows-builder-admin` secret — already mounted and Reloader-watched. No credential in git.

## Notes / scope

- The frontend never sends guacadmin credentials (no `/api/tokens` call — it connects via the WS tunnel with the staff JWT + VM-name token), so the password change has no client impact.
- `cargo check` on axum-kbve passes.

Refs #12973