### PR TITLE
ci(dashboard): move security + nx-report jobs to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -60,7 +60,7 @@ jobs:
         name: Security Audit
         needs: guard
         if: needs.guard.outputs.allowed == 'true'
-        runs-on: arc-runner-set
+        runs-on: ubuntu-latest
         timeout-minutes: 60
         permissions:
             contents: read
@@ -289,7 +289,7 @@ jobs:
         name: NX Report & Graph
         needs: guard
         if: needs.guard.outputs.allowed == 'true'
-        runs-on: arc-runner-set
+        runs-on: ubuntu-latest
         timeout-minutes: 120
         permissions:
             contents: read


### PR DESCRIPTION
## Why
First step of moving CI load off the single Talos control-plane node (the self-hosted ARC runners' DinD/build IO on sda starves etcd's WAL → control-plane flaps).

`ci-dashboard` is the cleanest candidate:
- **Daily scheduled** (cron 08:00 UTC) — ~1 run/day, negligible GitHub-minute cost
- **No in-cluster deps** — no registry-mirror, kubectl, or clickhouse
- Uses only repo-scoped `GITHUB_TOKEN` (CodeQL/Dependabot reads via the `security-events` permission it already declares) — **no new credential needed**

## Change
Both jobs (`security`, `report`) `runs-on: arc-runner-set` → `ubuntu-latest`. Guard job was already ubuntu-latest.

## Trade-off
Fresh toolchain installs (Node/pnpm/Python/Rust + audit tools) are slower without the in-cluster cache, but it's a daily job so cadence makes that irrelevant. Zero node IO for the audit churn.

First of several light, no-cluster-dep jobs to relocate; heavy builds (unreal/unity) stay on ARC.