### PR TITLE
fix(astro-kbve): stop refresh-token stampede that randomly logs users out

### DIFF
--- a/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
@@ -54,7 +54,7 @@ class AuthBridge {
 			auth: {
 				storage: this.storage, // Critical: same storage as worker!
 				persistSession: true,
-				autoRefreshToken: true,
+				autoRefreshToken: false,
 				detectSessionInUrl: true, // Important for OAuth redirects
 			},
 		});

--- a/apps/kbve/astro-kbve/src/lib/idb-cache.ts
+++ b/apps/kbve/astro-kbve/src/lib/idb-cache.ts
@@ -18,7 +18,7 @@ function sharedWorkerBackend(): CacheBackend | null {
 	try {
 		const worker = new SharedWorker(
 			new URL('../workers/supabase.shared.ts', import.meta.url),
-			{ type: 'module' },
+			{ type: 'module', name: 'supabase-shared' },
 		);
 		port = worker.port;
 	} catch {

--- a/apps/kbve/astro-kbve/src/lib/supabase-shared.ts
+++ b/apps/kbve/astro-kbve/src/lib/supabase-shared.ts
@@ -15,7 +15,7 @@ export class SupaShared {
 		// Use Vite's native worker import syntax
 		this.worker = new SharedWorker(
 			new URL('../workers/supabase.shared.ts', import.meta.url),
-			{ type: 'module' },
+			{ type: 'module', name: 'supabase-shared' },
 		);
 		this.port = this.worker.port;
 		this.port.onmessage = (e) => this.onMessage(e.data);


### PR DESCRIPTION
## Problem

Random sign-outs on kbve.com (esp. Safari): logged in, then "out of nowhere" logged out; sometimes login is broken until Safari is fully quit and reopened.

## Root cause

The session in IndexedDB `sb-auth-v2` is shared by **multiple Supabase clients in different JS realms**, all with `autoRefreshToken: true`:

1. Main-thread **AuthBridge** window client — `AuthBridge.ts`
2. Gateway **SharedWorker** client — `workers/supabase.shared.ts`
3. A **second SharedWorker** spawned by the realtime worker via `SupaShared` (`Realtime.worker.ts` → `lib/supabase-shared.ts`)

Supabase refresh tokens are single-use/rotating. supabase-js dedupes concurrent refreshes only with an **in-memory lock per client realm**, and the cross-realm `navigator.locks` fallback is unavailable/unreliable in Safari workers. As a token nears expiry, several contexts fire `grant_type=refresh_token` together — the first rotates the token, the rest present the consumed token and get **"Invalid Refresh Token: Already Used"**. The losing client's `onAuthStateChange` emits `SIGNED_OUT` and broadcasts `session: null` to every tab → logged-in user flips to logged-out.

On Safari the error storm + concurrent IDB writes also **wedges the module SharedWorker**, which lives for the whole browser session (survives tab reloads), so login stays broken until Safari is fully quit — matching the reported symptom.

The db-worker design comment already states the intent: *"the SharedWorker is the single auth writer to IndexedDB."* The window client and the duplicate worker violated it.

## Fix (minimal — single-writer invariant)

- **AuthBridge window client → `autoRefreshToken: false`.** Still performs OAuth sign-in + the callback session write; the SharedWorker is the sole refresher for `sb-auth-v2`. `DirectStrategy` keeps auto-refresh on (it is the only client in the no-worker fallback).
- **Name every `SharedWorker` construction `'supabase-shared'`** (`SupaShared`, `idb-cache`) so the browser coalesces them with the gateway worker into one instance instead of competing refreshers.

3 files, 3 lines.

## Verify

- Log into kbve.com (Safari + Chrome), leave idle past access-token expiry (~1h), confirm session persists and no spurious logout.
- Check console/network: no `400 Invalid Refresh Token: Already Used` on `/auth/v1/token`.
- Confirm only one `supabase-shared` SharedWorker in devtools.