### PR TITLE
feat(arpg): inventory pickup + panel + offline sim (follow-up to #13001)

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
@@ -8,7 +8,13 @@ import {
 	type ReactNode,
 	type RefObject,
 } from 'react';
-import { onHud, onHudClear, onInventory, type HudState } from './systems/hud';
+import {
+	onHud,
+	onHudClear,
+	onInventory,
+	onInventoryOpen,
+	type HudState,
+} from './systems/hud';
 import type { InventoryItem } from '@kbve/laser';
 import { PixelPanel } from './PixelPanel';
 
@@ -91,19 +97,23 @@ function Anchor({
 export default function ArpgHud({ debug = false }: { debug?: boolean }) {
 	const [hud, setHud] = useState<HudState | null>(null);
 	const [inv, setInv] = useState<InventoryItem[]>([]);
+	const [open, setOpen] = useState(false);
 	const rootRef = useRef<HTMLDivElement>(null);
 	const scale = useHudScale(rootRef);
 
 	useEffect(() => {
 		const off = onHud(setHud);
 		const offInv = onInventory(setInv);
+		const offOpen = onInventoryOpen(setOpen);
 		const offClear = onHudClear(() => {
 			setHud(null);
 			setInv([]);
+			setOpen(false);
 		});
 		return () => {
 			off();
 			offInv();
+			offOpen();
 			offClear();
 		};
 	}, []);
@@ -135,6 +145,7 @@ export default function ArpgHud({ debug = false }: { debug?: boolean }) {
 						/>
 					</Anchor>
 					<InventoryBar items={inv} />
+					{open && <InventoryPanel items={inv} />}
 					{debug && (
 						<Anchor corner="bl" scale={scale}>
 							<DebugReadout fps={hud.fps} tile={hud.tile} />
@@ -206,6 +217,122 @@ function InventoryBar({
 					</div>
 				</PixelPanel>
 			))}
+		</div>
+	);
+}
+
+/**
+ * Full inventory window, toggled with the I key (Escape closes). Centered grid of
+ * every held item; the first nine show their 1-9 hotkey. The hotbar stays visible
+ * underneath. Server-authoritative via `arpg:inventory`.
+ */
+function InventoryPanel({ items }: { items: InventoryItem[] }): ReactElement {
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				inset: 0,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(2,3,6,0.45)',
+				pointerEvents: 'auto',
+			}}>
+			<PixelPanel
+				variant="gold"
+				scale={3}
+				style={{ width: 360, padding: '14px 16px 18px' }}>
+				<div
+					style={{
+						fontSize: 14,
+						fontWeight: 700,
+						color: ACCENT,
+						textShadow: TEXT_SHADOW,
+						letterSpacing: 0.5,
+						marginBottom: 12,
+						textAlign: 'center',
+					}}>
+					Inventory
+				</div>
+				{items.length === 0 ? (
+					<div
+						style={{
+							color: MUTED,
+							textShadow: TEXT_SHADOW,
+							textAlign: 'center',
+							fontSize: 11,
+							padding: '18px 0',
+						}}>
+						Empty — walk over loot to pick it up.
+					</div>
+				) : (
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns: 'repeat(4, 1fr)',
+							gap: 8,
+						}}>
+						{items.map((it, i) => (
+							<div
+								key={it.ref}
+								style={{
+									position: 'relative',
+									minHeight: 54,
+									padding: '8px 4px',
+									borderRadius: 4,
+									background: 'rgba(0,0,0,0.35)',
+									border: '1px solid rgba(120,140,180,0.35)',
+									textAlign: 'center',
+								}}>
+								{i < 9 && (
+									<span
+										style={{
+											position: 'absolute',
+											top: 2,
+											left: 4,
+											fontSize: 9,
+											color: ACCENT,
+											textShadow: TEXT_SHADOW,
+											opacity: 0.85,
+										}}>
+										{i + 1}
+									</span>
+								)}
+								<div
+									style={{
+										fontSize: 10,
+										color: TEXT,
+										textShadow: TEXT_SHADOW,
+										marginTop: 6,
+										wordBreak: 'break-word',
+									}}>
+									{it.ref}
+								</div>
+								<div
+									style={{
+										fontSize: 11,
+										fontWeight: 700,
+										color: ACCENT,
+										textShadow: TEXT_SHADOW,
+									}}>
+									×{it.count}
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+				<div
+					style={{
+						marginTop: 12,
+						fontSize: 9,
+						color: MUTED,
+						textShadow: TEXT_SHADOW,
+						textAlign: 'center',
+						opacity: 0.8,
+					}}>
+					I / Esc to close · 1-9 to use
+				</div>
+			</PixelPanel>
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import {
 	GameClient,
 	ACTION_ATTACK,
+	ACTION_PICKUP,
 	attachCameraZoom,
 	flashEntity,
 	floatingText,
@@ -173,6 +174,9 @@ export class IsoArpgScene extends Phaser.Scene {
 	// Latest server-authoritative inventory (from EPHEMERAL_INVENTORY). Drives the
 	// HUD panel and the 1-9 hotkeys.
 	private inventory: InventoryItem[] = [];
+	// Ground items we've already sent a pickup for, so auto-pickup doesn't spam
+	// the same item during the request → despawn round-trip.
+	private pickupSent = new Set<number>();
 
 	private syncBridge!: SyncBridge<EntityRefs>;
 	private syncResolvers!: SyncResolvers;
@@ -594,6 +598,23 @@ export class IsoArpgScene extends Phaser.Scene {
 		if (item) this.client?.useItem(item.ref);
 	}
 
+	// Walk-over pickup: any ground item within one tile is grabbed automatically.
+	// The server validates proximity, despawns the item, and broadcasts the
+	// updated inventory; pickupSent dedupes until the despawn round-trips back.
+	private tryAutoPickup(): void {
+		if (!this.client) return;
+		const me = floatTile(this.floatState);
+		for (const sid of this.store.serverIdsWith('item')) {
+			if (this.pickupSent.has(sid)) continue;
+			const t = this.store.tile(sid);
+			if (!t) continue;
+			if (Math.max(Math.abs(t.x - me.x), Math.abs(t.y - me.y)) <= 1) {
+				this.client.action(ACTION_PICKUP, sid);
+				this.pickupSent.add(sid);
+			}
+		}
+	}
+
 	private applySnapshot(s: Snapshot) {
 		for (const p of s.players) {
 			this.slotUsername.set(p.slot, p.kbve_username);
@@ -713,6 +734,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		const myRefs = this.store.refs(this.myEid);
 		if (myRefs) this.tickLocalMotion(myRefs, delta);
 
+		this.tryAutoPickup();
 		this.tickHud(delta);
 	}
 

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -78,7 +78,12 @@ import {
 } from './systems/dungeon';
 import { findHierPath, type GateGraph } from './systems/pathfind';
 import { fireBow, showDamage, type BowShot } from './combat/bow';
-import { emitHud, clearHud, emitInventory } from './systems/hud';
+import {
+	emitHud,
+	clearHud,
+	emitInventory,
+	emitInventoryOpen,
+} from './systems/hud';
 import { facingDegFromDelta } from './entities/classes';
 import {
 	makeSprite,
@@ -177,6 +182,8 @@ export class IsoArpgScene extends Phaser.Scene {
 	// Ground items we've already sent a pickup for, so auto-pickup doesn't spam
 	// the same item during the request → despawn round-trip.
 	private pickupSent = new Set<number>();
+	// Full inventory panel open state (toggled with I).
+	private inventoryOpen = false;
 
 	private syncBridge!: SyncBridge<EntityRefs>;
 	private syncResolvers!: SyncResolvers;
@@ -457,10 +464,17 @@ export class IsoArpgScene extends Phaser.Scene {
 			right: kb.addKey(Phaser.Input.Keyboard.KeyCodes.D),
 		};
 		this.fireKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-		// Number keys 1-9 use the matching inventory slot.
+		// Number keys 1-9 use the matching inventory slot; I toggles the full
+		// inventory panel; Escape closes it.
 		kb.on('keydown', (ev: KeyboardEvent) => {
 			if (ev.key >= '1' && ev.key <= '9') {
 				this.useInventorySlot(Number(ev.key) - 1);
+			} else if (ev.key === 'i' || ev.key === 'I') {
+				this.inventoryOpen = !this.inventoryOpen;
+				emitInventoryOpen(this.inventoryOpen);
+			} else if (ev.key === 'Escape' && this.inventoryOpen) {
+				this.inventoryOpen = false;
+				emitInventoryOpen(false);
 			}
 		});
 		this.input.mouse?.disableContextMenu();
@@ -527,6 +541,17 @@ export class IsoArpgScene extends Phaser.Scene {
 				}
 				this.placeSprite(refs.sprite, e.tile.x, e.tile.y);
 				this.syncShadow(refs);
+				// Ground loot bobs gently so it reads as a pickup, not scenery.
+				if (this.kinds.catName(e.kind) === 'item') {
+					this.tweens.add({
+						targets: refs.sprite,
+						y: refs.sprite.y - 6,
+						duration: 650,
+						yoyo: true,
+						repeat: -1,
+						ease: 'Sine.easeInOut',
+					});
+				}
 				if (label) {
 					refs.nameplate = makeNameplate(this, label);
 					this.placeNameplate(refs);

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -110,6 +110,22 @@ import { resolvePlayerName } from './playerName';
 
 const LOCAL_PLAYER_EID = 1;
 const LOCAL_PLAYER_KIND = 1;
+// Offline (DEBUG_LOCAL_PLAYER) sim: there is no server, so a small client-only
+// fixture seeds ground loot + a heal table to exercise the inventory loop. The
+// real game is server-authoritative; this only runs when localMode is set.
+const LOCAL_ITEM_KIND = 2;
+const LOCAL_ITEM_EID_BASE = 1000;
+const LOCAL_LOOT: ReadonlyArray<{
+	ref: string;
+	count: number;
+	dx: number;
+	dy: number;
+}> = [
+	{ ref: 'potion', count: 3, dx: 1, dy: -2 },
+	{ ref: 'potion', count: 1, dx: -2, dy: 1 },
+	{ ref: 'coin', count: 12, dx: 2, dy: 2 },
+];
+const LOCAL_HEAL: ReadonlyMap<string, number> = new Map([['potion', 15]]);
 
 /**
  * Collapse a 16-direction facing degree (screen-space, 0=N CW) into the four
@@ -184,6 +200,11 @@ export class IsoArpgScene extends Phaser.Scene {
 	private pickupSent = new Set<number>();
 	// Full inventory panel open state (toggled with I).
 	private inventoryOpen = false;
+	// Offline-only ground loot (server eid -> ref/count/tile). Empty online.
+	private localItems = new Map<
+		number,
+		{ ref: string; count: number; tile: TileXY }
+	>();
 
 	private syncBridge!: SyncBridge<EntityRefs>;
 	private syncResolvers!: SyncResolvers;
@@ -620,24 +641,78 @@ export class IsoArpgScene extends Phaser.Scene {
 	// EPHEMERAL_INVENTORY refreshes the HUD.
 	private useInventorySlot(idx: number): void {
 		const item = this.inventory[idx];
-		if (item) this.client?.useItem(item.ref);
+		if (!item) return;
+		if (this.client) {
+			this.client.useItem(item.ref);
+			return;
+		}
+		if (!this.localMode) return;
+		// Offline: apply the heal + consume the item client-side.
+		const heal = LOCAL_HEAL.get(item.ref) ?? 0;
+		if (heal > 0) {
+			const hp = Math.min(
+				this.store.maxHp(this.myEid),
+				this.store.hp(this.myEid) + heal,
+			);
+			this.store.update(this.myEid, { hp });
+		}
+		const left = item.count - 1;
+		this.inventory =
+			left <= 0
+				? this.inventory.filter((_, i) => i !== idx)
+				: this.inventory.map((s, i) =>
+						i === idx ? { ...s, count: left } : s,
+					);
+		emitInventory(this.inventory);
 	}
 
 	// Walk-over pickup: any ground item within one tile is grabbed automatically.
 	// The server validates proximity, despawns the item, and broadcasts the
 	// updated inventory; pickupSent dedupes until the despawn round-trips back.
 	private tryAutoPickup(): void {
-		if (!this.client) return;
 		const me = floatTile(this.floatState);
-		for (const sid of this.store.serverIdsWith('item')) {
-			if (this.pickupSent.has(sid)) continue;
-			const t = this.store.tile(sid);
-			if (!t) continue;
-			if (Math.max(Math.abs(t.x - me.x), Math.abs(t.y - me.y)) <= 1) {
-				this.client.action(ACTION_PICKUP, sid);
-				this.pickupSent.add(sid);
+		if (this.client) {
+			for (const sid of this.store.serverIdsWith('item')) {
+				if (this.pickupSent.has(sid)) continue;
+				const t = this.store.tile(sid);
+				if (!t) continue;
+				if (Math.max(Math.abs(t.x - me.x), Math.abs(t.y - me.y)) <= 1) {
+					this.client.action(ACTION_PICKUP, sid);
+					this.pickupSent.add(sid);
+				}
 			}
+			return;
 		}
+		if (!this.localMode) return;
+		for (const [eid, item] of this.localItems) {
+			const d = Math.max(
+				Math.abs(item.tile.x - me.x),
+				Math.abs(item.tile.y - me.y),
+			);
+			if (d <= 1) this.localPickup(eid, item);
+		}
+	}
+
+	/** Offline: grab a local ground item into the inventory + remove its sprite. */
+	private localPickup(
+		eid: number,
+		item: { ref: string; count: number; tile: TileXY },
+	): void {
+		const refs = this.store.despawn(eid);
+		if (refs) {
+			this.tweens.killTweensOf(refs.sprite);
+			refs.sprite.destroy();
+		}
+		this.localItems.delete(eid);
+		const has = this.inventory.some((s) => s.ref === item.ref);
+		this.inventory = has
+			? this.inventory.map((s) =>
+					s.ref === item.ref
+						? { ...s, count: s.count + item.count }
+						: s,
+				)
+			: [...this.inventory, { ref: item.ref, count: item.count }];
+		emitInventory(this.inventory);
 	}
 
 	private applySnapshot(s: Snapshot) {
@@ -1074,6 +1149,55 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.floatState = makeFloatState(tile);
 		this.cameras.main.startFollow(refs.sprite, true, 0.12, 0.12);
 		this.cameras.main.setZoom(1.5);
+
+		// Seed offline loot so the inventory loop is testable without a server.
+		LOCAL_LOOT.forEach((l, i) => {
+			const t = this.dungeon.nearestFloor({
+				x: tile.x + l.dx,
+				y: tile.y + l.dy,
+			});
+			this.spawnLocalItem(LOCAL_ITEM_EID_BASE + i, l.ref, l.count, t);
+		});
+	}
+
+	/** Offline only: render a floating ground-loot sprite tracked in localItems. */
+	private spawnLocalItem(
+		eid: number,
+		ref: string,
+		count: number,
+		tile: TileXY,
+	): void {
+		if (!this.kindRegistry.has(LOCAL_ITEM_KIND)) {
+			this.kindRegistry.set(LOCAL_ITEM_KIND, {
+				kind: LOCAL_ITEM_KIND,
+				ref,
+				cat: 2, // KIND_CAT_ITEM
+			});
+		}
+		const sprite = makeSprite(this, this.kinds, LOCAL_ITEM_KIND, false);
+		this.placeSprite(sprite, tile.x, tile.y);
+		this.tweens.add({
+			targets: sprite,
+			y: sprite.y - 6,
+			duration: 650,
+			yoyo: true,
+			repeat: -1,
+			ease: 'Sine.easeInOut',
+		});
+		this.store.spawn(
+			eid,
+			{
+				tile,
+				kind: LOCAL_ITEM_KIND,
+				cat: 'item',
+				owner: 0,
+				hostile: false,
+				hp: 0,
+				maxHp: 0,
+			},
+			{ sprite },
+		);
+		this.localItems.set(eid, { ref, count, tile });
 	}
 
 	/**

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/sprites.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/entities/sprites.ts
@@ -82,7 +82,8 @@ export interface EntityRefs {
 }
 
 function bodyColor(cat: number, hostile: boolean): number {
-	if (cat === KIND_CAT_ITEM) return COLORS.npc;
+	// Ground loot reads as a bright amber gem so it stands out against the floor.
+	if (cat === KIND_CAT_ITEM) return 0xfacc15;
 	return hostile ? COLORS.enemy : COLORS.npc;
 }
 

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
@@ -32,6 +32,19 @@ export function onInventory(
 	return laserEvents.on(INVENTORY_EVENT, handler as (data: unknown) => void);
 }
 
+export const INVENTORY_OPEN_EVENT = 'arpg:inventory:open';
+
+export function emitInventoryOpen(open: boolean): void {
+	laserEvents.emit(INVENTORY_OPEN_EVENT, open);
+}
+
+export function onInventoryOpen(handler: (open: boolean) => void): () => void {
+	return laserEvents.on(
+		INVENTORY_OPEN_EVENT,
+		handler as (data: unknown) => void,
+	);
+}
+
 export const HUD_CLEAR_EVENT = 'arpg:hud:clear';
 
 export function clearHud(): void {


### PR DESCRIPTION
## ARPG inventory — pickup + panel + offline sim (follow-up to #13001)

Three commits that stranded after #13001 was squash-merged (pushed to the branch post-merge). Re-applied cleanly onto dev.

- **Walk-over auto-pickup** — the client never sent `ACTION_PICKUP`, so inventory could never populate. Any ground item within one tile is now grabbed automatically (server validates + despawns + rebroadcasts; dedup during the round-trip).
- **Inventory panel + floating loot** — `I` toggles a full centered inventory window (Esc closes); the bottom hotbar stays. Ground items render as a bright amber gem with a gentle bob so loot reads as a pickup.
- **Offline inventory sim** — `DEBUG_LOCAL_PLAYER` skips the server, so the loop had nothing to drive it. A client-only fixture (gated on `localMode`, dev-only) seeds floating loot near spawn + does pickup/use locally (potion +15). Online stays fully server-authoritative.

### Checks
Client typechecks clean (no isometric-arpg errors). No server changes.
