### PR TITLE
fix(arpg): ship real LFS sprites to kbve.com (pointer-stub crash) + 1.0.206

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -113,6 +113,44 @@ jobs:
                   chmod 600 "$HOME/.netrc"
                   echo "Forgejo LFS credentials configured for git.kbve.com"
 
+            - name: Pull per-game Forgejo LFS blobs
+              if: ${{ steps.lfs_detect.outputs.uses_lfs == 'true' }}
+              run: |
+                  set -euo pipefail
+                  # Stock git-lfs only resolves the repo-root .lfsconfig (rareicon
+                  # endpoint). Games whose blobs live on other Forgejo repos (arpg,
+                  # chuck, cryptothrone, ...) must be pulled through the kbve.sh
+                  # wrapper, which injects the correct per-game lfs.url. Pull every
+                  # game whose asset tree falls under this build's source_path so the
+                  # docker COPY bundles real binaries, not ~130-byte pointer stubs.
+                  SCOPE="${{ inputs.source_path }}"
+                  PREFIXES=""
+                  for game in chuck rareicon rentearth arpg cryptothrone; do
+                    prefix="$(./kbve.sh -lfs "$game" path 2>/dev/null || true)"
+                    [ -n "$prefix" ] || continue
+                    case "$prefix" in
+                      "$SCOPE"|"$SCOPE"/*)
+                        if git lfs ls-files -- "$prefix" 2>/dev/null | grep -q .; then
+                          echo "→ pulling $game LFS under $prefix"
+                          ./kbve.sh -lfs "$game" pull --include="$prefix/**"
+                          PREFIXES="$PREFIXES $prefix"
+                        fi
+                        ;;
+                    esac
+                  done
+                  # Fail the build if any pulled asset is still a pointer stub.
+                  # Real art is binary so -I skips it; a text match means the blob
+                  # never resolved and would ship broken (the arpg crash on
+                  # kbve.com/arcade/arpg was exactly this).
+                  if [ -n "$PREFIXES" ]; then
+                    STUBS="$(grep -rlI 'git-lfs.github.com/spec' $PREFIXES 2>/dev/null || true)"
+                    if [ -n "$STUBS" ]; then
+                      echo "::error::Forgejo LFS blobs unresolved — these would ship as pointer stubs:"
+                      echo "$STUBS"
+                      exit 1
+                    fi
+                  fi
+
             - name: Sync version from MDX to build manifest
               if: ${{ inputs.version_source != '' && inputs.version_target != '' }}
               run: |

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -223,6 +223,40 @@ jobs:
                   chmod 600 "$HOME/.netrc"
                   echo "Forgejo LFS credentials configured for git.kbve.com"
 
+            - name: Pull per-game Forgejo LFS blobs
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' && steps.lfs_detect.outputs.uses_lfs == 'true' }}
+              run: |
+                  set -euo pipefail
+                  # Stock git-lfs only resolves the repo-root .lfsconfig (rareicon
+                  # endpoint). Games whose blobs live on other Forgejo repos (arpg,
+                  # chuck, cryptothrone, ...) must be pulled via the kbve.sh wrapper,
+                  # which injects the correct per-game lfs.url. Pull every game whose
+                  # asset tree falls under this build's source_path so the rebuild
+                  # fallback bundles real binaries, not ~130-byte pointer stubs.
+                  SCOPE="${{ inputs.source_path }}"
+                  PREFIXES=""
+                  for game in chuck rareicon rentearth arpg cryptothrone; do
+                    prefix="$(./kbve.sh -lfs "$game" path 2>/dev/null || true)"
+                    [ -n "$prefix" ] || continue
+                    case "$prefix" in
+                      "$SCOPE"|"$SCOPE"/*)
+                        if git lfs ls-files -- "$prefix" 2>/dev/null | grep -q .; then
+                          echo "→ pulling $game LFS under $prefix"
+                          ./kbve.sh -lfs "$game" pull --include="$prefix/**"
+                          PREFIXES="$PREFIXES $prefix"
+                        fi
+                        ;;
+                    esac
+                  done
+                  if [ -n "$PREFIXES" ]; then
+                    STUBS="$(grep -rlI 'git-lfs.github.com/spec' $PREFIXES 2>/dev/null || true)"
+                    if [ -n "$STUBS" ]; then
+                      echo "::error::Forgejo LFS blobs unresolved — these would ship as pointer stubs:"
+                      echo "$STUBS"
+                      exit 1
+                    fi
+                  fi
+
             - name: Build Docker Image with Nx
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
               env:

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/sprites.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/sprites.ts
@@ -30,6 +30,35 @@ import {
 const isOneShot = (s: ClassState): boolean => ONE_SHOT_STATES.includes(s);
 const isLocomotion = (s: ClassState): boolean => LOCOMOTION_STATES.includes(s);
 
+const warnedAnims = new Set<string>();
+
+/**
+ * Play an animation only when it exists and has frames. A texture that failed to
+ * load — e.g. a Git LFS pointer stub shipped instead of the real PNG — produces
+ * a zero-frame animation, and Phaser then throws in getFirstTick reading
+ * `currentFrame.duration`, taking down the whole scene at spawn. Guarding here
+ * keeps the game alive (the sprite holds its static first frame) and logs the
+ * offending key once so the missing asset is diagnosable.
+ */
+function safePlay(
+	sprite: Phaser.GameObjects.Sprite,
+	key: string,
+	ignoreIfPlaying = false,
+): void {
+	const mgr = sprite.scene.anims;
+	const anim = mgr.exists(key) ? mgr.get(key) : undefined;
+	if (!anim || anim.frames.length === 0) {
+		if (!warnedAnims.has(key)) {
+			warnedAnims.add(key);
+			console.warn(
+				`[arpg] animation "${key}" missing or has no frames — texture failed to load (LFS pointer stub?); skipping play()`,
+			);
+		}
+		return;
+	}
+	sprite.play(key, ignoreIfPlaying);
+}
+
 /** Per-player directional pose state, tracked on the entity refs. */
 export interface ClassView {
 	def: ClassDef;
@@ -86,12 +115,12 @@ export function makeClassSprite(
 	);
 	shadow.setOrigin(0.5, def.originY);
 	shadow.setDisplaySize(def.displaySize, def.displaySize);
-	shadow.play(classAnimKey(def, 'Idle', angle, 'Shadow'));
+	safePlay(shadow, classAnimKey(def, 'Idle', angle, 'Shadow'));
 
 	const sprite = scene.add.sprite(0, 0, classSheetKey(def, 'Idle', angle), 0);
 	sprite.setOrigin(0.5, def.originY);
 	sprite.setDisplaySize(def.displaySize, def.displaySize);
-	sprite.play(classAnimKey(def, 'Idle', angle));
+	safePlay(sprite, classAnimKey(def, 'Idle', angle));
 
 	const view: ClassView = {
 		def,
@@ -217,10 +246,11 @@ export function setClassPose(
 	const entryProgress = blend ? (sprite.anims?.getProgress() ?? 0) : 0;
 
 	sprite.setDisplaySize(view.def.displaySize, view.def.displaySize);
-	sprite.play(classAnimKey(view.def, state, view.angle), !oneShot);
+	safePlay(sprite, classAnimKey(view.def, state, view.angle), !oneShot);
 	if (view.shadow) {
 		view.shadow.setDisplaySize(view.def.displaySize, view.def.displaySize);
-		view.shadow.play(
+		safePlay(
+			view.shadow,
 			classAnimKey(view.def, state, view.angle, 'Shadow'),
 			!oneShot,
 		);
@@ -247,10 +277,11 @@ export function tickClassFacing(
 	if (angle === view.angle) return false;
 	view.angle = angle;
 	const progress = sprite.anims?.getProgress() ?? 0;
-	sprite.play(classAnimKey(view.def, view.state, angle), true);
+	safePlay(sprite, classAnimKey(view.def, view.state, angle), true);
 	sprite.anims?.setProgress(Phaser.Math.Clamp(progress, 0, 1));
 	if (view.shadow) {
-		view.shadow.play(
+		safePlay(
+			view.shadow,
 			classAnimKey(view.def, view.state, angle, 'Shadow'),
 			true,
 		);

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.205"
+version: "1.0.206"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml

--- a/kbve.sh
+++ b/kbve.sh
@@ -1080,6 +1080,11 @@ EOF
         return 1
     fi
 
+    if [ "$1" = "path" ]; then
+        echo "$path_prefix"
+        return 0
+    fi
+
     if [ "$1" = "register" ]; then
         shift
         local remote="${1:-origin}"


### PR DESCRIPTION
## Symptom
kbve.com/arcade/arpg crashes on load:
```
TypeError: undefined is not an object (evaluating 'C.currentFrame.duration')
  getFirstTick → startAnimation → makePlayerRefs → spawnLocalPlayer → create
```

## Root cause
Every arpg art asset on prod is a **~130-byte Git LFS pointer stub**, not the real PNG (confirmed live: `Idle_Bow_Shadow_180.png` etc. return `version https://git-lfs.github.com/spec/v1 ...`). Phaser loads the pointer text as an image → texture fails to decode → `generateFrameNumbers` returns **0 frames** → `play()` crashes in `getFirstTick`.

The `kbve/kbve` image (axum API + astro site) builds the site in its Dockerfile, which `COPY`s the checked-out assets and runs `astro build` — but **nothing pulls the arpg LFS blobs first**. Stock git-lfs only honours the repo-root `.lfsconfig` (`KBVE/rareicon`); arpg blobs live on `KBVE/arpg`, reachable only via the `kbve.sh -lfs arpg pull` wrapper (which injects that endpoint). CI configured a Forgejo netrc but never ran the pull.

## Fix
**CI (real fix)** — `docker-test-app.yml` (primary build) + `utils-publish-docker-image.yml` (rebuild fallback): after the netrc step, pull every game whose asset tree falls under the build's `source_path` via `kbve.sh -lfs <game> pull`, then **fail the build** if any asset is still a pointer stub (`grep -I` flags unresolved text pointers). Silent degradation → hard failure, so stubs can't reach prod again. Adds `kbve.sh -lfs <game> path` to map a game to its asset prefix.

**Game resilience** — `makeClassSprite` / `setClassState` / `tickClassFacing` route every `anims.play()` through a new `safePlay()` guard that skips zero-frame animations (logging the key once) instead of crashing the whole scene. A missing sheet now degrades to a static frame, not a white screen.

**Deploy** — bumps the api app `1.0.205 → 1.0.206` so a rebuild picks up the fix.

## Verification
`bash -n kbve.sh` OK; both workflows parse; `kbve.sh -lfs arpg path` → `apps/kbve/astro-kbve/public/assets/arcade/arpg`. Local assets are intact real PNGs — this is purely a build/deploy LFS-resolution gap.

Note: metrics.kbve.com `/api/v1/ingest/errors` returns 503 (observ ingest down) — separate issue, not addressed here.