### PR TITLE
fix(kbve): wire SUPABASE_JWT_SECRET for arpg discord session

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -229,6 +229,11 @@ spec:
                                 name: arpg-discord
                                 key: DISCORD_CLIENT_SECRET
                                 optional: true
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: jwt-secret
                   volumeMounts:
                       - name: pg-ca
                         mountPath: /etc/ssl/pgca


### PR DESCRIPTION
## Problem
ARPG Discord Activity boot failed at session exchange with `500 — discord session bridge not configured`.

`axum-kbve` `/api/v1/discord/session` requires three envs (`DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `SUPABASE_JWT_SECRET`) but the deployment only wired the two Discord ones. Empty `SUPABASE_JWT_SECRET` tripped the unconfigured guard before any Discord call → 500 on every boot.

## Fix
Source `SUPABASE_JWT_SECRET` from `supabase-shared/jwt-secret` (same value as GoTrue's `GOTRUE_JWT_SECRET` / `supabase-jwt` secret), so the minted game JWT signs with the key GoTrue and the game server verify against.

`supabase-shared` already in the Reloader annotation → pod restarts on change.

## Notes
- Discord Portal redirect-URI registration for app `1518…` was the prior fix (unblocked authorize); this unblocks the next step.
- ArgoCD tracks main → reaches cluster after the dev→main release.