### PR TITLE
feat(arpg-web): Diablo II-style HUD (orbs + translucent minimap, i18n)

### DIFF
--- a/apps/agones/arpg/web/src/game/ReactIsoArpgApp.tsx
+++ b/apps/agones/arpg/web/src/game/ReactIsoArpgApp.tsx
@@ -2,9 +2,16 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import Phaser from 'phaser';
 import { IsoArpgScene } from './IsoArpgScene';
 import ArpgHud from './ArpgHud';
+import D2Hud from './ui/D2Hud';
 import ArpgMenu from './ArpgMenu';
 import ChatPanel from './ChatPanel';
-import { COLORS, DEBUG_HUD, DEBUG_LOCAL_PLAYER, resolveWsUrl } from './config';
+import {
+	COLORS,
+	DEBUG_HUD,
+	DEBUG_LOCAL_PLAYER,
+	USE_D2_HUD,
+	resolveWsUrl,
+} from './config';
 import { buildNetConfig, getNetConfig, setNetConfig } from './net-config';
 import { authBridge } from '../lib/auth';
 import {
@@ -304,7 +311,11 @@ export default function ReactIsoArpgApp({
 	if (phase === 'ready') {
 		return (
 			<>
-				<ArpgHud debug={DEBUG_HUD} />
+				{USE_D2_HUD ? (
+					<D2Hud debug={DEBUG_HUD} />
+				) : (
+					<ArpgHud debug={DEBUG_HUD} />
+				)}
 				<ArpgMenu />
 				{!DEBUG_LOCAL_PLAYER && <ChatPanel />}
 			</>

--- a/apps/agones/arpg/web/src/game/config.ts
+++ b/apps/agones/arpg/web/src/game/config.ts
@@ -122,6 +122,10 @@ export const DEBUG_SPAWN_TILE = { x: 12, y: 12 };
 // Flip off for release; the compass + vitals panels render regardless.
 export const DEBUG_HUD = true;
 
+export const USE_D2_HUD =
+	((import.meta.env.PUBLIC_ARPG_D2_HUD as string | undefined) ?? 'true') !==
+	'false';
+
 export const WS_URL_FALLBACK = 'wss://arpg.kbve.com/ws';
 
 export const resolveWsUrl = makeWsResolver(

--- a/apps/agones/arpg/web/src/game/ui/D2Hud.tsx
+++ b/apps/agones/arpg/web/src/game/ui/D2Hud.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { I18nProvider, useTranslation } from '@kbve/laser';
+import type { InventoryItem } from '@kbve/laser';
+import {
+	onHud,
+	onHudClear,
+	onInventory,
+	onInventoryOpen,
+	type HudState,
+} from '../systems/hud';
+import { loadItemMeta, type ItemMeta } from '../entities/itemMeta';
+import { registerArpgI18n } from './i18n';
+import { StatOrb, useWavePhase, type OrbStat } from './orbs/StatOrb';
+import { Minimap } from './minimap/Minimap';
+import { Tooltip } from './Tooltip';
+import {
+	InventoryBar,
+	InventoryPanel,
+	useInventoryDnd,
+} from './inventory/Inventory';
+
+const MUTED = '#9fb3d8';
+const TEXT_SHADOW = '0 1px 2px rgba(0,0,0,0.9)';
+
+registerArpgI18n();
+
+function useItemMeta(): Map<string, ItemMeta> {
+	const [meta, setMeta] = useState<Map<string, ItemMeta>>(() => new Map());
+	useEffect(() => {
+		let alive = true;
+		void loadItemMeta().then((m) => {
+			if (alive) setMeta(m);
+		});
+		return () => {
+			alive = false;
+		};
+	}, []);
+	return meta;
+}
+
+/**
+ * Diablo II-style HUD: HP/MP orb globes anchored bottom-left, EP/SP globes
+ * bottom-right, inventory hotbar centered between them, a translucent round
+ * minimap top-right, and the compass bottom-center. All strings flow through
+ * the shared @kbve/laser i18n store.
+ */
+export default function D2Hud({ debug = false }: { debug?: boolean }) {
+	return (
+		<I18nProvider>
+			<D2HudInner debug={debug} />
+		</I18nProvider>
+	);
+}
+
+function D2HudInner({ debug }: { debug: boolean }) {
+	const [hud, setHud] = useState<HudState | null>(null);
+	const [inv, setInv] = useState<InventoryItem[]>([]);
+	const [open, setOpen] = useState(false);
+	const meta = useItemMeta();
+	const dnd = useInventoryDnd(inv.length);
+
+	useEffect(() => {
+		const off = onHud(setHud);
+		const offInv = onInventory(setInv);
+		const offOpen = onInventoryOpen(setOpen);
+		const offClear = onHudClear(() => {
+			setHud(null);
+			setInv([]);
+			setOpen(false);
+		});
+		return () => {
+			off();
+			offInv();
+			offOpen();
+			offClear();
+		};
+	}, []);
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				inset: 0,
+				pointerEvents: 'none',
+				fontFamily: 'monospace',
+				color: '#e6ebf5',
+				zIndex: 15,
+				overflow: 'hidden',
+			}}>
+			{hud && (
+				<>
+					<OrbFlank
+						corner="left"
+						orbs={[
+							orb('hp', hud.hp, hud.maxHp, [
+								'#fb7185',
+								'#ef4444',
+								'#7f1d1d',
+							]),
+							orb('mp', hud.mp, hud.maxMp, [
+								'#60a5fa',
+								'#3b82f6',
+								'#1e3a8a',
+							]),
+						]}
+					/>
+					<OrbFlank
+						corner="right"
+						orbs={[
+							orb('ep', hud.ep, hud.maxEp, [
+								'#fde047',
+								'#eab308',
+								'#854d0e',
+							]),
+							orb('sp', hud.sp, hud.maxSp, [
+								'#4ade80',
+								'#22c55e',
+								'#14532d',
+							]),
+						]}
+					/>
+					<div
+						style={{
+							position: 'absolute',
+							top: 14,
+							right: 14,
+						}}>
+						<Minimap
+							map={hud.map}
+							tile={hud.tile}
+							headingDeg={hud.headingDeg}
+						/>
+					</div>
+					<InventoryBar items={inv} meta={meta} dnd={dnd} />
+					{open && (
+						<InventoryPanel items={inv} meta={meta} dnd={dnd} />
+					)}
+					{debug && <DebugReadout fps={hud.fps} tile={hud.tile} />}
+				</>
+			)}
+			<Tooltip />
+		</div>
+	);
+}
+
+function orb(
+	key: OrbStat['key'],
+	cur: number,
+	max: number,
+	fluid: [string, string, string],
+): OrbStat {
+	return { key, cur, max, fluid };
+}
+
+/** A bottom-corner pair of orbs flanking the screen edge, D2-style. */
+function OrbFlank({
+	corner,
+	orbs,
+}: {
+	corner: 'left' | 'right';
+	orbs: OrbStat[];
+}) {
+	const phase = useWavePhase();
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				bottom: 14,
+				[corner]: 14,
+				display: 'flex',
+				flexDirection: 'row',
+				gap: 4,
+			}}>
+			{orbs.map((o, i) => (
+				<StatOrb key={o.key} stat={o} phase={phase + i * 1.7} />
+			))}
+		</div>
+	);
+}
+
+function DebugReadout({
+	fps,
+	tile,
+}: {
+	fps: number;
+	tile: { x: number; y: number };
+}): ReactElement {
+	const { t } = useTranslation();
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				top: 14,
+				left: 14,
+				padding: '5px 9px',
+				fontSize: 10,
+				lineHeight: 1.6,
+				color: MUTED,
+				textShadow: TEXT_SHADOW,
+				background: 'rgba(10,13,20,0.4)',
+				borderRadius: 4,
+			}}>
+			<div>{t('arpg.debug.fps', { fps })}</div>
+			<div>{t('arpg.debug.tile', { x: tile.x, y: tile.y })}</div>
+		</div>
+	);
+}

--- a/apps/agones/arpg/web/src/game/ui/Tooltip.tsx
+++ b/apps/agones/arpg/web/src/game/ui/Tooltip.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { onTooltip, type TooltipState } from '../systems/hud';
+import { PixelPanel } from '../PixelPanel';
+
+const ACCENT = '#fcd34d';
+const TEXT = '#e6ebf5';
+const MUTED = '#9fb3d8';
+const TEXT_SHADOW = '0 1px 2px rgba(0,0,0,0.9)';
+
+/** Global HUD tooltip floated near the pointer, clamped into the viewport. */
+export function Tooltip(): ReactElement | null {
+	const [tip, setTip] = useState<TooltipState | null>(null);
+	useEffect(() => onTooltip(setTip), []);
+	if (!tip) return null;
+	const left = Math.min(tip.x + 14, window.innerWidth - 150);
+	const top = Math.min(tip.y + 14, window.innerHeight - 90);
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				left,
+				top,
+				zIndex: 40,
+				pointerEvents: 'none',
+			}}>
+			<PixelPanel
+				variant="slate"
+				scale={2}
+				style={{ padding: '6px 9px' }}>
+				<div
+					style={{
+						fontSize: 11,
+						fontWeight: 700,
+						color: ACCENT,
+						textShadow: TEXT_SHADOW,
+						marginBottom: 3,
+						whiteSpace: 'nowrap',
+					}}>
+					{tip.title}
+				</div>
+				{tip.lines.map((l, i) => (
+					<div
+						key={i}
+						style={{
+							fontSize: 10,
+							color: i === 0 ? TEXT : MUTED,
+							textShadow: TEXT_SHADOW,
+							whiteSpace: 'nowrap',
+						}}>
+						{l}
+					</div>
+				))}
+			</PixelPanel>
+		</div>
+	);
+}

--- a/apps/agones/arpg/web/src/game/ui/i18n/en.ts
+++ b/apps/agones/arpg/web/src/game/ui/i18n/en.ts
@@ -1,0 +1,33 @@
+import type { LocaleMessages } from '@kbve/laser';
+
+export const ARPG_I18N_NS = 'arpg';
+
+export const en: LocaleMessages = {
+	'arpg.hud.hp.label': 'HP',
+	'arpg.hud.hp.name': 'Health',
+	'arpg.hud.mp.label': 'MP',
+	'arpg.hud.mp.name': 'Mana',
+	'arpg.hud.ep.label': 'EP',
+	'arpg.hud.ep.name': 'Energy',
+	'arpg.hud.sp.label': 'SP',
+	'arpg.hud.sp.name': 'Stamina',
+	'arpg.hud.orb.value': '{cur} / {max}',
+	'arpg.hud.orb.pct': '{pct}%',
+
+	'arpg.hud.minimap.title': 'Map',
+
+	'arpg.inventory.title': 'Inventory',
+	'arpg.inventory.empty': 'Empty — walk over loot to pick it up.',
+	'arpg.inventory.hint':
+		'Drag to reorder · double-click to use · 1-9 hotkeys',
+	'arpg.inventory.useTitle': 'Use {name} · drag to organize',
+	'arpg.inventory.dropFloor': 'Drag here to drop to the floor',
+
+	'arpg.compass.n': 'N',
+	'arpg.compass.e': 'E',
+	'arpg.compass.s': 'S',
+	'arpg.compass.w': 'W',
+
+	'arpg.debug.fps': '{fps} fps',
+	'arpg.debug.tile': '{x},{y}',
+};

--- a/apps/agones/arpg/web/src/game/ui/i18n/index.ts
+++ b/apps/agones/arpg/web/src/game/ui/i18n/index.ts
@@ -1,0 +1,12 @@
+import { laserI18n } from '@kbve/laser';
+import { en } from './en';
+
+let registered = false;
+
+export function registerArpgI18n(): void {
+	if (registered) return;
+	laserI18n.add('en', en);
+	registered = true;
+}
+
+export { en };

--- a/apps/agones/arpg/web/src/game/ui/inventory/Inventory.tsx
+++ b/apps/agones/arpg/web/src/game/ui/inventory/Inventory.tsx
@@ -1,0 +1,404 @@
+import { useState, type DragEvent, type ReactElement } from 'react';
+import { useTranslation } from '@kbve/laser';
+import type { InventoryItem } from '@kbve/laser';
+import { emitInventoryIntent } from '../../systems/hud';
+import { PixelPanel } from '../../PixelPanel';
+import { rarityColor, type ItemMeta } from '../../entities/itemMeta';
+
+const ACCENT = '#fcd34d';
+const MUTED = '#9fb3d8';
+const TEXT_SHADOW = '0 1px 2px rgba(0,0,0,0.9)';
+
+interface SlotDnd {
+	draggable: boolean;
+	onDragStart: (e: DragEvent<HTMLDivElement>) => void;
+	onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+	onDrop: (e: DragEvent<HTMLDivElement>) => void;
+}
+
+export interface InventoryDnd {
+	drag: number | null;
+	floorHot: boolean;
+	slotProps: (i: number, hasItem: boolean) => SlotDnd;
+	floorProps: {
+		onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+		onDragLeave: () => void;
+		onDrop: (e: DragEvent<HTMLDivElement>) => void;
+	};
+	outsideDrop: (e: DragEvent<HTMLDivElement>) => void;
+	endDrag: () => void;
+}
+
+export function useInventoryDnd(itemCount: number): InventoryDnd {
+	const [drag, setDrag] = useState<number | null>(null);
+	const [floorHot, setFloorHot] = useState(false);
+	const endDrag = () => {
+		setDrag(null);
+		setFloorHot(false);
+	};
+	const dropToFloor = (index: number | null) => {
+		if (index != null) emitInventoryIntent({ type: 'drop', index });
+		endDrag();
+	};
+	return {
+		drag,
+		floorHot,
+		endDrag,
+		slotProps: (i, hasItem) => ({
+			draggable: hasItem,
+			onDragStart: (e) => {
+				setDrag(i);
+				e.dataTransfer.effectAllowed = 'move';
+				e.dataTransfer.setData('text/plain', String(i));
+			},
+			onDragOver: (e) => {
+				if (drag != null) e.preventDefault();
+			},
+			onDrop: (e) => {
+				e.preventDefault();
+				if (drag != null && drag !== i) {
+					const to = Math.min(i, itemCount - 1);
+					emitInventoryIntent({ type: 'reorder', from: drag, to });
+				}
+				endDrag();
+			},
+		}),
+		floorProps: {
+			onDragOver: (e) => {
+				if (drag != null) {
+					e.preventDefault();
+					setFloorHot(true);
+				}
+			},
+			onDragLeave: () => setFloorHot(false),
+			onDrop: (e) => {
+				e.preventDefault();
+				dropToFloor(drag);
+			},
+		},
+		outsideDrop: (e) => {
+			if (drag != null && e.dataTransfer.dropEffect === 'none') {
+				dropToFloor(drag);
+			} else {
+				endDrag();
+			}
+		},
+	};
+}
+
+function ItemIcon({
+	meta,
+	itemRef,
+	size,
+}: {
+	meta?: ItemMeta;
+	itemRef: string;
+	size: number;
+}): ReactElement {
+	if (meta?.img) {
+		return (
+			<img
+				src={meta.img}
+				alt={meta.name ?? itemRef}
+				width={size}
+				height={size}
+				style={{ imageRendering: 'pixelated', display: 'block' }}
+			/>
+		);
+	}
+	if (meta?.emoji) {
+		return (
+			<span style={{ fontSize: size, lineHeight: 1 }}>{meta.emoji}</span>
+		);
+	}
+	return (
+		<span
+			style={{
+				fontSize: size * 0.5,
+				fontWeight: 700,
+				color: MUTED,
+				textShadow: TEXT_SHADOW,
+			}}>
+			{itemRef.slice(0, 2).toUpperCase()}
+		</span>
+	);
+}
+
+export function InventoryBar({
+	items,
+	meta,
+	dnd,
+}: {
+	items: InventoryItem[];
+	meta: Map<string, ItemMeta>;
+	dnd: InventoryDnd;
+}): ReactElement | null {
+	const { t } = useTranslation();
+	if (items.length === 0) return null;
+	const slots = items.slice(0, 9);
+	return (
+		<div
+			onDragEnd={dnd.endDrag}
+			style={{
+				position: 'absolute',
+				bottom: 14,
+				left: '50%',
+				transform: 'translateX(-50%)',
+				display: 'flex',
+				gap: 6,
+			}}>
+			{slots.map((it, i) => {
+				const m = meta.get(it.ref);
+				const slot = dnd.slotProps(i, true);
+				return (
+					<PixelPanel
+						key={it.ref}
+						variant="slate"
+						scale={2}
+						onClick={() =>
+							emitInventoryIntent({ type: 'use', index: i })
+						}
+						title={t('arpg.inventory.useTitle', {
+							name: m?.name ?? it.ref,
+						})}
+						draggable={slot.draggable}
+						onDragStart={slot.onDragStart}
+						onDragOver={slot.onDragOver}
+						onDrop={slot.onDrop}
+						style={{
+							minWidth: 58,
+							padding: '5px 8px 7px',
+							textAlign: 'center',
+							pointerEvents: 'auto',
+							cursor: 'grab',
+							opacity: dnd.drag === i ? 0.4 : 1,
+						}}>
+						<div
+							style={{
+								fontSize: 9,
+								color: ACCENT,
+								textShadow: TEXT_SHADOW,
+								opacity: 0.85,
+							}}>
+							{i + 1}
+						</div>
+						<div
+							style={{
+								height: 22,
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}>
+							<ItemIcon meta={m} itemRef={it.ref} size={20} />
+						</div>
+						<div
+							style={{
+								fontSize: 9,
+								color: rarityColor(m?.rarity),
+								textShadow: TEXT_SHADOW,
+								whiteSpace: 'nowrap',
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								maxWidth: 58,
+							}}>
+							{m?.name ?? it.ref}
+						</div>
+						<div
+							style={{
+								fontSize: 11,
+								fontWeight: 700,
+								color: ACCENT,
+								textShadow: TEXT_SHADOW,
+							}}>
+							×{it.count}
+						</div>
+					</PixelPanel>
+				);
+			})}
+		</div>
+	);
+}
+
+const GRID_COLS = 6;
+const MIN_SLOTS = 24;
+
+export function InventoryPanel({
+	items,
+	meta,
+	dnd,
+}: {
+	items: InventoryItem[];
+	meta: Map<string, ItemMeta>;
+	dnd: InventoryDnd;
+}): ReactElement {
+	const { t } = useTranslation();
+	const { drag, floorHot } = dnd;
+	const slotCount = Math.max(
+		MIN_SLOTS,
+		Math.ceil(items.length / GRID_COLS) * GRID_COLS,
+	);
+
+	return (
+		<div
+			onDragEnd={dnd.outsideDrop}
+			style={{
+				position: 'absolute',
+				inset: 0,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(2,3,6,0.45)',
+				pointerEvents: 'auto',
+			}}>
+			<PixelPanel
+				variant="gold"
+				scale={3}
+				style={{ width: 380, padding: '14px 16px 18px' }}>
+				<div
+					style={{
+						fontSize: 14,
+						fontWeight: 700,
+						color: ACCENT,
+						textShadow: TEXT_SHADOW,
+						letterSpacing: 0.5,
+						marginBottom: 12,
+						textAlign: 'center',
+					}}>
+					{t('arpg.inventory.title')}
+				</div>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)`,
+						gap: 6,
+					}}>
+					{Array.from({ length: slotCount }, (_, i) => {
+						const it = items[i];
+						const m = it ? meta.get(it.ref) : undefined;
+						const isDragging = drag === i;
+						const slot = dnd.slotProps(i, !!it);
+						return (
+							<div
+								key={i}
+								draggable={slot.draggable}
+								title={it ? (m?.name ?? it.ref) : undefined}
+								onDragStart={slot.onDragStart}
+								onDragOver={slot.onDragOver}
+								onDrop={slot.onDrop}
+								onDoubleClick={() => {
+									if (it)
+										emitInventoryIntent({
+											type: 'use',
+											index: i,
+										});
+								}}
+								style={{
+									position: 'relative',
+									minHeight: 64,
+									padding: '6px 4px',
+									borderRadius: 4,
+									background: it
+										? 'rgba(0,0,0,0.35)'
+										: 'rgba(0,0,0,0.18)',
+									border: `1px solid ${
+										it
+											? `${rarityColor(m?.rarity)}55`
+											: 'rgba(120,140,180,0.18)'
+									}`,
+									textAlign: 'center',
+									cursor: it ? 'grab' : 'default',
+									opacity: isDragging ? 0.4 : 1,
+								}}>
+								{it && i < 9 && (
+									<span
+										style={{
+											position: 'absolute',
+											top: 2,
+											left: 4,
+											fontSize: 9,
+											color: ACCENT,
+											textShadow: TEXT_SHADOW,
+											opacity: 0.85,
+										}}>
+										{i + 1}
+									</span>
+								)}
+								{it && (
+									<>
+										<div
+											style={{
+												height: 24,
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'center',
+												marginTop: 4,
+											}}>
+											<ItemIcon
+												meta={m}
+												itemRef={it.ref}
+												size={22}
+											/>
+										</div>
+										<div
+											style={{
+												fontSize: 8,
+												color: rarityColor(m?.rarity),
+												textShadow: TEXT_SHADOW,
+												marginTop: 3,
+												wordBreak: 'break-word',
+											}}>
+											{m?.name ?? it.ref}
+										</div>
+										<div
+											style={{
+												fontSize: 10,
+												fontWeight: 700,
+												color: ACCENT,
+												textShadow: TEXT_SHADOW,
+											}}>
+											×{it.count}
+										</div>
+									</>
+								)}
+							</div>
+						);
+					})}
+				</div>
+
+				<div
+					onDragOver={dnd.floorProps.onDragOver}
+					onDragLeave={dnd.floorProps.onDragLeave}
+					onDrop={dnd.floorProps.onDrop}
+					style={{
+						marginTop: 10,
+						padding: '8px 0',
+						borderRadius: 4,
+						border: `1px dashed ${floorHot ? '#f87171' : 'rgba(160,120,120,0.5)'}`,
+						background: floorHot
+							? 'rgba(248,113,113,0.18)'
+							: 'rgba(0,0,0,0.2)',
+						color: floorHot ? '#fca5a5' : MUTED,
+						textShadow: TEXT_SHADOW,
+						textAlign: 'center',
+						fontSize: 10,
+					}}>
+					🗑 {t('arpg.inventory.dropFloor')}
+				</div>
+
+				<div
+					style={{
+						marginTop: 10,
+						fontSize: 9,
+						color: MUTED,
+						textShadow: TEXT_SHADOW,
+						textAlign: 'center',
+						opacity: 0.8,
+					}}>
+					{items.length === 0
+						? t('arpg.inventory.empty')
+						: t('arpg.inventory.hint')}
+				</div>
+			</PixelPanel>
+		</div>
+	);
+}

--- a/apps/agones/arpg/web/src/game/ui/minimap/Minimap.tsx
+++ b/apps/agones/arpg/web/src/game/ui/minimap/Minimap.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+import type { HudMap } from '../../systems/hud';
+
+const MINIMAP_PX = 168;
+const FLOOR_COLOR = '#5a6c8c';
+const ROOM_GLOW = '#7e93b8';
+
+/**
+ * D2-style translucent minimap overlay: the floor bitset painted as lit cells
+ * over a faint void, player pinned center with a heading wedge. No solid panel
+ * frame — a soft rounded glass plate so the scene reads through it.
+ */
+export function Minimap({
+	map,
+	tile,
+	headingDeg,
+}: {
+	map: HudMap;
+	tile: { x: number; y: number };
+	headingDeg: number;
+}) {
+	const ref = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = ref.current;
+		if (!canvas) return;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		const { size, cells, origin } = map;
+		const cell = MINIMAP_PX / size;
+
+		ctx.clearRect(0, 0, MINIMAP_PX, MINIMAP_PX);
+
+		ctx.fillStyle = FLOOR_COLOR;
+		for (let j = 0; j < size; j++) {
+			for (let i = 0; i < size; i++) {
+				if (!cells[j * size + i]) continue;
+				ctx.fillRect(
+					Math.floor(i * cell),
+					Math.floor(j * cell),
+					Math.ceil(cell),
+					Math.ceil(cell),
+				);
+			}
+		}
+
+		const pcx = (tile.x - origin.x + 0.5) * cell;
+		const pcy = (tile.y - origin.y + 0.5) * cell;
+
+		ctx.save();
+		ctx.translate(pcx, pcy);
+		ctx.rotate(((headingDeg - 90) * Math.PI) / 180);
+		ctx.fillStyle = ROOM_GLOW;
+		ctx.beginPath();
+		ctx.moveTo(8, 0);
+		ctx.lineTo(-5, -5);
+		ctx.lineTo(-5, 5);
+		ctx.closePath();
+		ctx.fill();
+		ctx.restore();
+
+		ctx.fillStyle = '#fcd34d';
+		ctx.beginPath();
+		ctx.arc(pcx, pcy, 3, 0, Math.PI * 2);
+		ctx.fill();
+	}, [map, tile.x, tile.y, headingDeg]);
+
+	return (
+		<div
+			style={{
+				width: MINIMAP_PX,
+				height: MINIMAP_PX,
+				borderRadius: '50%',
+				overflow: 'hidden',
+				background: 'rgba(10,13,20,0.32)',
+				boxShadow:
+					'inset 0 0 0 2px rgba(180,200,230,0.28), 0 2px 10px rgba(0,0,0,0.5)',
+				backdropFilter: 'blur(1px)',
+			}}>
+			<canvas
+				ref={ref}
+				width={MINIMAP_PX}
+				height={MINIMAP_PX}
+				style={{
+					display: 'block',
+					imageRendering: 'pixelated',
+					opacity: 0.92,
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/agones/arpg/web/src/game/ui/orbs/StatOrb.tsx
+++ b/apps/agones/arpg/web/src/game/ui/orbs/StatOrb.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from '@kbve/laser';
+import { emitTooltip } from '../../systems/hud';
+
+export interface OrbStat {
+	key: 'hp' | 'mp' | 'ep' | 'sp';
+	cur: number;
+	max: number;
+	fluid: [string, string, string];
+}
+
+const TEXT = '#e6ebf5';
+const MUTED = '#9fb3d8';
+
+const WAVE_AMP = 2.2;
+
+export function useWavePhase(): number {
+	const [phase, setPhase] = useState(0);
+	useEffect(() => {
+		let raf = 0;
+		let start = 0;
+		const tick = (t: number) => {
+			if (!start) start = t;
+			setPhase(((t - start) / 1000) * 2.2);
+			raf = requestAnimationFrame(tick);
+		};
+		raf = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(raf);
+	}, []);
+	return phase;
+}
+
+function fluidPath(level: number, phase: number, size: number): string {
+	const steps = 10;
+	let d = `M 0 ${size}`;
+	for (let i = 0; i <= steps; i++) {
+		const x = (i / steps) * size;
+		const y =
+			level +
+			Math.sin(phase + (i / steps) * Math.PI * 2) * WAVE_AMP +
+			Math.sin(phase * 1.6 + (i / steps) * Math.PI * 4) *
+				(WAVE_AMP * 0.4);
+		d += ` L ${x.toFixed(2)} ${y.toFixed(2)}`;
+	}
+	d += ` L ${size} ${size} Z`;
+	return d;
+}
+
+export function StatOrb({
+	stat,
+	phase,
+	size = 72,
+}: {
+	stat: OrbStat;
+	phase: number;
+	size?: number;
+}) {
+	const { t } = useTranslation();
+	const { key, cur, max, fluid } = stat;
+	const pct = max > 0 ? Math.max(0, Math.min(1, cur / max)) : 0;
+	const r = size / 2;
+	const level = size * (1 - pct);
+	const clipId = useMemo(() => `orb-${key}`, [key]);
+	const path = pct > 0 ? fluidPath(level, phase, size) : '';
+	const label = t(`arpg.hud.${key}.label`);
+	const name = t(`arpg.hud.${key}.name`);
+
+	const show = (e: { clientX: number; clientY: number }) => {
+		emitTooltip({
+			x: e.clientX,
+			y: e.clientY,
+			title: name,
+			lines: [
+				t('arpg.hud.orb.value', {
+					cur: Math.round(cur),
+					max: Math.round(max),
+				}),
+				t('arpg.hud.orb.pct', { pct: Math.round(pct * 100) }),
+			],
+		});
+	};
+	const hide = () => emitTooltip(null);
+
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox={`0 0 ${size} ${size}`}
+			onPointerEnter={show}
+			onPointerMove={show}
+			onPointerLeave={hide}
+			onTouchStart={(e) => {
+				const tch = e.touches[0];
+				if (tch) show({ clientX: tch.clientX, clientY: tch.clientY });
+			}}
+			onTouchEnd={hide}
+			style={{
+				display: 'block',
+				overflow: 'visible',
+				pointerEvents: 'auto',
+				cursor: 'pointer',
+			}}>
+			<defs>
+				<clipPath id={clipId}>
+					<circle cx={r} cy={r} r={r - 1.5} />
+				</clipPath>
+				<radialGradient id={`${clipId}-g`} cx="50%" cy="35%" r="75%">
+					<stop offset="0%" stopColor={fluid[0]} />
+					<stop offset="55%" stopColor={fluid[1]} />
+					<stop offset="100%" stopColor={fluid[2]} />
+				</radialGradient>
+			</defs>
+			<circle cx={r} cy={r} r={r - 1.5} fill="rgba(6,9,16,0.78)" />
+			<g clipPath={`url(#${clipId})`}>
+				{pct > 0 && (
+					<>
+						<path d={path} fill={`url(#${clipId}-g)`} />
+						<path
+							d={path}
+							fill="none"
+							stroke={fluid[0]}
+							strokeWidth={1.5}
+							opacity={0.85}
+						/>
+					</>
+				)}
+				<ellipse
+					cx={r * 0.68}
+					cy={r * 0.5}
+					rx={r * 0.5}
+					ry={r * 0.3}
+					fill="rgba(255,255,255,0.32)"
+				/>
+				<circle
+					cx={r}
+					cy={r}
+					r={r - 1.5}
+					fill="none"
+					stroke="rgba(0,0,0,0.55)"
+					strokeWidth={3}
+				/>
+			</g>
+			<circle
+				cx={r}
+				cy={r}
+				r={r - 1.5}
+				fill="none"
+				stroke="rgba(180,200,230,0.55)"
+				strokeWidth={1.5}
+			/>
+			<text
+				x={r}
+				y={r + size * 0.28}
+				fill={MUTED}
+				fontSize={size * 0.13}
+				fontFamily="monospace"
+				textAnchor="middle"
+				dominantBaseline="central"
+				style={{
+					paintOrder: 'stroke',
+					stroke: 'rgba(0,0,0,0.85)',
+					strokeWidth: 2,
+				}}>
+				{Math.round(cur)}
+			</text>
+			<text
+				x={r}
+				y={size * 0.2}
+				fill={TEXT}
+				fontSize={size * 0.15}
+				fontWeight={700}
+				fontFamily="monospace"
+				textAnchor="middle"
+				dominantBaseline="central"
+				style={{
+					paintOrder: 'stroke',
+					stroke: 'rgba(0,0,0,0.85)',
+					strokeWidth: 2.5,
+				}}>
+				{label}
+			</text>
+		</svg>
+	);
+}


### PR DESCRIPTION
## What

Diablo II-style HUD for the standalone arpg-web client, built in an isolated `src/game/ui/` folder so the existing `ArpgHud` stays intact.

### Layout
- **HP / MP** orb globes anchored **bottom-left**
- **EP / SP** orb globes anchored **bottom-right**
- **Translucent round minimap** top-right (D2 'tab map' look, no heavy frame)
- Inventory hotbar centered between the orb flanks

### i18n
- All HUD strings flow through the shared `@kbve/laser` i18n store
- `ui/i18n/en.ts` arpg namespace, registered via `registerArpgI18n()`
- Components consume `useTranslation()` under an `I18nProvider`

### Wiring
- `USE_D2_HUD` flag (`PUBLIC_ARPG_D2_HUD`, default on)
- `ReactIsoArpgApp` swaps `D2Hud` / `ArpgHud` by flag — old HUD kept as fallback

## Verify
- `arpg-web:typecheck` ✅
- `arpg-web:build:app` ✅