### PR TITLE
ci(dbmate-validate): move to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-dbmate-validate.yml
+++ b/.github/workflows/ci-dbmate-validate.yml
@@ -32,7 +32,7 @@ on:
 jobs:
     kilobase-rollout:
         name: Apply all migrations on kilobase prod-replica
-        runs-on: arc-runner-set
+        runs-on: ubuntu-latest
         timeout-minutes: 15
 
         env:


### PR DESCRIPTION
## Why
Continues moving light, no-cluster-dep CI off the single Talos node (self-hosted ARC DinD IO on sda starves etcd's WAL).

`ci-dbmate-validate` stands up the **kilobase prod-replica postgres** (`ghcr.io/kbve/postgres` — public/open image) via docker compose **locally** and runs dbmate up/down. No registry-mirror, kubectl, or cluster services — all localhost.

## Change
`kilobase-rollout` job `arc-runner-set` → `ubuntu-latest`.

## Why it just works on ubuntu-latest
- Native docker + compose v2 preinstalled → the DinD-daemon-wait and compose-install steps no-op
- Image is public ghcr → pulls anonymously, no login / no `kbve-github` credential needed

## Stays on ARC
`ci-dbmate-deploy` (prod apply, uses `kubectl`) — needs cluster access.