### PR TITLE
fix(ci): copy Cargo.lock into cargo-chef Docker builds (unblocks metrics publish)

### DIFF
--- a/apps/jobboard/Dockerfile
+++ b/apps/jobboard/Dockerfile
@@ -26,6 +26,8 @@ ENV CARGO_INCREMENTAL=0
 
 RUN printf '[workspace]\nmembers = ["apps/jobboard", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
 
+COPY Cargo.lock Cargo.lock
+
 COPY apps/jobboard/Cargo.toml apps/jobboard/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
@@ -43,6 +45,8 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS coo
 ENV CARGO_INCREMENTAL=0
 
 RUN printf '[workspace]\nmembers = ["apps/jobboard", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+
+COPY Cargo.lock Cargo.lock
 
 COPY apps/jobboard/Cargo.toml apps/jobboard/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml

--- a/apps/metrics/Dockerfile
+++ b/apps/metrics/Dockerfile
@@ -4,6 +4,10 @@ ENV CARGO_INCREMENTAL=0
 
 RUN printf '[workspace]\nmembers = ["apps/metrics", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
 
+# Pin dependency resolution to the committed lockfile — without it cargo-chef
+# resolves fresh and can pick an uncompilable pairing (e.g. time/time-macros).
+COPY Cargo.lock Cargo.lock
+
 COPY apps/metrics/Cargo.toml apps/metrics/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
@@ -20,6 +24,8 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS coo
 ENV CARGO_INCREMENTAL=0
 
 RUN printf '[workspace]\nmembers = ["apps/metrics", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+
+COPY Cargo.lock Cargo.lock
 
 COPY apps/metrics/Cargo.toml apps/metrics/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml

--- a/apps/vm/factorio-ctl/Dockerfile
+++ b/apps/vm/factorio-ctl/Dockerfile
@@ -14,6 +14,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS pla
 ENV CARGO_INCREMENTAL=0
 
 COPY apps/vm/factorio-ctl/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
 COPY apps/vm/factorio-ctl/Cargo.toml apps/vm/factorio-ctl/Cargo.toml
 
 COPY packages/rust/jedi packages/rust/jedi
@@ -30,7 +31,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS bui
 ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
-COPY --from=planner /app/Cargo.toml ./
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 


### PR DESCRIPTION
## Problem
`CI - Docker / metrics` (publish) fails:
```
error[E0432]: unresolved import `time_macros::timestamp`
error: could not compile `time`
ERROR: cargo chef cook --release -p met → exit code 101
```
The metrics image never publishes, so the merged 0.1.2 sanitization / 0.1.3 prometheus / 0.1.4 perf work can't deploy.

## Cause
The metrics (and jobboard, factorio-ctl) Dockerfiles synthesize a workspace and copy member manifests **but never copy `Cargo.lock`** — so cargo-chef resolves dependencies fresh and can pick an uncompilable `time`/`time-macros` pairing. It builds locally only because the local `Cargo.lock` pins good versions.

## Fix
Copy the committed `Cargo.lock` into the planner + cook stages, mirroring the pattern already used by `kbve-gate` and ~10 other Rust Dockerfiles. Builds now use the exact locked versions.

- `apps/metrics/Dockerfile` (the failing one)
- `apps/jobboard/Dockerfile`, `apps/vm/factorio-ctl/Dockerfile` — same latent gap, fixed pre-emptively

## Verify
`cargo build -p met --locked` succeeds against the committed lock (`time 0.3.47` / `time-macros 0.2.27` compile fine). No app code or versions changed.