### PR TITLE
feat(jobboard): lightweight DOM skeleton loaders

### DIFF
--- a/apps/jobboard/web/src/components/ui.tsx
+++ b/apps/jobboard/web/src/components/ui.tsx
@@ -53,6 +53,23 @@ export function Spinner({ label }: { label?: string }) {
 	);
 }
 
+export function Skeleton({
+	width = '100%',
+	height = 14,
+	radius = 6,
+}: {
+	width?: number | string;
+	height?: number;
+	radius?: number;
+}) {
+	return (
+		<div
+			className="animate-pulse bg-zinc-800"
+			style={{ width, height, borderRadius: radius }}
+		/>
+	);
+}
+
 export function Stars({
 	value,
 	count,

--- a/apps/jobboard/web/src/layout/BrowseView.tsx
+++ b/apps/jobboard/web/src/layout/BrowseView.tsx
@@ -1,13 +1,7 @@
 import { useEffect, useState } from 'react';
 import { View } from 'react-native';
-import {
-	Stack,
-	PressableSurface,
-	Text,
-	Badge,
-	Skeleton,
-	tokens,
-} from '@kbve/rn/ui';
+import { Stack, PressableSurface, Text, Badge, tokens } from '@kbve/rn/ui';
+import { Skeleton } from '../components/ui';
 import { fetchVerticals, type Vertical } from '../api/client';
 
 export function BrowseView({

--- a/apps/jobboard/web/src/layout/Profile.tsx
+++ b/apps/jobboard/web/src/layout/Profile.tsx
@@ -1,6 +1,7 @@
 import { View } from 'react-native';
-import { Stack, Text, Badge, Avatar, Skeleton, tokens } from '@kbve/rn/ui';
+import { Stack, Text, Badge, Avatar, tokens } from '@kbve/rn/ui';
 import { useApiResource } from '@kbve/rn/auth';
+import { Skeleton } from '../components/ui';
 import { Coins, Gem } from 'lucide-react';
 import { Panel } from '../ui/Panel';
 

--- a/apps/jobboard/web/src/layout/RightPanel.tsx
+++ b/apps/jobboard/web/src/layout/RightPanel.tsx
@@ -5,10 +5,10 @@ import {
 	Text,
 	Badge,
 	Avatar,
-	Skeleton,
 	PressableSurface,
 	tokens,
 } from '@kbve/rn/ui';
+import { Skeleton } from '../components/ui';
 import { Phone, Video, MessageSquare } from 'lucide-react';
 import { Panel } from '../ui/Panel';
 import { fetchTaxonomy, type TaxonomyItem, type Vertical } from '../api/client';

--- a/apps/jobboard/web/src/router.tsx
+++ b/apps/jobboard/web/src/router.tsx
@@ -31,6 +31,7 @@ import { GigsPage } from './routes/gigs';
 import { TalentPage } from './routes/talent';
 import { NavBar } from './components/NavBar';
 import { Footer } from './components/Footer';
+import { Skeleton } from './components/ui';
 
 const GigDetailPage = lazyRouteComponent(
 	() => import('./routes/gig-detail'),
@@ -315,8 +316,19 @@ const routeTree = rootRoute.addChildren([
 
 function RoutePending() {
 	return (
-		<div className="flex min-h-[40vh] items-center justify-center">
-			<div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-700 border-t-quest-400" />
+		<div className="mx-auto max-w-5xl space-y-6 px-6 py-8">
+			<Skeleton width="40%" height={28} />
+			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{Array.from({ length: 6 }).map((_, i) => (
+					<div
+						key={i}
+						className="space-y-3 rounded-xl border border-zinc-800 p-4">
+						<Skeleton width="60%" height={18} />
+						<Skeleton width="100%" />
+						<Skeleton width="80%" />
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## What
Lightweight skeleton placeholders that swap out once content loads.

- New local DOM `Skeleton` (CSS `animate-pulse`, no react-native-web / reanimated) in `components/ui.tsx` — `width`/`height`/`radius` props matching the prior `@kbve/rn/ui` API.
- **Route pending fallback** upgraded from a bare spinner to a page skeleton (header + card grid) — lazy-route navigation now shows layout-shaped placeholders instead of a spinner.
- Repointed `RightPanel` / `BrowseView` / `Profile` off the `@kbve/rn/ui` `Skeleton` (which pulls reanimated) to the local one.

## Notes
- Eager set unchanged (Skeleton is tiny DOM).
- Brief auth/transition spinners (dashboard gate, vetting fetch) stay as spinners — they're not content loads.
- Stacks conceptually on the localized `components/ui.tsx` from #13062 (merged).

## Testing
`tsc --noEmit` clean; `npm run build` EXIT 0.