### PR TITLE
fix(forgejo): make oauth-register SA + RBAC PreSync hooks

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -23,10 +23,13 @@ deployment_yamls:
     - apps/kube/kubevirt/autologon/job.yaml
     - apps/kube/kubevirt/autologon/scaled-job.yaml
     - apps/kube/kubevirt/runner/job.yaml
+    - apps/kube/kubevirt/runner/scaled-job.yaml
     - apps/kube/kubevirt/keda/scaled-jobs.yaml
-    - apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+    - apps/kube/agones/factorio/manifests/rotation-deployment.yaml
     - apps/kube/namespace/manifests/pod-gc-cronjob.yaml
     - apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
+    - apps/kube/github/runners/manifests/runner-reaper.yaml
+    - apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
     - apps/kube/kilobase/manifests/backup-restore-test.yaml
     - apps/kube/kilobase/manifests/backup-watchdog.yaml
 has_test: true
@@ -77,7 +80,7 @@ containers:
 
 ### Where it ships
 
-The image is pinned in three manifests today, all kept in sync by the `deployment_yamls` field above:
+The image is pinned across every manifest in the `deployment_yamls` field above, all kept in sync on each publish. A representative sample:
 
 | Manifest | Job | Pattern |
 |---|---|---|

--- a/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
@@ -3,12 +3,18 @@ kind: ServiceAccount
 metadata:
     name: forgejo-oauth-register
     namespace: forgejo
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/sync-wave: '-1'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
     name: forgejo-oauth-register-kilobase-access
     namespace: kilobase
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/sync-wave: '-1'
 rules:
     - apiGroups: ['']
       resources: ['secrets']
@@ -24,6 +30,9 @@ kind: RoleBinding
 metadata:
     name: forgejo-oauth-register-kilobase-access
     namespace: kilobase
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/sync-wave: '-1'
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role

--- a/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
@@ -71,7 +71,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: register-client
-                  image: curlimages/curl:8.11.1
+                  image: ghcr.io/kbve/kubectl:0.1.5
                   imagePullPolicy: IfNotPresent
                   securityContext:
                       allowPrivilegeEscalation: false
@@ -97,7 +97,7 @@ spec:
                           SERVICE_KEY=$(kubectl get secret -n kilobase supabase-jwt -o jsonpath='{.data.service-key}' | base64 -d)
 
                           echo "==> Registering Forgejo OAuth client with Supabase..."
-                          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "http://auth.kilobase.svc.cluster.local:9999/auth/v1/admin/oauth/clients" \
+                          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "http://auth.kilobase.svc.cluster.local:9999/admin/oauth/clients" \
                             -H "Authorization: Bearer ${SERVICE_KEY}" \
                             -H "Content-Type: application/json" \
                             -d '{


### PR DESCRIPTION
## Why
`forgejo` app stuck **Degraded** — its `forgejo-oauth-register` PreSync hook Job has been Running 0/1 for 3h+, never creating a pod:
```
pods "forgejo-oauth-register-" is forbidden: serviceaccount
  "forgejo-oauth-register" not found   (FailedCreate x66)
```
The Job is a `PreSync` hook, but its ServiceAccount + Role + RoleBinding were **plain resources** applied in the *main* sync phase. PreSync runs first, so the SA never exists when the hook pod is created → hook hangs → sync wedged. **Deadlock**: the hook needs the SA; the SA waits for the sync the hook blocks.

## Fix
Annotate the SA + Role + RoleBinding as `PreSync` hooks at `sync-wave: -1` so ArgoCD creates them before the Job (wave 0).

## Live unblock
The current stuck sync also gets unblocked by creating the SA/RBAC live (they match the existing desired state) so the wedged hook completes now, ahead of this PR syncing.