### PR TITLE
feat(gh-sync): archive+lock on close + one-shot backfill for already-closed issues

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -174,7 +174,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.20",
+			"version": "0.1.21",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",

--- a/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
@@ -163,6 +163,11 @@ async fn run_loop(
     cfg: GhSyncConfig,
 ) {
     let routes: Arc<RwLock<RoutingTable>> = Arc::new(RwLock::new(RoutingTable::default()));
+
+    if backfill_on_start_enabled() {
+        backfill_closed_threads(&store, &http).await;
+    }
+
     loop {
         tokio::time::sleep(cfg.poll).await;
 
@@ -430,41 +435,138 @@ async fn comment_is_mirrored(store: &Arc<GithubStore>, ev: &UndeliveredEvent) ->
     }
 }
 
-/// Mirror GitHub issue state onto the forum thread (close→archive,
-/// reopen→unarchive). Event-driven only (never a reconcile loop), so a human
-/// who manually re-opens a thread is not repeatedly re-archived. Best-effort:
-/// missing MANAGE_THREADS or any HTTP error logs + returns without failing the
+fn lock_on_close_enabled() -> bool {
+    matches!(
+        std::env::var("GH_SYNC_LOCK_ON_CLOSE").ok().as_deref(),
+        Some("1") | Some("true") | Some("on")
+    )
+}
+
+fn backfill_on_start_enabled() -> bool {
+    matches!(
+        std::env::var("GH_SYNC_BACKFILL_ON_START").ok().as_deref(),
+        Some("1") | Some("true") | Some("on")
+    )
+}
+
+/// One-shot reverse-sync reconcile run at worker start when
+/// `GH_SYNC_BACKFILL_ON_START` is set. Archives (and locks, if
+/// `GH_SYNC_LOCK_ON_CLOSE`) the threads of issues that are already closed —
+/// these closed before VS6 was live so no `closed` webhook will ever fire for
+/// them. Idempotent against already-archived threads. Best-effort; unset the
+/// env after a clean run so a restart does not re-archive a thread a human has
+/// since manually reopened.
+async fn backfill_closed_threads(store: &Arc<GithubStore>, http: &Arc<serenity::Http>) {
+    const CAP: u32 = 1000;
+    let rows = match store.list_closed_issue_threads(CAP).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "gh sync: backfill list_closed_issue_threads failed");
+            return;
+        }
+    };
+    if rows.is_empty() {
+        info!("gh sync: backfill — no closed-issue threads to reconcile");
+        return;
+    }
+    warn!(
+        count = rows.len(),
+        "gh sync: BACKFILL running — archiving closed-issue threads; unset GH_SYNC_BACKFILL_ON_START after this completes"
+    );
+    for issue in &rows {
+        set_thread_archived(http, issue, true).await;
+    }
+    if rows.len() as u32 == CAP {
+        warn!(
+            cap = CAP,
+            "gh sync: backfill hit cap — more closed threads may remain, rerun"
+        );
+    }
+    info!(archived = rows.len(), "gh sync: backfill complete");
+}
+
+/// Mirror GitHub issue state onto the forum thread (close→archive[+lock],
+/// reopen→unarchive+unlock). Event-driven only (never a reconcile loop), so a
+/// human who manually re-opens a thread is not repeatedly re-archived.
+///
+/// On close the archive and lock are SEPARATE best-effort calls: the archive
+/// lands first, then (if `GH_SYNC_LOCK_ON_CLOSE`) a second call re-asserts
+/// archived + adds the lock, so a lock failure (e.g. missing MANAGE_THREADS)
+/// never costs us the archive. All steps log + continue without failing the
 /// event delivery.
 async fn set_thread_archived(http: &Arc<serenity::Http>, issue: &CachedIssue, archived: bool) {
     let Some(thread_id) = issue.discord_thread_id else {
         return;
     };
-    let lock_on_close = archived
-        && matches!(
-            std::env::var("GH_SYNC_LOCK_ON_CLOSE").ok().as_deref(),
-            Some("1") | Some("true") | Some("on")
-        );
-    let mut builder = EditThread::new().archived(archived);
-    if lock_on_close {
-        builder = builder.locked(true);
-    } else if !archived {
-        builder = builder.locked(false);
-    }
     let thread = serenity::ChannelId::new(thread_id as u64);
+
+    if !archived {
+        // Reopen: unarchive + unlock in one call.
+        edit_thread_step(
+            http,
+            thread,
+            EditThread::new().archived(false).locked(false),
+            issue.number,
+            thread_id,
+            "unarchive",
+        )
+        .await;
+        return;
+    }
+
+    // Close: archive first so it lands even if a later lock is rejected.
+    let archived_ok = edit_thread_step(
+        http,
+        thread,
+        EditThread::new().archived(true),
+        issue.number,
+        thread_id,
+        "archive",
+    )
+    .await;
+
+    // Then try to lock (re-assert archived so the thread stays archived).
+    if archived_ok && lock_on_close_enabled() {
+        edit_thread_step(
+            http,
+            thread,
+            EditThread::new().archived(true).locked(true),
+            issue.number,
+            thread_id,
+            "lock",
+        )
+        .await;
+    }
+}
+
+async fn edit_thread_step(
+    http: &Arc<serenity::Http>,
+    thread: serenity::ChannelId,
+    builder: EditThread<'_>,
+    number: u32,
+    thread_id: i64,
+    step: &str,
+) -> bool {
     match thread.edit_thread(&**http, builder).await {
-        Ok(_) => debug!(
-            number = issue.number,
-            thread = thread_id,
-            archived,
-            "gh sync: thread lifecycle updated"
-        ),
-        Err(e) => warn!(
-            error = %e,
-            number = issue.number,
-            thread = thread_id,
-            archived,
-            "gh sync: thread lifecycle update failed (missing MANAGE_THREADS?)"
-        ),
+        Ok(_) => {
+            debug!(
+                number,
+                thread = thread_id,
+                step,
+                "gh sync: thread lifecycle step ok"
+            );
+            true
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                number,
+                thread = thread_id,
+                step,
+                "gh sync: thread lifecycle step failed (missing MANAGE_THREADS?)"
+            );
+            false
+        }
     }
 }
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.20"
+version: "0.1.21"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -115,6 +115,17 @@ spec:
                         value: '935690630657638422'
                       - name: RELAY_IRC_CHANNEL
                         value: '#general'
+                      # gh reverse-sync VS6: on issue close, archive the forum
+                      # thread then lock it (needs the bot to have MANAGE_THREADS).
+                      - name: GH_SYNC_LOCK_ON_CLOSE
+                        value: 'true'
+                      # One-shot backfill: archive/lock threads for issues that
+                      # were ALREADY closed before VS6 shipped (no webhook fires
+                      # for them). Runs once at worker start. UNSET this after a
+                      # clean run so restarts don't re-archive manually-reopened
+                      # threads.
+                      - name: GH_SYNC_BACKFILL_ON_START
+                        value: 'true'
                   resources:
                       requests:
                           memory: '256Mi'

--- a/packages/data/sql/dbmate/migrations/20260622090000_gh_list_closed_threads.sql
+++ b/packages/data/sql/dbmate/migrations/20260622090000_gh_list_closed_threads.sql
@@ -1,0 +1,41 @@
+-- migrate:up
+
+SET search_path = '';
+
+-- Enumerate closed issues that still have a linked Discord thread, for the
+-- one-shot reverse-sync backfill (archive/lock threads whose issues were closed
+-- before VS6 thread-lifecycle shipped — those never got a `closed` webhook).
+-- Reuses the existing gh_issue_discord_thread_unique partial index.
+CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
+RETURNS SETOF gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 500
+COST 50
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL
+    ORDER BY owner, repo, number
+    LIMIT LEAST(GREATEST(p_limit, 1), 2000);
+$$;
+
+ALTER FUNCTION gh.list_closed_issue_threads(INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
+
+COMMENT ON FUNCTION gh.list_closed_issue_threads(INT) IS
+'Closed issues that still carry a discord_thread_id, ordered (owner,repo,number), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+SET search_path = '';
+
+DROP FUNCTION IF EXISTS gh.list_closed_issue_threads(INT);
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/gh/gh_list_closed_threads.sql
+++ b/packages/data/sql/schema/gh/gh_list_closed_threads.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- GH LIST CLOSED THREADS — enumerate closed issues that still have a linked
+--                          Discord thread, for the one-shot reverse-sync
+--                          backfill (archive/lock threads for issues closed
+--                          before VS6 thread-lifecycle shipped).
+--
+-- Reference mirror of the dbmate migration
+-- (../../dbmate/migrations/20260622090000_gh_list_closed_threads.sql).
+-- Hand-authored review surface — do not run directly; promote changes into a
+-- new dbmate migration when ready. Depends on gh_core.sql.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
+RETURNS SETOF gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 500
+COST 50
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL
+    ORDER BY owner, repo, number
+    LIMIT LEAST(GREATEST(p_limit, 1), 2000);
+$$;
+
+ALTER FUNCTION gh.list_closed_issue_threads(INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
+
+COMMENT ON FUNCTION gh.list_closed_issue_threads(INT) IS
+'Closed issues that still carry a discord_thread_id, ordered (owner,repo,number), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -326,6 +326,35 @@ impl GithubStore {
         Ok(rows)
     }
 
+    /// Closed issues that still carry a `discord_thread_id`, for the one-shot
+    /// reverse-sync backfill (archive/lock threads whose issues closed before
+    /// VS6 thread-lifecycle shipped). Not cached — a startup sweep, not a
+    /// hot path.
+    pub async fn list_closed_issue_threads(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<CachedIssue>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_limit": limit });
+        let resp = client
+            .rpc_schema("list_closed_issue_threads", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, "gh.list_closed_issue_threads HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        let rows: Vec<CachedIssue> = serde_json::from_str(&text)?;
+        info!(count = rows.len(), "gh.list_closed_issue_threads");
+        Ok(rows)
+    }
+
     pub async fn set_discord_thread(
         &self,
         owner: &str,


### PR DESCRIPTION
Follow-up to the bidirectional sync (#13008/#13046). Fixes two VS6 thread-lifecycle gaps.

## 1. Archive-then-lock (sequential, best-effort)
On issue close, archive and lock are now **separate** `edit_thread` calls — the archive lands first, then a second call re-asserts archived + adds the lock. A lock failure (or missing MANAGE_THREADS) no longer costs the archive. Reopen unarchives + unlocks. Enabled via `GH_SYNC_LOCK_ON_CLOSE=true`.

## 2. One-shot backfill for already-closed issues
VS6 is event-driven, so issues closed **before** it shipped never got a `closed` webhook → their threads stayed open. New:
- `gh.list_closed_issue_threads(limit)` RPC — closed issues that still carry a `discord_thread_id` (the DB knows exactly which; no GitHub walk).
- `GH_SYNC_BACKFILL_ON_START=true` runs a one-shot sweep at worker start, archiving/locking those threads. Idempotent; logs a loud reminder to **unset the flag after a clean run** so restarts don't re-archive a thread a human manually reopened.

## Files
- migration `20260622090000_gh_list_closed_threads` (+ schema mirror)
- `kbve/github_store.rs`: `list_closed_issue_threads`
- `gh_sync.rs`: sequential archive/lock + backfill
- deployment: `GH_SYNC_LOCK_ON_CLOSE=true`, `GH_SYNC_BACKFILL_ON_START=true`
- discordsh-bot `0.1.20 → 0.1.21` (+ manifest regen)

## Verification
- RPC applied/asserted/rolled-back on the kilobase image (returns only closed+threaded; excludes open-with-thread and closed-without-thread).
- `cargo check` + `clippy -D warnings` (both kbve feature paths) clean; gh tests pass.

## Deploy ordering / ops
- **Apply the migration to prod BEFORE the 0.1.21 image rolls** (backfill calls the new RPC; otherwise it logs + skips until applied).
- Bot needs **MANAGE_THREADS** in the guild for archive/lock to take effect (else best-effort skip).
- **Unset `GH_SYNC_BACKFILL_ON_START`** after the first clean run.