### PR TITLE
fix(ci): regen ci-dispatch-manifest for gate deployment paths

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.210",
+			"version": "1.0.212",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -81,7 +81,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -94,7 +94,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"source_path": "apps/agones/arpg",
@@ -340,7 +340,7 @@
 		{
 			"key": "kbve_gate",
 			"app_name": "kbve-gate",
-			"version": "0.1.3",
+			"version": "0.1.5",
 			"version_toml": "apps/kbve/kbve-gate/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
 			"version_target": "apps/kbve/kbve-gate/Cargo.toml",
@@ -349,7 +349,9 @@
 			"image": "kbve/kbve-gate",
 			"deployment_yamls": [
 				"apps/kube/n8n/manifest/n8n-deployment.yaml",
-				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml"
+				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml",
+				"apps/kube/argocd/manifests/argocd-gate-deployment.yaml",
+				"apps/kube/storage/manifests/longhorn-gate-deployment.yaml"
 			],
 			"has_test": false
 		},
@@ -1197,12 +1199,11 @@
 				],
 				"game_mode": "/Script/Chuck.ChuckGameMode",
 				"custom_config": "Beta",
-				"verify_baked_config": true,
 				"use_logging_in_shipping": "1"
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.36",
+			"version": "0.3.40",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",


### PR DESCRIPTION
Resolves structural drift flagged by the manifest guard ([run](https://github.com/KBVE/kbve/actions/runs/28134512945)).

MDX frontmatter added argocd-gate + longhorn-gate deployment paths and dropped `verify_baked_config` on grafana-gate, but the manifest wasn't regenerated. Ran `astro-kbve:build` + `sync:ci-manifest` and committed the full regenerated diff.