### PR TITLE
fix(spo): pin operator image to v0.9.1 + privileged ns label (stop 3000x crashloop)

### DIFF
--- a/apps/kube/security-profiles-operator/application.yaml
+++ b/apps/kube/security-profiles-operator/application.yaml
@@ -31,6 +31,11 @@ spec:
         automated:
             selfHeal: true
             prune: true
+        managedNamespaceMetadata:
+            labels:
+                pod-security.kubernetes.io/enforce: privileged
+                pod-security.kubernetes.io/audit: privileged
+                pod-security.kubernetes.io/warn: privileged
         syncOptions:
             - CreateNamespace=true
             - ServerSideApply=true

--- a/apps/kube/security-profiles-operator/manifests/values.yaml
+++ b/apps/kube/security-profiles-operator/manifests/values.yaml
@@ -2,6 +2,16 @@
 # Manages SeccompProfile CRDs so pods can reference custom profiles
 # without placing files on node filesystems (required for Talos).
 
+# Pin the operator image to the chart's release (v0.9.1). The chart default
+# is gcr.io/k8s-staging-sp-operator/...:latest, a floating staging tag that
+# drifted to 1.0.1-dev, which expects the SecurityProfilesOperatorDaemon
+# kind in v1 while the v0.9.1 chart only ships v1alpha1 -> operator
+# crashlooped (3000+ restarts) on "no matches for kind ... v1".
+spoImage:
+    registry: registry.k8s.io
+    repository: security-profiles-operator/security-profiles-operator
+    tag: v0.9.1
+
 enableLogEnricher: false
 enableRecordingHook: false
 


### PR DESCRIPTION
## Why
`security-profiles-operator` is a top etcd-churn source — **3,000+ restarts × 3 pods**, crashlooping every ~3 min, plus its `spod` DaemonSet endlessly failing to schedule (`FailedCreate` spam). Constant pod-status + event writes to etcd.

## Root causes
1. **Image/CRD version skew (the crashloop).** App pins chart `v0.9.1` (ships `SecurityProfilesOperatorDaemon` CRD at **v1alpha1**), but the chart's default `spoImage` is `gcr.io/k8s-staging-sp-operator/...:**latest**` — a floating staging tag that drifted to **1.0.1-dev**, which expects the kind in **v1**. Operator dies on startup: `no matches for kind SecurityProfilesOperatorDaemon in version ...v1`.
2. **spod blocked by PodSecurity.** The namespace had no PSA label → cluster-default `baseline`, which rejects spod's hostPath + seLinuxOptions.

## Fix
1. Pin `spoImage` → `registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.9.1` (matches the chart's v1alpha1 CRD).
2. `managedNamespaceMetadata` → label the ns `pod-security.kubernetes.io/enforce=privileged` so spod can schedule.

## Why SPO stays (not removed)
`firecracker-jailer` seccompprofile depends on it; spod delivers that profile to nodes (required on Talos, per the values comment).

Net: eliminates a constant etcd-write firehose.