### PR TITLE
refactor(ch): rename shared ingest user logflare -> kbve_ingest

### DIFF
--- a/apps/kube/clickhouse/manifests/ch-ingest-grants-job.yaml
+++ b/apps/kube/clickhouse/manifests/ch-ingest-grants-job.yaml
@@ -17,12 +17,12 @@ data:
         \ \\\n    -d \"$1\" || {\n    echo \"ERROR: grant failed: $1\"\n    exit 1\n \
         \ }\n}\n\n# CLUSTER privilege is required for every ON CLUSTER statement (CH 25.x);\n\
         # without it the per-pipeline setup jobs fail ACCESS_DENIED (Code 497).\ngrant\
-        \ \"GRANT CLUSTER ON *.* TO logflare ON CLUSTER 'cluster'\"\n\n# Data access for\
+        \ \"GRANT CLUSTER ON *.* TO kbve_ingest ON CLUSTER 'cluster'\"\n\n# Data access for\
         \ each direct-write pipeline. Creating a table does not\n# grant the creator data\
-        \ rights in CH RBAC.\ngrant \"GRANT ALL ON logflare.* TO logflare ON CLUSTER 'cluster'\"\
-        \ngrant \"GRANT ALL ON telemetry.* TO logflare ON CLUSTER 'cluster'\"\ngrant \"\
-        GRANT ALL ON observability.* TO logflare ON CLUSTER 'cluster'\"\ngrant \"GRANT\
-        \ ALL ON mc.* TO logflare ON CLUSTER 'cluster'\"\n\necho \"\"\necho \"Ingest-user\
+        \ rights in CH RBAC.\ngrant \"GRANT ALL ON logflare.* TO kbve_ingest ON CLUSTER 'cluster'\"\
+        \ngrant \"GRANT ALL ON telemetry.* TO kbve_ingest ON CLUSTER 'cluster'\"\ngrant \"\
+        GRANT ALL ON observability.* TO kbve_ingest ON CLUSTER 'cluster'\"\ngrant \"GRANT\
+        \ ALL ON mc.* TO kbve_ingest ON CLUSTER 'cluster'\"\n\necho \"\"\necho \"Ingest-user\
         \ grants applied.\"\n"
 ---
 apiVersion: batch/v1

--- a/apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml
+++ b/apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml
@@ -70,10 +70,7 @@ spec:
                                 name: clickhouse-credentials
                                 key: endpoint
                       - name: CLICKHOUSE_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: clickhouse-credentials
-                                key: username
+                        value: kbve_ingest
                       - name: CLICKHOUSE_PASSWORD
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -69,10 +69,7 @@ spec:
                       - name: CLICKHOUSE_ENDPOINT
                         value: http://clickhouse-clickhouse-cluster.clickhouse.svc.cluster.local:8123
                       - name: CLICKHOUSE_USERNAME
-                        valueFrom:
-                            secretKeyRef:
-                                name: clickhouse-credentials
-                                key: username
+                        value: kbve_ingest
                       - name: CLICKHOUSE_PASSWORD
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/metrics/manifest/telemetry-ch-setup-job.yaml
+++ b/apps/kube/metrics/manifest/telemetry-ch-setup-job.yaml
@@ -97,10 +97,7 @@ spec:
                       - name: CLICKHOUSE_ENDPOINT
                         value: http://clickhouse-clickhouse-cluster.clickhouse.svc.cluster.local:8123
                       - name: CLICKHOUSE_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: clickhouse-credentials
-                                key: username
+                        value: kbve_ingest
                       - name: CLICKHOUSE_PASSWORD
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/vector/manifests/alerts-poll-cronjob.yaml
+++ b/apps/kube/vector/manifests/alerts-poll-cronjob.yaml
@@ -99,10 +99,7 @@ spec:
                                         name: clickhouse-vector-credentials
                                         key: endpoint
                               - name: CLICKHOUSE_USER
-                                valueFrom:
-                                    secretKeyRef:
-                                        name: clickhouse-vector-credentials
-                                        key: username
+                                value: kbve_ingest
                               - name: CLICKHOUSE_PASSWORD
                                 valueFrom:
                                     secretKeyRef:

--- a/apps/kube/vector/manifests/observability-ch-setup-job.yaml
+++ b/apps/kube/vector/manifests/observability-ch-setup-job.yaml
@@ -105,10 +105,7 @@ spec:
                                 name: clickhouse-vector-credentials
                                 key: endpoint
                       - name: CLICKHOUSE_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: clickhouse-vector-credentials
-                                key: username
+                        value: kbve_ingest
                       - name: CLICKHOUSE_PASSWORD
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/vector/manifests/vector-daemonset.yaml
+++ b/apps/kube/vector/manifests/vector-daemonset.yaml
@@ -55,10 +55,7 @@ spec:
                                 name: clickhouse-vector-credentials
                                 key: endpoint
                       - name: CLICKHOUSE_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: clickhouse-vector-credentials
-                                key: username
+                        value: kbve_ingest
                       - name: CLICKHOUSE_PASSWORD
                         valueFrom:
                             secretKeyRef:

--- a/packages/data/ch/schemas/grants.sql
+++ b/packages/data/ch/schemas/grants.sql
@@ -1,26 +1,28 @@
--- grants.sql — privileges for the shared `logflare` ingest user.
+-- grants.sql — privileges for the shared `kbve_ingest` ingest user.
 -- =============================================================================
--- The `logflare` CH user is the single ingest identity for the direct-write
--- pipelines (Logflare-the-service is no longer in the path):
+-- The `kbve_ingest` CH user is the single ingest identity for the direct-write
+-- pipelines (renamed from the legacy `logflare` user — Logflare-the-service is
+-- no longer in the path):
 --   • apps/metrics  (Rust frontend telemetry)  → telemetry.*
 --   • Vector (DaemonSet)                        → observability.*
 --   • mc presence snapshots (apps/kbve)         → mc.*
 --
--- `CREATE USER logflare ... IDENTIFIED WITH sha256_password` is issued by the
+-- `CREATE USER kbve_ingest ... IDENTIFIED WITH sha256_password` is issued by the
 -- bootstrap Job from a sealed secret (password never lands in git). This file
--- is the canonical record of the GRANTs that must accompany it.
+-- is the canonical record of the GRANTs that must accompany it. The username is
+-- supplied to consumers as plain env (not sensitive); only the password is sealed.
 --
 -- ClickHouse 25.x gates every `ON CLUSTER` statement behind the global CLUSTER
 -- privilege — without it, CREATE DATABASE/TABLE ON CLUSTER fails ACCESS_DENIED
 -- (Code 497) and the per-pipeline setup jobs can never provision their schema.
 -- =============================================================================
 
--- Required to run any `ON CLUSTER` DDL (the setup jobs run as logflare).
-GRANT CLUSTER ON *.* TO logflare ON CLUSTER 'cluster';
+-- Required to run any `ON CLUSTER` DDL (the setup jobs run as kbve_ingest).
+GRANT CLUSTER ON *.* TO kbve_ingest ON CLUSTER 'cluster';
 
 -- Data access for each direct-write pipeline (creating a table does not grant
 -- the creator data rights in CH RBAC — these are required for INSERT/SELECT).
-GRANT ALL ON logflare.* TO logflare ON CLUSTER 'cluster';
-GRANT ALL ON telemetry.* TO logflare ON CLUSTER 'cluster';
-GRANT ALL ON observability.* TO logflare ON CLUSTER 'cluster';
-GRANT ALL ON mc.* TO logflare ON CLUSTER 'cluster';
+GRANT ALL ON logflare.* TO kbve_ingest ON CLUSTER 'cluster';
+GRANT ALL ON telemetry.* TO kbve_ingest ON CLUSTER 'cluster';
+GRANT ALL ON observability.* TO kbve_ingest ON CLUSTER 'cluster';
+GRANT ALL ON mc.* TO kbve_ingest ON CLUSTER 'cluster';


### PR DESCRIPTION
## Why
Logflare-the-service is no longer in the ingest path, but the shared ClickHouse direct-write user was still legacy-named `logflare`. Rename to `kbve_ingest`.

## Key idea — no re-seal needed
The username isn't sensitive, so consumers now take it as **plain env** (`value: kbve_ingest`) instead of a sealed-secret `username` key. Only the **password** stays sealed (untouched). So this is a pure manifest change — no kubeseal/secret rotation.

## Changes (8 files)
Username → `kbve_ingest`:
- vector-daemonset, alerts-poll-cronjob, observability-ch-setup (vector)
- metrics-deployment, telemetry-ch-setup (metrics)
- mc-presence-ch-setup (kbve)

Grant target `logflare` → `kbve_ingest`:
- `packages/data/ch/schemas/grants.sql`
- `apps/kube/clickhouse/manifests/ch-ingest-grants-job.yaml`

## Live state (already applied, zero-downtime)
`kbve_ingest` was created in CH with the **same password** + grants on all pipeline DBs. Both users coexist, so consumers keep working before AND after rollout. The legacy `logflare` user is **retained for rollback**.

## Not in this PR (follow-up)
- Retire the Kyverno-blocked kilobase `logflare-ch-setup` bootstrap (Logflare-service-specific) + move `CREATE USER kbve_ingest` into a GitOps job, so the user is reproducible (currently created live).
- Drop the `logflare` user once `kbve_ingest` is confirmed across all consumers.