### PR TITLE
chore(arc): bound remaining linux runners (kbve 6->2, ue 3->2)

### DIFF
--- a/apps/kube/github/runners/manifests/values-kbve.yaml
+++ b/apps/kube/github/runners/manifests/values-kbve.yaml
@@ -28,7 +28,7 @@ controllerServiceAccount:
 # releases, version-sync PRs, Win VM boot) so no UE job touches a
 # GitHub-hosted runner. Sized for concurrent game+server dispatch.
 minRunners: 0
-maxRunners: 6
+maxRunners: 2
 
 template:
     metadata:

--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -15,7 +15,7 @@ controllerServiceAccount:
 
 # Scaling — UE builds are heavy, keep pool small
 minRunners: 0
-maxRunners: 3
+maxRunners: 2
 
 # Bump RESTART_TRIGGER to force a pod rollout without changing images.
 template:


### PR DESCRIPTION
## Why
Follow-up to #13232. Even after capping `arc-runner-set`, on-node worst-case runner concurrency was still **12** (2 + 6 + 3 + 1; ue-mac is off-node). Concurrent DinD/UE builds saturate the SATA SSD holding etcd's WAL → etcd flaps → control-plane crashloops.

## Changes
| Scale set | before | after | note |
|--|--|--|--|
| `arc-runner-set-kbve` | 6 | **2** | canary mirror of arc-runner-set (same DinD workload, 12 workflows target it) — match its cap |
| `arc-runner-ue` | 3 | **2** | heavy UE-linux builds |

On-node worst case **12 → 7**.

## Untouched
- `arc-runner-ue-mac` (2) — runs on the real Mac, off-node
- `arc-runner-set` (2), `ue-win` (1) — already capped in #13232

`minRunners` stays 0 everywhere. Applies after dev→main release + ArgoCD sync.