### PR TITLE
test(simgrid): fix stale duplicate-session test blocking Dev→Main gate

### DIFF
--- a/packages/rust/simgrid/tests/ws_flow.rs
+++ b/packages/rust/simgrid/tests/ws_flow.rs
@@ -193,20 +193,29 @@ async fn move_input_moves_player() {
 }
 
 #[tokio::test]
-async fn second_login_evicts_first() {
+async fn second_live_session_is_rejected() {
     let url = spawn_server(8).await;
     let mut first = join_and_welcome(&url, "dup").await;
-    let _second = join_and_welcome(&url, "dup").await;
 
-    // The first session should be disconnected (stream ends) by the newest-wins
-    // eviction once "dup" reconnects.
-    for _ in 0..200 {
-        match next_event(&mut first).await {
-            None => return, // closed/evicted
-            Some(_) => continue,
+    // A second live login for the same identity is rejected — the existing
+    // session keeps the slot (reject-duplicate, not newest-wins eviction).
+    let (mut second, _) = connect_async(&url).await.expect("connect");
+    second.send(join("dup")).await.expect("send join");
+    match next_event(&mut second).await {
+        Some(ServerEvent::Reject { reason }) => {
+            assert!(
+                reason.contains("already connected"),
+                "unexpected reason: {reason}"
+            );
         }
+        other => panic!("expected Reject for a duplicate live session, got {other:?}"),
     }
-    panic!("first session for duplicate username was never evicted");
+
+    // The first session survives — it still receives snapshots.
+    match next_event(&mut first).await {
+        Some(_) => {}
+        None => panic!("first session was evicted; it should outlive the rejected duplicate"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #13173.

## Problem

`594e02290` changed duplicate-identity handling from **newest-wins eviction** to **rejecting the second live session** (`claim_slot` rejects when `conns` already holds the identity's ULID — "already connected — close the other window or tab"). The `ws_flow` integration test `second_login_evicts_first` still asserted the old eviction, so `simgrid:test` failed — which fails the **Validate Dev→Main PR** gate and blocks the release train.

## Fix

Rewrote the test as `second_live_session_is_rejected` to match the intended behavior:
- the second live login for the same identity receives a `Reject` containing "already connected";
- the original session survives (still receives snapshots).

Test-only change. `simgrid:test` green (ws_flow 5/5, full suite passes).