### PR TITLE
feat(arpg): interpolate creature movement for smooth turns

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -125,6 +125,13 @@ import {
 	DEBUG_CREATURE_DIRS,
 } from './entities/creatures';
 import {
+	newInterp,
+	pushSample,
+	resetInterp,
+	sampleAt,
+	INTERP_DELAY_MS,
+} from './systems/interp';
+import {
 	preloadEnv,
 	registerEnvAnims,
 	makeEnvSprite,
@@ -713,6 +720,7 @@ export class IsoArpgScene extends Phaser.Scene {
 					refs = {
 						sprite: creatureSprite.sprite,
 						creature: creatureSprite.creature,
+						interp: newInterp(this.time.now, e.tile.x, e.tile.y),
 					};
 					if (DEBUG_CREATURE_DIRS) {
 						refs.dbgText = this.add
@@ -770,8 +778,18 @@ export class IsoArpgScene extends Phaser.Scene {
 				refs.statusFx = this.add.graphics().setDepth(DEPTH_UI - 1);
 				return refs;
 			},
-			move: (refs, tile) => this.tweenTo(refs, tile, true),
-			setPos: (refs, tile) => this.placeRefs(refs, tile),
+			move: (refs, tile) => {
+				if (refs.interp) {
+					pushSample(refs.interp, this.time.now, tile.x, tile.y);
+				} else {
+					this.tweenTo(refs, tile, true);
+				}
+			},
+			setPos: (refs, tile) => {
+				if (refs.interp)
+					resetInterp(refs.interp, this.time.now, tile.x, tile.y);
+				this.placeRefs(refs, tile);
+			},
 			follow: (refs) =>
 				this.cameras.main.startFollow(refs.sprite, true, 0.12, 0.12),
 			remove: (refs, eid) => {
@@ -1336,8 +1354,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	}
 
 	update(time: number, delta: number) {
-		// Smooth facing runs every frame (independent of the movement sim) so
-		// the 16-dir turn curve stays fluid even between tile crossings.
+		this.tickCreatureInterp();
 		this.tickFacing();
 		this.syncFogToZoom();
 		if (this.envDirty) {
@@ -1588,6 +1605,33 @@ export class IsoArpgScene extends Phaser.Scene {
 		);
 		this.syncShadow(refs);
 		this.placeNameplate(refs);
+	}
+
+	private tickCreatureInterp() {
+		const renderTime = this.time.now - INTERP_DELAY_MS;
+		for (const [, , refs] of this.store.entries()) {
+			if (!refs.interp || !refs.creature) continue;
+			if (!(refs.sprite instanceof Phaser.GameObjects.Sprite)) continue;
+			const s = sampleAt(refs.interp, renderTime);
+			if (!s) continue;
+			const p = worldToScreen(s.x, s.y);
+			refs.sprite.setPosition(p.x, p.y + 8);
+			refs.sprite.setDepth(
+				DEPTH_ENTITY_BASE + tileDepth(Math.round(s.x), Math.round(s.y)),
+			);
+			this.syncShadow(refs);
+			this.placeNameplate(refs);
+			const st = refs.creature.state;
+			if (st !== 'Idle' && st !== 'Walking' && st !== 'Running') continue;
+			if (s.moving && (Math.abs(s.vx) > 1e-4 || Math.abs(s.vy) > 1e-4)) {
+				setCreaturePose(refs.sprite, refs.creature, 'Walking', {
+					dx: s.vx,
+					dy: s.vy,
+				});
+			} else {
+				setCreaturePose(refs.sprite, refs.creature, 'Idle');
+			}
+		}
 	}
 
 	/** Lerp every class entity's facing toward its movement target this frame. */

--- a/apps/agones/arpg/web/src/game/config.ts
+++ b/apps/agones/arpg/web/src/game/config.ts
@@ -57,7 +57,7 @@ export const WAYPOINT_REACH = 0.6; // looser reach for intermediate A* waypoints
 // BLEND_TIMESCALE_FROM up to 1 so the flipbook spins up instead of snapping.
 // Facing turn curve: per-frame lerp factor pulling the visual facing angle
 // toward the movement target. Lower = lazier, smoother arcs; 1 = instant snap.
-export const TURN_LERP = 0.22;
+export const TURN_LERP = 0.15;
 
 export const BLEND_MS = 110;
 export const BLEND_TIMESCALE_FROM = 0.45;

--- a/apps/agones/arpg/web/src/game/entities/sprites.ts
+++ b/apps/agones/arpg/web/src/game/entities/sprites.ts
@@ -12,6 +12,7 @@ import {
 	KIND_CAT_PLAYER,
 	type KindResolvers,
 } from '../systems/kindResolvers';
+import type { InterpBuffer } from '../systems/interp';
 import {
 	CLASS_ANGLES,
 	LOCOMOTION_STATES,
@@ -99,6 +100,7 @@ export interface EntityRefs {
 	statusFx?: Phaser.GameObjects.Graphics;
 	cls?: ClassView;
 	creature?: CreatureView;
+	interp?: InterpBuffer;
 	dbgText?: Phaser.GameObjects.Text;
 	dbgArrow?: Phaser.GameObjects.Graphics;
 	/** Time of this entity's last step tween — used to pace the next one to the

--- a/apps/agones/arpg/web/src/game/systems/interp.ts
+++ b/apps/agones/arpg/web/src/game/systems/interp.ts
@@ -1,0 +1,84 @@
+export interface InterpSample {
+	t: number;
+	x: number;
+	y: number;
+}
+
+export interface InterpBuffer {
+	buf: InterpSample[];
+}
+
+export const INTERP_DELAY_MS = 200;
+const BUF_MAX = 6;
+
+export function newInterp(t: number, x: number, y: number): InterpBuffer {
+	return { buf: [{ t, x, y }] };
+}
+
+export function pushSample(b: InterpBuffer, t: number, x: number, y: number) {
+	const last = b.buf[b.buf.length - 1];
+	if (last && last.x === x && last.y === y) return;
+	b.buf.push({ t, x, y });
+	if (b.buf.length > BUF_MAX) b.buf.shift();
+}
+
+export function resetInterp(b: InterpBuffer, t: number, x: number, y: number) {
+	b.buf.length = 0;
+	b.buf.push({ t, x, y });
+}
+
+function catmull(
+	p0: number,
+	p1: number,
+	p2: number,
+	p3: number,
+	t: number,
+): number {
+	const t2 = t * t;
+	const t3 = t2 * t;
+	return (
+		0.5 *
+		(2 * p1 +
+			(-p0 + p2) * t +
+			(2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+			(-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+	);
+}
+
+export interface InterpResult {
+	x: number;
+	y: number;
+	vx: number;
+	vy: number;
+	moving: boolean;
+}
+
+export function sampleAt(
+	b: InterpBuffer,
+	renderTime: number,
+): InterpResult | null {
+	const buf = b.buf;
+	const n = buf.length;
+	if (n === 0) return null;
+	const last = buf[n - 1];
+	if (n === 1 || renderTime >= last.t) {
+		return { x: last.x, y: last.y, vx: 0, vy: 0, moving: false };
+	}
+	if (renderTime <= buf[0].t) {
+		return { x: buf[0].x, y: buf[0].y, vx: 0, vy: 0, moving: true };
+	}
+	let i = 0;
+	while (i < n - 1 && buf[i + 1].t < renderTime) i++;
+	const p1 = buf[i];
+	const p2 = buf[i + 1];
+	const p0 = buf[i - 1] ?? p1;
+	const p3 = buf[i + 2] ?? p2;
+	const span = p2.t - p1.t || 1;
+	const tt = Math.min(1, Math.max(0, (renderTime - p1.t) / span));
+	const x = catmull(p0.x, p1.x, p2.x, p3.x, tt);
+	const y = catmull(p0.y, p1.y, p2.y, p3.y, tt);
+	const e = Math.min(1, tt + 0.06);
+	const xe = catmull(p0.x, p1.x, p2.x, p3.x, e);
+	const ye = catmull(p0.y, p1.y, p2.y, p3.y, e);
+	return { x, y, vx: xe - x, vy: ye - y, moving: true };
+}


### PR DESCRIPTION
Smooths predator movement, especially direction changes, with a client-side **per-entity position interpolation buffer** (the standard remote-entity interp).

## How
- `systems/interp.ts`: a per-creature ring buffer of recent `(time, tile)` samples + a Catmull-Rom sampler.
- Creatures push each server tile to their buffer (players/goblins keep the per-tile tween) and render at a **200ms-lagged clock**, sampling the spline through the buffer each frame — so the path and turns **curve** instead of hard-cornering tween-to-tween. The lag buys the lookahead sample the spline needs to round the corner it's approaching.
- `tickCreatureInterp` drives position + depth + shadow + Walking/Idle + facing from the sampled heading; one-shot states (Attack/GetHit/Dead) keep their pose while position still interps under them.
- `TURN_LERP` 0.22→0.15 for a lazier facing arc (the 8-dir sheet still steps, just crosses buckets more gradually).

Per-entity, component-style state on the store refs (the client's ECS-ish layer).

Tradeoff: ~200ms render lag for creatures — invisible for AI mobs, standard for remote entities. Tunables: `INTERP_DELAY_MS` (interp.ts), `TURN_LERP` (config.ts).

Client-only; `arpg-web` typecheck green; verified live via compose. Rides the pending 0.1.6 MDX (no double-bump).