### PR TITLE
release(discordsh-bot): 0.1.20 + Valkey L2 for gh reverse-sync

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -172,7 +172,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.19",
+			"version": "0.1.20",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -447,7 +447,7 @@
 		{
 			"key": "metrics",
 			"app_name": "metrics",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"version_toml": "apps/metrics/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx",
 			"version_target": "apps/metrics/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.19"
+version: "0.1.20"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -79,6 +79,16 @@ spec:
                             secretKeyRef:
                                 name: valkey-auth
                                 key: valkey-password
+                      # KBVE_KV_URL (jedi KvCache → Valkey) = shared L2 for the
+                      # gh reverse-sync lookups (thread→issue, comment_mirror).
+                      # Optional so the pod boots before the ExternalSecret
+                      # renders; KvCache falls back to L1-only until then.
+                      - name: KBVE_KV_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: discordsh-bot-valkey
+                                key: KBVE_KV_URL
+                                optional: true
                       - name: SUPABASE_URL
                         value: 'http://kong.kilobase.svc.cluster.local:8000'
                       - name: SUPABASE_SERVICE_ROLE_KEY

--- a/apps/kube/discordsh/manifest/discordsh-externalsecret.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-externalsecret.yaml
@@ -136,3 +136,50 @@ spec:
           remoteRef:
               key: discordsh-n8n-hmac
               property: N8N_HMAC_SECRET
+---
+# Valkey password from the valkey namespace, composed into a full KBVE_KV_URL
+# for jedi KvCache (gh reverse-sync L2). Needs discordsh-external-secrets granted
+# read on valkey-auth (apps/kube/valkey/manifests/discordsh-valkey-rbac.yaml).
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: discordsh-valkey-secret-store
+    namespace: discordsh
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: valkey
+            auth:
+                serviceAccount:
+                    name: discordsh-external-secrets
+                    namespace: discordsh
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: discordsh-bot-valkey
+    namespace: discordsh
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-valkey-secret-store
+        kind: SecretStore
+    target:
+        name: discordsh-bot-valkey
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                KBVE_KV_URL: 'redis://:{{ .valkeypassword | urlquery }}@valkey.valkey.svc.cluster.local:6379'
+    data:
+        - secretKey: valkeypassword
+          remoteRef:
+              key: valkey-auth
+              property: valkey-password

--- a/apps/kube/valkey/manifests/discordsh-valkey-rbac.yaml
+++ b/apps/kube/valkey/manifests/discordsh-valkey-rbac.yaml
@@ -1,0 +1,16 @@
+# Lets the discordsh ExternalSecrets ServiceAccount read valkey-auth out of the
+# valkey namespace, so its discordsh-valkey-secret-store can compose KBVE_KV_URL
+# for the gh reverse-sync KvCache L2. Reuses the existing valkey-auth-reader Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: discordsh-read-valkey-auth
+    namespace: valkey
+subjects:
+    - kind: ServiceAccount
+      name: discordsh-external-secrets
+      namespace: discordsh
+roleRef:
+    kind: Role
+    name: valkey-auth-reader
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
     - valkey-auth-sync-policy.yaml
     - cryptothrone-valkey-rbac.yaml
     - irc-gateway-valkey-rbac.yaml
+    - discordsh-valkey-rbac.yaml


### PR DESCRIPTION
Ships the bidirectional GitHub↔Discord reverse-sync (#12984, code merged in #13008; prod migration already applied) by publishing a new discordsh-bot image and wiring its Valkey L2 cache.

## Changes
- **Version**: discordsh-bot MDX `0.1.19 → 0.1.20` → triggers image republish; post-publish atom PR auto-syncs version.toml + deployment image tag.
- **ci-dispatch-manifest**: regenerated (full regen). Bumps discordsh_bot → 0.1.20 and also catches up a pre-existing `metrics 0.1.3 → 0.1.4` drift already on dev (manifest was stale vs its MDX; this unblocks metrics' own publish).
- **Deployment env**: `KBVE_KV_URL` via optional `secretKeyRef` (discordsh-bot-valkey) — jedi KvCache L2 for the reverse-sync thread→issue + comment_mirror lookups. `optional: true` so the pod boots L1-only until the secret renders. `GH_REVERSE_SYNC_ENABLED` defaults on (no env needed).
- **ExternalSecret**: valkey SecretStore + ExternalSecret composing `KBVE_KV_URL = redis://:<pw>@valkey.valkey.svc:6379`, reusing the existing `discordsh-external-secrets` SA (mirrors the irc-gateway pattern).
- **valkey ns RBAC**: RoleBinding granting that SA read on `valkey-auth` (reuses `valkey-auth-reader` Role); registered in valkey kustomization.

## Notes
- Reaches the cluster after the periodic dev→main release (ArgoCD tracks main).
- No DB work here — `gh.comment_mirror` migration already applied to prod (run 27933577089).