### PR TITLE
fix(arc): cap UE runner to 1, bump dind tmpfs 64Gi + mem 80Gi

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -15,13 +15,13 @@ controllerServiceAccount:
 
 # Scaling — UE builds are heavy, keep pool small
 minRunners: 0
-maxRunners: 2
+maxRunners: 1
 
 # Bump RESTART_TRIGGER to force a pod rollout without changing images.
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260624-ram-dind'
+            kbve.com/restart-trigger: '20260624-ram-dind-64g'
     spec:
         initContainers:
             - name: init-dind-externals
@@ -91,7 +91,7 @@ template:
               resources:
                   limits:
                       cpu: '4'
-                      memory: 56Gi
+                      memory: 80Gi
                   requests:
                       cpu: '1'
                       memory: 8Gi
@@ -118,7 +118,7 @@ template:
             - name: dind-storage
               emptyDir:
                   medium: Memory
-                  sizeLimit: 40Gi
+                  sizeLimit: 64Gi
             - name: shared-tmp
               emptyDir:
                   medium: Memory


### PR DESCRIPTION
## Problem
`game_build_linux` on `arc-runner-ue` died with:
```
no space left on device
write /var/lib/docker/.../libcef.so: no space left on device
```
UE image `dev-5.8.0` extracts past the 40Gi RAM-backed `/var/lib/docker` tmpfs → fails mid-extract. ([run](https://github.com/KBVE/kbve/actions/runs/28088762252/job/83161460732))

## Fix
Keep dind on tmpfs (deliberate — avoids node/Longhorn I/O thrash on every UE extract) but raise the ceiling:
- `dind-storage` tmpfs 40 → 64Gi
- dind container memory 56 → 80Gi
- `maxRunners` 2 → 1 so two UE pods never contend for node RAM; builds serialize onto one runner instead of racing OOM/disk-full
- restart-trigger bump → `-64g`

## Notes
- ARC manifests track `main` — reaches cluster only after dev→main release.
- If `dev-5.8.0` ever extracts past 64Gi, tmpfs is still a hard ceiling; node-local persistent PVC (extract once) is the durable follow-up.