### PR TITLE
fix(ci): post-publish version-label sync was a no-op on every deployment (#13122)

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -250,9 +250,7 @@ jobs:
                     OLD_TAG=$(grep -oP "image: ${IMAGE}:\K[^\s\"]+" "$FILE" | head -1 || echo "unknown")
 
                     sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${VERSION}|g" "$FILE"
-                    if [ "$OLD_TAG" != "unknown" ]; then
-                      sed -i "s|version: \"${OLD_TAG}\"|version: \"${VERSION}\"|g" "$FILE"
-                    fi
+                    sed -i -E "s|^([[:space:]]+)version: ['\"][^'\"]*['\"]|\1version: '${VERSION}'|g" "$FILE"
                     # Keep an APP_VERSION env (apps that surface a runtime version
                     # via /health) in sync with the image tag. No-op if absent.
                     if grep -q "name: APP_VERSION" "$FILE"; then

--- a/apps/kube/jobboard/manifest/jobboard-deployment.yaml
+++ b/apps/kube/jobboard/manifest/jobboard-deployment.yaml
@@ -19,7 +19,7 @@ spec:
                 rollout-restart: '2026-06-15T00:00:00Z'
             labels:
                 app: jobboard
-                version: '0.1.0'
+                version: '0.1.9'
         spec:
             serviceAccountName: jobboard-sa
             automountServiceAccountToken: false


### PR DESCRIPTION
Closes #13122. Audit item from #12973.

## Finding (broader than the issue title)

#13122 flagged jobboard's pod label `version: 0.1.0` vs image/env `0.1.9` as cosmetic. Tracing it down, the label-sync in `utils-post-publish.yml` has **never worked for any app**:

```sh
# line 254 (before)
sed -i "s|version: \"${OLD_TAG}\"|version: \"${VERSION}\"|g" "$FILE"
```

Two faults:
1. **Double quotes** — matches `version: "x"`, but every manifest is single-quoted by prettier (`version: 'x'`).
2. **Keyed on `${OLD_TAG}`** (the current image tag) — once a label drifts it no longer equals the image tag, so even with correct quotes it can't match.

So `image:` + `APP_VERSION` advanced while the label froze. Drift across the fleet:

| app | label | image |
|---|---|---|
| kbve | 1.0.22 | 1.0.207 |
| cryptothrone | 0.1.0 | 0.1.51 |
| jobboard | 0.1.0 | 0.1.9 |
| irc-gateway | 0.1.25 | 0.1.27 |
| metrics | 0.1.0 | 0.1.4 |

(memes/cityvote/rentearth/herbmail happen to match only because they haven't republished since the label was last hand-set.)

## Fix

```sh
# after — quote/value-agnostic, anchored to the indented label line
sed -i -E "s|^([[:space:]]+)version: ['\"][^'\"]*['\"]|\1version: '${VERSION}'|g" "$FILE"
```

- Matches single- or double-quoted, any current value.
- Leading-whitespace anchor leaves `apiVersion:` untouched (verified: `api` precedes `version`, not whitespace).
- Emits single quotes → prettier-stable.
- Verified on GNU sed (CI runtime, Ubuntu container): label rewritten, both `apiVersion:` lines untouched.

Also realigns jobboard's label to its current tag (`0.1.9`) so the named issue closes immediately. The other drifted apps self-heal on their next publish — not bumped here to avoid forcing unrelated pod restarts.

Refs #12973