### PR TITLE
perf(rn): route web supabase HTTP through the worker

### DIFF
--- a/packages/npm/rn/src/auth/supabase.web.ts
+++ b/packages/npm/rn/src/auth/supabase.web.ts
@@ -1,10 +1,40 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 import type { AuthSession } from '@kbve/core';
+import { createWorkerPool } from '../worker/pool';
 
-export interface SupabaseConfig {
-	url: string;
-	anonKey: string;
+const NULL_BODY_STATUS = new Set([204, 205, 304]);
+
+function createWorkerFetch(): typeof fetch {
+	const pool = createWorkerPool();
+	return async (input, init) => {
+		const body = init?.body;
+		if (
+			input instanceof Request ||
+			(body != null && typeof body !== 'string')
+		)
+			return fetch(input, init);
+
+		const url = typeof input === 'string' ? input : input.toString();
+		const headers: Record<string, string> = {};
+		new Headers(init?.headers).forEach((value, key) => {
+			headers[key] = value;
+		});
+
+		const raw = await pool.fetchRaw(url, {
+			method: init?.method,
+			headers,
+			body: body ?? undefined,
+		});
+		return new Response(
+			NULL_BODY_STATUS.has(raw.status) ? null : raw.body,
+			{
+				status: raw.status,
+				statusText: raw.statusText,
+				headers: raw.headers,
+			},
+		);
+	};
 }
 
 export function createSupabaseClient(config: SupabaseConfig): SupabaseClient {
@@ -17,7 +47,13 @@ export function createSupabaseClient(config: SupabaseConfig): SupabaseClient {
 			detectSessionInUrl: true,
 			flowType: 'pkce',
 		},
+		global: { fetch: createWorkerFetch() },
 	});
+}
+
+export interface SupabaseConfig {
+	url: string;
+	anonKey: string;
 }
 
 function claimUsername(accessToken: string): string | null {

--- a/packages/npm/rn/src/worker/pool.ts
+++ b/packages/npm/rn/src/worker/pool.ts
@@ -12,6 +12,23 @@ export function createWorkerPool(): WorkerPool {
 				headers: init?.headers,
 				body: init?.body,
 			}),
+		fetchRaw: async (url, init) => {
+			const res = await fetch(url, {
+				method: init?.method ?? 'GET',
+				headers: init?.headers,
+				body: init?.body,
+			});
+			const headers: Record<string, string> = {};
+			res.headers.forEach((value, key) => {
+				headers[key] = value;
+			});
+			return {
+				status: res.status,
+				statusText: res.statusText,
+				headers,
+				body: await res.text(),
+			};
+		},
 		cacheGet: (key) => kvStore.get(key),
 		cacheSet: (key, value) => kvStore.set(key, value),
 		cacheRemove: (key) => kvStore.remove(key),

--- a/packages/npm/rn/src/worker/pool.web.ts
+++ b/packages/npm/rn/src/worker/pool.web.ts
@@ -1,8 +1,14 @@
 import * as Comlink from 'comlink';
-import type { PoolRequestInit, PoolResponse, WorkerPool } from './types';
+import type {
+	PoolRawResponse,
+	PoolRequestInit,
+	PoolResponse,
+	WorkerPool,
+} from './types';
 
 interface PoolApi {
 	request<T>(url: string, init?: PoolRequestInit): Promise<PoolResponse<T>>;
+	fetchRaw(url: string, init?: PoolRequestInit): Promise<PoolRawResponse>;
 	cacheGet<T>(key: string): Promise<T | null>;
 	cacheSet<T>(key: string, value: T): Promise<void>;
 	cacheRemove(key: string): Promise<void>;
@@ -36,6 +42,8 @@ export function createWorkerPool(): WorkerPool {
 	const pool = {
 		request: (url: string, init?: PoolRequestInit) =>
 			get().request(url, init),
+		fetchRaw: (url: string, init?: PoolRequestInit) =>
+			get().fetchRaw(url, init),
 		cacheGet: (key: string) => get().cacheGet(key),
 		cacheSet: (key: string, value: unknown) => get().cacheSet(key, value),
 		cacheRemove: (key: string) => get().cacheRemove(key),

--- a/packages/npm/rn/src/worker/pool.worker.ts
+++ b/packages/npm/rn/src/worker/pool.worker.ts
@@ -2,7 +2,10 @@ import * as Comlink from 'comlink';
 import Dexie from 'dexie';
 import type { Table } from 'dexie';
 import { request as coreRequest } from '@kbve/core';
-import type { PoolRequestInit, PoolResponse } from './types';
+import type { PoolRawResponse, PoolRequestInit, PoolResponse } from './types';
+
+const RAW_TIMEOUT_MS = 20000;
+const STRIP_HEADERS = new Set(['content-encoding', 'content-length']);
 
 interface Row {
 	key: string;
@@ -29,6 +32,34 @@ const api = {
 			headers: init?.headers,
 			body: init?.body,
 		});
+	},
+	async fetchRaw(
+		url: string,
+		init?: PoolRequestInit,
+	): Promise<PoolRawResponse> {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), RAW_TIMEOUT_MS);
+		try {
+			const res = await fetch(url, {
+				method: init?.method ?? 'GET',
+				headers: init?.headers,
+				body: init?.body,
+				signal: controller.signal,
+			});
+			const body = await res.text();
+			const headers: Record<string, string> = {};
+			res.headers.forEach((value, key) => {
+				if (!STRIP_HEADERS.has(key.toLowerCase())) headers[key] = value;
+			});
+			return {
+				status: res.status,
+				statusText: res.statusText,
+				headers,
+				body,
+			};
+		} finally {
+			clearTimeout(timer);
+		}
 	},
 	async cacheGet<T>(key: string): Promise<T | null> {
 		const row = await db.kv.get(key);

--- a/packages/npm/rn/src/worker/types.ts
+++ b/packages/npm/rn/src/worker/types.ts
@@ -11,6 +11,13 @@ export interface PoolResponse<T> {
 	error: string | null;
 }
 
+export interface PoolRawResponse {
+	status: number;
+	statusText: string;
+	headers: Record<string, string>;
+	body: string;
+}
+
 // Off-main-thread network + cache. On web these run in a persistent Comlink
 // Worker (fetch parsing + IndexedDB off the render thread); on native they run
 // inline (no background JS thread for fetch/AsyncStorage), same surface.
@@ -19,6 +26,7 @@ export interface WorkerPool {
 		url: string,
 		init?: PoolRequestInit,
 	): Promise<PoolResponse<T>>;
+	fetchRaw(url: string, init?: PoolRequestInit): Promise<PoolRawResponse>;
 	cacheGet<T = unknown>(key: string): Promise<T | null>;
 	cacheSet<T = unknown>(key: string, value: T): Promise<void>;
 	cacheRemove(key: string): Promise<void>;


### PR DESCRIPTION
## What
I/O track — moves the **largest remaining main-thread network + JSON parse** for jobboard off the render thread.

Web `supabase-js` used the main-thread `global` fetch for **all** auth / rest / rpc / token-refresh traffic. This injects a `global.fetch` that delegates to the existing web worker.

## How
supabase-js needs a real `Response`, which can't cross the Comlink boundary. So:
- New worker method `fetchRaw` → returns raw `{status, statusText, headers, body}`.
- A main-thread shim reconstructs `new Response(body, { status, statusText, headers })`.

Details:
- `fetchRaw` strips `content-encoding`/`content-length` (body is already decoded → avoids consumer mismatch) and carries a **20s internal timeout** (an `AbortSignal` can't cross Comlink).
- 204/205/304 → null body (Response throws otherwise).
- Non-string bodies (Blob/FormData) and `Request` inputs **fall back to direct fetch** — supabase auth/rest only sends string bodies + string URLs.
- Native pool implements `fetchRaw` inline for interface parity; **native supabase is unchanged**. Session storage stays on `localStorage` (decided against moving it — tiny blob, no perf gain, would force a one-time logout).

## Why not move session storage
The heavy storage (IndexedDB cache, form drafts) is already worker-isolated. The only main-thread storage left is supabase's tiny localStorage session — sync microsecond reads, not a jank source; moving it adds auth risk + a one-time user logout for no perf gain. This PR targets the real cost: supabase HTTP.

## Testing
- `tsc --noEmit` clean; `npm run build` EXIT 0.
- ⚠️ **Auth-critical transport** — needs a live smoke test after deploy: login (email + OAuth/PKCE), dashboard load, `staff_permissions` RPC, and a token refresh. Build can't cover these.