### PR TITLE
perf(jobboard): code-split routes + local footer

### DIFF
--- a/apps/jobboard/web/src/components/Footer.tsx
+++ b/apps/jobboard/web/src/components/Footer.tsx
@@ -1,0 +1,25 @@
+const LINKS = [
+	{ label: 'About', url: 'https://kbve.com/about/' },
+	{ label: 'Legal', url: 'https://kbve.com/legal/' },
+	{ label: 'Discord', url: 'https://kbve.com/discord/' },
+];
+
+export function Footer() {
+	return (
+		<footer className="flex flex-col items-center gap-2 py-12">
+			<div className="flex gap-6">
+				{LINKS.map((link) => (
+					<a
+						key={link.url}
+						href={link.url}
+						target="_blank"
+						rel="noreferrer"
+						className="text-xs text-quest-400 transition hover:text-quest-300">
+						{link.label}
+					</a>
+				))}
+			</div>
+			<span className="text-xs text-zinc-500">© KBVE</span>
+		</footer>
+	);
+}

--- a/apps/jobboard/web/src/router.tsx
+++ b/apps/jobboard/web/src/router.tsx
@@ -3,6 +3,7 @@ import {
 	createRootRoute,
 	createRoute,
 	createRouter,
+	lazyRouteComponent,
 	Outlet,
 	redirect,
 	useNavigate,
@@ -27,15 +28,34 @@ import {
 import { queryClient } from './lib/queryClient';
 import { HomePage } from './routes/home';
 import { GigsPage } from './routes/gigs';
-import { GigDetailPage } from './routes/gig-detail';
 import { TalentPage } from './routes/talent';
-import { TalentProfilePage } from './routes/talent-profile';
-import { PostGigPage } from './routes/post-gig';
-import { LoginPage } from './routes/login';
-import { ApplyPage } from './routes/apply';
-import { DashboardPage } from './routes/dashboard';
 import { NavBar } from './components/NavBar';
-import { Footer } from '@kbve/rn/ui';
+import { Footer } from './components/Footer';
+
+const GigDetailPage = lazyRouteComponent(
+	() => import('./routes/gig-detail'),
+	'GigDetailPage',
+);
+const TalentProfilePage = lazyRouteComponent(
+	() => import('./routes/talent-profile'),
+	'TalentProfilePage',
+);
+const PostGigPage = lazyRouteComponent(
+	() => import('./routes/post-gig'),
+	'PostGigPage',
+);
+const LoginPage = lazyRouteComponent(
+	() => import('./routes/login'),
+	'LoginPage',
+);
+const ApplyPage = lazyRouteComponent(
+	() => import('./routes/apply'),
+	'ApplyPage',
+);
+const DashboardPage = lazyRouteComponent(
+	() => import('./routes/dashboard'),
+	'DashboardPage',
+);
 
 const GAME_DEV_ID = 1;
 
@@ -293,11 +313,20 @@ const routeTree = rootRoute.addChildren([
 	accountRoute,
 ]);
 
+function RoutePending() {
+	return (
+		<div className="flex min-h-[40vh] items-center justify-center">
+			<div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-700 border-t-quest-400" />
+		</div>
+	);
+}
+
 export const router = createRouter({
 	routeTree,
 	defaultViewTransition: true,
 	defaultPreload: 'intent',
 	defaultPreloadStaleTime: 0,
+	defaultPendingComponent: RoutePending,
 });
 
 declare module '@tanstack/react-router' {


### PR DESCRIPTION
## What
Bundle/load-perf pass. Every route was statically imported → the whole app shipped as one **1.47 MB** entry chunk (gz 432 KB).

## Changes
- **Lazy-load non-landing routes** via `lazyRouteComponent`: dashboard, talent-profile, post-gig, apply, login, gig-detail. Keep home/gigs/talent eager (the landing/browse path).
- Route **loaders stay eager** → data still prefetches while the component chunk loads; `defaultPreload: 'intent'` warms chunks on hover; added a minimal `defaultPendingComponent` for direct/deep-link loads.
- **Local DOM `Footer`** replaces the `@kbve/rn/ui` one (it pulled react-native-web into the shell).

## Result (gzip)
- Entry chunk **1.47 MB → 369 KB** (gz **432 → 113 KB**).
- Eager first-load JS (preloaded entry + AuthGate + ui + link) **~432 → ~334 KB (~23%)**.
- Deferred to navigation: dashboard (82 KB), forms (10 KB), apply/post/login/gig-detail/talent-profile (~15 KB) — landing visitors no longer download them.

## Honest ceiling
The remaining eager `AuthGate` chunk (597 KB raw / 177 KB gz) is **react-native-web + reanimated + supabase-js**, pulled by the app-wide `ThemeProvider`/`ToastViewport`/`OverlayHost` (from `@kbve/rn/ui`) + `KbveProvider`. Those wrap every page, so RN-web can't be deferred without replacing the shell providers with local DOM — a larger, separate effort. This PR captures the route-splitting win without that risk.

## Testing
`tsc --noEmit` clean; `npm run build` EXIT 0.