### PR TITLE
fix(arpg-web): map dispatch to arpg:container-web nx target

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -101,7 +101,9 @@
 			"runner": "arc-runner-set",
 			"image": "kbve/arpg-web",
 			"deployment_yaml": "apps/kube/agones/arpg/manifests/web-deployment.yaml",
-			"has_test": false
+			"has_test": false,
+			"target": "container-web",
+			"nx_project": "arpg"
 		},
 		{
 			"key": "chisel_ubuntu_axum",
@@ -1209,7 +1211,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.30",
+			"version": "0.3.31",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
@@ -18,6 +18,8 @@ source_path: apps/agones/arpg/web
 version_toml: apps/agones/arpg/web/version.toml
 runner: arc-runner-set
 image: kbve/arpg-web
+nx_project: arpg
+target: container-web
 deployment_yaml: apps/kube/agones/arpg/manifests/web-deployment.yaml
 has_test: false
 author: h0lybyte


### PR DESCRIPTION
## Problem

CI - Docker / arpg-web failed (#13049):

```
NX  Cannot find configuration for task arpg-web:container
```

`ci-docker.yml` resolves the nx project from `app_name` and the target from the manifest, defaulting to `<app_name>:container`. But `arpg-web` has no standalone nx project — its container target lives on the `arpg` project as `container-web` (unlike `arpg-server`, which is its own `arpg-server` project with a default `container` target).

## Fix

- Add `nx_project: arpg` + `target: container-web` to `arpg-web.mdx` registry frontmatter.
- Regenerate `.github/ci-dispatch-manifest.json` (full regen also folds in the pending chuck `0.3.31` MDX bump).

Dispatch now runs `arpg:container-web`.

Closes #13049