### PR TITLE
fix(jobboard): unblock vite build (stub expo type-decl side-effect)

### DIFF
--- a/apps/jobboard/web/vite.config.ts
+++ b/apps/jobboard/web/vite.config.ts
@@ -6,8 +6,33 @@ import path from 'node:path';
 const API_TARGET = process.env.JOBBOARD_API_TARGET || 'http://127.0.0.1:5400';
 const repoRoot = path.resolve(__dirname, '../../..');
 
+// expo-modules-core ships only raw TS (no built JS) and its index side-effect
+// imports ./ts-declarations/global, a pure ambient-types file whose value-style
+// imports of `declare class` symbols rolldown follows to type-only modules
+// (MISSING_EXPORT). On web the expo native layer is never used (RN libs resolve
+// their .web.ts variants), so neutralize that type-only side-effect import.
+function stubExpoTypeDeclarations() {
+	const virtual = '\0expo-empty-global';
+	return {
+		name: 'stub-expo-ts-declarations',
+		enforce: 'pre' as const,
+		resolveId(source: string, importer: string | undefined) {
+			if (
+				source.includes('ts-declarations/global') &&
+				importer?.includes('expo-modules-core')
+			)
+				return virtual;
+			return null;
+		},
+		load(id: string) {
+			return id === virtual ? 'export {};' : null;
+		},
+	};
+}
+
 export default defineConfig(({ mode }) => ({
 	plugins: [
+		stubExpoTypeDeclarations(),
 		react({
 			babel: {
 				// reanimated v4 ships its babel plugin via react-native-worklets


### PR DESCRIPTION
## Problem
`apps/jobboard/web` `npm run build` failed at HEAD (verification on the prior PR was typecheck-only). rolldown errored with 4 × `MISSING_EXPORT` on `expo-modules-core/src/ts-declarations/{SharedObject,SharedRef,EventEmitter,NativeModule}.ts`.

## Root cause
`expo-modules-core` ships **only raw TS** (no built JS — `build/` has just `.d.ts`). Its `src/index.ts` does a side-effect import of `./ts-declarations/global`, a pure ambient-types file that value-imports `declare class` symbols (zero runtime) used only inside `declare global`/`declare namespace`. esbuild keeps the import edge; rolldown follows it into the type-only modules → MISSING_EXPORT.

This is an Expo SDK design (expects Metro/babel) and is unrelated to app code — it reproduced on a clean base.

## Fix
A small `resolveId`/`load` vite plugin (`stubExpoTypeDeclarations`) neutralizes that single type-only side-effect import (scoped to `expo-modules-core` as importer). On web the expo native layer is never executed — RN libs (`executor`, `openExternal`, `HCaptcha`, …) resolve their `.web.ts` variants — so dropping the ambient-types import is runtime-safe.

## Result
- `npm run build` → **EXIT 0**, dist emitted (2977 modules).
- `tsc --noEmit` still clean.
- Remaining `eval` warning on expo's `uuid/index.web.ts` is non-fatal (Node-crypto fallback; browser uses `crypto.randomUUID`).