### PR TITLE
feat(kilobase): Kyverno operator-level delete-guard for CNPG supabase-cluster (#13082)

### DIFF
--- a/apps/kube/kilobase/manifests/cnpg-cluster-delete-guard-kyverno-policy.yaml
+++ b/apps/kube/kilobase/manifests/cnpg-cluster-delete-guard-kyverno-policy.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: kyverno:cnpg-cluster-read
+    labels:
+        rbac.kyverno.io/aggregate-to-admission-controller: 'true'
+        rbac.kyverno.io/aggregate-to-background-controller: 'true'
+        rbac.kyverno.io/aggregate-to-reports-controller: 'true'
+rules:
+    - apiGroups: ['postgresql.cnpg.io']
+      resources: ['clusters']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+    name: kilobase-cnpg-cluster-delete-guard
+    annotations:
+        policies.kyverno.io/title: kilobase-cnpg-cluster-delete-guard
+        policies.kyverno.io/category: Reliability
+        policies.kyverno.io/severity: critical
+        policies.kyverno.io/description: >-
+            Blocks DELETE of the supabase-cluster CNPG Cluster in the
+            kilobase namespace at the admission layer. The Cluster keeps
+            bootstrap.recovery (a DR-only restore from the S3 base backup
+            that runs on fresh creation). Argo already carries
+            Prune=false,Delete=false on the Cluster so GitOps cannot
+            delete + recreate it, but that guard is a sync-option only —
+            a manual kubectl delete (or namespace delete cascade) would
+            still re-trigger the recovery bootstrap and silently roll
+            production Postgres back to the last backup. This policy is
+            the operator-level second wall: even cluster-admin cannot
+            delete the Cluster CR without first removing or disabling
+            this policy. For an intentional DR rebuild, delete this
+            ClusterPolicy first, then the Cluster.
+spec:
+    validationFailureAction: Enforce
+    background: false
+    rules:
+        - name: block-delete-supabase-cluster
+          match:
+              any:
+                  - resources:
+                        kinds:
+                            - postgresql.cnpg.io/v1/Cluster
+                        names:
+                            - supabase-cluster
+                        namespaces:
+                            - kilobase
+                        operations:
+                            - DELETE
+          validate:
+              message: >-
+                  Deleting the supabase-cluster CNPG Cluster is blocked:
+                  it carries a DR-only bootstrap.recovery that would
+                  silently restore production from the last S3 base backup
+                  on recreate. For an intentional disaster-recovery
+                  rebuild, remove the kilobase-cnpg-cluster-delete-guard
+                  ClusterPolicy first, then delete the Cluster.
+              deny: {}


### PR DESCRIPTION
Closes #13082.

## Problem

`kilobase/manifests/postgres-cluster.yaml` keeps `bootstrap.recovery.source: kilobase-postgres-backup` (DR-only restore from the S3 base backup, runs on fresh Cluster creation). The Argo-driven recreate path was already closed in #12978 by adding `argocd.argoproj.io/sync-options: Prune=false,Delete=false` to the Cluster — verified live (`phase=healthy`, `3/3 ready`, annotation present).

Residual risk: that guard is a **sync-option only**. A manual `kubectl delete cluster` or a namespace delete cascade still re-triggers `bootstrap.recovery` → silent production rollback to the last backup. CNPG is operator-level, so the doc-comment guardrail in the manifest is the only thing standing between a stray delete and data loss.

> Note: the audit's alternative fix (switch `recovery` → `initdb`) is **worse** — on a real recreate it would produce an empty DB instead of restoring, destroying the DR path. The danger was accidental deletion, not the recovery stanza itself.

## Fix

`cnpg-cluster-delete-guard-kyverno-policy.yaml`:

- **ClusterPolicy `kilobase-cnpg-cluster-delete-guard`** (`Enforce`) — denies `DELETE` on `postgresql.cnpg.io/v1/Cluster` named `supabase-cluster` in `kilobase`. Even cluster-admin must remove the policy first → forces a deliberate action for an intentional DR rebuild (the documented escape hatch).
- **ClusterRole `kyverno:cnpg-cluster-read`** — `aggregate-to-{admission,background,reports}-controller` granting `get/list/watch` on cnpg clusters so the controllers can evaluate the rule (mirrors the `kyverno:valkey-auth-sync` pattern).

Defense in depth on top of #12978's GitOps guard.

## Validation

- `kubectl apply --dry-run=server` accepts both docs (Kyverno v1.18.0).
- RBAC warning in dry-run is expected — the aggregate ClusterRole isn't persisted in dry-run; it reconciles once both objects apply together.

Argo source for kilobase is a plain directory (`path: apps/kube/kilobase/manifests`), so the new file auto-applies — no kustomization wiring needed.

Refs #12978, audit #12973