### PR TITLE
feat(jobboard): observ metrics + staff/cache identity fixes

### DIFF
--- a/apps/jobboard/web/src/components/ErrorBoundary.tsx
+++ b/apps/jobboard/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { captureException } from '../lib/observ';
+
+interface Props {
+	children: ReactNode;
+	fallback?: ReactNode;
+}
+
+interface State {
+	hasError: boolean;
+}
+
+function DefaultFallback() {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				minHeight: '100vh',
+				gap: '1rem',
+				padding: '2rem',
+				textAlign: 'center',
+				fontFamily: 'system-ui, sans-serif',
+			}}>
+			<h1 style={{ fontSize: '1.25rem', margin: 0 }}>
+				Something went wrong
+			</h1>
+			<p style={{ margin: 0, opacity: 0.7 }}>
+				The error was reported. Try reloading the page.
+			</p>
+			<button
+				type="button"
+				onClick={() => window.location.reload()}
+				style={{
+					padding: '0.5rem 1rem',
+					borderRadius: '0.5rem',
+					border: '1px solid currentColor',
+					background: 'transparent',
+					cursor: 'pointer',
+				}}>
+				Reload
+			</button>
+		</div>
+	);
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+	state: State = { hasError: false };
+
+	static getDerivedStateFromError(): State {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo): void {
+		captureException(error, { componentStack: info.componentStack });
+	}
+
+	render(): ReactNode {
+		if (this.state.hasError) {
+			return this.props.fallback ?? <DefaultFallback />;
+		}
+		return this.props.children;
+	}
+}

--- a/apps/jobboard/web/src/components/LoginChecklist.tsx
+++ b/apps/jobboard/web/src/components/LoginChecklist.tsx
@@ -1,0 +1,96 @@
+import { Check, Loader2 } from 'lucide-react';
+
+export interface ChecklistStep {
+	label: string;
+	done: boolean;
+}
+
+export function LoginChecklist({ steps }: { steps: ChecklistStep[] }) {
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				inset: 0,
+				zIndex: 9999,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(10,10,12,0.72)',
+				backdropFilter: 'blur(6px)',
+			}}>
+			<div
+				style={{
+					minWidth: 280,
+					padding: '24px 28px',
+					borderRadius: 16,
+					background: '#16161a',
+					border: '1px solid rgba(255,255,255,0.08)',
+					fontFamily: 'system-ui, sans-serif',
+					color: '#f4f4f5',
+				}}>
+				<div
+					style={{
+						fontSize: 15,
+						fontWeight: 700,
+						marginBottom: 18,
+					}}>
+					Signing you in…
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 12,
+					}}>
+					{steps.map((s) => (
+						<div
+							key={s.label}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 12,
+							}}>
+							<span
+								style={{
+									width: 22,
+									height: 22,
+									borderRadius: 6,
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'center',
+									flexShrink: 0,
+									background: s.done
+										? '#22c55e'
+										: 'transparent',
+									border: s.done
+										? '1px solid #22c55e'
+										: '1px solid rgba(255,255,255,0.2)',
+								}}>
+								{s.done ? (
+									<Check size={14} color="#fff" />
+								) : (
+									<Loader2
+										size={14}
+										color="rgba(255,255,255,0.55)"
+										style={{
+											animation:
+												'spin 0.9s linear infinite',
+										}}
+									/>
+								)}
+							</span>
+							<span
+								style={{
+									fontSize: 14,
+									opacity: s.done ? 1 : 0.65,
+								}}>
+								{s.label}
+							</span>
+						</div>
+					))}
+				</div>
+			</div>
+			<style>{'@keyframes spin{to{transform:rotate(360deg)}}'}</style>
+		</div>
+	);
+}

--- a/apps/jobboard/web/src/lib/loginReadiness.ts
+++ b/apps/jobboard/web/src/lib/loginReadiness.ts
@@ -1,0 +1,34 @@
+import { kvStore } from '@kbve/rn/store';
+
+const OWNER_KEY = 'cache-owner-uid';
+
+interface SessionClient {
+	auth: {
+		getSession(): Promise<{
+			data: { session: { access_token?: string } | null };
+		}>;
+	};
+}
+
+export async function reconcileCache(
+	uid: string,
+): Promise<'cleared' | 'matched'> {
+	const owner = await kvStore.get<string>(OWNER_KEY);
+	if (owner === uid) return 'matched';
+	await kvStore.clear();
+	await kvStore.set(OWNER_KEY, uid);
+	return 'cleared';
+}
+
+export async function ensureSessionReady(
+	client: SessionClient,
+	timeoutMs = 4000,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const { data } = await client.auth.getSession();
+		if (data.session?.access_token) return true;
+		await new Promise((res) => setTimeout(res, 150));
+	}
+	return false;
+}

--- a/apps/jobboard/web/src/lib/observ.ts
+++ b/apps/jobboard/web/src/lib/observ.ts
@@ -1,0 +1,19 @@
+import { captureException, initObserv } from '@kbve/observ';
+
+let currentUserId: string | undefined;
+
+export function setObservUserId(id: string | undefined): void {
+	currentUserId = id;
+}
+
+export function initJobboardObserv(): void {
+	initObserv({
+		endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+		project: 'jobboard',
+		platform: 'web',
+		environment: import.meta.env.MODE,
+		getUserId: () => currentUserId,
+	});
+}
+
+export { captureException };

--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -9,11 +9,16 @@ import { OverlayHost, ThemeProvider, ToastViewport } from '@kbve/rn/ui';
 import { createKvPersister } from '@kbve/rn/store';
 import { router } from './router';
 import { DevBanner } from './components/DevBanner';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { StaffProvider } from './lib/staff';
 import { setAuthTokenGetter } from './api/client';
+import { initJobboardObserv, setObservUserId } from './lib/observ';
+import { reconcileCache } from './lib/loginReadiness';
 import { queryClient } from './lib/queryClient';
 import { jobboardTheme } from './lib/theme';
 import './styles.css';
+
+initJobboardObserv();
 
 // Same-origin Supabase: the vite dev server (:5401) and Axum (:5400 / jobs.kbve.com)
 // both proxy /supabase -> supabase.kbve.com. No browser CORS, no Kong allow-list.
@@ -30,32 +35,46 @@ function AuthBridge() {
 			const { data } = await client.auth.getSession();
 			return data.session?.access_token ?? null;
 		});
+		void client.auth.getSession().then(async ({ data }) => {
+			const uid = data.session?.user?.id;
+			setObservUserId(uid);
+			if (uid && (await reconcileCache(uid)) === 'cleared') {
+				queryClient.clear();
+			}
+		});
+		const { data: sub } = client.auth.onAuthStateChange(
+			(event, session) => {
+				setObservUserId(session?.user?.id);
+				if (event === 'SIGNED_OUT') queryClient.clear();
+			},
+		);
+		return () => sub.subscription.unsubscribe();
 	}, [client]);
 	return null;
 }
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<KbveProvider
-			supabaseUrl={supabaseUrl}
-			anonKey={KBVE_SUPABASE_ANON_KEY}
-			apiBaseUrl={`${window.location.origin}/kbveapi`}
-			oauthUrl="https://supabase.kbve.com">
-			<AuthBridge />
-			<StaffProvider>
-				<ThemeProvider theme={jobboardTheme}>
-					<PersistQueryClientProvider
-						client={queryClient}
-						persistOptions={{ persister }}>
-						<DevBanner />
-						{/* Public marketplace — browsing needs no auth. Login
-						    lives at /login; KbveProvider supplies the session. */}
-						<RouterProvider router={router} />
-					</PersistQueryClientProvider>
-					<OverlayHost />
-					<ToastViewport />
-				</ThemeProvider>
-			</StaffProvider>
-		</KbveProvider>
+		<ErrorBoundary>
+			<KbveProvider
+				supabaseUrl={supabaseUrl}
+				anonKey={KBVE_SUPABASE_ANON_KEY}
+				apiBaseUrl={`${window.location.origin}/kbveapi`}
+				oauthUrl="https://supabase.kbve.com">
+				<AuthBridge />
+				<StaffProvider>
+					<ThemeProvider theme={jobboardTheme}>
+						<PersistQueryClientProvider
+							client={queryClient}
+							persistOptions={{ persister }}>
+							<DevBanner />
+							<RouterProvider router={router} />
+						</PersistQueryClientProvider>
+						<OverlayHost />
+						<ToastViewport />
+					</ThemeProvider>
+				</StaffProvider>
+			</KbveProvider>
+		</ErrorBoundary>
 	</StrictMode>,
 );

--- a/apps/jobboard/web/src/router.tsx
+++ b/apps/jobboard/web/src/router.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
 	createRootRoute,
 	createRoute,
@@ -8,7 +8,9 @@ import {
 	useNavigate,
 	useRouterState,
 } from '@tanstack/react-router';
-import { useAuth as useKbveAuth } from '@kbve/rn/auth';
+import { useAuth as useKbveAuth, useKbve } from '@kbve/rn/auth';
+import { reconcileCache, ensureSessionReady } from './lib/loginReadiness';
+import { LoginChecklist } from './components/LoginChecklist';
 import type {
 	Availability,
 	GigQuery,
@@ -55,13 +57,18 @@ const num = (v: unknown): number | undefined => {
 // /). Fires only on the false→true transition so a signed-in user can still
 // browse home; a brand-new social signup needing a username is sent to /login
 // where SetUsernameScreen renders.
-function usePostAuthRedirect(pathname: string) {
+function PostAuthGate({ pathname }: { pathname: string }) {
 	const auth = useKbveAuth();
+	const { client } = useKbve();
 	const navigate = useNavigate();
 	const wasSignedIn = useRef(auth.signedIn);
+	const running = useRef(false);
+	const [steps, setSteps] = useState<{
+		idb: boolean;
+		cookie: boolean;
+	} | null>(null);
+
 	useEffect(() => {
-		// navigate() rejects with AbortError when a transition is superseded;
-		// that's expected here, so swallow it.
 		const go = (to: string) =>
 			void Promise.resolve(navigate({ to })).catch(() => {});
 
@@ -74,14 +81,57 @@ function usePostAuthRedirect(pathname: string) {
 
 		if (auth.needsUsername) {
 			if (pathname !== '/login') go('/login');
-		} else if (pathname === '/login') {
-			// never leave a signed-in member on the login page
-			go('/dashboard');
-		} else if (justSignedIn && pathname === '/') {
-			// social OAuth returns to the app root — forward to the dashboard
-			go('/dashboard');
+			return;
 		}
-	}, [auth.signedIn, auth.needsUsername, pathname, navigate]);
+
+		const dest =
+			pathname === '/login'
+				? '/dashboard'
+				: justSignedIn && pathname === '/'
+					? '/dashboard'
+					: null;
+		if (!dest || running.current) return;
+
+		running.current = true;
+		let active = true;
+		setSteps({ idb: false, cookie: false });
+		void (async () => {
+			const uid = auth.user?.id;
+			if (uid && (await reconcileCache(uid)) === 'cleared') {
+				queryClient.clear();
+			}
+			if (!active) return;
+			setSteps({ idb: true, cookie: false });
+			await ensureSessionReady(client);
+			if (!active) return;
+			setSteps({ idb: true, cookie: true });
+			await new Promise((res) => setTimeout(res, 350));
+			if (!active) return;
+			setSteps(null);
+			running.current = false;
+			go(dest);
+		})();
+		return () => {
+			active = false;
+		};
+	}, [
+		auth.signedIn,
+		auth.needsUsername,
+		auth.user?.id,
+		pathname,
+		navigate,
+		client,
+	]);
+
+	if (!steps) return null;
+	return (
+		<LoginChecklist
+			steps={[
+				{ label: 'Preparing IDB', done: steps.idb },
+				{ label: 'Preparing Cookie Auth', done: steps.cookie },
+			]}
+		/>
+	);
 }
 
 // Flat route tree (children of root) so getRouteApi('/gigs') etc. resolve
@@ -91,10 +141,17 @@ function RootLayout() {
 	const pathname = useRouterState({
 		select: (s) => s.location.pathname,
 	});
-	usePostAuthRedirect(pathname);
-	if (pathname === '/login' || pathname === '/dashboard') return <Outlet />;
+	const gate = <PostAuthGate pathname={pathname} />;
+	if (pathname === '/login' || pathname === '/dashboard')
+		return (
+			<>
+				{gate}
+				<Outlet />
+			</>
+		);
 	return (
 		<div className="min-h-screen text-zinc-100">
+			{gate}
 			<NavBar />
 			<main className="px-6 py-8">
 				<Outlet />

--- a/apps/jobboard/web/tsconfig.json
+++ b/apps/jobboard/web/tsconfig.json
@@ -22,6 +22,7 @@
 			"@kbve/rn": ["../../../packages/npm/rn/src/index.ts"],
 			"@kbve/core": ["../../../packages/npm/core/src/index.ts"],
 			"@kbve/fx": ["../../../packages/npm/fx/src/index.ts"],
+			"@kbve/observ": ["../../../packages/npm/observ/src/index.ts"],
 			"@kbve/jobboard-schema": [
 				"../../../packages/data/codegen/generated/jobboard-schema.ts"
 			]

--- a/apps/jobboard/web/vite.config.ts
+++ b/apps/jobboard/web/vite.config.ts
@@ -75,6 +75,13 @@ export default defineConfig(({ mode }) => ({
 				),
 			},
 			{
+				find: /^@kbve\/observ$/,
+				replacement: path.join(
+					repoRoot,
+					'packages/npm/observ/src/index.ts',
+				),
+			},
+			{
 				find: /^@kbve\/jobboard-schema$/,
 				replacement: path.join(
 					repoRoot,

--- a/packages/npm/observ/src/client.ts
+++ b/packages/npm/observ/src/client.ts
@@ -99,6 +99,14 @@ export class Observer {
 		return this;
 	}
 
+	stop(): void {
+		if (this.timer !== null) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		this.flush(true);
+	}
+
 	captureException(err: unknown, extra?: Record<string, unknown>): void {
 		this.capture({
 			message: err instanceof Error ? err.message : String(err),

--- a/packages/npm/rn/src/auth/useStaff.ts
+++ b/packages/npm/rn/src/auth/useStaff.ts
@@ -31,14 +31,42 @@ export function useStaff(): StaffState {
 
 	useEffect(() => {
 		let active = true;
-		void client
-			.rpc('staff_permissions')
-			.then(({ data, error }: { data: unknown; error: unknown }) => {
-				if (!active) return;
-				setPermissions(!error && typeof data === 'number' ? data : 0);
-			});
+		let lastUid: string | undefined;
+
+		const resolve = (uid: string | undefined) => {
+			if (!uid) {
+				if (active) setPermissions(0);
+				return;
+			}
+			void client
+				.rpc('staff_permissions')
+				.then(({ data, error }: { data: unknown; error: unknown }) => {
+					if (!active) return;
+					setPermissions(
+						!error && typeof data === 'number' ? data : 0,
+					);
+				});
+		};
+
+		void client.auth.getSession().then(({ data }) => {
+			if (!active) return;
+			lastUid = data.session?.user?.id;
+			resolve(lastUid);
+		});
+
+		const { data: sub } = client.auth.onAuthStateChange(
+			(_event, session) => {
+				const uid = session?.user?.id;
+				if (uid === lastUid) return;
+				lastUid = uid;
+				setPermissions(uid ? null : 0);
+				resolve(uid);
+			},
+		);
+
 		return () => {
 			active = false;
+			sub.subscription.unsubscribe();
 		};
 	}, [client]);
 


### PR DESCRIPTION
## Summary
Hardening pass on jobboard web after the `/auth/me` 500 (CA-fix already merged). Three fronts: metrics/error reporting, a staff-state leak, and identity-gated cache.

## Changes
**Metrics + error reporting**
- Wire `@kbve/observ` into jobboard web — `initObserv` → `metrics.kbve.com/api/v1/ingest/errors` (project `jobboard`, `user_id` from live Supabase session, updates on auth change).
- Add an `ErrorBoundary` that reports React render crashes via `captureException` + a reload fallback, instead of blanking the dashboard (the `Object.keys(n.props)` class of crash).
- Fix observ's write-only `timer` field (`TS6133` under strict consumers): add a `stop()` teardown that clears the interval + flushes. Additive; astro-kbve unaffected.

**Staff-state leak (security/UX)**
- `useStaff` resolved `staff_permissions` once against the stable supabase client and never refetched on account switch — a prior staff session left `isStaff` frozen `true` across logins (a non-staff user saw the staff console).
- Now refetches on session-**user** change (ignores token refreshes), resets to `0` on sign-out. Also fixes the RN app's DashboardScreen/HomeView (same hook).

**Identity-gated persisted cache**
- Tag IndexedDB with the owning uid; `reconcileCache` clears the cache **only on uid mismatch** (wipes RQ cache + form drafts), re-tags on match.
- Runs headlessly on boot/refresh (AuthBridge) and as a visible login gate (`PostAuthGate` + `LoginChecklist`: **Preparing IDB** / **Preparing Cookie Auth**, green-checks each, then forwards).
- Logout clears in-memory queries only — no IDB wipe; reconcile is uid-gated on next login.

## Testing
- `tsc --noEmit` clean.
- ⚠️ Full `vite build` not run: pre-existing `expo-modules-core` SharedObject/SharedRef rolldown break at HEAD (reproduces on clean base, unrelated to this PR). Verification is typecheck-level.