### PR TITLE
fix(arpg): COPY codegen/generated into arpg-web Docker build

### DIFF
--- a/apps/agones/arpg/web/Dockerfile
+++ b/apps/agones/arpg/web/Dockerfile
@@ -21,6 +21,7 @@ RUN cd apps/agones/arpg/web && npm install --no-save
 # @kbve/laser is the one cross-repo dep the vite config aliases to source.
 COPY tsconfig.base.json tsconfig.base.json
 COPY packages/npm/laser packages/npm/laser
+COPY packages/data/codegen/generated packages/data/codegen/generated
 COPY apps/agones/arpg/web apps/agones/arpg/web
 
 # Prod endpoints baked at build time. arpg.kbve.com and supabase.kbve.com are


### PR DESCRIPTION
## Problem
arpg-web Docker build fails at `vite build` ([run 28074912224](https://github.com/KBVE/kbve/actions/runs/28074912224)):

```
[vite:load-fallback] Could not load /app/packages/data/codegen/generated/itemdb.json
(imported by src/game/entities/itemMeta.ts): ENOENT
```

## Cause
`web/vite.config.ts` aliases `@kbve/itemdb-data`, `@kbve/spelldb-data`, and `@kbve/itemdb-schema` to `packages/data/codegen/generated/*`, but the Dockerfile only COPYs `tsconfig.base.json`, `packages/npm/laser`, and `apps/agones/arpg/web`. The generated dir was never in the build context. Regression from the itemdb-atlas (#13187) + spelldb (#13202) wiring, which added the aliases without updating the Dockerfile COPY list.

## Fix
Add `COPY packages/data/codegen/generated packages/data/codegen/generated` before the build. All three artifacts are git-tracked, so they're in the context.

## Note
`docker-test-app.yml` runs `@main`, but the Dockerfile is read from the checked-out tree at build time — merging to dev fixes the build immediately on the next arpg docker run.