### PR TITLE
fix(crossplane): s3-healthcheck use /bin/sh not /bin/bash

### DIFF
--- a/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
+++ b/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
@@ -106,7 +106,7 @@ spec:
                                   cpu: 50m
                                   memory: 64Mi
                           command:
-                              - /bin/bash
+                              - /bin/sh
                               - -c
                               - |
                                   set -euo pipefail


### PR DESCRIPTION
## Why
The `s3-healthcheck` CronJob (crossplane-system, every 12h) StartError'd on every run:
```
exec: "/bin/bash": stat /bin/bash: no such file or directory (exit 128)
```
Its image `ghcr.io/kbve/kubectl:0.1.5` is minimal and ships only `/bin/sh` (ash), no bash. Each failed run leaves a StartError pod behind (churn).

## Fix
Switch the command interpreter `/bin/bash` → `/bin/sh`. The script is POSIX-clean (no `[[`, arrays, `<<<`); `set -euo pipefail`, `trap`, and the heredoc all work in the image's ash — same as the other KBVE jobs on this image.

## Context
Crossplane itself is healthy + load-bearing (provider-kubernetes manages the CNPG postgres TLS certs; provider-aws-s3 handles kilobase backup lifecycle). This was the one real bug; the rbac-manager's 847 restarts are etcd-flap leader-loss symptoms, not a crossplane fault.