### PR TITLE
feat(metrics): harden telemetry ingest — sanitization + access controls (belt & suspenders)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -24,7 +24,7 @@ tags:
 key: metrics
 pipeline: docker
 app_name: metrics
-version: "0.1.1"
+version: "0.1.2"
 source_path: apps/metrics
 version_toml: apps/metrics/version.toml
 version_target: apps/metrics/Cargo.toml

--- a/apps/kube/metrics/manifest/telemetry-ch-setup-job.yaml
+++ b/apps/kube/metrics/manifest/telemetry-ch-setup-job.yaml
@@ -81,6 +81,26 @@ data:
         }
         echo "Table 'telemetry.errors_distributed' ready."
 
+        # Defense-in-depth tripwires on the raw table (canonical list:
+        # packages/data/ch/schemas/telemetry.sql). Caps sit above the metrics
+        # ingest clamps; ADD CONSTRAINT only checks future inserts (no backfill).
+        echo "Applying sanitization constraints on errors_raw..."
+        for c in \
+          "chk_project_len CHECK length(project) > 0 AND length(project) <= 256" \
+          "chk_fingerprint_len CHECK length(fingerprint) <= 64" \
+          "chk_message_len CHECK length(message) <= 8192" \
+          "chk_stack_len CHECK length(stack) <= 32768" \
+          "chk_url_len CHECK length(url) <= 2048" \
+          "chk_handled_bit CHECK handled <= 1"; do
+          curl -sf --max-time 30 \
+            "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+            -d "ALTER TABLE telemetry.errors_raw ON CLUSTER 'cluster' ADD CONSTRAINT IF NOT EXISTS ${c}" || {
+            echo "ERROR: Failed to add constraint: ${c}"
+            exit 1
+          }
+        done
+        echo "Constraints on 'telemetry.errors_raw' applied."
+
         echo "Creating error_groups view (fingerprint rollup)..."
         curl -sf --max-time 30 \
           "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \

--- a/apps/metrics/src/config.rs
+++ b/apps/metrics/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub channel_capacity: usize,
     pub flush_rows: usize,
     pub flush_interval_ms: u64,
+    pub insert_timeout_ms: u64,
+    pub insert_max_retries: u32,
     pub rate_limit_per_min: u32,
     pub project_rate_limit_per_min: u32,
     pub global_rate_limit_per_min: u32,
@@ -46,6 +48,10 @@ impl Config {
             flush_interval_ms: get("METRICS_FLUSH_INTERVAL_MS", "2000")
                 .parse()
                 .unwrap_or(2000),
+            insert_timeout_ms: get("METRICS_INSERT_TIMEOUT_MS", "5000")
+                .parse()
+                .unwrap_or(5000),
+            insert_max_retries: get("METRICS_INSERT_MAX_RETRIES", "2").parse().unwrap_or(2),
             rate_limit_per_min: get("METRICS_RATE_LIMIT_PER_MIN", "120")
                 .parse()
                 .unwrap_or(120),

--- a/apps/metrics/src/config.rs
+++ b/apps/metrics/src/config.rs
@@ -12,6 +12,10 @@ pub struct Config {
     pub flush_rows: usize,
     pub flush_interval_ms: u64,
     pub rate_limit_per_min: u32,
+    pub project_rate_limit_per_min: u32,
+    pub global_rate_limit_per_min: u32,
+    pub trusted_proxy_hops: usize,
+    pub ingest_token: Option<String>,
 }
 
 fn get(key: &str, default: &str) -> String {
@@ -45,6 +49,17 @@ impl Config {
             rate_limit_per_min: get("METRICS_RATE_LIMIT_PER_MIN", "120")
                 .parse()
                 .unwrap_or(120),
+            project_rate_limit_per_min: get("METRICS_PROJECT_RATE_LIMIT_PER_MIN", "6000")
+                .parse()
+                .unwrap_or(6000),
+            global_rate_limit_per_min: get("METRICS_GLOBAL_RATE_LIMIT_PER_MIN", "60000")
+                .parse()
+                .unwrap_or(60000),
+            trusted_proxy_hops: get("METRICS_TRUSTED_PROXY_HOPS", "1").parse().unwrap_or(1),
+            ingest_token: env::var("METRICS_INGEST_TOKEN")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
         }
     }
 }

--- a/apps/metrics/src/error.rs
+++ b/apps/metrics/src/error.rs
@@ -11,6 +11,8 @@ pub enum ApiError {
     TooLarge(String),
     #[error("rate limited")]
     RateLimited,
+    #[error("unauthorized")]
+    Unauthorized,
 }
 
 impl ApiError {
@@ -19,6 +21,7 @@ impl ApiError {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::TooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
             Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
+            Self::Unauthorized => StatusCode::UNAUTHORIZED,
         }
     }
 
@@ -27,6 +30,7 @@ impl ApiError {
             Self::BadRequest(_) => "BAD_REQUEST",
             Self::TooLarge(_) => "PAYLOAD_TOO_LARGE",
             Self::RateLimited => "RATE_LIMITED",
+            Self::Unauthorized => "UNAUTHORIZED",
         }
     }
 }

--- a/apps/metrics/src/main.rs
+++ b/apps/metrics/src/main.rs
@@ -8,7 +8,7 @@ mod telemetry;
 use std::sync::Arc;
 
 use axum::http::{HeaderValue, Method, header};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
@@ -25,6 +25,9 @@ fn cors_layer(cfg: &Config) -> CorsLayer {
         .filter_map(|o| o.parse().ok())
         .collect();
     let allow = if origins.is_empty() {
+        tracing::warn!(
+            "METRICS_ALLOWED_ORIGINS unset — CORS allows any origin; set it in production"
+        );
         AllowOrigin::any()
     } else {
         AllowOrigin::list(origins)
@@ -55,8 +58,9 @@ async fn main() -> anyhow::Result<()> {
     let cors = cors_layer(&cfg);
     let addr = format!("{}:{}", cfg.host, cfg.port);
 
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let state = Arc::new(AppState::new(cfg, ch, tx, auth));
-    spawn_flusher(state.clone(), rx);
+    let flusher = spawn_flusher(state.clone(), rx, shutdown_rx);
 
     let app = rest::router(state)
         .layer(cors)
@@ -65,6 +69,37 @@ async fn main() -> anyhow::Result<()> {
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!(%addr, "metrics ingest listening");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    // Drain buffered telemetry before exit.
+    tracing::info!("shutdown signal received; draining telemetry buffer");
+    let _ = shutdown_tx.send(());
+    let _ = flusher.await;
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
 }

--- a/apps/metrics/src/rest/groups.rs
+++ b/apps/metrics/src/rest/groups.rs
@@ -70,18 +70,31 @@ async fn authorize(app: &AppState, headers: &HeaderMap) -> Result<(), Response> 
     }
 }
 
+const QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 async fn query(app: &AppState, sql: String, key: &str) -> Response {
-    match app.ch.execute_select(&sql).await {
-        Ok(rows) => {
+    match tokio::time::timeout(QUERY_TIMEOUT, app.ch.execute_select(&sql)).await {
+        Ok(Ok(rows)) => {
             let mut body = serde_json::Map::new();
             body.insert(key.to_string(), json!(rows));
             (StatusCode::OK, Json(serde_json::Value::Object(body))).into_response()
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             tracing::error!(error = %e, "telemetry query failed");
             (
                 StatusCode::BAD_GATEWAY,
                 Json(json!({ "error": "query failed" })),
+            )
+                .into_response()
+        }
+        Err(_) => {
+            tracing::error!(
+                timeout_s = QUERY_TIMEOUT.as_secs(),
+                "telemetry query timed out"
+            );
+            (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(json!({ "error": "query timed out" })),
             )
                 .into_response()
         }

--- a/apps/metrics/src/rest/groups.rs
+++ b/apps/metrics/src/rest/groups.rs
@@ -31,6 +31,22 @@ fn clamp(limit: Option<u32>, fallback: u32) -> u32 {
     limit.unwrap_or(fallback).clamp(1, 1000)
 }
 
+/// Bound a project filter before it reaches the query (length cap; quote()
+/// already neutralizes injection — this is defense in depth).
+fn cap_project(project: Option<String>) -> Option<String> {
+    project.map(|p| p.chars().take(256).collect())
+}
+
+/// Fingerprints are server-generated hex (see telemetry::fingerprint); reject
+/// anything that isn't, so the read path can't be probed with arbitrary input.
+fn valid_fingerprint(fp: &str) -> bool {
+    !fp.is_empty() && fp.len() <= 64 && fp.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn bad_request(msg: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+}
+
 fn auth_status(err: &AuthError) -> StatusCode {
     match err {
         AuthError::MissingToken | AuthError::InvalidToken(_) | AuthError::TokenExpired => {
@@ -80,8 +96,7 @@ pub async fn groups(
     if let Err(resp) = authorize(&app, &headers).await {
         return resp;
     }
-    let where_clause = p
-        .project
+    let where_clause = cap_project(p.project)
         .as_deref()
         .map(|pr| format!("WHERE project = {}", quote(pr)))
         .unwrap_or_default();
@@ -104,8 +119,11 @@ pub async fn events(
     if let Err(resp) = authorize(&app, &headers).await {
         return resp;
     }
+    if !valid_fingerprint(&p.fingerprint) {
+        return bad_request("invalid fingerprint");
+    }
     let mut conds = vec![format!("fingerprint = {}", quote(&p.fingerprint))];
-    if let Some(pr) = p.project.as_deref() {
+    if let Some(pr) = cap_project(p.project).as_deref() {
         conds.push(format!("project = {}", quote(pr)));
     }
     let sql = format!(
@@ -116,4 +134,25 @@ pub async fn events(
         clamp(p.limit, 50)
     );
     query(&app, sql, "events").await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_validation() {
+        assert!(valid_fingerprint("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"));
+        assert!(!valid_fingerprint(""));
+        assert!(!valid_fingerprint("' OR 1=1 --"));
+        assert!(!valid_fingerprint("xyz"));
+        assert!(!valid_fingerprint(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn project_is_length_capped() {
+        let long = "p".repeat(500);
+        assert_eq!(cap_project(Some(long)).unwrap().chars().count(), 256);
+        assert!(cap_project(None).is_none());
+    }
 }

--- a/apps/metrics/src/rest/ingest.rs
+++ b/apps/metrics/src/rest/ingest.rs
@@ -17,10 +17,22 @@ fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
         .unwrap_or("")
 }
 
-fn client_ip(headers: &HeaderMap) -> String {
+/// Resolve the client IP from `X-Forwarded-For`, counting from the RIGHT so the
+/// value is one the infrastructure appended — not the attacker-controlled
+/// leftmost entry (which let anyone rotate IPs to bypass the rate limit).
+/// `trusted_hops` is how many reverse proxies sit between us and the internet.
+fn client_ip(headers: &HeaderMap, trusted_hops: usize) -> String {
     let xff = header_str(headers, "x-forwarded-for");
     if !xff.is_empty() {
-        return xff.split(',').next().unwrap_or(xff).trim().to_string();
+        let parts: Vec<&str> = xff
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !parts.is_empty() {
+            let idx = parts.len().saturating_sub(1 + trusted_hops);
+            return parts[idx].to_string();
+        }
     }
     let real = header_str(headers, "x-real-ip");
     if !real.is_empty() {
@@ -29,13 +41,36 @@ fn client_ip(headers: &HeaderMap) -> String {
     "unknown".to_string()
 }
 
+/// Constant-time string comparison so the token check can't be probed by timing.
+fn ct_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 pub async fn ingest_errors(
     State(app): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(batch): Json<ErrorBatch>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ip = client_ip(&headers);
-    if !app.allow(&ip) {
+    if let Some(expected) = &app.cfg.ingest_token {
+        let provided = header_str(&headers, "x-kbve-ingest");
+        if !ct_eq(provided, expected) {
+            return Err(ApiError::Unauthorized);
+        }
+    }
+
+    let ip = client_ip(&headers, app.cfg.trusted_proxy_hops);
+    if !app.allow_ip(&ip) {
+        return Err(ApiError::RateLimited);
+    }
+    if !app.allow_global() {
         return Err(ApiError::RateLimited);
     }
     if batch.events.is_empty() {
@@ -53,10 +88,17 @@ pub async fn ingest_errors(
     let mut dropped = 0usize;
     for event in batch.events {
         match event.into_row(&user_agent) {
-            Some(row) => match app.tx.try_send(row) {
-                Ok(_) => accepted += 1,
-                Err(_) => dropped += 1,
-            },
+            Some(row) => {
+                let project = row.get("project").and_then(|v| v.as_str()).unwrap_or("");
+                if !app.allow_project(project) {
+                    dropped += 1;
+                    continue;
+                }
+                match app.tx.try_send(row) {
+                    Ok(_) => accepted += 1,
+                    Err(_) => dropped += 1,
+                }
+            }
             None => dropped += 1,
         }
     }
@@ -65,4 +107,40 @@ pub async fn ingest_errors(
         StatusCode::ACCEPTED,
         Json(json!({ "accepted": accepted, "dropped": dropped })),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hdrs(xff: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if !xff.is_empty() {
+            h.insert("x-forwarded-for", xff.parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn client_ip_ignores_spoofed_left_entry() {
+        // Attacker prepends a fake IP; with one trusted proxy we pick the
+        // infra-appended right side, not the spoofed "1.1.1.1".
+        let h = hdrs("1.1.1.1, 9.9.9.9, 8.8.8.8");
+        assert_eq!(client_ip(&h, 1), "9.9.9.9");
+        assert_eq!(client_ip(&h, 0), "8.8.8.8");
+    }
+
+    #[test]
+    fn client_ip_handles_short_chain_and_missing() {
+        assert_eq!(client_ip(&hdrs("7.7.7.7"), 1), "7.7.7.7");
+        assert_eq!(client_ip(&hdrs(""), 1), "unknown");
+    }
+
+    #[test]
+    fn ct_eq_matches_and_rejects() {
+        assert!(ct_eq("secret-token", "secret-token"));
+        assert!(!ct_eq("secret-token", "secret-toke"));
+        assert!(!ct_eq("secret-token", "wrong"));
+        assert!(!ct_eq("", "x"));
+    }
 }

--- a/apps/metrics/src/rest/system.rs
+++ b/apps/metrics/src/rest/system.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Json;
 use axum::extract::State;
@@ -7,6 +8,8 @@ use axum::response::IntoResponse;
 use serde_json::json;
 
 use crate::state::AppState;
+
+const READINESS_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub async fn health() -> Json<serde_json::Value> {
     Json(json!({
@@ -17,7 +20,12 @@ pub async fn health() -> Json<serde_json::Value> {
 }
 
 pub async fn readiness(State(app): State<Arc<AppState>>) -> impl IntoResponse {
-    let ready = app.ch.execute_select("SELECT 1").await.is_ok();
+    // Bounded so a hung ClickHouse fails fast to "degraded" instead of hanging
+    // until the kube probe deadline.
+    let ready = matches!(
+        tokio::time::timeout(READINESS_TIMEOUT, app.ch.execute_select("SELECT 1")).await,
+        Ok(Ok(_))
+    );
     let status = if ready {
         StatusCode::OK
     } else {

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -5,7 +5,8 @@ use ahash::AHashMap;
 use jedi::state::sidecar::ClickHouseConfig;
 use parking_lot::Mutex;
 use serde_json::Value;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 
 use crate::auth::StaffAuth;
 use crate::config::Config;
@@ -81,10 +82,16 @@ impl AppState {
     }
 }
 
-pub fn spawn_flusher(state: Arc<AppState>, mut rx: mpsc::Receiver<Value>) {
+pub fn spawn_flusher(
+    state: Arc<AppState>,
+    mut rx: mpsc::Receiver<Value>,
+    mut shutdown: oneshot::Receiver<()>,
+) -> JoinHandle<()> {
     let table = state.cfg.errors_table.clone();
     let flush_rows = state.cfg.flush_rows;
     let interval = Duration::from_millis(state.cfg.flush_interval_ms);
+    let timeout = Duration::from_millis(state.cfg.insert_timeout_ms);
+    let retries = state.cfg.insert_max_retries;
     tokio::spawn(async move {
         let mut buf: Vec<Value> = Vec::with_capacity(flush_rows);
         let mut tick = tokio::time::interval(interval);
@@ -95,34 +102,77 @@ pub fn spawn_flusher(state: Arc<AppState>, mut rx: mpsc::Receiver<Value>) {
                         Some(row) => {
                             buf.push(row);
                             if buf.len() >= flush_rows {
-                                flush(&state.ch, &table, &mut buf).await;
+                                flush(&state.ch, &table, &mut buf, timeout, retries).await;
                             }
                         }
                         None => {
-                            flush(&state.ch, &table, &mut buf).await;
+                            flush(&state.ch, &table, &mut buf, timeout, retries).await;
                             break;
                         }
                     }
                 }
                 _ = tick.tick() => {
                     if !buf.is_empty() {
-                        flush(&state.ch, &table, &mut buf).await;
+                        flush(&state.ch, &table, &mut buf, timeout, retries).await;
                     }
+                }
+                _ = &mut shutdown => {
+                    // Drain anything still queued, then final flush before exit
+                    // so a rollout doesn't lose buffered telemetry.
+                    while let Ok(row) = rx.try_recv() {
+                        buf.push(row);
+                    }
+                    flush(&state.ch, &table, &mut buf, timeout, retries).await;
+                    break;
                 }
             }
         }
-    });
+    })
 }
 
-async fn flush(ch: &ClickHouseConfig, table: &str, buf: &mut Vec<Value>) {
+/// Insert with a per-attempt timeout (a hung ClickHouse must not stall the
+/// single flusher forever) and bounded retries with backoff (survive a
+/// transient CH blip instead of dropping the whole buffer on first error).
+async fn flush(
+    ch: &ClickHouseConfig,
+    table: &str,
+    buf: &mut Vec<Value>,
+    timeout: Duration,
+    max_retries: u32,
+) {
     if buf.is_empty() {
         return;
     }
     let rows = std::mem::take(buf);
     let n = rows.len();
-    if let Err(e) = ch.execute_insert(table, &rows).await {
-        tracing::error!(error = %e, rows = n, "clickhouse insert failed");
-    } else {
-        tracing::debug!(rows = n, "flushed telemetry rows");
+    let mut attempt = 0u32;
+    loop {
+        let result = tokio::time::timeout(timeout, ch.execute_insert(table, &rows)).await;
+        match result {
+            Ok(Ok(())) => {
+                tracing::debug!(rows = n, "flushed telemetry rows");
+                return;
+            }
+            outcome => {
+                if attempt >= max_retries {
+                    match outcome {
+                        Ok(Err(e)) => {
+                            tracing::error!(error = %e, rows = n, attempts = attempt + 1, "clickhouse insert failed; dropping rows")
+                        }
+                        _ => {
+                            tracing::error!(
+                                timeout_ms = timeout.as_millis() as u64,
+                                rows = n,
+                                attempts = attempt + 1,
+                                "clickhouse insert timed out; dropping rows"
+                            )
+                        }
+                    }
+                    return;
+                }
+                attempt += 1;
+                tokio::time::sleep(Duration::from_millis(250 * attempt as u64)).await;
+            }
+        }
     }
 }

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -41,7 +41,12 @@ impl AppState {
         }
     }
 
-    pub fn allow(&self, key: &str) -> bool {
+    /// Fixed-window counter. Returns false once `limit` is exceeded for `key`
+    /// within the 60s window. A limit of 0 disables the check (always allows).
+    fn check(&self, key: &str, limit: u32) -> bool {
+        if limit == 0 {
+            return true;
+        }
         let now = Instant::now();
         let window = Duration::from_secs(60);
         let mut map = self.limiter.lock();
@@ -57,7 +62,22 @@ impl AppState {
             bucket.window_start = now;
         }
         bucket.count += 1;
-        bucket.count <= self.cfg.rate_limit_per_min
+        bucket.count <= limit
+    }
+
+    /// Per-client-IP request cap.
+    pub fn allow_ip(&self, ip: &str) -> bool {
+        self.check(ip, self.cfg.rate_limit_per_min)
+    }
+
+    /// Per-project event cap (keyed separately from IPs).
+    pub fn allow_project(&self, project: &str) -> bool {
+        self.check(&format!("p:{project}"), self.cfg.project_rate_limit_per_min)
+    }
+
+    /// Global ingest ceiling across all clients.
+    pub fn allow_global(&self) -> bool {
+        self.check("__global__", self.cfg.global_rate_limit_per_min)
     }
 }
 

--- a/apps/metrics/src/telemetry.rs
+++ b/apps/metrics/src/telemetry.rs
@@ -6,7 +6,20 @@ const MAX_MESSAGE: usize = 4096;
 const MAX_STACK: usize = 16384;
 const MAX_URL: usize = 1024;
 const MAX_EXTRA_KEYS: usize = 32;
+const MAX_EXTRA_KEY: usize = 128;
 const MAX_EXTRA_VALUE: usize = 1024;
+
+const PLATFORMS: &[&str] = &[
+    "web", "ios", "android", "desktop", "server", "node", "unknown",
+];
+const ENVIRONMENTS: &[&str] = &[
+    "production",
+    "staging",
+    "development",
+    "preview",
+    "test",
+    "local",
+];
 
 const NOISE: &[&str] = &[
     "ResizeObserver loop limit exceeded",
@@ -46,16 +59,55 @@ pub struct ErrorEvent {
     pub extra: Option<Map<String, Value>>,
 }
 
-fn truncate(mut s: String, max: usize) -> String {
-    if s.len() > max {
-        s.truncate(max);
+/// Byte-truncate without splitting a UTF-8 code point (`String::truncate`
+/// panics on a non-boundary index — a multibyte char at the limit would crash
+/// the ingest handler).
+fn truncate(s: String, max: usize) -> String {
+    if s.len() <= max {
+        return s;
     }
-    s
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Strip null bytes and control characters (incl. ESC, so ANSI escape
+/// sequences and terminal/log-injection payloads can't survive), then truncate.
+/// `keep_newlines` preserves `\n`/`\t` for multi-line fields like stacks.
+fn sanitize(s: &str, max: usize, keep_newlines: bool) -> String {
+    let cleaned: String = s
+        .chars()
+        .filter(|c| {
+            if keep_newlines && (*c == '\n' || *c == '\t') {
+                return true;
+            }
+            !c.is_control()
+        })
+        .collect();
+    truncate(cleaned, max)
+}
+
+/// Clamp a free-form dimension to a known allow-list, falling back to a default.
+/// Keeps `LowCardinality` columns from exploding on attacker-supplied values.
+fn allow_enum(val: Option<String>, allowed: &[&str], default: &str) -> String {
+    match val {
+        Some(v) => {
+            let v = v.trim().to_lowercase();
+            if allowed.contains(&v.as_str()) {
+                v
+            } else {
+                default.to_string()
+            }
+        }
+        None => default.to_string(),
+    }
 }
 
 fn strip_query(url: &str) -> String {
     let base = url.split(['?', '#']).next().unwrap_or(url);
-    truncate(base.to_string(), MAX_URL)
+    sanitize(base, MAX_URL, false)
 }
 
 fn is_noise(message: &str) -> bool {
@@ -85,48 +137,132 @@ fn sanitize_extra(extra: Option<Map<String, Value>>) -> String {
     };
     let mut out = Map::new();
     for (k, v) in map.into_iter().take(MAX_EXTRA_KEYS) {
+        let key = sanitize(&k, MAX_EXTRA_KEY, false);
+        if key.is_empty() {
+            continue;
+        }
         let s = match v {
-            Value::String(s) => Value::String(truncate(s, MAX_EXTRA_VALUE)),
+            Value::String(s) => Value::String(sanitize(&s, MAX_EXTRA_VALUE, false)),
             Value::Object(_) | Value::Array(_) => {
-                Value::String(truncate(v.to_string(), MAX_EXTRA_VALUE))
+                Value::String(sanitize(&v.to_string(), MAX_EXTRA_VALUE, false))
             }
             other => other,
         };
-        out.insert(k, s);
+        out.insert(key, s);
     }
     serde_json::to_string(&out).unwrap_or_else(|_| "{}".to_string())
 }
 
 impl ErrorEvent {
     pub fn into_row(self, user_agent: &str) -> Option<Value> {
-        let message = truncate(self.message, MAX_MESSAGE);
+        let message = sanitize(&self.message, MAX_MESSAGE, true);
         if message.is_empty() || is_noise(&message) {
             return None;
         }
-        let project = truncate(self.project, 128);
+        let project = sanitize(&self.project, 128, false);
         if project.is_empty() {
             return None;
         }
-        let error_type = truncate(self.error_type.unwrap_or_default(), 128);
-        let stack = truncate(self.stack.unwrap_or_default(), MAX_STACK);
+        let error_type = sanitize(&self.error_type.unwrap_or_default(), 128, false);
+        let stack = sanitize(&self.stack.unwrap_or_default(), MAX_STACK, true);
         let url = self.url.map(|u| strip_query(&u)).unwrap_or_default();
         let fp = fingerprint(&project, &error_type, &stack, &message);
 
         Some(json!({
             "project": project,
-            "platform": truncate(self.platform.unwrap_or_else(|| "web".into()), 32),
-            "release": truncate(self.release.unwrap_or_default(), 64),
-            "environment": truncate(self.environment.unwrap_or_else(|| "production".into()), 32),
+            "platform": allow_enum(self.platform, PLATFORMS, "web"),
+            "release": sanitize(&self.release.unwrap_or_default(), 64, false),
+            "environment": allow_enum(self.environment, ENVIRONMENTS, "production"),
             "fingerprint": fp,
             "error_type": error_type,
             "message": message,
             "stack": stack,
             "url": url,
-            "user_id": truncate(self.user_id.unwrap_or_default(), 128),
-            "session_id": truncate(self.session_id.unwrap_or_default(), 128),
-            "user_agent": truncate(user_agent.to_string(), 512),
+            "user_id": sanitize(&self.user_id.unwrap_or_default(), 128, false),
+            "session_id": sanitize(&self.session_id.unwrap_or_default(), 128, false),
+            "user_agent": sanitize(user_agent, 512, false),
             "handled": if self.handled.unwrap_or(false) { 1u8 } else { 0u8 },
             "extra": sanitize_extra(self.extra),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(message: &str) -> ErrorEvent {
+        ErrorEvent {
+            project: "kbve".into(),
+            platform: None,
+            release: None,
+            environment: None,
+            error_type: None,
+            message: message.into(),
+            stack: None,
+            url: None,
+            user_id: None,
+            session_id: None,
+            handled: None,
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn truncate_does_not_split_utf8() {
+        // "💥" is 4 bytes; truncating to 2 must not panic and yields "".
+        let out = truncate("💥".to_string(), 2);
+        assert!(out.is_empty());
+        // Boundary inside the second char drops it cleanly.
+        let out = truncate("a💥".to_string(), 3);
+        assert_eq!(out, "a");
+    }
+
+    #[test]
+    fn sanitize_strips_control_and_ansi() {
+        let out = sanitize("a\u{0}b\u{1b}[31mred\u{1b}[0mc\u{7}", 64, false);
+        assert_eq!(out, "ab[31mred[0mc");
+    }
+
+    #[test]
+    fn sanitize_keeps_newlines_when_asked() {
+        assert_eq!(sanitize("a\nb\tc", 64, true), "a\nb\tc");
+        assert_eq!(sanitize("a\nb\tc", 64, false), "abc");
+    }
+
+    #[test]
+    fn allow_enum_clamps_unknown() {
+        assert_eq!(allow_enum(Some("iOS".into()), PLATFORMS, "web"), "ios");
+        assert_eq!(allow_enum(Some("'; DROP".into()), PLATFORMS, "web"), "web");
+        assert_eq!(allow_enum(None, ENVIRONMENTS, "production"), "production");
+    }
+
+    #[test]
+    fn multibyte_message_at_limit_does_not_panic() {
+        let msg = "x".repeat(MAX_MESSAGE - 1) + "💥";
+        let row = event(&msg).into_row("ua");
+        assert!(row.is_some());
+    }
+
+    #[test]
+    fn empty_and_noise_dropped() {
+        assert!(event("").into_row("ua").is_none());
+        assert!(event("Script error.").into_row("ua").is_none());
+    }
+
+    #[test]
+    fn enum_and_extra_sanitized_in_row() {
+        let mut ev = event("boom");
+        ev.platform = Some("android".into());
+        ev.environment = Some("hacker".into());
+        let mut map = Map::new();
+        map.insert("ok\u{0}key".into(), Value::String("va\u{1b}lue".into()));
+        ev.extra = Some(map);
+        let row = ev.into_row("agent\u{0}x").unwrap();
+        assert_eq!(row["platform"], "android");
+        assert_eq!(row["environment"], "production");
+        assert_eq!(row["user_agent"], "agentx");
+        let extra: Value = serde_json::from_str(row["extra"].as_str().unwrap()).unwrap();
+        assert_eq!(extra["okkey"], "value");
     }
 }

--- a/packages/data/ch/schemas/telemetry.sql
+++ b/packages/data/ch/schemas/telemetry.sql
@@ -23,7 +23,18 @@ CREATE TABLE IF NOT EXISTS telemetry.errors_raw ON CLUSTER 'cluster'
     session_id      String DEFAULT '',
     user_agent      String DEFAULT '',
     handled         UInt8 DEFAULT 0,
-    extra           String DEFAULT '{}'
+    extra           String DEFAULT '{}',
+
+    -- Last-resort tripwires: the metrics ingest already clamps every field, so
+    -- these caps sit ABOVE the app limits and only fire if a writer bypasses it
+    -- (e.g. direct CH access with the ingest creds). A violating row rejects its
+    -- INSERT batch by design — fail loud.
+    CONSTRAINT chk_project_len     CHECK length(project) > 0 AND length(project) <= 256,
+    CONSTRAINT chk_fingerprint_len CHECK length(fingerprint) <= 64,
+    CONSTRAINT chk_message_len     CHECK length(message) <= 8192,
+    CONSTRAINT chk_stack_len       CHECK length(stack) <= 32768,
+    CONSTRAINT chk_url_len         CHECK length(url) <= 2048,
+    CONSTRAINT chk_handled_bit     CHECK handled <= 1
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/telemetry/errors_raw', '{replica}')
 ORDER BY (project, fingerprint, timestamp)


### PR DESCRIPTION
Defense-in-depth for the **public, unauthenticated** error-telemetry path (`/api/v1/ingest/errors`). Two fronts: **content** (what gets stored) and **access** (who can write + how much).

## Content sanitization
**Metrics ingest (`telemetry.rs`) — non-fatal clamping:**
- **Fix a panic/DoS**: `truncate()` used `String::truncate`, which panics on a non-UTF-8 boundary — a multibyte char at a byte limit crashed the handler. Now char-boundary-safe.
- `sanitize()`: strips null bytes + control chars incl. ESC (ANSI / log-injection); keeps `\n`/`\t` only for `stack`/`message`.
- Allow-list `platform` + `environment` → `LowCardinality` columns can't be blown up.
- Hardened `extra` keys (length + control strip; drop empties).

**ClickHouse (`telemetry.sql` + setup job) — fail-loud tripwire:**
- `CONSTRAINT` CHECKs on `errors_raw` (caps above the ingest clamps + `handled<=1`); only fire if a writer bypasses the app. Applied via `ALTER ... ADD CONSTRAINT IF NOT EXISTS ON CLUSTER` (future inserts only, no backfill).

## Access controls
- **Trusted client IP**: `client_ip()` read `X-Forwarded-For` left-to-right, but the leftmost entry is attacker-controlled — trivially spoofed to rotate past the per-IP rate limit. Now reads from the right (infra-appended), tunable via `METRICS_TRUSTED_PROXY_HOPS`. **The per-IP limit was effectively defeatable before this.**
- **Optional ingest token** (`METRICS_INGEST_TOKEN`): when set, requires `x-kbve-ingest` header (constant-time compare) → 401. Opt-in — nothing breaks until enabled + SDK sends it. Rotatable kill-switch. (Note: a token shipped in a frontend bundle is public; value is rotation + blocking non-browser actors, not true auth.)
- **Per-project cap** (`METRICS_PROJECT_RATE_LIMIT_PER_MIN`, default 6000) + **global ceiling** (`METRICS_GLOBAL_RATE_LIMIT_PER_MIN`, default 60000) layered over per-IP — bounds blast radius from one project or a distributed flood.

## Tests
`cargo test -p met --bins` → **10/10 pass** (utf8 truncation, control/ANSI strip, enum clamp, noise drop, IP selection, constant-time compare). Clippy clean.

Bumps metrics `0.1.1` → `0.1.2`.

## Rollout notes (ops)
1. Deploy is safe as-is — token unset (open), caps generous, IP-trust improves immediately.
2. **Set `METRICS_TRUSTED_PROXY_HOPS` to match the real chain** — Cloudflare + Cilium gateway likely = `2` (default `1`). Verify against an X-Forwarded-For sample so the rate limit keys on the true client IP.
3. To enable the token: update the `@kbve/observ` SDK to send `x-kbve-ingest`, deploy it, then set `METRICS_INGEST_TOKEN` (rotate by changing the env).