### PR TITLE
test(metrics): docker-compose e2e + per-PR cargo build --locked gate

### DIFF
--- a/.github/workflows/ci-metrics-e2e.yml
+++ b/.github/workflows/ci-metrics-e2e.yml
@@ -1,0 +1,46 @@
+name: CI - Metrics E2E
+
+on:
+    pull_request:
+        paths:
+            - 'apps/metrics/**'
+            - 'packages/rust/jedi/**'
+            - 'packages/rust/kbve/**'
+            - 'packages/rust/holy/**'
+            - 'Cargo.lock'
+            - 'Cargo.toml'
+            - '.github/workflows/ci-metrics-e2e.yml'
+    schedule:
+        - cron: '0 7 * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: metrics-e2e-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    # Fast per-PR gate: compile against the committed lockfile. Catches the
+    # dependency-resolution / lockfile breaks that only surface in the Docker
+    # publish (e.g. the time/time-macros mismatch) before they reach main.
+    build-locked:
+        name: cargo build --locked
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  shared-key: metrics-locked
+            - name: Build met with the committed lockfile
+              run: cargo build -p met --locked
+
+    # Full ingest -> sanitize -> ClickHouse path against a real CH.
+    # Heavy (builds the image + boots CH); runs nightly and on demand, not per-PR.
+    e2e:
+        name: docker-compose e2e
+        if: github.event_name != 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Run metrics e2e
+              run: bash apps/metrics/e2e/run.sh

--- a/apps/metrics/e2e/README.md
+++ b/apps/metrics/e2e/README.md
@@ -1,0 +1,40 @@
+# metrics e2e
+
+Black-box end-to-end test for the telemetry ingest: a real ClickHouse plus the
+metrics binary built from source, driven through the public ingest endpoint.
+
+## What it checks
+
+- missing ingest token → `401`
+- valid batch → `202` with `accepted:1`
+- the row lands in ClickHouse, **sanitized**:
+    - `platform` clamped to the allow-list (`HACKER` → `web`)
+    - control characters stripped from `message`
+    - query string stripped from `url`
+
+This exercises the whole path — HTTP → auth → rate limit → sanitize →
+queue → flush → `INSERT ... FORMAT JSONEachRow` — against a real database.
+
+## Run locally
+
+```bash
+apps/metrics/e2e/run.sh
+```
+
+Requires `docker compose` and `curl`. The script builds the image, boots CH,
+waits for `/readiness`, runs the assertions, and tears everything down.
+
+## Schema note
+
+`init/01-telemetry.sql` is a **single-node** schema (plain `MergeTree`).
+Production (`packages/data/ch/schemas/telemetry.sql`) uses
+`ReplicatedMergeTree` + `Distributed` `ON CLUSTER 'cluster'`, which a one-node CH
+can't run — the ingest writes to `errors_distributed` either way.
+
+## CI
+
+`.github/workflows/ci-metrics-e2e.yml`:
+
+- **per-PR**: `cargo build -p met --locked` (fast gate; catches lockfile/dep
+  resolution breaks before the Docker publish does)
+- **nightly + manual dispatch**: the full docker-compose e2e above

--- a/apps/metrics/e2e/docker-compose.yml
+++ b/apps/metrics/e2e/docker-compose.yml
@@ -1,0 +1,42 @@
+# Metrics ingest e2e: real ClickHouse + the metrics binary built from source.
+# Run via ./run.sh (orchestrates readiness + assertions + teardown).
+services:
+    clickhouse:
+        image: clickhouse/clickhouse-server:25.8
+        ulimits:
+            nofile:
+                soft: 262144
+                hard: 262144
+        volumes:
+            - ./init:/docker-entrypoint-initdb.d:ro
+        healthcheck:
+            test:
+                ['CMD', 'wget', '--spider', '-q', 'http://localhost:8123/ping']
+            interval: 2s
+            timeout: 3s
+            retries: 30
+        ports:
+            - '8123' # ephemeral host port; queried inside the compose network
+
+    metrics:
+        build:
+            context: ../../..
+            dockerfile: apps/metrics/Dockerfile
+        depends_on:
+            clickhouse:
+                condition: service_healthy
+        environment:
+            HTTP_HOST: '0.0.0.0'
+            HTTP_PORT: '5500'
+            RUST_LOG: 'met=info,tower_http=warn'
+            CLICKHOUSE_ENDPOINT: 'http://clickhouse:8123'
+            CLICKHOUSE_DATABASE: 'telemetry'
+            CLICKHOUSE_USERNAME: 'default'
+            CLICKHOUSE_PASSWORD: ''
+            METRICS_ERRORS_TABLE: 'errors_distributed'
+            METRICS_FLUSH_INTERVAL_MS: '500'
+            METRICS_FLUSH_ROWS: '10'
+            METRICS_INGEST_TOKEN: 'e2e-secret-token'
+            METRICS_RATE_LIMIT_PER_MIN: '1000'
+        ports:
+            - '5500:5500'

--- a/apps/metrics/e2e/init/01-telemetry.sql
+++ b/apps/metrics/e2e/init/01-telemetry.sql
@@ -1,0 +1,29 @@
+-- Single-node telemetry schema for the metrics e2e harness.
+-- Production uses ReplicatedMergeTree + Distributed ON CLUSTER 'cluster'
+-- (packages/data/ch/schemas/telemetry.sql); a one-node CH has no cluster, so
+-- errors_distributed is a plain MergeTree the ingest writes to directly.
+
+CREATE DATABASE IF NOT EXISTS telemetry;
+
+CREATE TABLE IF NOT EXISTS telemetry.errors_distributed
+(
+    timestamp       DateTime64(3, 'UTC') DEFAULT now64(3),
+    project         LowCardinality(String),
+    platform        LowCardinality(String) DEFAULT 'web',
+    release         LowCardinality(String) DEFAULT '',
+    environment     LowCardinality(String) DEFAULT 'production',
+    fingerprint     String,
+    error_type      LowCardinality(String) DEFAULT '',
+    message         String,
+    stack           String DEFAULT '',
+    url             String DEFAULT '',
+    user_id         String DEFAULT '',
+    session_id      String DEFAULT '',
+    user_agent      String DEFAULT '',
+    handled         UInt8 DEFAULT 0,
+    extra           String DEFAULT '{}'
+)
+ENGINE = MergeTree
+ORDER BY (project, fingerprint, timestamp)
+PARTITION BY toYYYYMMDD(timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;

--- a/apps/metrics/e2e/run.sh
+++ b/apps/metrics/e2e/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# End-to-end test: boots real ClickHouse + the metrics binary, drives the public
+# ingest endpoint, and asserts rows land in CH correctly sanitized.
+#
+# Usage: apps/metrics/e2e/run.sh
+# Requires: docker compose, curl.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+INGEST="http://localhost:5500/api/v1/ingest/errors"
+TOKEN="e2e-secret-token"
+PASS=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    echo "--- metrics logs ---" >&2
+    docker compose logs metrics 2>&1 | tail -40 >&2 || true
+    exit 1
+}
+
+cleanup() {
+    docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+ch() {
+    docker compose exec -T clickhouse clickhouse-client -q "$1"
+}
+
+echo "==> Building + starting stack"
+docker compose up -d --build
+
+echo "==> Waiting for metrics readiness"
+ready=""
+for _ in $(seq 1 60); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5500/readiness || true)
+    if [ "$code" = "200" ]; then
+        ready=1
+        break
+    fi
+    sleep 2
+done
+[ -n "$ready" ] || fail "metrics never became ready"
+
+echo "==> Case 1: missing token is rejected (401)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$INGEST" \
+    -H 'content-type: application/json' \
+    -d '{"events":[{"project":"e2e","message":"no token"}]}')
+[ "$code" = "401" ] || fail "expected 401 without token, got $code"
+
+echo "==> Case 2: valid batch is accepted (202)"
+body=$(curl -s -X POST "$INGEST" \
+    -H 'content-type: application/json' \
+    -H "x-kbve-ingest: $TOKEN" \
+    -d '{"events":[{
+          "project":"e2e",
+          "message":"boomctrl",
+          "platform":"HACKER",
+          "environment":"chaos",
+          "error_type":"TypeError",
+          "stack":"at foo\nat bar",
+          "url":"https://example.com/p?secret=1",
+          "handled":false
+        }]}')
+echo "    response: $body"
+echo "$body" | grep -q '"accepted":1' || fail "expected accepted:1, got $body"
+
+echo "==> Waiting for flush"
+sleep 3
+
+echo "==> Case 3: row landed in ClickHouse, sanitized"
+count=$(ch "SELECT count() FROM telemetry.errors_distributed WHERE project='e2e'")
+[ "$count" -ge 1 ] || fail "expected >=1 row in CH, got $count"
+
+platform=$(ch "SELECT platform FROM telemetry.errors_distributed WHERE project='e2e' LIMIT 1")
+[ "$platform" = "web" ] || fail "platform not clamped to allowlist (got '$platform')"
+
+message=$(ch "SELECT message FROM telemetry.errors_distributed WHERE project='e2e' LIMIT 1")
+[ "$message" = "boomctrl" ] || fail "control char not stripped from message (got '$message')"
+
+url=$(ch "SELECT url FROM telemetry.errors_distributed WHERE project='e2e' LIMIT 1")
+[ "$url" = "https://example.com/p" ] || fail "url query string not stripped (got '$url')"
+
+PASS=1
+echo "==> PASS: ingest -> sanitize -> ClickHouse verified end to end"
+[ "$PASS" = "1" ]


### PR DESCRIPTION
metrics had only unit tests — no end-to-end coverage of the real `HTTP → sanitize → queue → flush → ClickHouse` path, and nothing per-PR guarded against the lockfile/dep break that just broke the Docker publish.

## `apps/metrics/e2e/` (full docker-compose + real CH)
`run.sh` boots a real ClickHouse + the metrics binary built from source and drives the public ingest endpoint:
- missing ingest token → **401**
- valid batch → **202** (`accepted:1`)
- row lands in CH **sanitized**: `platform` clamped to the allow-list (`HACKER`→`web`), control chars stripped from `message`, query string stripped from `url`

Single-node `MergeTree` schema (`init/01-telemetry.sql`) — prod uses `ReplicatedMergeTree`/`Distributed` `ON CLUSTER`, which one node can't run; the ingest writes `errors_distributed` either way.

## `.github/workflows/ci-metrics-e2e.yml`
- **per-PR** (`apps/metrics/**`, `packages/rust/**`, `Cargo.lock`): `cargo build -p met --locked` — the fast gate that would have caught the `time`/`time-macros` break **before** publish.
- **nightly + workflow_dispatch**: the full docker-compose e2e (too heavy for every PR).

## Validation
`bash -n run.sh`, `docker compose config -q`, and `actionlint` all pass. `cargo build -p met --locked` verified locally.

Pairs with #13034 (the actual Cargo.lock Dockerfile fix); this adds the guardrails so it can't silently regress.