### PR TITLE
fix(ci): topo-sort UE plugin dependency build order

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1019,7 +1019,7 @@
 			"key": "ue_kbveui",
 			"plugin_name": "KBVEUI",
 			"plugin_path": "packages/unreal/KBVEUI",
-			"dependency_plugins": "packages/unreal/KBVESupabase packages/unreal/KBVEROWS",
+			"dependency_plugins": "packages/unreal/KBVEROWS packages/unreal/KBVESupabase",
 			"supported_platforms": [
 				"Win64",
 				"Linux",

--- a/.github/scripts/ue-plugin-matrix.mjs
+++ b/.github/scripts/ue-plugin-matrix.mjs
@@ -19,6 +19,23 @@ function depPaths(p) {
 		.filter(Boolean);
 }
 
+function orderedDeps(p) {
+	const ordered = [];
+	const done = new Set();
+	const stack = new Set();
+	const visit = (path) => {
+		if (done.has(path) || stack.has(path)) return;
+		stack.add(path);
+		const node = byPath.get(path);
+		if (node) for (const d of depPaths(node)) visit(d);
+		stack.delete(path);
+		done.add(path);
+		ordered.push(path);
+	};
+	for (const d of depPaths(p)) visit(d);
+	return ordered;
+}
+
 function selectAll() {
 	return new Set(plugins.map((p) => p.plugin_path));
 }
@@ -68,7 +85,7 @@ for (const p of plugins) {
 			key: p.key,
 			plugin_name: p.plugin_name,
 			plugin_path: p.plugin_path,
-			dependency_plugins: p.dependency_plugins || '',
+			dependency_plugins: orderedDeps(p).join(' '),
 			ue_image_tag: ueImageTag,
 			platform,
 		};

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
@@ -12,7 +12,7 @@ key: ue_kbveui
 pipeline: unreal
 plugin_name: KBVEUI
 plugin_path: packages/unreal/KBVEUI
-dependency_plugins: packages/unreal/KBVESupabase packages/unreal/KBVEROWS
+dependency_plugins: packages/unreal/KBVEROWS packages/unreal/KBVESupabase
 version: "0.1.0"
 source_path: packages/unreal/KBVEUI
 version_toml: packages/unreal/KBVEUI/version.toml


### PR DESCRIPTION
Follow-up to #13218 — the topo-sort commit pushed after that PR squash-merged, so it stranded off dev. Re-PRing.

## Problem
Dependency plugins build in list order on Mac/Win64 (Linux globs `/deps/*/` alphabetically). A dependent listed before its own dep fails to resolve at build time. `KBVEUI` declared `dependency_plugins: "KBVESupabase KBVEROWS"`, but KBVESupabase depends on KBVEROWS → KBVESupabase's dep build runs first and can't find KBVEROWS in Marketplace.

#13218 fixed *where* deps are packaged (outside engine) but not the *order*; without this, KBVEUI still fails on Mac/Win64.

## Fix
- `kbveui.mdx`: reorder deps-first (KBVEROWS before KBVESupabase), regenerated into `ci-dispatch-manifest.json` (release path reads the manifest raw, so order must be correct there).
- `ue-plugin-matrix.mjs`: emit each plugin's deps as a transitive-closure topological sort (deps before dependents, deduped) so the verify-path order is correct regardless of how the manifest is authored.

Manifest must stay flat (transitively complete) — the topo-sort only normalizes the verify matrix, not the release path.

Relates #13206, #13207.