### PR TITLE
chore(clickhouse): rightsize to 1 shard / 1 replica + single keeper

### DIFF
--- a/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
@@ -32,8 +32,8 @@ spec:
         clusters:
             - name: cluster
               layout:
-                  shardsCount: 2
-                  replicasCount: 2
+                  shardsCount: 1
+                  replicasCount: 1
     defaults:
         templates:
             dataVolumeClaimTemplate: data-storage

--- a/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
@@ -8,7 +8,7 @@ spec:
         clusters:
             - name: keeper
               layout:
-                  replicasCount: 3
+                  replicasCount: 1
     defaults:
         templates:
             dataVolumeClaimTemplate: keeper-storage


### PR DESCRIPTION
## Why
Single-node Talos cluster. ClickHouse ran **2 shards × 2 replicas (4 pods) + 3 keeper replicas** — all co-located on the one node, so replication bought **zero** availability (node dies → all pods die) while costing:
- 2× CPU (merges run per replica) + ~5.5GB duplicated RAM
- 2× disk fsync on the shared SATA SSD → starves **etcd WAL fsync** → `context deadline exceeded` health flaps → leader leases expire → controller-manager / scheduler / cnpg / CSI all crashloop (500+ restarts each)

ClickHouse is the largest always-on workload; rightsizing it is the biggest safe steady-load win.

## Change
| | before | after |
|--|--|--|
| CH shards × replicas | 2 × 2 = 4 pods | **1 × 1 = 1 pod** |
| keeper replicas | 3 | **1** |

7 pods → 2.

## Data
Acceptable to lose. `observability.logs_raw` is plain MergeTree under `internal_replication=true` (data split, not duplicated across replicas) and telemetry is **TTL'd at 7 days** anyway. Dropping shard-1 + the replicas discards a small slice that ages out regardless.

## Rollout
ArgoCD tracks `main`; this lands on `dev` and applies after the next dev→main release. Live cluster was already patched to replicasCount=1 to start relief; this manifest makes it the durable GitOps state (otherwise ArgoCD reverts to 2).