### PR TITLE
fix(arc): harden Docker Hub pull-through mirror (#13092)

### DIFF
--- a/apps/kube/github/runners/manifests/registry-mirror.yaml
+++ b/apps/kube/github/runners/manifests/registry-mirror.yaml
@@ -56,11 +56,9 @@ data:
             X-Content-Type-Options: [nosniff]
         proxy:
           remoteurl: https://registry-1.docker.io
-          # Hub creds bypass anon 100/6h pull cap. Wire later via
-          # ExternalSecret if rate-limit hit; for now anon is fine
-          # because cached layers don't re-fetch from upstream.
-          # username: ""
-          # password: ""
+          # Hub creds (bypass the anon 100/6h pull cap) come from the optional
+          # registry-mirror-hub-creds secret via REGISTRY_PROXY_USERNAME /
+          # REGISTRY_PROXY_PASSWORD env. Absent secret -> anonymous pulls.
         health:
           storagedriver:
             enabled: true
@@ -101,6 +99,18 @@ spec:
                   env:
                       - name: REGISTRY_HTTP_ADDR
                         value: ':5000'
+                      - name: REGISTRY_PROXY_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: registry-mirror-hub-creds
+                                key: username
+                                optional: true
+                      - name: REGISTRY_PROXY_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: registry-mirror-hub-creds
+                                key: password
+                                optional: true
                   volumeMounts:
                       - name: config
                         mountPath: /etc/docker/registry
@@ -154,3 +164,31 @@ spec:
           port: 5000
           targetPort: http
           protocol: TCP
+---
+# The mirror serves cached Hub layers over unauthenticated HTTP, and
+# 'delete: enabled' means any client reaching :5000 could evict tags or
+# poison the cache. Restrict ingress to pods inside arc-runners (the only
+# legitimate clients are the runner DinD sidecars) so nothing in another
+# namespace can MITM/poison the cache. Mirrors the registry-mirror-ghcr lock.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: registry-mirror-ingress
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: registry-mirror
+        app.kubernetes.io/part-of: arc-runner-set
+spec:
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/name: registry-mirror
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: arc-runners
+          ports:
+              - port: http
+                protocol: TCP


### PR DESCRIPTION
## Summary
Resolves #13092. The Docker Hub pull-through `registry-mirror` (ns `arc-runners`) served cached layers over unauthenticated HTTP with `delete: enabled` and **no NetworkPolicy** — any pod in another namespace could reach `:5000` to MITM/poison the cache or evict tags. The sibling `registry-mirror-ghcr` already has this lock; the Hub mirror was missing it.

## Audit
- `registry-mirror.yaml`: plaintext HTTP, `delete: enabled`, anonymous Hub pullthrough, no ingress restriction.
- `registry-mirror-ghcr.yaml`: already NetworkPolicy-locked to `arc-runners` ingress — the pattern to mirror.
- dockerd (`values.yaml:127`) uses `--registry-mirror=http://…` + `--insecure-registry` for intra-cluster pulls.

## Change
- **NetworkPolicy `registry-mirror-ingress`**: restrict `:5000` ingress to pods inside `arc-runners` (only the runner DinD sidecars). Closes the cross-ns MITM/poison/tag-delete path. Issue accepted "NetworkPolicy-lock its path."
- **Optional Hub creds**: `REGISTRY_PROXY_USERNAME/PASSWORD` env from the optional `registry-mirror-hub-creds` secret (`optional: true`) → authenticated pulls bypass the anon 100/6h cap when the secret is provisioned; stays anonymous + non-breaking until then.

`--insecure-registry` kept (intra-cluster HTTP behind the NetworkPolicy, same posture as the ghcr mirror — no cert management). `kubectl kustomize` validates clean.