### PR TITLE
build(axum-kbve): container-prep arpg LFS pull (parity with cryptothrone)

### DIFF
--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -68,9 +68,19 @@
 				"parallel": false
 			}
 		},
+		"container-prep": {
+			"executor": "nx:run-commands",
+			"options": {
+				"parallel": false,
+				"commands": [
+					"(cd \"$(git rev-parse --show-toplevel)\" && ./kbve.sh -lfs arpg pull --include='apps/kbve/astro-kbve/public/assets/arcade/arpg/**') || echo 'arpg LFS pull skipped (no creds / offline) — sprites may ship as pointer stubs'"
+				]
+			}
+		},
 		"container": {
 			"executor": "nx:run-commands",
 			"defaultConfiguration": "local",
+			"dependsOn": ["container-prep"],
 			"options": {
 				"parallel": false
 			},


### PR DESCRIPTION
## Context
Follow-up to the arpg LFS crash (#13002). While confirming cryptothrone's frontend was "hooked up right" for LFS, I found the asymmetry is the **opposite** of expected:

- **cryptothrone is already correct.** `axum-cryptothrone:container` → `container-prep` runs `astro-cryptothrone:build`, which runs `kbve.sh -lfs cryptothrone pull` on the runner before the Docker COPY. That's why cryptothrone.com serves real assets (verified: 439KB webp, 200).
- **axum-kbve was the one missing it.** No `container-prep`, no `dependsOn` on `container` — so the arpg LFS blobs were never resolved before the Dockerfile COPYs the astro source and builds in-image → ~130-byte pointer stubs → the kbve.com/arcade/arpg crash.

## Change
Give axum-kbve the same pattern cryptothrone already has: a `container-prep` target that runs `kbve.sh -lfs arpg pull` (offline-guarded for local dev), and make `container` `dependsOn` it.

## Why, given #13002 already added a CI workflow pull
- #13002's per-game pull lives in the reusable **workflows** (`docker-test-app` / `utils-publish`) — it fixes CI/prod.
- This fixes **local** `nx run axum-kbve:container` builds too (the workflow doesn't run locally), and is defense-in-depth: arpg's fix no longer depends solely on the workflow step.
- Both frontends now use the identical app-level LFS-resolution pattern.

No version bump (build-config only; rides the next axum-kbve build). No cryptothrone change — it was already correct.