### PR TITLE
chore(n8n): upgrade n8n + runners 2.9.4 -> 2.27.3

### DIFF
--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -45,7 +45,7 @@ spec:
                               topologyKey: kubernetes.io/hostname
             containers:
                 - name: n8n
-                  image: n8nio/n8n:2.9.4
+                  image: n8nio/n8n:2.27.3
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: http
@@ -254,7 +254,7 @@ spec:
                       failureThreshold: 3
                 # Task runner sidecar (executes Code node JS/Python)
                 - name: n8n-runner
-                  image: n8nio/runners:2.9.4
+                  image: n8nio/runners:2.27.3
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: launcher-health

--- a/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
@@ -43,7 +43,7 @@ spec:
                               topologyKey: kubernetes.io/hostname
             containers:
                 - name: n8n-worker
-                  image: n8nio/n8n:2.9.4
+                  image: n8nio/n8n:2.27.3
                   imagePullPolicy: IfNotPresent
                   command: ['n8n', 'worker', '--concurrency=10']
                   ports:
@@ -182,7 +182,7 @@ spec:
                       failureThreshold: 3
                 # Task runner sidecar (executes Code node JS/Python)
                 - name: n8n-runner
-                  image: n8nio/runners:2.9.4
+                  image: n8nio/runners:2.27.3
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: launcher-health


### PR DESCRIPTION
## Summary
Upgrade n8n from pinned **2.9.4** to current stable **2.27.3** (2.28.0 is pre-release, skipped). All 4 image refs bumped, n8n + runners kept version-matched (required for external task-runner mode):

- `n8n-deployment.yaml`: `n8nio/n8n` + `n8nio/runners`
- `n8n-worker-deployment.yaml`: `n8nio/n8n` + `n8nio/runners`

## Compatibility
In-major (2.x) bump — no major-version boundary. The 2.0 breaking changes are already satisfied by this deployment:
- Separate `n8nio/runners` image for external mode ✅
- `N8N_RUNNERS_ENABLED=true`, `N8N_RUNNERS_MODE=external` ✅
- Removed `QUEUE_WORKER_MAX_STALLED_COUNT` not used (we set `QUEUE_WORKER_STALLED_INTERVAL`, still valid) ✅

No env/config changes required beyond the tags.

## Rollout notes (important)
- **DB migration**: first 2.27.3 boot runs the full chain of n8n schema migrations against shared supabase (`n8n` schema). n8n 2.x uses advisory locks so concurrent main/worker boots are tolerated, but **take a backup of the `n8n` schema before this reaches prod** — migrations are irreversible.
- ArgoCD tracks `main`; not live until the dev→main release. Watch the `n8n` main pod logs for migration completion before trusting worker throughput.
- `kbve-gate` sidecar (`0.1.3`) unaffected — separate image, not bumped here.