### PR TITLE
feat(rn/dash): generic data-stream dashboard kit + ArgoCD adapter

### DIFF
--- a/apps/kbve/astro-kbve/src/components/rnweb/AstroArgoDashRN.astro
+++ b/apps/kbve/astro-kbve/src/components/rnweb/AstroArgoDashRN.astro
@@ -1,0 +1,5 @@
+---
+import ReactArgoDashRN from './ReactArgoDashRN';
+---
+
+<ReactArgoDashRN client:only="react" />

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactArgoDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactArgoDashRN.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { StreamView, createArgoStream, argoLens } from '@kbve/rn/dash';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Proof that the generic @kbve/rn/dash kit renders a real ArgoCD stream on the
+ * web via react-native-web — the same source + lens a future Expo screen mounts.
+ */
+export default function ReactArgoDashRN() {
+	const store = useMemo(() => createArgoStream({ getToken }), []);
+	return (
+		<StreamView
+			store={store}
+			lens={argoLens}
+			layout="rows"
+			searchPlaceholder="filter by name / namespace / project"
+		/>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/argo-rn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/argo-rn.mdx
@@ -1,0 +1,23 @@
+---
+title: ArgoCD Dashboard (RN)
+description: ArgoCD stream rendered via the generic @kbve/rn/dash kit on react-native-web
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: ArgoCD (RN)
+    order: 4
+    badge: POC
+tags:
+    - dashboard
+    - argocd
+    - react-native
+---
+
+import AstroArgoDashRN from '@/components/rnweb/AstroArgoDashRN.astro';
+
+Proof-of-concept: the same ArgoCD applications stream rendered through the
+generic `@kbve/rn/dash` library (StreamSource + StreamLens) on
+react-native-web. One source + lens, destined to also mount on Expo mobile.
+
+<AstroArgoDashRN />

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -32,6 +32,7 @@
 			"@kbve/observ": ["../../../packages/npm/observ/src/index.ts"],
 			"@kbve/rn": ["../../../packages/npm/rn/src/index.web.ts"],
 			"@kbve/rn/ui": ["../../../packages/npm/rn/src/ui/index.web.ts"],
+			"@kbve/rn/dash": ["../../../packages/npm/rn/src/dash/index.ts"],
 			"@kbve/rn-astro": ["../../../packages/npm/rn-astro/src/index.ts"],
 			"@kbve/rn-astro/integration": [
 				"../../../packages/npm/rn-astro/src/integration.ts"

--- a/packages/npm/rn/package.json
+++ b/packages/npm/rn/package.json
@@ -39,6 +39,10 @@
 			"types": "./src/store/index.ts",
 			"import": "./src/store/index.ts"
 		},
+		"./dash": {
+			"types": "./src/dash/index.ts",
+			"import": "./src/dash/index.ts"
+		},
 		"./toasts": {
 			"types": "./src/toasts/index.ts",
 			"import": "./src/toasts/index.ts"

--- a/packages/npm/rn/src/dash/StatGrid.tsx
+++ b/packages/npm/rn/src/dash/StatGrid.tsx
@@ -1,0 +1,65 @@
+import { memo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Stack, Text, tokens } from '../ui';
+import type { StatModel } from './types';
+
+const TONE_COLOR: Record<string, string> = {
+	primary: tokens.color.primary,
+	success: tokens.color.success,
+	danger: tokens.color.danger,
+	warning: tokens.color.warning,
+	neutral: tokens.color.textMuted,
+};
+
+function StatCard({ stat }: { stat: StatModel }) {
+	const accent = TONE_COLOR[stat.tone ?? 'neutral'] ?? tokens.color.textMuted;
+	const body = (
+		<Stack gap="xs" style={styles.card}>
+			<Text variant="caption" tone="muted">
+				{stat.label}
+			</Text>
+			<Text variant="title" style={{ color: accent }}>
+				{stat.value}
+			</Text>
+		</Stack>
+	);
+	if (!stat.onPress) return body;
+	return (
+		<Pressable onPress={stat.onPress} style={styles.pressable}>
+			{body}
+		</Pressable>
+	);
+}
+
+export const StatGrid = memo(function StatGrid({
+	stats,
+}: {
+	stats: readonly StatModel[];
+}) {
+	if (!stats.length) return null;
+	return (
+		<View style={styles.grid}>
+			{stats.map((stat) => (
+				<StatCard key={stat.id} stat={stat} />
+			))}
+		</View>
+	);
+});
+
+const styles = StyleSheet.create({
+	grid: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		gap: tokens.space.sm,
+	},
+	card: {
+		minWidth: 120,
+		flexGrow: 1,
+		padding: tokens.space.md,
+		backgroundColor: tokens.color.surface,
+		borderRadius: tokens.radius.lg,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	pressable: { minWidth: 120, flexGrow: 1 },
+});

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -1,0 +1,298 @@
+import { memo, useMemo } from 'react';
+import type { ReactElement } from 'react';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
+import {
+	ErrorState,
+	LoadingState,
+	Stack,
+	Text,
+	VirtualList,
+	tokens,
+} from '../ui';
+import { StatGrid } from './StatGrid';
+import { useStream, useStreamLifecycle } from './useStream';
+import type { StreamFilter, StreamLens, StreamStore } from './types';
+
+const TONE_COLOR: Record<string, string> = {
+	primary: tokens.color.primary,
+	success: tokens.color.success,
+	danger: tokens.color.danger,
+	warning: tokens.color.warning,
+	neutral: tokens.color.textMuted,
+};
+
+type Row =
+	| { kind: 'header'; key: string; label: string }
+	| { kind: 'item'; key: string; item: unknown; expanded: boolean };
+
+interface RowProps {
+	row: Row;
+	lens: StreamLens<unknown>;
+	layout: 'rows' | 'cards';
+	onToggle: (key: string) => void;
+}
+
+const StreamRow = memo(
+	function StreamRow({ row, lens, layout, onToggle }: RowProps) {
+		if (row.kind === 'header') {
+			return (
+				<Text variant="label" tone="muted" style={styles.groupHeader}>
+					{row.label}
+				</Text>
+			);
+		}
+		const render = layout === 'cards' && lens.card ? lens.card : lens.row;
+		return (
+			<View>
+				<Pressable onPress={() => onToggle(row.key)}>
+					{render(row.item, row.expanded)}
+				</Pressable>
+				{row.expanded && lens.detail ? (
+					<View style={styles.detail}>{lens.detail(row.item)}</View>
+				) : null}
+			</View>
+		);
+	},
+	(a, b) =>
+		a.lens === b.lens &&
+		a.layout === b.layout &&
+		a.onToggle === b.onToggle &&
+		rowEqual(a.row, b.row),
+);
+
+// Compare row CONTENT, not the wrapper identity — buildRows produces fresh
+// wrappers each poll, but a reconciled item keeps its ref, so this lets an
+// unchanged row skip re-render while only flipped/expanded rows update.
+function rowEqual(a: Row, b: Row): boolean {
+	if (a.kind !== b.kind || a.key !== b.key) return false;
+	if (a.kind === 'item' && b.kind === 'item') {
+		return a.item === b.item && a.expanded === b.expanded;
+	}
+	if (a.kind === 'header' && b.kind === 'header') {
+		return a.label === b.label;
+	}
+	return false;
+}
+
+function FilterChips({
+	filters,
+	active,
+	onPick,
+}: {
+	filters: readonly StreamFilter<unknown>[];
+	active: string | null;
+	onPick: (id: string | null) => void;
+}) {
+	return (
+		<Stack direction="row" gap="sm" wrap>
+			{filters.map((f) => {
+				const on = active === f.id;
+				const tone =
+					TONE_COLOR[f.tone ?? 'primary'] ?? tokens.color.primary;
+				return (
+					<Pressable
+						key={f.id}
+						onPress={() => onPick(on ? null : f.id)}
+						style={[
+							styles.chip,
+							{ borderColor: tone },
+							on ? { backgroundColor: tone } : null,
+						]}>
+						<Text
+							variant="caption"
+							weight="medium"
+							style={{
+								color: on ? tokens.color.onPrimary : tone,
+							}}>
+							{f.label}
+						</Text>
+					</Pressable>
+				);
+			})}
+		</Stack>
+	);
+}
+
+export interface StreamViewProps<TItem> {
+	store: StreamStore<TItem>;
+	lens: StreamLens<TItem>;
+	layout?: 'rows' | 'cards';
+	searchPlaceholder?: string;
+}
+
+export function StreamView<TItem>({
+	store,
+	lens,
+	layout = 'rows',
+	searchPlaceholder = 'Filter…',
+}: StreamViewProps<TItem>): ReactElement {
+	useStreamLifecycle(store);
+	const state = useStream(store);
+
+	const visible = useMemo(() => {
+		const q = state.search.trim().toLowerCase();
+		const filter = lens.filters?.find((f) => f.id === state.filterId);
+		let items = state.items;
+		if (filter) items = items.filter(filter.predicate);
+		if (q && lens.searchText) {
+			items = items.filter((it) =>
+				lens.searchText!(it).toLowerCase().includes(q),
+			);
+		}
+		return items;
+	}, [state.items, state.search, state.filterId, lens]);
+
+	const rows = useMemo(
+		() => buildRows(visible, state.expandedId, state.groupKey, store, lens),
+		[visible, state.expandedId, state.groupKey, store, lens],
+	);
+
+	if (state.loading && state.items.length === 0) {
+		return <LoadingState label="Loading…" />;
+	}
+	if (state.error && state.items.length === 0) {
+		return (
+			<ErrorState
+				message={state.error}
+				onRetry={() => void store.refresh()}
+			/>
+		);
+	}
+
+	const stats = lens.stats?.(state.items) ?? [];
+	const lensU = lens as unknown as StreamLens<unknown>;
+
+	return (
+		<Stack gap="md">
+			{stats.length ? <StatGrid stats={stats} /> : null}
+
+			<Stack direction="row" gap="sm" align="center" wrap>
+				{lens.filters?.length ? (
+					<FilterChips
+						filters={
+							lens.filters as readonly StreamFilter<unknown>[]
+						}
+						active={state.filterId}
+						onPick={store.setFilter}
+					/>
+				) : null}
+				{lens.searchText ? (
+					<TextInput
+						value={state.search}
+						onChangeText={store.setSearch}
+						placeholder={searchPlaceholder}
+						placeholderTextColor={tokens.color.textFaint}
+						style={styles.search}
+					/>
+				) : null}
+			</Stack>
+
+			<VirtualList
+				data={rows}
+				keyExtractor={(r) => r.key}
+				extraData={`${state.expandedId}:${state.groupKey}`}
+				renderItem={({ item }) => (
+					<StreamRow
+						row={item}
+						lens={lensU}
+						layout={layout}
+						onToggle={store.toggleExpanded}
+					/>
+				)}
+				ItemSeparatorComponent={Separator}
+				ListEmptyComponent={EmptyRow}
+			/>
+		</Stack>
+	);
+}
+
+function buildRows<TItem>(
+	items: TItem[],
+	expandedId: string | null,
+	groupKey: string | null,
+	store: StreamStore<TItem>,
+	lens: StreamLens<TItem>,
+): Row[] {
+	if (!groupKey || !lens.group) {
+		return items.map((it) => {
+			const key = store.id(it);
+			return {
+				kind: 'item',
+				key,
+				item: it,
+				expanded: expandedId === key,
+			};
+		});
+	}
+
+	const buckets = new Map<string, TItem[]>();
+	for (const it of items) {
+		const g = lens.group(it) || '—';
+		const arr = buckets.get(g) ?? [];
+		arr.push(it);
+		buckets.set(g, arr);
+	}
+	const out: Row[] = [];
+	for (const [label, bucket] of [...buckets.entries()].sort((a, b) =>
+		a[0].localeCompare(b[0]),
+	)) {
+		out.push({ kind: 'header', key: `h:${label}`, label });
+		for (const it of bucket) {
+			const key = store.id(it);
+			out.push({
+				kind: 'item',
+				key,
+				item: it,
+				expanded: expandedId === key,
+			});
+		}
+	}
+	return out;
+}
+
+function Separator() {
+	return <View style={styles.separator} />;
+}
+
+function EmptyRow() {
+	return (
+		<Text variant="caption" tone="muted" style={styles.empty}>
+			Nothing matches the current filter
+		</Text>
+	);
+}
+
+const styles = StyleSheet.create({
+	groupHeader: {
+		marginTop: tokens.space.sm,
+		textTransform: 'uppercase',
+		letterSpacing: 0.5,
+	},
+	detail: {
+		marginTop: tokens.space.xs,
+		padding: tokens.space.md,
+		backgroundColor: tokens.color.surfaceAlt,
+		borderRadius: tokens.radius.lg,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	chip: {
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 4,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 1,
+	},
+	search: {
+		flexGrow: 1,
+		minWidth: 160,
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 6,
+		color: tokens.color.text,
+		backgroundColor: tokens.color.surface,
+		borderRadius: tokens.radius.md,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	separator: { height: tokens.space.sm },
+	empty: { padding: tokens.space.lg, textAlign: 'center' },
+});

--- a/packages/npm/rn/src/dash/adapters/argo.tsx
+++ b/packages/npm/rn/src/dash/adapters/argo.tsx
@@ -1,0 +1,260 @@
+import { StyleSheet, View } from 'react-native';
+import { Badge, Stack, Surface, Text, tokens } from '../../ui';
+import type { BadgeTone } from '../../ui';
+import { createStreamSource } from '../createStreamSource';
+import type { StreamLens, StreamStore } from '../types';
+
+// Minimal shape of the ArgoCD application payload we depend on. Kept local so
+// the dash library has no coupling to the astro-kbve argoService.
+interface RawArgoApp {
+	metadata: { name: string };
+	spec: {
+		project: string;
+		source?: { repoURL?: string };
+		destination: { namespace: string };
+	};
+	status: {
+		sync: { status: string; revision?: string };
+		health: { status: string };
+		operationState?: { finishedAt?: string };
+		reconciledAt?: string;
+		resources?: Array<{ status?: string; health?: { status?: string } }>;
+	};
+}
+
+export interface ArgoItem {
+	name: string;
+	project: string;
+	namespace: string;
+	health: string;
+	sync: string;
+	repo: string;
+	revision: string;
+	lastSync: string;
+	total: number;
+	healthy: number;
+	degraded: number;
+	outOfSync: number;
+}
+
+export interface ArgoStreamOptions {
+	/** Returns a fresh bearer token (Supabase access token). */
+	getToken: () => Promise<string | null>;
+	/** Origin for the proxy. '' (relative) on web, absolute URL on mobile. */
+	baseUrl?: string;
+	pollMs?: number;
+}
+
+function normalize(raw: RawArgoApp): ArgoItem {
+	const res = raw.status.resources ?? [];
+	let healthy = 0;
+	let degraded = 0;
+	let outOfSync = 0;
+	for (const r of res) {
+		const h = r.health?.status;
+		if (h === 'Healthy') healthy++;
+		else if (h === 'Degraded' || h === 'Missing') degraded++;
+		if (r.status && r.status !== 'Synced') outOfSync++;
+	}
+	return {
+		name: raw.metadata.name,
+		project: raw.spec.project,
+		namespace: raw.spec.destination.namespace || '',
+		health: raw.status.health.status || 'Unknown',
+		sync: raw.status.sync.status || 'Unknown',
+		repo: raw.spec.source?.repoURL ?? '',
+		revision: (raw.status.sync.revision ?? '').slice(0, 7),
+		lastSync:
+			raw.status.operationState?.finishedAt ??
+			raw.status.reconciledAt ??
+			'',
+		total: res.length,
+		healthy,
+		degraded,
+		outOfSync,
+	};
+}
+
+export function createArgoStream(
+	opts: ArgoStreamOptions,
+): StreamStore<ArgoItem> {
+	const { getToken, baseUrl = '', pollMs = 30_000 } = opts;
+	return createStreamSource<RawArgoApp, ArgoItem>({
+		key: 'argo:applications',
+		pollMs,
+		cacheTtlMs: 60_000,
+		id: (it) => it.name,
+		signature: (it) =>
+			`${it.sync}|${it.health}|${it.lastSync}|${it.total}|${it.degraded}|${it.outOfSync}`,
+		normalize,
+		fetch: async ({ signal }) => {
+			const token = await getToken();
+			const res = await fetch(
+				`${baseUrl}/dashboard/argo/proxy/api/v1/applications`,
+				{
+					headers: token
+						? { Authorization: `Bearer ${token}` }
+						: undefined,
+					signal,
+				},
+			);
+			if (res.status === 403) throw new Error('Access restricted');
+			if (!res.ok) throw new Error(`ArgoCD upstream ${res.status}`);
+			const json = (await res.json()) as { items?: RawArgoApp[] };
+			return json.items ?? [];
+		},
+	});
+}
+
+function healthTone(status: string): BadgeTone {
+	if (status === 'Healthy') return 'success';
+	if (status === 'Degraded' || status === 'Missing') return 'danger';
+	if (status === 'Progressing') return 'warning';
+	return 'neutral';
+}
+
+function syncTone(status: string): BadgeTone {
+	if (status === 'Synced') return 'success';
+	if (status === 'OutOfSync') return 'warning';
+	return 'neutral';
+}
+
+function healthDotColor(status: string): string {
+	if (status === 'Healthy') return tokens.color.success;
+	if (status === 'Degraded' || status === 'Missing')
+		return tokens.color.danger;
+	if (status === 'Progressing') return tokens.color.warning;
+	return tokens.color.textFaint;
+}
+
+/** The Argo lens (t): projects an ArgoItem into row/card/detail/stat models. */
+export const argoLens: StreamLens<ArgoItem> = {
+	searchText: (it) => `${it.name} ${it.namespace} ${it.project}`,
+	group: (it) => it.project,
+	filters: [
+		{
+			id: 'degraded',
+			label: 'Degraded',
+			tone: 'danger',
+			predicate: (it) =>
+				it.health === 'Degraded' || it.health === 'Missing',
+		},
+		{
+			id: 'outofsync',
+			label: 'OutOfSync',
+			tone: 'warning',
+			predicate: (it) => it.sync === 'OutOfSync',
+		},
+	],
+	stats: (items) => [
+		{ id: 'total', label: 'Applications', value: items.length },
+		{
+			id: 'healthy',
+			label: 'Healthy',
+			tone: 'success',
+			value: items.filter((i) => i.health === 'Healthy').length,
+		},
+		{
+			id: 'synced',
+			label: 'Synced',
+			tone: 'success',
+			value: items.filter((i) => i.sync === 'Synced').length,
+		},
+		{
+			id: 'degraded',
+			label: 'Degraded',
+			tone: 'danger',
+			value: items.filter(
+				(i) => i.health === 'Degraded' || i.health === 'Missing',
+			).length,
+		},
+		{
+			id: 'outofsync',
+			label: 'OutOfSync',
+			tone: 'warning',
+			value: items.filter((i) => i.sync === 'OutOfSync').length,
+		},
+	],
+	row: (it) => (
+		<Surface padded={false} style={styles.row}>
+			<View
+				style={[
+					styles.dot,
+					{ backgroundColor: healthDotColor(it.health) },
+				]}
+			/>
+			<Text variant="label" numberOfLines={1} style={styles.name}>
+				{it.name}
+			</Text>
+			<Text variant="caption" tone="muted" numberOfLines={1}>
+				{it.project}
+			</Text>
+			<View style={styles.spacer} />
+			<Badge label={it.sync} tone={syncTone(it.sync)} />
+			<Badge label={it.health} tone={healthTone(it.health)} />
+		</Surface>
+	),
+	card: (it) => (
+		<Surface style={styles.card}>
+			<Stack gap="sm">
+				<Stack direction="row" align="center" gap="sm">
+					<View
+						style={[
+							styles.dot,
+							{ backgroundColor: healthDotColor(it.health) },
+						]}
+					/>
+					<Text variant="label" numberOfLines={1} style={styles.name}>
+						{it.name}
+					</Text>
+				</Stack>
+				<Text variant="caption" tone="muted" numberOfLines={1}>
+					{it.namespace || '—'} · {it.project}
+				</Text>
+				<Stack direction="row" gap="sm" wrap>
+					<Badge label={it.sync} tone={syncTone(it.sync)} />
+					<Badge label={it.health} tone={healthTone(it.health)} />
+				</Stack>
+			</Stack>
+		</Surface>
+	),
+	detail: (it) => (
+		<Stack gap="xs">
+			<Fact label="Repo" value={it.repo || '—'} />
+			<Fact label="Revision" value={it.revision || '—'} />
+			<Fact label="Last sync" value={it.lastSync || '—'} />
+			<Fact
+				label="Resources"
+				value={`${it.total} total · ${it.degraded} degraded · ${it.outOfSync} out-of-sync`}
+			/>
+		</Stack>
+	),
+};
+
+function Fact({ label, value }: { label: string; value: string }) {
+	return (
+		<Stack direction="row" gap="sm" justify="space-between">
+			<Text variant="caption" tone="muted">
+				{label}
+			</Text>
+			<Text variant="caption" numberOfLines={1} style={styles.factValue}>
+				{value}
+			</Text>
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: tokens.space.sm,
+	},
+	card: { padding: tokens.space.md },
+	dot: { width: 9, height: 9, borderRadius: 5 },
+	name: { flexShrink: 1 },
+	spacer: { flexGrow: 1 },
+	factValue: { flexShrink: 1, textAlign: 'right' },
+});

--- a/packages/npm/rn/src/dash/createStreamSource.ts
+++ b/packages/npm/rn/src/dash/createStreamSource.ts
@@ -1,0 +1,148 @@
+import { createSignal } from '@kbve/core';
+import { kvStore } from '../store/kv';
+import type { CacheEntry } from '../store/types';
+import type { StreamSourceConfig, StreamState, StreamStore } from './types';
+
+const EMPTY = <TItem>(): StreamState<TItem> => ({
+	items: [],
+	loading: true,
+	error: null,
+	lastUpdated: null,
+	fromCache: false,
+	expandedId: null,
+	search: '',
+	filterId: null,
+	groupKey: null,
+});
+
+/**
+ * Build a polling/caching data source for one stream of items. Domain code
+ * supplies fetch + normalize + identity; the source owns the lifecycle:
+ * cache hydrate, poll, abort/supersede, and signature-based reference reuse so
+ * memoized rows skip re-render when nothing visible changed.
+ */
+export function createStreamSource<TRaw, TItem>(
+	config: StreamSourceConfig<TRaw, TItem>,
+): StreamStore<TItem> {
+	const {
+		key,
+		fetch,
+		normalize,
+		id,
+		signature = (item: TItem) => JSON.stringify(item),
+		pollMs,
+		cacheTtlMs,
+	} = config;
+
+	const cacheKey = `dash:${key}`;
+	const signal = createSignal<StreamState<TItem>>(EMPTY<TItem>());
+
+	// Reference-reuse caches: previous item by id + its fingerprint, so an
+	// unchanged item keeps its object identity across polls.
+	let prevById = new Map<string, TItem>();
+	const sigCache = new WeakMap<object, string>();
+
+	const sigOf = (item: TItem): string => {
+		const obj = item as unknown as object;
+		let sig = sigCache.get(obj);
+		if (sig === undefined) {
+			sig = signature(item);
+			sigCache.set(obj, sig);
+		}
+		return sig;
+	};
+
+	const reconcile = (next: TItem[]): TItem[] => {
+		const out = next.map((item) => {
+			const old = prevById.get(id(item));
+			return old && sigOf(old) === sigOf(item) ? old : item;
+		});
+		const map = new Map<string, TItem>();
+		for (const item of out) map.set(id(item), item);
+		prevById = map;
+		return out;
+	};
+
+	const patch = (next: Partial<StreamState<TItem>>) =>
+		signal.set((prev) => ({ ...prev, ...next }));
+
+	let controller: AbortController | null = null;
+	let timer: ReturnType<typeof setInterval> | undefined;
+	let started = false;
+
+	const runFetch = async (): Promise<void> => {
+		controller?.abort();
+		const ctrl = new AbortController();
+		controller = ctrl;
+		try {
+			const raw = await fetch({ signal: ctrl.signal });
+			if (ctrl.signal.aborted) return;
+			const items = reconcile(raw.map(normalize));
+			patch({
+				items,
+				loading: false,
+				error: null,
+				fromCache: false,
+				lastUpdated: Date.now(),
+			});
+			if (cacheTtlMs) {
+				void kvStore.set(cacheKey, {
+					value: items,
+					storedAt: Date.now(),
+				});
+			}
+		} catch (e: unknown) {
+			if (ctrl.signal.aborted) return;
+			patch({
+				loading: false,
+				error: e instanceof Error ? e.message : 'Request failed',
+			});
+		}
+	};
+
+	const hydrate = async (): Promise<void> => {
+		if (!cacheTtlMs) return;
+		try {
+			const cached = await kvStore.get<CacheEntry<TItem[]>>(cacheKey);
+			if (cached && signal.get().items.length === 0) {
+				prevById = new Map(cached.value.map((i) => [id(i), i]));
+				patch({
+					items: cached.value,
+					loading: false,
+					fromCache: true,
+					lastUpdated: cached.storedAt,
+				});
+			}
+		} catch {
+			/* cache miss / unavailable — fall through to network */
+		}
+	};
+
+	return {
+		subscribe: signal.subscribe,
+		get: signal.get,
+		id,
+		refresh: runFetch,
+		start: () => {
+			if (started) return;
+			started = true;
+			void hydrate().then(runFetch);
+			if (pollMs && pollMs > 0) {
+				timer = setInterval(() => void runFetch(), pollMs);
+			}
+		},
+		stop: () => {
+			started = false;
+			controller?.abort();
+			if (timer) clearInterval(timer);
+			timer = undefined;
+		},
+		toggleExpanded: (target) =>
+			patch({
+				expandedId: signal.get().expandedId === target ? null : target,
+			}),
+		setSearch: (q) => patch({ search: q }),
+		setFilter: (filterId) => patch({ filterId }),
+		setGroupKey: (groupKey) => patch({ groupKey }),
+	};
+}

--- a/packages/npm/rn/src/dash/index.ts
+++ b/packages/npm/rn/src/dash/index.ts
@@ -1,0 +1,11 @@
+// @kbve/rn/dash — generic data-stream dashboard kit.
+// `<T> of <t> of <n>`: a StreamSource (N) yields items (T), a StreamLens (t)
+// projects each item into row/card/detail/stat models. Web-safe (no nav/icons),
+// renders on native (Expo) and web (react-native-web via @kbve/rn-astro).
+
+export * from './types';
+export * from './createStreamSource';
+export * from './useStream';
+export * from './StreamView';
+export * from './StatGrid';
+export * from './adapters/argo';

--- a/packages/npm/rn/src/dash/types.ts
+++ b/packages/npm/rn/src/dash/types.ts
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+import type { BadgeTone } from '../ui';
+
+/**
+ * The generic dashboard contract: `<T> of <t> of <n>`.
+ *   N = Stream  — a {@link StreamSource} owning fetch/poll/cache, yields N items.
+ *   T = Item    — the entity type a source normalizes raw payloads into.
+ *   t = Lens    — a {@link StreamLens} projecting one T into render models.
+ * Any data stream (ArgoCD, Forgejo, Grafana, …) plugs in as a source + a lens.
+ */
+
+export interface FetchContext {
+	/** Aborts when the source is disposed or a newer fetch supersedes this one. */
+	signal: AbortSignal;
+}
+
+export interface StreamSourceConfig<TRaw, TItem> {
+	/** Cache key prefix; the source namespaces its own keys under it. */
+	key: string;
+	/** Fetch the raw payload list. Owns auth, URL, and transport (domain concern). */
+	fetch: (ctx: FetchContext) => Promise<TRaw[]>;
+	/** Project one raw record into the stable item shape the views render. */
+	normalize: (raw: TRaw) => TItem;
+	/** Stable identity for an item (dedupe, expand target, list key). */
+	id: (item: TItem) => string;
+	/**
+	 * Render-relevant fingerprint. When unchanged across a poll the previous
+	 * item reference is reused, so memoized rows skip re-render. Defaults to
+	 * `JSON.stringify(item)`.
+	 */
+	signature?: (item: TItem) => string;
+	/** Auto-refresh interval in ms. Omit/0 to disable polling. */
+	pollMs?: number;
+	/** Cache TTL in ms. Omit to skip persistence. */
+	cacheTtlMs?: number;
+}
+
+export interface StreamState<TItem> {
+	items: TItem[];
+	loading: boolean;
+	error: string | null;
+	lastUpdated: number | null;
+	fromCache: boolean;
+	expandedId: string | null;
+	search: string;
+	filterId: string | null;
+	groupKey: string | null;
+}
+
+export interface StreamStore<TItem> {
+	/** Subscribe for change notifications (drives React via useSyncExternalStore). */
+	subscribe: (listener: () => void) => () => void;
+	/** Current immutable snapshot. */
+	get: () => StreamState<TItem>;
+	/** Stable identity for an item — the view keys rows off this. */
+	id: (item: TItem) => string;
+	/** Force a fetch now (bypasses poll cadence; keeps cache write). */
+	refresh: () => Promise<void>;
+	/** Begin polling + hydrate from cache. Idempotent. */
+	start: () => void;
+	/** Stop polling and abort in-flight work. */
+	stop: () => void;
+	toggleExpanded: (id: string) => void;
+	setSearch: (q: string) => void;
+	setFilter: (id: string | null) => void;
+	setGroupKey: (key: string | null) => void;
+}
+
+export interface StatModel {
+	id: string;
+	label: string;
+	value: string | number;
+	tone?: BadgeTone;
+	/** Optional click target (e.g. apply the matching filter). */
+	onPress?: () => void;
+}
+
+export interface StreamAction<TItem> {
+	id: string;
+	label: string;
+	busy?: boolean;
+	disabled?: boolean;
+	destructive?: boolean;
+	run: (item: TItem) => void;
+}
+
+export interface StreamFilter<TItem> {
+	id: string;
+	label: string;
+	tone?: BadgeTone;
+	predicate: (item: TItem) => boolean;
+}
+
+/**
+ * The Lens (t): everything needed to render a stream of T without the view
+ * knowing anything domain-specific.
+ */
+export interface StreamLens<TItem> {
+	/** Dense single-line row (table layout). */
+	row: (item: TItem, expanded: boolean) => ReactNode;
+	/** Rich card (grid layout). Falls back to `row` when omitted. */
+	card?: (item: TItem, expanded: boolean) => ReactNode;
+	/** Inline detail rendered under an expanded item. */
+	detail?: (item: TItem) => ReactNode;
+	/** Summary stat cards derived from the full item set. */
+	stats?: (items: TItem[]) => StatModel[];
+	/** Free-text search haystack for an item. */
+	searchText?: (item: TItem) => string;
+	/** Grouping bucket label for an item (used when groupKey is active). */
+	group?: (item: TItem) => string;
+	/** Chip filters shown above the list. */
+	filters?: readonly StreamFilter<TItem>[];
+}

--- a/packages/npm/rn/src/dash/useStream.ts
+++ b/packages/npm/rn/src/dash/useStream.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
+import type { StreamState, StreamStore } from './types';
+
+/** Subscribe to the full stream snapshot. */
+export function useStream<TItem>(
+	store: StreamStore<TItem>,
+): StreamState<TItem> {
+	return useSyncExternalStore(store.subscribe, store.get, store.get);
+}
+
+/** Narrow subscription: re-render only when the selected slice changes. */
+export function useStreamSelector<TItem, T>(
+	store: StreamStore<TItem>,
+	selector: (state: StreamState<TItem>) => T,
+): T {
+	return useSyncExternalStore(
+		store.subscribe,
+		() => selector(store.get()),
+		() => selector(store.get()),
+	);
+}
+
+/** Start polling on mount, stop on unmount. */
+export function useStreamLifecycle<TItem>(store: StreamStore<TItem>): void {
+	useEffect(() => {
+		store.start();
+		return () => store.stop();
+	}, [store]);
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,6 +36,7 @@
 			"@kbve/rn/auth": ["packages/npm/rn/src/auth/index.ts"],
 			"@kbve/rn/ui": ["packages/npm/rn/src/ui/index.ts"],
 			"@kbve/rn/store": ["packages/npm/rn/src/store/index.ts"],
+			"@kbve/rn/dash": ["packages/npm/rn/src/dash/index.ts"],
 			"@kbve/rn-astro": ["packages/npm/rn-astro/src/index.ts"],
 			"@kbve/rn-astro/integration": [
 				"packages/npm/rn-astro/src/integration.ts"


### PR DESCRIPTION
## What

Phase 1 of the generic, source-agnostic dashboard component library at the `@kbve/rn` level — renders on native (Expo) and web (react-native-web via `@kbve/rn-astro`).

Models the **T/t/n** contract discussed:
- **N = StreamSource** — `createStreamSource` owns fetch + poll + cache + signature-based ref-reconcile.
- **T = Item** — entity a source normalizes raw payloads into.
- **t = StreamLens** — projects one item into row/card/detail/stat/filter models.

The perf patterns we hand-rolled for the Argo dashboard (signature reconcile, memoized rows, virtualization, deferred poll) are now **framework defaults** every adapter inherits — `StreamView` is built on `VirtualList` (FlatList) and a content-comparing `React.memo`.

### New: `@kbve/rn/dash`
- `types.ts` — `StreamSourceConfig`, `StreamStore`, `StreamLens`, `StatModel`, filters/actions.
- `createStreamSource.ts` — polling/caching source factory with WeakMap signature reconcile.
- `useStream.ts` — `useStream` / `useStreamSelector` / `useStreamLifecycle`.
- `StreamView.tsx` — generic list: stat grid + filter chips + search + grouped, virtualized, inline-expand rows.
- `StatGrid.tsx` — summary stat cards.
- `adapters/argo.tsx` — first adapter: `createArgoStream` + `argoLens`.

### Web POC
- `/dashboard/argo-rn` mounts the real ArgoCD applications stream through the kit on react-native-web — the same source + lens a future Expo screen will use.
- Wiring: `@kbve/rn/dash` export + tsconfig paths (base + astro-kbve web).

## Test
- `tsc --noEmit` clean for all `dash/*` and the web demo (both the `@kbve/rn` lib config and astro-kbve).
- Renders via the proven `@kbve/rn` → react-native-web Astro pipeline (same as the existing `/application/rn-web` POC).

## Not in this PR (follow-ups)
- Forgejo + Grafana adapters (multi-source proof).
- Expo mobile mount (base-URL/auth/icon splits).
- Time-series lane for the Grafana metric-stream shape.
- Full Argo resource-tree/diff/events detail lens (P1 detail is a compact fact list).
- Unit tests for the source core (no vitest runner in `@kbve/rn` yet).