### PR TITLE
fix(kube/kyverno): sync-wave -1 fixes CRD-before-CR bootstrap race

### DIFF
--- a/apps/kube/kyverno/application.yaml
+++ b/apps/kube/kyverno/application.yaml
@@ -4,7 +4,7 @@ metadata:
     name: kyverno
     namespace: argocd
     annotations:
-        argocd.argoproj.io/sync-wave: '1'
+        argocd.argoproj.io/sync-wave: '-1'
 spec:
     project: default
     source:


### PR DESCRIPTION
## Problem (#13111)

Fresh-cluster bootstrap race. kyverno installed at `sync-wave: 1`, but the `ClusterPolicy` CRs in:
- `rows/manifest/rows-tenant-allocator-kyverno.yaml`
- `valkey/manifests/valkey-auth-sync-policy.yaml`
- `kilobase/manifests/dbmate-runner-kyverno-policy.yaml`

all sync at default wave `0`. CRs hit a missing CRD → those apps go `OutOfSync` until ArgoCD retries. Self-heals; steady-state unaffected.

## Fix

Move kyverno app to `sync-wave: -1`. CRD always lands before any consumer. Future-proof: new policy CRs need no per-app wave bumps.

Closes #13111