### PR TITLE
fix(ci-unreal): retry game-build LFS pull on transient git.kbve.com 503

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -460,7 +460,17 @@ jobs:
                       fi
                       echo "::notice::Forgejo LFS auth OK (HTTP ${LFS_CODE})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
-                      git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"
+                      git config --local lfs.transfer.maxretries 10
+                      n=0
+                      until git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"; do
+                        n=$((n+1))
+                        if [ "$n" -ge 4 ]; then
+                          echo "::error::LFS pull from git.kbve.com failed after ${n} tries (transient 503/ingress hiccup — single-replica Forgejo rolled or LFS-store IO stalled). Re-run the job."
+                          exit 1
+                        fi
+                        echo "::warning::LFS pull attempt ${n} hit a transient git.kbve.com error; retrying in $((n*15))s"
+                        sleep $((n*15))
+                      done
                       ;;
                     *)
                       echo "::notice::Pulling LFS (${INCLUDE}) from origin (GitHub-native)"
@@ -833,7 +843,17 @@ jobs:
                       fi
                       echo "::notice::Forgejo LFS auth OK (HTTP ${LFS_CODE})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
-                      git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"
+                      git config --local lfs.transfer.maxretries 10
+                      n=0
+                      until git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"; do
+                        n=$((n+1))
+                        if [ "$n" -ge 4 ]; then
+                          echo "::error::LFS pull from git.kbve.com failed after ${n} tries (transient 503/ingress hiccup — single-replica Forgejo rolled or LFS-store IO stalled). Re-run the job."
+                          exit 1
+                        fi
+                        echo "::warning::LFS pull attempt ${n} hit a transient git.kbve.com error; retrying in $((n*15))s"
+                        sleep $((n*15))
+                      done
                       ;;
                     *)
                       echo "::notice::Pulling LFS (${INCLUDE}) from origin (GitHub-native)"


### PR DESCRIPTION
## Problem
`Game Build (Mac client)` failed (run 28141282739):
```
batch response: Fatal error: Server error ...git.kbve.com/KBVE/chuck.git/info/lfs/objects/batch from HTTP 503
Failed to fetch some objects from 'git.kbve.com/KBVE/chuck.git/info/lfs'
##[error]Process completed with exit code 2
```
Linux client **passed the same run** — pure timing. Both game builds pull from the **public `git.kbve.com` ingress** (single-replica Forgejo, LFS objects on an sda Longhorn PVC `gitea-shared-storage`). A Forgejo rollout or brief LFS-store IO stall returns **503** to whichever job is mid-pull. The block's preflight only classifies **401/403**, so a 503 sails through to a **no-retry** `git lfs pull` → instant job fail.

Forgejo confirmed healthy now (0 restarts); this was a transient blip, not an outage.

## Fix
Wrap the game-client LFS pull (the block shared **identically** by Linux + Mac) in a **4-attempt retry, 15/30/45s backoff** + `lfs.transfer.maxretries 10` — covers a Forgejo restart/IO-stall window. A genuinely persistent 503 still fails after ~90s with a clear, classifiable error.

## Not in scope
Server + plugin Forgejo pulls (lines ~767 / ~1065 / ~1122 / ~1312) share the same risk but use different var names / shells (some pwsh on the Win runner) — follow-up, edited carefully per-shell.

`@dev` workflow → live on next dispatch after merge.