### PR TITLE
feat(arpg): fullscreen embed with pause menu and dungeon minimap

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgHud.tsx
@@ -14,6 +14,7 @@ import {
 	onInventory,
 	onInventoryOpen,
 	type HudState,
+	type HudMap,
 } from './systems/hud';
 import type { InventoryItem } from '@kbve/laser';
 import { PixelPanel } from './PixelPanel';
@@ -136,7 +137,11 @@ export default function ArpgHud({ debug = false }: { debug?: boolean }) {
 						<Vitals name={hud.name} hp={hud.hp} maxHp={hud.maxHp} />
 					</Anchor>
 					<Anchor corner="tr" scale={scale}>
-						<MinimapSlot />
+						<MinimapSlot
+							map={hud.map}
+							tile={hud.tile}
+							headingDeg={hud.headingDeg}
+						/>
 					</Anchor>
 					<Anchor corner="br" scale={scale}>
 						<Compass
@@ -406,30 +411,87 @@ function Vitals({
 	);
 }
 
-function MinimapSlot() {
+const MINIMAP_PX = 128;
+const FLOOR_COLOR = '#5a6c8c';
+const ROOM_GLOW = '#7e93b8';
+
+/**
+ * Top-down dungeon minimap: paints the floor bitset (rooms + the carved
+ * corridor paths) as lit cells over a dark void, with the player pinned at the
+ * center and a heading wedge showing walk direction. Canvas keeps the per-cell
+ * fill cheap at 15 Hz.
+ */
+function MinimapSlot({
+	map,
+	tile,
+	headingDeg,
+}: {
+	map: HudMap;
+	tile: { x: number; y: number };
+	headingDeg: number;
+}) {
+	const ref = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = ref.current;
+		if (!canvas) return;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		const { size, cells, origin } = map;
+		const cell = MINIMAP_PX / size;
+
+		ctx.clearRect(0, 0, MINIMAP_PX, MINIMAP_PX);
+		ctx.fillStyle = 'rgba(10,13,20,0.55)';
+		ctx.fillRect(0, 0, MINIMAP_PX, MINIMAP_PX);
+
+		ctx.fillStyle = FLOOR_COLOR;
+		for (let j = 0; j < size; j++) {
+			for (let i = 0; i < size; i++) {
+				if (!cells[j * size + i]) continue;
+				ctx.fillRect(
+					Math.floor(i * cell),
+					Math.floor(j * cell),
+					Math.ceil(cell),
+					Math.ceil(cell),
+				);
+			}
+		}
+
+		// Player marker at its true cell within the window (center, but use the
+		// real offset so it tracks if the window ever lags a step).
+		const pcx = (tile.x - origin.x + 0.5) * cell;
+		const pcy = (tile.y - origin.y + 0.5) * cell;
+
+		ctx.save();
+		ctx.translate(pcx, pcy);
+		ctx.rotate(((headingDeg - 90) * Math.PI) / 180);
+		ctx.fillStyle = ROOM_GLOW;
+		ctx.beginPath();
+		ctx.moveTo(7, 0);
+		ctx.lineTo(-4, -4);
+		ctx.lineTo(-4, 4);
+		ctx.closePath();
+		ctx.fill();
+		ctx.restore();
+
+		ctx.fillStyle = '#fcd34d';
+		ctx.beginPath();
+		ctx.arc(pcx, pcy, 2.5, 0, Math.PI * 2);
+		ctx.fill();
+	}, [map, tile.x, tile.y, headingDeg]);
+
 	return (
-		<PixelPanel
-			variant="slate"
-			scale={2}
-			style={{
-				width: 132,
-				height: 132,
-			}}>
-			<div
+		<PixelPanel variant="slate" scale={2} style={{ lineHeight: 0 }}>
+			<canvas
+				ref={ref}
+				width={MINIMAP_PX}
+				height={MINIMAP_PX}
 				style={{
-					width: '100%',
-					height: '100%',
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					fontSize: 9,
-					letterSpacing: 2,
-					color: MUTED,
-					opacity: 0.5,
-					textShadow: TEXT_SHADOW,
-				}}>
-				MAP
-			</div>
+					display: 'block',
+					imageRendering: 'pixelated',
+					margin: -6,
+				}}
+			/>
 		</PixelPanel>
 	);
 }

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgMenu.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ArpgMenu.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PixelPanel } from './PixelPanel';
+
+const ACCENT = '#fcd34d';
+const TEXT = '#e6ebf5';
+const MUTED = '#9fb3d8';
+
+/**
+ * Escape-driven pause menu for the fullscreen arpg embed. Toggling adds
+ * `arpg-menu-open` to <body>, which the shell stylesheet uses to bring the
+ * starlight nav back over the game. Holds Resume + Exit; a settings slot is
+ * left for later. Phaser doesn't bind Escape, so the window listener is safe.
+ */
+export default function ArpgMenu() {
+	const [open, setOpen] = useState(false);
+
+	const close = useCallback(() => setOpen(false), []);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			e.preventDefault();
+			setOpen((v) => !v);
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, []);
+
+	useEffect(() => {
+		document.body.classList.toggle('arpg-menu-open', open);
+		return () => document.body.classList.remove('arpg-menu-open');
+	}, [open]);
+
+	if (!open) return null;
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				inset: 0,
+				zIndex: 30,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(8,9,14,0.6)',
+				backdropFilter: 'blur(3px)',
+				fontFamily: 'monospace',
+				color: TEXT,
+			}}
+			onClick={close}>
+			<div onClick={(e) => e.stopPropagation()}>
+				<PixelPanel
+					variant="gold"
+					scale={3}
+					style={{ minWidth: 260, padding: '20px 22px' }}>
+					<div
+						style={{
+							fontSize: 18,
+							fontWeight: 700,
+							color: ACCENT,
+							textShadow: '0 1px 2px rgba(0,0,0,0.9)',
+							textAlign: 'center',
+							letterSpacing: 1,
+							marginBottom: 16,
+						}}>
+						PAUSED
+					</div>
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 10,
+						}}>
+						<MenuButton primary onClick={close}>
+							Resume
+						</MenuButton>
+						<MenuButton
+							onClick={() => {
+								window.location.assign('/arcade/');
+							}}>
+							Exit to Arcade
+						</MenuButton>
+					</div>
+					<div
+						style={{
+							marginTop: 14,
+							fontSize: 10,
+							color: MUTED,
+							textAlign: 'center',
+							opacity: 0.7,
+						}}>
+						Esc to resume
+					</div>
+				</PixelPanel>
+			</div>
+		</div>
+	);
+}
+
+function MenuButton({
+	children,
+	onClick,
+	primary = false,
+}: {
+	children: React.ReactNode;
+	onClick: () => void;
+	primary?: boolean;
+}) {
+	return (
+		<button
+			onClick={onClick}
+			style={{
+				padding: '11px 14px',
+				fontSize: 14,
+				fontFamily: 'monospace',
+				fontWeight: 700,
+				borderRadius: 6,
+				border: 'none',
+				cursor: 'pointer',
+				color: primary ? '#0b0e16' : TEXT,
+				background: primary ? ACCENT : 'rgba(76,90,120,0.35)',
+				boxShadow: primary
+					? '0 0 10px rgba(252,211,77,0.4)'
+					: 'inset 0 0 0 1px rgba(120,138,170,0.4)',
+				transition: 'filter 120ms',
+			}}
+			onMouseEnter={(e) => {
+				e.currentTarget.style.filter = 'brightness(1.15)';
+			}}
+			onMouseLeave={(e) => {
+				e.currentTarget.style.filter = 'none';
+			}}>
+			{children}
+		</button>
+	);
+}

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/AstroIsoArpg.astro
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/AstroIsoArpg.astro
@@ -2,26 +2,71 @@
 import ReactIsoArpgApp from './ReactIsoArpgApp';
 ---
 
-<div class="not-content w-full h-full">
+<div class="iso-arpg-shell not-content">
 	<div
 		id="iso-arpg-container"
-		class="rounded-lg overflow-hidden border-2 border-gray-700 shadow-xl focus:outline-none relative bg-[#10131c]"
-		style="width: 100%; aspect-ratio: 16/9;"
+		class="focus:outline-none relative bg-[#10131c]"
 		tabindex="0">
-		<div id="iso-arpg-inner" class="w-full h-full">
+		<div id="iso-arpg-inner">
 			<ReactIsoArpgApp client:only="react" />
 		</div>
 	</div>
 </div>
 
 <style>
-	#iso-arpg-container {
-		container-type: inline-size;
+	/* Fullscreen game overlay: cover the whole viewport (nav/sidebar/footer
+	   included) so the canvas resizes to the real window instead of bleeding
+	   past an aspect-ratio box. Mirrors the isometric WebGPU embed. */
+	.iso-arpg-shell {
+		position: fixed;
+		inset: 0;
+		width: 100vw;
+		height: 100dvh;
+		margin: 0;
+		padding: 0;
+		z-index: 99999;
+		background: #10131c;
+		overflow: hidden;
 	}
 
-	@container (max-width: 600px) {
-		#iso-arpg-container {
-			aspect-ratio: 4/3;
+	#iso-arpg-container {
+		width: 100%;
+		height: 100%;
+		container-type: size;
+	}
+
+	#iso-arpg-inner {
+		width: 100%;
+		height: 100%;
+	}
+
+	:global(body:has(.iso-arpg-shell)) {
+		overflow: hidden;
+	}
+
+	:global(body:has(.iso-arpg-shell) header.header),
+	:global(body:has(.iso-arpg-shell) .sl-flex.header),
+	:global(body:has(.iso-arpg-shell) footer),
+	:global(body:has(.iso-arpg-shell) .footer),
+	:global(body:has(.iso-arpg-shell) [class*='footer']),
+	:global(body:has(.iso-arpg-shell) .sidebar),
+	:global(body:has(.iso-arpg-shell) aside),
+	:global(body:has(.iso-arpg-shell) .sl-sidebar),
+	:global(body:has(.iso-arpg-shell) .page-sidebar) {
+		display: none !important;
+	}
+
+	/* Escape opens the pause menu (body gets .arpg-menu-open): bring the
+	   starlight header back, lifted above the game shell so it's clickable. */
+	:global(body.arpg-menu-open header.header),
+	:global(body.arpg-menu-open .sl-flex.header) {
+		display: flex !important;
+		z-index: 100001 !important;
+	}
+
+	@media (pointer: coarse) {
+		:global(.iso-arpg-shell) {
+			touch-action: manipulation;
 		}
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/IsoArpgScene.ts
@@ -83,7 +83,10 @@ import {
 	clearHud,
 	emitInventory,
 	emitInventoryOpen,
+	type HudMap,
 } from './systems/hud';
+
+const HUD_MAP_SIZE = 33;
 import { facingDegFromDelta } from './entities/classes';
 import {
 	makeSprite,
@@ -186,6 +189,9 @@ export class IsoArpgScene extends Phaser.Scene {
 	// Last movement heading (screen deg, 0=N CW); held while idle so the compass
 	// needle doesn't snap back when the player stops.
 	private hudHeadingDeg = 0;
+	// Cached minimap window; resampled only when the player crosses a tile.
+	private hudMap: HudMap | null = null;
+	private hudMapTile: TileXY | null = null;
 	// Last cardinal facing sent to the server, so face() only fires on change.
 	private lastSentFacing: Facing | null = null;
 	// Dungeon floor the local player is on (z). Server-authoritative via the
@@ -813,6 +819,8 @@ export class IsoArpgScene extends Phaser.Scene {
 			floorSeed(DUNGEON_SEED, f.z),
 			DUNGEON_RADIUS,
 		);
+		this.hudMap = null;
+		this.hudMapTile = null;
 		this.rebuildDungeon();
 	}
 
@@ -863,7 +871,40 @@ export class IsoArpgScene extends Phaser.Scene {
 			moving,
 			fps: Math.round(this.game.loop.actualFps),
 			tile,
+			map: this.sampleHudMap(tile),
 		});
+	}
+
+	/**
+	 * Sample a square dungeon window centered on the player into a floor bitset
+	 * for the minimap — rooms + the carved corridor paths between them. Rebuilt
+	 * only when the player crosses a tile (the layout is static between steps),
+	 * reusing the cached buffer otherwise to keep the 15 Hz emit cheap.
+	 */
+	private sampleHudMap(tile: TileXY): HudMap {
+		const size = HUD_MAP_SIZE;
+		if (
+			this.hudMap &&
+			this.hudMapTile &&
+			this.hudMapTile.x === tile.x &&
+			this.hudMapTile.y === tile.y
+		) {
+			return this.hudMap;
+		}
+		const r = size >> 1;
+		const ox = tile.x - r;
+		const oy = tile.y - r;
+		const cells = new Uint8Array(size * size);
+		for (let j = 0; j < size; j++) {
+			for (let i = 0; i < size; i++) {
+				if (this.dungeon.isFloor(ox + i, oy + j)) {
+					cells[j * size + i] = 1;
+				}
+			}
+		}
+		this.hudMapTile = { x: tile.x, y: tile.y };
+		this.hudMap = { origin: { x: ox, y: oy }, size, cells };
+		return this.hudMap;
 	}
 
 	/**

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ReactIsoArpgApp.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/ReactIsoArpgApp.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import Phaser from 'phaser';
 import { IsoArpgScene } from './IsoArpgScene';
 import ArpgHud from './ArpgHud';
+import ArpgMenu from './ArpgMenu';
 import { COLORS, DEBUG_HUD, resolveWsUrl } from './config';
 import { buildNetConfig, setNetConfig } from './net-config';
 import {
@@ -208,7 +209,12 @@ export default function ReactIsoArpgApp({
 	}
 
 	if (phase === 'ready') {
-		return <ArpgHud debug={DEBUG_HUD} />;
+		return (
+			<>
+				<ArpgHud debug={DEBUG_HUD} />
+				<ArpgMenu />
+			</>
+		);
 	}
 
 	return null;

--- a/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
+++ b/apps/kbve/astro-kbve/src/arcade/isometric-arpg/systems/hud.ts
@@ -2,6 +2,18 @@ import { laserEvents, type InventoryItem } from '@kbve/laser';
 
 export const HUD_EVENT = 'arpg:hud';
 
+/**
+ * A square window of the dungeon around the player for the minimap. `cells` is
+ * row-major, length `size*size`, 1 = floor (walkable path/room) else wall. The
+ * window is centered so the player sits at the middle cell; `origin` is the
+ * world tile of cell (0,0).
+ */
+export interface HudMap {
+	origin: { x: number; y: number };
+	size: number;
+	cells: Uint8Array;
+}
+
 export interface HudState {
 	name: string;
 	hp: number;
@@ -10,6 +22,7 @@ export interface HudState {
 	moving: boolean;
 	fps: number;
 	tile: { x: number; y: number };
+	map: HudMap;
 }
 
 export function emitHud(state: HudState): void {


### PR DESCRIPTION
## Summary
- Fullscreen arpg arcade embed: a fixed overlay covering nav/sidebar/footer (mirrors the isometric WebGPU game) so the Phaser canvas resizes to the real window instead of bleeding past a 16:9 box.
- **Escape pause menu** (`ArpgMenu`): toggles `body.arpg-menu-open` to bring the starlight nav back over the game; Resume + Exit to Arcade.
- **Live dungeon minimap**: the scene samples a floor window around the player (rooms + carved corridor paths) via `DungeonField.isFloor`, cached per-tile and pushed over the HUD event bus; the minimap canvas paints it with the player marker + heading wedge.

## Also in this branch (already on dev, carried through merge)
- Beveled/studded transparent 9-slice `PixelPanel` family + responsive corner-anchored HUD scaling.

## Notes
- Panels are LFS-tracked PNGs generated by `scripts/gen-arpg-panel.py`.
- Discord Activity embed not yet re-verified against the fullscreen overlay.