### PR TITLE
feat(arpg): roam behavior for apex predators

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -59,6 +59,11 @@ pub const PREDATOR_DAMAGE: i32 = 8;
 pub const PREDATOR_DEFENSE: i32 = 2;
 pub const PREDATOR_TICKS_PER_TILE: u8 = 5;
 pub const PREDATOR_LEVEL: i32 = 3;
+// Roam: wander toward a random tile up to this far from spawn, then idle a
+// random dwell in [min,max] before the next trip — longer, deliberate movement.
+pub const PREDATOR_ROAM_RADIUS: i32 = 10;
+pub const PREDATOR_DWELL_MIN_TICKS: u32 = SIM_TICK_HZ;
+pub const PREDATOR_DWELL_MAX_TICKS: u32 = SIM_TICK_HZ * 3;
 // Streaming spawn budget: how many predators may exist near each player, the
 // ring (in tiles) they appear within, and how close they're allowed to pop in.
 pub const PREDATOR_PER_PLAYER: usize = 3;
@@ -318,6 +323,7 @@ fn goblin_spec(registry: &KindRegistry, origin: Tile) -> Option<NpcSpec> {
         level: 1,
         defense: GOBLIN_DEFENSE,
         wander: Some((8, 25)),
+        roam: None,
         aggro: Some(AggroSpec {
             range: HOSTILE_AGGRO_RANGE,
             damage: GOBLIN_DAMAGE,
@@ -338,7 +344,14 @@ fn predator_spec(registry: &KindRegistry, origin: Tile) -> Option<NpcSpec> {
         max_hp: PREDATOR_HP,
         level: PREDATOR_LEVEL,
         defense: PREDATOR_DEFENSE,
-        wander: Some((6, 18)),
+        wander: None,
+        // Roam in longer purposeful trips with idle dwells between, instead of
+        // the single-tile jitter `wander` produces.
+        roam: Some((
+            PREDATOR_ROAM_RADIUS,
+            PREDATOR_DWELL_MIN_TICKS,
+            PREDATOR_DWELL_MAX_TICKS,
+        )),
         aggro: Some(AggroSpec {
             range: HOSTILE_AGGRO_RANGE,
             damage: PREDATOR_DAMAGE,

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -1151,6 +1151,23 @@ export class IsoArpgScene extends Phaser.Scene {
 		if (refs.sprite instanceof Phaser.GameObjects.Sprite) {
 			flashEntity(this, refs.sprite);
 		}
+
+		// Drive creature combat poses: the attacker swings (facing its target),
+		// the victim recoils. Death is left to the hp<=0 check in refreshHud.
+		const atk = this.store.refs(c.attacker);
+		if (atk?.creature && atk.sprite instanceof Phaser.GameObjects.Sprite) {
+			const a = this.store.tile(c.attacker);
+			const t = this.store.tile(c.target);
+			const face = a && t ? { dx: t.x - a.x, dy: t.y - a.y } : undefined;
+			setCreaturePose(atk.sprite, atk.creature, 'Attack1', face);
+		}
+		if (
+			refs.creature &&
+			refs.sprite instanceof Phaser.GameObjects.Sprite &&
+			!c.died
+		) {
+			setCreaturePose(refs.sprite, refs.creature, 'GetHit');
+		}
 	}
 
 	/**

--- a/apps/agones/arpg/web/src/game/entities/creatures.ts
+++ b/apps/agones/arpg/web/src/game/entities/creatures.ts
@@ -114,7 +114,9 @@ export const APEX_PREDATOR: CreatureDef = {
 	assetPath: '/assets/arcade/arpg/creatures/apex_predator',
 	frameSize: 512,
 	displaySize: 160,
-	originY: 0.86,
+	// Feet + baked shadow sit ~0.82 down the 512px frame; anchor there so the
+	// creature stands ON the tile instead of floating a few px above it.
+	originY: 0.82,
 	// Calibrated in-game vs the debug overlay: side profiles read L/R-swapped
 	// (block 1 = head-LEFT/W, block 2 = head-RIGHT/E) and the NE/SW diagonal
 	// pair is swapped from a naive read.

--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -400,7 +400,16 @@ export function setCreaturePose(
 	}
 	if (!changed) return;
 	sprite.setDisplaySize(view.def.displaySize, view.def.displaySize);
-	safePlay(sprite, creatureAnimKey(view.def, state, view.dir), !oneShot);
+	const key = creatureAnimKey(view.def, state, view.dir);
+	safePlay(sprite, key, !oneShot);
+	// One-shots (Attack/GetHit/…) play once then would freeze on their last
+	// frame; settle back to Idle when done so the creature keeps breathing. Dead
+	// is the exception — it holds its final frame.
+	if (oneShot && state !== 'Dead') {
+		sprite.once(`animationcomplete-${key}`, () => {
+			if (view.state === state) setCreaturePose(sprite, view, 'Idle');
+		});
+	}
 }
 
 /**

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -1968,6 +1968,36 @@ fn try_move(
     true
 }
 
+/// Queue a one-tile move by an arbitrary (dx,dy) step where each component is
+/// -1/0/1 — the 8-way counterpart to `try_move`. A diagonal step also requires
+/// both orthogonal neighbors to be open so mobs can't cut through wall corners.
+fn try_step(
+    dx: i32,
+    dy: i32,
+    map: &WalkableMap,
+    z: i32,
+    pos: &GridPos,
+    mv: &mut MoveTarget,
+) -> bool {
+    if mv.target.is_some() || (dx == 0 && dy == 0) {
+        return false;
+    }
+    let candidate = Tile::new(pos.tile.x + dx, pos.tile.y + dy);
+    if !map.is_walkable_z(z, candidate) {
+        return false;
+    }
+    if dx != 0
+        && dy != 0
+        && (!map.is_walkable_z(z, Tile::new(pos.tile.x + dx, pos.tile.y))
+            || !map.is_walkable_z(z, Tile::new(pos.tile.x, pos.tile.y + dy)))
+    {
+        return false;
+    }
+    mv.target = Some(candidate);
+    mv.progress = 0;
+    true
+}
+
 fn step_tile(tile: Tile, dir: Dir) -> Tile {
     let (dx, dy) = dir.delta();
     Tile::new(tile.x + dx, tile.y + dy)
@@ -2029,21 +2059,16 @@ fn roam_system(
         let z = floor.map(|f| f.0).unwrap_or(0);
         match roam.target {
             Some(dest) if dest != pos.tile => {
-                let dx = dest.x - pos.tile.x;
-                let dy = dest.y - pos.tile.y;
-                let horizontal = if dx > 0 { Dir::Right } else { Dir::Left };
-                let vertical = if dy > 0 { Dir::Down } else { Dir::Up };
-                let (primary, secondary) = if dx.abs() >= dy.abs() {
-                    (horizontal, if dy != 0 { vertical } else { horizontal })
-                } else {
-                    (vertical, if dx != 0 { horizontal } else { vertical })
-                };
-                pos.facing = primary.facing();
-                if !try_move(primary, &map, z, &pos, &mut mv, None) && secondary != primary {
-                    pos.facing = secondary.facing();
-                    try_move(secondary, &map, z, &pos, &mut mv, None);
-                }
-                // Both ways blocked — abandon this trip and dwell briefly.
+                // 8-way stepping: prefer the diagonal toward the target, then
+                // fall back to a single axis. Diagonal tile-steps give the
+                // client true diagonal deltas, so all 8 sheet facings surface.
+                let sx = (dest.x - pos.tile.x).signum();
+                let sy = (dest.y - pos.tile.y).signum();
+                pos.facing = facing_from_intent(sx as i8, sy as i8);
+                let _ = try_step(sx, sy, &map, z, &pos, &mut mv)
+                    || (sx != 0 && try_step(sx, 0, &map, z, &pos, &mut mv))
+                    || (sy != 0 && try_step(0, sy, &map, z, &pos, &mut mv));
+                // Fully blocked — abandon this trip and dwell briefly.
                 if mv.target.is_none() {
                     roam.target = None;
                     roam.resume_tick = clock.tick.saturating_add(roam.dwell_min);

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -314,6 +314,11 @@ pub struct NpcSpec {
     pub level: i32,
     pub defense: i32,
     pub wander: Option<(i32, u32)>,
+    /// Roam-to-target behavior: (radius, dwell_min_ticks, dwell_max_ticks). The
+    /// mob picks a random tile within `radius` of its origin, walks the whole
+    /// path there, then idles a random dwell in [min,max] before the next trip —
+    /// longer purposeful movement vs `wander`'s single-tile jitter.
+    pub roam: Option<(i32, u32, u32)>,
     pub aggro: Option<AggroSpec>,
     pub loot: Option<String>,
     pub respawn_ticks: u32,
@@ -423,6 +428,35 @@ impl Wander {
     }
 }
 
+/// Roam-to-target wandering: walk the whole path to a random tile within
+/// `radius` of `origin`, then idle a random dwell before the next trip. Gives
+/// longer, more purposeful movement than `Wander`'s single-tile jitter.
+#[derive(Component, Clone, Copy)]
+pub struct Roam {
+    pub origin: Tile,
+    pub radius: i32,
+    pub dwell_min: u32,
+    pub dwell_max: u32,
+    /// Current destination, or None while dwelling/awaiting a new pick.
+    pub target: Option<Tile>,
+    /// Earliest tick the next trip may begin (set when a trip completes).
+    pub resume_tick: u32,
+}
+
+impl Roam {
+    pub fn new(origin: Tile, radius: i32, dwell_min: u32, dwell_max: u32) -> Self {
+        let dwell_min = dwell_min.max(1);
+        Self {
+            origin,
+            radius: radius.max(1),
+            dwell_min,
+            dwell_max: dwell_max.max(dwell_min),
+            target: None,
+            resume_tick: 0,
+        }
+    }
+}
+
 pub fn ground_item_bundle(
     registry: &KindRegistry,
     item_ref: &str,
@@ -461,6 +495,9 @@ pub fn spawn_npc_from_spec(commands: &mut Commands, spec: &NpcSpec) {
     ));
     if let Some((radius, period)) = spec.wander {
         e.insert(Wander::new(spec.origin, radius, period));
+    }
+    if let Some((radius, dwell_min, dwell_max)) = spec.roam {
+        e.insert(Roam::new(spec.origin, radius, dwell_min, dwell_max));
     }
     if let Some(a) = spec.aggro {
         e.insert(Aggro {
@@ -694,7 +731,9 @@ pub fn build_app(
         )
         .add_systems(
             Update,
-            (hostile_ai, wander_system).chain().in_set(SimSet::Ai),
+            (hostile_ai, wander_system, roam_system)
+                .chain()
+                .in_set(SimSet::Ai),
         )
         .add_systems(
             Update,
@@ -1967,6 +2006,77 @@ fn wander_system(
     }
 }
 
+/// Roam: greedy-step toward a random target tile within `radius` of the origin,
+/// then dwell idle a random span before the next trip. One tile is queued per
+/// call (advance_movement walks it); the whole path plays out across ticks, so
+/// the mob reads as deliberately travelling rather than jittering in place.
+fn roam_system(
+    clock: Res<SimClock>,
+    seed: Res<SimSeed>,
+    map: Res<WalkableMap>,
+    mut q: Query<(
+        Entity,
+        &mut GridPos,
+        &mut MoveTarget,
+        &mut Roam,
+        Option<&Floor>,
+    )>,
+) {
+    for (entity, mut pos, mut mv, mut roam, floor) in q.iter_mut() {
+        if mv.target.is_some() {
+            continue;
+        }
+        let z = floor.map(|f| f.0).unwrap_or(0);
+        match roam.target {
+            Some(dest) if dest != pos.tile => {
+                let dx = dest.x - pos.tile.x;
+                let dy = dest.y - pos.tile.y;
+                let horizontal = if dx > 0 { Dir::Right } else { Dir::Left };
+                let vertical = if dy > 0 { Dir::Down } else { Dir::Up };
+                let (primary, secondary) = if dx.abs() >= dy.abs() {
+                    (horizontal, if dy != 0 { vertical } else { horizontal })
+                } else {
+                    (vertical, if dx != 0 { horizontal } else { vertical })
+                };
+                pos.facing = primary.facing();
+                if !try_move(primary, &map, z, &pos, &mut mv, None) && secondary != primary {
+                    pos.facing = secondary.facing();
+                    try_move(secondary, &map, z, &pos, &mut mv, None);
+                }
+                // Both ways blocked — abandon this trip and dwell briefly.
+                if mv.target.is_none() {
+                    roam.target = None;
+                    roam.resume_tick = clock.tick.saturating_add(roam.dwell_min);
+                }
+            }
+            Some(_) => {
+                // Arrived: dwell a random span before picking the next target.
+                let span = (roam.dwell_max - roam.dwell_min + 1).max(1) as u64;
+                let dwell = roam.dwell_min
+                    + (hash3(seed.0, entity.index_u32() as u64, clock.tick as u64) % span) as u32;
+                roam.target = None;
+                roam.resume_tick = clock.tick.saturating_add(dwell);
+            }
+            None => {
+                if clock.tick < roam.resume_tick {
+                    continue;
+                }
+                let h = hash3(seed.0, entity.index_u32() as u64, clock.tick as u64);
+                let span = (2 * roam.radius + 1) as u64;
+                let rx = (h % span) as i32 - roam.radius;
+                let ry = ((h >> 20) % span) as i32 - roam.radius;
+                let cand = Tile::new(roam.origin.x + rx, roam.origin.y + ry);
+                if cand != pos.tile && map.is_walkable_z(z, cand) {
+                    roam.target = Some(cand);
+                } else {
+                    // Bad pick — retry shortly instead of every tick.
+                    roam.resume_tick = clock.tick.saturating_add(1);
+                }
+            }
+        }
+    }
+}
+
 fn facing_from_intent(mx: i8, my: i8) -> proto::Facing {
     if mx.abs() >= my.abs() {
         if mx >= 0 {
@@ -2732,6 +2842,7 @@ mod tests {
             level: 1,
             defense: 0,
             wander: None,
+            roam: None,
             aggro: Some(AggroSpec {
                 range: 8,
                 damage: 60,


### PR DESCRIPTION
Bundles the apex predator follow-ups onto one PR for dev.

## 1. Roam behavior (simgrid)
Replaces the predator's twitchy single-tile `wander` with deliberate roaming: a new `Roam` component + `roam_system` (in the `SimSet::Ai` chain, goblins' wander untouched) picks a random tile within `radius` of spawn, walks the **whole path**, then idles a random dwell. `NpcSpec` gains `roam: Option<(radius, dwell_min, dwell_max)>`; predator uses `(10, 1s, 3s)`.

## 2. 8-way diagonal movement
`try_step` (delta move with a diagonal corner-cut guard) + roam preferring the diagonal toward its target → the client sees true diagonal deltas, so **all 8 sheet facings** surface while roaming (was ~4). Chase/wander stay 4-way.

## 3. Combat-state anims
On a `CombatEvent` (the existing `EPHEMERAL_COMBAT` path), the attacker creature plays **Attack1** facing its target and the victim recoils with **GetHit**; death stays on the hp<=0 path. Creature one-shots now settle back to Idle on animation-complete (Dead holds its last frame) so they don't freeze.

## 4. Float fix
`originY` 0.86 → 0.82 (measured: feet+baked shadow sit ~0.82 down the 512px frame) so the larger creature stands on its tile.

Green: `arpg-server`/`simgrid` clippy `-D warnings`, 106 sim tests, `arpg-web` typecheck.

## Still open
- Combat anims only fire for predators attacking the local player (`EPHEMERAL_COMBAT` is sent to the targeted slot); broadcasting for spectator visibility is a later pass.
- `DEBUG_CREATURE_DIRS` overlay still on — flip off once directions are fully confirmed.
- NPCDB full integration.