### PR TITLE
feat(arpg): burn DoT via itemdb StatusEffectKind

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -149,16 +149,14 @@ pub fn item_db() -> bevy_items::ItemDb {
 /// max_hp.
 const FULL_HEAL: i32 = 9_999;
 
-/// Map an itemdb `StatusEffectKind` onto the three runtime `StatusKind`s the sim
-/// supports. Burning collapses to Poison (both periodic damage); unsupported
-/// effects return `None` so the item simply grants no buff.
+/// Map an itemdb `StatusEffectKind` onto the runtime `StatusKind`s the sim
+/// supports. Unsupported effects return `None` so the item simply grants no buff.
 fn map_status(raw: i32) -> Option<StatusKind> {
     match StatusEffectKind::try_from(raw).ok()? {
         StatusEffectKind::StatusEffectRegen => Some(StatusKind::Regen),
         StatusEffectKind::StatusEffectHaste => Some(StatusKind::Haste),
-        StatusEffectKind::StatusEffectPoison | StatusEffectKind::StatusEffectBurning => {
-            Some(StatusKind::Poison)
-        }
+        StatusEffectKind::StatusEffectPoison => Some(StatusKind::Poison),
+        StatusEffectKind::StatusEffectBurning => Some(StatusKind::Burn),
         _ => None,
     }
 }
@@ -373,5 +371,26 @@ mod tests {
         let mana = buffs.0.get("mana-potion").expect("mana-potion buff");
         assert_eq!(mana.kind, super::StatusKind::Regen);
         assert!(!heals.0.is_empty() && !buffs.0.is_empty());
+    }
+
+    #[test]
+    fn status_kind_subset_of_itemdb() {
+        use super::{StatusEffectKind, StatusKind};
+        fn itemdb_of(k: StatusKind) -> StatusEffectKind {
+            match k {
+                StatusKind::Poison => StatusEffectKind::StatusEffectPoison,
+                StatusKind::Regen => StatusEffectKind::StatusEffectRegen,
+                StatusKind::Haste => StatusEffectKind::StatusEffectHaste,
+                StatusKind::Burn => StatusEffectKind::StatusEffectBurning,
+            }
+        }
+        for (k, name) in [
+            (StatusKind::Poison, "STATUS_EFFECT_POISON"),
+            (StatusKind::Regen, "STATUS_EFFECT_REGEN"),
+            (StatusKind::Haste, "STATUS_EFFECT_HASTE"),
+            (StatusKind::Burn, "STATUS_EFFECT_BURNING"),
+        ] {
+            assert_eq!(itemdb_of(k).as_str_name(), name);
+        }
     }
 }

--- a/apps/agones/arpg/web/src/game/ecs/store.ts
+++ b/apps/agones/arpg/web/src/game/ecs/store.ts
@@ -7,6 +7,7 @@ import {
 	queryInRange,
 	query,
 	type World,
+	type StatusView,
 } from '@kbve/laser';
 import {
 	Position,
@@ -31,19 +32,24 @@ export interface SpawnData {
 	hostile: boolean;
 	hp: number;
 	maxHp: number;
+	effects?: StatusView[];
 }
 
 export interface UpdateData {
 	tile?: { x: number; y: number };
 	hp?: number;
 	maxHp?: number;
+	effects?: StatusView[];
 }
+
+const NO_EFFECTS: readonly StatusView[] = [];
 
 export class EntityStore<R> {
 	readonly world: World = createWorld();
 	private toEid = new Map<number, number>();
 	private toServer = new Map<number, number>();
 	private sideRefs = new SideMap<R>();
+	private effectsMap = new Map<number, StatusView[]>();
 
 	private tagFor(cat: EntityCat): Record<string, never> {
 		return cat === 'player'

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -85,7 +85,7 @@ export interface PlayerView {
 	connected: boolean;
 }
 
-export type StatusKind = 'Poison' | 'Regen' | 'Haste';
+export type StatusKind = 'Poison' | 'Regen' | 'Haste' | 'Burn';
 
 export interface StatusView {
 	kind: StatusKind;

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -229,6 +229,7 @@ pub enum StatusKind {
     Poison = 0,
     Regen = 1,
     Haste = 2,
+    Burn = 3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -375,5 +376,19 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn status_kind_serializes_by_name() {
+        assert_eq!(
+            serde_json::to_string(&StatusKind::Burn).unwrap(),
+            "\"Burn\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StatusKind::Poison).unwrap(),
+            "\"Poison\""
+        );
+        let back: StatusKind = serde_json::from_str("\"Burn\"").unwrap();
+        assert_eq!(back, StatusKind::Burn);
     }
 }

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -561,21 +561,38 @@ fn env_heal_aura(
     }
 }
 
-/// Burn any entity (player or NPC) standing on a hazard tile (same floor).
+/// Burn any entity standing on a hazard tile (same floor). Status-bearers refresh a
+/// `Burn` effect (ticked by the status system); bare entities take it directly.
 #[allow(clippy::type_complexity)]
 fn env_hazard_burn(
     clock: Res<SimClock>,
     hazards: Query<(&HazardZone, &GridPos, Option<&Floor>)>,
-    mut victims: Query<(&mut Health, &GridPos, Option<&Floor>)>,
+    mut victims: Query<(
+        &mut Health,
+        &GridPos,
+        Option<&Floor>,
+        Option<&mut StatusEffects>,
+    )>,
 ) {
+    let now = clock.tick;
     for (hz, hpos, hfloor) in hazards.iter() {
-        if hz.period_ticks == 0 || !clock.tick.is_multiple_of(hz.period_ticks) {
+        if hz.period_ticks == 0 || !now.is_multiple_of(hz.period_ticks) {
             continue;
         }
         let hz_z = hfloor.map(|f| f.0).unwrap_or(0);
-        for (mut hp, vpos, vfloor) in victims.iter_mut() {
-            if vfloor.map(|f| f.0).unwrap_or(0) == hz_z && vpos.tile == hpos.tile {
-                hp.hp -= hz.magnitude;
+        for (mut hp, vpos, vfloor, status) in victims.iter_mut() {
+            if vfloor.map(|f| f.0).unwrap_or(0) != hz_z || vpos.tile != hpos.tile {
+                continue;
+            }
+            match status {
+                Some(mut s) => s.apply(StatusEffect {
+                    kind: proto::StatusKind::Burn,
+                    magnitude: hz.magnitude,
+                    period_ticks: hz.period_ticks,
+                    next_tick: now.saturating_add(hz.period_ticks),
+                    expires_tick: now.saturating_add(hz.period_ticks.saturating_mul(3)),
+                }),
+                None => hp.hp -= hz.magnitude,
             }
         }
     }
@@ -1730,7 +1747,7 @@ fn tick_status_effects(
             }
             while now >= e.next_tick && e.next_tick <= e.expires_tick {
                 match e.kind {
-                    proto::StatusKind::Poison => hp.hp -= e.magnitude,
+                    proto::StatusKind::Poison | proto::StatusKind::Burn => hp.hp -= e.magnitude,
                     proto::StatusKind::Regen => hp.hp = (hp.hp + e.magnitude).min(hp.max_hp),
                     proto::StatusKind::Haste => {}
                 }
@@ -2277,6 +2294,44 @@ mod tests {
         }
         let hp = app.world().get::<Health>(victim).unwrap().hp;
         assert_eq!(hp, 100 - 8 * 3, "burned 8/tick for 3 ticks");
+    }
+
+    #[test]
+    fn env_hazard_applies_burn_status_to_player() {
+        let (mut app, _rx, _tx, _roster) = harness(0x333);
+        let t = Tile::new(12, 12);
+        let player = app
+            .world_mut()
+            .spawn((
+                EntityKind(PLAYER_KIND),
+                GridPos::at(t),
+                MoveTarget::default(),
+                MoveSpeed { ticks_per_tile: 4 },
+                Health {
+                    hp: 100,
+                    max_hp: 100,
+                },
+                StatusEffects::default(),
+                PlayerSlotTag(proto::PlayerSlot(0)),
+            ))
+            .id();
+        app.world_mut().spawn((
+            HazardZone {
+                magnitude: 8,
+                period_ticks: 2,
+            },
+            GridPos::at(t),
+        ));
+        for _ in 0..6 {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(player).unwrap().hp;
+        assert_eq!(hp, 100 - 8 * 2, "burn status ticked 8 twice");
+        let status = app.world().get::<StatusEffects>(player).unwrap();
+        assert!(
+            status.0.iter().any(|e| e.kind == proto::StatusKind::Burn),
+            "Burn status present while standing on hazard"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #12961. Part of #12955.

## Server — burn DoT via existing `StatusEffectKind` (no new proto)

Source of truth = `item/itemdb.proto` `StatusEffectKind`. simgrid's runtime `StatusKind` stays the tiny JSON wire enum (serde encodes by PascalCase variant name), tied to the SoT by a parity test — no bevy_items dep added to simgrid.

### Changes
- `StatusKind::Burn = 3` (aligns `STATUS_EFFECT_BURNING`) in simgrid `proto.rs`; `'Burn'` into laser `protocol.ts` union.
- `env_hazard_burn`: status-bearing victims (players) get a refreshed `Burn` status — round-trips over the JSON snapshot wire (`StatusView` → `"Burn"`) and the status system applies the periodic damage. Bare entities (NPCs, no `StatusEffects`) keep direct damage, so the existing NPC hazard test is unchanged.
- `tick_status_effects`: `Burn` = periodic HP loss (Poison-style).
- `map_status`: `Burning` → `Burn` instead of folding into `Poison`.

### Tests
- `status_kind_serializes_by_name` (simgrid) — `serde_json` of `Burn` == `"Burn"`, round-trips back.
- `status_kind_subset_of_itemdb` (arpg-server) — exhaustive match makes a runtime `StatusKind` without an itemdb `StatusEffectKind` a compile error; asserts `Burn` ↔ `STATUS_EFFECT_BURNING`.
- `env_hazard_applies_burn_status_to_player` (simgrid) — player on hazard loses HP via the `Burn` status and carries it while standing on the tile.

### Acceptance
Entity on a hazard tile loses HP each period; `Burn` round-trips over the JSON wire; parity tests green.

### Out of scope
- Client effect icon/tint for Burn — #12965.
- Hazard spawn from itemdb env def — #12972.

### Notes
Two pre-existing failures on `dev`, unrelated to this change: `simgrid` `second_login_evicts_first` (login-eviction race) and a `trade/tests.rs` unused-import clippy lint.