### PR TITLE
fix(simgrid): remove unused Entity import in trade tests

### DIFF
--- a/packages/rust/simgrid/src/trade/tests.rs
+++ b/packages/rust/simgrid/src/trade/tests.rs
@@ -1,5 +1,4 @@
 use bevy::app::App;
-use bevy::ecs::entity::Entity;
 
 use crate::proto::{self, Input};
 use crate::sim::Inventory;


### PR DESCRIPTION
Removes unused `use bevy::ecs::entity::Entity;` in `packages/rust/simgrid/src/trade/tests.rs` that broke `simgrid:lint` (`-D unused-imports`). Only `EntityId` is used.

`./kbve.sh -nx simgrid:lint` passes.