### PR TITLE
feat(gh-sync): bidirectional GitHub ↔ Discord issue sync (#12984)

### DIFF
--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -32,8 +32,8 @@ hex = "0.4.3"
 globset = "0.4.18"
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi" }
-kbve = { path = "../../../packages/rust/kbve", features = ["supabase", "image-gen"] }
+jedi = { path = "../../../packages/rust/jedi", features = ["valkey"] }
+kbve = { path = "../../../packages/rust/kbve", features = ["supabase", "image-gen", "kv"] }
 bevy_items = { path = "../../../packages/rust/bevy/bevy_items", features = ["inventory"] }
 bevy_inventory = { path = "../../../packages/rust/bevy/bevy_inventory", default-features = false }
 bevy_battle = { path = "../../../packages/rust/bevy/bevy_battle" }

--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -242,6 +242,45 @@ async fn event_handler(
 
         serenity::FullEvent::Message { new_message } => {
             super::relay::handle_discord_message(new_message, &data.app).await;
+            super::gh_reverse::handle_reverse_message(new_message, &data.app).await;
+        }
+
+        serenity::FullEvent::MessageUpdate { new, event, .. } => {
+            let (author, content) = match new {
+                Some(msg) => (
+                    Some(
+                        msg.author
+                            .global_name
+                            .clone()
+                            .unwrap_or_else(|| msg.author.name.clone()),
+                    ),
+                    Some(msg.content.clone()),
+                ),
+                None => (
+                    event
+                        .author
+                        .as_ref()
+                        .map(|a| a.global_name.clone().unwrap_or_else(|| a.name.clone())),
+                    event.content.clone(),
+                ),
+            };
+            super::gh_reverse::handle_reverse_edit(
+                event.channel_id,
+                event.id,
+                author,
+                content,
+                &data.app,
+            )
+            .await;
+        }
+
+        serenity::FullEvent::MessageDelete {
+            channel_id,
+            deleted_message_id,
+            ..
+        } => {
+            super::gh_reverse::handle_reverse_delete(*channel_id, *deleted_message_id, &data.app)
+                .await;
         }
 
         _ => {}

--- a/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
@@ -1,0 +1,375 @@
+use std::sync::Arc;
+
+use jedi::entity::github::GitHubClient;
+use poise::serenity_prelude as serenity;
+use tracing::{debug, info, warn};
+
+use crate::discord::github::resolve_github_token;
+use crate::state::AppState;
+
+const DIRECTION: &str = "discord_to_github";
+const MAX_COMMENT_LEN: usize = 65_536;
+const TRUNCATE_NOTICE: &str = "\n\n…(truncated)";
+const TOMBSTONE: &str = "_[deleted on Discord]_";
+
+fn reverse_enabled() -> bool {
+    !matches!(
+        std::env::var("GH_REVERSE_SYNC_ENABLED").ok().as_deref(),
+        Some("0") | Some("false") | Some("off")
+    )
+}
+
+fn delete_mode_hard() -> bool {
+    matches!(
+        std::env::var("GH_REVERSE_DELETE_MODE").ok().as_deref(),
+        Some("delete")
+    )
+}
+
+async fn github_client_for(app: &Arc<AppState>, guild_id: u64) -> Option<GitHubClient> {
+    let token = resolve_github_token(Some(guild_id)).await?;
+    let client = GitHubClient::new(&token).with_policy(app.github_repo_policy.clone());
+    let client = match std::env::var("GITHUB_API_BASE_URL") {
+        Ok(url) if !url.is_empty() => client.with_base_url(&url),
+        _ => client,
+    };
+    Some(client)
+}
+
+/// A human reply in a synced issue thread → a GitHub issue comment.
+///
+/// Guards: not bot-authored (echo), reverse-sync enabled, the channel is a
+/// tracked forum thread mapped to a `gh.issue`, the message's guild matches the
+/// mapped guild, a guild PAT resolves, and the message has not already been
+/// mirrored (idempotency claim). Any failure logs + returns; it never panics
+/// and never blocks the forward sync or IRC relay.
+pub async fn handle_reverse_message(message: &serenity::Message, app: &Arc<AppState>) {
+    if !reverse_enabled() || !app.github_store.is_enabled() || message.author.bot {
+        return;
+    }
+    let Some(guild_id) = message.guild_id else {
+        return;
+    };
+
+    let thread_id = message.channel_id.get() as i64;
+    let issue = match app.github_store.get_issue_by_thread_id(thread_id).await {
+        Ok(Some(i)) => i,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(error = %e, thread_id, "gh reverse: thread→issue lookup failed");
+            return;
+        }
+    };
+
+    if issue.discord_guild_id != Some(guild_id.get() as i64) {
+        warn!(
+            thread_id,
+            mapped = ?issue.discord_guild_id,
+            actual = guild_id.get(),
+            "gh reverse: thread guild mismatch, skipping"
+        );
+        return;
+    }
+
+    let author = author_name(message);
+    let body = render_comment(&author, &message.content, &message.attachments);
+    if body.trim().is_empty() {
+        return;
+    }
+
+    let message_id = message.id.get() as i64;
+    match app
+        .github_store
+        .claim_comment_mirror(
+            message_id,
+            thread_id,
+            &issue.owner,
+            &issue.repo,
+            issue.number,
+            DIRECTION,
+            Some(&author),
+        )
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            debug!(
+                counter = "pipe_gh_reverse_skipped_loop",
+                message_id, "gh reverse: already mirrored, skipping"
+            );
+            return;
+        }
+        Err(e) => {
+            warn!(error = %e, message_id, "gh reverse: claim_comment_mirror failed");
+            return;
+        }
+    }
+
+    let Some(client) = github_client_for(app, guild_id.get()).await else {
+        warn!(
+            counter = "pipe_gh_reverse_skipped_auth",
+            guild = guild_id.get(),
+            number = issue.number,
+            "gh reverse: no guild PAT, skipping"
+        );
+        return;
+    };
+
+    match client
+        .create_comment(&issue.owner, &issue.repo, issue.number as u64, &body)
+        .await
+    {
+        Ok(c) => {
+            if let Err(e) = app
+                .github_store
+                .set_comment_mirror_github_id(message_id, c.id as i64)
+                .await
+            {
+                warn!(error = %e, message_id, comment_id = c.id, "gh reverse: failed to record comment id");
+            }
+            info!(
+                counter = "pipe_gh_reverse_posted",
+                owner = %issue.owner,
+                repo = %issue.repo,
+                number = issue.number,
+                message_id,
+                comment_id = c.id,
+                "gh reverse: thread reply mirrored to GitHub"
+            );
+        }
+        Err(e) => {
+            warn!(
+                counter = "pipe_gh_reverse_failed",
+                error = %e,
+                number = issue.number,
+                message_id,
+                "gh reverse: create_comment failed"
+            );
+        }
+    }
+}
+
+/// An edit to a previously mirrored thread message → PATCH the GH comment.
+pub async fn handle_reverse_edit(
+    channel_id: serenity::ChannelId,
+    message_id: serenity::MessageId,
+    author: Option<String>,
+    content: Option<String>,
+    app: &Arc<AppState>,
+) {
+    if !reverse_enabled() || !app.github_store.is_enabled() {
+        return;
+    }
+    let Some(content) = content else {
+        return;
+    };
+
+    let mid = message_id.get() as i64;
+    let mirror = match app.github_store.get_comment_mirror(mid).await {
+        Ok(Some(m)) => m,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(error = %e, message_id = mid, "gh reverse: get_comment_mirror (edit) failed");
+            return;
+        }
+    };
+    if mirror.direction != DIRECTION || mirror.deleted_at.is_some() {
+        return;
+    }
+    let Some(comment_id) = mirror.github_comment_id else {
+        return;
+    };
+
+    let Some(guild_id) = guild_for_thread(app, channel_id).await else {
+        return;
+    };
+    let display = author.unwrap_or_else(|| mirror.author.clone().unwrap_or_default());
+    let body = render_comment(&display, &content, &[]);
+
+    let Some(client) = github_client_for(app, guild_id).await else {
+        warn!(
+            counter = "pipe_gh_reverse_skipped_auth",
+            message_id = mid,
+            "gh reverse: no PAT for edit"
+        );
+        return;
+    };
+    match client
+        .update_comment(&mirror.owner, &mirror.repo, comment_id as u64, &body)
+        .await
+    {
+        Ok(_) => info!(
+            counter = "pipe_gh_reverse_edited",
+            message_id = mid,
+            comment_id,
+            "gh reverse: edit propagated"
+        ),
+        Err(e) => warn!(
+            counter = "pipe_gh_reverse_failed",
+            error = %e, message_id = mid, comment_id, "gh reverse: update_comment failed"
+        ),
+    }
+}
+
+/// A delete of a mirrored thread message → tombstone (default) or hard-delete
+/// the GH comment, then mark the mirror row deleted.
+pub async fn handle_reverse_delete(
+    channel_id: serenity::ChannelId,
+    message_id: serenity::MessageId,
+    app: &Arc<AppState>,
+) {
+    if !reverse_enabled() || !app.github_store.is_enabled() {
+        return;
+    }
+    let mid = message_id.get() as i64;
+    let mirror = match app.github_store.get_comment_mirror(mid).await {
+        Ok(Some(m)) => m,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(error = %e, message_id = mid, "gh reverse: get_comment_mirror (delete) failed");
+            return;
+        }
+    };
+    if mirror.direction != DIRECTION || mirror.deleted_at.is_some() {
+        return;
+    }
+    let Some(comment_id) = mirror.github_comment_id else {
+        return;
+    };
+    let Some(guild_id) = guild_for_thread(app, channel_id).await else {
+        return;
+    };
+    let Some(client) = github_client_for(app, guild_id).await else {
+        warn!(
+            counter = "pipe_gh_reverse_skipped_auth",
+            message_id = mid,
+            "gh reverse: no PAT for delete"
+        );
+        return;
+    };
+
+    let outcome = if delete_mode_hard() {
+        client
+            .delete_comment(&mirror.owner, &mirror.repo, comment_id as u64)
+            .await
+            .map(|_| "deleted")
+    } else {
+        client
+            .update_comment(&mirror.owner, &mirror.repo, comment_id as u64, TOMBSTONE)
+            .await
+            .map(|_| "tombstoned")
+    };
+
+    match outcome {
+        Ok(kind) => {
+            if let Err(e) = app.github_store.mark_comment_mirror_deleted(mid).await {
+                warn!(error = %e, message_id = mid, "gh reverse: mark_comment_mirror_deleted failed");
+            }
+            info!(
+                counter = "pipe_gh_reverse_deleted",
+                message_id = mid,
+                comment_id,
+                kind,
+                "gh reverse: delete propagated"
+            );
+        }
+        Err(e) => warn!(
+            counter = "pipe_gh_reverse_failed",
+            error = %e, message_id = mid, comment_id, "gh reverse: delete propagation failed"
+        ),
+    }
+}
+
+async fn guild_for_thread(app: &Arc<AppState>, channel_id: serenity::ChannelId) -> Option<u64> {
+    match app
+        .github_store
+        .get_issue_by_thread_id(channel_id.get() as i64)
+        .await
+    {
+        Ok(Some(issue)) => issue.discord_guild_id.map(|g| g as u64),
+        _ => None,
+    }
+}
+
+fn author_name(message: &serenity::Message) -> String {
+    message
+        .author
+        .global_name
+        .clone()
+        .unwrap_or_else(|| message.author.name.clone())
+}
+
+/// Render a GitHub comment body from a Discord message: attribution prefix,
+/// neutralized mentions (no pings reach GitHub), appended attachment URLs, and
+/// a hard truncate to GitHub's 65536-char limit.
+fn render_comment(author: &str, content: &str, attachments: &[serenity::Attachment]) -> String {
+    let mut body = String::new();
+    let who = neutralize_mentions(author.trim());
+    if !who.is_empty() {
+        body.push_str(&format!("**{who}** _(via Discord)_:\n\n"));
+    }
+    body.push_str(&neutralize_mentions(content.trim()));
+    for att in attachments {
+        body.push_str(&format!("\n\n{}", att.url));
+    }
+    truncate_comment(&body)
+}
+
+/// Insert a zero-width space after every `@` so no Discord content can ping a
+/// GitHub user, team, or `@everyone`/`@here` once mirrored.
+fn neutralize_mentions(input: &str) -> String {
+    input.replace('@', "@\u{200b}")
+}
+
+fn truncate_comment(s: &str) -> String {
+    if s.len() <= MAX_COMMENT_LEN {
+        return s.to_string();
+    }
+    let budget = MAX_COMMENT_LEN - TRUNCATE_NOTICE.len();
+    let cut = s
+        .char_indices()
+        .take_while(|(i, _)| *i <= budget)
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    format!("{}{}", &s[..cut], TRUNCATE_NOTICE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neutralize_blocks_mass_mentions() {
+        let out = neutralize_mentions("hey @everyone and @here and @user");
+        assert!(!out.contains("@everyone"));
+        assert!(!out.contains("@here"));
+        assert!(out.contains("@\u{200b}everyone"));
+    }
+
+    #[test]
+    fn render_has_attribution_and_attachments() {
+        let body = render_comment("h0lyMac", "hello world", &[]);
+        assert!(body.starts_with("**h0lyMac** _(via Discord)_:"));
+        assert!(body.contains("hello world"));
+    }
+
+    #[test]
+    fn render_empty_content_no_author_is_blank() {
+        let body = render_comment("", "   ", &[]);
+        assert!(body.trim().is_empty());
+    }
+
+    #[test]
+    fn truncate_appends_notice_when_oversized() {
+        let long = "a".repeat(MAX_COMMENT_LEN + 100);
+        let out = truncate_comment(&long);
+        assert!(out.len() <= MAX_COMMENT_LEN);
+        assert!(out.ends_with(TRUNCATE_NOTICE));
+    }
+
+    #[test]
+    fn truncate_passthrough_when_small() {
+        assert_eq!(truncate_comment("short"), "short");
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use jedi::entity::github::GitHubClient;
 use poise::serenity_prelude as serenity;
@@ -24,6 +25,32 @@ fn delete_mode_hard() -> bool {
         std::env::var("GH_REVERSE_DELETE_MODE").ok().as_deref(),
         Some("delete")
     )
+}
+
+const FINALIZE_ATTEMPTS: u32 = 3;
+
+/// Record the posted GitHub comment id against the mirror row, retrying a few
+/// times. If the comment lands but the mapping never finalizes, the lease keeps
+/// the placeholder unfinalized and a much-later redelivery could double-post;
+/// the bounded retry closes that window for transient RPC blips.
+async fn finalize_mirror(app: &Arc<AppState>, message_id: i64, comment_id: i64) {
+    for attempt in 1..=FINALIZE_ATTEMPTS {
+        match app
+            .github_store
+            .set_comment_mirror_github_id(message_id, comment_id)
+            .await
+        {
+            Ok(_) => return,
+            Err(e) if attempt < FINALIZE_ATTEMPTS => {
+                warn!(error = %e, message_id, comment_id, attempt, "gh reverse: finalize retry");
+                tokio::time::sleep(Duration::from_millis(200 * attempt as u64)).await;
+            }
+            Err(e) => warn!(
+                error = %e, message_id, comment_id,
+                "gh reverse: finalize failed; comment posted but mapping unfinalized"
+            ),
+        }
+    }
 }
 
 async fn github_client_for(app: &Arc<AppState>, guild_id: u64) -> Option<GitHubClient> {
@@ -138,13 +165,7 @@ pub async fn handle_reverse_message(message: &serenity::Message, app: &Arc<AppSt
         .await
     {
         Ok(c) => {
-            if let Err(e) = app
-                .github_store
-                .set_comment_mirror_github_id(message_id, c.id as i64)
-                .await
-            {
-                warn!(error = %e, message_id, comment_id = c.id, "gh reverse: failed to record comment id");
-            }
+            finalize_mirror(app, message_id, c.id as i64).await;
             info!(
                 counter = "pipe_gh_reverse_posted",
                 owner = %issue.owner,

--- a/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_reverse.rs
@@ -38,18 +38,36 @@ async fn github_client_for(app: &Arc<AppState>, guild_id: u64) -> Option<GitHubC
 
 /// A human reply in a synced issue thread → a GitHub issue comment.
 ///
-/// Guards: not bot-authored (echo), reverse-sync enabled, the channel is a
-/// tracked forum thread mapped to a `gh.issue`, the message's guild matches the
-/// mapped guild, a guild PAT resolves, and the message has not already been
-/// mirrored (idempotency claim). Any failure logs + returns; it never panics
-/// and never blocks the forward sync or IRC relay.
+/// Guards (cheapest first, DB lookup last): reverse-sync enabled + store
+/// configured; not bot-authored / not a webhook (echo); a regular/reply message
+/// (not a system/thread-created notice); in a guild; non-empty payload; the
+/// channel is a tracked forum thread mapped to a `gh.issue`; the message's guild
+/// matches the mapped guild; a guild PAT resolves; and the message has not
+/// already been mirrored (lease-based idempotency claim). Any failure logs +
+/// returns; it never panics and never blocks the forward sync or IRC relay.
 pub async fn handle_reverse_message(message: &serenity::Message, app: &Arc<AppState>) {
-    if !reverse_enabled() || !app.github_store.is_enabled() || message.author.bot {
+    if !reverse_enabled() || !app.github_store.is_enabled() {
+        return;
+    }
+    // Echo guard: our own forward posts, other bots, and webhook deliveries.
+    if message.author.bot || message.webhook_id.is_some() {
+        return;
+    }
+    // Only mirror real user content — skip system notices (thread created,
+    // pins, joins, etc.).
+    if !matches!(
+        message.kind,
+        serenity::MessageType::Regular | serenity::MessageType::InlineReply
+    ) {
         return;
     }
     let Some(guild_id) = message.guild_id else {
         return;
     };
+    // Skip empty payloads before paying for a thread→issue lookup.
+    if message.content.trim().is_empty() && message.attachments.is_empty() {
+        return;
+    }
 
     let thread_id = message.channel_id.get() as i64;
     let issue = match app.github_store.get_issue_by_thread_id(thread_id).await {

--- a/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
@@ -6,9 +6,9 @@ use kbve::entity::client::vault::VaultClient;
 use kbve::{CachedIssue, GithubStore, UndeliveredEvent};
 use poise::serenity_prelude as serenity;
 use serde::Deserialize;
-use serenity::builder::{CreateForumPost, CreateMessage};
+use serenity::builder::{CreateForumPost, CreateMessage, EditThread};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::state::AppState;
 
@@ -371,8 +371,33 @@ async fn dispatch(
 
     match ev.event_type.as_str() {
         "opened" => ensure_thread(store, http, route, &issue).await,
-        "closed" | "reopened" | "commented" | "labeled" | "assigned" | "unassigned"
-        | "unlabeled" | "edited" | "renamed" => post_into_thread(http, &issue, ev).await,
+        "commented" => {
+            if comment_is_mirrored(store, ev).await {
+                debug!(
+                    number = ev.number,
+                    "gh sync: comment originated from reverse sync — skipping echo"
+                );
+                return Ok(());
+            }
+            post_into_thread(http, &issue, ev).await
+        }
+        "closed" => {
+            post_into_thread(http, &issue, ev).await?;
+            set_thread_archived(http, &issue, true).await;
+            Ok(())
+        }
+        "reopened" => {
+            set_thread_archived(http, &issue, false).await;
+            post_into_thread(http, &issue, ev).await
+        }
+        "deleted" | "transferred" => {
+            post_into_thread(http, &issue, ev).await?;
+            set_thread_archived(http, &issue, true).await;
+            Ok(())
+        }
+        "labeled" | "assigned" | "unassigned" | "unlabeled" | "edited" | "renamed" => {
+            post_into_thread(http, &issue, ev).await
+        }
         _ => {
             debug!(
                 event = %ev.event_type,
@@ -381,6 +406,65 @@ async fn dispatch(
             );
             Ok(())
         }
+    }
+}
+
+/// Echo guard: a "commented" event whose GitHub comment id is already mapped in
+/// gh.comment_mirror originated from the reverse-sync path; re-posting it would
+/// duplicate the user's own thread reply. Fails open (posts) on lookup error.
+async fn comment_is_mirrored(store: &Arc<GithubStore>, ev: &UndeliveredEvent) -> bool {
+    let Some(comment_id) = ev
+        .payload
+        .get("comment")
+        .and_then(|c| c.get("id"))
+        .and_then(|id| id.as_i64())
+    else {
+        return false;
+    };
+    match store.is_github_comment_mirrored(comment_id).await {
+        Ok(mirrored) => mirrored,
+        Err(e) => {
+            warn!(error = %e, comment_id, "gh sync: echo-guard lookup failed, posting anyway");
+            false
+        }
+    }
+}
+
+/// Mirror GitHub issue state onto the forum thread (close→archive,
+/// reopen→unarchive). Event-driven only (never a reconcile loop), so a human
+/// who manually re-opens a thread is not repeatedly re-archived. Best-effort:
+/// missing MANAGE_THREADS or any HTTP error logs + returns without failing the
+/// event delivery.
+async fn set_thread_archived(http: &Arc<serenity::Http>, issue: &CachedIssue, archived: bool) {
+    let Some(thread_id) = issue.discord_thread_id else {
+        return;
+    };
+    let lock_on_close = archived
+        && matches!(
+            std::env::var("GH_SYNC_LOCK_ON_CLOSE").ok().as_deref(),
+            Some("1") | Some("true") | Some("on")
+        );
+    let mut builder = EditThread::new().archived(archived);
+    if lock_on_close {
+        builder = builder.locked(true);
+    } else if !archived {
+        builder = builder.locked(false);
+    }
+    let thread = serenity::ChannelId::new(thread_id as u64);
+    match thread.edit_thread(&**http, builder).await {
+        Ok(_) => debug!(
+            number = issue.number,
+            thread = thread_id,
+            archived,
+            "gh sync: thread lifecycle updated"
+        ),
+        Err(e) => warn!(
+            error = %e,
+            number = issue.number,
+            thread = thread_id,
+            archived,
+            "gh sync: thread lifecycle update failed (missing MANAGE_THREADS?)"
+        ),
     }
 }
 

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod components;
 pub mod embeds;
 pub mod game;
+pub mod gh_reverse;
 pub mod gh_sync;
 #[allow(dead_code)]
 pub mod github;

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -239,6 +239,10 @@ impl AppState {
             );
         }
 
+        // Shared L1+L2 cache (Valkey via KBVE_KV_URL when set, else L1-only) for
+        // the gh reverse-sync lookups. Same namespace/Valkey as other services.
+        let kv_cache = jedi::state::kv::KvCache::from_env().await;
+
         Self {
             health_monitor,
             tracker,
@@ -255,7 +259,7 @@ impl AppState {
             github_repo_policy: jedi::entity::github::RepoPolicy::from_env(),
             github_guard: GitHubCommandGuard::from_env(),
             github_cache: GitHubCache::new(),
-            github_store: Arc::new(GithubStore::from_env()),
+            github_store: Arc::new(GithubStore::from_env().with_kv(Some(kv_cache))),
             irc,
             relay,
             irc_forwarder_started: AtomicBool::new(false),

--- a/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
+++ b/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
@@ -25,14 +25,14 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
     CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
-    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR length(author) <= 256),
+    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR octet_length(author) <= 1024),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
 )
--- Claim retries (claim_expires_at/updated_at) and delete tombstones
--- (deleted_at/updated_at) touch no indexed column → HOT-update eligible; reserve
--- page headroom so they stay HOT and avoid index bloat.
-WITH (fillfactor = 90);
+-- Most rows take one non-HOT finalize (github_comment_id is indexed); only the
+-- rare lease reclaim / tombstone updates are HOT-eligible, so a light 5% reserve
+-- keeps headroom for those without sacrificing page density.
+WITH (fillfactor = 95);
 
 -- Echo guard (is_github_comment_mirrored) + one-comment-one-mapping invariant.
 CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
@@ -92,6 +92,7 @@ AS $$
             SET claim_expires_at = EXCLUDED.claim_expires_at,
                 updated_at       = statement_timestamp()
             WHERE gh.comment_mirror.github_comment_id IS NULL
+              AND gh.comment_mirror.deleted_at IS NULL
               AND COALESCE(gh.comment_mirror.claim_expires_at, '-infinity'::timestamptz)
                   <= statement_timestamp()
         RETURNING TRUE
@@ -177,8 +178,9 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
     UPDATE gh.comment_mirror
-        SET deleted_at = statement_timestamp(),
-            updated_at = statement_timestamp()
+        SET deleted_at       = statement_timestamp(),
+            claim_expires_at = NULL,
+            updated_at       = statement_timestamp()
         WHERE discord_message_id = p_discord_message_id
           AND deleted_at IS NULL
         RETURNING *;

--- a/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
+++ b/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     deleted_at          TIMESTAMPTZ,
+    claim_expires_at    TIMESTAMPTZ,
     PRIMARY KEY (discord_message_id),
     CONSTRAINT gh_comment_mirror_owner_shape_chk CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
     CONSTRAINT gh_comment_mirror_repo_shape_chk  CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
@@ -26,14 +27,20 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
-);
+)
+-- Claim retries (claim_expires_at/updated_at) and delete tombstones
+-- (deleted_at/updated_at) touch no indexed column → HOT-update eligible; reserve
+-- page headroom so they stay HOT and avoid index bloat.
+WITH (fillfactor = 90);
 
+-- Echo guard (is_github_comment_mirrored) + one-comment-one-mapping invariant.
 CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
     ON gh.comment_mirror (github_comment_id)
     WHERE github_comment_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS gh_comment_mirror_issue_idx
-    ON gh.comment_mirror (owner, repo, number, created_at DESC);
+-- No list-by-issue query exists yet; an (owner, repo, number, created_at DESC,
+-- discord_message_id DESC) index — partial on deleted_at IS NULL — should be
+-- added together with that query so it is not pure write amplification now.
 
 COMMENT ON TABLE gh.comment_mirror IS
 'Maps Discord thread messages to GitHub issue comments for bidirectional sync. discord_to_github rows are created when a human reply in a synced forum thread is mirrored to GitHub; the PK on discord_message_id makes the reverse handler idempotent (one GH comment per Discord message), and github_comment_id targets edit/delete propagation + acts as an echo guard.';
@@ -61,62 +68,67 @@ CREATE OR REPLACE FUNCTION gh.claim_comment_mirror(
     p_repo               TEXT,
     p_number             INT,
     p_direction          TEXT,
-    p_author             TEXT
+    p_author             TEXT,
+    p_lease_secs         INT DEFAULT 300
 )
 RETURNS BOOLEAN
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_claimed BOOLEAN := FALSE;
-BEGIN
-    INSERT INTO gh.comment_mirror (
-        discord_message_id, discord_channel_id, github_comment_id,
-        owner, repo, number, direction, author
+    WITH ins AS (
+        INSERT INTO gh.comment_mirror (
+            discord_message_id, discord_channel_id, github_comment_id,
+            owner, repo, number, direction, author, claim_expires_at
+        )
+        VALUES (
+            p_discord_message_id, p_discord_channel_id, NULL,
+            p_owner, p_repo, p_number, p_direction, p_author,
+            now() + make_interval(secs => GREATEST(p_lease_secs, 1))
+        )
+        ON CONFLICT (discord_message_id) DO UPDATE
+            SET claim_expires_at = EXCLUDED.claim_expires_at,
+                updated_at       = now()
+            WHERE gh.comment_mirror.github_comment_id IS NULL
+              AND gh.comment_mirror.claim_expires_at <= now()
+        RETURNING TRUE AS claimed
     )
-    VALUES (
-        p_discord_message_id, p_discord_channel_id, NULL,
-        p_owner, p_repo, p_number, p_direction, p_author
-    )
-    ON CONFLICT (discord_message_id) DO UPDATE
-        SET updated_at = now()
-        WHERE gh.comment_mirror.github_comment_id IS NULL
-    RETURNING TRUE INTO v_claimed;
-
-    RETURN COALESCE(v_claimed, FALSE);
-END;
+    SELECT COALESCE((SELECT claimed FROM ins), FALSE);
 $$;
 
-ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT)
     TO service_role;
 
-COMMENT ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) IS
-'Idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL) and returns TRUE when the caller now owns posting the GitHub comment. Returns TRUE again if a prior placeholder exists but was never finalized (github_comment_id still NULL) so a failed/restarted post retries. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
+COMMENT ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) IS
+'Lease-based idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL, claim_expires_at = now()+lease) and returns TRUE when the caller now owns posting the GitHub comment. On a duplicate delivery it re-claims (TRUE) only if the row is still unfinalized AND the prior lease has expired — so concurrent/rapid redeliveries do NOT each fire a GitHub POST, while a genuinely failed post can retry after the lease lapses. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
 
 CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
     p_discord_message_id BIGINT,
     p_github_comment_id  BIGINT
 )
 RETURNS BOOLEAN
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_rows INT;
-BEGIN
-    UPDATE gh.comment_mirror
-        SET github_comment_id = p_github_comment_id,
-            updated_at        = now()
-        WHERE discord_message_id = p_discord_message_id;
-
-    GET DIAGNOSTICS v_rows = ROW_COUNT;
-    RETURN v_rows > 0;
-END;
+    WITH upd AS (
+        UPDATE gh.comment_mirror
+            SET github_comment_id = p_github_comment_id,
+                updated_at        = now()
+            WHERE discord_message_id = p_discord_message_id
+              AND github_comment_id IS NULL
+        RETURNING TRUE
+    )
+    SELECT EXISTS (SELECT FROM upd)
+        OR EXISTS (
+            SELECT 1
+            FROM gh.comment_mirror
+            WHERE discord_message_id = p_discord_message_id
+              AND github_comment_id = p_github_comment_id
+        );
 $$;
 
 ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
@@ -162,21 +174,16 @@ COMMENT ON FUNCTION gh.is_github_comment_mirrored(BIGINT) IS
 
 CREATE OR REPLACE FUNCTION gh.mark_comment_mirror_deleted(p_discord_message_id BIGINT)
 RETURNS gh.comment_mirror
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_row gh.comment_mirror;
-BEGIN
     UPDATE gh.comment_mirror
         SET deleted_at = now(),
             updated_at = now()
         WHERE discord_message_id = p_discord_message_id
-        RETURNING * INTO v_row;
-
-    RETURN v_row;
-END;
+          AND deleted_at IS NULL
+        RETURNING *;
 $$;
 
 ALTER FUNCTION gh.mark_comment_mirror_deleted(BIGINT) OWNER TO service_role;
@@ -195,7 +202,7 @@ DROP FUNCTION IF EXISTS gh.mark_comment_mirror_deleted(BIGINT);
 DROP FUNCTION IF EXISTS gh.is_github_comment_mirrored(BIGINT);
 DROP FUNCTION IF EXISTS gh.get_comment_mirror(BIGINT);
 DROP FUNCTION IF EXISTS gh.set_comment_mirror_github_id(BIGINT, BIGINT);
-DROP FUNCTION IF EXISTS gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT);
 DROP FUNCTION IF EXISTS gh.get_issue_by_thread_id(BIGINT);
 DROP TABLE IF EXISTS gh.comment_mirror;
 

--- a/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
+++ b/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
     CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
+    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR length(author) <= 256),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
 )
@@ -84,16 +85,18 @@ AS $$
         VALUES (
             p_discord_message_id, p_discord_channel_id, NULL,
             p_owner, p_repo, p_number, p_direction, p_author,
-            now() + make_interval(secs => GREATEST(p_lease_secs, 1))
+            statement_timestamp()
+                + make_interval(secs => LEAST(GREATEST(COALESCE(p_lease_secs, 300), 1), 3600))
         )
         ON CONFLICT (discord_message_id) DO UPDATE
             SET claim_expires_at = EXCLUDED.claim_expires_at,
-                updated_at       = now()
+                updated_at       = statement_timestamp()
             WHERE gh.comment_mirror.github_comment_id IS NULL
-              AND gh.comment_mirror.claim_expires_at <= now()
-        RETURNING TRUE AS claimed
+              AND COALESCE(gh.comment_mirror.claim_expires_at, '-infinity'::timestamptz)
+                  <= statement_timestamp()
+        RETURNING TRUE
     )
-    SELECT COALESCE((SELECT claimed FROM ins), FALSE);
+    SELECT EXISTS (SELECT FROM ins);
 $$;
 
 ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) OWNER TO service_role;
@@ -103,7 +106,7 @@ GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, IN
     TO service_role;
 
 COMMENT ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) IS
-'Lease-based idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL, claim_expires_at = now()+lease) and returns TRUE when the caller now owns posting the GitHub comment. On a duplicate delivery it re-claims (TRUE) only if the row is still unfinalized AND the prior lease has expired — so concurrent/rapid redeliveries do NOT each fire a GitHub POST, while a genuinely failed post can retry after the lease lapses. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
+'Lease-based idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL, claim_expires_at = statement_timestamp()+lease, lease clamped 1..3600s) and returns TRUE when the caller now owns posting the GitHub comment. On a duplicate delivery it re-claims (TRUE) only if the row is still unfinalized AND the prior lease has expired — so concurrent/rapid redeliveries do NOT each fire a GitHub POST, while a genuinely failed post can retry after the lease lapses. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
 
 CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
     p_discord_message_id BIGINT,
@@ -117,18 +120,13 @@ AS $$
     WITH upd AS (
         UPDATE gh.comment_mirror
             SET github_comment_id = p_github_comment_id,
-                updated_at        = now()
+                claim_expires_at  = NULL,
+                updated_at        = statement_timestamp()
             WHERE discord_message_id = p_discord_message_id
               AND github_comment_id IS NULL
-        RETURNING TRUE
+        RETURNING 1
     )
-    SELECT EXISTS (SELECT FROM upd)
-        OR EXISTS (
-            SELECT 1
-            FROM gh.comment_mirror
-            WHERE discord_message_id = p_discord_message_id
-              AND github_comment_id = p_github_comment_id
-        );
+    SELECT EXISTS (SELECT FROM upd);
 $$;
 
 ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
@@ -179,8 +177,8 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
     UPDATE gh.comment_mirror
-        SET deleted_at = now(),
-            updated_at = now()
+        SET deleted_at = statement_timestamp(),
+            updated_at = statement_timestamp()
         WHERE discord_message_id = p_discord_message_id
           AND deleted_at IS NULL
         RETURNING *;

--- a/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
+++ b/packages/data/sql/dbmate/migrations/20260621000000_gh_comment_mirror.sql
@@ -1,0 +1,202 @@
+-- migrate:up
+
+SET search_path = '';
+
+-- Reverse lookup (thread_id → issue) is already served by the existing
+-- gh_issue_discord_thread_unique partial index from the cache-init migration.
+
+CREATE TABLE IF NOT EXISTS gh.comment_mirror (
+    discord_message_id  BIGINT      NOT NULL,
+    discord_channel_id  BIGINT      NOT NULL,
+    github_comment_id   BIGINT,
+    owner               TEXT        NOT NULL,
+    repo                TEXT        NOT NULL,
+    number              INT         NOT NULL,
+    direction           TEXT        NOT NULL,
+    author              TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at          TIMESTAMPTZ,
+    PRIMARY KEY (discord_message_id),
+    CONSTRAINT gh_comment_mirror_owner_shape_chk CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_comment_mirror_repo_shape_chk  CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_comment_mirror_number_pos_chk  CHECK (number > 0),
+    CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
+    CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
+    CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
+    CONSTRAINT gh_comment_mirror_direction_chk
+        CHECK (direction IN ('discord_to_github', 'github_to_discord'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
+    ON gh.comment_mirror (github_comment_id)
+    WHERE github_comment_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS gh_comment_mirror_issue_idx
+    ON gh.comment_mirror (owner, repo, number, created_at DESC);
+
+COMMENT ON TABLE gh.comment_mirror IS
+'Maps Discord thread messages to GitHub issue comments for bidirectional sync. discord_to_github rows are created when a human reply in a synced forum thread is mirrored to GitHub; the PK on discord_message_id makes the reverse handler idempotent (one GH comment per Discord message), and github_comment_id targets edit/delete propagation + acts as an echo guard.';
+
+CREATE OR REPLACE FUNCTION gh.get_issue_by_thread_id(p_thread_id BIGINT)
+RETURNS gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE discord_thread_id = p_thread_id;
+$$;
+
+ALTER FUNCTION gh.get_issue_by_thread_id(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.get_issue_by_thread_id(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.get_issue_by_thread_id(BIGINT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.claim_comment_mirror(
+    p_discord_message_id BIGINT,
+    p_discord_channel_id BIGINT,
+    p_owner              TEXT,
+    p_repo               TEXT,
+    p_number             INT,
+    p_direction          TEXT,
+    p_author             TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_claimed BOOLEAN := FALSE;
+BEGIN
+    INSERT INTO gh.comment_mirror (
+        discord_message_id, discord_channel_id, github_comment_id,
+        owner, repo, number, direction, author
+    )
+    VALUES (
+        p_discord_message_id, p_discord_channel_id, NULL,
+        p_owner, p_repo, p_number, p_direction, p_author
+    )
+    ON CONFLICT (discord_message_id) DO UPDATE
+        SET updated_at = now()
+        WHERE gh.comment_mirror.github_comment_id IS NULL
+    RETURNING TRUE INTO v_claimed;
+
+    RETURN COALESCE(v_claimed, FALSE);
+END;
+$$;
+
+ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+    TO service_role;
+
+COMMENT ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) IS
+'Idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL) and returns TRUE when the caller now owns posting the GitHub comment. Returns TRUE again if a prior placeholder exists but was never finalized (github_comment_id still NULL) so a failed/restarted post retries. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
+
+CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
+    p_discord_message_id BIGINT,
+    p_github_comment_id  BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    UPDATE gh.comment_mirror
+        SET github_comment_id = p_github_comment_id,
+            updated_at        = now()
+        WHERE discord_message_id = p_discord_message_id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.get_comment_mirror(p_discord_message_id BIGINT)
+RETURNS gh.comment_mirror
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.comment_mirror
+    WHERE discord_message_id = p_discord_message_id;
+$$;
+
+ALTER FUNCTION gh.get_comment_mirror(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.get_comment_mirror(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.get_comment_mirror(BIGINT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.is_github_comment_mirrored(p_github_comment_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM gh.comment_mirror
+        WHERE github_comment_id = p_github_comment_id
+    );
+$$;
+
+ALTER FUNCTION gh.is_github_comment_mirrored(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.is_github_comment_mirrored(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.is_github_comment_mirrored(BIGINT) TO service_role;
+
+COMMENT ON FUNCTION gh.is_github_comment_mirrored(BIGINT) IS
+'Echo guard for the forward worker: returns TRUE when a GitHub comment originated from the reverse-sync path, so gh_sync skips re-posting our own mirrored comment back into the thread.';
+
+CREATE OR REPLACE FUNCTION gh.mark_comment_mirror_deleted(p_discord_message_id BIGINT)
+RETURNS gh.comment_mirror
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_row gh.comment_mirror;
+BEGIN
+    UPDATE gh.comment_mirror
+        SET deleted_at = now(),
+            updated_at = now()
+        WHERE discord_message_id = p_discord_message_id
+        RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+ALTER FUNCTION gh.mark_comment_mirror_deleted(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_comment_mirror_deleted(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_comment_mirror_deleted(BIGINT) TO service_role;
+
+ALTER TABLE gh.comment_mirror OWNER TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+SET search_path = '';
+
+DROP FUNCTION IF EXISTS gh.mark_comment_mirror_deleted(BIGINT);
+DROP FUNCTION IF EXISTS gh.is_github_comment_mirrored(BIGINT);
+DROP FUNCTION IF EXISTS gh.get_comment_mirror(BIGINT);
+DROP FUNCTION IF EXISTS gh.set_comment_mirror_github_id(BIGINT, BIGINT);
+DROP FUNCTION IF EXISTS gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS gh.get_issue_by_thread_id(BIGINT);
+DROP TABLE IF EXISTS gh.comment_mirror;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/gh/gh_comment_mirror.sql
+++ b/packages/data/sql/schema/gh/gh_comment_mirror.sql
@@ -1,0 +1,209 @@
+-- ============================================================================
+-- GH COMMENT MIRROR — Discord thread message ↔ GitHub issue comment mapping
+--                     for bidirectional sync (Discord → GitHub comments) and
+--                     the reverse thread→issue lookup.
+--
+-- Reference mirror of the dbmate migration
+-- (../../dbmate/migrations/20260621000000_gh_comment_mirror.sql).
+-- Hand-authored review surface — do not run directly against the database;
+-- promote changes into a new dbmate migration when ready. Depends on
+-- gh_core.sql + gh_rpcs.sql.
+--
+-- Mental model:
+--   The forward worker (gh_sync.rs) creates a forum thread per issue and
+--   stores discord_thread_id on gh.issue. The reverse handler (gh_reverse.rs)
+--   does the opposite: a human reply in that thread becomes a GitHub issue
+--   comment. get_issue_by_thread_id resolves the thread back to its issue;
+--   gh.comment_mirror dedupes posts (one GH comment per Discord message),
+--   targets edit/delete propagation, and guards against echo loops.
+--
+-- All functions are SECURITY DEFINER, owned by service_role, reachable
+-- only by service_role (PUBLIC/anon/authenticated revoked from each).
+-- ============================================================================
+
+-- Reverse lookup (thread_id → issue) reuses gh_issue_discord_thread_unique
+-- (the existing unique partial index on gh.issue.discord_thread_id).
+
+CREATE TABLE IF NOT EXISTS gh.comment_mirror (
+    discord_message_id  BIGINT      NOT NULL,
+    discord_channel_id  BIGINT      NOT NULL,
+    github_comment_id   BIGINT,
+    owner               TEXT        NOT NULL,
+    repo                TEXT        NOT NULL,
+    number              INT         NOT NULL,
+    direction           TEXT        NOT NULL,
+    author              TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at          TIMESTAMPTZ,
+    PRIMARY KEY (discord_message_id),
+    CONSTRAINT gh_comment_mirror_owner_shape_chk CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_comment_mirror_repo_shape_chk  CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_comment_mirror_number_pos_chk  CHECK (number > 0),
+    CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
+    CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
+    CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
+    CONSTRAINT gh_comment_mirror_direction_chk
+        CHECK (direction IN ('discord_to_github', 'github_to_discord'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
+    ON gh.comment_mirror (github_comment_id)
+    WHERE github_comment_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS gh_comment_mirror_issue_idx
+    ON gh.comment_mirror (owner, repo, number, created_at DESC);
+
+-- thread_id → issue reverse lookup.
+CREATE OR REPLACE FUNCTION gh.get_issue_by_thread_id(p_thread_id BIGINT)
+RETURNS gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE discord_thread_id = p_thread_id;
+$$;
+
+ALTER FUNCTION gh.get_issue_by_thread_id(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.get_issue_by_thread_id(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.get_issue_by_thread_id(BIGINT) TO service_role;
+
+-- Idempotency claim: returns TRUE when the caller owns posting the GH comment.
+CREATE OR REPLACE FUNCTION gh.claim_comment_mirror(
+    p_discord_message_id BIGINT,
+    p_discord_channel_id BIGINT,
+    p_owner              TEXT,
+    p_repo               TEXT,
+    p_number             INT,
+    p_direction          TEXT,
+    p_author             TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_claimed BOOLEAN := FALSE;
+BEGIN
+    INSERT INTO gh.comment_mirror (
+        discord_message_id, discord_channel_id, github_comment_id,
+        owner, repo, number, direction, author
+    )
+    VALUES (
+        p_discord_message_id, p_discord_channel_id, NULL,
+        p_owner, p_repo, p_number, p_direction, p_author
+    )
+    ON CONFLICT (discord_message_id) DO UPDATE
+        SET updated_at = now()
+        WHERE gh.comment_mirror.github_comment_id IS NULL
+    RETURNING TRUE INTO v_claimed;
+
+    RETURN COALESCE(v_claimed, FALSE);
+END;
+$$;
+
+ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+    TO service_role;
+
+-- Finalize a claimed mirror row with the posted GitHub comment id.
+CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
+    p_discord_message_id BIGINT,
+    p_github_comment_id  BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    UPDATE gh.comment_mirror
+        SET github_comment_id = p_github_comment_id,
+            updated_at        = now()
+        WHERE discord_message_id = p_discord_message_id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) TO service_role;
+
+-- Read a mirror row (edit/delete propagation + echo guard).
+CREATE OR REPLACE FUNCTION gh.get_comment_mirror(p_discord_message_id BIGINT)
+RETURNS gh.comment_mirror
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.comment_mirror
+    WHERE discord_message_id = p_discord_message_id;
+$$;
+
+ALTER FUNCTION gh.get_comment_mirror(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.get_comment_mirror(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.get_comment_mirror(BIGINT) TO service_role;
+
+-- Echo guard: did this GitHub comment originate from the reverse path?
+CREATE OR REPLACE FUNCTION gh.is_github_comment_mirrored(p_github_comment_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM gh.comment_mirror
+        WHERE github_comment_id = p_github_comment_id
+    );
+$$;
+
+ALTER FUNCTION gh.is_github_comment_mirrored(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.is_github_comment_mirrored(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.is_github_comment_mirrored(BIGINT) TO service_role;
+
+-- Tombstone a mirror row when its Discord message is deleted.
+CREATE OR REPLACE FUNCTION gh.mark_comment_mirror_deleted(p_discord_message_id BIGINT)
+RETURNS gh.comment_mirror
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_row gh.comment_mirror;
+BEGIN
+    UPDATE gh.comment_mirror
+        SET deleted_at = now(),
+            updated_at = now()
+        WHERE discord_message_id = p_discord_message_id
+        RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+ALTER FUNCTION gh.mark_comment_mirror_deleted(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_comment_mirror_deleted(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_comment_mirror_deleted(BIGINT) TO service_role;
+
+ALTER TABLE gh.comment_mirror OWNER TO service_role;
+
+COMMENT ON TABLE gh.comment_mirror IS
+'Maps Discord thread messages to GitHub issue comments for bidirectional sync. discord_to_github rows are created when a human reply in a synced forum thread is mirrored to GitHub; the PK on discord_message_id makes the reverse handler idempotent (one GH comment per Discord message), and github_comment_id targets edit/delete propagation + acts as an echo guard.';
+COMMENT ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) IS
+'Idempotency claim for reverse sync. Inserts a placeholder mirror row (github_comment_id NULL) and returns TRUE when the caller now owns posting the GitHub comment. Returns TRUE again if a prior placeholder exists but was never finalized (github_comment_id still NULL) so a failed/restarted post retries. Returns FALSE once github_comment_id is set, so a replayed message_create posts exactly one comment.';
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/gh/gh_comment_mirror.sql
+++ b/packages/data/sql/schema/gh/gh_comment_mirror.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
     CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
+    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR length(author) <= 256),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
 )
@@ -103,16 +104,18 @@ AS $$
         VALUES (
             p_discord_message_id, p_discord_channel_id, NULL,
             p_owner, p_repo, p_number, p_direction, p_author,
-            now() + make_interval(secs => GREATEST(p_lease_secs, 1))
+            statement_timestamp()
+                + make_interval(secs => LEAST(GREATEST(COALESCE(p_lease_secs, 300), 1), 3600))
         )
         ON CONFLICT (discord_message_id) DO UPDATE
             SET claim_expires_at = EXCLUDED.claim_expires_at,
-                updated_at       = now()
+                updated_at       = statement_timestamp()
             WHERE gh.comment_mirror.github_comment_id IS NULL
-              AND gh.comment_mirror.claim_expires_at <= now()
-        RETURNING TRUE AS claimed
+              AND COALESCE(gh.comment_mirror.claim_expires_at, '-infinity'::timestamptz)
+                  <= statement_timestamp()
+        RETURNING TRUE
     )
-    SELECT COALESCE((SELECT claimed FROM ins), FALSE);
+    SELECT EXISTS (SELECT FROM ins);
 $$;
 
 ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) OWNER TO service_role;
@@ -121,8 +124,9 @@ REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, 
 GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT)
     TO service_role;
 
--- Finalize a claimed mirror row with the posted GitHub comment id. No-op
--- (still TRUE) when already finalized with the same id, so retries don't rewrite.
+-- Finalize a claimed mirror row with the posted GitHub comment id + clear the
+-- lease. Updates only the unfinalized row (github_comment_id IS NULL), so a
+-- duplicate finalize is a no-op (returns FALSE) and never rewrites the tuple.
 CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
     p_discord_message_id BIGINT,
     p_github_comment_id  BIGINT
@@ -135,18 +139,13 @@ AS $$
     WITH upd AS (
         UPDATE gh.comment_mirror
             SET github_comment_id = p_github_comment_id,
-                updated_at        = now()
+                claim_expires_at  = NULL,
+                updated_at        = statement_timestamp()
             WHERE discord_message_id = p_discord_message_id
               AND github_comment_id IS NULL
-        RETURNING TRUE
+        RETURNING 1
     )
-    SELECT EXISTS (SELECT FROM upd)
-        OR EXISTS (
-            SELECT 1
-            FROM gh.comment_mirror
-            WHERE discord_message_id = p_discord_message_id
-              AND github_comment_id = p_github_comment_id
-        );
+    SELECT EXISTS (SELECT FROM upd);
 $$;
 
 ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
@@ -197,8 +196,8 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
     UPDATE gh.comment_mirror
-        SET deleted_at = now(),
-            updated_at = now()
+        SET deleted_at = statement_timestamp(),
+            updated_at = statement_timestamp()
         WHERE discord_message_id = p_discord_message_id
           AND deleted_at IS NULL
         RETURNING *;

--- a/packages/data/sql/schema/gh/gh_comment_mirror.sql
+++ b/packages/data/sql/schema/gh/gh_comment_mirror.sql
@@ -44,13 +44,14 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_message_pos_chk CHECK (discord_message_id > 0),
     CONSTRAINT gh_comment_mirror_channel_pos_chk CHECK (discord_channel_id > 0),
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
-    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR length(author) <= 256),
+    CONSTRAINT gh_comment_mirror_author_len_chk  CHECK (author IS NULL OR octet_length(author) <= 1024),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
 )
--- Claim retries + delete tombstones touch no indexed column → HOT-eligible;
--- reserve page headroom to keep them HOT and avoid index bloat.
-WITH (fillfactor = 90);
+-- Most rows take one non-HOT finalize (github_comment_id is indexed); only the
+-- rare lease reclaim / tombstone updates are HOT-eligible, so a light 5% reserve
+-- keeps headroom for those without sacrificing page density.
+WITH (fillfactor = 95);
 
 -- Echo guard (is_github_comment_mirrored) + one-comment-one-mapping invariant.
 CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
@@ -111,6 +112,7 @@ AS $$
             SET claim_expires_at = EXCLUDED.claim_expires_at,
                 updated_at       = statement_timestamp()
             WHERE gh.comment_mirror.github_comment_id IS NULL
+              AND gh.comment_mirror.deleted_at IS NULL
               AND COALESCE(gh.comment_mirror.claim_expires_at, '-infinity'::timestamptz)
                   <= statement_timestamp()
         RETURNING TRUE
@@ -196,8 +198,9 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
     UPDATE gh.comment_mirror
-        SET deleted_at = statement_timestamp(),
-            updated_at = statement_timestamp()
+        SET deleted_at       = statement_timestamp(),
+            claim_expires_at = NULL,
+            updated_at       = statement_timestamp()
         WHERE discord_message_id = p_discord_message_id
           AND deleted_at IS NULL
         RETURNING *;

--- a/packages/data/sql/schema/gh/gh_comment_mirror.sql
+++ b/packages/data/sql/schema/gh/gh_comment_mirror.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     deleted_at          TIMESTAMPTZ,
+    claim_expires_at    TIMESTAMPTZ,
     PRIMARY KEY (discord_message_id),
     CONSTRAINT gh_comment_mirror_owner_shape_chk CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
     CONSTRAINT gh_comment_mirror_repo_shape_chk  CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
@@ -45,14 +46,20 @@ CREATE TABLE IF NOT EXISTS gh.comment_mirror (
     CONSTRAINT gh_comment_mirror_github_pos_chk  CHECK (github_comment_id IS NULL OR github_comment_id > 0),
     CONSTRAINT gh_comment_mirror_direction_chk
         CHECK (direction IN ('discord_to_github', 'github_to_discord'))
-);
+)
+-- Claim retries + delete tombstones touch no indexed column → HOT-eligible;
+-- reserve page headroom to keep them HOT and avoid index bloat.
+WITH (fillfactor = 90);
 
+-- Echo guard (is_github_comment_mirrored) + one-comment-one-mapping invariant.
 CREATE UNIQUE INDEX IF NOT EXISTS gh_comment_mirror_github_comment_unique
     ON gh.comment_mirror (github_comment_id)
     WHERE github_comment_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS gh_comment_mirror_issue_idx
-    ON gh.comment_mirror (owner, repo, number, created_at DESC);
+-- No list-by-issue query exists yet; add an (owner, repo, number,
+-- created_at DESC, discord_message_id DESC) index — partial on
+-- deleted_at IS NULL — alongside that query rather than carrying pure write
+-- amplification now.
 
 -- thread_id → issue reverse lookup.
 CREATE OR REPLACE FUNCTION gh.get_issue_by_thread_id(p_thread_id BIGINT)
@@ -71,7 +78,8 @@ ALTER FUNCTION gh.get_issue_by_thread_id(BIGINT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION gh.get_issue_by_thread_id(BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION gh.get_issue_by_thread_id(BIGINT) TO service_role;
 
--- Idempotency claim: returns TRUE when the caller owns posting the GH comment.
+-- Lease-based idempotency claim: returns TRUE when the caller owns posting the
+-- GH comment (fresh row, or unfinalized row whose prior lease has expired).
 CREATE OR REPLACE FUNCTION gh.claim_comment_mirror(
     p_discord_message_id BIGINT,
     p_discord_channel_id BIGINT,
@@ -79,60 +87,66 @@ CREATE OR REPLACE FUNCTION gh.claim_comment_mirror(
     p_repo               TEXT,
     p_number             INT,
     p_direction          TEXT,
-    p_author             TEXT
+    p_author             TEXT,
+    p_lease_secs         INT DEFAULT 300
 )
 RETURNS BOOLEAN
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_claimed BOOLEAN := FALSE;
-BEGIN
-    INSERT INTO gh.comment_mirror (
-        discord_message_id, discord_channel_id, github_comment_id,
-        owner, repo, number, direction, author
+    WITH ins AS (
+        INSERT INTO gh.comment_mirror (
+            discord_message_id, discord_channel_id, github_comment_id,
+            owner, repo, number, direction, author, claim_expires_at
+        )
+        VALUES (
+            p_discord_message_id, p_discord_channel_id, NULL,
+            p_owner, p_repo, p_number, p_direction, p_author,
+            now() + make_interval(secs => GREATEST(p_lease_secs, 1))
+        )
+        ON CONFLICT (discord_message_id) DO UPDATE
+            SET claim_expires_at = EXCLUDED.claim_expires_at,
+                updated_at       = now()
+            WHERE gh.comment_mirror.github_comment_id IS NULL
+              AND gh.comment_mirror.claim_expires_at <= now()
+        RETURNING TRUE AS claimed
     )
-    VALUES (
-        p_discord_message_id, p_discord_channel_id, NULL,
-        p_owner, p_repo, p_number, p_direction, p_author
-    )
-    ON CONFLICT (discord_message_id) DO UPDATE
-        SET updated_at = now()
-        WHERE gh.comment_mirror.github_comment_id IS NULL
-    RETURNING TRUE INTO v_claimed;
-
-    RETURN COALESCE(v_claimed, FALSE);
-END;
+    SELECT COALESCE((SELECT claimed FROM ins), FALSE);
 $$;
 
-ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+ALTER FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT)
+GRANT EXECUTE ON FUNCTION gh.claim_comment_mirror(BIGINT, BIGINT, TEXT, TEXT, INT, TEXT, TEXT, INT)
     TO service_role;
 
--- Finalize a claimed mirror row with the posted GitHub comment id.
+-- Finalize a claimed mirror row with the posted GitHub comment id. No-op
+-- (still TRUE) when already finalized with the same id, so retries don't rewrite.
 CREATE OR REPLACE FUNCTION gh.set_comment_mirror_github_id(
     p_discord_message_id BIGINT,
     p_github_comment_id  BIGINT
 )
 RETURNS BOOLEAN
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_rows INT;
-BEGIN
-    UPDATE gh.comment_mirror
-        SET github_comment_id = p_github_comment_id,
-            updated_at        = now()
-        WHERE discord_message_id = p_discord_message_id;
-
-    GET DIAGNOSTICS v_rows = ROW_COUNT;
-    RETURN v_rows > 0;
-END;
+    WITH upd AS (
+        UPDATE gh.comment_mirror
+            SET github_comment_id = p_github_comment_id,
+                updated_at        = now()
+            WHERE discord_message_id = p_discord_message_id
+              AND github_comment_id IS NULL
+        RETURNING TRUE
+    )
+    SELECT EXISTS (SELECT FROM upd)
+        OR EXISTS (
+            SELECT 1
+            FROM gh.comment_mirror
+            WHERE discord_message_id = p_discord_message_id
+              AND github_comment_id = p_github_comment_id
+        );
 $$;
 
 ALTER FUNCTION gh.set_comment_mirror_github_id(BIGINT, BIGINT) OWNER TO service_role;
@@ -178,21 +192,16 @@ GRANT EXECUTE ON FUNCTION gh.is_github_comment_mirrored(BIGINT) TO service_role;
 -- Tombstone a mirror row when its Discord message is deleted.
 CREATE OR REPLACE FUNCTION gh.mark_comment_mirror_deleted(p_discord_message_id BIGINT)
 RETURNS gh.comment_mirror
-LANGUAGE plpgsql
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-DECLARE
-    v_row gh.comment_mirror;
-BEGIN
     UPDATE gh.comment_mirror
         SET deleted_at = now(),
             updated_at = now()
         WHERE discord_message_id = p_discord_message_id
-        RETURNING * INTO v_row;
-
-    RETURN v_row;
-END;
+          AND deleted_at IS NULL
+        RETURNING *;
 $$;
 
 ALTER FUNCTION gh.mark_comment_mirror_deleted(BIGINT) OWNER TO service_role;

--- a/packages/rust/jedi/src/entity/github/client.rs
+++ b/packages/rust/jedi/src/entity/github/client.rs
@@ -458,6 +458,72 @@ impl GitHubClient {
         self.parse_response(resp).await
     }
 
+    /// Edit an existing issue/PR comment by its comment id.
+    pub async fn update_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> Result<GitHubComment, JediError> {
+        self.policy.check(owner, repo)?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/comments/{}",
+            self.base_url, owner, repo, comment_id
+        );
+
+        let payload = serde_json::json!({ "body": body });
+        let resp = self
+            .client
+            .patch(&url)
+            .bearer_auth(&self.token)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("GitHub request failed: {e}"))))?;
+
+        let resp = self.check_rate_limit(resp);
+        self.parse_response(resp).await
+    }
+
+    /// Delete an issue/PR comment by its comment id.
+    pub async fn delete_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<(), JediError> {
+        self.policy.check(owner, repo)?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/comments/{}",
+            self.base_url, owner, repo, comment_id
+        );
+
+        let resp = self
+            .client
+            .delete(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("GitHub request failed: {e}"))))?;
+
+        let resp = self.check_rate_limit(resp);
+        let status = resp.status();
+        if status == StatusCode::NO_CONTENT || status.is_success() {
+            Ok(())
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            match status {
+                StatusCode::UNAUTHORIZED => Err(JediError::Unauthorized),
+                StatusCode::FORBIDDEN => Err(JediError::Forbidden),
+                StatusCode::NOT_FOUND => Err(JediError::NotFound),
+                _ => Err(JediError::Internal(Cow::Owned(format!(
+                    "GitHub API error {status}: {body}"
+                )))),
+            }
+        }
+    }
+
     // ── Assignees ────────────────────────────────────────────────────
 
     /// Add assignees to an issue.

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.78"
 [features]
 default = []
 supabase = ["dep:lru", "dep:uuid"]
+kv = ["supabase", "jedi/valkey"]
 image-gen = ["dep:resvg"]
 wallet = ["dep:uuid"]
 legacy-sync-db = ["diesel/postgres", "diesel/r2d2", "dep:r2d2"]

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -2,15 +2,27 @@ use std::num::NonZeroUsize;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "kv")]
+use std::sync::Arc;
+
+#[cfg(feature = "kv")]
+use jedi::entity::error::JediError;
+#[cfg(feature = "kv")]
+use jedi::state::kv::KvCache;
 use lru::LruCache;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use super::supabase::SupabaseClient;
 
 const SCHEMA: &str = "gh";
+/// KvCache key prefixes for the reverse-sync lookups (namespaced again by KvCache).
+#[cfg(feature = "kv")]
+const KV_THREAD_PREFIX: &str = "gh:thread:";
+#[cfg(feature = "kv")]
+const KV_MIRROR_PREFIX: &str = "gh:cmirror:";
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CachedIssue {
     pub owner: String,
     pub repo: String,
@@ -96,7 +108,7 @@ pub struct UndeliveredEvent {
     pub claim_token: uuid::Uuid,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CommentMirror {
     pub discord_message_id: i64,
     pub discord_channel_id: i64,
@@ -129,6 +141,15 @@ pub enum GithubStoreError {
     Decode(#[from] serde_json::Error),
     #[error("response body: {0}")]
     Body(#[from] reqwest::Error),
+    #[cfg(feature = "kv")]
+    #[error("cache: {0}")]
+    Cache(String),
+}
+
+/// Bridge a store error into the `JediError` the KvCache fetch closure expects.
+#[cfg(feature = "kv")]
+fn into_jedi(e: GithubStoreError) -> JediError {
+    JediError::Internal(e.to_string().into())
 }
 
 struct CachedEntry {
@@ -139,11 +160,14 @@ struct CachedEntry {
 pub struct GithubStore {
     client: Option<SupabaseClient>,
     cache: Mutex<LruCache<(String, String, u32), CachedEntry>>,
-    /// Negative-caching reverse lookup keyed by Discord thread id. Bounds the
-    /// per-message Supabase load: `handle_reverse_message` runs on every guild
-    /// message, but most channels are not synced threads — caching the `None`
-    /// result keeps a busy non-thread channel from hammering the RPC.
-    thread_cache: Mutex<LruCache<i64, CachedEntry>>,
+    /// Optional L1(in-mem)+L2(Valkey) read-through cache for the reverse-sync
+    /// lookups. `handle_reverse_message` runs on every guild message, but most
+    /// channels are not synced threads — caching the `None` result (negative
+    /// caching) keeps a busy non-thread channel from hammering the Supabase RPC,
+    /// and the shared L2 survives pod restarts. Falls back to direct RPC when
+    /// unset.
+    #[cfg(feature = "kv")]
+    kv: Option<Arc<KvCache>>,
     ttl: Duration,
     stale_after: Duration,
 }
@@ -154,10 +178,32 @@ impl GithubStore {
         Self {
             client,
             cache: Mutex::new(LruCache::new(cap)),
-            thread_cache: Mutex::new(LruCache::new(cap)),
+            #[cfg(feature = "kv")]
+            kv: None,
             ttl,
             stale_after: Duration::from_secs(5 * 60),
         }
+    }
+
+    /// Attach a shared L1+L2 KvCache for reverse-sync lookups.
+    #[cfg(feature = "kv")]
+    pub fn with_kv(mut self, kv: Option<Arc<KvCache>>) -> Self {
+        self.kv = kv;
+        self
+    }
+
+    /// Drop the cached comment-mirror row (both cache layers) after a write so a
+    /// later edit/delete reads fresh `github_comment_id`/`deleted_at`. Best-effort.
+    async fn invalidate_mirror(&self, discord_message_id: i64) {
+        #[cfg(feature = "kv")]
+        if let Some(kv) = self.kv.as_ref() {
+            let key = format!("{KV_MIRROR_PREFIX}{discord_message_id}");
+            if let Err(e) = kv.invalidate(&key).await {
+                warn!(error = %e, discord_message_id, "gh: comment_mirror cache invalidate failed");
+            }
+        }
+        #[cfg(not(feature = "kv"))]
+        let _ = discord_message_id;
     }
 
     pub fn from_env() -> Self {
@@ -327,15 +373,25 @@ impl GithubStore {
         &self,
         thread_id: i64,
     ) -> Result<Option<CachedIssue>, GithubStoreError> {
-        {
-            let mut cache = self.thread_cache.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(entry) = cache.get(&thread_id) {
-                if Instant::now() < entry.expires_at {
-                    return Ok(entry.issue.clone());
-                }
-            }
+        #[cfg(feature = "kv")]
+        if let Some(kv) = self.kv.as_ref() {
+            let key = format!("{KV_THREAD_PREFIX}{thread_id}");
+            return kv
+                .get_or_fetch_json(&key, Some(self.ttl), || async {
+                    self.fetch_issue_by_thread_id(thread_id)
+                        .await
+                        .map_err(into_jedi)
+                })
+                .await
+                .map_err(|e| GithubStoreError::Cache(e.to_string()));
         }
+        self.fetch_issue_by_thread_id(thread_id).await
+    }
 
+    async fn fetch_issue_by_thread_id(
+        &self,
+        thread_id: i64,
+    ) -> Result<Option<CachedIssue>, GithubStoreError> {
         let Some(client) = self.client.as_ref() else {
             return Err(GithubStoreError::NotConfigured);
         };
@@ -352,20 +408,7 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        let issue = parse_optional_row::<CachedIssue>(&text)?;
-
-        {
-            let mut cache = self.thread_cache.lock().unwrap_or_else(|e| e.into_inner());
-            cache.put(
-                thread_id,
-                CachedEntry {
-                    issue: issue.clone(),
-                    expires_at: Instant::now() + self.ttl,
-                },
-            );
-        }
-
-        Ok(issue)
+        parse_optional_row::<CachedIssue>(&text)
     }
 
     /// Idempotency claim for reverse sync. Returns `true` when the caller now
@@ -408,7 +451,9 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        parse_bool_body(&text)
+        let claimed = parse_bool_body(&text)?;
+        self.invalidate_mirror(discord_message_id).await;
+        Ok(claimed)
     }
 
     /// Finalize a claimed mirror row with the posted GitHub comment id.
@@ -436,11 +481,32 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        parse_bool_body(&text)
+        let updated = parse_bool_body(&text)?;
+        self.invalidate_mirror(discord_message_id).await;
+        Ok(updated)
     }
 
     /// Read a mirror row (edit/delete propagation + echo guard).
     pub async fn get_comment_mirror(
+        &self,
+        discord_message_id: i64,
+    ) -> Result<Option<CommentMirror>, GithubStoreError> {
+        #[cfg(feature = "kv")]
+        if let Some(kv) = self.kv.as_ref() {
+            let key = format!("{KV_MIRROR_PREFIX}{discord_message_id}");
+            return kv
+                .get_or_fetch_json(&key, Some(self.ttl), || async {
+                    self.fetch_comment_mirror(discord_message_id)
+                        .await
+                        .map_err(into_jedi)
+                })
+                .await
+                .map_err(|e| GithubStoreError::Cache(e.to_string()));
+        }
+        self.fetch_comment_mirror(discord_message_id).await
+    }
+
+    async fn fetch_comment_mirror(
         &self,
         discord_message_id: i64,
     ) -> Result<Option<CommentMirror>, GithubStoreError> {
@@ -509,7 +575,9 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        parse_optional_row::<CommentMirror>(&text)
+        let row = parse_optional_row::<CommentMirror>(&text)?;
+        self.invalidate_mirror(discord_message_id).await;
+        Ok(row)
     }
 
     pub async fn claim_undelivered(

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -139,6 +139,11 @@ struct CachedEntry {
 pub struct GithubStore {
     client: Option<SupabaseClient>,
     cache: Mutex<LruCache<(String, String, u32), CachedEntry>>,
+    /// Negative-caching reverse lookup keyed by Discord thread id. Bounds the
+    /// per-message Supabase load: `handle_reverse_message` runs on every guild
+    /// message, but most channels are not synced threads — caching the `None`
+    /// result keeps a busy non-thread channel from hammering the RPC.
+    thread_cache: Mutex<LruCache<i64, CachedEntry>>,
     ttl: Duration,
     stale_after: Duration,
 }
@@ -149,6 +154,7 @@ impl GithubStore {
         Self {
             client,
             cache: Mutex::new(LruCache::new(cap)),
+            thread_cache: Mutex::new(LruCache::new(cap)),
             ttl,
             stale_after: Duration::from_secs(5 * 60),
         }
@@ -321,6 +327,15 @@ impl GithubStore {
         &self,
         thread_id: i64,
     ) -> Result<Option<CachedIssue>, GithubStoreError> {
+        {
+            let mut cache = self.thread_cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(entry) = cache.get(&thread_id) {
+                if Instant::now() < entry.expires_at {
+                    return Ok(entry.issue.clone());
+                }
+            }
+        }
+
         let Some(client) = self.client.as_ref() else {
             return Err(GithubStoreError::NotConfigured);
         };
@@ -337,7 +352,20 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        parse_optional_row::<CachedIssue>(&text)
+        let issue = parse_optional_row::<CachedIssue>(&text)?;
+
+        {
+            let mut cache = self.thread_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.put(
+                thread_id,
+                CachedEntry {
+                    issue: issue.clone(),
+                    expires_at: Instant::now() + self.ttl,
+                },
+            );
+        }
+
+        Ok(issue)
     }
 
     /// Idempotency claim for reverse sync. Returns `true` when the caller now

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -96,6 +96,24 @@ pub struct UndeliveredEvent {
     pub claim_token: uuid::Uuid,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct CommentMirror {
+    pub discord_message_id: i64,
+    pub discord_channel_id: i64,
+    #[serde(default)]
+    pub github_comment_id: Option<i64>,
+    pub owner: String,
+    pub repo: String,
+    pub number: u32,
+    pub direction: String,
+    #[serde(default)]
+    pub author: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum GithubStoreError {
     #[error("supabase client not configured")]
@@ -295,6 +313,175 @@ impl GithubStore {
             repo, number, thread_id, "Discord thread linked to gh.issue"
         );
         Ok(())
+    }
+
+    /// Reverse lookup: resolve a Discord forum thread back to its GitHub issue.
+    /// Used by the reverse-sync handler to map a thread reply onto an issue.
+    pub async fn get_issue_by_thread_id(
+        &self,
+        thread_id: i64,
+    ) -> Result<Option<CachedIssue>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_thread_id": thread_id });
+        let resp = client
+            .rpc_schema("get_issue_by_thread_id", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, thread_id, "gh.get_issue_by_thread_id HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_optional_row::<CachedIssue>(&text)
+    }
+
+    /// Idempotency claim for reverse sync. Returns `true` when the caller now
+    /// owns posting the GitHub comment for this Discord message (fresh row, or
+    /// a prior placeholder that was never finalized). Returns `false` once the
+    /// mapping already carries a `github_comment_id`, so replayed deliveries
+    /// post exactly one comment.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn claim_comment_mirror(
+        &self,
+        discord_message_id: i64,
+        discord_channel_id: i64,
+        owner: &str,
+        repo: &str,
+        number: u32,
+        direction: &str,
+        author: Option<&str>,
+    ) -> Result<bool, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({
+            "p_discord_message_id": discord_message_id,
+            "p_discord_channel_id": discord_channel_id,
+            "p_owner": owner,
+            "p_repo": repo,
+            "p_number": number,
+            "p_direction": direction,
+            "p_author": author,
+        });
+        let resp = client
+            .rpc_schema("claim_comment_mirror", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, discord_message_id, "gh.claim_comment_mirror HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_bool_body(&text)
+    }
+
+    /// Finalize a claimed mirror row with the posted GitHub comment id.
+    pub async fn set_comment_mirror_github_id(
+        &self,
+        discord_message_id: i64,
+        github_comment_id: i64,
+    ) -> Result<bool, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({
+            "p_discord_message_id": discord_message_id,
+            "p_github_comment_id": github_comment_id,
+        });
+        let resp = client
+            .rpc_schema("set_comment_mirror_github_id", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, discord_message_id, "gh.set_comment_mirror_github_id HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_bool_body(&text)
+    }
+
+    /// Read a mirror row (edit/delete propagation + echo guard).
+    pub async fn get_comment_mirror(
+        &self,
+        discord_message_id: i64,
+    ) -> Result<Option<CommentMirror>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_discord_message_id": discord_message_id });
+        let resp = client
+            .rpc_schema("get_comment_mirror", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, discord_message_id, "gh.get_comment_mirror HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_optional_row::<CommentMirror>(&text)
+    }
+
+    /// Echo guard for the forward worker: did this GitHub comment originate
+    /// from the reverse-sync path? If so, skip re-posting it into the thread.
+    pub async fn is_github_comment_mirrored(
+        &self,
+        github_comment_id: i64,
+    ) -> Result<bool, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_github_comment_id": github_comment_id });
+        let resp = client
+            .rpc_schema("is_github_comment_mirrored", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, github_comment_id, "gh.is_github_comment_mirrored HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_bool_body(&text)
+    }
+
+    /// Tombstone a mirror row when its Discord message is deleted.
+    pub async fn mark_comment_mirror_deleted(
+        &self,
+        discord_message_id: i64,
+    ) -> Result<Option<CommentMirror>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_discord_message_id": discord_message_id });
+        let resp = client
+            .rpc_schema("mark_comment_mirror_deleted", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, discord_message_id, "gh.mark_comment_mirror_deleted HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        parse_optional_row::<CommentMirror>(&text)
     }
 
     pub async fn claim_undelivered(


### PR DESCRIPTION
Closes #12984.

Makes the GitHub↔Discord issue sync bidirectional: a human reply in a synced forum thread becomes a GitHub issue comment — attributed, deduped, loop-safe — and edits/deletes/state stay consistent.

## Slices
- **VS1** thread reply → GH comment (loop-safe), **VS2** idempotency via `gh.comment_mirror`, **VS3** attribution + mention-neutralize + 65536 truncate, **VS4** edit→PATCH / delete→tombstone, **VS5** `pipe_gh_reverse_*` log counters, **VS6** issue state → thread lifecycle (close→archive, reopen→unarchive).

## Changes
- **SQL** `20260621000000_gh_comment_mirror.sql` (+ schema mirror): `gh.comment_mirror` table + RPCs `get_issue_by_thread_id`, `claim_comment_mirror` (idempotency placeholder), `set_comment_mirror_github_id`, `get_comment_mirror`, `mark_comment_mirror_deleted`, `is_github_comment_mirrored` (echo guard). Reverse lookup reuses the existing `gh_issue_discord_thread_unique` index.
- **kbve/github_store.rs** matching async methods + `CommentMirror` struct.
- **jedi/github/client.rs** `update_comment` (PATCH) + `delete_comment` (DELETE).
- **gh_reverse.rs** (new) reverse handlers with guards: not-bot, enable flag, resolvable thread→issue, guild match, PAT-or-skip, claim idempotency.
- **bot.rs** wires Message (relay + reverse), MessageUpdate, MessageDelete.
- **gh_sync.rs** VS6 lifecycle (best-effort; missing MANAGE_THREADS logs, no panic) + "commented" echo-skip.

## Echo prevention
Forward posts are bot-authored (reverse skips) + mirror rows + forward skips its own mirrored comments. No echo loop reproducible.

## Toggles
`GH_REVERSE_SYNC_ENABLED` (default on), `GH_REVERSE_DELETE_MODE=delete` (default tombstone), `GH_SYNC_LOCK_ON_CLOSE`.

## Verification
`cargo check` clean; `clippy -D warnings` clean (kbve + jedi); gh_reverse unit tests pass.

## Deploy note
Migration applies via `ci-dbmate-deploy.yml` + manual `kilobase-prod` approval — not auto-applied by this merge.

## Deferred
Per-guild reverse toggle + role-gating; full rate-limit backoff/queue (currently relies on jedi `check_rate_limit`, reverse failures log without retry).