### PR TITLE
feat(keycloak): GitOps DB provisioning (PR2)

### DIFF
--- a/apps/kube/keycloak/README.md
+++ b/apps/kube/keycloak/README.md
@@ -12,42 +12,51 @@ Keycloak (sso.kbve.com, IdP / OAuth provider)
 ```
 
 - **Image**: `quay.io/keycloak/keycloak:26.0`, production `start` mode
-- **DB**: `keycloak` schema on the kilobase CNPG cluster (`supabase` database)
+- **DB**: `keycloak` schema on the kilobase CNPG cluster (`supabase` database),
+  role + password managed by CNPG, schema by a dbmate migration
 - **Ingress**: `sso.kbve.com` via `kbve-gateway` (TLS terminates at the gateway;
   Keycloak runs plain HTTP with `KC_PROXY_HEADERS=xforwarded`)
 
 ## Deploy runbook
 
-### 1. Database (kilobase CNPG)
+No manual `psql` — the `keycloak` role, schema, and password are all GitOps.
 
-Create the schema + user (mirrors the forgejo pattern):
+| Concern | Owner |
+|---------|-------|
+| `keycloak` role + password | CNPG `managed.roles` on `supabase-cluster` (reads `keycloak-db-password`) |
+| `keycloak` schema + grants | dbmate migration `20260625120000_keycloak_schema.sql` (runs as `postgres`) |
+| pod DB auth + bootstrap admin | `keycloak-credentials` secret (this dir) |
 
-```bash
-kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432
-```
-```sql
-CREATE SCHEMA IF NOT EXISTS keycloak;
-CREATE USER keycloak WITH PASSWORD '<db-password>';
-GRANT ALL ON SCHEMA keycloak TO keycloak;
-ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON TABLES TO keycloak;
-ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON SEQUENCES TO keycloak;
-```
+The migration is order-independent: it creates the role `NOLOGIN` with no
+password if absent; CNPG then layers `login: true` + the password from the
+sealed secret. Either reconcile order converges.
 
-### 2. Seal credentials
+### 1. Seal credentials
 
 ```bash
-./apps/kube/keycloak/seal-credentials.sh   # prompts for db + admin creds
-git add apps/kube/keycloak/manifest/sealed-credentials.yaml
+./apps/kube/keycloak/seal-credentials.sh   # generates a random DB password
+```
+Writes **two** sealed files from one generated password (so they always agree)
+and prints the bootstrap admin creds — **save them**, they are not recoverable
+from the sealed file:
+
+```
+apps/kube/kilobase/manifests/sealed-keycloak-db-password.yaml   # CNPG, ns kilobase
+apps/kube/keycloak/manifest/sealed-credentials.yaml             # pod,  ns keycloak
+```
+```bash
+git add apps/kube/kilobase/manifests/sealed-keycloak-db-password.yaml \
+        apps/kube/keycloak/manifest/sealed-credentials.yaml
 ```
 The committed `sealed-credentials.yaml` placeholder is **not** valid — Keycloak
-will not start until you regenerate it with the script and commit the result.
+will not start until you regenerate it and commit the result.
 
-### 3. Go live
+### 2. Go live
 
-`keycloak/application.yaml` is wired into `apps/kube/kustomization.yaml`. Once
-the schema exists and the sealed secret is committed + synced to `main`,
-ArgoCD brings Keycloak up. First boot runs the Keycloak build + DB migration
-(slow — watch the startup probe).
+Both `keycloak/application.yaml` and the kilobase CNPG change track `main`, so
+land them via the dev→main release. On sync: CNPG creates the role, the
+`dbmate-up` CI job applies the schema migration, and Keycloak builds its tables
+on first boot (slow — watch the startup probe).
 
 ## Phase 2 — wire the clients (after Keycloak is up)
 

--- a/apps/kube/keycloak/seal-credentials.sh
+++ b/apps/kube/keycloak/seal-credentials.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
-# Seal the keycloak-credentials Secret into manifest/sealed-credentials.yaml.
+# Generate a random keycloak DB password and seal it into BOTH namespaces it is
+# needed in, plus the bootstrap admin creds. Run from the repo root, then commit
+# the two regenerated sealed files.
 #
-# Prereqs:
-#   - kubectl + kubeseal (brew install kubeseal)
-#   - sealed-secrets-controller running in kube-system
-#   - the keycloak Postgres schema + user already created on the kilobase
-#     CNPG cluster (see README.md "Database" section)
+#   1. keycloak-db-password  (ns kilobase, basic-auth) — CNPG managed-role reads
+#      this to set the `keycloak` role password on the supabase-cluster.
+#   2. keycloak-credentials  (ns keycloak)             — the Keycloak pod auths
+#      to Postgres with db-password (== the password above) and seeds the
+#      master-realm admin from admin-username/admin-password.
 #
-# Usage: run from the repo root, then commit the regenerated sealed file.
+# The DB password is generated ONCE here so both secrets always agree.
+#
+# Prereqs: kubectl + kubeseal, sealed-secrets-controller in kube-system.
 set -euo pipefail
 
-OUT="apps/kube/keycloak/manifest/sealed-credentials.yaml"
+DB_OUT="apps/kube/kilobase/manifests/sealed-keycloak-db-password.yaml"
+CRED_OUT="apps/kube/keycloak/manifest/sealed-credentials.yaml"
 
-for cmd in kubectl kubeseal; do
+DB_ROLE="keycloak"
+ADMIN_USER="${KC_ADMIN_USER:-admin}"
+
+for cmd in kubectl kubeseal openssl; do
     command -v "$cmd" >/dev/null || { echo "Error: $cmd not found" >&2; exit 1; }
 done
 
@@ -21,22 +29,40 @@ if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null
     exit 1
 fi
 
-read -rp  "Keycloak DB username (kilobase): " DB_USER
-read -rsp "Keycloak DB password: " DB_PASS; echo
-read -rp  "Keycloak admin username [admin]: " ADMIN_USER; ADMIN_USER=${ADMIN_USER:-admin}
-read -rsp "Keycloak admin password: " ADMIN_PASS; echo
+DB_PASS="$(openssl rand -base64 32 | tr -d '/+=' | head -c 40)"
+ADMIN_PASS="$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)"
+
+seal() {
+    kubeseal \
+        --controller-name=sealed-secrets-controller \
+        --controller-namespace=kube-system \
+        --format=yaml
+}
+
+kubectl create secret generic keycloak-db-password \
+    --namespace=kilobase \
+    --type=kubernetes.io/basic-auth \
+    --from-literal=username="$DB_ROLE" \
+    --from-literal=password="$DB_PASS" \
+    --dry-run=client -o yaml \
+| seal > "$DB_OUT"
 
 kubectl create secret generic keycloak-credentials \
     --namespace=keycloak \
-    --from-literal=db-username="$DB_USER" \
+    --from-literal=db-username="$DB_ROLE" \
     --from-literal=db-password="$DB_PASS" \
     --from-literal=admin-username="$ADMIN_USER" \
     --from-literal=admin-password="$ADMIN_PASS" \
     --dry-run=client -o yaml \
-| kubeseal \
-    --controller-name=sealed-secrets-controller \
-    --controller-namespace=kube-system \
-    --format=yaml \
-> "$OUT"
+| seal > "$CRED_OUT"
 
-echo "Wrote $OUT — commit it."
+echo "Wrote:"
+echo "  $DB_OUT"
+echo "  $CRED_OUT"
+echo
+echo "Bootstrap admin (SAVE NOW — not recoverable from the sealed file):"
+echo "  username: $ADMIN_USER"
+echo "  password: $ADMIN_PASS"
+echo
+echo "Commit both files. CNPG sets the role password on reconcile; the dbmate"
+echo "keycloak_schema migration creates the schema; Keycloak builds its tables."

--- a/apps/kube/kilobase/manifests/postgres-cluster.yaml
+++ b/apps/kube/kilobase/manifests/postgres-cluster.yaml
@@ -63,6 +63,18 @@ spec:
               connectionLimit: 10
               passwordSecret:
                   name: ows-db-password
+            - name: keycloak
+              ensure: present
+              comment: Keycloak IdP service role — owns the keycloak schema, no superuser
+              login: true
+              superuser: false
+              createdb: false
+              createrole: false
+              bypassrls: false
+              inherit: true
+              connectionLimit: 20
+              passwordSecret:
+                  name: keycloak-db-password
             - name: supabase_admin
               ensure: present
               comment: Supabase Admin

--- a/packages/data/sql/dbmate/migrations/20260625120000_keycloak_schema.sql
+++ b/packages/data/sql/dbmate/migrations/20260625120000_keycloak_schema.sql
@@ -1,0 +1,31 @@
+-- migrate:up
+
+SET search_path = '';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'keycloak') THEN
+        CREATE ROLE keycloak NOLOGIN;
+    END IF;
+END
+$$;
+
+CREATE SCHEMA IF NOT EXISTS keycloak AUTHORIZATION keycloak;
+
+GRANT ALL ON SCHEMA keycloak TO keycloak;
+ALTER DEFAULT PRIVILEGES FOR ROLE keycloak IN SCHEMA keycloak GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES FOR ROLE keycloak IN SCHEMA keycloak GRANT ALL ON SEQUENCES TO keycloak;
+
+-- migrate:down
+
+SET search_path = '';
+
+DROP SCHEMA IF EXISTS keycloak CASCADE;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'keycloak') THEN
+        DROP ROLE keycloak;
+    END IF;
+END
+$$;


### PR DESCRIPTION
Follow-up to #13334 (PR1 scaffold, merged). Provisions the Keycloak DB role + schema via GitOps so Keycloak can go Healthy without manual `psql` on the prod CNPG cluster.

## What
Three decoupled, order-independent concerns:

| Concern | Owner |
|---------|-------|
| `keycloak` role + password | CNPG `managed.roles` on `supabase-cluster` → reads sealed `keycloak-db-password` (basic-auth, ns kilobase) |
| `keycloak` schema + grants | dbmate migration `20260625120000_keycloak_schema.sql` (runs as `postgres` vs `supabase` DB) |
| pod DB auth + bootstrap admin | `keycloak-credentials` (ns keycloak, from PR1) |

The migration creates the role `NOLOGIN`/no-password if absent; CNPG then layers `login: true` + the password. Either reconcile order converges — no ordering dependency between the `dbmate-up` Job and CNPG role reconcile.

`seal-credentials.sh` now generates **one** random DB password and seals it into both namespaces so they always agree, and prints the bootstrap admin creds (save them — not recoverable from the sealed file).

## Operator step (needs cluster + kubeseal)
```bash
./apps/kube/keycloak/seal-credentials.sh
git add apps/kube/kilobase/manifests/sealed-keycloak-db-password.yaml \
        apps/kube/keycloak/manifest/sealed-credentials.yaml
```
Commit the two sealed files, then dev→main release. On sync: CNPG makes the role, `dbmate-up` makes the schema, Keycloak builds its tables on first boot.

No plaintext passwords in git, no manual psql.