### PR TITLE
fix(arc): reaper sweeps stuck cleanup-protection finalizers

### DIFF
--- a/apps/kube/github/runners/manifests/runner-reaper.yaml
+++ b/apps/kube/github/runners/manifests/runner-reaper.yaml
@@ -18,6 +18,23 @@ rules:
           - get
           - list
           - delete
+    - apiGroups:
+          - ''
+      resources:
+          - serviceaccounts
+      verbs:
+          - get
+          - list
+          - patch
+    - apiGroups:
+          - rbac.authorization.k8s.io
+      resources:
+          - roles
+          - rolebindings
+      verbs:
+          - get
+          - list
+          - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -64,12 +81,38 @@ spec:
                               - /bin/sh
                               - -c
                           args:
-                              - "set -eu\nNS=arc-runners\nFAILED=$(kubectl get ephemeralrunner -n \"\
-                                $NS\" -o json \\\n  | jq -r '.items[] | select(.status.phase == \"Failed\"\
-                                ) | .metadata.name')\nif [ -z \"$FAILED\" ]; then\n  echo \"No Failed\
-                                \ ephemeralrunners; nothing to reap.\"\n  exit 0\nfi\necho \"Reaping\
-                                \ Failed ephemeralrunners:\"\necho \"$FAILED\"\necho \"$FAILED\" | xargs\
-                                \ -r kubectl delete ephemeralrunner -n \"$NS\"\n"
+                              - |
+                                  set -eu
+                                  NS=arc-runners
+                                  FZ=actions.github.com/cleanup-protection
+                                  STUCK_AFTER=1800
+
+                                  FAILED=$(kubectl get ephemeralrunner -n "$NS" -o json \
+                                    | jq -r '.items[] | select(.status.phase == "Failed") | .metadata.name')
+                                  if [ -z "$FAILED" ]; then
+                                    echo "No Failed ephemeralrunners; nothing to reap."
+                                  else
+                                    echo "Reaping Failed ephemeralrunners:"
+                                    echo "$FAILED"
+                                    echo "$FAILED" | xargs -r kubectl delete ephemeralrunner -n "$NS"
+                                  fi
+
+                                  for KIND in serviceaccount role rolebinding; do
+                                    STUCK=$(kubectl get "$KIND" -n "$NS" -o json \
+                                      | jq -r --arg fz "$FZ" --argjson after "$STUCK_AFTER" '
+                                          .items[]
+                                          | select(.metadata.deletionTimestamp != null)
+                                          | select((.metadata.finalizers // []) | index($fz))
+                                          | select(now - (.metadata.deletionTimestamp | fromdateiso8601) > $after)
+                                          | .metadata.name')
+                                    if [ -z "$STUCK" ]; then
+                                      continue
+                                    fi
+                                    echo "Clearing stuck $FZ finalizer on ${KIND}s (Terminating > ${STUCK_AFTER}s):"
+                                    echo "$STUCK"
+                                    echo "$STUCK" | xargs -r -I{} kubectl patch "$KIND" {} -n "$NS" \
+                                      --type=merge -p '{"metadata":{"finalizers":null}}'
+                                  done
                           resources:
                               requests:
                                   cpu: 25m


### PR DESCRIPTION
## Summary

Live fix for #12987: the `arc-runners` Argo app got wedged on a stuck `actions.github.com/cleanup-protection` finalizer, blocking the ghcr pull-through cache deploy (PR #12977). Cleared the finalizers by hand to unblock; this PR is the **real fix** so it never recurs.

## Root cause

The gha-runner-scale-set Helm chart auto-generates RBAC per `containerMode` (`<name>-gha-rs-kube-mode` SA/Role/RoleBinding, or `<name>-gha-rs-no-permission` SA). ARC stamps each with the `cleanup-protection` finalizer and only clears it during a **full AutoscalingRunnerSet teardown** (so the cleanup runner keeps perms to deregister from GitHub).

When `containerMode` is reconfigured, the old auto-RBAC leaves the desired set and Argo prunes the SA **directly** — out of band of the CR lifecycle. ARC never fires its cleanup logic for a lone SA delete, so the finalizer hangs and the object sits `Terminating` forever. Argo then blocks the whole app: `waiting for deletion of /ServiceAccount/... and 3 more resources`.

Found 4 stuck: kbve `-no-permission` (Jun 13) + ue-mac `-kube-mode` SA/Role/RoleBinding (stuck since **Apr 4**, ~2.5 months).

## Fix

Extend the existing `arc-runner-reaper` CronJob (added in #12299 for Failed ephemeralrunners) to also sweep stuck finalizers:

- Widen its Role: `serviceaccounts` + `roles` + `rolebindings` `get/list/patch`.
- New sweep clears `cleanup-protection` on SA/Role/RoleBinding `Terminating` past a **30m threshold** (legit ARC teardown takes seconds, so 30m = definitely orphaned). Age math in jq (`now - fromdateiso8601`) — no busybox/GNU `date` portability gamble.

Self-heals existing and future orphans, no manual `kubectl patch`, no Argo block.

## Validation

- YAML parses (all 4 docs), `sh -n` clean.
- jq selection tested: only >30m-Terminating + matching-finalizer resources selected; fresh/alive/other-finalizer all skipped.

## Notes

- The "3 more" in the ticket were the ue-mac April orphans from a separate retirement, unrelated to the kbve scale-set.
- ArgoCD apps track `main`; reaches cluster on the next dev→main release.

Closes #12987