### PR TITLE
fix(kube): wire SUPABASE_ANON_KEY into n8n + grafana gates

### DIFF
--- a/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
+++ b/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
@@ -55,6 +55,11 @@ spec:
                             secretKeyRef:
                                 name: grafana-gate-supabase-jwt
                                 key: SUPABASE_JWT_SECRET
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: grafana-gate-supabase-jwt
+                                key: anon-key
                       - name: RUST_LOG
                         value: 'info'
                   resources:

--- a/apps/kube/monitoring/manifests/grafana-gate-externalsecret.yaml
+++ b/apps/kube/monitoring/manifests/grafana-gate-externalsecret.yaml
@@ -49,11 +49,16 @@ spec:
             engineVersion: v2
             data:
                 SUPABASE_JWT_SECRET: '{{ .jwt_secret }}'
+                anon-key: '{{ .anonkey }}'
     data:
         - secretKey: jwt_secret
           remoteRef:
               key: supabase-jwt
               property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -217,6 +217,11 @@ spec:
                             secretKeyRef:
                                 name: n8n-gate-supabase-jwt
                                 key: SUPABASE_JWT_SECRET
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: n8n-gate-supabase-jwt
+                                key: anon-key
                       - name: RUST_LOG
                         value: 'info'
                   resources:

--- a/apps/kube/n8n/manifest/n8n-externalsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-externalsecret.yaml
@@ -68,11 +68,16 @@ spec:
             engineVersion: v2
             data:
                 SUPABASE_JWT_SECRET: '{{ .jwt_secret }}'
+                anon-key: '{{ .anonkey }}'
     data:
         - secretKey: jwt_secret
           remoteRef:
               key: supabase-jwt
               property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
 ---
 # n8n-encryption-secret: Run ../seal-encryption-key.sh before first deployment.
 # The script generates a random key, seals it via kubeseal, and writes


### PR DESCRIPTION
## Problem

`n8n.kbve.com` (and grafana gate) return **502 on every valid login** — Cloudflare `error code: 502`. Reproduced: bad token → 401, valid token → 502.

Behind CF the gate's real error is:
```
authz backend: is_staff 401 Unauthorized → {"message":"Unauthorized","request_id":"..."}
```

## Root cause

When `SUPABASE_ANON_KEY` is unset, the gate falls back to sending the **minted service_role JWT as the `apikey` header** (`gate/auth.rs:278`). Supabase Kong `key-auth` is an **exact string match** against the configured anon key (`kong-config.yaml`), so a freshly-minted JWT never matches → Kong **401** → gate maps non-5xx to **502** (`gate/proxy.rs:366`) → CF shows `error code: 502`.

PR #12990 fixed the `SUPABASE_URL` DNS (kong:8000) which let the request *reach* Kong, exposing this next layer. Both gate deployments were missing `SUPABASE_ANON_KEY` entirely.

## Fix

Source `anon-key` from the existing `supabase-jwt` secret (property `anon-key` — the same string Kong validates against) via the gate ExternalSecrets, and set `SUPABASE_ANON_KEY` on both gate containers.

- `n8n`: externalsecret + deployment
- `grafana-gate` (monitoring): externalsecret + deployment

RBAC already grants `get` on `supabase-jwt`; anon-key is a property of that same secret, so no RBAC change.

## Notes

- ArgoCD tracks `main`; reaches cluster after the dev→main release.
- n8n app currently also OutOfSync/Degraded on unrelated redis resources (separate issue).