### PR TITLE
feat(arpg): stream apex predator creatures around players

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -1,14 +1,16 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use bevy::prelude::{Commands, Local, Res, ResMut};
+use bevy::prelude::{Commands, Entity, Local, Query, Res, ResMut, With, Without};
 use bevy_items::{StatusEffectKind, UseEffect, UseEffectType};
 use simgrid::arpg_dungeon;
 use simgrid::proto::{StatusKind, Tile};
+use simgrid::rng::hash3;
 use simgrid::{
-    AggroSpec, BuffEffects, BuffSpec, ConsumableEffects, DeployableSpec, Deployables, EnvOpts,
-    HazardZone, HealAura, KindRegistry, NpcSpec, SIM_TICK_HZ, SimConfig, Stairs, WalkableMap,
-    ground_item_bundle, spawn_env_object, spawn_npc_from_spec,
+    AggroSpec, BuffEffects, BuffSpec, ConsumableEffects, DeployableSpec, Deployables, EntityKind,
+    EnvOpts, GridPos, HazardZone, HealAura, KindRegistry, NpcSpec, PlayerSlotTag, SIM_TICK_HZ,
+    SimClock, SimConfig, SimSeed, Stairs, WalkableMap, ground_item_bundle, spawn_env_object,
+    spawn_npc_from_spec,
 };
 
 pub const MAX_PLAYERS: usize = 32;
@@ -47,6 +49,25 @@ pub const HOSTILE_AGGRO_RANGE: i32 = 6;
 // Campfire: a placed env object near spawn. Blocks its tile, heals players in the
 // adjacent ring, and burns anything forced onto the tile. Behavior is read from
 // the `campfire` mapdb WorldObjectDef — change the MDX + sync:mapdb to retune it.
+// Apex Predator — a roaming hostile creature streamed in around players as they
+// explore the endless dungeon (vs goblins, which are seeded once near spawn).
+// Tankier and harder-hitting than a goblin; rendered with the packed creature
+// sheets on the client.
+pub const PREDATOR_REF: &str = "apex_predator";
+pub const PREDATOR_HP: i32 = 60;
+pub const PREDATOR_DAMAGE: i32 = 8;
+pub const PREDATOR_DEFENSE: i32 = 2;
+pub const PREDATOR_TICKS_PER_TILE: u8 = 5;
+pub const PREDATOR_LEVEL: i32 = 3;
+// Streaming spawn budget: how many predators may exist near each player, the
+// ring (in tiles) they appear within, and how close they're allowed to pop in.
+pub const PREDATOR_PER_PLAYER: usize = 3;
+pub const PREDATOR_SPAWN_MIN: i32 = 12;
+pub const PREDATOR_SPAWN_MAX: i32 = 22;
+pub const PREDATOR_DESPAWN_RADIUS: i32 = 40;
+// Re-evaluate the streamed population a few times a second, not every tick.
+pub const PREDATOR_STREAM_PERIOD_TICKS: u32 = SIM_TICK_HZ / 2;
+
 pub const CAMPFIRE_REF: &str = "campfire";
 
 // The deployable inventory item that places a `campfire` env object. Carried in
@@ -88,6 +109,7 @@ fn floor_near(hint: Tile) -> Tile {
 pub fn registry() -> KindRegistry {
     let mut reg = KindRegistry::new();
     reg.register_npc(GOBLIN_REF);
+    reg.register_npc(PREDATOR_REF);
     reg.register_item(GOBLIN_LOOT_REF);
     reg.register_item(STAIR_KEY_REF);
     reg.register_item(POTION_REF);
@@ -305,6 +327,115 @@ fn goblin_spec(registry: &KindRegistry, origin: Tile) -> Option<NpcSpec> {
         loot: Some(GOBLIN_LOOT_REF.to_string()),
         respawn_ticks: NPC_RESPAWN_TICKS,
     })
+}
+
+fn predator_spec(registry: &KindRegistry, origin: Tile) -> Option<NpcSpec> {
+    let kind = registry.kind_of(PREDATOR_REF)?;
+    Some(NpcSpec {
+        kind,
+        origin,
+        ticks_per_tile: PREDATOR_TICKS_PER_TILE,
+        max_hp: PREDATOR_HP,
+        level: PREDATOR_LEVEL,
+        defense: PREDATOR_DEFENSE,
+        wander: Some((6, 18)),
+        aggro: Some(AggroSpec {
+            range: HOSTILE_AGGRO_RANGE,
+            damage: PREDATOR_DAMAGE,
+            period_ticks: SIM_TICK_HZ,
+            poison: None,
+        }),
+        loot: Some(GOBLIN_LOOT_REF.to_string()),
+        // Streamed predators are culled by distance, not respawned in place.
+        respawn_ticks: 0,
+    })
+}
+
+fn chebyshev(a: Tile, b: Tile) -> i32 {
+    (a.x - b.x).abs().max((a.y - b.y).abs())
+}
+
+/// Stream apex predators around players as they explore. Periodically: cull any
+/// predator that has drifted out of every player's despawn radius, then top each
+/// player's local population back up to `PREDATOR_PER_PLAYER` by spawning fresh
+/// ones on floor tiles in a ring ahead of them. Ground-floor only for now
+/// (matches the seeded-goblin scope); deeper floors stream once spawns carry a
+/// `Floor`.
+pub fn stream_predators(
+    clock: Res<SimClock>,
+    seed: Res<SimSeed>,
+    registry: Res<KindRegistry>,
+    players: Query<&GridPos, With<PlayerSlotTag>>,
+    predators: Query<(Entity, &GridPos, &EntityKind), Without<PlayerSlotTag>>,
+    mut commands: Commands,
+) {
+    if !clock.tick.is_multiple_of(PREDATOR_STREAM_PERIOD_TICKS) {
+        return;
+    }
+    let Some(pred_kind) = registry.kind_of(PREDATOR_REF) else {
+        return;
+    };
+
+    let player_tiles: Vec<Tile> = players.iter().map(|p| p.tile).collect();
+    if player_tiles.is_empty() {
+        return;
+    }
+
+    let mut alive: Vec<Tile> = Vec::new();
+    for (entity, pos, kind) in predators.iter() {
+        if kind.0 != pred_kind {
+            continue;
+        }
+        let near_any = player_tiles
+            .iter()
+            .any(|pt| chebyshev(*pt, pos.tile) <= PREDATOR_DESPAWN_RADIUS);
+        if near_any {
+            alive.push(pos.tile);
+        } else {
+            commands.entity(entity).despawn();
+        }
+    }
+
+    for (i, ptile) in player_tiles.iter().enumerate() {
+        let local = alive
+            .iter()
+            .filter(|t| chebyshev(**t, *ptile) <= PREDATOR_SPAWN_MAX)
+            .count();
+        if local >= PREDATOR_PER_PLAYER {
+            continue;
+        }
+        for attempt in 0..8u64 {
+            let h = hash3(seed.0, ((i as u64) << 8) | attempt, clock.tick as u64);
+            let span = (PREDATOR_SPAWN_MAX - PREDATOR_SPAWN_MIN + 1) as u64;
+            let dist = PREDATOR_SPAWN_MIN + ((h >> 8) % span) as i32;
+            let (dx, dy) = ring_offset((h % 8) as u8, dist);
+            let hint = Tile::new(ptile.x + dx, ptile.y + dy);
+            let origin = floor_near(hint);
+            if chebyshev(origin, *ptile) < PREDATOR_SPAWN_MIN {
+                continue;
+            }
+            if let Some(spec) = predator_spec(&registry, origin) {
+                spawn_npc_from_spec(&mut commands, &spec);
+                alive.push(origin);
+            }
+            break;
+        }
+    }
+}
+
+/// One of 8 compass offsets at `dist` tiles — picks a coarse heading for a ring
+/// spawn so predators appear spread around the player, not all in a line.
+fn ring_offset(oct: u8, dist: i32) -> (i32, i32) {
+    match oct % 8 {
+        0 => (0, -dist),
+        1 => (dist, -dist),
+        2 => (dist, 0),
+        3 => (dist, dist),
+        4 => (0, dist),
+        5 => (-dist, dist),
+        6 => (-dist, 0),
+        _ => (-dist, -dist),
+    }
 }
 
 pub fn spawn_world(

--- a/apps/agones/arpg/server/src/main.rs
+++ b/apps/agones/arpg/server/src/main.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         app.insert_resource(game::deployables());
         app.add_systems(
             bevy::prelude::Update,
-            game::spawn_world.in_set(simgrid::SimSet::Spawn),
+            (game::spawn_world, game::stream_predators).in_set(simgrid::SimSet::Spawn),
         );
         rt.block_on(run_sim_loop(app));
     });

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/ApexPredator_Large.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/ApexPredator_Large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:430c9902afd56c62759765c22f6d66940cc2711dcbdc0889c6d97151d5ad244a
+size 1605106

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_1.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a9ff0e1e9a74f865b9b5ae4bd533073262ca1e8f86b5b3297e898c9e091308
+size 4595505

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_2.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f57623029865871f89ea816dba0503c1afd16277b52f6d4bc83ac868ffe38d
+size 4605340

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_3.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34370865173b31efece603d2aab4bf644672cc56fccce0099f1a185f8e964212
+size 3386462

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_4.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f61760ab3692ebcd27ec20a2294e738e660d9d8ba1d252e9b0d425e4737c9b9d
+size 3566553

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_5.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5c67a8ba79c93a18ce5709c64bb8291c76da987c3c5de5711df03958f2d1e13
+size 3498109

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_6.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bad5b33bc188c980996571edb1d629c5416a37fc9fc0733c0cbba2b4dc6dd7c
+size 3636845

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_7.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45e49d4268e7dfe73b717b60731dd0c1210b6bfdb1f4562e9fe797cc6d4f31d6
+size 3309633

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_8.png
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/Sprite_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f53ea1114ed9fbf6c33b318705bb8b7dcb52bb3dc62ca29b52ee74982961d12f
+size 2539279

--- a/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/readme.md
+++ b/apps/agones/arpg/web/public/assets/arcade/arpg/creatures/apex_predator/readme.md
@@ -1,0 +1,46 @@
+# Apex Predator (creature)
+
+Rendered isometric reptilian apex predator. Unlike the player `ranger` class
+(per-angle flipbook PNGs, 16 directions), this creature ships as packed sprite
+sheets: each `Sprite_N.png` is **4096×4096**, a uniform **8×8 grid of 512×512
+frames** (64 slots, row-major index 0–63).
+
+Each sheet packs one or two animation states. Every state is split into a
+**cardinal** half (N/E/W/S) and a **diagonal** half (NW/NE/SW/SE), each direction
+occupying a contiguous run of frames.
+
+## Direction → frame order (within a state's frame range)
+
+8 directions, in this slot order:
+
+| cardinal block | diagonal block |
+| -------------- | -------------- |
+| N, E, W, S     | NW, NE, SW, SE |
+
+So a 64-frame state (8 frames/dir) lays out as:
+`N 0-7 · E 8-15 · W 16-23 · S 24-31 · NW 32-39 · NE 40-47 · SW 48-55 · SE 56-63`.
+A 24-frame state (3 frames/dir) lays out cardinal 0-11, diagonal 12-23.
+
+## Sheet → state map
+
+| sheet      | state       | total | cardinal                             | diagonal |
+| ---------- | ----------- | ----- | ------------------------------------ | -------- |
+| `Sprite_1` | Walking     | 64    | 0-31                                 | 32-63    |
+| `Sprite_2` | Running     | 64    | 0-31                                 | 32-63    |
+| `Sprite_3` | Idle        | 24    | 0-11                                 | 12-23    |
+| `Sprite_3` | Resting     | 24    | 24-35                                | 36-47    |
+| `Sprite_4` | Attack 1    | 24    | 0-11                                 | 12-23    |
+| `Sprite_4` | Attack 2    | 24    | 24-35                                | 36-47    |
+| `Sprite_5` | Use Skill   | 24    | 0-11                                 | 12-23    |
+| `Sprite_5` | Block       | 24    | 24-35                                | 36-47    |
+| `Sprite_6` | Evade       | 24    | 0-11                                 | 12-23    |
+| `Sprite_6` | Get Hit     | 24    | 24-35                                | 36-47    |
+| `Sprite_7` | Critical HP | 24    | 0-11                                 | 12-23    |
+| `Sprite_7` | Woozy       | 24    | 24-35                                | 36-47    |
+| `Sprite_8` | Behavior    | 24    | 0-11                                 | 12-23    |
+| `Sprite_8` | Dead        | 8     | 24-31 (all directions share one run) |
+
+`ApexPredator_Large.png` is a single hero/preview render (not a sheet).
+
+Blobs are tracked in Git LFS at the arpg Forgejo endpoint — see the `.lfsconfig`
+one level up. Push/pull with `./kbve.sh -lfs arpg <push|pull>`.

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -94,9 +94,12 @@ import { facingDegFromDelta } from './entities/classes';
 import {
 	makeSprite,
 	makeClassSprite,
+	makeCreatureSprite,
 	makeNameplate,
 	setClassPose,
+	setCreaturePose,
 	tickClassFacing,
+	tickCreatureFacing,
 	isPlayerKind,
 	type EntityRefs,
 } from './entities/sprites';
@@ -105,6 +108,12 @@ import {
 	registerClassAnims,
 	RANGER_CLASS,
 } from './entities/classes';
+import {
+	preloadCreature,
+	registerCreatureAnims,
+	resolveCreature,
+	APEX_PREDATOR,
+} from './entities/creatures';
 import {
 	preloadEnv,
 	registerEnvAnims,
@@ -278,6 +287,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	preload() {
 		this.load.image(GROUND_TEXTURE_KEY, arpgAsset(GROUND_TEXTURE_PATH));
 		preloadClass(this, RANGER_CLASS);
+		preloadCreature(this, APEX_PREDATOR);
 		for (const def of ENV_REGISTRY.values()) preloadEnv(this, def);
 	}
 
@@ -285,6 +295,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.cameras.main.setBackgroundColor(COLORS.background);
 		this.kinds = makeKindResolvers(this.kindRegistry);
 		registerClassAnims(this, RANGER_CLASS);
+		registerCreatureAnims(this, APEX_PREDATOR);
 		for (const def of ENV_REGISTRY.values()) registerEnvAnims(this, def);
 
 		this.drawGrid();
@@ -650,8 +661,16 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.syncBridge = {
 			create: (e: EntityDelta, label) => {
 				let refs: EntityRefs;
+				const creatureSprite = isPlayerKind(this.kinds, e.kind)
+					? null
+					: makeCreatureSprite(this, this.kinds.ref(e.kind));
 				if (isPlayerKind(this.kinds, e.kind)) {
 					refs = this.makePlayerRefs(e.kind);
+				} else if (creatureSprite) {
+					refs = {
+						sprite: creatureSprite.sprite,
+						creature: creatureSprite.creature,
+					};
 				} else if (this.kinds.catName(e.kind) === 'env') {
 					const envSprite = makeEnvSprite(
 						this,
@@ -1378,6 +1397,11 @@ export class IsoArpgScene extends Phaser.Scene {
 		for (const [, , refs] of this.store.entries()) {
 			if (refs.cls && refs.sprite instanceof Phaser.GameObjects.Sprite) {
 				tickClassFacing(refs.sprite, refs.cls);
+			} else if (
+				refs.creature &&
+				refs.sprite instanceof Phaser.GameObjects.Sprite
+			) {
+				tickCreatureFacing(refs.sprite, refs.creature);
 			}
 		}
 	}
@@ -1682,6 +1706,14 @@ export class IsoArpgScene extends Phaser.Scene {
 				{ dx: tile.x - from.x, dy: tile.y - from.y },
 				this,
 			);
+		} else if (
+			refs.creature &&
+			refs.sprite instanceof Phaser.GameObjects.Sprite
+		) {
+			setCreaturePose(refs.sprite, refs.creature, 'Walking', {
+				dx: tile.x - from.x,
+				dy: tile.y - from.y,
+			});
 		}
 
 		this.tweens.add({
@@ -1704,10 +1736,15 @@ export class IsoArpgScene extends Phaser.Scene {
 	 * float-driven and settles itself in tickLocalMotion.
 	 */
 	private settleRemoteIdle(refs: EntityRefs) {
-		if (!refs.cls || !(refs.sprite instanceof Phaser.GameObjects.Sprite))
-			return;
-		if (refs.cls.state !== 'Run') return;
+		if (!(refs.sprite instanceof Phaser.GameObjects.Sprite)) return;
 		if (this.tweens.isTweening(refs.sprite)) return;
+		if (refs.creature) {
+			if (refs.creature.state !== 'Walking') return;
+			setCreaturePose(refs.sprite, refs.creature, 'Idle');
+			return;
+		}
+		if (!refs.cls) return;
+		if (refs.cls.state !== 'Run') return;
 		setClassPose(refs.sprite, refs.cls, 'Idle', undefined, this);
 	}
 
@@ -1736,6 +1773,15 @@ export class IsoArpgScene extends Phaser.Scene {
 				refs.cls.state !== 'Death'
 			) {
 				setClassPose(refs.sprite, refs.cls, 'Death');
+			}
+
+			if (
+				refs.creature &&
+				refs.sprite instanceof Phaser.GameObjects.Sprite &&
+				hp <= 0 &&
+				refs.creature.state !== 'Dead'
+			) {
+				setCreaturePose(refs.sprite, refs.creature, 'Dead');
 			}
 
 			if (!refs.hpBar) continue;

--- a/apps/agones/arpg/web/src/game/entities/creatures.ts
+++ b/apps/agones/arpg/web/src/game/entities/creatures.ts
@@ -1,0 +1,329 @@
+import Phaser from 'phaser';
+import { arpgAsset } from '../config';
+import { facingDegFromDelta, SOUTH_DEG } from './classes';
+
+/**
+ * Creatures differ from player classes: instead of one PNG per facing angle,
+ * the art ships as packed sprite sheets. Each sheet is a 4096x4096 image laid
+ * out as an 8x8 grid of 512px frames (row-major index 0..63), and one or two
+ * animation states share a sheet. Every state is split into a CARDINAL half
+ * (N/E/W/S) and a DIAGONAL half (NW/NE/SW/SE); each direction occupies a
+ * contiguous run of `framesPerDir` frames inside its half.
+ *
+ * See the asset readme for the canonical sheet->state->frame-range table.
+ */
+
+// 8-way facing, in the order each half packs its directions.
+export const CREATURE_DIRS = [
+	'N',
+	'E',
+	'W',
+	'S',
+	'NW',
+	'NE',
+	'SW',
+	'SE',
+] as const;
+export type CreatureDir = (typeof CREATURE_DIRS)[number];
+
+const DIAGONAL_DIRS: ReadonlySet<CreatureDir> = new Set([
+	'NW',
+	'NE',
+	'SW',
+	'SE',
+]);
+
+// Index of a direction WITHIN its half (cardinal or diagonal), 0..3. This is
+// the block multiplier into the half's frame run.
+const DIR_BLOCK: Record<CreatureDir, number> = {
+	N: 0,
+	E: 1,
+	W: 2,
+	S: 3,
+	NW: 0,
+	NE: 1,
+	SW: 2,
+	SE: 3,
+};
+
+export type CreatureState =
+	| 'Idle'
+	| 'Resting'
+	| 'Walking'
+	| 'Running'
+	| 'Attack1'
+	| 'Attack2'
+	| 'UseSkill'
+	| 'Block'
+	| 'Evade'
+	| 'GetHit'
+	| 'CriticalHP'
+	| 'Woozy'
+	| 'Behavior'
+	| 'Dead';
+
+export const CREATURE_LOCOMOTION: CreatureState[] = [
+	'Idle',
+	'Walking',
+	'Running',
+];
+
+/**
+ * One animation packed in a sheet. `cardinalBase`/`diagonalBase` are the frame
+ * index where each half's first direction begins; `framesPerDir` is the run
+ * length per direction. `dirless` states (e.g. Dead) ignore direction and play
+ * the single run starting at `cardinalBase`.
+ */
+export interface CreatureAnim {
+	sheet: string;
+	cardinalBase: number;
+	diagonalBase: number;
+	framesPerDir: number;
+	frameRate: number;
+	loop: boolean;
+	dirless?: boolean;
+}
+
+export interface CreatureDef {
+	id: string;
+	assetPath: string;
+	frameSize: number;
+	displaySize: number;
+	originY: number;
+	anims: Partial<Record<CreatureState, CreatureAnim>>;
+}
+
+// Apex Predator — rendered isometric reptilian creature. Sheets Sprite_1..8.
+export const APEX_PREDATOR: CreatureDef = {
+	id: 'apex_predator',
+	assetPath: '/assets/arcade/arpg/creatures/apex_predator',
+	frameSize: 512,
+	displaySize: 160,
+	originY: 0.86,
+	anims: {
+		Walking: {
+			sheet: 'Sprite_1',
+			cardinalBase: 0,
+			diagonalBase: 32,
+			framesPerDir: 8,
+			frameRate: 14,
+			loop: true,
+		},
+		Running: {
+			sheet: 'Sprite_2',
+			cardinalBase: 0,
+			diagonalBase: 32,
+			framesPerDir: 8,
+			frameRate: 18,
+			loop: true,
+		},
+		Idle: {
+			sheet: 'Sprite_3',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 6,
+			loop: true,
+		},
+		Resting: {
+			sheet: 'Sprite_3',
+			cardinalBase: 24,
+			diagonalBase: 36,
+			framesPerDir: 3,
+			frameRate: 6,
+			loop: true,
+		},
+		Attack1: {
+			sheet: 'Sprite_4',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 16,
+			loop: false,
+		},
+		Attack2: {
+			sheet: 'Sprite_4',
+			cardinalBase: 24,
+			diagonalBase: 36,
+			framesPerDir: 3,
+			frameRate: 16,
+			loop: false,
+		},
+		UseSkill: {
+			sheet: 'Sprite_5',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 14,
+			loop: false,
+		},
+		Block: {
+			sheet: 'Sprite_5',
+			cardinalBase: 24,
+			diagonalBase: 36,
+			framesPerDir: 3,
+			frameRate: 12,
+			loop: false,
+		},
+		Evade: {
+			sheet: 'Sprite_6',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 16,
+			loop: false,
+		},
+		GetHit: {
+			sheet: 'Sprite_6',
+			cardinalBase: 24,
+			diagonalBase: 36,
+			framesPerDir: 3,
+			frameRate: 16,
+			loop: false,
+		},
+		CriticalHP: {
+			sheet: 'Sprite_7',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 8,
+			loop: true,
+		},
+		Woozy: {
+			sheet: 'Sprite_7',
+			cardinalBase: 24,
+			diagonalBase: 36,
+			framesPerDir: 3,
+			frameRate: 8,
+			loop: true,
+		},
+		Behavior: {
+			sheet: 'Sprite_8',
+			cardinalBase: 0,
+			diagonalBase: 12,
+			framesPerDir: 3,
+			frameRate: 10,
+			loop: false,
+		},
+		Dead: {
+			sheet: 'Sprite_8',
+			cardinalBase: 24,
+			diagonalBase: 24,
+			framesPerDir: 8,
+			frameRate: 12,
+			loop: false,
+			dirless: true,
+		},
+	},
+};
+
+const CREATURE_REGISTRY: Record<string, CreatureDef> = {
+	apex_predator: APEX_PREDATOR,
+};
+
+/** Look up a creature def by its kind ref, or null if the ref isn't a creature. */
+export function resolveCreature(ref: string | null): CreatureDef | null {
+	return ref ? (CREATURE_REGISTRY[ref] ?? null) : null;
+}
+
+/** Texture key for a creature's packed sheet (one texture per Sprite_N). */
+function sheetKey(def: CreatureDef, sheet: string): string {
+	return `creature:${def.id}:${sheet}`;
+}
+
+/** Phaser animation key for one state+direction of a creature. */
+export function creatureAnimKey(
+	def: CreatureDef,
+	state: CreatureState,
+	dir: CreatureDir,
+): string {
+	const anim = def.anims[state];
+	if (anim?.dirless) return `canim:${def.id}:${state}`;
+	return `canim:${def.id}:${state}:${dir}`;
+}
+
+/** Inclusive [start,end] frame range for a state+direction within its sheet. */
+function frameRange(
+	anim: CreatureAnim,
+	dir: CreatureDir,
+): { start: number; end: number } {
+	if (anim.dirless) {
+		return {
+			start: anim.cardinalBase,
+			end: anim.cardinalBase + anim.framesPerDir - 1,
+		};
+	}
+	const base = DIAGONAL_DIRS.has(dir) ? anim.diagonalBase : anim.cardinalBase;
+	const start = base + DIR_BLOCK[dir] * anim.framesPerDir;
+	return { start, end: start + anim.framesPerDir - 1 };
+}
+
+/** Load every packed sheet a creature uses (deduped across states). */
+export function preloadCreature(scene: Phaser.Scene, def: CreatureDef): void {
+	const seen = new Set<string>();
+	for (const anim of Object.values(def.anims)) {
+		if (!anim || seen.has(anim.sheet)) continue;
+		seen.add(anim.sheet);
+		scene.load.spritesheet(
+			sheetKey(def, anim.sheet),
+			arpgAsset(`${def.assetPath}/${anim.sheet}.png`),
+			{ frameWidth: def.frameSize, frameHeight: def.frameSize },
+		);
+	}
+}
+
+/** Register every state+direction animation once the sheets are loaded. */
+export function registerCreatureAnims(
+	scene: Phaser.Scene,
+	def: CreatureDef,
+): void {
+	for (const state of Object.keys(def.anims) as CreatureState[]) {
+		const anim = def.anims[state];
+		if (!anim) continue;
+		const dirs: CreatureDir[] = anim.dirless ? ['N'] : [...CREATURE_DIRS];
+		for (const dir of dirs) {
+			const key = creatureAnimKey(def, state, dir);
+			if (scene.anims.exists(key)) continue;
+			const { start, end } = frameRange(anim, dir);
+			scene.anims.create({
+				key,
+				frames: scene.anims.generateFrameNumbers(
+					sheetKey(def, anim.sheet),
+					{
+						start,
+						end,
+					},
+				),
+				frameRate: anim.frameRate,
+				repeat: anim.loop ? -1 : 0,
+			});
+		}
+	}
+}
+
+/** First-frame texture key + frame for a state+direction (initial sprite). */
+export function creatureFirstFrame(
+	def: CreatureDef,
+	state: CreatureState,
+	dir: CreatureDir,
+): { key: string; frame: number } {
+	const anim = def.anims[state] ?? def.anims.Idle!;
+	return {
+		key: sheetKey(def, anim.sheet),
+		frame: frameRange(anim, dir).start,
+	};
+}
+
+/** Snap continuous screen-facing degrees to one of the 8 creature directions. */
+export function dirFromDeg(deg: number): CreatureDir {
+	const idx = ((Math.round(deg / 45) % 8) + 8) % 8;
+	// 0=N,45=NE,90=E,135=SE,180=S,225=SW,270=W,315=NW
+	return (['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const)[idx];
+}
+
+/** Map a tile-space movement delta straight to the nearest creature direction. */
+export function nearestCreatureDir(dx: number, dy: number): CreatureDir {
+	return dirFromDeg(facingDegFromDelta(dx, dy));
+}
+
+export const CREATURE_SOUTH = SOUTH_DEG;

--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -26,8 +26,22 @@ import {
 	type ClassDef,
 	type ClassState,
 } from './classes';
+import {
+	CREATURE_LOCOMOTION,
+	CREATURE_SOUTH,
+	creatureAnimKey,
+	creatureFirstFrame,
+	dirFromDeg,
+	nearestCreatureDir,
+	resolveCreature,
+	type CreatureDef,
+	type CreatureDir,
+	type CreatureState,
+} from './creatures';
 
 const isOneShot = (s: ClassState): boolean => ONE_SHOT_STATES.includes(s);
+const isCreatureLocomotion = (s: CreatureState): boolean =>
+	CREATURE_LOCOMOTION.includes(s);
 const isLocomotion = (s: ClassState): boolean => LOCOMOTION_STATES.includes(s);
 
 const warnedAnims = new Set<string>();
@@ -80,6 +94,16 @@ export interface EntityRefs {
 	hpBar?: Phaser.GameObjects.Graphics;
 	statusFx?: Phaser.GameObjects.Graphics;
 	cls?: ClassView;
+	creature?: CreatureView;
+}
+
+/** Per-creature directional pose state, analogous to ClassView for NPCs. */
+export interface CreatureView {
+	def: CreatureDef;
+	dir: CreatureDir;
+	state: CreatureState;
+	facingDeg: number;
+	targetDeg: number;
 }
 
 function bodyColor(cat: number, hostile: boolean): number {
@@ -322,4 +346,76 @@ export function makeNameplate(
 		})
 		.setOrigin(0.5, 1)
 		.setDepth(DEPTH_UI + 1);
+}
+
+/**
+ * Spawn an animated creature NPC (e.g. apex_predator) facing south at Idle.
+ * Returns null when the kind ref isn't a registered creature, so callers can
+ * fall back to the plain Rectangle sprite path.
+ */
+export function makeCreatureSprite(
+	scene: Phaser.Scene,
+	ref: string | null,
+): { sprite: Phaser.GameObjects.Sprite; creature: CreatureView } | null {
+	const def = resolveCreature(ref);
+	if (!def) return null;
+	const dir: CreatureDir = dirFromDeg(CREATURE_SOUTH);
+	const first = creatureFirstFrame(def, 'Idle', dir);
+	const sprite = scene.add.sprite(0, 0, first.key, first.frame);
+	sprite.setOrigin(0.5, def.originY);
+	sprite.setDisplaySize(def.displaySize, def.displaySize);
+	const view: CreatureView = {
+		def,
+		dir,
+		state: 'Idle',
+		facingDeg: CREATURE_SOUTH,
+		targetDeg: CREATURE_SOUTH,
+	};
+	safePlay(sprite, creatureAnimKey(def, 'Idle', dir));
+	return { sprite, creature: view };
+}
+
+/**
+ * Set a creature's STATE and (when given a movement delta) facing TARGET. Like
+ * setClassPose but 8-way and shadow-less: locomotion re-plays only on a state
+ * change; one-shots always re-play and snap facing to the aim immediately.
+ */
+export function setCreaturePose(
+	sprite: Phaser.GameObjects.Sprite,
+	view: CreatureView,
+	state: CreatureState,
+	facing?: { dx: number; dy: number },
+): void {
+	if (facing && (facing.dx !== 0 || facing.dy !== 0)) {
+		view.targetDeg = facingDegFromDelta(facing.dx, facing.dy);
+	}
+	const oneShot = !isCreatureLocomotion(state);
+	const changed = state !== view.state || oneShot;
+	view.state = state;
+	if (oneShot && facing && (facing.dx !== 0 || facing.dy !== 0)) {
+		view.facingDeg = view.targetDeg;
+		view.dir = nearestCreatureDir(facing.dx, facing.dy);
+	}
+	if (!changed) return;
+	sprite.setDisplaySize(view.def.displaySize, view.def.displaySize);
+	safePlay(sprite, creatureAnimKey(view.def, state, view.dir), !oneShot);
+}
+
+/**
+ * Advance a creature's smooth facing each frame: lerp toward the target and,
+ * when it crosses into a new 8-way bucket, swap the looping sheet run WITHOUT
+ * restarting (progress preserved) so a turn re-aims mid-stride. One-shots hold.
+ */
+export function tickCreatureFacing(
+	sprite: Phaser.GameObjects.Sprite,
+	view: CreatureView,
+): void {
+	if (!isCreatureLocomotion(view.state)) return;
+	view.facingDeg = lerpAngleDeg(view.facingDeg, view.targetDeg, TURN_LERP);
+	const dir = dirFromDeg(view.facingDeg);
+	if (dir === view.dir) return;
+	view.dir = dir;
+	const progress = sprite.anims?.getProgress() ?? 0;
+	safePlay(sprite, creatureAnimKey(view.def, view.state, dir), true);
+	sprite.anims?.setProgress(Phaser.Math.Clamp(progress, 0, 1));
 }

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -23,7 +23,7 @@ pub use sim::{
     Aggro, AggroSpec, Blocker, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense,
     DeployableSpec, Deployables, EntityKind, EnvObject, EnvOpts, EquipBonus, EquipmentEffects,
     Equipped, HazardZone, HealAura, Health, Inventory, ItemPrices, Loot, NpcLevel, NpcSpec,
-    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimConfig, SimSet,
-    StatusEffect, StatusEffects, Wander, XpState, build_app, ground_item_bundle, level_attack,
-    level_max_hp, run_sim_loop, spawn_env_object, spawn_npc_from_spec, xp_to_next,
+    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimClock, SimConfig,
+    SimSeed, SimSet, StatusEffect, StatusEffects, Wander, XpState, build_app, ground_item_bundle,
+    level_attack, level_max_hp, run_sim_loop, spawn_env_object, spawn_npc_from_spec, xp_to_next,
 };


### PR DESCRIPTION
## What

Adds the **Apex Predator** as the first animated NPC in the arpg, streamed in around players as they explore — analogous to how goblins spawn, but dynamic instead of seeded-once. Goblins still render as plain rectangles; predators get a full directional sprite path.

## Assets (Git LFS)

8 packed sprite sheets under `assets/arcade/arpg/creatures/apex_predator/` — each `Sprite_N.png` is 4096×4096, an 8×8 grid of 512px frames. Blobs pushed to the arpg Forgejo LFS endpoint; pointers tracked here. `readme.md` documents the canonical sheet→state→frame-range table.

## Client

- **`creatures.ts`** — `CreatureDef` + 8-direction packed-sheet loader. States split into a cardinal half (N,E,W,S) and a diagonal half (NW,NE,SW,SE), each direction a contiguous per-direction frame run. Registers an anim per state+direction; snaps screen-facing degrees to the nearest of 8 dirs.
- **`sprites.ts`** — `makeCreatureSprite` / `setCreaturePose` / `tickCreatureFacing` + a `CreatureView` on `EntityRefs`, mirroring the player `ClassView` path.
- **`IsoArpgScene.ts`** — preload + register predator anims, branch the entity-create bridge to creature sprites by kind, and reuse the existing tween / settle / facing-tick movement plumbing to drive Walking↔Idle + 8-way facing.

## Server

- **`game.rs`** — `apex_predator` NPC ref + spec (tankier, harder-hitting than a goblin; wanders, aggros, drops coin) and `stream_predators`: every 0.5s it culls predators beyond every player's despawn radius and tops each player's local population up to a cap by spawning on floor tiles in a ring ahead of them. Ground-floor only for now (matches seeded-goblin scope).
- **`main.rs`** — registers `stream_predators` in `SimSet::Spawn`.
- **simgrid `lib.rs`** — exports `SimClock` / `SimSeed` so the host app can write the system.

## Verify

Run with a server (offline mode won't stream): `docker compose -f apps/agones/arpg/docker-compose.yml --profile web up --build`. Walk around — predators stream in within a 12–22 tile ring and cull past 40 tiles.

Builds green: `arpg-web:typecheck`, `arpg-server` clippy `-D warnings`.

## Follow-ups

- **Direction mapping** decoded from contact sheets (N,E,W,S / NW,NE,SW,SE) — confirm live; tune `DIR_BLOCK` / `dirFromDeg` if a facing reads wrong.
- **Scale/pivot** (`displaySize` 160, `originY` 0.86) — tune live.
- **VRAM**: 8 × 4096² RGBA ≈ 0.5 GB texture mem; fine on desktop, heavy for mobile — downscale or lazy-load non-locomotion sheets later.
- **Floor > 0** streaming needs spawns to carry a `Floor`.
- **NPCDB** full integration is the next pass once the above is confirmed.