### PR TITLE
fix(ci-unreal): harden Boot Windows VM against hard-cancel timeout

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -962,7 +962,7 @@ jobs:
         needs: [guard, game_gate]
         if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true' && needs.game_gate.outputs.should_build == 'true' && contains(inputs.build_targets, 'Win64')
         runs-on: arc-runner-set-kbve
-        timeout-minutes: 10
+        timeout-minutes: 15
         permissions:
             contents: read
         outputs:
@@ -978,7 +978,7 @@ jobs:
                   VM=windows-builder
                   status() {
                     local body
-                    body=$(curl -sS --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
+                    body=$(curl -sS --max-time 8 --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
                       "$API/apis/kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM" 2>/dev/null) \
                       || { echo "Unknown"; return 0; }
                     printf '%s' "$body" | jq -r '.status.printableStatus? // "Unknown"' 2>/dev/null \
@@ -987,21 +987,21 @@ jobs:
                   S=$(status); echo "::notice::$VM status: $S"
                   if [ "$S" != "Running" ]; then
                     echo "Requesting start..."
-                    curl -sS --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
+                    curl -sS --max-time 15 --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
                       -X PUT -H "Content-Type: application/json" -d '{}' \
                       "$API/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM/start" || true
                   fi
-                  for i in $(seq 1 30); do
+                  for i in $(seq 1 36); do
                     S=$(status)
                     if [ "$S" = "Running" ]; then
                       echo "::notice::$VM is Running; Win64 build proceeds once the UE5-Win runner registers."
                       echo "vm_ready=true" >> "$GITHUB_OUTPUT"
                       exit 0
                     fi
-                    echo "waiting for $VM to reach Running ($i/30): $S"
+                    echo "waiting for $VM to reach Running ($i/36): $S"
                     sleep 10
                   done
-                  echo "::warning::$VM did not reach Running in ~5m; SKIPPING the Win64 client build so the run still finishes (Linux client + dedicated server + publish unaffected)."
+                  echo "::warning::$VM did not reach Running in ~6m; SKIPPING the Win64 client build so the run still finishes (Linux client + dedicated server + publish unaffected)."
                   echo "vm_ready=false" >> "$GITHUB_OUTPUT"
 
     game_build_windows:

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -962,7 +962,7 @@ jobs:
         needs: [guard, game_gate]
         if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true' && needs.game_gate.outputs.should_build == 'true' && contains(inputs.build_targets, 'Win64')
         runs-on: arc-runner-set-kbve
-        timeout-minutes: 15
+        timeout-minutes: 20
         permissions:
             contents: read
         outputs:
@@ -984,24 +984,29 @@ jobs:
                     printf '%s' "$body" | jq -r '.status.printableStatus? // "Unknown"' 2>/dev/null \
                       || echo "Unknown"
                   }
-                  S=$(status); echo "::notice::$VM status: $S"
-                  if [ "$S" != "Running" ]; then
+                  request_start() {
                     echo "Requesting start..."
                     curl -sS --max-time 15 --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
                       -X PUT -H "Content-Type: application/json" -d '{}' \
                       "$API/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM/start" || true
-                  fi
-                  for i in $(seq 1 36); do
+                  }
+                  S=$(status); echo "::notice::$VM status: $S"
+                  [ "$S" != "Running" ] && request_start
+                  for i in $(seq 1 48); do
                     S=$(status)
                     if [ "$S" = "Running" ]; then
                       echo "::notice::$VM is Running; Win64 build proceeds once the UE5-Win runner registers."
                       echo "vm_ready=true" >> "$GITHUB_OUTPUT"
                       exit 0
                     fi
-                    echo "waiting for $VM to reach Running ($i/36): $S"
-                    sleep 10
+                    if [ "$S" = "Stopped" ]; then
+                      echo "$VM is Stopped (idle-shutdown race or lost start) — re-requesting start"
+                      request_start
+                    fi
+                    echo "waiting for $VM to reach Running ($i/48): $S"
+                    sleep 15
                   done
-                  echo "::warning::$VM did not reach Running in ~6m; SKIPPING the Win64 client build so the run still finishes (Linux client + dedicated server + publish unaffected)."
+                  echo "::warning::$VM did not reach Running in ~12m; SKIPPING the Win64 client build so the run still finishes (Linux client + dedicated server + publish unaffected)."
                   echo "vm_ready=false" >> "$GITHUB_OUTPUT"
 
     game_build_windows:


### PR DESCRIPTION
## Problem

`Game Build / Boot Windows VM` hit the **10m hard cancel** ("exceeded the maximum execution time of 10m0s" → "operation was canceled").

### Root cause (from the boot job log, run 28137601872)
Every KubeVirt API call returned `Unknown` for **2–4.5 minutes** each:
```
00:03:54  step starts
00:06:08  windows-builder status: Unknown   (first status() ~2m14s)
00:06:08  Requesting start...
00:10:38  waiting (1/30): Unknown           (~4.5m)
00:13:01  waiting (2/30): Unknown           (~2.4m)
00:14:08  hard cancel
```
The `status()`/`start` curls had **no `--max-time`**, so when the core kube-apiserver/etcd stalled (single Talos node IO-saturated by 3 concurrent CI jobs — same contention that flaps etcd), each call hung for minutes. Only 2 poll iterations completed in 10m → blew the cap. `/start` hit the same dead path → VM stayed `Stopped`, no VMI.

Confirmed **not** RBAC (`arc-vm-starter` Role has `virtualmachines/start`) and **not** the KEDA `vm-stop-windows-builder` idle-shutdown (it's age- and busy-runner-gated; won't stop a fresh VM). Underlying infra signal: `virt-controller`/`virt-operator` are crashlooping (460+/294+ restarts) from the same etcd instability.

## Fix
- `--max-time 8` (status) / `15` (start) → curl can no longer hang
- job `timeout-minutes` 10 → 20; wait loop 30 → 48 @ 15s (~12m boot budget under contention); worst-case loop < 20m so the graceful `vm_ready=false` skip always wins
- factor start into `request_start()`; **re-issue it whenever the poll sees a definitive `Stopped`** (recovers from a transient API stall or the hourly KEDA :00–:15 idle-shutdown race) — not on `Unknown` (API failing, pointless to hammer)

Net: VM-not-ready degrades to a clean Win64 skip (Linux + dedicated server + publish unaffected), never a hard-cancel; and a momentarily-stalled API now self-heals into a successful boot.

## Not in scope
- `retention-days: 30` "Using 3 instead" warnings — cosmetic, GitHub auto-clamps; fix is a repo-settings retention bump, not a workflow change.
- The deeper etcd/IO contention + virt-controller crashloop is the environmental root cause (tracked separately — node IO rightsizing / dedicated etcd disk). This PR makes the boot resilient to it.

Workflow is called `@dev` → live on next dispatch after merge.