### PR TITLE
feat(arpg): persist placed env objects across server restart (Valkey)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "bevy_items",
  "bevy_mapdb",
  "jedi",
+ "serde_json",
  "simgrid",
  "tokio",
  "tracing",

--- a/apps/agones/arpg/docker-compose.yml
+++ b/apps/agones/arpg/docker-compose.yml
@@ -1,8 +1,9 @@
 # Personal local-dev compose for the ARPG vertical. NOT used by Agones/k8s.
 #
 #   docker compose -f apps/agones/arpg/docker-compose.yml up --build
-#       -> builds + runs only arpg-server on :7979 (no PG/Valkey: persistence
-#          degrades gracefully, sim + itemdb still load).
+#       -> builds + runs arpg-server on :7979 + a Valkey on :6379. Placed env
+#          objects (campfires) persist to Valkey and survive a server restart;
+#          drop the valkey service / unset KBVE_KV_URL to degrade gracefully.
 #
 #   docker compose -f apps/agones/arpg/docker-compose.yml --profile web up --build
 #       -> also runs the standalone vite arpg client on :5402, pointed at the
@@ -40,6 +41,22 @@ services:
             # Fallback: local HS256 verification if you'd rather hold the secret.
             # Unset SUPABASE_URL to fall back to this, or to dev-accept if both unset.
             SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}
+            # Durable store for player-placed env objects (campfires). Unset to
+            # run without persistence (sim still works, placements are in-memory).
+            KBVE_KV_URL: ${KBVE_KV_URL:-redis://valkey:6379}
+        depends_on:
+            - valkey
+        restart: unless-stopped
+
+    valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+            - '6379:6379'
+        # appendonly so placed objects survive a Valkey container restart too —
+        # restart persistence is then genuinely end-to-end testable.
+        command: ['valkey-server', '--appendonly', 'yes']
+        volumes:
+            - arpg-valkey-data:/data
         restart: unless-stopped
 
     arpg-web:
@@ -66,3 +83,4 @@ services:
 
 volumes:
     arpg-web-node-modules:
+    arpg-valkey-data:

--- a/apps/agones/arpg/server/Cargo.toml
+++ b/apps/agones/arpg/server/Cargo.toml
@@ -22,3 +22,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 async-trait = "0.1.88"
 agones = "1.57"
+serde_json = "1.0"

--- a/apps/agones/arpg/server/src/db/kv_cache.rs
+++ b/apps/agones/arpg/server/src/db/kv_cache.rs
@@ -16,3 +16,31 @@ pub async fn init_kv_cache() -> bool {
 pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
     KV_CACHE.get()
 }
+
+/// Load the durable placed-env snapshot for a world. Empty when Valkey is
+/// unconfigured, the key is unset, or the stored JSON fails to parse.
+pub async fn load_persisted_env(key: &str) -> Vec<simgrid::PersistedEnvObject> {
+    let Some(kv) = get_kv_cache() else {
+        return Vec::new();
+    };
+    kv.kv_get_str(key)
+        .await
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Overwrite the durable placed-env snapshot for a world. Best-effort: logs and
+/// returns on serialize or write failure (the next change re-attempts).
+pub async fn save_persisted_env(key: &str, objects: &[simgrid::PersistedEnvObject]) {
+    let Some(kv) = get_kv_cache() else {
+        return;
+    };
+    match serde_json::to_string(objects) {
+        Ok(json) => {
+            if kv.kv_set_str(key, &json).await.is_none() {
+                tracing::warn!(key, "failed to persist env objects to Valkey");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "failed to serialize env objects"),
+    }
+}

--- a/apps/agones/arpg/server/src/db/mod.rs
+++ b/apps/agones/arpg/server/src/db/mod.rs
@@ -7,6 +7,6 @@ mod kv_cache;
 mod pg_cluster;
 
 #[allow(unused_imports)]
-pub use kv_cache::{get_kv_cache, init_kv_cache};
+pub use kv_cache::{get_kv_cache, init_kv_cache, load_persisted_env, save_persisted_env};
 #[allow(unused_imports)]
 pub use pg_cluster::{get_pg_cluster, init_pg_cluster};

--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -8,9 +8,9 @@ use simgrid::proto::{StatusKind, Tile};
 use simgrid::rng::hash3;
 use simgrid::{
     AggroSpec, BuffEffects, BuffSpec, ConsumableEffects, DeployableSpec, Deployables, EntityKind,
-    EnvOpts, GridPos, HazardZone, HealAura, KindRegistry, NpcSpec, PlayerSlotTag, SIM_TICK_HZ,
-    SimClock, SimConfig, SimSeed, Stairs, WalkableMap, ground_item_bundle, spawn_env_object,
-    spawn_npc_from_spec,
+    EnvOpts, GridPos, HazardZone, HealAura, KindRegistry, NpcSpec, PersistedEnvLog, PlayerSlotTag,
+    SIM_TICK_HZ, SimClock, SimConfig, SimSeed, Stairs, WalkableMap, ground_item_bundle,
+    spawn_env_object, spawn_npc_from_spec,
 };
 
 pub const MAX_PLAYERS: usize = 32;
@@ -442,6 +442,7 @@ pub fn spawn_world(
     mut done: Local<bool>,
     registry: Res<KindRegistry>,
     mut walkable: ResMut<WalkableMap>,
+    restored: Res<PersistedEnvLog>,
     mut commands: Commands,
 ) {
     if *done {
@@ -503,6 +504,20 @@ pub fn spawn_world(
         .is_some()
     {
         walkable.block_tile_z(SPAWN_FLOOR, fire);
+    }
+
+    // Restore player-placed objects persisted from a previous server lifetime.
+    // They return as unowned world fixtures (no PlacedBy, behavior re-derived
+    // from the mapdb def) — still block/heal/burn, but no longer reclaimable.
+    for o in &restored.0 {
+        let tile = Tile::new(o.x, o.y);
+        let Some(opts) = env_opts_from_mapdb(&o.env_ref, o.floor) else {
+            continue;
+        };
+        let blocker = opts.blocker;
+        if spawn_env_object(&mut commands, &registry, &o.env_ref, tile, opts).is_some() && blocker {
+            walkable.block_tile_z(o.floor, tile);
+        }
     }
 }
 

--- a/apps/agones/arpg/server/src/main.rs
+++ b/apps/agones/arpg/server/src/main.rs
@@ -79,6 +79,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = game::config();
     let map = game::walkable_map();
 
+    // Durable store for player-placed env objects (campfires), keyed per world
+    // seed. Load the prior snapshot so they survive a restart; wire a channel the
+    // sim pushes every change through, drained by an async writer below.
+    let env_key = format!("arpg:env:{seed}");
+    let restored_env = db::load_persisted_env(&env_key).await;
+    if !restored_env.is_empty() {
+        tracing::info!(count = restored_env.len(), "restored placed env objects");
+    }
+    let (env_tx, mut env_rx) = mpsc::unbounded_channel::<Vec<simgrid::PersistedEnvObject>>();
+
     let sim_handle = tokio::task::spawn_blocking(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_time()
@@ -98,11 +108,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         app.insert_resource(item_db);
         app.insert_resource(game::stairs());
         app.insert_resource(game::deployables());
+        app.insert_resource(simgrid::PersistedEnvLog(restored_env));
+        app.insert_resource(simgrid::EnvPersistSink(Some(env_tx)));
         app.add_systems(
             bevy::prelude::Update,
             (game::spawn_world, game::stream_predators).in_set(simgrid::SimSet::Spawn),
         );
         rt.block_on(run_sim_loop(app));
+    });
+
+    // Drain placed-object snapshots from the sim and write them to the durable
+    // store. Best-effort: a write failure is logged inside the db layer and the
+    // next change overwrites it.
+    let env_writer = tokio::spawn(async move {
+        while let Some(snapshot) = env_rx.recv().await {
+            db::save_persisted_env(&env_key, &snapshot).await;
+        }
     });
 
     let router = simgrid::router(state);
@@ -120,6 +141,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _ = tokio::time::timeout(std::time::Duration::from_secs(1), agones::shutdown()).await;
     agones_handle.abort();
+    env_writer.abort();
     drop(sim_handle);
     Ok(())
 }

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -482,6 +482,29 @@ impl KvCache {
         let lkey = self.qualified(key);
         pool.lrange::<Vec<String>, _>(&lkey, 0, -1).await.ok()
     }
+
+    /// Authoritative write to L2 (Valkey) with no TTL — durable app/game state,
+    /// not a cache entry. `None` when L2 is unavailable.
+    pub async fn kv_set_str(&self, key: &str, value: &str) -> Option<()> {
+        let pool = self.l2.as_ref()?;
+        let qkey = self.qualified(key);
+        let fut = pool.set::<(), _, _>(&qkey, value, None, None, false);
+        match tokio::time::timeout(L2_OP_TIMEOUT, fut).await {
+            Ok(Ok(())) => Some(()),
+            _ => None,
+        }
+    }
+
+    /// Read a persistent L2 string written by [`KvCache::kv_set_str`]. `None`
+    /// when L2 is unavailable or the key is unset.
+    pub async fn kv_get_str(&self, key: &str) -> Option<String> {
+        let pool = self.l2.as_ref()?;
+        let qkey = self.qualified(key);
+        match tokio::time::timeout(L2_OP_TIMEOUT, pool.get::<Option<String>, _>(&qkey)).await {
+            Ok(Ok(v)) => v,
+            _ => None,
+        }
+    }
 }
 
 async fn build_valkey_pool() -> Result<ValkeyPool, String> {

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -21,9 +21,10 @@ pub use grid::{FloatMove, Floor, GridPos, MoveSpeed, MoveTarget, StairLink, Stai
 pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
     Aggro, AggroSpec, Blocker, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense,
-    DeployableSpec, Deployables, EntityKind, EnvObject, EnvOpts, EquipBonus, EquipmentEffects,
-    Equipped, HazardZone, HealAura, Health, Inventory, ItemPrices, Loot, NpcLevel, NpcSpec,
-    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimClock, SimConfig,
-    SimSeed, SimSet, StatusEffect, StatusEffects, Wander, XpState, build_app, ground_item_bundle,
-    level_attack, level_max_hp, run_sim_loop, spawn_env_object, spawn_npc_from_spec, xp_to_next,
+    DeployableSpec, Deployables, EntityKind, EnvObject, EnvOpts, EnvPersistSink, EquipBonus,
+    EquipmentEffects, Equipped, HazardZone, HealAura, Health, Inventory, ItemPrices, Loot,
+    NpcLevel, NpcSpec, PersistedEnvLog, PersistedEnvObject, PlayerSlotTag, PlayerStore,
+    RespawnOnDeath, SIM_TICK_HZ, ShopStock, SimClock, SimConfig, SimSeed, SimSet, StatusEffect,
+    StatusEffects, Wander, XpState, build_app, ground_item_bundle, level_attack, level_max_hp,
+    run_sim_loop, spawn_env_object, spawn_npc_from_spec, xp_to_next,
 };

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -144,6 +144,28 @@ pub struct DeployQueues<'w> {
     pickups: ResMut<'w, PendingPickups>,
 }
 
+/// A durably-persisted player-placed env object. Behavior is re-derived from
+/// `env_ref` on restore (mapdb), so only placement coordinates are stored.
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PersistedEnvObject {
+    pub env_ref: String,
+    pub x: i32,
+    pub y: i32,
+    pub floor: i32,
+}
+
+/// Authoritative set of player-placed env objects to persist across restarts.
+/// World fixtures (starter campfire) are re-spawned by the game each boot and
+/// are deliberately absent. Mutated by `apply_placements`/`apply_pickups`, which
+/// push the snapshot through `EnvPersistSink`.
+#[derive(Resource, Default)]
+pub struct PersistedEnvLog(pub Vec<PersistedEnvObject>);
+
+/// Optional sink the game wires to a durable store. When present, every change
+/// to `PersistedEnvLog` sends the full snapshot; absent in tests / no-DB runs.
+#[derive(Resource, Default)]
+pub struct EnvPersistSink(pub Option<mpsc::UnboundedSender<Vec<PersistedEnvObject>>>);
+
 pub const COIN_REF: &str = "coin";
 pub const GOLD_BAR_REF: &str = "gold-bar";
 pub const GOLD_BAR_VALUE: u32 = 100;
@@ -645,6 +667,8 @@ pub fn build_app(
         .insert_resource(Deployables::default())
         .insert_resource(PendingPlacements::default())
         .insert_resource(PendingPickups::default())
+        .insert_resource(PersistedEnvLog::default())
+        .insert_resource(EnvPersistSink::default())
         .insert_resource(ShopStock::default())
         .insert_resource(ItemPrices::default())
         .insert_resource(Tables::default())
@@ -1601,8 +1625,11 @@ fn apply_placements(
     deployables: Res<Deployables>,
     registry: Res<KindRegistry>,
     mut map: ResMut<WalkableMap>,
+    mut log: ResMut<PersistedEnvLog>,
+    sink: Res<EnvPersistSink>,
     mut commands: Commands,
 ) {
+    let mut changed = false;
     for (slot, item_ref, tile, z) in placements.0.drain(..) {
         let Some(spec) = deployables.0.get(&item_ref) else {
             continue;
@@ -1618,22 +1645,42 @@ fn apply_placements(
             if blocker {
                 map.block_tile_z(z, tile);
             }
+            log.0.push(PersistedEnvObject {
+                env_ref: spec.env_ref.clone(),
+                x: tile.x,
+                y: tile.y,
+                floor: z,
+            });
+            changed = true;
         }
+    }
+    if changed {
+        persist_env_snapshot(&log, &sink);
+    }
+}
+
+/// Push the current placed-object set to the durable sink, if wired.
+fn persist_env_snapshot(log: &PersistedEnvLog, sink: &EnvPersistSink) {
+    if let Some(tx) = &sink.0 {
+        let _ = tx.send(log.0.clone());
     }
 }
 
 /// Resolve queued pickups: the owning player reclaims a placed env object within
 /// reach — the kit is refunded, the object despawned, and its tile unblocked. A
 /// mismatched owner, out-of-range request, or missing object is dropped silently.
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn apply_pickups(
     mut pickups: ResMut<PendingPickups>,
     bcast: Res<Outbound>,
     mut map: ResMut<WalkableMap>,
+    mut log: ResMut<PersistedEnvLog>,
+    sink: Res<EnvPersistSink>,
     env_q: Query<(Entity, &GridPos, Option<&Floor>, &PlacedBy)>,
     mut players: Query<(&PlayerSlotTag, &mut Inventory)>,
     mut commands: Commands,
 ) {
+    let mut changed = false;
     for (slot, tile, z, from) in pickups.0.drain(..) {
         if from.chebyshev(tile) > PLACE_RANGE {
             continue;
@@ -1649,6 +1696,12 @@ fn apply_pickups(
         }
         commands.entity(eid).despawn();
         map.unblock_tile_z(z, tile);
+        log.0
+            .retain(|o| !(o.x == tile.x && o.y == tile.y && o.floor == z));
+        changed = true;
+    }
+    if changed {
+        persist_env_snapshot(&log, &sink);
     }
 }
 
@@ -2441,6 +2494,65 @@ mod tests {
             !app.world().resource::<WalkableMap>().is_walkable_z(0, tile),
             "tile stays blocked"
         );
+    }
+
+    #[test]
+    fn placement_persists_and_pickup_clears_snapshot() {
+        let (mut app, _rx, _tx, _roster) = harness(0x557);
+        let (ptx, mut prx) = mpsc::unbounded_channel::<Vec<PersistedEnvObject>>();
+        {
+            let w = app.world_mut();
+            w.resource_mut::<EnvPersistSink>().0 = Some(ptx);
+            w.resource_mut::<KindRegistry>().register_item("test-kit");
+            w.resource_mut::<KindRegistry>().register_env("test-env");
+            let mut dep = Deployables::default();
+            dep.0.insert(
+                "test-kit".to_string(),
+                DeployableSpec {
+                    env_ref: "test-env".to_string(),
+                    opts: EnvOpts {
+                        blocker: true,
+                        ..Default::default()
+                    },
+                },
+            );
+            w.insert_resource(dep);
+        }
+        let tile = Tile::new(5, 5);
+        let from = Tile::new(5, 6);
+        app.world_mut().spawn((
+            EntityKind(PLAYER_KIND),
+            GridPos::at(from),
+            MoveTarget::default(),
+            Inventory {
+                slots: vec![("test-kit".to_string(), 1)],
+            },
+            PlayerSlotTag(proto::PlayerSlot(0)),
+        ));
+
+        app.world_mut().resource_mut::<PendingPlacements>().0.push((
+            proto::PlayerSlot(0),
+            "test-kit".to_string(),
+            tile,
+            0,
+        ));
+        app.update();
+        let placed = prx.try_recv().expect("placement snapshot sent");
+        assert_eq!(placed.len(), 1);
+        assert_eq!(
+            (placed[0].x, placed[0].y, placed[0].env_ref.as_str()),
+            (5, 5, "test-env")
+        );
+
+        app.world_mut().resource_mut::<PendingPickups>().0.push((
+            proto::PlayerSlot(0),
+            tile,
+            0,
+            from,
+        ));
+        app.update();
+        let cleared = prx.try_recv().expect("pickup snapshot sent");
+        assert!(cleared.is_empty(), "log cleared after pickup");
     }
 
     #[test]


### PR DESCRIPTION
Closes #12966 / part of #12955 — the deferred persistence phase. In-memory placement + ownership already shipped; this makes player-placed campfires survive a server restart.

## Approach (Valkey, per the chosen scope)

Placed objects persist; ownership does **not** survive restart — restored campfires come back as **unowned world fixtures** (behavior re-derived from the mapdb def), reclaim stays in-session only. Avoids the owner-by-identity / slot-rebind machinery for a much smaller change.

### simgrid
- `PersistedEnvObject` (env_ref + coords) + `PersistedEnvLog` resource = authoritative set. `apply_placements`/`apply_pickups` mutate it and push the full snapshot through a new `EnvPersistSink` channel (game-agnostic; absent in tests / no-DB runs).

### arpg-server
- Boot: `db::load_persisted_env(seed_key)` → `PersistedEnvLog`; `spawn_world` respawns each as an unowned fixture (blocker/aura/burn intact) + blocks its tile.
- Runtime: an async task drains the channel → `db::save_persisted_env` → Valkey, keyed `arpg:env:<seed>`.
- Best-effort: degrades to in-memory when Valkey is unconfigured.

### jedi
- `KvCache::kv_set_str` / `kv_get_str` — persistent (no TTL) durable writes alongside the read-through cache. Additive; no existing consumer affected.

### Local dev
- `docker-compose.yml` gains a Valkey service (`appendonly`) + `KBVE_KV_URL`, so restart persistence is end-to-end testable: place a campfire → restart `arpg-server` → it's still there.

### Tests
`simgrid` 107 lib tests incl. `placement_persists_and_pickup_clears_snapshot`. Clippy clean (jedi + simgrid + arpg-server).

### Out of scope
Ownership surviving restart (owner-by-username + join-time slot rebind) — deliberately not done.