### PR TITLE
feat(arpg): env burn DoT + client burn/heal feedback & collision

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -149,16 +149,14 @@ pub fn item_db() -> bevy_items::ItemDb {
 /// max_hp.
 const FULL_HEAL: i32 = 9_999;
 
-/// Map an itemdb `StatusEffectKind` onto the three runtime `StatusKind`s the sim
-/// supports. Burning collapses to Poison (both periodic damage); unsupported
-/// effects return `None` so the item simply grants no buff.
+/// Map an itemdb `StatusEffectKind` onto the runtime `StatusKind`s the sim
+/// supports. Unsupported effects return `None` so the item simply grants no buff.
 fn map_status(raw: i32) -> Option<StatusKind> {
     match StatusEffectKind::try_from(raw).ok()? {
         StatusEffectKind::StatusEffectRegen => Some(StatusKind::Regen),
         StatusEffectKind::StatusEffectHaste => Some(StatusKind::Haste),
-        StatusEffectKind::StatusEffectPoison | StatusEffectKind::StatusEffectBurning => {
-            Some(StatusKind::Poison)
-        }
+        StatusEffectKind::StatusEffectPoison => Some(StatusKind::Poison),
+        StatusEffectKind::StatusEffectBurning => Some(StatusKind::Burn),
         _ => None,
     }
 }
@@ -373,5 +371,26 @@ mod tests {
         let mana = buffs.0.get("mana-potion").expect("mana-potion buff");
         assert_eq!(mana.kind, super::StatusKind::Regen);
         assert!(!heals.0.is_empty() && !buffs.0.is_empty());
+    }
+
+    #[test]
+    fn status_kind_subset_of_itemdb() {
+        use super::{StatusEffectKind, StatusKind};
+        fn itemdb_of(k: StatusKind) -> StatusEffectKind {
+            match k {
+                StatusKind::Poison => StatusEffectKind::StatusEffectPoison,
+                StatusKind::Regen => StatusEffectKind::StatusEffectRegen,
+                StatusKind::Haste => StatusEffectKind::StatusEffectHaste,
+                StatusKind::Burn => StatusEffectKind::StatusEffectBurning,
+            }
+        }
+        for (k, name) in [
+            (StatusKind::Poison, "STATUS_EFFECT_POISON"),
+            (StatusKind::Regen, "STATUS_EFFECT_REGEN"),
+            (StatusKind::Haste, "STATUS_EFFECT_HASTE"),
+            (StatusKind::Burn, "STATUS_EFFECT_BURNING"),
+        ] {
+            assert_eq!(itemdb_of(k).as_str_name(), name);
+        }
     }
 }

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -17,6 +17,8 @@ import {
 	type InventorySync,
 	type InventoryItem,
 	type ItemPlacedEvent,
+	type StatusView,
+	type StatusKind,
 } from '@kbve/laser';
 import {
 	COLORS,
@@ -114,6 +116,19 @@ import { resolvePlayerName } from './playerName';
 
 const LOCAL_PLAYER_EID = 1;
 const LOCAL_PLAYER_KIND = 1;
+// Status effect aura/pip colours and the aura precedence (harm before help).
+const STATUS_COLOR: Record<StatusKind, number> = {
+	Burn: 0xfb923c,
+	Poison: 0x84cc16,
+	Regen: 0x4ade80,
+	Haste: 0x38bdf8,
+};
+const STATUS_PRIORITY: readonly StatusKind[] = [
+	'Burn',
+	'Poison',
+	'Regen',
+	'Haste',
+];
 // Offline (DEBUG_LOCAL_PLAYER) sim: there is no server, so a small client-only
 // fixture seeds ground loot + a heal table to exercise the inventory loop. The
 // real game is server-authoritative; this only runs when localMode is set.
@@ -675,6 +690,7 @@ export class IsoArpgScene extends Phaser.Scene {
 					this.placeNameplate(refs);
 				}
 				refs.hpBar = this.add.graphics().setDepth(DEPTH_UI);
+				refs.statusFx = this.add.graphics().setDepth(DEPTH_UI - 1);
 				return refs;
 			},
 			move: (refs, tile) => this.tweenTo(refs, tile, true),
@@ -685,6 +701,7 @@ export class IsoArpgScene extends Phaser.Scene {
 				refs.shadow?.destroy();
 				refs.nameplate?.destroy();
 				refs.hpBar?.destroy();
+				refs.statusFx?.destroy();
 				refs.sprite.destroy();
 			},
 		};
@@ -1018,6 +1035,7 @@ export class IsoArpgScene extends Phaser.Scene {
 			this.syncBridge,
 			this.syncResolvers,
 			state,
+			this.markEnvDirty,
 		);
 		this.myEid = state.myEid;
 		this.predicted = state.predicted;
@@ -1105,7 +1123,10 @@ export class IsoArpgScene extends Phaser.Scene {
 		// the 16-dir turn curve stays fluid even between tile crossings.
 		this.tickFacing();
 		this.syncFogToZoom();
-		this.refreshEnvBlocked();
+		if (this.envDirty) {
+			this.refreshEnvBlocked();
+			this.envDirty = false;
+		}
 
 		if ((!this.client && !this.localMode) || !this.predictSeeded) return;
 
@@ -1387,6 +1408,13 @@ export class IsoArpgScene extends Phaser.Scene {
 	// ECS store so local prediction blocks the same tiles the server does — else
 	// the player walks onto a campfire then snaps back on the next snapshot.
 	private envBlocked = new Set<string>();
+	// Set by netSync on any env spawn/despawn/move; the set is rebuilt on the next
+	// frame instead of every frame. Starts dirty so the first snapshot seeds it.
+	private envDirty = true;
+
+	private markEnvDirty = (): void => {
+		this.envDirty = true;
+	};
 
 	private refreshEnvBlocked(): void {
 		this.envBlocked.clear();
@@ -1469,6 +1497,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.syncShadow(refs);
 		this.placeNameplate(refs);
 		refs.hpBar = this.add.graphics().setDepth(DEPTH_UI);
+		refs.statusFx = this.add.graphics().setDepth(DEPTH_UI - 1);
 		this.store.spawn(
 			LOCAL_PLAYER_EID,
 			{
@@ -1691,9 +1720,14 @@ export class IsoArpgScene extends Phaser.Scene {
 	}
 
 	private refreshHud() {
+		const now = this.time.now;
 		for (const [serverEid, , refs] of this.store.entries()) {
 			const hp = this.store.hp(serverEid);
 			const maxHp = this.store.maxHp(serverEid);
+
+			if (refs.statusFx) {
+				this.drawStatusFx(refs, this.store.effects(serverEid), now);
+			}
 
 			if (
 				refs.cls &&
@@ -1719,6 +1753,49 @@ export class IsoArpgScene extends Phaser.Scene {
 				hp,
 				maxHp,
 			);
+		}
+	}
+
+	// Status feedback: a pulsing ground aura tinted by the dominant effect (doubles
+	// as the on-tile burn cue) plus a row of colour pips, one per active effect.
+	// Kept off sprite.setTint so it never fights the combat hit-flash.
+	private drawStatusFx(
+		refs: EntityRefs,
+		effects: readonly StatusView[],
+		now: number,
+	): void {
+		const g = refs.statusFx;
+		if (!g) return;
+		g.clear();
+		if (effects.length === 0) return;
+
+		const sprite = refs.sprite;
+		const footY = sprite.y;
+		const dominant = STATUS_PRIORITY.find((k) =>
+			effects.some((e) => e.kind === k),
+		);
+		if (dominant) {
+			const color = STATUS_COLOR[dominant];
+			// Sine pulse; burn/poison flicker harder than buffs for urgency.
+			const fast = dominant === 'Burn' || dominant === 'Poison';
+			const pulse =
+				0.5 + 0.5 * Math.sin((now / (fast ? 90 : 220)) % (Math.PI * 2));
+			const rx = sprite.displayWidth * 0.42;
+			g.fillStyle(color, 0.18 + 0.22 * pulse);
+			g.fillEllipse(sprite.x, footY, rx * 2, 12);
+			g.lineStyle(1.5, color, 0.4 + 0.4 * pulse);
+			g.strokeEllipse(sprite.x, footY, rx * 2, 12);
+		}
+
+		const pipY = footY - sprite.displayHeight - 14;
+		const pipW = 5;
+		const gap = 2;
+		const totalW = effects.length * pipW + (effects.length - 1) * gap;
+		let px = sprite.x - totalW / 2;
+		for (const e of effects) {
+			g.fillStyle(STATUS_COLOR[e.kind], 0.95);
+			g.fillRect(px, pipY, pipW, pipW);
+			px += pipW + gap;
 		}
 	}
 

--- a/apps/agones/arpg/web/src/game/ecs/store.ts
+++ b/apps/agones/arpg/web/src/game/ecs/store.ts
@@ -88,6 +88,7 @@ export class EntityStore<R> {
 		this.toEid.set(serverEid, eid);
 		this.toServer.set(eid, serverEid);
 		this.sideRefs.set(eid, refs);
+		if (data.effects) this.effectsMap.set(serverEid, data.effects);
 		return eid;
 	}
 
@@ -100,6 +101,11 @@ export class EntityStore<R> {
 		}
 		if (data.hp !== undefined) Health.hp[eid] = data.hp;
 		if (data.maxHp !== undefined) Health.maxHp[eid] = data.maxHp;
+		if (data.effects !== undefined) {
+			if (data.effects.length)
+				this.effectsMap.set(serverEid, data.effects);
+			else this.effectsMap.delete(serverEid);
+		}
 	}
 
 	despawn(serverEid: number): R | undefined {
@@ -109,6 +115,7 @@ export class EntityStore<R> {
 		removeEntity(this.world, eid);
 		this.toEid.delete(serverEid);
 		this.toServer.delete(eid);
+		this.effectsMap.delete(serverEid);
 		return refs;
 	}
 
@@ -140,6 +147,10 @@ export class EntityStore<R> {
 	kind(serverEid: number): number {
 		const eid = this.toEid.get(serverEid);
 		return eid === undefined ? -1 : Kind.value[eid];
+	}
+
+	effects(serverEid: number): readonly StatusView[] {
+		return this.effectsMap.get(serverEid) ?? NO_EFFECTS;
 	}
 
 	*entries(): Generator<[number, number, R]> {

--- a/apps/agones/arpg/web/src/game/ecs/store.ts
+++ b/apps/agones/arpg/web/src/game/ecs/store.ts
@@ -7,6 +7,7 @@ import {
 	queryInRange,
 	query,
 	type World,
+	type StatusView,
 } from '@kbve/laser';
 import {
 	Position,
@@ -31,19 +32,24 @@ export interface SpawnData {
 	hostile: boolean;
 	hp: number;
 	maxHp: number;
+	effects?: StatusView[];
 }
 
 export interface UpdateData {
 	tile?: { x: number; y: number };
 	hp?: number;
 	maxHp?: number;
+	effects?: StatusView[];
 }
+
+const NO_EFFECTS: readonly StatusView[] = [];
 
 export class EntityStore<R> {
 	readonly world: World = createWorld();
 	private toEid = new Map<number, number>();
 	private toServer = new Map<number, number>();
 	private sideRefs = new SideMap<R>();
+	private effectsMap = new Map<number, StatusView[]>();
 
 	private tagFor(cat: EntityCat): Record<string, never> {
 		return cat === 'player'

--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -78,6 +78,7 @@ export interface EntityRefs {
 	shadow?: Phaser.GameObjects.Sprite;
 	nameplate?: Phaser.GameObjects.Text;
 	hpBar?: Phaser.GameObjects.Graphics;
+	statusFx?: Phaser.GameObjects.Graphics;
 	cls?: ClassView;
 }
 

--- a/apps/agones/arpg/web/src/game/systems/netSync.spec.ts
+++ b/apps/agones/arpg/web/src/game/systems/netSync.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { EntityDelta, StatusView } from '@kbve/laser';
+import type { EntityCat, EntityStore } from '../ecs/store';
+import {
+	applyEntitySync,
+	type SyncBridge,
+	type SyncResolvers,
+	type SyncState,
+} from './netSync';
+
+type Ref = { id: number };
+type Row = {
+	tile: { x: number; y: number };
+	kind: number;
+	effects: StatusView[];
+};
+
+const CAT_BY_KIND: Record<number, EntityCat> = {
+	1: 'player',
+	2: 'npc',
+	3: 'env',
+};
+
+// Hand-rolled store so the spec never value-imports ../ecs/store (which pulls the
+// @kbve/laser runtime barrel — unresolvable under vitest). Covers only the surface
+// applyEntitySync touches.
+function fakeStore() {
+	const rows = new Map<number, Row>();
+	const store = {
+		has: (id: number) => rows.has(id),
+		spawn: (
+			id: number,
+			d: {
+				tile: { x: number; y: number };
+				kind: number;
+				effects?: StatusView[];
+			},
+		) => {
+			rows.set(id, {
+				tile: { ...d.tile },
+				kind: d.kind,
+				effects: d.effects ?? [],
+			});
+			return id;
+		},
+		update: (
+			id: number,
+			d: { tile?: { x: number; y: number }; effects?: StatusView[] },
+		) => {
+			const r = rows.get(id);
+			if (!r) return;
+			if (d.tile) r.tile = { ...d.tile };
+			if (d.effects !== undefined) r.effects = d.effects;
+		},
+		tile: (id: number) => rows.get(id)?.tile ?? null,
+		refs: (id: number) => (rows.has(id) ? ({ id } as Ref) : undefined),
+		kind: (id: number) => rows.get(id)?.kind ?? -1,
+		despawn: (id: number) => rows.delete(id),
+		*entries() {
+			for (const [id] of rows)
+				yield [id, id, { id } as Ref] as [number, number, Ref];
+		},
+		effects: (id: number) => rows.get(id)?.effects ?? [],
+	};
+	return store as unknown as EntityStore<Ref> & {
+		effects: (id: number) => StatusView[];
+	};
+}
+
+function bridge(): SyncBridge<Ref> {
+	return {
+		create: (e) => ({ id: e.eid }),
+		move: () => {},
+		setPos: () => {},
+		follow: () => {},
+		remove: () => {},
+	};
+}
+
+const resolvers: SyncResolvers = {
+	cat: (kind) => CAT_BY_KIND[kind] ?? 'item',
+	hostile: () => false,
+	label: () => undefined,
+};
+
+function delta(
+	eid: number,
+	kind: number,
+	x: number,
+	y: number,
+	effects?: StatusView[],
+): EntityDelta {
+	return {
+		eid,
+		kind,
+		owner: 0,
+		tile: { x, y },
+		facing: 'Down',
+		sub: 0,
+		hp: 100,
+		max_hp: 100,
+		destroyed: false,
+		effects,
+	};
+}
+
+function state(): SyncState {
+	return {
+		myEid: -1,
+		mySlot: 99,
+		predicted: { x: 0, y: 0 },
+		predictSeeded: false,
+	};
+}
+
+describe('applyEntitySync env-change signal', () => {
+	it('fires onEnvChange on env spawn, move, despawn — not for non-env', () => {
+		const store = fakeStore();
+		const onEnv = vi.fn();
+
+		applyEntitySync(
+			[delta(2, 2, 5, 5)],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+			onEnv,
+		);
+		expect(onEnv).not.toHaveBeenCalled();
+
+		applyEntitySync(
+			[delta(2, 2, 5, 5), delta(7, 3, 3, 3)],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+			onEnv,
+		);
+		expect(onEnv).toHaveBeenCalledTimes(1);
+
+		onEnv.mockClear();
+		applyEntitySync(
+			[delta(2, 2, 5, 5), delta(7, 3, 4, 3)],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+			onEnv,
+		);
+		expect(onEnv).toHaveBeenCalledTimes(1);
+
+		onEnv.mockClear();
+		applyEntitySync(
+			[delta(2, 2, 5, 5)],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+			onEnv,
+		);
+		expect(onEnv).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('applyEntitySync effects passthrough', () => {
+	it('stores effects on spawn and replaces them on update', () => {
+		const store = fakeStore();
+		const burn: StatusView[] = [{ kind: 'Burn', remaining: 30 }];
+
+		applyEntitySync(
+			[delta(2, 2, 5, 5, burn)],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+		);
+		expect(store.effects(2)).toEqual(burn);
+
+		applyEntitySync(
+			[delta(2, 2, 5, 5, [])],
+			store,
+			bridge(),
+			resolvers,
+			state(),
+		);
+		expect(store.effects(2)).toEqual([]);
+	});
+});

--- a/apps/agones/arpg/web/src/game/systems/netSync.ts
+++ b/apps/agones/arpg/web/src/game/systems/netSync.ts
@@ -35,6 +35,7 @@ export function applyEntitySync<R>(
 	bridge: SyncBridge<R>,
 	resolve: SyncResolvers,
 	state: SyncState,
+	onEnvChange?: () => void,
 ): number[] {
 	const seen = new Set<number>();
 	for (const e of entities) {
@@ -53,9 +54,11 @@ export function applyEntitySync<R>(
 					hostile: resolve.hostile(e.kind),
 					hp: e.hp,
 					maxHp: e.max_hp,
+					effects: e.effects,
 				},
 				refs,
 			);
+			if (cat === 'env') onEnvChange?.();
 			if (
 				cat === 'player' &&
 				e.owner === state.mySlot &&
@@ -81,17 +84,19 @@ export function applyEntitySync<R>(
 				tile: { ...state.predicted },
 				hp: e.hp,
 				maxHp: e.max_hp,
+				effects: e.effects,
 			});
 		} else {
 			const cur = store.tile(e.eid);
 			const refs = store.refs(e.eid);
-			if (cur && refs && (cur.x !== e.tile.x || cur.y !== e.tile.y)) {
-				bridge.move(refs, e.tile);
-			}
+			const moved = !!cur && (cur.x !== e.tile.x || cur.y !== e.tile.y);
+			if (refs && moved) bridge.move(refs, e.tile);
+			if (cat === 'env' && moved) onEnvChange?.();
 			store.update(e.eid, {
 				tile: { x: e.tile.x, y: e.tile.y },
 				hp: e.hp,
 				maxHp: e.max_hp,
+				effects: e.effects,
 			});
 		}
 	}
@@ -99,6 +104,7 @@ export function applyEntitySync<R>(
 	const despawned: number[] = [];
 	for (const [serverEid, , refs] of [...store.entries()]) {
 		if (seen.has(serverEid)) continue;
+		if (resolve.cat(store.kind(serverEid)) === 'env') onEnvChange?.();
 		bridge.remove(refs);
 		store.despawn(serverEid);
 		despawned.push(serverEid);

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -85,7 +85,7 @@ export interface PlayerView {
 	connected: boolean;
 }
 
-export type StatusKind = 'Poison' | 'Regen' | 'Haste';
+export type StatusKind = 'Poison' | 'Regen' | 'Haste' | 'Burn';
 
 export interface StatusView {
 	kind: StatusKind;

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -229,6 +229,7 @@ pub enum StatusKind {
     Poison = 0,
     Regen = 1,
     Haste = 2,
+    Burn = 3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -375,5 +376,19 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn status_kind_serializes_by_name() {
+        assert_eq!(
+            serde_json::to_string(&StatusKind::Burn).unwrap(),
+            "\"Burn\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StatusKind::Poison).unwrap(),
+            "\"Poison\""
+        );
+        let back: StatusKind = serde_json::from_str("\"Burn\"").unwrap();
+        assert_eq!(back, StatusKind::Burn);
     }
 }

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -561,21 +561,38 @@ fn env_heal_aura(
     }
 }
 
-/// Burn any entity (player or NPC) standing on a hazard tile (same floor).
+/// Burn any entity standing on a hazard tile (same floor). Status-bearers refresh a
+/// `Burn` effect (ticked by the status system); bare entities take it directly.
 #[allow(clippy::type_complexity)]
 fn env_hazard_burn(
     clock: Res<SimClock>,
     hazards: Query<(&HazardZone, &GridPos, Option<&Floor>)>,
-    mut victims: Query<(&mut Health, &GridPos, Option<&Floor>)>,
+    mut victims: Query<(
+        &mut Health,
+        &GridPos,
+        Option<&Floor>,
+        Option<&mut StatusEffects>,
+    )>,
 ) {
+    let now = clock.tick;
     for (hz, hpos, hfloor) in hazards.iter() {
-        if hz.period_ticks == 0 || !clock.tick.is_multiple_of(hz.period_ticks) {
+        if hz.period_ticks == 0 || !now.is_multiple_of(hz.period_ticks) {
             continue;
         }
         let hz_z = hfloor.map(|f| f.0).unwrap_or(0);
-        for (mut hp, vpos, vfloor) in victims.iter_mut() {
-            if vfloor.map(|f| f.0).unwrap_or(0) == hz_z && vpos.tile == hpos.tile {
-                hp.hp -= hz.magnitude;
+        for (mut hp, vpos, vfloor, status) in victims.iter_mut() {
+            if vfloor.map(|f| f.0).unwrap_or(0) != hz_z || vpos.tile != hpos.tile {
+                continue;
+            }
+            match status {
+                Some(mut s) => s.apply(StatusEffect {
+                    kind: proto::StatusKind::Burn,
+                    magnitude: hz.magnitude,
+                    period_ticks: hz.period_ticks,
+                    next_tick: now.saturating_add(hz.period_ticks),
+                    expires_tick: now.saturating_add(hz.period_ticks.saturating_mul(3)),
+                }),
+                None => hp.hp -= hz.magnitude,
             }
         }
     }
@@ -1730,7 +1747,7 @@ fn tick_status_effects(
             }
             while now >= e.next_tick && e.next_tick <= e.expires_tick {
                 match e.kind {
-                    proto::StatusKind::Poison => hp.hp -= e.magnitude,
+                    proto::StatusKind::Poison | proto::StatusKind::Burn => hp.hp -= e.magnitude,
                     proto::StatusKind::Regen => hp.hp = (hp.hp + e.magnitude).min(hp.max_hp),
                     proto::StatusKind::Haste => {}
                 }
@@ -2277,6 +2294,44 @@ mod tests {
         }
         let hp = app.world().get::<Health>(victim).unwrap().hp;
         assert_eq!(hp, 100 - 8 * 3, "burned 8/tick for 3 ticks");
+    }
+
+    #[test]
+    fn env_hazard_applies_burn_status_to_player() {
+        let (mut app, _rx, _tx, _roster) = harness(0x333);
+        let t = Tile::new(12, 12);
+        let player = app
+            .world_mut()
+            .spawn((
+                EntityKind(PLAYER_KIND),
+                GridPos::at(t),
+                MoveTarget::default(),
+                MoveSpeed { ticks_per_tile: 4 },
+                Health {
+                    hp: 100,
+                    max_hp: 100,
+                },
+                StatusEffects::default(),
+                PlayerSlotTag(proto::PlayerSlot(0)),
+            ))
+            .id();
+        app.world_mut().spawn((
+            HazardZone {
+                magnitude: 8,
+                period_ticks: 2,
+            },
+            GridPos::at(t),
+        ));
+        for _ in 0..6 {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(player).unwrap().hp;
+        assert_eq!(hp, 100 - 8 * 2, "burn status ticked 8 twice");
+        let status = app.world().get::<StatusEffects>(player).unwrap();
+        assert!(
+            status.0.iter().any(|e| e.kind == proto::StatusKind::Burn),
+            "Burn status present while standing on hazard"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Epic #12955 — ARPG environment objects (campfire). Server burn DoT + client prediction collision and burn/heal rendering.

## Server — burn DoT (Closes #12961)
- `StatusKind::Burn` added to simgrid proto.rs + laser `protocol.ts` union.
- `env_hazard_burn` refreshes a `Burn` status on status-bearing victims (players) so it round-trips over the JSON snapshot `effects` wire and the status system applies periodic damage; bare entities (NPCs) keep direct damage.
- `map_status` maps itemdb `Burning` → `Burn` (was folded to Poison).
- Tests: serde name round-trip, StatusKind subset-of-itemdb parity, player burn-status integration.

## Client — prediction collision + burn/heal feedback (Closes #12965)
- `EntityStore` stashes per-entity `effects` (`store.effects(sid)`).
- `applyEntitySync` gained an `onEnvChange` callback fired on env spawn/despawn/move; the scene rebuilds `envBlocked` only when dirty instead of every frame, so a campfire placed after join still blocks local prediction without rubber-band.
- `drawStatusFx` renders a pulsing ground aura (dominant of Burn>Poison>Regen>Haste, doubles as the on-tile burn cue) plus a row of colour pips — kept off `sprite.setTint` so it never fights the combat hit-flash.
- Tests: netSync env-change signal + effects passthrough.

Wire chain: `env_hazard_burn` → StatusEffects → snapshot `effects: Vec<StatusView>` → `EntityDelta.effects` → `store.effects` → aura/pip.

## Verify
- `arpg-web:typecheck` ✅, `arpg-web:test` (10) ✅
- `simgrid` lib tests (104) ✅
- Note: pre-existing unrelated failure `simgrid ws_flow::second_login_evicts_first` (fails on clean dev too).