### PR TITLE
feat(arpg): per-creature dirBlocks for predator direction mapping

### DIFF
--- a/apps/agones/arpg/web/src/game/entities/creatures.ts
+++ b/apps/agones/arpg/web/src/game/entities/creatures.ts
@@ -38,9 +38,17 @@ const DIAGONAL_DIRS: ReadonlySet<CreatureDir> = new Set([
 	'SE',
 ]);
 
-// Index of a direction WITHIN its half (cardinal or diagonal), 0..3. This is
-// the block multiplier into the half's frame run.
-const DIR_BLOCK: Record<CreatureDir, number> = {
+/**
+ * Maps each facing to its block index (0..3) WITHIN its half (cardinal or
+ * diagonal) — the multiplier into that half's frame run. Sheets from different
+ * art packs order their 8 renders differently, so this lives per-creature on
+ * `CreatureDef.dirBlocks` rather than as one global table.
+ */
+export type DirBlocks = Record<CreatureDir, number>;
+
+// The order a naive left-to-right read of a sheet would assume. Handy starting
+// point; most packs need a tweak or two against the in-game debug overlay.
+export const NAIVE_DIR_BLOCKS: DirBlocks = {
 	N: 0,
 	E: 1,
 	W: 2,
@@ -95,6 +103,8 @@ export interface CreatureDef {
 	frameSize: number;
 	displaySize: number;
 	originY: number;
+	/** Facing -> in-half block index for this creature's sheet packing. */
+	dirBlocks: DirBlocks;
 	anims: Partial<Record<CreatureState, CreatureAnim>>;
 }
 
@@ -105,6 +115,19 @@ export const APEX_PREDATOR: CreatureDef = {
 	frameSize: 512,
 	displaySize: 160,
 	originY: 0.86,
+	// Calibrated in-game vs the debug overlay: side profiles read L/R-swapped
+	// (block 1 = head-LEFT/W, block 2 = head-RIGHT/E) and the NE/SW diagonal
+	// pair is swapped from a naive read.
+	dirBlocks: {
+		N: 0,
+		W: 1,
+		E: 2,
+		S: 3,
+		SW: 0,
+		NW: 1,
+		SE: 2,
+		NE: 3,
+	},
 	anims: {
 		Walking: {
 			sheet: 'Sprite_1',
@@ -251,6 +274,7 @@ export function creatureAnimKey(
 function frameRange(
 	anim: CreatureAnim,
 	dir: CreatureDir,
+	dirBlocks: DirBlocks,
 ): { start: number; end: number } {
 	if (anim.dirless) {
 		return {
@@ -259,7 +283,7 @@ function frameRange(
 		};
 	}
 	const base = DIAGONAL_DIRS.has(dir) ? anim.diagonalBase : anim.cardinalBase;
-	const start = base + DIR_BLOCK[dir] * anim.framesPerDir;
+	const start = base + dirBlocks[dir] * anim.framesPerDir;
 	return { start, end: start + anim.framesPerDir - 1 };
 }
 
@@ -289,7 +313,7 @@ export function registerCreatureAnims(
 		for (const dir of dirs) {
 			const key = creatureAnimKey(def, state, dir);
 			if (scene.anims.exists(key)) continue;
-			const { start, end } = frameRange(anim, dir);
+			const { start, end } = frameRange(anim, dir, def.dirBlocks);
 			scene.anims.create({
 				key,
 				frames: scene.anims.generateFrameNumbers(
@@ -315,7 +339,7 @@ export function creatureFirstFrame(
 	const anim = def.anims[state] ?? def.anims.Idle!;
 	return {
 		key: sheetKey(def, anim.sheet),
-		frame: frameRange(anim, dir).start,
+		frame: frameRange(anim, dir, def.dirBlocks).start,
 	};
 }
 


### PR DESCRIPTION
Follow-up to the apex predator streaming work + the debug overlay (already on dev).

Moves the 8-way facing→frame-block table off a global `DIR_BLOCK` const onto `CreatureDef.dirBlocks`, so each creature's sheet packing is self-describing — data-driven and consistent with treating creatures as ECS-style data. Exports `NAIVE_DIR_BLOCKS` as the naive left-to-right starting point for new sheets.

Apex Predator carries its **calibrated** map, verified in-game against the `DEBUG_CREATURE_DIRS` arrow overlay:
- side profiles read L/R-swapped (block 1 = head-left/W, block 2 = head-right/E)
- the NE/SW diagonal pair is swapped from a naive read

Single-file change (`creatures.ts`); typecheck green.

Still open (next pass): final N/S + NW/SE diagonal confirmation, then flip the debug flag off and tune the larger creature's `originY`/scale so it stops floating over void tiles.