### PR TITLE
chore(clickhouse): move storage to longhorn-sdb (off etcd's sda disk)

### DIFF
--- a/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
@@ -79,7 +79,7 @@ spec:
                   resources:
                       requests:
                           storage: 50Gi
-                  storageClassName: longhorn
+                  storageClassName: longhorn-sdb
             - name: log-storage
               spec:
                   accessModes:
@@ -87,4 +87,4 @@ spec:
                   resources:
                       requests:
                           storage: 10Gi
-                  storageClassName: longhorn
+                  storageClassName: longhorn-sdb

--- a/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
@@ -28,4 +28,4 @@ spec:
                   resources:
                       requests:
                           storage: 5Gi
-                  storageClassName: longhorn
+                  storageClassName: longhorn-sdb


### PR DESCRIPTION
## Why
etcd WAL is on `/dev/sda5` (EPHEMERAL). The default `longhorn` StorageClass provisions to `/var/lib/longhorn` — **same sda disk**. ClickHouse inserts/merges + keeper Raft fsync compete with etcd's WAL fsync → etcd `context deadline exceeded` flaps → control-plane crashloops.

## Change
Pin CH volumes to the existing `longhorn-sdb` StorageClass (`/var/mnt/longhorn-sdb` on the dedicated **sdb** SSD, 339Gi free):
| Volume | size | longhorn → longhorn-sdb |
|--|--|--|
| data-storage | 50Gi | ✓ |
| log-storage | 10Gi | ✓ |
| keeper-storage | 5Gi | ✓ |

Isolates ClickHouse I/O from etcd's disk — the structural fix for the fsync starvation.

## ⚠️ Requires a manual PVC recreate after sync
Changing `storageClassName` on a CHI/CHK volumeClaimTemplate does **not** migrate existing bound PVCs — the Altinity operator leaves them on `longhorn` (sda). After this merges + ArgoCD syncs, the old PVCs must be deleted so the operator reprovisions on `longhorn-sdb`. Data is TTL'd at 7 days and acceptable to drop, so this is a clean recreate (no migration needed).

Applies after dev→main release + ArgoCD sync, then the PVC recreate.