### PR TITLE
fix(cryptothrone): correct SA token config — pod does call the kube API (#13120)

### DIFF
--- a/apps/kube/cryptothrone/README.md
+++ b/apps/kube/cryptothrone/README.md
@@ -23,7 +23,7 @@ The Deployment runs under a restricted PodSecurity profile:
 - `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch
 - `allowPrivilegeEscalation: false`, all Linux capabilities dropped
 - `seccompProfile: RuntimeDefault`
-- Dedicated `cryptothrone-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA.
+- Dedicated `cryptothrone-sa` ServiceAccount with `automountServiceAccountToken: true` at both the SA and pod level — the pod calls the kube API to allocate Agones game servers (`GameServerAllocation`), scoped by the `cryptothrone-sa-agones-allocator` Role. The pod no longer rides on the `default` SA. (Sibling web apps that never touch the API set this `false`.)
 - CPU/memory `requests` and `limits` set so the kubelet enforces a cgroup; bursts cap at `2 CPU / 512 MiB`.
 
 ## Reloader integration

--- a/apps/kube/cryptothrone/manifest/cryptothrone-serviceaccount.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-serviceaccount.yaml
@@ -7,13 +7,15 @@ metadata:
     name: cryptothrone-external-secrets
     namespace: cryptothrone
 ---
-# ServiceAccount used by the cryptothrone Deployment pod. The pod does
-# not call the kube API, so the projected token is unused weight —
-# disable it here at the SA level. The pod spec re-states the field so
-# any future template binding the SA inherits the safe default.
+# ServiceAccount used by the cryptothrone Deployment pod. The pod calls
+# the kube API to allocate Agones game servers (axum-cryptothrone agones.rs
+# POSTs GameServerAllocation via kube::Client::try_default, which reads the
+# projected token), bound by cryptothrone-sa-agones-allocator in
+# apps/kube/agones/cryptothrone. The token must be mounted — both here and
+# in the pod spec.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: cryptothrone-sa
     namespace: cryptothrone
-automountServiceAccountToken: false
+automountServiceAccountToken: true


### PR DESCRIPTION
Closes #13120. Audit item from #12973.

## Finding: false positive on the pod, real bug on the SA

#13120 flagged `cryptothrone-deployment.yaml` `automountServiceAccountToken: true` as inconsistent with sibling web apps (jobboard/memes/herbmail/rentearth/cityvote, all `false`).

It's **intentional** — cryptothrone is the only one that calls the Kubernetes API:
- `apps/cryptothrone/axum-cryptothrone/src/agones.rs` → `kube::Client::try_default()` (in-cluster config, reads the projected SA token) → `POST /apis/allocation.agones.dev/v1/.../gameserverallocations`.
- Deployment env `CT_AGONES_NAMESPACE` / `CT_AGONES_FLEET`.
- `cryptothrone-sa` is bound to the `cryptothrone-sa-agones-allocator` Role (`gameserverallocations: create`, `gameservers`/`fleets: get,list`) in `apps/kube/agones/cryptothrone/manifests/allocator-rbac.yaml`.

Flipping the pod to `false` would break game-server allocation. Left `true`.

## The actual defect (inverted)

The **ServiceAccount** manifest was the wrong one:
```yaml
# "The pod does not call the kube API, so the projected token is unused weight"
automountServiceAccountToken: false   # cryptothrone-sa
```
The pod spec's `true` overrides this, so it works today — but it's a footgun: drop the pod override and the token silently vanishes, breaking allocation. The comment and README line said the opposite of reality.

Fix:
- `cryptothrone-sa` SA-level → `true`, comment rewritten to state the pod allocates Agones servers and needs the token.
- README updated, noting siblings set `false` because they never touch the API.
- Pod spec unchanged (`true`, correct).

No behavioral change in-cluster (pod already mounted the token); removes the latent footgun and the misleading docs that triggered the audit flag.

Refs #12973