### PR TITLE
fix(arpg): guard creature animation play against destroyed sprite

### DIFF
--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -59,6 +59,10 @@ function safePlay(
 	key: string,
 	ignoreIfPlaying = false,
 ): void {
+	// A destroyed sprite (despawned/killed mid-animation) has a null scene; a
+	// deferred callback — e.g. a one-shot's animationcomplete settling to Idle —
+	// can still reach here after the entity was removed. Bail instead of throwing.
+	if (!sprite.scene) return;
 	const mgr = sprite.scene.anims;
 	const anim = mgr.exists(key) ? mgr.get(key) : undefined;
 	if (!anim || anim.frames.length === 0) {
@@ -407,7 +411,8 @@ export function setCreaturePose(
 	// is the exception — it holds its final frame.
 	if (oneShot && state !== 'Dead') {
 		sprite.once(`animationcomplete-${key}`, () => {
-			if (view.state === state) setCreaturePose(sprite, view, 'Idle');
+			if (sprite.scene && view.state === state)
+				setCreaturePose(sprite, view, 'Idle');
 		});
 	}
 }


### PR DESCRIPTION
Follow-up to the predator combat-state anims (#13178).

A predator despawned (streaming cull) or killed **mid one-shot** (Attack/GetHit) left its sprite's `scene` null, but the one-shot's `animationcomplete` revert callback still fired and called `play()` on the dead sprite — `sprite.scene.anims` threw `TypeError: undefined is not an object` and took down the whole Phaser scene (looked like a server crash; server was fine).

- `safePlay` bails when `sprite.scene` is null (guards every caller).
- the one-shot revert callback checks the sprite is still alive before re-posing.

Verified live — predators dying/despawning mid-swing no longer crash the client.