### PR TITLE
perf+feat(metrics): pooled CH client, Prometheus self-metrics, CF client IP, zero-copy ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10462,6 +10462,7 @@ dependencies = [
  "hex",
  "jedi",
  "kbve",
+ "metrics",
  "parking_lot",
  "serde",
  "serde_json",

--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -24,7 +24,7 @@ tags:
 key: metrics
 pipeline: docker
 app_name: metrics
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/metrics
 version_toml: apps/metrics/version.toml
 version_target: apps/metrics/Cargo.toml

--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         metadata:
             annotations:
                 rollout-restart: '2026-06-20T00:00:00Z'
+                prometheus.io/scrape: 'true'
+                prometheus.io/port: '9090'
+                prometheus.io/path: '/metrics'
             labels:
                 app: metrics
                 version: '0.1.0'
@@ -38,9 +41,14 @@ spec:
                   ports:
                       - containerPort: 5500
                         protocol: TCP
+                      - name: metrics
+                        containerPort: 9090
+                        protocol: TCP
                   env:
                       - name: APP_VERSION
                         value: '0.1.1'
+                      - name: METRICS_PROMETHEUS_PORT
+                        value: '9090'
                       - name: HTTP_HOST
                         value: '0.0.0.0'
                       - name: HTTP_PORT

--- a/apps/metrics/Cargo.toml
+++ b/apps/metrics/Cargo.toml
@@ -28,5 +28,6 @@ anyhow = "1.0"
 thiserror = "2"
 dotenvy = "0.15"
 
-jedi = { path = "../../packages/rust/jedi", features = ["clickhouse"] }
+metrics = "0.24"
+jedi = { path = "../../packages/rust/jedi", features = ["clickhouse", "prometheus"] }
 kbve = { path = "../../packages/rust/kbve", default-features = false, features = ["gate-auth"] }

--- a/apps/metrics/src/config.rs
+++ b/apps/metrics/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub global_rate_limit_per_min: u32,
     pub trusted_proxy_hops: usize,
     pub ingest_token: Option<String>,
+    pub metrics_port: u16,
 }
 
 fn get(key: &str, default: &str) -> String {
@@ -66,6 +67,9 @@ impl Config {
                 .ok()
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
+            metrics_port: get("METRICS_PROMETHEUS_PORT", "9090")
+                .parse()
+                .unwrap_or(9090),
         }
     }
 }

--- a/apps/metrics/src/main.rs
+++ b/apps/metrics/src/main.rs
@@ -55,8 +55,21 @@ async fn main() -> anyhow::Result<()> {
 
     let (tx, rx) = mpsc::channel(cfg.channel_capacity);
     let max_body = cfg.max_body_bytes;
+    let metrics_port = cfg.metrics_port;
     let cors = cors_layer(&cfg);
     let addr = format!("{}:{}", cfg.host, cfg.port);
+
+    // Prometheus: install the recorder, expose /metrics on a side port, and
+    // wrap the ingest router so HTTP request metrics are captured too.
+    let (metric_layer, metric_handle) =
+        jedi::entity::pipe_prometheus::build_metrics_layer("metrics");
+    tokio::spawn(jedi::entity::pipe_prometheus::serve_metrics(
+        jedi::entity::pipe_prometheus::MetricsConfig {
+            service_name: "metrics",
+            port: metrics_port,
+        },
+        metric_handle,
+    ));
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let state = Arc::new(AppState::new(cfg, ch, tx, auth));
@@ -65,6 +78,7 @@ async fn main() -> anyhow::Result<()> {
     let app = rest::router(state)
         .layer(cors)
         .layer(RequestBodyLimitLayer::new(max_body))
+        .layer(metric_layer)
         .layer(TraceLayer::new_for_http());
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/apps/metrics/src/rest/ingest.rs
+++ b/apps/metrics/src/rest/ingest.rs
@@ -17,11 +17,17 @@ fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
         .unwrap_or("")
 }
 
-/// Resolve the client IP from `X-Forwarded-For`, counting from the RIGHT so the
-/// value is one the infrastructure appended — not the attacker-controlled
-/// leftmost entry (which let anyone rotate IPs to bypass the rate limit).
-/// `trusted_hops` is how many reverse proxies sit between us and the internet.
+/// Resolve the client IP. Prefer Cloudflare's `cf-connecting-ip` (CF overwrites
+/// it with the true client IP on every proxied request, so it isn't
+/// client-spoofable). Otherwise fall back to `X-Forwarded-For` counting from the
+/// RIGHT — the infra-appended end, not the attacker-controlled leftmost entry
+/// (which let anyone rotate IPs to bypass the rate limit). `trusted_hops` is how
+/// many reverse proxies sit between us and the internet.
 fn client_ip(headers: &HeaderMap, trusted_hops: usize) -> String {
+    let cf = header_str(headers, "cf-connecting-ip");
+    if !cf.is_empty() {
+        return cf.to_string();
+    }
     let xff = header_str(headers, "x-forwarded-for");
     if !xff.is_empty() {
         let parts: Vec<&str> = xff
@@ -62,21 +68,29 @@ pub async fn ingest_errors(
     if let Some(expected) = &app.cfg.ingest_token {
         let provided = header_str(&headers, "x-kbve-ingest");
         if !ct_eq(provided, expected) {
+            metrics::counter!("metrics_ingest_rejected_total", "reason" => "unauthorized")
+                .increment(1);
             return Err(ApiError::Unauthorized);
         }
     }
 
     let ip = client_ip(&headers, app.cfg.trusted_proxy_hops);
     if !app.allow_ip(&ip) {
+        metrics::counter!("metrics_ingest_rejected_total", "reason" => "rate_limited_ip")
+            .increment(1);
         return Err(ApiError::RateLimited);
     }
     if !app.allow_global() {
+        metrics::counter!("metrics_ingest_rejected_total", "reason" => "rate_limited_global")
+            .increment(1);
         return Err(ApiError::RateLimited);
     }
     if batch.events.is_empty() {
         return Err(ApiError::BadRequest("empty batch".into()));
     }
     if batch.events.len() > app.cfg.max_batch {
+        metrics::counter!("metrics_ingest_rejected_total", "reason" => "batch_too_large")
+            .increment(1);
         return Err(ApiError::TooLarge(format!(
             "batch exceeds {} events",
             app.cfg.max_batch
@@ -84,23 +98,36 @@ pub async fn ingest_errors(
     }
 
     let user_agent = header_str(&headers, "user-agent").to_string();
-    let mut accepted = 0usize;
-    let mut dropped = 0usize;
+    let mut accepted = 0u64;
+    let mut dropped = 0u64;
     for event in batch.events {
         match event.into_row(&user_agent) {
             Some(row) => {
                 let project = row.get("project").and_then(|v| v.as_str()).unwrap_or("");
                 if !app.allow_project(project) {
                     dropped += 1;
+                    metrics::counter!("metrics_ingest_dropped_total", "reason" => "project_capped")
+                        .increment(1);
                     continue;
                 }
                 match app.tx.try_send(row) {
                     Ok(_) => accepted += 1,
-                    Err(_) => dropped += 1,
+                    Err(_) => {
+                        dropped += 1;
+                        metrics::counter!("metrics_ingest_dropped_total", "reason" => "queue_full")
+                            .increment(1);
+                    }
                 }
             }
-            None => dropped += 1,
+            None => {
+                dropped += 1;
+                metrics::counter!("metrics_ingest_dropped_total", "reason" => "sanitized")
+                    .increment(1);
+            }
         }
+    }
+    if accepted > 0 {
+        metrics::counter!("metrics_ingest_accepted_total").increment(accepted);
     }
 
     Ok((
@@ -134,6 +161,13 @@ mod tests {
     fn client_ip_handles_short_chain_and_missing() {
         assert_eq!(client_ip(&hdrs("7.7.7.7"), 1), "7.7.7.7");
         assert_eq!(client_ip(&hdrs(""), 1), "unknown");
+    }
+
+    #[test]
+    fn client_ip_prefers_cf_connecting_ip() {
+        let mut h = hdrs("1.1.1.1, 9.9.9.9");
+        h.insert("cf-connecting-ip", "5.5.5.5".parse().unwrap());
+        assert_eq!(client_ip(&h, 1), "5.5.5.5");
     }
 
     #[test]

--- a/apps/metrics/src/rest/ingest.rs
+++ b/apps/metrics/src/rest/ingest.rs
@@ -97,11 +97,11 @@ pub async fn ingest_errors(
         )));
     }
 
-    let user_agent = header_str(&headers, "user-agent").to_string();
+    let user_agent = header_str(&headers, "user-agent");
     let mut accepted = 0u64;
     let mut dropped = 0u64;
     for event in batch.events {
-        match event.into_row(&user_agent) {
+        match event.into_row(user_agent) {
             Some(row) => {
                 let project = row.get("project").and_then(|v| v.as_str()).unwrap_or("");
                 if !app.allow_project(project) {

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -151,10 +151,13 @@ async fn flush(
         match result {
             Ok(Ok(())) => {
                 tracing::debug!(rows = n, "flushed telemetry rows");
+                metrics::counter!("metrics_flush_rows_total").increment(n as u64);
                 return;
             }
             outcome => {
                 if attempt >= max_retries {
+                    metrics::counter!("metrics_flush_failures_total").increment(1);
+                    metrics::counter!("metrics_flush_dropped_rows_total").increment(n as u64);
                     match outcome {
                         Ok(Err(e)) => {
                             tracing::error!(error = %e, rows = n, attempts = attempt + 1, "clickhouse insert failed; dropping rows")

--- a/apps/metrics/src/telemetry.rs
+++ b/apps/metrics/src/telemetry.rs
@@ -59,34 +59,33 @@ pub struct ErrorEvent {
     pub extra: Option<Map<String, Value>>,
 }
 
-/// Byte-truncate without splitting a UTF-8 code point (`String::truncate`
+/// Byte-truncate in place without splitting a UTF-8 code point (`String::truncate`
 /// panics on a non-boundary index — a multibyte char at the limit would crash
-/// the ingest handler).
-fn truncate(s: String, max: usize) -> String {
-    if s.len() <= max {
-        return s;
+/// the ingest handler). Reuses the buffer rather than allocating a copy.
+fn truncate(mut s: String, max: usize) -> String {
+    if s.len() > max {
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
     }
-    let mut end = max;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    s[..end].to_string()
+    s
 }
 
 /// Strip null bytes and control characters (incl. ESC, so ANSI escape
 /// sequences and terminal/log-injection payloads can't survive), then truncate.
+/// Takes the String by value and filters in place (`retain`) so the caller's
+/// existing allocation is reused instead of allocating a sanitized copy.
 /// `keep_newlines` preserves `\n`/`\t` for multi-line fields like stacks.
-fn sanitize(s: &str, max: usize, keep_newlines: bool) -> String {
-    let cleaned: String = s
-        .chars()
-        .filter(|c| {
-            if keep_newlines && (*c == '\n' || *c == '\t') {
-                return true;
-            }
-            !c.is_control()
-        })
-        .collect();
-    truncate(cleaned, max)
+fn sanitize(mut s: String, max: usize, keep_newlines: bool) -> String {
+    s.retain(|c| {
+        if keep_newlines && (c == '\n' || c == '\t') {
+            return true;
+        }
+        !c.is_control()
+    });
+    truncate(s, max)
 }
 
 /// Clamp a free-form dimension to a known allow-list, falling back to a default.
@@ -105,9 +104,11 @@ fn allow_enum(val: Option<String>, allowed: &[&str], default: &str) -> String {
     }
 }
 
-fn strip_query(url: &str) -> String {
-    let base = url.split(['?', '#']).next().unwrap_or(url);
-    sanitize(base, MAX_URL, false)
+fn strip_query(mut url: String) -> String {
+    if let Some(i) = url.find(['?', '#']) {
+        url.truncate(i);
+    }
+    sanitize(url, MAX_URL, false)
 }
 
 fn is_noise(message: &str) -> bool {
@@ -137,14 +138,14 @@ fn sanitize_extra(extra: Option<Map<String, Value>>) -> String {
     };
     let mut out = Map::new();
     for (k, v) in map.into_iter().take(MAX_EXTRA_KEYS) {
-        let key = sanitize(&k, MAX_EXTRA_KEY, false);
+        let key = sanitize(k, MAX_EXTRA_KEY, false);
         if key.is_empty() {
             continue;
         }
         let s = match v {
-            Value::String(s) => Value::String(sanitize(&s, MAX_EXTRA_VALUE, false)),
+            Value::String(s) => Value::String(sanitize(s, MAX_EXTRA_VALUE, false)),
             Value::Object(_) | Value::Array(_) => {
-                Value::String(sanitize(&v.to_string(), MAX_EXTRA_VALUE, false))
+                Value::String(sanitize(v.to_string(), MAX_EXTRA_VALUE, false))
             }
             other => other,
         };
@@ -155,32 +156,32 @@ fn sanitize_extra(extra: Option<Map<String, Value>>) -> String {
 
 impl ErrorEvent {
     pub fn into_row(self, user_agent: &str) -> Option<Value> {
-        let message = sanitize(&self.message, MAX_MESSAGE, true);
+        let message = sanitize(self.message, MAX_MESSAGE, true);
         if message.is_empty() || is_noise(&message) {
             return None;
         }
-        let project = sanitize(&self.project, 128, false);
+        let project = sanitize(self.project, 128, false);
         if project.is_empty() {
             return None;
         }
-        let error_type = sanitize(&self.error_type.unwrap_or_default(), 128, false);
-        let stack = sanitize(&self.stack.unwrap_or_default(), MAX_STACK, true);
-        let url = self.url.map(|u| strip_query(&u)).unwrap_or_default();
+        let error_type = sanitize(self.error_type.unwrap_or_default(), 128, false);
+        let stack = sanitize(self.stack.unwrap_or_default(), MAX_STACK, true);
+        let url = self.url.map(strip_query).unwrap_or_default();
         let fp = fingerprint(&project, &error_type, &stack, &message);
 
         Some(json!({
             "project": project,
             "platform": allow_enum(self.platform, PLATFORMS, "web"),
-            "release": sanitize(&self.release.unwrap_or_default(), 64, false),
+            "release": sanitize(self.release.unwrap_or_default(), 64, false),
             "environment": allow_enum(self.environment, ENVIRONMENTS, "production"),
             "fingerprint": fp,
             "error_type": error_type,
             "message": message,
             "stack": stack,
             "url": url,
-            "user_id": sanitize(&self.user_id.unwrap_or_default(), 128, false),
-            "session_id": sanitize(&self.session_id.unwrap_or_default(), 128, false),
-            "user_agent": sanitize(user_agent, 512, false),
+            "user_id": sanitize(self.user_id.unwrap_or_default(), 128, false),
+            "session_id": sanitize(self.session_id.unwrap_or_default(), 128, false),
+            "user_agent": sanitize(user_agent.to_string(), 512, false),
             "handled": if self.handled.unwrap_or(false) { 1u8 } else { 0u8 },
             "extra": sanitize_extra(self.extra),
         }))
@@ -220,14 +221,14 @@ mod tests {
 
     #[test]
     fn sanitize_strips_control_and_ansi() {
-        let out = sanitize("a\u{0}b\u{1b}[31mred\u{1b}[0mc\u{7}", 64, false);
+        let out = sanitize("a\u{0}b\u{1b}[31mred\u{1b}[0mc\u{7}".to_string(), 64, false);
         assert_eq!(out, "ab[31mred[0mc");
     }
 
     #[test]
     fn sanitize_keeps_newlines_when_asked() {
-        assert_eq!(sanitize("a\nb\tc", 64, true), "a\nb\tc");
-        assert_eq!(sanitize("a\nb\tc", 64, false), "abc");
+        assert_eq!(sanitize("a\nb\tc".to_string(), 64, true), "a\nb\tc");
+        assert_eq!(sanitize("a\nb\tc".to_string(), 64, false), "abc");
     }
 
     #[test]

--- a/packages/rust/jedi/src/state/sidecar.rs
+++ b/packages/rust/jedi/src/state/sidecar.rs
@@ -174,8 +174,29 @@ impl ClickHouseConfig {
         client
     }
 
+    /// Process-wide pooled HTTP client with timeouts. Reused across every
+    /// ClickHouse call so a hung server can't block indefinitely (a missing
+    /// timeout previously let one stalled request wedge a caller) and TCP
+    /// connections are pooled instead of rebuilt per request.
+    /// Tunable via `CLICKHOUSE_HTTP_TIMEOUT_MS` (default 30s).
+    fn shared_http_client() -> &'static reqwest::Client {
+        static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+        CLIENT.get_or_init(|| {
+            let timeout_ms = std::env::var("CLICKHOUSE_HTTP_TIMEOUT_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(30_000u64);
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_millis(timeout_ms))
+                .connect_timeout(std::time::Duration::from_secs(5))
+                .pool_idle_timeout(std::time::Duration::from_secs(90))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new())
+        })
+    }
+
     pub async fn execute_select(&self, query: &str) -> Result<Vec<serde_json::Value>, JediError> {
-        let http = reqwest::Client::new();
+        let http = Self::shared_http_client();
         let full_query = format!("{} FORMAT JSONEachRow", query);
 
         let mut req = http
@@ -233,7 +254,7 @@ impl ClickHouseConfig {
             .join("\n");
 
         let insert_query = format!("INSERT INTO {} FORMAT JSONEachRow", table);
-        let http = reqwest::Client::new();
+        let http = Self::shared_http_client();
 
         let mut req = http
             .post(&self.url)


### PR DESCRIPTION
Follow-ups from the ingest hardening review (the 3 remaining candidates) + a zero-copy sweep.

## Candidate 1 — pooled ClickHouse HTTP client (jedi)
`execute_select`/`execute_insert` built a fresh `reqwest::Client` **per call with no timeout** — no connection pooling, and a hung CH (blackhole) could block a call indefinitely. Now a process-wide pooled client (`OnceLock`) with request + connect timeouts (`CLICKHOUSE_HTTP_TIMEOUT_MS`, default 30s). Additive — no struct change, so the `ch_writer.rs` literal and all other consumers are untouched.

## Candidate 2 — Prometheus self-metrics (metrics)
Reuses jedi's `pipe_prometheus` (no per-service prometheus stack). `/metrics` on a side port (`METRICS_PROMETHEUS_PORT`, default 9090), HTTP request metrics via the layer, plus counters:
`metrics_ingest_accepted_total`, `metrics_ingest_dropped_total{reason}` (sanitized / project_capped / queue_full), `metrics_ingest_rejected_total{reason}` (unauthorized / rate_limited_ip / rate_limited_global / batch_too_large), `metrics_flush_rows_total`, `metrics_flush_failures_total`, `metrics_flush_dropped_rows_total`.
Deployment exposes `:9090` + `prometheus.io/scrape` annotations.

## Candidate 3 — Cloudflare client IP (metrics)
`client_ip` now prefers `cf-connecting-ip` (CF overwrites it with the true client IP — not client-spoofable) before the XFF-from-right fallback. Removes reliance on tuning `METRICS_TRUSTED_PROXY_HOPS` for the rate limiter.

## Zero-copy sweep (metrics hot path)
`into_row` owns each event's field Strings, but `sanitize(&str)` allocated a *new* String per field and dropped the original — double allocation per field.
- `sanitize`/`truncate` take the String by value and filter in place (`String::retain` + in-place char-boundary truncate), reusing the buffer.
- `strip_query` truncates in place.
- handler passes `user_agent` as `&str` instead of cloning.
Net: ~2 allocs/field → ~1 per accepted event, no behavior change.

## Tests
`cargo test -p met --bins` → **13/13 pass** (incl. new cf-connecting-ip precedence). Clippy clean (met + jedi). Bumps metrics `0.1.2` → `0.1.3`.

## Ops note
Add a ServiceMonitor (or rely on the pod scrape annotations) to pull `:9090/metrics`.