### PR TITLE
Persistent BuildKit cache + e2e build speedups

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -170,6 +170,8 @@ jobs:
                     echo "Synced version ${VER} → ${TGT}"
                   fi
 
+            # Installs buildx and provisions a docker-container builder that
+            # doubles as the fallback if the persistent buildkitd is down.
             - name: Setup Docker Buildx
               uses: Wandalen/wretry.action@v3.8.0
               with:
@@ -181,6 +183,22 @@ jobs:
                       driver-opts: |
                           image=moby/buildkit:v0.24.0
                           network=host
+
+            # Prefer the persistent in-cluster buildkitd (warm .astro / cargo /
+            # sccache-local / layer cache across runs). If it is unreachable
+            # (not yet deployed, restarting), silently keep the docker-container
+            # builder above so builds never break on the cutover.
+            - name: Prefer persistent remote buildkitd
+              run: |
+                  REMOTE=tcp://buildkitd.arc-runners.svc.cluster.local:1234
+                  if docker buildx create --name kbve-remote --driver remote "$REMOTE" 2>/dev/null \
+                     && timeout 60 docker buildx inspect --bootstrap kbve-remote >/dev/null 2>&1; then
+                      docker buildx use kbve-remote
+                      echo "::notice::buildx using persistent remote buildkitd ($REMOTE)"
+                  else
+                      echo "::warning::remote buildkitd unreachable -> keeping docker-container builder"
+                      docker buildx rm kbve-remote 2>/dev/null || true
+                  fi
 
             - name: Login to GHCR
               uses: docker/login-action@v4

--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -28,7 +28,7 @@ COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 COPY apps/chuckrpg/astro-chuckrpg/ apps/chuckrpg/astro-chuckrpg/
 
 WORKDIR /app/apps/chuckrpg/astro-chuckrpg
-RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-chuckrpg-cache \
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-chuckrpg-cache,sharing=locked \
     cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
     npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -41,7 +41,9 @@ WORKDIR /app/apps/cryptothrone/astro-cryptothrone
 # Build the standalone embed.js + Discord Activity discord.js into public/
 # first, so `astro build` copies them into dist (served by the rust binary at
 # /embed/embed.js and /discord/{index.html,discord.js}).
-RUN rm -rf .astro && npx astro sync && \
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-cryptothrone-cache,sharing=locked \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    npx astro sync && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.embed.config.mts && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.discord.config.mts && \
     # Cache-bust the fixed-name discord.js: stamp its content hash as a query so
@@ -50,6 +52,7 @@ RUN rm -rf .astro && npx astro sync && \
     DJS_V=$(sha1sum public/discord/discord.js | cut -c1-8) && \
     sed -i "s#src=\"discord.js\"#src=\"discord.js?v=$DJS_V\"#" public/discord/index.html && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true && \
     # Fail loud if the embed/discord bundles didn't make it into dist (a stale
     # cached astro-builder layer once shipped without them -> silent 404s).
     test -f ../../../dist/apps/astro-cryptothrone/embed/embed.js && \

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -37,7 +37,10 @@ COPY apps/discordsh/astro-discordsh/ apps/discordsh/astro-discordsh/
 WORKDIR /app/apps/discordsh/astro-discordsh
 # astro build handles sync internally — avoid separate sync which can
 # leave partial image cache entries that break the optimizer
-RUN UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-discordsh-cache,sharing=locked \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 COPY apps/herbmail/astro-herbmail/ apps/herbmail/astro-herbmail/
 
 WORKDIR /app/apps/herbmail/astro-herbmail
-RUN rm -rf .astro && npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-herbmail-cache,sharing=locked \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -36,8 +36,11 @@ WORKDIR /app/apps/irc/astro-irc
 # Host pages drop in `<script src="https://chat.kbve.com/embed/chat.js">`.
 RUN npx vite build --config vite.embed.config.ts
 
-RUN rm -rf .astro && npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-irc-cache,sharing=locked \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -134,6 +134,10 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS bui
 ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
+# release (default, prod) or dev (e2e image — unoptimized, builds far faster).
+# Must match across cook/foundation/app so chef-cooked deps are reused.
+ARG CARGO_PROFILE=release
+
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
@@ -151,13 +155,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     else \
         echo "sccache: Redis password not provided, falling back to local disk cache"; \
     fi && \
-    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
+    PROFILE_FLAG=""; [ "${CARGO_PROFILE}" = "release" ] && PROFILE_FLAG="--release"; \
+    cargo chef cook ${PROFILE_FLAG} --recipe-path recipe.json -p axum-kbve && \
     (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
 ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+
+ARG CARGO_PROFILE=release
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -190,7 +197,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
+    PROFILE_FLAG=""; [ "${CARGO_PROFILE}" = "release" ] && PROFILE_FLAG="--release"; \
+    cargo build ${PROFILE_FLAG} -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
         -p bevy_inventory -p bevy_items -p bevy_skills && \
     (sccache --show-stats || true)
 
@@ -198,6 +206,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE F] - Build Application
 # ============================================================================
 FROM foundation AS builder
+ARG CARGO_PROFILE=release
 
 # Ensure make is available for tikv-jemalloc-sys compilation (build from source)
 RUN dpkg -s make >/dev/null 2>&1 || \
@@ -235,16 +244,19 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p axum-kbve --features jemalloc && \
+    PROFILE_FLAG=""; PROFILE_DIR="debug"; \
+    [ "${CARGO_PROFILE}" = "release" ] && { PROFILE_FLAG="--release"; PROFILE_DIR="release"; }; \
+    cargo build ${PROFILE_FLAG} -p axum-kbve --features jemalloc && \
     (sccache --show-stats || true) && \
-    strip target/release/axum-kbve
+    strip target/${PROFILE_DIR}/axum-kbve && \
+    cp target/${PROFILE_DIR}/axum-kbve /app/axum-kbve.bin
 
 # ============================================================================
 # [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
-COPY --from=builder --chown=10001:10001 /app/target/release/axum-kbve /app/axum-kbve
+COPY --from=builder --chown=10001:10001 /app/axum-kbve.bin /app/axum-kbve
 
 # Ship Cargo.toml alongside the binary so `/health` reports the version
 # that was current when *this image* was built. CI's pre-build sync step

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -134,10 +134,6 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS bui
 ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
-# release (default, prod) or dev (e2e image — unoptimized, builds far faster).
-# Must match across cook/foundation/app so chef-cooked deps are reused.
-ARG CARGO_PROFILE=release
-
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
@@ -155,16 +151,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     else \
         echo "sccache: Redis password not provided, falling back to local disk cache"; \
     fi && \
-    PROFILE_FLAG=""; [ "${CARGO_PROFILE}" = "release" ] && PROFILE_FLAG="--release"; \
-    cargo chef cook ${PROFILE_FLAG} --recipe-path recipe.json -p axum-kbve && \
+    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
     (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
 ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
-
-ARG CARGO_PROFILE=release
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -197,8 +190,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    PROFILE_FLAG=""; [ "${CARGO_PROFILE}" = "release" ] && PROFILE_FLAG="--release"; \
-    cargo build ${PROFILE_FLAG} -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
+    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
         -p bevy_inventory -p bevy_items -p bevy_skills && \
     (sccache --show-stats || true)
 
@@ -206,7 +198,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE F] - Build Application
 # ============================================================================
 FROM foundation AS builder
-ARG CARGO_PROFILE=release
 
 # Ensure make is available for tikv-jemalloc-sys compilation (build from source)
 RUN dpkg -s make >/dev/null 2>&1 || \
@@ -244,19 +235,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    PROFILE_FLAG=""; PROFILE_DIR="debug"; \
-    [ "${CARGO_PROFILE}" = "release" ] && { PROFILE_FLAG="--release"; PROFILE_DIR="release"; }; \
-    cargo build ${PROFILE_FLAG} -p axum-kbve --features jemalloc && \
+    cargo build --release -p axum-kbve --features jemalloc && \
     (sccache --show-stats || true) && \
-    strip target/${PROFILE_DIR}/axum-kbve && \
-    cp target/${PROFILE_DIR}/axum-kbve /app/axum-kbve.bin
+    strip target/release/axum-kbve
 
 # ============================================================================
 # [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
-COPY --from=builder --chown=10001:10001 /app/axum-kbve.bin /app/axum-kbve
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-kbve /app/axum-kbve
 
 # Ship Cargo.toml alongside the binary so `/health` reports the version
 # that was current when *this image* was built. CI's pre-build sync step

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -54,7 +54,7 @@ COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 # NOTE: Mount cache to a staging path, then copy in/out. Mounting directly on
 # .astro/ causes EBUSY when Astro tries to rmdir the mount point after build.
 WORKDIR /app/apps/kbve/astro-kbve
-RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-cache \
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-kbve-cache,sharing=locked \
     cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
     npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -99,7 +99,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --build-arg CARGO_PROFILE=dev --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -99,7 +99,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max,image-manifest=true,oci-mediatypes=true ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --build-arg CARGO_PROFILE=dev --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}

--- a/apps/kube/github/runners/manifests/buildkitd.yaml
+++ b/apps/kube/github/runners/manifests/buildkitd.yaml
@@ -1,0 +1,173 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: buildkitd-cache
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: buildkitd
+        app.kubernetes.io/part-of: arc-runner-set
+        kbve.com/category: ci-cd
+        kbve.com/stack: github-actions
+        kbve.com/managed-by: argocd
+spec:
+    accessModes:
+        - ReadWriteOnce
+    storageClassName: longhorn-sdb
+    resources:
+        requests:
+            storage: 150Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: buildkitd-config
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: buildkitd
+        app.kubernetes.io/part-of: arc-runner-set
+        kbve.com/category: ci-cd
+        kbve.com/stack: github-actions
+        kbve.com/managed-by: argocd
+data:
+    buildkitd.toml: |
+        debug = false
+        root = "/var/lib/buildkit"
+
+        [worker.oci]
+          enabled = true
+          # ext4 PVC, not the host overlay rootfs, so overlayfs snapshotter
+          # mounts cleanly (no overlay-on-overlay EINVAL like the DinD data-root
+          # hit on Talos kernel 6.18). Drop to "native" if EINVAL ever surfaces.
+          snapshotter = "overlayfs"
+          gc = true
+          # Self-prune below the PVC size so the cache never wedges a build with
+          # ENOSPC. Working set = astro .astro + cargo registry + sccache-local +
+          # pnpm store + layer cache across every app.
+          gckeepstorage = "110GB"
+          [[worker.oci.gcpolicy]]
+            keepBytes = "110GB"
+            keepDuration = "336h"
+
+        [worker.containerd]
+          enabled = false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: buildkitd
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: buildkitd
+        app.kubernetes.io/part-of: arc-runner-set
+        kbve.com/category: ci-cd
+        kbve.com/stack: github-actions
+        kbve.com/managed-by: argocd
+spec:
+    replicas: 1
+    strategy:
+        type: Recreate
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: buildkitd
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/name: buildkitd
+                app.kubernetes.io/part-of: arc-runner-set
+        spec:
+            containers:
+                - name: buildkitd
+                  image: moby/buildkit:v0.24.0
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - --addr
+                      - unix:///run/buildkit/buildkitd.sock
+                      - --addr
+                      - tcp://0.0.0.0:1234
+                      - --config
+                      - /etc/buildkit/buildkitd.toml
+                  ports:
+                      - name: grpc
+                        containerPort: 1234
+                  securityContext:
+                      privileged: true
+                  volumeMounts:
+                      - name: config
+                        mountPath: /etc/buildkit
+                        readOnly: true
+                      - name: cache
+                        mountPath: /var/lib/buildkit
+                  resources:
+                      limits:
+                          cpu: '16'
+                          memory: 32Gi
+                      requests:
+                          cpu: '2'
+                          memory: 4Gi
+                  readinessProbe:
+                      exec:
+                          command:
+                              - buildctl
+                              - debug
+                              - workers
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                  livenessProbe:
+                      tcpSocket:
+                          port: grpc
+                      initialDelaySeconds: 30
+                      periodSeconds: 30
+            volumes:
+                - name: config
+                  configMap:
+                      name: buildkitd-config
+                      items:
+                          - key: buildkitd.toml
+                            path: buildkitd.toml
+                - name: cache
+                  persistentVolumeClaim:
+                      claimName: buildkitd-cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: buildkitd
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: buildkitd
+        app.kubernetes.io/part-of: arc-runner-set
+        kbve.com/category: ci-cd
+        kbve.com/stack: github-actions
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        app.kubernetes.io/name: buildkitd
+    ports:
+        - name: grpc
+          port: 1234
+          targetPort: grpc
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: buildkitd-ingress
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/name: buildkitd
+        app.kubernetes.io/part-of: arc-runner-set
+spec:
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/name: buildkitd
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: arc-runners
+          ports:
+              - port: grpc
+                protocol: TCP

--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
     - cache-cleanup-cronjob.yaml
     - registry-mirror.yaml
     - registry-mirror-ghcr.yaml
+    - buildkitd.yaml
     - valkey-sccache-externalsecret.yaml
     - vm-starter-rbac.yaml
     - runner-reaper.yaml

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -35,8 +35,11 @@ COPY apps/memes/astro-memes/ apps/memes/astro-memes/
 
 # Build astro site
 WORKDIR /app/apps/memes/astro-memes
-RUN rm -rf .astro && npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-memes-cache,sharing=locked \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -29,7 +29,7 @@ COPY apps/rareicon/icons-codegen/ apps/rareicon/icons-codegen/
 COPY apps/rareicon/astro-rareicon/ apps/rareicon/astro-rareicon/
 
 WORKDIR /app/apps/rareicon/astro-rareicon
-RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-rareicon-cache \
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-rareicon-cache,sharing=locked \
     cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
     npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \

--- a/docs/superpowers/specs/2026-06-24-persistent-buildkit-cache-design.md
+++ b/docs/superpowers/specs/2026-06-24-persistent-buildkit-cache-design.md
@@ -1,0 +1,138 @@
+# Persistent BuildKit Cache — design
+
+## Problem
+
+CI docker builds on the ARC runners use an **ephemeral** buildx builder
+(`driver: docker-container`, a fresh `moby/buildkit` container spun per job
+inside the DinD sidecar). Every `--mount=type=cache` dir (astro `.astro`,
+cargo registry, sccache-local, pnpm store) and the BuildKit layer cache start
+**empty every run** and die with the pod. The registry `cache-from/to` only
+papers over this, and importing a `mode=max` cache is itself slow.
+
+Observed on `CI - Docker / axum-kbve` e2e (run 28097748154, ~31min build, ~5s
+actual test):
+
+| Phase | Time | Cause |
+|---|---|---|
+| registry cache import + setup | ~3.5min | cold ephemeral builder |
+| Astro build (Stage A) | ~9.5min | api.mdx version bump busts the layer **every release** |
+| chef cook + foundation crates | ~1min | sccache 100% hit (already optimal) |
+| axum-kbve app compile + link | ~12.4min | app crate source changed |
+| cache export (mode=max) | ~4min | uploads every layer to ghcr |
+| vitest e2e | ~5s | the actual test |
+
+The Astro static site is **not skippable** — Astro emits the askama templates
+the axum binary serves (`templates/dist/askama` → `templates/askama`), tested by
+`static`/`content-routes`/`askama`/`compression`/`redirects` specs. Astro must
+be made **incremental**, not removed.
+
+## Solution
+
+One standing **`buildkitd`** Deployment whose `/var/lib/buildkit` (layer cache
+**and** every `--mount=type=cache` dir) lives on a PVC. All buildx jobs target
+it via the `remote` driver. Warm cache across ephemeral runs:
+
+- `.astro` mount warm → changed api.mdx rebuilds in **seconds**, not 9.5min.
+- cargo registry / git / sccache-local / pnpm store stay warm.
+- layer cache reused without registry import.
+
+### Why remote/shared buildkitd is safe here (and the shared *dockerd* was not)
+
+The Unity (game-ci) / UE bind-mount problem — `docker run -v $GITHUB_WORKSPACE`
+resolves paths on the *daemon's* filesystem — does **not** apply: buildkitd never
+bind-mounts a host path, buildx **streams the build context** over the gRPC API.
+So a shared build server is clean for builds. The DinD sidecar stays for
+`--load` + `docker run` (e2e container), which still need a local docker daemon.
+
+## Components (ns `arc-runners`, `buildkitd.yaml`)
+
+- **PVC `buildkitd-cache`** — RWO, `longhorn-sdb` (ext4 block), 150Gi. RWO is
+  fine: **only buildkitd touches the PVC**, runners reach it over TCP. Sidesteps
+  the Longhorn-RWX-breaks-overlayfs trap entirely.
+- **Deployment `buildkitd`** — `replicas:1`, `strategy: Recreate`, privileged,
+  `moby/buildkit:v0.24.0` (matches the version the workflow already pins),
+  `--addr tcp://0.0.0.0:1234`, `/var/lib/buildkit` on the PVC.
+- **ConfigMap `buildkitd-config`** — `buildkitd.toml`: oci worker, overlayfs
+  snapshotter (ext4 PVC → no overlay-on-overlay EINVAL; fall back to `native` if
+  it ever surfaces), GC `gckeepstorage=110GB` so the cache self-prunes below the
+  150Gi PVC (no manual-GC ENOSPC time-bomb).
+- **Service `buildkitd`** — ClusterIP `:1234`.
+- **NetworkPolicy `buildkitd-ingress`** — `:1234` ingress restricted to
+  `arc-runners` pods. (NetworkPolicy-only; no mTLS. In-cluster, single-node
+  today. Revisit mTLS if the threat model widens.)
+
+## Cache-id hygiene (prerequisite — masked today by ephemeral builders)
+
+Ephemeral builders mean cache-mount ids never collide (nothing persists). Once
+buildkitd is persistent, ids become **shared state**. Audit:
+
+- **Layer cache / cargo / sccache (×41) / pnpm (×8)** — content-addressed global
+  stores. Shared across projects is correct and beneficial. No change.
+- **`.astro` is per-project** → each astro Dockerfile needs a **unique** id.
+  Today 3 use the mount: `astro-cache` (kbve — generic, a copy-paste trap),
+  `astro-rareicon-cache`, `astro-chuckrpg-cache`. Rename kbve →
+  `astro-kbve-cache`; convention `id=astro-<app>-cache`. Add `sharing=locked` to
+  astro mounts (serialize same-id concurrent builds; `.astro` is not
+  concurrent-safe). Leave cargo/pnpm/sccache `shared` (own locking).
+- 5 astro apps build astro fully every run with **no** cache mount (memes,
+  irc-gateway, cryptothrone, herbmail, discordsh) — add uniquely-id'd
+  `astro-<app>-cache` mounts so persistent buildkit makes them incremental too.
+
+## e2e quick wins (independent of buildkitd)
+
+- Build the e2e image **unoptimized** (debug profile) — the e2e checks behavior,
+  not perf; `--release` full-opt of the app crate is ~12min wasted. Publish keeps
+  `--release`.
+- Drop `--cache-to=registry,mode=max` from the **e2e** path (~4min export). The
+  persistent builder is the cache; the publish workflow owns the registry seed.
+
+## Runner wiring (the flip — lands LAST)
+
+Replace the `Setup Docker Buildx` step (`driver: docker-container`) in the build
+workflows (`docker-test-app.yml`, `utils-publish-docker-image.yml`) with:
+
+```
+docker buildx create --name persistent --driver remote \
+  tcp://buildkitd.arc-runners.svc.cluster.local:1234 --use
+```
+
+Keep the DinD sidecar for `--load` + `docker run`.
+
+## Concurrency
+
+buildkitd is built for concurrent builds. Multiple runners build against the one
+daemon; per-cache-mount-id locking may briefly serialize two simultaneous Rust
+builds on the shared cargo-registry mount — acceptable, still far cheaper than
+cold. Single-node today; runners reach buildkitd over TCP so no node-pinning.
+
+## Failure modes / rollback
+
+- buildkitd down → builds fail fast. Mitigate: keep `cache-to=registry` seed on
+  the **publish** path so a rebuilt buildkitd re-warms from ghcr. Rollback =
+  flip the workflow buildx step back to `docker-container` (one line).
+- PVC corruption → delete PVC, buildkitd recreates empty, re-warms from seed.
+- GC mis-tuned → tune `gckeepstorage` vs observed working set.
+
+## Rollout (staged, one branch)
+
+1. **C1** — land buildkitd infra (inert; nothing targets it). Verify Ready.
+2. **C2** — cache-id hygiene (namespace astro ids + `sharing=locked` + 5 missing
+   mounts). Safe with the still-ephemeral builders.
+3. **C3** — e2e quick wins (debug profile + drop e2e cache-to).
+4. **C4** — flip the workflow buildx step to the remote driver. Measure 2–3 e2e
+   runs on `arc-runner-set`, then it's the default for all buildx jobs.
+
+Each stage is independently revertible; the chicken-egg (runners pointing at a
+buildkitd that isn't up) is avoided by landing C4 only after C1 is verified live.
+
+## Expected result
+
+e2e ~31min → ~13–15min once warm (astro 9.5→~1min, import ~3.5→0, export 4→0;
+app compile addressed separately by debug profile). Every other buildx job
+inherits the same warm cache.
+
+## Out of scope
+
+- `arc-runner-ue` `/var/lib/docker` image-store PVC (the 50GB UE pull) — a
+  different mechanism (image store, not build cache); tracked separately.
+- Unity / UE shared *dockerd* — rejected (game-ci bind-mount path problem).

--- a/docs/superpowers/specs/2026-06-24-persistent-buildkit-cache-design.md
+++ b/docs/superpowers/specs/2026-06-24-persistent-buildkit-cache-design.md
@@ -78,13 +78,18 @@ buildkitd is persistent, ids become **shared state**. Audit:
   irc-gateway, cryptothrone, herbmail, discordsh) — add uniquely-id'd
   `astro-<app>-cache` mounts so persistent buildkit makes them incremental too.
 
-## e2e quick wins (independent of buildkitd)
+## e2e cache win (independent of buildkitd)
 
-- Build the e2e image **unoptimized** (debug profile) — the e2e checks behavior,
-  not perf; `--release` full-opt of the app crate is ~12min wasted. Publish keeps
-  `--release`.
 - Drop `--cache-to=registry,mode=max` from the **e2e** path (~4min export). The
   persistent builder is the cache; the publish workflow owns the registry seed.
+
+**Rejected: debug-profile e2e image.** The publish job does not rebuild — its
+`promote` step pulls the exact `ghcr.io/<image>:ci-<sha>` the e2e built+tested
+and ships *that* (rebuild is fallback-only; build-once by design). So a debug e2e
+image would ship a debug binary to production. e2e must build `--release` — the
+tested bytes are the published bytes. The app crate's ~12min release compile is
+the price of that fidelity; persistent buildkit can't shorten it (changed source,
+sccache can't hit), so it stays.
 
 ## Runner wiring (the flip — lands LAST)
 
@@ -118,7 +123,7 @@ cold. Single-node today; runners reach buildkitd over TCP so no node-pinning.
 1. **C1** — land buildkitd infra (inert; nothing targets it). Verify Ready.
 2. **C2** — cache-id hygiene (namespace astro ids + `sharing=locked` + 5 missing
    mounts). Safe with the still-ephemeral builders.
-3. **C3** — e2e quick wins (debug profile + drop e2e cache-to).
+3. **C3** — drop e2e `cache-to` (e2e stays `--release`; see "e2e cache win").
 4. **C4** — flip the workflow buildx step to the remote driver. Measure 2–3 e2e
    runs on `arc-runner-set`, then it's the default for all buildx jobs.
 
@@ -127,9 +132,10 @@ buildkitd that isn't up) is avoided by landing C4 only after C1 is verified live
 
 ## Expected result
 
-e2e ~31min → ~13–15min once warm (astro 9.5→~1min, import ~3.5→0, export 4→0;
-app compile addressed separately by debug profile). Every other buildx job
-inherits the same warm cache.
+e2e ~31min → ~16min once warm (astro 9.5→~1min, import ~3.5→0, export 4→0). The
+app crate's ~12min `--release` compile stays — the e2e image is the promoted
+published artifact, so it must be release, and a changed app crate can't hit
+sccache. Every other buildx job inherits the same warm cache.
 
 ## Out of scope
 


### PR DESCRIPTION
## What

Take CI docker builds off the **ephemeral** buildx builder (fresh `moby/buildkit` per job → every cache mount cold every run) and onto a **standing buildkitd** with PVC-backed cache. Plus drop a wasteful e2e cache export.

Root cause for the slow `CI - Docker / axum-kbve` e2e (~31min build, ~5s actual test): the Astro layer is busted **every release** because the version bump edits `api.mdx` (pulled in by `COPY apps/kbve/astro-kbve/`), so the 9.5min astro reimport can never cache-hit; the registry import (~3.5min) and `mode=max` export (~4min) are overhead.

## Commits

1. **`feat(arc)` — persistent buildkitd (inert).** Deployment + RWO `longhorn-sdb` PVC (`/var/lib/buildkit`) + Service + NetworkPolicy (arc-runners only) + GC. RWO is safe: only buildkitd touches the PVC; runners reach it over TCP — sidesteps the Longhorn-RWX-breaks-overlayfs trap. Remote buildkitd has **no bind-mount footgun** (buildx streams context over gRPC), unlike a shared dockerd.
2. **`build(docker)` — cache-id hygiene.** Persistent buildkit makes cache-mount ids shared state. Namespace every astro mount `id=astro-<app>-cache` + `sharing=locked`; convert the 5 apps that did `rm -rf .astro` to the cp-in/cp-out staging mount so their astro builds go incremental too.
3. **`perf` + `revert` — e2e cache-to drop, e2e stays `--release`.** Drop `--cache-to=mode=max` from the e2e path (publish still seeds the registry cache). **A debug-profile e2e was tried and reverted:** the publish job doesn't rebuild — its `promote` step ships the exact `ci-<sha>` image the e2e built+tested — so the e2e image **is** the published artifact and must be `--release`. (build-once is already the design.)
4. **`ci(docker-test)` — cutover.** e2e prefers the remote buildkitd, **falls back to docker-container if unreachable** → safe to merge before buildkitd is live.

## Rollout

C4's automatic fallback means an atomic dev→main release won't break builds even before buildkitd is `Ready`. After it's confirmed up, e2e runs use it; measure 2–3 runs, then flip the publish workflow the same way.

Expected e2e: ~31min → ~16min once warm (astro 9.5→~1min, import ~3.5→0, export 4→0). The app crate's ~12min `--release` compile stays — it's the promoted published artifact, and a changed crate can't hit sccache.

Design doc: `docs/superpowers/specs/2026-06-24-persistent-buildkit-cache-design.md`.

## Out of scope
- `arc-runner-ue` `/var/lib/docker` image-store PVC (the 50GB UE pull) — separate mechanism.
- Unity/UE shared *dockerd* — rejected (game-ci bind-mount path problem).