### PR TITLE
feat(keycloak): deploy Keycloak as central SSO/OIDC provider (PR1 scaffold)

### DIFF
--- a/apps/kube/keycloak/README.md
+++ b/apps/kube/keycloak/README.md
@@ -1,0 +1,68 @@
+# Keycloak — central SSO / OIDC provider
+
+Keycloak is the identity provider for KBVE single sign-on. It is a real
+OAuth2 / OIDC **authorization server** — the capability self-hosted Supabase
+Auth (GoTrue) does **not** have (GoTrue can only consume external providers,
+not act as one for third-party apps like Forgejo).
+
+```
+Keycloak (sso.kbve.com, IdP / OAuth provider)
+   ├── Forgejo   → OIDC client   (replaces the dead GoTrue oauth-register job)
+   └── Supabase  → OIDC client   (GOTRUE_EXTERNAL_KEYCLOAK_*)
+```
+
+- **Image**: `quay.io/keycloak/keycloak:26.0`, production `start` mode
+- **DB**: `keycloak` schema on the kilobase CNPG cluster (`supabase` database)
+- **Ingress**: `sso.kbve.com` via `kbve-gateway` (TLS terminates at the gateway;
+  Keycloak runs plain HTTP with `KC_PROXY_HEADERS=xforwarded`)
+
+## Deploy runbook
+
+### 1. Database (kilobase CNPG)
+
+Create the schema + user (mirrors the forgejo pattern):
+
+```bash
+kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432
+```
+```sql
+CREATE SCHEMA IF NOT EXISTS keycloak;
+CREATE USER keycloak WITH PASSWORD '<db-password>';
+GRANT ALL ON SCHEMA keycloak TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON SEQUENCES TO keycloak;
+```
+
+### 2. Seal credentials
+
+```bash
+./apps/kube/keycloak/seal-credentials.sh   # prompts for db + admin creds
+git add apps/kube/keycloak/manifest/sealed-credentials.yaml
+```
+The committed `sealed-credentials.yaml` placeholder is **not** valid — Keycloak
+will not start until you regenerate it with the script and commit the result.
+
+### 3. Go live
+
+`keycloak/application.yaml` is wired into `apps/kube/kustomization.yaml`. Once
+the schema exists and the sealed secret is committed + synced to `main`,
+ArgoCD brings Keycloak up. First boot runs the Keycloak build + DB migration
+(slow — watch the startup probe).
+
+## Phase 2 — wire the clients (after Keycloak is up)
+
+1. Log into `https://sso.kbve.com` with the bootstrap admin, create a realm
+   (e.g. `kbve`).
+2. **Forgejo client**: OIDC, confidential, redirect
+   `https://forgejo.kbve.com/user/oauth2/keycloak/callback`. Configure Forgejo's
+   OAuth2 source to point at the Keycloak issuer
+   `https://sso.kbve.com/realms/kbve`. This replaces the removed
+   `forgejo-oauth-register` GoTrue job.
+3. **Supabase client**: OIDC, confidential, redirect
+   `https://supabase.kbve.com/auth/v1/callback`. Set
+   `GOTRUE_EXTERNAL_KEYCLOAK_ENABLED=true`,
+   `GOTRUE_EXTERNAL_KEYCLOAK_CLIENT_ID`,
+   `GOTRUE_EXTERNAL_KEYCLOAK_SECRET`,
+   `GOTRUE_EXTERNAL_KEYCLOAK_URL=https://sso.kbve.com/realms/kbve`,
+   `GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI` on the supabase-auth deployment
+   (`apps/kube/auth/manifests/supabase-gotrue-auth.yaml`).

--- a/apps/kube/keycloak/application.yaml
+++ b/apps/kube/keycloak/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: keycloak
+    namespace: argocd
+    annotations:
+        kbve.com/source-path: kube/keycloak
+        kbve.com/manifest-path: kube/keycloak/manifest
+        kbve.com/application-file: kube/keycloak/application.yaml
+        kbve.com/managed-by: argocd
+        kbve.com/schema-version: v1
+        kbve.com/category: security
+        kbve.com/stack: core
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve.git
+        targetRevision: main
+        path: apps/kube/keycloak/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: keycloak
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 30s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/keycloak/manifest/deployment.yaml
+++ b/apps/kube/keycloak/manifest/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: keycloak
+    namespace: keycloak
+    labels:
+        app: keycloak
+        kbve.com/category: security
+        kbve.com/stack: core
+spec:
+    replicas: 1
+    strategy:
+        type: Recreate
+    selector:
+        matchLabels:
+            app: keycloak
+    template:
+        metadata:
+            labels:
+                app: keycloak
+        spec:
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                fsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: keycloak
+                  image: quay.io/keycloak/keycloak:26.0
+                  imagePullPolicy: IfNotPresent
+                  args: ['start']
+                  env:
+                      - name: KC_DB
+                        value: postgres
+                      - name: KC_DB_URL
+                        value: jdbc:postgresql://supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?currentSchema=keycloak
+                      - name: KC_DB_SCHEMA
+                        value: keycloak
+                      - name: KC_DB_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: keycloak-credentials
+                                key: db-username
+                      - name: KC_DB_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: keycloak-credentials
+                                key: db-password
+                      # Hostname v2 (Keycloak 26). TLS terminates at kbve-gateway,
+                      # so run plain HTTP and trust the forwarded headers.
+                      - name: KC_HOSTNAME
+                        value: https://sso.kbve.com
+                      - name: KC_HTTP_ENABLED
+                        value: 'true'
+                      - name: KC_PROXY_HEADERS
+                        value: xforwarded
+                      - name: KC_HEALTH_ENABLED
+                        value: 'true'
+                      - name: KC_METRICS_ENABLED
+                        value: 'true'
+                      # Bootstrap admin (Keycloak 26 renamed from KEYCLOAK_ADMIN).
+                      # Used once to seed the master-realm admin; rotate after.
+                      - name: KC_BOOTSTRAP_ADMIN_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: keycloak-credentials
+                                key: admin-username
+                      - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: keycloak-credentials
+                                key: admin-password
+                  ports:
+                      - name: http
+                        containerPort: 8080
+                      - name: management
+                        containerPort: 9000
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  startupProbe:
+                      httpGet:
+                          path: /health/started
+                          port: 9000
+                      failureThreshold: 30
+                      periodSeconds: 10
+                  readinessProbe:
+                      httpGet:
+                          path: /health/ready
+                          port: 9000
+                      periodSeconds: 10
+                  livenessProbe:
+                      httpGet:
+                          path: /health/live
+                          port: 9000
+                      periodSeconds: 15
+                  resources:
+                      requests:
+                          cpu: 250m
+                          memory: 768Mi
+                      limits:
+                          cpu: '2'
+                          memory: 1536Mi

--- a/apps/kube/keycloak/manifest/httproute.yaml
+++ b/apps/kube/keycloak/manifest/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: keycloak-route
+    namespace: keycloak
+    labels:
+        app: keycloak
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - sso.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: keycloak-http
+                port: 8080

--- a/apps/kube/keycloak/manifest/kustomization.yaml
+++ b/apps/kube/keycloak/manifest/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml
+    - sealed-credentials.yaml
+    - deployment.yaml
+    - service.yaml
+    - httproute.yaml

--- a/apps/kube/keycloak/manifest/namespace.yaml
+++ b/apps/kube/keycloak/manifest/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: keycloak
+    labels:
+        kbve.com/category: security
+        kbve.com/stack: core
+        pod-security.kubernetes.io/enforce: baseline
+        pod-security.kubernetes.io/audit: restricted
+        pod-security.kubernetes.io/warn: restricted

--- a/apps/kube/keycloak/manifest/sealed-credentials.yaml
+++ b/apps/kube/keycloak/manifest/sealed-credentials.yaml
@@ -1,0 +1,27 @@
+# PLACEHOLDER — regenerate with apps/kube/keycloak/seal-credentials.sh
+#
+# This is NOT a valid SealedSecret. Keycloak will not start until you run the
+# seal script (which overwrites this file with real encrypted values) and
+# commit the result. See apps/kube/keycloak/README.md.
+#
+# The resulting `keycloak-credentials` Secret must carry four keys:
+#   db-username      Postgres user for the keycloak schema (kilobase CNPG)
+#   db-password      that user's password
+#   admin-username   bootstrap master-realm admin
+#   admin-password   bootstrap master-realm admin password
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: keycloak-credentials
+    namespace: keycloak
+spec:
+    encryptedData:
+        db-username: REPLACE_ME
+        db-password: REPLACE_ME
+        admin-username: REPLACE_ME
+        admin-password: REPLACE_ME
+    template:
+        metadata:
+            name: keycloak-credentials
+            namespace: keycloak
+        type: Opaque

--- a/apps/kube/keycloak/manifest/service.yaml
+++ b/apps/kube/keycloak/manifest/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: keycloak-http
+    namespace: keycloak
+    labels:
+        app: keycloak
+spec:
+    type: ClusterIP
+    selector:
+        app: keycloak
+    ports:
+        - name: http
+          port: 8080
+          targetPort: http

--- a/apps/kube/keycloak/seal-credentials.sh
+++ b/apps/kube/keycloak/seal-credentials.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Seal the keycloak-credentials Secret into manifest/sealed-credentials.yaml.
+#
+# Prereqs:
+#   - kubectl + kubeseal (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#   - the keycloak Postgres schema + user already created on the kilobase
+#     CNPG cluster (see README.md "Database" section)
+#
+# Usage: run from the repo root, then commit the regenerated sealed file.
+set -euo pipefail
+
+OUT="apps/kube/keycloak/manifest/sealed-credentials.yaml"
+
+for cmd in kubectl kubeseal; do
+    command -v "$cmd" >/dev/null || { echo "Error: $cmd not found" >&2; exit 1; }
+done
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system" >&2
+    exit 1
+fi
+
+read -rp  "Keycloak DB username (kilobase): " DB_USER
+read -rsp "Keycloak DB password: " DB_PASS; echo
+read -rp  "Keycloak admin username [admin]: " ADMIN_USER; ADMIN_USER=${ADMIN_USER:-admin}
+read -rsp "Keycloak admin password: " ADMIN_PASS; echo
+
+kubectl create secret generic keycloak-credentials \
+    --namespace=keycloak \
+    --from-literal=db-username="$DB_USER" \
+    --from-literal=db-password="$DB_PASS" \
+    --from-literal=admin-username="$ADMIN_USER" \
+    --from-literal=admin-password="$ADMIN_PASS" \
+    --dry-run=client -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "$OUT"
+
+echo "Wrote $OUT — commit it."

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
     - valkey/application.yaml
     - storage/application.yaml
     - irc/application.yaml
+    - keycloak/application.yaml
     - kilobase/application.yaml
     - kong/application.yaml
     - auth/application.yaml


### PR DESCRIPTION
## Why
Self-hosted Supabase Auth (GoTrue) **cannot** be an OAuth2 authorization server for third-party apps — confirmed there's no `/admin/oauth/clients` route in any OSS version (v2.177 or master source). That's why `forgejo-oauth-register` could never work. Keycloak is a real OIDC provider, and Supabase officially supports consuming it, so it becomes the central IdP:

```
Keycloak (sso.kbve.com) ──► Forgejo  (OIDC client)
                        └──► Supabase (OIDC client, GOTRUE_EXTERNAL_KEYCLOAK_*)
```

## PR1 — deploy scaffold
- **Deployment** `quay.io/keycloak/keycloak:26.0`, production `start`, `KC_PROXY_HEADERS=xforwarded` (TLS at kbve-gateway), health probes on `:9000`, 768Mi-1.5Gi
- **DB**: `keycloak` schema on kilobase CNPG (`supabase` db)
- **Service** + **HTTPRoute** `sso.kbve.com` via `kbve-gateway`
- **sealed-credentials** placeholder + `seal-credentials.sh` + **README runbook**
- wired into the app-of-apps

## Prereqs before it goes Healthy (in README)
1. Create the `keycloak` schema + user on kilobase CNPG
2. Run `seal-credentials.sh`, commit the real sealed secret

Until then the app will be Degraded (missing secret) — these are hands-on prod steps (DB + kubeseal cert) I can't do for you.

## Phase 2 (separate PR, once up)
Create the `kbve` realm + Forgejo/Supabase OIDC clients, point Forgejo's OAuth source + Supabase `GOTRUE_EXTERNAL_KEYCLOAK_*` at `https://sso.kbve.com/realms/kbve`. Replaces the dead GoTrue oauth-register job (still recommend neutering that via #13331).