### PR TITLE
fix(kube/rows): tenant seed Job → Argo Sync hook (no thrash)

### DIFF
--- a/apps/kube/rows/tenants/base/seed-job.yaml
+++ b/apps/kube/rows/tenants/base/seed-job.yaml
@@ -10,6 +10,9 @@ metadata:
     labels:
         app: rows
         app.kubernetes.io/part-of: ows
+    annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
     backoffLimit: 3
     ttlSecondsAfterFinished: 600


### PR DESCRIPTION
## Problem (#13106)

`rows/tenants/base/seed-job.yaml` is a plain `kind: Job` with no Argo hook annotations. Job `spec.template` is immutable, so under app `selfHeal` ArgoCD attempts to reconcile it on every re-sync — any overlay/env drift errors and thrashes.

## Fix

Mark the base Job as a Sync hook:
```yaml
argocd.argoproj.io/hook: Sync
argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
```
`BeforeHookCreation` deletes the prior Job before recreating it each sync → no immutable-patch error, no thrash. In base → applies to all tenant overlays.

Closes #13106