### PR TITLE
feat(kilobase): PrometheusRule for backup/restore drill failures (#13107)

### DIFF
--- a/apps/kube/kilobase/manifests/backup-drill-alert.yaml
+++ b/apps/kube/kilobase/manifests/backup-drill-alert.yaml
@@ -1,0 +1,100 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: kilobase-backup-drills
+    namespace: kilobase
+    labels:
+        prometheus: kube-prometheus
+        role: alert-rules
+spec:
+    groups:
+        - name: kilobase-backup-drills.failures
+          rules:
+              - alert: BackupWatchdogJobFailed
+                annotations:
+                    summary: 'Backup watchdog drill job failed'
+                    description: |
+                        CronJob backup-watchdog (namespace kilobase) has a failed Job.
+                        The watchdog that verifies CNPG backups are fresh is itself
+                        failing — backup freshness is now unverified. Inspect:
+                        kubectl logs -n kilobase job/{{ $labels.job_name }}
+                expr: |
+                    kube_job_status_failed{namespace="kilobase",job_name=~"backup-watchdog.*"} > 0
+                for: 5m
+                labels:
+                    severity: warning
+
+              - alert: BackupRestoreDrillJobFailed
+                annotations:
+                    summary: 'CNPG restore fire-drill failed'
+                    description: |
+                        CronJob backup-restore-test (namespace kilobase) has a failed Job.
+                        The drill that restores prod from S3 and asserts data integrity
+                        is failing — disaster-recovery restore capability is unproven.
+                        Inspect: kubectl logs -n kilobase job/{{ $labels.job_name }}
+                expr: |
+                    kube_job_status_failed{namespace="kilobase",job_name=~"backup-restore-test.*"} > 0
+                for: 5m
+                labels:
+                    severity: critical
+
+              - alert: S3HealthcheckJobFailed
+                annotations:
+                    summary: 'S3 backup-store healthcheck failed'
+                    description: |
+                        CronJob s3-healthcheck (namespace crossplane-system) has a failed
+                        Job. The object store backing CNPG barman backups may be
+                        unreachable or misconfigured. Inspect:
+                        kubectl logs -n crossplane-system job/{{ $labels.job_name }}
+                expr: |
+                    kube_job_status_failed{namespace="crossplane-system",job_name=~"s3-healthcheck.*"} > 0
+                for: 10m
+                labels:
+                    severity: warning
+
+        - name: kilobase-backup-drills.success
+          rules:
+              - alert: BackupWatchdogNoRecentSuccess
+                annotations:
+                    summary: 'Backup watchdog has no recent successful run'
+                    description: |
+                        backup-watchdog (daily) has not completed successfully in 48h, or
+                        has never succeeded. The drill that verifies CNPG backup freshness
+                        is not producing a healthy result — backup freshness is unverified.
+                expr: |
+                    absent(kube_cronjob_status_last_successful_time{namespace="kilobase",cronjob="backup-watchdog"})
+                    or
+                    time() - kube_cronjob_status_last_successful_time{namespace="kilobase",cronjob="backup-watchdog"} > 172800
+                for: 1h
+                labels:
+                    severity: warning
+
+              - alert: BackupRestoreDrillNoRecentSuccess
+                annotations:
+                    summary: 'CNPG restore fire-drill has no recent successful run'
+                    description: |
+                        backup-restore-test (weekly) has not completed successfully in 14d,
+                        or has never succeeded. Covers a wedged drill too: with
+                        concurrencyPolicy Forbid, a hung Job blocks all future runs while
+                        emitting neither success nor failure. DR restore is unproven.
+                expr: |
+                    absent(kube_cronjob_status_last_successful_time{namespace="kilobase",cronjob="backup-restore-test"})
+                    or
+                    time() - kube_cronjob_status_last_successful_time{namespace="kilobase",cronjob="backup-restore-test"} > 1209600
+                for: 1h
+                labels:
+                    severity: critical
+
+              - alert: S3HealthcheckNoRecentSuccess
+                annotations:
+                    summary: 'S3 healthcheck has no recent successful run'
+                    description: |
+                        s3-healthcheck (every 12h) has not completed successfully in 26h, or
+                        has never succeeded. Backup-store reachability is unverified.
+                expr: |
+                    absent(kube_cronjob_status_last_successful_time{namespace="crossplane-system",cronjob="s3-healthcheck"})
+                    or
+                    time() - kube_cronjob_status_last_successful_time{namespace="crossplane-system",cronjob="s3-healthcheck"} > 93600
+                for: 1h
+                labels:
+                    severity: warning


### PR DESCRIPTION
Closes #13107. Audit item from #12973.

## Problem

Three DR drill CronJobs `exit 1` on failure with `backoffLimit: 0`, but nothing alerts on `kube_job_status_failed`:

| CronJob | ns | cadence |
|---|---|---|
| `backup-watchdog` | kilobase | daily `30 3 * * *` |
| `backup-restore-test` | kilobase | weekly `0 4 * * 0` |
| `s3-healthcheck` | crossplane-system | every 12h `0 */12 * * *` |

## Fix

New `kilobase-backup-drills` PrometheusRule (same selector labels as `pooler-health-alert.yaml`; auto-applies via the kilobase directory Argo source). Two groups:

- **failures** — `kube_job_status_failed{job_name=~"<drill>.*"} > 0`. `backup-restore-test` = critical, the other two = warning.
- **success** — absent-aware "no recent successful run" per drill: `absent(last_successful_time) OR time() - last_successful_time > 2×cadence`. The `absent` arm is the important one — it fires when a drill has **never** produced a healthy result, including a `backup-restore-test` wedged by `concurrencyPolicy: Forbid` behind a hung Job (`failed=0, succeeded=0`) that a failed-only rule cannot see.

## Verified against live Prometheus

KSM labels confirmed: `cronjob`, `job_name`, `namespace`. `promtool check rules` → SUCCESS, 6 rules. All six already fire — and surfaced a real, pre-existing outage:

- **backup-watchdog** — never succeeded; latest job `failed=1`.
- **s3-healthcheck** — never succeeded; latest jobs `failed=1`.
- **backup-restore-test** — never succeeded; **wedged on an active Job from 2026-05-03 (~50 days)**; `Forbid` blocks all new runs → emits neither success nor failure. Caught only by the `success`/absent group.

The alert is doing its job on day one. Fixing the drills themselves (the wedged restore Job + the failing watchdog/healthcheck) is separate operational follow-up — see issue comment.

Refs #12973