### PR TITLE
chore(elk): retire unused Elasticsearch + Kibana stack

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -89,9 +89,11 @@ resources:
     # Cilium LB IPAM — IP pools + L2 announcements (replaces MetalLB)
     - cilium/lb-application.yaml
 
-    # ECK (Elastic Cloud on Kubernetes) — operator + Elasticsearch + Kibana
+    # ECK (Elastic Cloud on Kubernetes) — operator only; ES + Kibana retired
+    # (unused: Vector ships to ClickHouse, no Kibana route, no consumers).
+    # Operator kept transiently so it runs the ES/Kibana finalizers (pod+PVC
+    # cleanup); removed in the follow-up once the stack is fully pruned.
     - elk/application.yaml
-    - elk/stack-application.yaml
 
     # Forgejo — Git LFS server + Actions runner, UE asset storage on sdb
     - forgejo/application.yaml


### PR DESCRIPTION
## Why
ElasticSearch + Kibana are confirmed unused:
| Check | Result |
|---|---|
| Vector sink | ClickHouse only — no ES sink, nothing feeds it |
| ES endpoint consumers | none outside the elk manifests |
| Kibana route | none — not viewable |
| Status | legacy logging, superseded by the ClickHouse observability stack |

Cost it burns idle: **~2-4Gi RAM** (ES JVM) + **~0.5-1Gi** (Kibana) + a **50Gi PVC on `longhorn` (sda = etcd's disk)**, whose JVM indexing/merge IO contends with etcd's WAL.

## Change
Remove the `elk-stack` Application from the app-of-apps → ArgoCD prunes the Elasticsearch + Kibana CRs.

## Ordering (why operator stays for now)
The `eck-operator` (`elk` app) is **kept transiently** so it runs the ES/Kibana **finalizers** (deletes pods + the 50Gi PVC). Removing the operator at the same time would orphan the CRs on their finalizers. Once the stack is confirmed pruned, a follow-up removes the operator + the `apps/kube/elk` dir.

## Data
The 50Gi ES index is discarded — unused/unread.