### PR TITLE
perf(rn): worker request reuses @kbve/core (timeout/retry parity)

### DIFF
--- a/packages/npm/rn/src/worker/pool.worker.ts
+++ b/packages/npm/rn/src/worker/pool.worker.ts
@@ -1,6 +1,7 @@
 import * as Comlink from 'comlink';
 import Dexie from 'dexie';
 import type { Table } from 'dexie';
+import { request as coreRequest } from '@kbve/core';
 import type { PoolRequestInit, PoolResponse } from './types';
 
 interface Row {
@@ -23,27 +24,11 @@ const api = {
 		url: string,
 		init?: PoolRequestInit,
 	): Promise<PoolResponse<T>> {
-		try {
-			const res = await fetch(url, {
-				method: init?.method ?? 'GET',
-				headers: init?.headers,
-				body: init?.body,
-			});
-			const data = (await res.json().catch(() => null)) as T | null;
-			return {
-				ok: res.ok,
-				status: res.status,
-				data,
-				error: res.ok ? null : `HTTP ${res.status}`,
-			};
-		} catch (e) {
-			return {
-				ok: false,
-				status: 0,
-				data: null,
-				error: e instanceof Error ? e.message : 'request failed',
-			};
-		}
+		return coreRequest<T>(url, {
+			method: init?.method,
+			headers: init?.headers,
+			body: init?.body,
+		});
 	},
 	async cacheGet<T>(key: string): Promise<T | null> {
 		const row = await db.kv.get(key);


### PR DESCRIPTION
## Audit
Reviewed the off-main-thread worker setup for RN + web.

**Solid as-is**
- Web: real Comlink Worker (`pool.worker.ts`), singleton, sole Dexie/IndexedDB writer (no main-thread Dexie → no races), code-split. fetch + JSON parse run off the render thread.
- All web consumers (KbveProvider, kvStore, useFormDraft, jobboard api) share the one worker.
- Native: inline passthrough by design — RN has no Web Workers; `@kbve/core request` is already used there.

## Fix
The web worker's `request` was a bare `fetch`: no timeout, no abort, no retry, JSON-only, generic `HTTP <n>` errors. The native path already uses `@kbve/core request` (15s timeout, `AbortController`, 5xx retry/backoff, body-aware error extraction).

Delegate the worker `request` to the same `coreRequest` → web and native share identical network semantics, and a hung request can no longer wedge a query on web. `RequestResult<T>` and `PoolResponse<T>` are the same shape.

## Testing
- `tsc --noEmit` clean.
- `npm run build` EXIT 0; worker chunk `pool.worker-*.js` ~102 kB (+~1.6 kB for core, negligible).

## Notes (not in this PR)
- Native still has no real worker thread (RN constraint); heavy JSON parse stays on the JS thread. A JSI/worklets-based worker is a larger separate effort.
- `@kbve/rn` `api.*` on web stays main-thread (`pooledApi=false`); jobboard uses its own pooled client, so no impact. Flip `pooledApi` on the provider to route chat/profile through the worker later.