### PR TITLE
ci(dbmate): wait for dind daemon before compose up

### DIFF
--- a/.github/workflows/ci-dbmate-validate.yml
+++ b/.github/workflows/ci-dbmate-validate.yml
@@ -71,6 +71,18 @@ jobs:
                   psql --version
                   docker compose version
 
+            - name: Wait for docker daemon
+              run: |
+                  for i in $(seq 1 60); do
+                    if docker info >/dev/null 2>&1; then
+                      echo "docker daemon ready after $i attempts"
+                      exit 0
+                    fi
+                    sleep 2
+                  done
+                  echo "::error::docker daemon (dind sidecar) never came up in 120s"
+                  exit 1
+
             - name: Bring up kilobase compose stack
               working-directory: packages/data/sql/dbmate
               run: |
@@ -127,4 +139,9 @@ jobs:
             - name: Tear down kilobase
               if: always()
               working-directory: packages/data/sql/dbmate
-              run: docker compose -f kilobase-docker-compose.yml down -v
+              run: |
+                  if docker info >/dev/null 2>&1; then
+                    docker compose -f kilobase-docker-compose.yml down -v
+                  else
+                    echo "docker daemon unreachable; nothing to tear down"
+                  fi


### PR DESCRIPTION
## Problem

`CI - dbmate validate` flakes intermittently with:

```
unable to get image 'ghcr.io/kbve/postgres:17.4.1.069-kilobase': Cannot connect to the Docker daemon at tcp://localhost:2376. Is the docker daemon running?
```

The job runs on `arc-runner-set` (ARC, docker-in-docker sidecar at `tcp://localhost:2376`). The install step only runs client-only `docker compose version`, which never contacts the daemon — so the **first** real daemon contact is `compose up -d`. When the dind sidecar hasn't finished coming up, the job dies immediately and the `always()` teardown errors on top, turning the run red for no code reason.

## Fix

- Add a **Wait for docker daemon** step that polls `docker info` (up to 120s) before bringing the stack up.
- Guard teardown so it no-ops when the daemon is unreachable instead of false-failing the job.

No migration / validation logic touched.