### PR TITLE
fix(ci): plugin verify runs no longer cancel each other on PR push

### DIFF
--- a/.github/workflows/ci-unreal-plugins.yml
+++ b/.github/workflows/ci-unreal-plugins.yml
@@ -29,8 +29,8 @@ permissions:
     actions: write
 
 concurrency:
-    group: ci-unreal-plugins-${{ github.ref }}
-    cancel-in-progress: true
+    group: ci-unreal-plugins-${{ github.ref }}-${{ github.sha }}
+    cancel-in-progress: false
 
 jobs:
     discover:


### PR DESCRIPTION
## Problem

`CI - Unreal Plugins (verify)` runs get **Cancelled** on PRs — each new commit supersedes the in-progress run (`cancel-in-progress: true`). On a continuously-pushed PR this reads as flaky and the check never reaches green.

## Fix

- Concurrency group now includes `${{ github.sha }}` → each commit's run is isolated (nothing supersedes it).
- `cancel-in-progress: false` → runs complete instead of being killed.

Scoped to `packages/unreal/**` PRs, matrix is Linux+Win64 only (Linux autoscales, no mac in verify), so queued runs stay bounded.

Follow-up to the plugin pipeline work merged in #13061 (which added the `pull_request` verify trigger).