### PR TITLE
fix(jobboard): align web zod to 4.3.6, clears typecheck errors

### DIFF
--- a/apps/jobboard/web/package-lock.json
+++ b/apps/jobboard/web/package-lock.json
@@ -31,7 +31,7 @@
 				"react-native-web": "^0.21.2",
 				"react-native-worklets": "0.8.3",
 				"typegpu": "0.11.8",
-				"zod": "^4.4.3"
+				"zod": "4.3.6"
 			},
 			"devDependencies": {
 				"@tailwindcss/vite": "^4.1.3",
@@ -9035,9 +9035,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/apps/jobboard/web/package.json
+++ b/apps/jobboard/web/package.json
@@ -33,7 +33,7 @@
 		"react-native-web": "^0.21.2",
 		"react-native-worklets": "0.8.3",
 		"typegpu": "0.11.8",
-		"zod": "^4.4.3"
+		"zod": "4.3.6"
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.1.3",


### PR DESCRIPTION
## Bug
`tsc --noEmit` in `apps/jobboard/web` reported 3 errors:
- `api/client.ts` — ZodObject not assignable (`version.minor '3' is not assignable to '4'`)
- `VettingView.tsx` — `'app' is of type 'unknown'` + downstream assignment error

## Cause
Single root cause: a **zod version split**. web pinned `^4.4.3` (resolved 4.4.3), but the rest of the monorepo — including `@kbve/jobboard-schema`'s `import { z } from 'zod'`, which resolves the **root 4.3.6** — used 4.3.6. zod v4 brands its types with `version.minor`, so a 4.3.6 schema isn't assignable to a 4.4.3 `ZodType`. `parseJson(...)` / `z.array(AdminApplicationSchema)` failed, and the broken generic cascaded into `VettingView` (`parseJson` fell back to `unknown`).

## Fix
Pin web `zod` to `4.3.6` to match root. One version → types align.

## Testing
- `tsc --noEmit` → **0 errors**.
- `npm run build` EXIT 0.

(Surfaced earlier because the worktree's `npm ci` installed web's own lockfile zod 4.4.3; root-hoisted resolution had masked it.)