### PR TITLE
fix(arpg): provision supabase-shared via ESO for arpg gameserver

### DIFF
--- a/apps/kube/agones/arpg/manifests/external-secrets.yaml
+++ b/apps/kube/agones/arpg/manifests/external-secrets.yaml
@@ -1,0 +1,81 @@
+# SecretStore + ExternalSecret rendering supabase-shared in the arpg
+# namespace. Mirrors the cryptothrone / rentearth pattern: the SecretStore
+# authenticates as arpg-external-secrets and reads the supabase-jwt and
+# supabase-postgres source secrets in kilobase, then composes them into a
+# single supabase-shared Secret with the env-var keys the arpg-server
+# GameServer expects (fleet.yaml secretKeyRefs).
+#
+# Activation requires arpg-external-secrets to appear in the
+# notification-bot-read-secrets RoleBinding subjects list in
+# apps/kube/kilobase/manifests/cross-namespace-rbac.yaml. Until that binding
+# lands the ExternalSecret fails to render and the GameServer stays in
+# CreateContainerConfigError on the non-optional SUPABASE_JWT_SECRET ref.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: arpg-external-secrets
+    namespace: arpg
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: arpg
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: arpg-external-secrets
+                    namespace: arpg
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: arpg-supabase-secrets
+    namespace: arpg
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                SUPABASE_URL: 'http://kong.kilobase.svc.cluster.local:8000'
+                SUPABASE_ANON_KEY: '{{ .anonkey }}'
+                SUPABASE_SERVICE_ROLE_KEY: '{{ .servicekey }}'
+                SUPABASE_JWT_SECRET: '{{ .jwtsecret }}'
+                DATABASE_URL: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+                # jedi PgCluster pool URLs (RW primary + RO replica). Consumed
+                # by the arpg-server gameserver.
+                KBVE_PG_RW_URL: 'postgres://postgres:{{ .dbpassword | urlquery }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=disable'
+                KBVE_PG_RO_URL: 'postgres://postgres:{{ .dbpassword | urlquery }}@supabase-cluster-ro.kilobase.svc.cluster.local:5432/supabase?sslmode=disable'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -75,6 +75,9 @@ subjects:
       name: cryptothrone-external-secrets
       namespace: cryptothrone
     - kind: ServiceAccount
+      name: arpg-external-secrets
+      namespace: arpg
+    - kind: ServiceAccount
       name: firecracker-external-secrets
       namespace: firecracker
 ---


### PR DESCRIPTION
## Problem

`wss://arpg.kbve.com/ws` returns **503**. The arpg-server Agones fleet never reaches Ready — the GameServer pod is stuck in `CreateContainerConfigError`:

```
secret "supabase-shared" not found
```

The `arpg` namespace was scaffolded **without** the Supabase ExternalSecret wiring that `cryptothrone`/`rentearth` have. The arpg-server fleet references `supabase-shared` via a **non-optional** `SUPABASE_JWT_SECRET` secretKeyRef, so the missing secret hard-fails pod admission.

(Separately, the `agones-sdk` ServiceAccount gap in the `arpg` ns — first blocker — was fixed by adding `arpg` to `apps/kube/agones/values.yaml` gameservers.namespaces, already on main as `c7e55ad42`.)

## Fix

Mirror the cryptothrone pattern (supabase-only, no valkey):

- `arpg-external-secrets` ServiceAccount (ns arpg)
- `kilobase-remote-secret-store` SecretStore authenticating as it
- `arpg-supabase-secrets` ExternalSecret composing `supabase-shared` from the kilobase `supabase-jwt` + `supabase-postgres` source secrets
- add `arpg-external-secrets`/`arpg` to the `notification-bot-read-secrets` RoleBinding subjects (the Role already grants `get` on those sources)

## After merge → main

ArgoCD (arpg + kilobase apps track main) renders `supabase-shared` in the arpg ns → GameServer boots → fleet Ready → `/ws` 200.