### PR TITLE
perf(rn): defer react-native-web off the jobboard eager bundle

### DIFF
--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -1,4 +1,3 @@
-import 'react-native-url-polyfill/auto';
 import { StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';

--- a/packages/npm/rn/src/auth/AuthSafeArea.tsx
+++ b/packages/npm/rn/src/auth/AuthSafeArea.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export function AuthSafeArea({ children }: { children: ReactNode }) {
+	return <SafeAreaProvider>{children}</SafeAreaProvider>;
+}

--- a/packages/npm/rn/src/auth/AuthSafeArea.web.tsx
+++ b/packages/npm/rn/src/auth/AuthSafeArea.web.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export function AuthSafeArea({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/packages/npm/rn/src/auth/KbveProvider.tsx
+++ b/packages/npm/rn/src/auth/KbveProvider.tsx
@@ -1,7 +1,5 @@
 import { createContext, useContext, useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { AppState } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import {
 	AuthStore,
 	authCore,
@@ -13,6 +11,8 @@ import type { KbveApi } from '@kbve/core';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseClient, mapSession } from './supabase';
 import { createSupabaseAuthExecutor } from './executor';
+import { useAutoRefresh } from './useAutoRefresh';
+import { AuthSafeArea } from './AuthSafeArea';
 import { createChatExecutor } from '../chat/executor';
 import { createWorkerPool } from '../worker/pool';
 import type { WorkerPool } from '../worker/types';
@@ -113,29 +113,14 @@ export function KbveProvider({
 		return () => data.subscription.unsubscribe();
 	}, [value]);
 
-	useEffect(() => {
-		const { client } = value;
-		const refresh = (state: string) => {
-			if (state === 'active') {
-				client.auth.startAutoRefresh();
-			} else {
-				client.auth.stopAutoRefresh();
-			}
-		};
-		refresh(AppState.currentState);
-		const subscription = AppState.addEventListener('change', refresh);
-		return () => {
-			subscription.remove();
-			client.auth.stopAutoRefresh();
-		};
-	}, [value]);
+	useAutoRefresh(value.client);
 
 	return (
-		<SafeAreaProvider>
+		<AuthSafeArea>
 			<KbveContext.Provider value={value}>
 				{children}
 			</KbveContext.Provider>
-		</SafeAreaProvider>
+		</AuthSafeArea>
 	);
 }
 

--- a/packages/npm/rn/src/auth/useAutoRefresh.ts
+++ b/packages/npm/rn/src/auth/useAutoRefresh.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export function useAutoRefresh(client: SupabaseClient): void {
+	useEffect(() => {
+		const refresh = (state: string) => {
+			if (state === 'active') {
+				client.auth.startAutoRefresh();
+			} else {
+				client.auth.stopAutoRefresh();
+			}
+		};
+		refresh(AppState.currentState);
+		const subscription = AppState.addEventListener('change', refresh);
+		return () => {
+			subscription.remove();
+			client.auth.stopAutoRefresh();
+		};
+	}, [client]);
+}

--- a/packages/npm/rn/src/auth/useAutoRefresh.web.ts
+++ b/packages/npm/rn/src/auth/useAutoRefresh.web.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export function useAutoRefresh(client: SupabaseClient): void {
+	useEffect(() => {
+		const refresh = () => {
+			if (document.visibilityState === 'visible') {
+				client.auth.startAutoRefresh();
+			} else {
+				client.auth.stopAutoRefresh();
+			}
+		};
+		refresh();
+		document.addEventListener('visibilitychange', refresh);
+		return () => {
+			document.removeEventListener('visibilitychange', refresh);
+			client.auth.stopAutoRefresh();
+		};
+	}, [client]);
+}


### PR DESCRIPTION
## What
Final lever from the bundle initiative — get react-native-web fully off the eager landing path.

Two eager importers were dragging all of react-native-web into the entry chunk:

1. **`KbveProvider`** imported `AppState` (react-native) for foreground auto-refresh and wrapped children in `SafeAreaProvider`. Split both into platform helpers:
   - `useAutoRefresh` — `.web` uses `document` `visibilitychange`; native uses `AppState`.
   - `AuthSafeArea` — `.web` is a passthrough; native is `SafeAreaProvider`.
   The shared `KbveProvider` now imports no `react-native`.
2. **`main.tsx`** imported `react-native-url-polyfill/auto`, whose only effect is `import {Platform} from 'react-native'` + a `Platform.OS !== 'web'` check (a no-op on web). Browsers have native `URL`, so it's dropped.

## Result (sourcemap-verified)
- **Zero** react-native / reanimated / expo modules in the eager index chunk.
- react-native-web now loads only with the routes that use it (dashboard, login) — landing/browse visitors never download it.
- Eager index ≈ **208 KB gz** (was ~265 with RN-web inside).

## Testing
- `npm run build` EXIT 0; eager preload = index only.
- ⚠️ `tsc --noEmit` reports the 2 **pre-existing** zod-version errors fixed by the open #13072 (not from this change) — clean once that merges.

Native unchanged (`useAutoRefresh.ts`/`AuthSafeArea.tsx` keep `AppState`/`SafeAreaProvider`).