### PR TITLE
fix(rn): revert supabase worker-fetch — broke OAuth PKCE exchange

### DIFF
--- a/packages/npm/rn/src/auth/supabase.web.ts
+++ b/packages/npm/rn/src/auth/supabase.web.ts
@@ -1,41 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 import type { AuthSession } from '@kbve/core';
-import { createWorkerPool } from '../worker/pool';
-
-const NULL_BODY_STATUS = new Set([204, 205, 304]);
-
-function createWorkerFetch(): typeof fetch {
-	const pool = createWorkerPool();
-	return async (input, init) => {
-		const body = init?.body;
-		if (
-			input instanceof Request ||
-			(body != null && typeof body !== 'string')
-		)
-			return fetch(input, init);
-
-		const url = typeof input === 'string' ? input : input.toString();
-		const headers: Record<string, string> = {};
-		new Headers(init?.headers).forEach((value, key) => {
-			headers[key] = value;
-		});
-
-		const raw = await pool.fetchRaw(url, {
-			method: init?.method,
-			headers,
-			body: body ?? undefined,
-		});
-		return new Response(
-			NULL_BODY_STATUS.has(raw.status) ? null : raw.body,
-			{
-				status: raw.status,
-				statusText: raw.statusText,
-				headers: raw.headers,
-			},
-		);
-	};
-}
 
 export function createSupabaseClient(config: SupabaseConfig): SupabaseClient {
 	return createClient(config.url, config.anonKey, {
@@ -47,7 +12,6 @@ export function createSupabaseClient(config: SupabaseConfig): SupabaseClient {
 			detectSessionInUrl: true,
 			flowType: 'pkce',
 		},
-		global: { fetch: createWorkerFetch() },
 	});
 }
 


### PR DESCRIPTION
## Bug
Social login (GitHub/Discord/Twitch) is broken on web: after the provider returns with `?code=…`, the PKCE code-exchange never completes — the page hangs on `/?code=…` and no session is established.

## Cause
#13045 routed **all** web supabase HTTP through the worker via a `global.fetch` shim (worker `fetchRaw` + main-thread `Response` reconstruction). The OAuth PKCE exchange (`POST /auth/v1/token?grant_type=pkce`, run by `detectSessionInUrl` on return) does not survive the Comlink round-trip + reconstructed `Response`, so the session is never created.

Confirmed by local repro: disabling the shim → GitHub login completes and forwards to the dashboard.

## Fix
Revert supabase to supabase-js's **default fetch**. The auth/rest/rpc payloads are tiny and infrequent, so the off-thread benefit never justified breaking a critical path. The worker still handles the real wins — IndexedDB cache, jobboard's own REST pool (`api/client`), and `@kbve/rn` `pooledApi`.

The worker `fetchRaw` primitive stays (now unused, harmless) for potential future use.

## Testing
- `npm run build` EXIT 0.
- ⚠️ `tsc --noEmit` reports 2 **pre-existing** errors unrelated to this change (a zod 3/4 version-type mismatch surfaced by `npm ci`, and a `VettingView` inference issue) — verified identical with this change stashed; the production build tolerates them.
- Local: GitHub OAuth → dashboard works with the shim removed.

Note for local dev: `apps/jobboard/web` is standalone npm — run `npm ci` in it before `npm run dev` or vite loads the wrong `@vitejs/plugin-react`.