### PR TITLE
perf(metrics): shard rate limiter, lock-free global cap, single-serialize ingest

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -24,7 +24,7 @@ tags:
 key: metrics
 pipeline: docker
 app_name: metrics
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/metrics
 version_toml: apps/metrics/version.toml
 version_target: apps/metrics/Cargo.toml

--- a/apps/metrics/src/rest/ingest.rs
+++ b/apps/metrics/src/rest/ingest.rs
@@ -102,15 +102,14 @@ pub async fn ingest_errors(
     let mut dropped = 0u64;
     for event in batch.events {
         match event.into_row(user_agent) {
-            Some(row) => {
-                let project = row.get("project").and_then(|v| v.as_str()).unwrap_or("");
-                if !app.allow_project(project) {
+            Some(prepared) => {
+                if !app.allow_project(&prepared.project) {
                     dropped += 1;
                     metrics::counter!("metrics_ingest_dropped_total", "reason" => "project_capped")
                         .increment(1);
                     continue;
                 }
-                match app.tx.try_send(row) {
+                match app.tx.try_send(prepared.line) {
                     Ok(_) => accepted += 1,
                     Err(_) => {
                         dropped += 1;

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -1,23 +1,30 @@
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use ahash::AHashMap;
 use jedi::state::sidecar::ClickHouseConfig;
 use parking_lot::Mutex;
-use serde_json::Value;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::auth::StaffAuth;
 use crate::config::Config;
 
+const LIMITER_SHARDS: usize = 32;
+const WINDOW: Duration = Duration::from_secs(60);
+
 pub struct AppState {
     pub cfg: Config,
     pub ch: ClickHouseConfig,
-    pub tx: mpsc::Sender<Value>,
+    pub tx: mpsc::Sender<String>,
     pub auth: Option<StaffAuth>,
     pub started_at: Instant,
-    limiter: Mutex<AHashMap<String, Bucket>>,
+    ip_limiter: Sharded,
+    project_limiter: Sharded,
+    global_count: AtomicU32,
+    global_window_ms: AtomicU64,
 }
 
 struct Bucket {
@@ -25,11 +32,58 @@ struct Bucket {
     window_start: Instant,
 }
 
+/// Fixed-window rate limiter split across `LIMITER_SHARDS` independently-locked
+/// maps. Under concurrent ingest, requests hash to different shards instead of
+/// all serializing on one global mutex.
+struct Sharded {
+    shards: [Mutex<AHashMap<String, Bucket>>; LIMITER_SHARDS],
+}
+
+impl Sharded {
+    fn new() -> Self {
+        Self {
+            shards: std::array::from_fn(|_| Mutex::new(AHashMap::new())),
+        }
+    }
+
+    fn check(&self, key: &str, limit: u32) -> bool {
+        if limit == 0 {
+            return true;
+        }
+        let now = Instant::now();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        key.hash(&mut hasher);
+        let shard = &self.shards[(hasher.finish() as usize) % LIMITER_SHARDS];
+
+        let mut map = shard.lock();
+        if map.len() > 4096 {
+            map.retain(|_, b| now.duration_since(b.window_start) < WINDOW);
+        }
+        // Fast path: existing key needs no allocation.
+        if let Some(b) = map.get_mut(key) {
+            if now.duration_since(b.window_start) >= WINDOW {
+                b.count = 0;
+                b.window_start = now;
+            }
+            b.count += 1;
+            return b.count <= limit;
+        }
+        map.insert(
+            key.to_string(),
+            Bucket {
+                count: 1,
+                window_start: now,
+            },
+        );
+        1 <= limit
+    }
+}
+
 impl AppState {
     pub fn new(
         cfg: Config,
         ch: ClickHouseConfig,
-        tx: mpsc::Sender<Value>,
+        tx: mpsc::Sender<String>,
         auth: Option<StaffAuth>,
     ) -> Self {
         Self {
@@ -38,53 +92,49 @@ impl AppState {
             tx,
             auth,
             started_at: Instant::now(),
-            limiter: Mutex::new(AHashMap::new()),
+            ip_limiter: Sharded::new(),
+            project_limiter: Sharded::new(),
+            global_count: AtomicU32::new(0),
+            global_window_ms: AtomicU64::new(0),
         }
-    }
-
-    /// Fixed-window counter. Returns false once `limit` is exceeded for `key`
-    /// within the 60s window. A limit of 0 disables the check (always allows).
-    fn check(&self, key: &str, limit: u32) -> bool {
-        if limit == 0 {
-            return true;
-        }
-        let now = Instant::now();
-        let window = Duration::from_secs(60);
-        let mut map = self.limiter.lock();
-        if map.len() > 50_000 {
-            map.retain(|_, b| now.duration_since(b.window_start) < window);
-        }
-        let bucket = map.entry(key.to_string()).or_insert(Bucket {
-            count: 0,
-            window_start: now,
-        });
-        if now.duration_since(bucket.window_start) >= window {
-            bucket.count = 0;
-            bucket.window_start = now;
-        }
-        bucket.count += 1;
-        bucket.count <= limit
     }
 
     /// Per-client-IP request cap.
     pub fn allow_ip(&self, ip: &str) -> bool {
-        self.check(ip, self.cfg.rate_limit_per_min)
+        self.ip_limiter.check(ip, self.cfg.rate_limit_per_min)
     }
 
-    /// Per-project event cap (keyed separately from IPs).
+    /// Per-project event cap (separate shard map; no key allocation on hits).
     pub fn allow_project(&self, project: &str) -> bool {
-        self.check(&format!("p:{project}"), self.cfg.project_rate_limit_per_min)
+        self.project_limiter
+            .check(project, self.cfg.project_rate_limit_per_min)
     }
 
-    /// Global ingest ceiling across all clients.
+    /// Global ingest ceiling — a single lock-free fixed-window counter so the
+    /// hottest check on every request never takes a lock.
     pub fn allow_global(&self) -> bool {
-        self.check("__global__", self.cfg.global_rate_limit_per_min)
+        let limit = self.cfg.global_rate_limit_per_min;
+        if limit == 0 {
+            return true;
+        }
+        let now_ms = self.started_at.elapsed().as_millis() as u64;
+        let start = self.global_window_ms.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(start) >= WINDOW.as_millis() as u64
+            && self
+                .global_window_ms
+                .compare_exchange(start, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            self.global_count.store(0, Ordering::Relaxed);
+        }
+        // fetch_add returns the prior value; prior + 1 <= limit  ==  prior < limit.
+        self.global_count.fetch_add(1, Ordering::Relaxed) < limit
     }
 }
 
 pub fn spawn_flusher(
     state: Arc<AppState>,
-    mut rx: mpsc::Receiver<Value>,
+    mut rx: mpsc::Receiver<String>,
     mut shutdown: oneshot::Receiver<()>,
 ) -> JoinHandle<()> {
     let table = state.cfg.errors_table.clone();
@@ -93,7 +143,7 @@ pub fn spawn_flusher(
     let timeout = Duration::from_millis(state.cfg.insert_timeout_ms);
     let retries = state.cfg.insert_max_retries;
     tokio::spawn(async move {
-        let mut buf: Vec<Value> = Vec::with_capacity(flush_rows);
+        let mut buf: Vec<String> = Vec::with_capacity(flush_rows);
         let mut tick = tokio::time::interval(interval);
         loop {
             tokio::select! {
@@ -136,7 +186,7 @@ pub fn spawn_flusher(
 async fn flush(
     ch: &ClickHouseConfig,
     table: &str,
-    buf: &mut Vec<Value>,
+    buf: &mut Vec<String>,
     timeout: Duration,
     max_retries: u32,
 ) {
@@ -145,9 +195,12 @@ async fn flush(
     }
     let rows = std::mem::take(buf);
     let n = rows.len();
+    // Rows arrive pre-serialized; the flusher only concatenates the
+    // JSONEachRow body (single allocation), never re-walks a Value.
+    let body = rows.join("\n");
     let mut attempt = 0u32;
     loop {
-        let result = tokio::time::timeout(timeout, ch.execute_insert(table, &rows)).await;
+        let result = tokio::time::timeout(timeout, ch.execute_insert_raw(table, &body)).await;
         match result {
             Ok(Ok(())) => {
                 tracing::debug!(rows = n, "flushed telemetry rows");
@@ -177,5 +230,20 @@ async fn flush(
                 tokio::time::sleep(Duration::from_millis(250 * attempt as u64)).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sharded_limiter_enforces_and_isolates_keys() {
+        let s = Sharded::new();
+        assert!(s.check("k", 2));
+        assert!(s.check("k", 2));
+        assert!(!s.check("k", 2)); // third over a limit of 2
+        assert!(s.check("other", 2)); // independent key unaffected
+        assert!(s.check("k", 0)); // limit 0 disables the check
     }
 }

--- a/apps/metrics/src/telemetry.rs
+++ b/apps/metrics/src/telemetry.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
-use serde_json::{Map, Value, json};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 const MAX_MESSAGE: usize = 4096;
@@ -154,8 +154,37 @@ fn sanitize_extra(extra: Option<Map<String, Value>>) -> String {
     serde_json::to_string(&out).unwrap_or_else(|_| "{}".to_string())
 }
 
+/// One sanitized telemetry row, shaped to match the `telemetry.errors_raw`
+/// columns. Serialized to a JSONEachRow line on the request thread so the
+/// flusher never has to walk a `serde_json::Value` again.
+#[derive(Serialize)]
+struct Row {
+    project: String,
+    platform: String,
+    release: String,
+    environment: String,
+    fingerprint: String,
+    error_type: String,
+    message: String,
+    stack: String,
+    url: String,
+    user_id: String,
+    session_id: String,
+    user_agent: String,
+    handled: u8,
+    extra: String,
+}
+
+/// A row ready for the queue: the pre-serialized JSONEachRow `line` plus the
+/// `project` it belongs to (needed for the per-project rate cap without
+/// re-parsing the line).
+pub struct PreparedRow {
+    pub project: String,
+    pub line: String,
+}
+
 impl ErrorEvent {
-    pub fn into_row(self, user_agent: &str) -> Option<Value> {
+    pub fn into_row(self, user_agent: &str) -> Option<PreparedRow> {
         let message = sanitize(self.message, MAX_MESSAGE, true);
         if message.is_empty() || is_noise(&message) {
             return None;
@@ -167,24 +196,27 @@ impl ErrorEvent {
         let error_type = sanitize(self.error_type.unwrap_or_default(), 128, false);
         let stack = sanitize(self.stack.unwrap_or_default(), MAX_STACK, true);
         let url = self.url.map(strip_query).unwrap_or_default();
-        let fp = fingerprint(&project, &error_type, &stack, &message);
+        let fingerprint = fingerprint(&project, &error_type, &stack, &message);
 
-        Some(json!({
-            "project": project,
-            "platform": allow_enum(self.platform, PLATFORMS, "web"),
-            "release": sanitize(self.release.unwrap_or_default(), 64, false),
-            "environment": allow_enum(self.environment, ENVIRONMENTS, "production"),
-            "fingerprint": fp,
-            "error_type": error_type,
-            "message": message,
-            "stack": stack,
-            "url": url,
-            "user_id": sanitize(self.user_id.unwrap_or_default(), 128, false),
-            "session_id": sanitize(self.session_id.unwrap_or_default(), 128, false),
-            "user_agent": sanitize(user_agent.to_string(), 512, false),
-            "handled": if self.handled.unwrap_or(false) { 1u8 } else { 0u8 },
-            "extra": sanitize_extra(self.extra),
-        }))
+        let row = Row {
+            project: project.clone(),
+            platform: allow_enum(self.platform, PLATFORMS, "web"),
+            release: sanitize(self.release.unwrap_or_default(), 64, false),
+            environment: allow_enum(self.environment, ENVIRONMENTS, "production"),
+            fingerprint,
+            error_type,
+            message,
+            stack,
+            url,
+            user_id: sanitize(self.user_id.unwrap_or_default(), 128, false),
+            session_id: sanitize(self.session_id.unwrap_or_default(), 128, false),
+            user_agent: sanitize(user_agent.to_string(), 512, false),
+            handled: u8::from(self.handled.unwrap_or(false)),
+            extra: sanitize_extra(self.extra),
+        };
+
+        let line = serde_json::to_string(&row).ok()?;
+        Some(PreparedRow { project, line })
     }
 }
 
@@ -259,7 +291,9 @@ mod tests {
         let mut map = Map::new();
         map.insert("ok\u{0}key".into(), Value::String("va\u{1b}lue".into()));
         ev.extra = Some(map);
-        let row = ev.into_row("agent\u{0}x").unwrap();
+        let prepared = ev.into_row("agent\u{0}x").unwrap();
+        assert_eq!(prepared.project, "kbve");
+        let row: Value = serde_json::from_str(&prepared.line).unwrap();
         assert_eq!(row["platform"], "android");
         assert_eq!(row["environment"], "production");
         assert_eq!(row["user_agent"], "agentx");

--- a/packages/rust/jedi/src/state/sidecar.rs
+++ b/packages/rust/jedi/src/state/sidecar.rs
@@ -253,13 +253,24 @@ impl ClickHouseConfig {
             .map_err(|e| JediError::Parse(format!("ClickHouse JSON serialize error: {}", e)))?
             .join("\n");
 
+        self.execute_insert_raw(table, &body).await
+    }
+
+    /// Insert a pre-serialized JSONEachRow body (newline-delimited JSON objects).
+    /// Lets hot callers serialize once on their own threads and hand the flusher
+    /// a ready body, avoiding a second pass over `serde_json::Value`.
+    pub async fn execute_insert_raw(&self, table: &str, body: &str) -> Result<(), JediError> {
+        if body.is_empty() {
+            return Ok(());
+        }
+
         let insert_query = format!("INSERT INTO {} FORMAT JSONEachRow", table);
         let http = Self::shared_http_client();
 
         let mut req = http
             .post(&self.url)
             .query(&[("database", &self.database), ("query", &insert_query)])
-            .body(body);
+            .body(body.to_string());
 
         if !self.user.is_empty() {
             req = req.header("X-ClickHouse-User", &self.user);


### PR DESCRIPTION
Maximizing ingest throughput so the metrics service can absorb error/telemetry traffic from every frontend endpoint.

## Two bottlenecks removed

### 1. Rate limiter lock contention
Every request took the **same global `Mutex<HashMap>`** — for the per-IP check, the global check, *and* the per-project check on each event. Under concurrent load that single lock serializes the whole service.
- Per-IP and per-project limiters now split across **32 independently-locked shards**; a key hashes to one shard, so concurrent requests rarely contend.
- Existing keys take a `get_mut` **fast path with no allocation** (removes the former `format!("p:{project}")` per event).
- The **global ceiling is now a lock-free atomic** fixed-window counter — the one check that's unavoidably shared no longer takes a lock at all.

### 2. Triple serialization
The path was: parse JSON → `ErrorEvent` structs → build a `serde_json::Value` → re-serialize that `Value` to JSON in the **single** flusher task.
- `into_row` now serializes each row **once** into a JSONEachRow line on the request thread (typed `Row` struct, no `Value`), returning `PreparedRow { project, line }`.
- The queue carries `String` lines; the flusher just `join("\n")`s the body (one allocation) — no `Value` walk.
- jedi gains `execute_insert_raw(table, body)` for a pre-serialized body; `execute_insert(&[Value])` delegates to it, so other consumers are unchanged.

Net effect: the central lock contention point is gone, and one full serialization pass per row is eliminated — with the remaining serialize moved **off** the single flusher onto the **parallel** request handlers.

## Verification
`cargo test -p met --bins` → **14/14** (added a sharded-limiter test). Clippy clean (met + jedi). Bumps metrics `0.1.3` → `0.1.4`.

## Notes / possible follow-ups
- The flusher is still a single task; batching (`flush_rows`) keeps it efficient, but if CH insert latency becomes the ceiling we could run N drain tasks or a larger batch. Flagged, not done.
- The shared `reqwest` client (prior PR) already pools connections for the inserts.