### PR TITLE
feat(rn/dash): mutations in the kit + ArgoCD sync/hard-refresh actions

### DIFF
--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactArgoDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactArgoDashRN.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StreamView, createArgoStream, argoLens } from '@kbve/rn/dash';
+import { StreamView, createArgoStream, createArgoLens } from '@kbve/rn/dash';
 import { initSupa, getSupa } from '@/lib/supa';
 
 async function getToken(): Promise<string | null> {
@@ -20,10 +20,11 @@ async function getToken(): Promise<string | null> {
  */
 export default function ReactArgoDashRN() {
 	const store = useMemo(() => createArgoStream({ getToken }), []);
+	const lens = useMemo(() => createArgoLens({ getToken }), []);
 	return (
 		<StreamView
 			store={store}
-			lens={argoLens}
+			lens={lens}
 			layout="rows"
 			searchPlaceholder="filter by name / namespace / project"
 		/>

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import {
@@ -10,8 +10,13 @@ import {
 	tokens,
 } from '../ui';
 import { StatGrid } from './StatGrid';
-import { useStream, useStreamLifecycle } from './useStream';
-import type { StreamFilter, StreamLens, StreamStore } from './types';
+import { useStream, useStreamLifecycle, useStreamSelector } from './useStream';
+import type {
+	StreamAction,
+	StreamFilter,
+	StreamLens,
+	StreamStore,
+} from './types';
 
 const TONE_COLOR: Record<string, string> = {
 	primary: tokens.color.primary,
@@ -29,11 +34,12 @@ interface RowProps {
 	row: Row;
 	lens: StreamLens<unknown>;
 	layout: 'rows' | 'cards';
+	store: StreamStore<unknown>;
 	onToggle: (key: string) => void;
 }
 
 const StreamRow = memo(
-	function StreamRow({ row, lens, layout, onToggle }: RowProps) {
+	function StreamRow({ row, lens, layout, store, onToggle }: RowProps) {
 		if (row.kind === 'header') {
 			return (
 				<Text variant="label" tone="muted" style={styles.groupHeader}>
@@ -47,8 +53,17 @@ const StreamRow = memo(
 				<Pressable onPress={() => onToggle(row.key)}>
 					{render(row.item, row.expanded)}
 				</Pressable>
-				{row.expanded && lens.detail ? (
-					<View style={styles.detail}>{lens.detail(row.item)}</View>
+				{row.expanded && (lens.detail || lens.actions?.length) ? (
+					<View style={styles.detail}>
+						{lens.detail ? lens.detail(row.item) : null}
+						{lens.actions?.length ? (
+							<ActionBar
+								store={store}
+								item={row.item}
+								actions={lens.actions}
+							/>
+						) : null}
+					</View>
 				) : null}
 			</View>
 		);
@@ -56,9 +71,78 @@ const StreamRow = memo(
 	(a, b) =>
 		a.lens === b.lens &&
 		a.layout === b.layout &&
+		a.store === b.store &&
 		a.onToggle === b.onToggle &&
 		rowEqual(a.row, b.row),
 );
+
+function ActionBar({
+	store,
+	item,
+	actions,
+}: {
+	store: StreamStore<unknown>;
+	item: unknown;
+	actions: readonly StreamAction<unknown>[];
+}) {
+	const busy = useStreamSelector(store, (s) => s.actionBusy);
+	const error = useStreamSelector(store, (s) => s.actionError);
+	const msg = useStreamSelector(store, (s) => s.actionMsg);
+	const [armed, setArmed] = useState<string | null>(null);
+	const anyBusy = busy !== null;
+	const id = store.id(item);
+
+	return (
+		<Stack gap="sm" style={styles.actionBar}>
+			<Stack direction="row" gap="sm" wrap>
+				{actions.map((a) => {
+					const key = `${id}:${a.id}`;
+					const thisBusy = busy === key;
+					const needsConfirm = a.destructive && armed !== a.id;
+					const tone = a.destructive
+						? tokens.color.danger
+						: tokens.color.primary;
+					return (
+						<Pressable
+							key={a.id}
+							disabled={anyBusy}
+							onPress={() => {
+								if (needsConfirm) {
+									setArmed(a.id);
+									return;
+								}
+								setArmed(null);
+								void store.runAction(key, () => a.run(item), {
+									successMsg: `${a.label} triggered`,
+								});
+							}}
+							style={[
+								styles.actionBtn,
+								{ borderColor: tone },
+								anyBusy ? styles.actionDisabled : null,
+							]}>
+							<Text
+								variant="caption"
+								weight="medium"
+								style={{ color: tone }}>
+								{thisBusy
+									? '…'
+									: needsConfirm
+										? `Confirm ${a.label}?`
+										: a.label}
+							</Text>
+						</Pressable>
+					);
+				})}
+			</Stack>
+			{error || msg ? (
+				<Text variant="caption" tone={error ? 'danger' : 'success'}>
+					{error ?? msg}
+				</Text>
+			) : null}
+		</Stack>
+	);
+}
 
 // Compare row CONTENT, not the wrapper identity — buildRows produces fresh
 // wrappers each poll, but a reconciled item keeps its ref, so this lets an
@@ -161,6 +245,7 @@ export function StreamView<TItem>({
 
 	const stats = lens.stats?.(state.items) ?? [];
 	const lensU = lens as unknown as StreamLens<unknown>;
+	const storeU = store as unknown as StreamStore<unknown>;
 
 	return (
 		<Stack gap="md">
@@ -196,6 +281,7 @@ export function StreamView<TItem>({
 						row={item}
 						lens={lensU}
 						layout={layout}
+						store={storeU}
 						onToggle={store.toggleExpanded}
 					/>
 				)}
@@ -295,4 +381,17 @@ const styles = StyleSheet.create({
 	},
 	separator: { height: tokens.space.sm },
 	empty: { padding: tokens.space.lg, textAlign: 'center' },
+	actionBar: {
+		marginTop: tokens.space.sm,
+		paddingTop: tokens.space.sm,
+		borderTopWidth: 1,
+		borderTopColor: tokens.color.border,
+	},
+	actionBtn: {
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 6,
+		borderRadius: tokens.radius.md,
+		borderWidth: 1,
+	},
+	actionDisabled: { opacity: 0.4 },
 });

--- a/packages/npm/rn/src/dash/adapters/argo.tsx
+++ b/packages/npm/rn/src/dash/adapters/argo.tsx
@@ -2,7 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../../ui';
 import type { BadgeTone } from '../../ui';
 import { createStreamSource } from '../createStreamSource';
-import type { StreamLens, StreamStore } from '../types';
+import type { StreamAction, StreamLens, StreamStore } from '../types';
 
 // Minimal shape of the ArgoCD application payload we depend on. Kept local so
 // the dash library has no coupling to the astro-kbve argoService.
@@ -104,6 +104,59 @@ export function createArgoStream(
 			return json.items ?? [];
 		},
 	});
+}
+
+async function argoMutate(
+	opts: ArgoStreamOptions,
+	path: string,
+	method: 'POST' | 'GET',
+): Promise<void> {
+	const token = await opts.getToken();
+	const headers: Record<string, string> = {};
+	if (token) headers['Authorization'] = `Bearer ${token}`;
+	if (method === 'POST') headers['Content-Type'] = 'application/json';
+	const res = await fetch(
+		`${opts.baseUrl ?? ''}/dashboard/argo/proxy${path}`,
+		{
+			method,
+			headers,
+			body: method === 'POST' ? '{}' : undefined,
+		},
+	);
+	if (res.status === 403) throw new Error('Manage permission required');
+	if (!res.ok) throw new Error(`ArgoCD ${method} ${res.status}`);
+}
+
+/** Argo mutations bound to a token/baseUrl. Require DASHBOARD_MANAGE. */
+export function argoActions(opts: ArgoStreamOptions): StreamAction<ArgoItem>[] {
+	const app = (it: ArgoItem) => encodeURIComponent(it.name);
+	return [
+		{
+			id: 'sync',
+			label: 'Sync',
+			run: (it) =>
+				argoMutate(
+					opts,
+					`/api/v1/applications/${app(it)}/sync`,
+					'POST',
+				),
+		},
+		{
+			id: 'refresh',
+			label: 'Hard Refresh',
+			run: (it) =>
+				argoMutate(
+					opts,
+					`/api/v1/applications/${app(it)}?refresh=hard`,
+					'GET',
+				),
+		},
+	];
+}
+
+/** Full Argo lens with token-bound actions (preferred over the view-only `argoLens`). */
+export function createArgoLens(opts: ArgoStreamOptions): StreamLens<ArgoItem> {
+	return { ...argoLens, actions: argoActions(opts) };
 }
 
 function healthTone(status: string): BadgeTone {

--- a/packages/npm/rn/src/dash/createStreamSource.ts
+++ b/packages/npm/rn/src/dash/createStreamSource.ts
@@ -13,6 +13,9 @@ const EMPTY = <TItem>(): StreamState<TItem> => ({
 	search: '',
 	filterId: null,
 	groupKey: null,
+	actionBusy: null,
+	actionError: null,
+	actionMsg: null,
 });
 
 /**
@@ -144,5 +147,21 @@ export function createStreamSource<TRaw, TItem>(
 		setSearch: (q) => patch({ search: q }),
 		setFilter: (filterId) => patch({ filterId }),
 		setGroupKey: (groupKey) => patch({ groupKey }),
+		runAction: async (key, fn, opts) => {
+			if (signal.get().actionBusy) return;
+			patch({ actionBusy: key, actionError: null, actionMsg: null });
+			try {
+				await fn();
+				patch({ actionMsg: opts?.successMsg ?? 'Done' });
+				if (opts?.refresh !== false) await runFetch();
+			} catch (e: unknown) {
+				patch({
+					actionError:
+						e instanceof Error ? e.message : 'Action failed',
+				});
+			} finally {
+				patch({ actionBusy: null });
+			}
+		},
 	};
 }

--- a/packages/npm/rn/src/dash/types.ts
+++ b/packages/npm/rn/src/dash/types.ts
@@ -45,6 +45,10 @@ export interface StreamState<TItem> {
 	search: string;
 	filterId: string | null;
 	groupKey: string | null;
+	/** Key of the in-flight action (`<itemId>:<actionId>`), or null. */
+	actionBusy: string | null;
+	actionError: string | null;
+	actionMsg: string | null;
 }
 
 export interface StreamStore<TItem> {
@@ -64,6 +68,16 @@ export interface StreamStore<TItem> {
 	setSearch: (q: string) => void;
 	setFilter: (id: string | null) => void;
 	setGroupKey: (key: string | null) => void;
+	/**
+	 * Run a mutation with single-flight + busy/error tracking. `key` scopes the
+	 * busy indicator (`<itemId>:<actionId>`); refreshes the stream on success
+	 * unless `opts.refresh === false`.
+	 */
+	runAction: (
+		key: string,
+		fn: () => Promise<void>,
+		opts?: { refresh?: boolean; successMsg?: string },
+	) => Promise<void>;
 }
 
 export interface StatModel {
@@ -78,10 +92,10 @@ export interface StatModel {
 export interface StreamAction<TItem> {
 	id: string;
 	label: string;
-	busy?: boolean;
-	disabled?: boolean;
+	/** Requires a two-tap inline confirm before running. */
 	destructive?: boolean;
-	run: (item: TItem) => void;
+	/** The raw mutation; the store wraps it with busy/error/refresh handling. */
+	run: (item: TItem) => Promise<void>;
 }
 
 export interface StreamFilter<TItem> {
@@ -110,4 +124,6 @@ export interface StreamLens<TItem> {
 	group?: (item: TItem) => string;
 	/** Chip filters shown above the list. */
 	filters?: readonly StreamFilter<TItem>[];
+	/** Mutations offered on an expanded item (sync, refresh, rollback…). */
+	actions?: readonly StreamAction<TItem>[];
 }


### PR DESCRIPTION
## What

Moves `@kbve/rn/dash` from read-only to **operational** by adding mutations as a kit primitive — every adapter inherits them. Follows #13016 (the dash kit + Argo read adapter).

### Kit
- `StreamState` carries `actionBusy` / `actionError` / `actionMsg`.
- `createStreamSource` gains `runAction(key, fn, opts?)` — single-flight, busy/error tracking, auto-refresh on success.
- `StreamView` renders an `ActionBar` on the expanded item that subscribes **only** to the action slice (one row re-renders, not the list), with a **two-tap inline confirm** for destructive actions (cross-platform — no `Alert`/`window.confirm` divergence).
- `StreamAction<TItem>` = `{ id, label, destructive?, run(item): Promise<void> }`; the adapter supplies the raw mutation, the kit wraps lifecycle.

### ArgoCD adapter
- `argoActions(opts)` + `createArgoLens(opts)` bind **Sync** (`POST .../sync`) and **Hard Refresh** (`GET ...?refresh=hard`) to the injected token/baseUrl. Both require `DASHBOARD_MANAGE` (surfaces a clear error on 403).
- Web POC `/dashboard/argo-rn` now triggers real syncs; the view-only `argoLens` stays for read-only mounts.

## Test
- `tsc --noEmit` clean for `dash/*` (rn lib config) and the web demo (astro-kbve).

## Follow-ups
- Expo mobile mount (absolute base-URL + `@kbve/rn/auth` token + icon split).
- Rollback action (needs sync-history selection in a richer detail lens).
- Push notifications for degraded/stalled apps.