### PR TITLE
fix(ci): stable itch channels for unreal game + plugin deploys

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -539,6 +539,7 @@ jobs:
                     maps=$(echo "$entry" | jq -c '.engine.maps // []')
                     itch_user=$(echo "$entry" | jq -r '.external_publish.itch_user // empty')
                     itch_game=$(echo "$entry" | jq -r '.external_publish.itch_game // empty')
+                    itch_chan=$(echo "$entry" | jq -r '.external_publish.itch_channel // empty')
                     deploy_itch="false"
                     [ -n "$itch_user" ] && [ -n "$itch_game" ] && deploy_itch="true"
 
@@ -571,8 +572,8 @@ jobs:
                       '(.engine // {}) + {app_name:$app, shell_path:$sp, build_targets:(.engine.build_targets // []), maps:(.engine.maps // [])}')
                     version_json=$(jq -nc --arg s "$src" --arg t "$vtoml" --arg m "$ver" \
                       '{source:$s, toml:$t, manifest:$m}')
-                    publish_json=$(jq -nc --argjson d "$deploy_itch" --arg u "$itch_user" --arg g "$itch_game" \
-                      '{deploy_to_itch:$d, itch_user:$u, itch_game:$g}')
+                    publish_json=$(jq -nc --argjson d "$deploy_itch" --arg u "$itch_user" --arg g "$itch_game" --arg c "$itch_chan" \
+                      '{deploy_to_itch:$d, itch_user:$u, itch_game:$g, itch_channel:$c}')
 
                     gh workflow run "$workflow" --repo "$REPO" --ref main \
                       --field key="$key" \

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -178,10 +178,10 @@ on:
                 type: string
                 default: ''
             itch_channel:
-                description: '[plugin] Itch.io build channel'
+                description: 'Itch.io channel. [game] empty = plain linux/macos/windows; set = suffix (e.g. dev -> linux-dev). [plugin] empty = plugin_name.'
                 required: false
                 type: string
-                default: 'plugin'
+                default: ''
         secrets:
             epic_pat:
                 description: 'PAT for ghcr.io/epicgames + game repo (falls back to UNITY_PAT)'
@@ -918,7 +918,7 @@ jobs:
                   gameData: ./ue5-game-output
                   itchUsername: ${{ inputs.itch_username }}
                   itchGameId: ${{ inputs.itch_game_id }}
-                  buildChannel: linux
+                  buildChannel: ${{ inputs.itch_channel != '' && format('linux-{0}', inputs.itch_channel) || 'linux' }}
                   buildNumber: ${{ needs.game_gate.outputs.version }}
 
             - name: Cleanup
@@ -1149,8 +1149,8 @@ jobs:
                   Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\butler" -Force
                   $butler = "$env:RUNNER_TEMP\butler\butler.exe"
                   $version = "${{ needs.game_gate.outputs.version }}"
-                  $channel = '${{ inputs.itch_channel }}'
-                  if (-not $channel) { $channel = "windows" }
+                  $ic = '${{ inputs.itch_channel }}'
+                  $channel = if ($ic) { "windows-$ic" } else { "windows" }
                   $target = "${{ inputs.itch_username }}/${{ inputs.itch_game_id }}:$channel"
                   Write-Host "::notice::butler push C:\ue5-game-output -> $target (v$version)"
                   & $butler push "C:\ue5-game-output" $target --userversion $version
@@ -1379,7 +1379,7 @@ jobs:
                   gameData: ./deploy
                   itchUsername: ${{ inputs.itch_username }}
                   itchGameId: ${{ inputs.itch_game_id }}
-                  buildChannel: macos
+                  buildChannel: ${{ inputs.itch_channel != '' && format('macos-{0}', inputs.itch_channel) || 'macos' }}
                   buildNumber: ${{ needs.game_gate.outputs.version }}
 
     game_post_publish:
@@ -2196,7 +2196,7 @@ jobs:
                   gameData: ./deploy/${{ inputs.plugin_name }}
                   itchUsername: ${{ inputs.itch_username }}
                   itchGameId: ${{ inputs.itch_game_id }}
-                  buildChannel: ${{ inputs.itch_channel }}-v${{ needs.plugin_check.outputs.version }}
+                  buildChannel: ${{ inputs.itch_channel != '' && inputs.itch_channel || inputs.plugin_name }}
                   buildNumber: ${{ needs.plugin_check.outputs.version }}
 
     # ════════════════ VM SETUP (Windows / macOS) ════════════════

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -36,7 +36,7 @@ on:
                 type: string
                 default: '{}'
             publish:
-                description: '[game] JSON publish config: deploy_to_itch, itch_user, itch_game'
+                description: '[game] JSON publish config: deploy_to_itch, itch_user, itch_game, itch_channel'
                 required: false
                 type: string
                 default: '{}'
@@ -74,6 +74,7 @@ jobs:
             deploy_to_itch: ${{ fromJSON(inputs.publish).deploy_to_itch }}
             itch_username: ${{ fromJSON(inputs.publish).itch_user }}
             itch_game_id: ${{ fromJSON(inputs.publish).itch_game }}
+            itch_channel: ${{ fromJSON(inputs.publish).itch_channel }}
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}


### PR DESCRIPTION
## Problem

itch.io shows confusing builds for ChuckRPG — duplicate `plugin 0.3.29` / `plugin 0.3.30` entries plus a stray `plugin` channel, instead of clean `linux`/`macos`/`windows`.

Root cause: the `itch_channel` workflow input **defaulted to `'plugin'`**.
- Game **Windows** deploy used `inputs.itch_channel` → pushed to a `plugin` channel, not `windows`.
- **Plugin** deploy used `${itch_channel}-v${version}` → a brand-new itch channel **every release** (`plugin-v0.3.29`, `plugin-v0.3.30`, ...) instead of updating one. (The version belongs in `buildNumber`/`--userversion`, not the channel name.)

The game deploy path also ignored `itch_channel` entirely, so `unreal-chuck-game`/`-beta`/`-dev` all collided on the same hardcoded `linux`/`macos`/`windows` channels.

## Fix

- Default `itch_channel` to `''` and plumb it through the game path: `ci-main` (publish JSON) → `ci-unreal` → `ci-unreal-build`.
- **Game** deploys: empty channel → plain `linux`/`macos`/`windows`; set → suffix (`itch_channel: dev` → `linux-dev`/`macos-dev`/`windows-dev`). Windows now hardcodes `windows` instead of inheriting the old `plugin` default.
- **Plugin** deploys: stable channel = `itch_channel` or `plugin_name` (no version suffix).

## Result (chuckrpg, beta = default)

| Config | itch_channel | Channels |
|---|---|---|
| beta (default) | _(none)_ | `linux` `macos` `windows` |
| dev | `dev` | `linux-dev` `macos-dev` `windows-dev` |
| plugins | _(none)_ | one channel per plugin (its name) |

Version is tracked via `buildNumber` / `--userversion`, not the channel.