### PR TITLE
ci(metrics-e2e): queue runs instead of cancelling in-progress

### DIFF
--- a/.github/workflows/ci-metrics-e2e.yml
+++ b/.github/workflows/ci-metrics-e2e.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
     group: metrics-e2e-${{ github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 jobs:
     # Fast per-PR gate: compile against the committed lockfile. Catches the


### PR DESCRIPTION
## Problem

`CI - Metrics E2E / cargo build --locked` shows up as `Cancelled after 3m`. The workflow's concurrency block uses `cancel-in-progress: true` on a per-ref group, so any new commit on the same PR kills the running `cargo build --locked` mid-flight — a flaky-looking cancel rather than a real failure.

## Fix

Set `cancel-in-progress: false`. The active run finishes, and the next run queues behind it in the same group. No more mid-build cancels.