### PR TITLE
fix(astro-kbve): repair mangled kube frontmatter in 27 project docs

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
@@ -25,7 +25,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: agonesn    environment: prodn    tier: databasen    owner: h0lybyten    criticality: high
+kube:
+    stack: agones
+    environment: prod
+    tier: database
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -31,7 +31,12 @@ external_publish:
           source_path: apps/agones/factorio/mods-local/kbve
         - name: kbve-spider
           source_path: apps/factorio/mods/kbve-spider
-kube:n    stack: agonesn    environment: prodn    tier: servern    owner: h0lybyten    criticality: high
+kube:
+    stack: agones
+    environment: prod
+    tier: server
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: infrastructuren    environment: prodn    tier: apin    owner: h0lybyten    criticality: critical
+kube:
+    stack: infrastructure
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: critical
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: MIT
 status: beta
-kube:n    stack: agonesn    environment: betan    tier: servern    owner: h0lybyten    criticality: low
+kube:
+    stack: agones
+    environment: beta
+    tier: server
+    owner: h0lybyte
+    criticality: low
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
@@ -23,7 +23,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: beta
-kube:n    stack: agonesn    environment: betan    tier: apin    owner: h0lybyten    criticality: low
+kube:
+    stack: agones
+    environment: beta
+    tier: api
+    owner: h0lybyte
+    criticality: low
 ---
 
 ChuckRPG is an open world multiplayer RPG powered by Unreal Engine with OWS (Open World Server) as the game backend.

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: MIT
 status: beta
-kube:n    stack: agonesn    environment: betan    tier: servern    owner: h0lybyten    criticality: low
+kube:
+    stack: agones
+    environment: beta
+    tier: server
+    owner: h0lybyte
+    criticality: low
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -268,7 +268,12 @@ Seasonal events and updates are planned, and a long-term roadmap is developed ba
 
 </Steps>
 
-kube:n    stack: agonesn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: agones
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -20,7 +20,12 @@ image: kbve/discordsh-bot
 deployment_yaml: apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
 e2e_name: discordsh-bot-e2e
 has_test: true
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
@@ -25,7 +25,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## DiscordSH

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -53,7 +53,12 @@ All functions share utilities under `functions/_shared/`:
 - **`formats.ts`** — Regex patterns for UUIDs, ULIDs, Discord snowflakes, etc.
 - **`firecracker.ts`** — Firecracker microVM client (Tier 2 dispatch)
 
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Firecracker MicroVM Integration

--- a/apps/kbve/astro-kbve/src/content/docs/project/factorio-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/factorio-ctl.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: agonesn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: agones
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -25,7 +25,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
@@ -25,7 +25,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: webn    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: web
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
@@ -25,7 +25,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: webn    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: web
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/herbmail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/herbmail.mdx
@@ -25,7 +25,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Introduction

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -23,7 +23,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
@@ -82,7 +82,12 @@ verticals:
           - [procgen, Procedural Generation]
           - [shader-graph, Shader Graph]
           - [vertical-slice, Vertical Slice]
-kube:n    stack: agonesn    environment: prodn    tier: webn    owner: h0lybyten    criticality: medium
+kube:
+    stack: agones
+    environment: prod
+    tier: web
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Job Board

--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -24,7 +24,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -27,7 +27,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: medium
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: medium
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx
@@ -21,7 +21,12 @@ image: kbve/mc-lobby
 e2e_name: mc-lobby
 deployment_yaml: apps/kube/agones/mc/manifests/lobby-deployment.yaml
 has_test: true
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx
@@ -21,7 +21,12 @@ image: kbve/mc-velocity
 e2e_name: mc-velocity
 deployment_yaml: apps/kube/agones/mc/manifests/velocity-deployment.yaml
 has_test: true
-kube:n    stack: applicationn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: application
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## `kbve-velocity-commands`

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -26,7 +26,12 @@ external_publish:
     modrinth_version_type: release
     modrinth_loaders: '["fabric"]'
     modrinth_game_versions: '["1.21.11"]'
-kube:n    stack: agonesn    environment: prodn    tier: apin    owner: h0lybyten    criticality: high
+kube:
+    stack: agones
+    environment: prod
+    tier: api
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
@@ -23,7 +23,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: applicationn    environment: prodn    tier: webn    owner: h0lybyten    criticality: high
+kube:
+    stack: application
+    environment: prod
+    tier: web
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -37,7 +37,12 @@ has_test: false
 author: h0lybyte
 license: KBVE
 status: active
-kube:n    stack: datan    environment: prodn    tier: databasen    owner: h0lybyten    criticality: high
+kube:
+    stack: data
+    environment: prod
+    tier: database
+    owner: h0lybyte
+    criticality: high
 ---
 
 ## Metrics — in-house observability

--- a/apps/kbve/astro-kbve/src/content/docs/project/rareicon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rareicon.mdx
@@ -25,7 +25,12 @@ has_test: true
 author: h0lybyte
 license: KBVE
 status: beta
-kube:n    stack: agonesn    environment: betan    tier: apin    owner: h0lybyten    criticality: low
+kube:
+    stack: agones
+    environment: beta
+    tier: api
+    owner: h0lybyte
+    criticality: low
 ---
 
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -111,7 +111,12 @@ ROWS has three distinct identities. They are different axes — do not conflate 
 
 `SUPABASE_SERVICE_KEY_HASH` (rows) and the plaintext `OWS_SERVICE_KEY` (fleet) both derive from the one kilobase secret `supabase-service-key` (`hash` + `key`). The GoTrue `customer_guid` JWT claim is intentionally unused — tenant identity comes from the process config (`OWS_API_KEY`), never from the token.
 
-kube:n    stack: applicationn    environment: betan    tier: apin    owner: h0lybyten    criticality: low
+kube:
+    stack: application
+    environment: beta
+    tier: api
+    owner: h0lybyte
+    criticality: low
 ---
 
 ### Procedural World — Seed-Based Multi-Zone Architecture


### PR DESCRIPTION
## Problem

CI build of `astro-kbve` failed all 3 retries ([run 27996126489](https://github.com/KBVE/kbve/actions/runs/27996126489)). Surfaced as flaky-graph retry, but root cause was broken MDX frontmatter:

```
bad indentation of a mapping entry
  Location: .../project/agones-factorio-relay.mdx:28:39
```

The `kube:` mapping block in 27 project docs was collapsed onto one line with literal `n` where newlines belonged:

```
kube:n    stack: agonesn    environment: prodn    tier: databasen    owner: h0lybyten    criticality: high
```

js-yaml could not parse it → astro build aborted.

## Fix

Restored the multiline `kube:` mapping across all 27 files:

```yaml
kube:
    stack: agones
    environment: prod
    tier: database
    owner: h0lybyte
    criticality: high
```

## Verify

- `./kbve.sh -nx astro-kbve:build` → green, 7775 pages built
- js-yaml parse sweep over all 7783 content frontmatter blocks → 0 errors

Note: some files (e.g. `jobboard.mdx`) carry `stack: agones` which looks like a bad template stamp — left untouched here since it's semantic data, not a parse error.