### PR TITLE
ci(e2e): move edge-e2e to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -91,11 +91,11 @@ jobs:
                     PLAYWRIGHT="true"
 
                     case "$project" in
-                      axum-kbve-e2e|edge-e2e|metrics-e2e)
+                      axum-kbve-e2e|metrics-e2e)
                         RUNNER="arc-runner-set"
                         PLAYWRIGHT="false"
                         ;;
-                      devops-e2e)
+                      devops-e2e|edge-e2e)
                         PLAYWRIGHT="false"
                         ;;
                     esac


### PR DESCRIPTION
## Why
Moves another self-hosted e2e off the single Talos node. `edge-e2e` is the light one of the three ARC-pinned e2e projects:
- Builds a **Deno** image (no cargo compile → no sccache benefit)
- **Self-contained**: `docker run kbve/edge:latest` with dummy env on localhost + vitest HTTP tests; CH-dependent specs already excluded
- No in-cluster services / registry-mirror dep

## Change
Drop `edge-e2e` from the `arc-runner-set` case in the discover matrix → falls to the `ubuntu-latest` default (keeps `playwright=false`).

## Stays on ARC
`axum-kbve-e2e` + `metrics-e2e` — heavy Rust/cargo Docker builds that need the in-cluster sccache + 12 CPU; ubuntu-latest would be slow cold builds + costly minutes.

No new credential — uses GITHUB_TOKEN + public images.