### PR TITLE
fix(cryptothrone): keep Phaser out of /game/play SSR graph (#13033)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { usernameFromToken as kbveUsernameFromToken } from '@kbve/laser';
 import { KbveUsernameSetup } from '@kbve/astro';
 import { authBridge, initSupa } from '@/lib/supa';
 import { setCtNetConfig, resolveWsUrl } from '@/lib/net-config';
@@ -87,7 +86,8 @@ export default function ReactGameGate() {
 			return;
 		}
 		setToken(accessToken);
-		const name = kbveUsernameFromToken(accessToken);
+		const { usernameFromToken } = await import('@kbve/laser');
+		const name = usernameFromToken(accessToken);
 		if (!name) {
 			setPhase('username');
 			return;


### PR DESCRIPTION
## Problem

CI `cryptothrone` Docker build failing on main (#13033, v0.1.51). astro-cryptothrone:build crashes prerendering `/game/play/`:

```
[ERROR] ReferenceError: window is not defined
    at init (phaser.esm.js:25128:9)
[ERROR] [build] Caught error rendering /game/play/: ReferenceError: window is not defined
```

(The LFS pull warning above it is a non-fatal red herring — `|| echo`, skips every CI run without Forgejo creds.)

## Root cause

Commit 0312cc859 swapped ReactGameGate's local zero-dep JWT decode for a static `import { usernameFromToken } from '@kbve/laser'`. The laser barrel eagerly re-exports `PhaserGame` et al, so the static import drags Phaser into the **SSR module graph** of the `/game/play` MDX page. `client:only` stops *rendering*, not top-level `import` evaluation — Phaser touches `window` at module init and the static prerender dies. Same barrel-pulls-Phaser class the CloudCityScene modules already avoid via `import type` only.

## Fix

Defer the laser barrel to a dynamic `import()` inside `check()`. That callback only runs in the browser (client:only never executes server-side), so the SSR static graph stays barrel-free while still reusing laser's shared `usernameFromToken`.

## Verify

`./kbve.sh -nx astro-cryptothrone:build` → 7 pages built, `/game/play/index.html` rendered, no `window is not defined`.