### PR TITLE
fix(arpg): sync bow hit registration + damage timing to the arrow

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -35,6 +35,7 @@ import {
 	DEPTH_ENTITY_BASE,
 	DEPTH_UI,
 	ARROW_MAX_RANGE,
+	ARROW_SPEED,
 	arpgAsset,
 	GROUND_TEXTURE_KEY,
 	GROUND_TEXTURE_PATH,
@@ -90,6 +91,11 @@ import {
 } from './systems/hud';
 
 const HUD_MAP_SIZE = 33;
+// Safety net for the deferred-bow-hit buffer: if the local arrow never visually
+// lands (its tile-path missed the target), flush the server hit after the
+// longest possible arrow flight so the number still shows. The visual onHit
+// normally flushes first.
+const ARROW_BUFFER_FALLBACK_MS = (ARROW_MAX_RANGE / ARROW_SPEED) * 1000 + 200;
 import { facingDegFromDelta } from './entities/classes';
 import {
 	makeSprite,
@@ -230,6 +236,10 @@ export class IsoArpgScene extends Phaser.Scene {
 	// no active click move. Keyboard input clears it.
 	private movePath: TileXY[] = [];
 	private bowShot: BowShot | null = null;
+	// In-flight bow shot (online): the server-authoritative hit for `target` is
+	// buffered until the local arrow lands so feedback syncs to impact.
+	private inflightArrow: { target: number; arrived: boolean } | null = null;
+	private bufferedHits = new Map<number, CombatEvent>();
 	private fireKey!: Phaser.Input.Keyboard.Key;
 	// HUD emits are throttled to ~15/s; this accumulates frame time between emits.
 	private hudAccum = 0;
@@ -1138,6 +1148,36 @@ export class IsoArpgScene extends Phaser.Scene {
 	}
 
 	private onCombat(c: CombatEvent) {
+		// The server resolves a bow shot the instant it looses, but the client's
+		// arrow is still in flight. If this hit is from the local player's arrow
+		// heading at this target, defer the feedback until the arrow lands
+		// (flushed in onArrowArrive / a travel-time fallback) so the number and
+		// recoil sync to impact instead of popping at release.
+		if (
+			c.attacker === this.myEid &&
+			this.inflightArrow &&
+			this.inflightArrow.target === c.target &&
+			!this.inflightArrow.arrived
+		) {
+			this.bufferedHits.set(c.target, c);
+			this.time.delayedCall(ARROW_BUFFER_FALLBACK_MS, () =>
+				this.flushBufferedHit(c.target),
+			);
+			return;
+		}
+		this.showCombat(c);
+	}
+
+	/** Flush a deferred bow hit (server already resolved it) on arrow impact. */
+	private flushBufferedHit(target: number) {
+		if (this.inflightArrow?.target === target) this.inflightArrow = null;
+		const c = this.bufferedHits.get(target);
+		if (!c) return;
+		this.bufferedHits.delete(target);
+		this.showCombat(c);
+	}
+
+	private showCombat(c: CombatEvent) {
 		const refs = this.store.refs(c.target);
 		if (!refs) return;
 		floatingText(
@@ -1721,17 +1761,34 @@ export class IsoArpgScene extends Phaser.Scene {
 			aim,
 			(tx, ty) => this.arrowHitTest(tx, ty),
 			(serverEid, dmg) => {
-				if (this.localMode) this.applyLocalHit(serverEid, dmg);
+				if (this.localMode) {
+					this.applyLocalHit(serverEid, dmg);
+					return;
+				}
+				// Online: the arrow reached the target — release the buffered
+				// server hit now so the number + recoil land on impact.
+				if (this.inflightArrow?.target === serverEid) {
+					this.inflightArrow.arrived = true;
+					this.flushBufferedHit(serverEid);
+				}
 			},
-			() => this.client?.action(ACTION_SHOOT, shotTarget ?? null),
+			() => {
+				this.client?.action(ACTION_SHOOT, shotTarget ?? null);
+				this.inflightArrow =
+					shotTarget != null
+						? { target: shotTarget, arrived: false }
+						: null;
+			},
 		);
 	}
 
 	/**
-	 * Pick the hostile best aligned with the aim ray within bow range: nearest
-	 * along the aim direction whose perpendicular offset from the line is small.
-	 * Lets right-click aim-fire send the server a concrete ACTION_SHOOT target
-	 * (the server resolves the hit from the target entity, not a bare direction).
+	 * Acquire the hostile the arrow will actually hit by marching the aim ray in
+	 * tile steps and returning the first hostile tile crossed — the SAME rounded
+	 * `store.at` model the flying arrow's `arrowHitTest` uses. Keeping acquisition
+	 * and the visual arrow on one hit model is what makes the server register the
+	 * shot the player sees connect (a perpendicular-distance test diverged from
+	 * the arrow and dropped grazing hits).
 	 */
 	private acquireBowTarget(from: TileXY, aim: TileXY): number | undefined {
 		const adx = aim.x - from.x;
@@ -1740,24 +1797,20 @@ export class IsoArpgScene extends Phaser.Scene {
 		if (amag < 1e-3) return undefined;
 		const nx = adx / amag;
 		const ny = ady / amag;
-		let best: number | undefined;
-		let bestAlong = Infinity;
-		for (const [serverEid] of this.store.entries()) {
-			if (!this.isHostileServer(serverEid)) continue;
-			const t = this.store.tile(serverEid);
-			if (!t) continue;
-			const dx = t.x - from.x;
-			const dy = t.y - from.y;
-			const along = dx * nx + dy * ny;
-			if (along <= 0 || along > ARROW_MAX_RANGE) continue;
-			const perp = Math.abs(dx * ny - dy * nx);
-			if (perp > 0.8) continue;
-			if (along < bestAlong) {
-				bestAlong = along;
-				best = serverEid;
-			}
+		const range = Math.min(amag, ARROW_MAX_RANGE);
+		let lastTx = Number.NaN;
+		let lastTy = Number.NaN;
+		for (let d = 0.5; d <= range; d += 0.5) {
+			const tx = Math.round(from.x + nx * d);
+			const ty = Math.round(from.y + ny * d);
+			if (tx === lastTx && ty === lastTy) continue;
+			lastTx = tx;
+			lastTy = ty;
+			const hit = this.store.at(tx, ty, this.myEid);
+			if (hit && this.isHostileServer(hit.serverEid))
+				return hit.serverEid;
 		}
-		return best;
+		return undefined;
 	}
 
 	/**


### PR DESCRIPTION
Two client-side bow combat desyncs, found while testing the predators.

## 1. Hits the player saw connect weren't registering
`acquireBowTarget` used a perpendicular-distance test (`perp < 0.8` of the aim ray) that diverged from the flying arrow and dropped grazing hits → sent `ACTION_SHOOT` with no target → the server [`continue`s on a null target](packages/rust/simgrid/src/sim.rs#L1316) and skips the shot entirely.

Now it **marches the aim ray in 0.5-tile steps and returns the first hostile tile crossed** — the same rounded `store.at` model the arrow's own `arrowHitTest` uses. Acquisition and the visual arrow share one hit model, so the server registers the shot the player sees land.

## 2. Damage popped at release, before the arrow arrived
The server resolves a bow shot the instant it looses; the client arrow is still in flight (`travelMs`), so the number appeared at release.

A `CombatEvent` from the **local player's** arrow at a target with an **in-flight arrow** is now buffered and flushed (number + flash + creature `GetHit`) on **arrow impact** (`onHit`), with a max-flight-time fallback if the visual misses. Melee and predator-on-player feedback stay instant. If the arrow lands before the event arrives, it shows immediately.

Client-only (no protocol/server change). `arpg-web` typecheck green; verified live via compose.

Follow-up (separate): big-creature clearance-aware movement + sprite size so predators stop clipping walls/void near tight halls.