### PR TITLE
feat(arpg): itemdb item usage + client env rendering

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -1,9 +1,13 @@
+use std::collections::HashMap;
+
 use bevy::prelude::{Commands, Local, Res, ResMut};
+use bevy_items::{StatusEffectKind, UseEffect, UseEffectType};
 use simgrid::arpg_dungeon;
-use simgrid::proto::Tile;
+use simgrid::proto::{StatusKind, Tile};
 use simgrid::{
-    AggroSpec, EnvOpts, HazardZone, HealAura, KindRegistry, NpcSpec, SIM_TICK_HZ, SimConfig,
-    Stairs, WalkableMap, ground_item_bundle, spawn_env_object, spawn_npc_from_spec,
+    AggroSpec, BuffEffects, BuffSpec, ConsumableEffects, EnvOpts, HazardZone, HealAura,
+    KindRegistry, NpcSpec, SIM_TICK_HZ, SimConfig, Stairs, WalkableMap, ground_item_bundle,
+    spawn_env_object, spawn_npc_from_spec,
 };
 
 pub const MAX_PLAYERS: usize = 32;
@@ -93,6 +97,89 @@ pub fn item_db() -> bevy_items::ItemDb {
         "../../../../../packages/data/codegen/generated/itemdb-data.binpb"
     ))
     .expect("embedded itemdb-data.binpb decodes as item.ItemRegistry")
+}
+
+/// FullHeal has no amount on the wire — use a large heal; `use_item` clamps to
+/// max_hp.
+const FULL_HEAL: i32 = 9_999;
+
+/// Map an itemdb `StatusEffectKind` onto the three runtime `StatusKind`s the sim
+/// supports. Burning collapses to Poison (both periodic damage); unsupported
+/// effects return `None` so the item simply grants no buff.
+fn map_status(raw: i32) -> Option<StatusKind> {
+    match StatusEffectKind::try_from(raw).ok()? {
+        StatusEffectKind::StatusEffectRegen => Some(StatusKind::Regen),
+        StatusEffectKind::StatusEffectHaste => Some(StatusKind::Haste),
+        StatusEffectKind::StatusEffectPoison | StatusEffectKind::StatusEffectBurning => {
+            Some(StatusKind::Poison)
+        }
+        _ => None,
+    }
+}
+
+/// Fold one itemdb `UseEffect` into the consumable-heal / status-buff maps.
+fn ingest_effect(
+    ref_id: &str,
+    ue: &UseEffect,
+    heals: &mut HashMap<String, i32>,
+    buffs: &mut HashMap<String, BuffSpec>,
+) {
+    match UseEffectType::try_from(ue.r#type) {
+        Ok(UseEffectType::UseEffectHeal) => {
+            if let Some(a) = ue.amount {
+                heals.entry(ref_id.to_string()).or_insert(a);
+            }
+        }
+        Ok(UseEffectType::UseEffectFullHeal) => {
+            heals.entry(ref_id.to_string()).or_insert(FULL_HEAL);
+        }
+        Ok(UseEffectType::UseEffectApplyEffect) => {
+            if let Some(kind) = ue.status_effect.and_then(map_status) {
+                let turns = ue.turns.unwrap_or(8).max(1) as u32;
+                let magnitude = ue.amount.or(ue.stacks).unwrap_or(2).max(1);
+                // Haste is a flat move-speed modifier (no periodic tick); damage
+                // and regen tick about once per second.
+                let period_ticks = if kind == StatusKind::Haste {
+                    0
+                } else {
+                    SIM_TICK_HZ
+                };
+                buffs.entry(ref_id.to_string()).or_insert(BuffSpec {
+                    kind,
+                    magnitude,
+                    period_ticks,
+                    duration_ticks: turns.saturating_mul(SIM_TICK_HZ),
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Derive consumable heals + status buffs from the itemdb so `UseItem` resolves
+/// real effects instead of being a no-op. Reads each item's `use_effects` and
+/// `food.buff_effects` / `food.heals`. This is the data-driven path (#12972) —
+/// editing the MDX + `sync:itemdb` changes in-game item behavior with no code.
+pub fn item_effects(db: &bevy_items::ItemDb) -> (ConsumableEffects, BuffEffects) {
+    let mut heals: HashMap<String, i32> = HashMap::new();
+    let mut buffs: HashMap<String, BuffSpec> = HashMap::new();
+    for (_, item) in db.iter() {
+        let ref_id = item.r#ref.as_str();
+        for ue in &item.use_effects {
+            ingest_effect(ref_id, ue, &mut heals, &mut buffs);
+        }
+        if let Some(food) = &item.food {
+            for ue in &food.buff_effects {
+                ingest_effect(ref_id, ue, &mut heals, &mut buffs);
+            }
+            if let Some(h) = food.heals
+                && h > 0
+            {
+                heals.entry(ref_id.to_string()).or_insert(h);
+            }
+        }
+    }
+    (ConsumableEffects(heals), BuffEffects(buffs))
 }
 
 /// Endless dungeon stairs: two seed-derived stairs per floor (down + up).
@@ -220,5 +307,19 @@ mod tests {
             db.get_by_ref("campfire-kit").is_some(),
             "campfire-kit present"
         );
+    }
+
+    #[test]
+    fn itemdb_effects_map_heal_and_buff() {
+        let db = super::item_db();
+        let (heals, buffs) = super::item_effects(&db);
+        // potion: use_effects [{ HEAL, amount 15 }]
+        assert_eq!(heals.0.get("potion").copied(), Some(15));
+        // elixir: use_effects [{ FULL_HEAL }]
+        assert_eq!(heals.0.get("elixir").copied(), Some(super::FULL_HEAL));
+        // mana-potion: food.buff_effects [{ APPLY_EFFECT, REGEN }]
+        let mana = buffs.0.get("mana-potion").expect("mana-potion buff");
+        assert_eq!(mana.kind, super::StatusKind::Regen);
+        assert!(!heals.0.is_empty() && !buffs.0.is_empty());
     }
 }

--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -52,6 +52,11 @@ pub const CAMPFIRE_HEAL_AMOUNT: i32 = 3;
 pub const CAMPFIRE_BURN_AMOUNT: i32 = 8;
 pub const CAMPFIRE_PERIOD_TICKS: u32 = SIM_TICK_HZ;
 
+// A few starter potions drop near spawn so the inventory + item-usage loop is
+// usable immediately: pick up -> 1-9 hotkey -> heal (itemdb says potion heals 15).
+pub const POTION_REF: &str = "potion";
+pub const POTION_START_COUNT: u32 = 3;
+
 /// Ground floor — players spawn here; stairs descend to deeper floors.
 pub const SPAWN_FLOOR: i32 = 0;
 
@@ -84,6 +89,7 @@ pub fn registry() -> KindRegistry {
     reg.register_npc(GOBLIN_REF);
     reg.register_item(GOBLIN_LOOT_REF);
     reg.register_item(STAIR_KEY_REF);
+    reg.register_item(POTION_REF);
     reg.register_env(CAMPFIRE_REF);
     reg
 }
@@ -260,6 +266,13 @@ pub fn spawn_world(
     // down. Deeper floors gate their own keys via loot later.
     let key_tile = floor_near(Tile::new(spawn.x - 2, spawn.y + 2));
     if let Some(bundle) = ground_item_bundle(&registry, STAIR_KEY_REF, 1, key_tile) {
+        commands.spawn(bundle);
+    }
+
+    // Starter potions so the inventory + use-item loop works from spawn.
+    let potion_tile = floor_near(Tile::new(spawn.x + 1, spawn.y - 2));
+    if let Some(bundle) = ground_item_bundle(&registry, POTION_REF, POTION_START_COUNT, potion_tile)
+    {
         commands.spawn(bundle);
     }
 

--- a/apps/agones/arpg/server/src/main.rs
+++ b/apps/agones/arpg/server/src/main.rs
@@ -68,7 +68,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("sim runtime");
         let mut app = build_app(out_tx, input_rx, roster, seed, config, map, registry);
         let item_db = game::item_db();
-        tracing::info!(items = item_db.len(), "itemdb loaded into sim");
+        let (consumables, buffs) = game::item_effects(&item_db);
+        tracing::info!(
+            items = item_db.len(),
+            consumables = consumables.0.len(),
+            buffs = buffs.0.len(),
+            "itemdb loaded into sim"
+        );
+        app.insert_resource(consumables);
+        app.insert_resource(buffs);
         app.insert_resource(item_db);
         app.insert_resource(game::stairs());
         app.add_systems(

--- a/apps/kbve/astro-kbve/public/assets/arcade/arpg/environment/hazards/campfire/campfire-Sheet.png
+++ b/apps/kbve/astro-kbve/public/assets/arcade/arpg/environment/hazards/campfire/campfire-Sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fb37222253b37d9c497c3fcfbc1ea2de0546e1ce123e641c346e009f1d03d34
+size 1369

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactElement } from 'react';
-import { onHud, onHudClear, type HudState } from './systems/hud';
+import { onHud, onHudClear, onInventory, type HudState } from './systems/hud';
+import type { InventoryItem } from '@kbve/laser';
 
 const PANEL_BG = 'rgba(8,9,14,0.62)';
 const PANEL_BORDER = '1px solid rgba(76,90,120,0.6)';
@@ -14,12 +15,18 @@ const TEXT = '#e6ebf5';
  */
 export default function ArpgHud({ debug = false }: { debug?: boolean }) {
 	const [hud, setHud] = useState<HudState | null>(null);
+	const [inv, setInv] = useState<InventoryItem[]>([]);
 
 	useEffect(() => {
 		const off = onHud(setHud);
-		const offClear = onHudClear(() => setHud(null));
+		const offInv = onInventory(setInv);
+		const offClear = onHudClear(() => {
+			setHud(null);
+			setInv([]);
+		});
 		return () => {
 			off();
+			offInv();
 			offClear();
 		};
 	}, []);
@@ -39,7 +46,64 @@ export default function ArpgHud({ debug = false }: { debug?: boolean }) {
 			<Vitals name={hud.name} hp={hud.hp} maxHp={hud.maxHp} />
 			<MinimapSlot />
 			<Compass headingDeg={hud.headingDeg} moving={hud.moving} />
+			<InventoryBar items={inv} />
 			{debug && <DebugReadout fps={hud.fps} tile={hud.tile} />}
+		</div>
+	);
+}
+
+/**
+ * Bottom-center inventory bar. Each slot shows the item ref + stack count and its
+ * 1-9 hotkey; pressing the number (handled in the scene) uses that item. Purely
+ * presentational — the server-authoritative inventory drives it via `arpg:inventory`.
+ */
+function InventoryBar({
+	items,
+}: {
+	items: InventoryItem[];
+}): ReactElement | null {
+	if (items.length === 0) return null;
+	const slots = items.slice(0, 9);
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				bottom: 12,
+				left: '50%',
+				transform: 'translateX(-50%)',
+				display: 'flex',
+				gap: 6,
+			}}>
+			{slots.map((it, i) => (
+				<div
+					key={it.ref}
+					style={{
+						position: 'relative',
+						minWidth: 64,
+						padding: '6px 8px',
+						background: PANEL_BG,
+						border: PANEL_BORDER,
+						borderRadius: 6,
+						textAlign: 'center',
+						fontSize: 11,
+					}}>
+					<span
+						style={{
+							position: 'absolute',
+							top: 2,
+							left: 4,
+							color: ACCENT,
+							fontSize: 9,
+							opacity: 0.8,
+						}}>
+						{i + 1}
+					</span>
+					<div style={{ color: TEXT }}>{it.ref}</div>
+					<div style={{ color: ACCENT, fontWeight: 700 }}>
+						×{it.count}
+					</div>
+				</div>
+			))}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -91,6 +91,12 @@ import {
 	registerClassAnims,
 	RANGER_CLASS,
 } from './entities/classes';
+import {
+	preloadEnv,
+	registerEnvAnims,
+	makeEnvSprite,
+	ENV_REGISTRY,
+} from './entities/env';
 import { getNetConfig } from './net-config';
 import { resolvePlayerName } from './playerName';
 
@@ -174,12 +180,14 @@ export class IsoArpgScene extends Phaser.Scene {
 	preload() {
 		this.load.image(GROUND_TEXTURE_KEY, arpgAsset(GROUND_TEXTURE_PATH));
 		preloadClass(this, RANGER_CLASS);
+		for (const def of ENV_REGISTRY.values()) preloadEnv(this, def);
 	}
 
 	create() {
 		this.cameras.main.setBackgroundColor(COLORS.background);
 		this.kinds = makeKindResolvers(this.kindRegistry);
 		registerClassAnims(this, RANGER_CLASS);
+		for (const def of ENV_REGISTRY.values()) registerEnvAnims(this, def);
 
 		this.drawGrid();
 		this.buildFog();
@@ -478,16 +486,29 @@ export class IsoArpgScene extends Phaser.Scene {
 	private buildBridge() {
 		this.syncBridge = {
 			create: (e: EntityDelta, label) => {
-				const refs: EntityRefs = isPlayerKind(this.kinds, e.kind)
-					? this.makePlayerRefs(e.kind)
-					: {
-							sprite: makeSprite(
-								this,
-								this.kinds,
-								e.kind,
-								this.syncResolvers.hostile(e.kind),
-							),
-						};
+				let refs: EntityRefs;
+				if (isPlayerKind(this.kinds, e.kind)) {
+					refs = this.makePlayerRefs(e.kind);
+				} else if (this.kinds.catName(e.kind) === 'env') {
+					const envSprite = makeEnvSprite(
+						this,
+						this.kinds.ref(e.kind),
+					);
+					refs = {
+						sprite:
+							envSprite ??
+							makeSprite(this, this.kinds, e.kind, false),
+					};
+				} else {
+					refs = {
+						sprite: makeSprite(
+							this,
+							this.kinds,
+							e.kind,
+							this.syncResolvers.hostile(e.kind),
+						),
+					};
+				}
 				this.placeSprite(refs.sprite, e.tile.x, e.tile.y);
 				this.syncShadow(refs);
 				if (label) {
@@ -655,6 +676,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		// the 16-dir turn curve stays fluid even between tile crossings.
 		this.tickFacing();
 		this.syncFogToZoom();
+		this.refreshEnvBlocked();
 
 		if ((!this.client && !this.localMode) || !this.predictSeeded) return;
 
@@ -865,7 +887,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		const path = findHierPath(
 			start,
 			tile,
-			(x, y) => this.dungeon.isFloor(x, y),
+			(x, y) => !this.isBlocked(x, y),
 			this.gateGraph,
 		);
 		if (!path) {
@@ -876,10 +898,23 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.client?.moveTo(tile);
 	}
 
-	// Endless dungeon: a tile is walkable iff it's a generated floor tile. No
-	// fixed bounds — walls are simply the absence of floor.
+	// Tiles occupied by env objects (campfire, …), rebuilt once per frame from the
+	// ECS store so local prediction blocks the same tiles the server does — else
+	// the player walks onto a campfire then snaps back on the next snapshot.
+	private envBlocked = new Set<string>();
+
+	private refreshEnvBlocked(): void {
+		this.envBlocked.clear();
+		for (const sid of this.store.serverIdsWith('env')) {
+			const t = this.store.tile(sid);
+			if (t) this.envBlocked.add(`${t.x},${t.y}`);
+		}
+	}
+
+	// Endless dungeon: a tile is walkable iff it's a generated floor tile AND not
+	// occupied by an env blocker. No fixed bounds — walls are the absence of floor.
 	private isBlocked = (x: number, y: number): boolean => {
-		return !this.dungeon.isFloor(x, y);
+		return !this.dungeon.isFloor(x, y) || this.envBlocked.has(`${x},${y}`);
 	};
 
 	private isHostileServer(serverEid: number): boolean {

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -14,6 +14,8 @@ import {
 	type ProjectileEvent,
 	type FloorChangeEvent,
 	type Facing,
+	type InventorySync,
+	type InventoryItem,
 } from '@kbve/laser';
 import {
 	COLORS,
@@ -75,7 +77,7 @@ import {
 } from './systems/dungeon';
 import { findHierPath, type GateGraph } from './systems/pathfind';
 import { fireBow, showDamage, type BowShot } from './combat/bow';
-import { emitHud, clearHud } from './systems/hud';
+import { emitHud, clearHud, emitInventory } from './systems/hud';
 import { facingDegFromDelta } from './entities/classes';
 import {
 	makeSprite,
@@ -167,6 +169,10 @@ export class IsoArpgScene extends Phaser.Scene {
 	// Dungeon floor the local player is on (z). Server-authoritative via the
 	// `floor` event; snapshot entities on other floors are not rendered.
 	private currentFloor = 0;
+
+	// Latest server-authoritative inventory (from EPHEMERAL_INVENTORY). Drives the
+	// HUD panel and the 1-9 hotkeys.
+	private inventory: InventoryItem[] = [];
 
 	private syncBridge!: SyncBridge<EntityRefs>;
 	private syncResolvers!: SyncResolvers;
@@ -447,6 +453,12 @@ export class IsoArpgScene extends Phaser.Scene {
 			right: kb.addKey(Phaser.Input.Keyboard.KeyCodes.D),
 		};
 		this.fireKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+		// Number keys 1-9 use the matching inventory slot.
+		kb.on('keydown', (ev: KeyboardEvent) => {
+			if (ev.key >= '1' && ev.key <= '9') {
+				this.useInventorySlot(Number(ev.key) - 1);
+			}
+		});
 		this.input.mouse?.disableContextMenu();
 
 		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
@@ -566,8 +578,20 @@ export class IsoArpgScene extends Phaser.Scene {
 		client.on('combat', (c: CombatEvent) => this.onCombat(c));
 		client.on('projectile', (p: ProjectileEvent) => this.onProjectile(p));
 		client.on('floor', (f: FloorChangeEvent) => this.onFloorChange(f));
+		client.on('inventory', (inv: InventorySync) => {
+			this.inventory = inv.items;
+			emitInventory(inv.items);
+		});
 
 		client.connect();
+	}
+
+	// Use the item in inventory slot `idx` (0-based), bound to keys 1-9. The
+	// server consumes it and applies the effect (heal/buff); the resulting
+	// EPHEMERAL_INVENTORY refreshes the HUD.
+	private useInventorySlot(idx: number): void {
+		const item = this.inventory[idx];
+		if (item) this.client?.useItem(item.ref);
 	}
 
 	private applySnapshot(s: Snapshot) {

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ecs/components.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ecs/components.ts
@@ -25,4 +25,5 @@ export const Active = {
 export const PlayerTag: Record<string, never> = {};
 export const NpcTag: Record<string, never> = {};
 export const ItemTag: Record<string, never> = {};
+export const EnvTag: Record<string, never> = {};
 export const MonsterTag: Record<string, never> = {};

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ecs/store.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ecs/store.ts
@@ -17,10 +17,11 @@ import {
 	PlayerTag,
 	NpcTag,
 	ItemTag,
+	EnvTag,
 	MonsterTag,
 } from './components';
 
-export type EntityCat = 'player' | 'npc' | 'item';
+export type EntityCat = 'player' | 'npc' | 'item' | 'env';
 
 export interface SpawnData {
 	tile: { x: number; y: number };
@@ -45,7 +46,13 @@ export class EntityStore<R> {
 	private sideRefs = new SideMap<R>();
 
 	private tagFor(cat: EntityCat): Record<string, never> {
-		return cat === 'player' ? PlayerTag : cat === 'npc' ? NpcTag : ItemTag;
+		return cat === 'player'
+			? PlayerTag
+			: cat === 'npc'
+				? NpcTag
+				: cat === 'env'
+					? EnvTag
+					: ItemTag;
 	}
 
 	has(serverEid: number): boolean {

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/env.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/env.ts
@@ -1,0 +1,77 @@
+import Phaser from 'phaser';
+import { arpgAsset } from '../config';
+
+/**
+ * A static environment prop (campfire, …). Unlike player classes these have no
+ * 16-angle rig — a single spritesheet looped as an idle animation, anchored on
+ * its tile. Keyed by the kind registry `ref` the server sends in the Welcome
+ * registry (category KIND_CAT_ENV).
+ */
+export interface EnvDef {
+	ref: string;
+	sheet: string;
+	frameWidth: number;
+	frameHeight: number;
+	frames: number;
+	frameRate: number;
+	displayWidth: number;
+	displayHeight: number;
+	originY: number;
+}
+
+export const CAMPFIRE_ENV: EnvDef = {
+	ref: 'campfire',
+	sheet: '/assets/arcade/arpg/environment/hazards/campfire/campfire-Sheet.png',
+	frameWidth: 36,
+	frameHeight: 48,
+	frames: 6,
+	frameRate: 8,
+	displayWidth: 40,
+	displayHeight: 54,
+	originY: 0.9,
+};
+
+export const ENV_REGISTRY: Map<string, EnvDef> = new Map([
+	[CAMPFIRE_ENV.ref, CAMPFIRE_ENV],
+]);
+
+const sheetKey = (def: EnvDef): string => `env:${def.ref}`;
+const animKey = (def: EnvDef): string => `anim:env:${def.ref}`;
+
+export function preloadEnv(scene: Phaser.Scene, def: EnvDef): void {
+	scene.load.spritesheet(sheetKey(def), arpgAsset(def.sheet), {
+		frameWidth: def.frameWidth,
+		frameHeight: def.frameHeight,
+	});
+}
+
+export function registerEnvAnims(scene: Phaser.Scene, def: EnvDef): void {
+	const key = animKey(def);
+	if (scene.anims.exists(key)) return;
+	scene.anims.create({
+		key,
+		frames: scene.anims.generateFrameNumbers(sheetKey(def), {
+			start: 0,
+			end: def.frames - 1,
+		}),
+		frameRate: def.frameRate,
+		repeat: -1,
+	});
+}
+
+/**
+ * Build a looping prop sprite for an env `ref`. Returns null when the ref has no
+ * registered def so the caller can fall back to the placeholder rectangle.
+ */
+export function makeEnvSprite(
+	scene: Phaser.Scene,
+	ref: string | null,
+): Phaser.GameObjects.Sprite | null {
+	const def = ref ? ENV_REGISTRY.get(ref) : undefined;
+	if (!def) return null;
+	const sprite = scene.add.sprite(0, 0, sheetKey(def), 0);
+	sprite.setOrigin(0.5, def.originY);
+	sprite.setDisplaySize(def.displayWidth, def.displayHeight);
+	sprite.play(animKey(def));
+	return sprite;
+}

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
@@ -1,4 +1,4 @@
-import { laserEvents } from '@kbve/laser';
+import { laserEvents, type InventoryItem } from '@kbve/laser';
 
 export const HUD_EVENT = 'arpg:hud';
 
@@ -18,6 +18,18 @@ export function emitHud(state: HudState): void {
 
 export function onHud(handler: (state: HudState) => void): () => void {
 	return laserEvents.on(HUD_EVENT, handler as (data: unknown) => void);
+}
+
+export const INVENTORY_EVENT = 'arpg:inventory';
+
+export function emitInventory(items: InventoryItem[]): void {
+	laserEvents.emit(INVENTORY_EVENT, items);
+}
+
+export function onInventory(
+	handler: (items: InventoryItem[]) => void,
+): () => void {
+	return laserEvents.on(INVENTORY_EVENT, handler as (data: unknown) => void);
 }
 
 export const HUD_CLEAR_EVENT = 'arpg:hud:clear';

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/kindResolvers.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/kindResolvers.ts
@@ -4,6 +4,7 @@ import type { EntityCat } from '../ecs/store';
 export const KIND_CAT_PLAYER = 0;
 export const KIND_CAT_NPC = 1;
 export const KIND_CAT_ITEM = 2;
+export const KIND_CAT_ENV = 3;
 
 export interface KindResolvers {
 	cat(kind: number): number;
@@ -24,7 +25,9 @@ export function makeKindResolvers(
 			? 'player'
 			: c === KIND_CAT_ITEM
 				? 'item'
-				: 'npc';
+				: c === KIND_CAT_ENV
+					? 'env'
+					: 'npc';
 	};
 	return { cat, ref, catName };
 }


### PR DESCRIPTION
## ARPG: itemdb-driven item usage + env rendering + inventory UI

Continues epic #12955 and makes the full pick-up → use → effect loop work.

### Server — itemdb-driven item usage (#12972)
`UseItem` was wired in simgrid but **dead** in the ARPG: `ConsumableEffects`/`BuffEffects` were never populated. Now derived from the embedded itemdb:
- `use_effects` `HEAL`/`FULL_HEAL` → consumable heal; `food.heals` fallback
- `use_effects` + `food.buff_effects` `APPLY_EFFECT` → status buff (`StatusEffectKind` REGEN/HASTE/POISON|BURNING → runtime `StatusKind`)

Edit item MDX + `sync:itemdb` changes behavior with **no code**. Test: potion heals 15, elixir full-heals, mana-potion grants Regen. Plus 3 starter potions drop near spawn so the loop is usable immediately.

### Client — env objects render + predicted collision (#12963 #12964 #12965 #12956)
- `KIND_CAT_ENV` plumbing (catName `'env'`, `EntityCat`, `EnvTag`; engine stays `@kbve/laser` BitECS).
- `entities/env.ts` lightweight static-prop loader (single sheet, looped idle, no 16-angle rig); campfire renders via a new `env` branch in the sprite bridge.
- Prediction: per-frame `envBlocked` tile cache feeds `isBlocked` + A* `findHierPath` → local movement routes around campfires (no rubber-band).
- `campfire-Sheet.png` (216×48, 6 frames) under `environment/hazards/campfire/` (LFS).

### Client — inventory UI + hotkeys
- Scene subscribes to laser's `'inventory'` event (from `EPHEMERAL_INVENTORY`); `ArpgHud` renders a bottom-center inventory bar (ref, count, hotkey).
- Keys **1-9** use the matching slot (`client.useItem` → server consumes + applies effect → refreshed inventory + HP).
- New `INVENTORY_EVENT` bus in `systems/hud.ts`.

### Tests / checks
- `arpg-server` tests pass (`itemdb_effects_map_heal_and_buff` + embed/decode).
- Client typechecks clean (no isometric-arpg errors).

### Tickets
Closes #12956 #12963 #12964 #12965 · Advances #12972

### Follow-ups (tracked)
Status-effect VFX (#12965 visual); equipment-effects from itemdb; `campfire` itemdb entry so the env object's aura/burn are data-driven (#12966/#12972); deploy/craft-place flow (#12966).
