### PR TITLE
fix(n8n): PDB maxUnavailable + rabbitmq/supabase workflow secrets

### DIFF
--- a/apps/kube/n8n/manifest/n8n-externalsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-externalsecret.yaml
@@ -79,6 +79,90 @@ spec:
               key: supabase-jwt
               property: anon-key
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: n8n-supabase-workflow
+    namespace: n8n
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: n8n-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: n8n-supabase-workflow
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                supabase-url: 'http://kong.kilobase.svc.cluster.local:8000'
+                anon-key: '{{ .anonkey }}'
+                service-key: '{{ .servicekey }}'
+    data:
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-service-key
+              property: hash
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: n8n-rabbitmq-secret-store
+    namespace: n8n
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rabbitmq-system
+            auth:
+                serviceAccount:
+                    name: n8n-external-secrets
+                    namespace: n8n
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: n8n-rabbitmq-secrets
+    namespace: n8n
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: n8n-rabbitmq-secret-store
+        kind: SecretStore
+    target:
+        name: n8n-rabbitmq-credentials
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                username: '{{ .username }}'
+                password: '{{ .password }}'
+                host: '{{ .host }}'
+                amqp-url: 'amqp://{{ .username }}:{{ .password }}@{{ .host }}:5672'
+    data:
+        - secretKey: username
+          remoteRef:
+              key: rabbitmq-default-user
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: rabbitmq-default-user
+              property: password
+        - secretKey: host
+          remoteRef:
+              key: rabbitmq-default-user
+              property: host
+---
 # n8n-encryption-secret: Run ../seal-encryption-key.sh before first deployment.
 # The script generates a random key, seals it via kubeseal, and writes
 # n8n-encryption-sealedsecret.yaml into this directory. Plaintext never touches disk.

--- a/apps/kube/n8n/manifest/n8n-pdb.yaml
+++ b/apps/kube/n8n/manifest/n8n-pdb.yaml
@@ -4,7 +4,7 @@ metadata:
     name: n8n-pdb
     namespace: n8n
 spec:
-    minAvailable: 1
+    maxUnavailable: 1
     selector:
         matchLabels:
             app: n8n
@@ -15,7 +15,7 @@ metadata:
     name: n8n-worker-pdb
     namespace: n8n
 spec:
-    minAvailable: 1
+    maxUnavailable: 1
     selector:
         matchLabels:
             app: n8n-worker

--- a/apps/kube/n8n/manifest/rbac.yaml
+++ b/apps/kube/n8n/manifest/rbac.yaml
@@ -20,7 +20,8 @@ metadata:
 rules:
     - apiGroups: ['']
       resources: ['secrets']
-      resourceNames: ['supabase-postgres', 'supabase-jwt']
+      resourceNames:
+          ['supabase-postgres', 'supabase-jwt', 'supabase-service-key']
       verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -61,3 +62,28 @@ subjects:
     - kind: ServiceAccount
       name: discordsh-external-secrets
       namespace: discordsh
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rabbitmq-secrets-reader-for-n8n
+    namespace: rabbitmq-system
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['rabbitmq-default-user']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: n8n-read-rabbitmq-secrets
+    namespace: rabbitmq-system
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rabbitmq-secrets-reader-for-n8n
+subjects:
+    - kind: ServiceAccount
+      name: n8n-external-secrets
+      namespace: n8n


### PR DESCRIPTION
## Summary
Resolves #13102 — n8n PodDisruptionBudgets used `minAvailable: 1` on `replicas: 1` (n8n) / KEDA min 1 (n8n-worker), permitting **zero** voluntary disruptions, so `kubectl drain` and node upgrades hang forever. Switched both PDBs to `maxUnavailable: 1`.

Also wires workflow connection secrets (k8s-secret-only model; `N8N_BLOCK_ENV_ACCESS_IN_NODE` stays `true`, no env injection):
- Cross-ns RBAC: `n8n-external-secrets` SA reads `rabbitmq-default-user` in `rabbitmq-system`; `supabase-service-key` added to the kilobase role.
- SecretStore + ExternalSecret → `n8n-rabbitmq-credentials` (`amqp-url`, host/user/pass).
- ExternalSecret → `n8n-supabase-workflow` (Kong `supabase-url`, `anon-key`, `service-key`).

Valkey already wired (queue + KEDA) — no change.

## Notes
- ArgoCD tracks `main`; live only after the dev→main release.
- n8n native nodes consume these via UI credential entries (values from `kubectl get secret -n n8n`); secrets are not auto-imported into n8n's store.

Closes #13102