### PR TITLE
Tier UE Linux DinD: persistent image store + RAM DDC

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -525,10 +525,20 @@ jobs:
                   docker run --rm \
                     -v "${PROJECT_MOUNT}:/project" \
                     -v /tmp/ue5-build-output:/output \
+                    --mount type=tmpfs,destination=/ram,tmpfs-size=34359738368 \
+                    --env UE-LocalDataCachePath=/ram/ddc \
                     ${LOGGING_ENV_ARG} \
                     "${{ env.UE_IMAGE }}" \
                     /bin/bash -c '
                       set -euo pipefail
+
+                      # Tier the write-heavy UE local DDC onto the /ram tmpfs (RAM) so it
+                      # stays out of dockers writable layer on the longhorn-sdb PVC store.
+                      # report() measures the DDC + residual home/tmp writes so a later
+                      # pass can redirect whatever still escapes to the overlay.
+                      mkdir -p /ram/ddc
+                      report() { echo "::group::DDC tiering report"; printf "DDC=%s\n" "$(printenv UE-LocalDataCachePath || true)"; df -h /ram || true; du -sh /ram/ddc 2>/dev/null || true; echo "-- residual (redirect next if large) --"; du -sh "$HOME/.cache" "$HOME/.config" "$HOME/.nuget" "$HOME/.dotnet" /tmp 2>/dev/null || true; echo "::endgroup::"; }
+                      trap report EXIT
 
                       RUNUAT=""
                       for candidate in \
@@ -894,10 +904,18 @@ jobs:
                   docker run --rm \
                     -v /tmp/game-project:/project \
                     -v "${GITHUB_WORKSPACE}/ue5-game-output:/output" \
+                    --mount type=tmpfs,destination=/ram,tmpfs-size=34359738368 \
+                    --env UE-LocalDataCachePath=/ram/ddc \
                     ${LOGGING_ENV_ARG} \
                     "${{ env.UE_IMAGE }}" \
                     /bin/bash -c '
                       set -euo pipefail
+                      # Tier the write-heavy UE local DDC onto the /ram tmpfs (RAM), out of
+                      # dockers writable layer on the longhorn-sdb PVC store. report()
+                      # measures the DDC + residual writes so a later pass can redirect them.
+                      mkdir -p /ram/ddc
+                      report() { echo "::group::DDC tiering report"; printf "DDC=%s\n" "$(printenv UE-LocalDataCachePath || true)"; df -h /ram || true; du -sh /ram/ddc 2>/dev/null || true; echo "-- residual (redirect next if large) --"; du -sh "$HOME/.cache" "$HOME/.config" "$HOME/.nuget" "$HOME/.dotnet" /tmp 2>/dev/null || true; echo "::endgroup::"; }
+                      trap report EXIT
                       RUNUAT=""
                       for candidate in /home/ue4/UnrealEngine /home/epic/UnrealEngine /UnrealEngine; do
                         if [ -f "$candidate/Engine/Build/BatchFiles/RunUAT.sh" ]; then

--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
     - longhorn-sdb-storageclass.yaml
     - runner-cache-pvc.yaml
     - engine-cache-pvc.yaml
+    - ue-dind-cache-pvc.yaml
     - ows-server-build-pvc.yaml
     - cache-cleanup-cronjob.yaml
     - registry-mirror.yaml

--- a/apps/kube/github/runners/manifests/ue-dind-cache-pvc.yaml
+++ b/apps/kube/github/runners/manifests/ue-dind-cache-pvc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: arc-ue-dind-cache
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/component: dind-cache
+        app.kubernetes.io/part-of: arc-runner-ue
+        engine: unrealengine
+        kbve.com/category: ci-cd
+        kbve.com/stack: github-actions
+        kbve.com/managed-by: argocd
+spec:
+    accessModes:
+        - ReadWriteOnce
+    storageClassName: longhorn-sdb
+    resources:
+        requests:
+            storage: 250Gi

--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -21,7 +21,7 @@ maxRunners: 1
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260624-ram-dind-64g'
+            kbve.com/restart-trigger: '20260624-pvc-dind-tiered'
     spec:
         initContainers:
             - name: init-dind-externals
@@ -85,7 +85,7 @@ template:
               # exceeds RLIMIT_NOFILE → exit code 134.
               command: ['sh', '-c']
               args:
-                  - 'ulimit -n 1048576 && exec dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376 --tls=false --default-ulimit=nofile=1048576:1048576 --insecure-registry=registry-mirror-ghcr.arc-runners.svc.cluster.local:5000'
+                  - 'ulimit -n 1048576 && exec dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376 --tls=false --default-ulimit=nofile=1048576:1048576 --feature=containerd-snapshotter=false --insecure-registry=registry-mirror-ghcr.arc-runners.svc.cluster.local:5000'
               securityContext:
                   privileged: true
               resources:
@@ -115,10 +115,15 @@ template:
               emptyDir: {}
             - name: dind-externals
               emptyDir: {}
+            # Persistent docker image store on longhorn-sdb (ext4 block → overlay2
+            # mounts cleanly; RWX would EINVAL). RWO is safe: maxRunners:1 = single
+            # attach. The 50GB UE image is pulled once and stays resident across
+            # ephemeral runner pods instead of re-extracting into RAM every job.
+            # Frees the 64Gi RAM the old tmpfs store burned; write-heavy UE caches
+            # (DDC) are tiered onto a per-build /ram tmpfs in ci-unreal-build.yml.
             - name: dind-storage
-              emptyDir:
-                  medium: Memory
-                  sizeLimit: 64Gi
+              persistentVolumeClaim:
+                  claimName: arc-ue-dind-cache
             - name: shared-tmp
               emptyDir:
                   medium: Memory


### PR DESCRIPTION
## What

The UE Linux builds (`arc-runner-ue`) re-extract the 50GB UE image into a **RAM emptyDir** `/var/lib/docker` every ephemeral job (~26min). This tiers the DinD by access pattern: persistent image store on disk, write-heavy caches in RAM.

Scoped to the **Linux server + Linux game (client)** builds.

## Changes

1. **`/var/lib/docker` → persistent RWO `longhorn-sdb` PVC** (`arc-ue-dind-cache`, 250Gi). UE image pulled once, resident across runs. RWO is safe (`maxRunners:1` = single attach); ext4 block → overlay2 mounts cleanly (RWX would EINVAL). **Frees 64Gi RAM** on the contended node.
2. **DDC → per-build `/ram` tmpfs** via `docker run --env UE-LocalDataCachePath=/ram/ddc`. Logical override (robust across `/home/ue4` vs `/home/epic` vs **Zen** local-cache layouts) — not a physical-dir bind, which Zen would bypass. Set on `docker run`, **not** the pod spec (k8s rejects the hyphenated env name as non-`C_IDENTIFIER`).
3. **`report()`/`trap`** logs the DDC size + residual `$HOME/.cache|.config|.nuget|.dotnet` + `/tmp` writes — so we *measure* whether a follow-up `HOME=/ram/home` redirect is warranted before adding it (GPT's measure-first sequence).
4. **`dockerd --feature=containerd-snapshotter=false`** — match the proven Talos overlay2 path now that the data-root is an ext4 PVC base.

## Why this resolves the I/O-thrashing worry
Heavy build writes already go to RAM (`/project`, `/output` are tmpfs bind-mounts); the remaining offender was UE's DDC landing in docker's writable layer. With DDC on `/ram`, the PVC sees **reads** (engine binaries, page-cached by the freed RAM), not GB-scale DDC write churn. The RAM store + DDC tmpfs can't both fit in RAM (64Gi + 32Gi > the 80Gi dind limit) — moving the store to the PVC is what *funds* the DDC tmpfs.

## Rollout (important)
- Workflow (`ci-unreal-build.yml`) is called `@dev` → the DDC-tmpfs change is live on dispatch immediately.
- Kube manifests reach the runner only via **dev→main + ArgoCD sync** (runner re-provisions with the PVC store + bumped `restart-trigger`).
- **Do not dispatch a validation build until the runner shows the PVC mounted** (`dind-storage` = `arc-ue-dind-cache`) — until then the RAM store + DDC tmpfs coexist in RAM → OOM.

## Validation (first run, post-deploy)
Acceptance from the `DDC tiering report` log group + Longhorn metrics:
- log shows DDC under `/ram/ddc`, `/ram/ddc` grows during cook;
- residual `$HOME/.*` writes small (else next pass adds `HOME=/ram/home`);
- Longhorn write throughput stays low during cook;
- first run seeds the PVC (~one slow pull), subsequent runs skip the 50GB re-extract.

## Follow-up
- If residuals are large: redirect `HOME` to `/ram` too.
- Extend the same DDC tmpfs to the engine-mode dedicated-server + plugin Linux jobs (also `arc-runner-ue`) to keep the shared PVC store read-mostly for them too.