### PR TITLE
chore(arc): cap runner concurrency (arc-runner-set 10->2, ue-win 2->1)

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue-win.yaml
+++ b/apps/kube/github/runners/manifests/values-ue-win.yaml
@@ -19,7 +19,7 @@ controllerServiceAccount:
 
 # Scaling — Windows UE builds are heavy
 minRunners: 0
-maxRunners: 2
+maxRunners: 1
 
 template:
     metadata:

--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -21,7 +21,7 @@ controllerServiceAccount:
 
 # Scaling configuration
 minRunners: 0
-maxRunners: 10
+maxRunners: 2
 
 # Runner group (optional - for enterprise/org runners)
 # runnerGroup: "default"


### PR DESCRIPTION
## Why
Single-node Talos box. Concurrent DinD / KVM-builder runners saturate the SATA SSD that also holds etcd's WAL → etcd `context deadline exceeded` flaps → control-plane crashloops (controller-manager/scheduler/cnpg 550+ restarts).

## Changes
| Scale set | before | after | role |
|--|--|--|--|
| `arc-runner-set` | 10 | **2** | generic/axum/astro DinD (each up to 12 CPU / 32Gi) |
| `arc-runner-ue-win` | 2 | **1** | Windows KVM builder (heaviest single runner) |

`minRunners` stays 0 on both. Other sets untouched (kbve=6, ue=3, ue-mac=2).

## Trade-off
CI queues deeper under burst, but the node can't sustain that many parallel heavy builds anyway — bounding them is the point.

Applies after dev→main release + ArgoCD sync.