### PR TITLE
fix(arpg): bevy_mapdb Dockerfile build + predator direction debug overlay

### DIFF
--- a/apps/agones/arpg/server/Dockerfile
+++ b/apps/agones/arpg/server/Dockerfile
@@ -15,6 +15,7 @@ COPY packages/rust/simgrid/Cargo.toml packages/rust/simgrid/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
 COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_inventory/Cargo.toml
+COPY packages/rust/bevy/bevy_mapdb/Cargo.toml packages/rust/bevy/bevy_mapdb/Cargo.toml
 
 RUN mkdir -p apps/agones/arpg/server/src && \
     echo "fn main() {}" > apps/agones/arpg/server/src/main.rs && \
@@ -25,7 +26,9 @@ RUN mkdir -p apps/agones/arpg/server/src && \
     mkdir -p packages/rust/bevy/bevy_items/src && \
     echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_inventory/src && \
-    echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs
+    echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_mapdb/src && \
+    echo "" > packages/rust/bevy/bevy_mapdb/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json --bin arpg-server
 
@@ -69,8 +72,10 @@ COPY packages/rust/simgrid packages/rust/simgrid
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
-# arpg-server include_bytes!s the canonical itemdb binary at compile time.
+COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
+# arpg-server include_bytes!s the canonical itemdb + mapdb binaries at compile time.
 COPY packages/data/codegen/generated/itemdb-data.binpb packages/data/codegen/generated/itemdb-data.binpb
+COPY packages/data/codegen/generated/mapdb-data.binpb packages/data/codegen/generated/mapdb-data.binpb
 COPY apps/agones/arpg/server apps/agones/arpg/server
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -113,6 +113,7 @@ import {
 	registerCreatureAnims,
 	resolveCreature,
 	APEX_PREDATOR,
+	DEBUG_CREATURE_DIRS,
 } from './entities/creatures';
 import {
 	preloadEnv,
@@ -671,6 +672,21 @@ export class IsoArpgScene extends Phaser.Scene {
 						sprite: creatureSprite.sprite,
 						creature: creatureSprite.creature,
 					};
+					if (DEBUG_CREATURE_DIRS) {
+						refs.dbgText = this.add
+							.text(0, 0, '', {
+								fontFamily: 'monospace',
+								fontSize: '13px',
+								color: '#34d399',
+								stroke: '#000000',
+								strokeThickness: 4,
+							})
+							.setOrigin(0.5, 1)
+							.setDepth(DEPTH_UI + 2);
+						refs.dbgArrow = this.add
+							.graphics()
+							.setDepth(DEPTH_UI + 2);
+					}
 				} else if (this.kinds.catName(e.kind) === 'env') {
 					const envSprite = makeEnvSprite(
 						this,
@@ -721,6 +737,8 @@ export class IsoArpgScene extends Phaser.Scene {
 				refs.nameplate?.destroy();
 				refs.hpBar?.destroy();
 				refs.statusFx?.destroy();
+				refs.dbgText?.destroy();
+				refs.dbgArrow?.destroy();
 				refs.sprite.destroy();
 			},
 		};
@@ -1402,7 +1420,55 @@ export class IsoArpgScene extends Phaser.Scene {
 				refs.sprite instanceof Phaser.GameObjects.Sprite
 			) {
 				tickCreatureFacing(refs.sprite, refs.creature);
+				if (DEBUG_CREATURE_DIRS) this.drawCreatureDebug(refs);
 			}
+		}
+	}
+
+	/**
+	 * Debug overlay: a green arrow in the creature's TRUE screen heading
+	 * (targetDeg, straight from the movement delta) plus the sheet direction
+	 * block the code currently picked. If the body visually faces away from the
+	 * arrow, the art<->direction mapping in creatures.ts is off.
+	 */
+	private drawCreatureDebug(refs: EntityRefs) {
+		if (
+			!refs.creature ||
+			!(refs.sprite instanceof Phaser.GameObjects.Sprite)
+		)
+			return;
+		const sx = refs.sprite.x;
+		const sy = refs.sprite.y - refs.sprite.displayHeight * 0.45;
+		if (refs.dbgText) {
+			refs.dbgText.setText(
+				`${refs.creature.dir} ${Math.round(refs.creature.targetDeg)}°`,
+			);
+			refs.dbgText.setPosition(sx, sy - 14);
+		}
+		if (refs.dbgArrow) {
+			const rad = (refs.creature.targetDeg * Math.PI) / 180;
+			const vx = Math.sin(rad);
+			const vy = -Math.cos(rad);
+			const len = 34;
+			const ex = sx + vx * len;
+			const ey = sy + vy * len;
+			const g = refs.dbgArrow;
+			g.clear();
+			g.lineStyle(3, 0x34d399, 1);
+			g.beginPath();
+			g.moveTo(sx, sy);
+			g.lineTo(ex, ey);
+			g.strokePath();
+			// arrowhead
+			const ah = 8;
+			const a1 = rad + Math.PI * 0.85;
+			const a2 = rad - Math.PI * 0.85;
+			g.beginPath();
+			g.moveTo(ex, ey);
+			g.lineTo(ex + Math.sin(a1) * ah, ey - Math.cos(a1) * ah);
+			g.moveTo(ex, ey);
+			g.lineTo(ex + Math.sin(a2) * ah, ey - Math.cos(a2) * ah);
+			g.strokePath();
 		}
 	}
 

--- a/apps/agones/arpg/web/src/game/entities/creatures.ts
+++ b/apps/agones/arpg/web/src/game/entities/creatures.ts
@@ -2,6 +2,11 @@ import Phaser from 'phaser';
 import { arpgAsset } from '../config';
 import { facingDegFromDelta, SOUTH_DEG } from './classes';
 
+// Temporary: draws each creature's code-believed direction + a movement arrow so
+// the 8-way sheet mapping can be eyeballed against actual facing. Flip off (or
+// delete the dbg* plumbing) once the mapping is locked.
+export const DEBUG_CREATURE_DIRS = true;
+
 /**
  * Creatures differ from player classes: instead of one PNG per facing angle,
  * the art ships as packed sprite sheets. Each sheet is a 4096x4096 image laid

--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -95,6 +95,8 @@ export interface EntityRefs {
 	statusFx?: Phaser.GameObjects.Graphics;
 	cls?: ClassView;
 	creature?: CreatureView;
+	dbgText?: Phaser.GameObjects.Text;
+	dbgArrow?: Phaser.GameObjects.Graphics;
 }
 
 /** Per-creature directional pose state, analogous to ClassView for NPCs. */


### PR DESCRIPTION
Two arpg follow-ups bundled for dev:

## 1. Dockerfile: add bevy_mapdb (build blocker)
arpg-server gained a `bevy_mapdb` dependency (campfire mapdb WorldObjectDef, #13167) but the multi-stage Dockerfile was never updated — `cargo chef prepare` fails loading the workspace (`failed to read packages/rust/bevy/bevy_mapdb/Cargo.toml`) and the image can't build. Adds the missing copies: bevy_mapdb manifest + src stub in the planner, the full crate in the builder, and `mapdb-data.binpb` (`include_bytes!`d at compile time alongside itemdb).

Verified: `docker compose -f apps/agones/arpg/docker-compose.yml --profile web up --build` now builds the server image and the stack comes up.

## 2. Predator direction debug overlay (temporary)
`DEBUG_CREATURE_DIRS` overlay on each streamed apex predator: a green arrow in its true screen heading + the sheet-direction block the code picked, to eyeball the 8-way packed-sheet mapping against actual facing. Cleaned up on entity remove. **Flip the flag off / strip the dbg* plumbing once the mapping is locked.**

Follow-up still open: correct the direction block table + tune the larger creature's `originY`/scale so it stops floating over void tiles.