### PR TITLE
perf(jobboard): route @kbve/rn api through the worker (pooledApi)

### DIFF
--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -60,7 +60,8 @@ createRoot(document.getElementById('root')!).render(
 				supabaseUrl={supabaseUrl}
 				anonKey={KBVE_SUPABASE_ANON_KEY}
 				apiBaseUrl={`${window.location.origin}/kbveapi`}
-				oauthUrl="https://supabase.kbve.com">
+				oauthUrl="https://supabase.kbve.com"
+				pooledApi>
 				<AuthBridge />
 				<StaffProvider>
 					<ThemeProvider theme={jobboardTheme}>


### PR DESCRIPTION
## What
First of the worker-coverage follow-ups: the guaranteed off-thread win.

`KbveProvider` exposes a `pooledApi` switch that runs `api.*` fetch + JSON parse in the web Comlink worker (off the render thread). It defaults **off**, and jobboard never set it — so `api.profile.me()` (and any `@kbve/rn` api the app uses via `useApiResource`) ran on the **main thread**, even though jobboard's own REST client (`api/client.ts`) was already pooled.

This flips `pooledApi` on so the `@kbve/rn` api joins the existing worker.

## Why it's safe
- `ApiClientConfig.fetch` is `RequestFn → Promise<RequestResult>`, the same shape the worker's `pool.request` returns. The core code comment literally says "pass the pool's request here to run fetch + parse off the main thread on web." Intended, built path — just default-off.
- The provider's `getToken` still injects the bearer into `opts.headers` before the pooled fetch, so authed routes keep working.
- `/kbveapi` is same-origin to the worker (default `same-origin` credentials flow).
- No new deps.

## Testing
- `tsc --noEmit` clean.
- `npm run build` EXIT 0.

## Context
Part of the worker-coverage plan. Remaining tracks (separate PRs): **I/O-bound** (AsyncStorage→MMKV for a JSI/worklet-accessible native cache; supabase-js worker-fetch shim) and **CPU-bound (native)** (RNW worklet `JSON.parse` offload — measurement-first, depends on MMKV landing).