### PR TITLE
fix(clickhouse): revert keeper storage to longhorn (operator recreate panic)

### DIFF
--- a/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
@@ -28,4 +28,4 @@ spec:
                   resources:
                       requests:
                           storage: 5Gi
-                  storageClassName: longhorn-sdb
+                  storageClassName: longhorn


### PR DESCRIPTION
## Incident
After #13236 synced, `clickhouse-operator` v0.25.4 went **CrashLoopBackOff**. Root cause: changing the keeper `storageClassName` (longhorn → longhorn-sdb) forces a StatefulSet recreate. The operator's CHK recreate path scales the keeper STS to 0, then `WaitHostStatefulSetReady` derefs a **nil host** (0 replicas = no host) → SIGSEGV. The crash kills the whole operator process before it ever reconciles the CHI, so the CH data/log migration also stalled and keeper is stuck at 0 replicas.

```
panic: nil pointer dereference [SIGSEGV]
  chk worker.reconcileHostStatefulSet → recreateStatefulSet
    → doDeleteStatefulSet → WaitHostStatefulSetReady → poller.go:78
```

## Fix
Revert **keeper** `storageClassName` to `longhorn`. Keeper is 5Gi with low write volume — moving it gained little. With the SC matching the existing STS, the operator no longer attempts the buggy recreate; it just scales keeper 0→1 and recovers, then proceeds to migrate the CH data/log volumes (separate `chi` code path) to `longhorn-sdb` as intended.

CH data (50Gi) + log (10Gi) stay on `longhorn-sdb` — that's where the heavy merge I/O is.

Main CH pod stayed Running throughout (telemetry uninterrupted).