### PR TITLE
fix(keycloak): scope kilobase Kyverno exception for the provision Job

### DIFF
--- a/apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
+++ b/apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
@@ -49,6 +49,15 @@ spec:
                             matchExpressions:
                                 - key: cnpg.io/jobRole
                                   operator: Exists
+                  # keycloak-db-provision: ArgoCD Sync-hook Job that sets the
+                  # keycloak role password (from keycloak-db-password) + creates
+                  # the keycloak schema as superuser. Cannot use the dbmate
+                  # contract because it must inject two secrets the dbmate-runner
+                  # is forbidden to see. Scoped to its own SA + this exact label.
+                  - resources:
+                        selector:
+                            matchLabels:
+                                kbve.com/job: keycloak-db-provision
           validate:
               message: >-
                   Jobs in kilobase must use the dbmate-runner SA, drop ALL
@@ -100,6 +109,10 @@ spec:
                             matchExpressions:
                                 - key: cnpg.io/jobRole
                                   operator: Exists
+                  - resources:
+                        selector:
+                            matchLabels:
+                                kbve.com/job: keycloak-db-provision
           validate:
               message: >-
                   Job volumes must use only the dbmate-runner contract:

--- a/apps/kube/kilobase/manifests/keycloak-db-provision-job.yaml
+++ b/apps/kube/kilobase/manifests/keycloak-db-provision-job.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: keycloak-db-provision
+    namespace: kilobase
+    labels:
+        app: keycloak-db-provision
+        kbve.com/category: security
+        kbve.com/stack: core
+automountServiceAccountToken: false
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -5,6 +16,7 @@ metadata:
     namespace: kilobase
     labels:
         app: keycloak-db-provision
+        kbve.com/job: keycloak-db-provision
         kbve.com/category: security
         kbve.com/stack: core
     annotations:
@@ -19,8 +31,11 @@ spec:
         metadata:
             labels:
                 app: keycloak-db-provision
+                kbve.com/job: keycloak-db-provision
         spec:
             restartPolicy: Never
+            serviceAccountName: keycloak-db-provision
+            automountServiceAccountToken: false
             securityContext:
                 runAsNonRoot: true
                 runAsUser: 101
@@ -32,6 +47,7 @@ spec:
                   image: ghcr.io/kbve/postgres:17.4.1.069-kilobase
                   imagePullPolicy: IfNotPresent
                   securityContext:
+                      runAsNonRoot: true
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true
                       capabilities:


### PR DESCRIPTION
Unblocks the wedged kilobase sync. The `keycloak-db-provision` Job (shipped in the prior PR, now on main) is denied by `kilobase-jobs-restricted` — every kilobase Job must use the `dbmate-runner` SA + dbmate-only mounts. The Job retries-then-fails on every sync, so **kilobase is stuck OutOfSync and Keycloak stays crashlooping** (`password authentication failed`).

The Job can't fit the dbmate contract: it injects `supabase-postgres` (superuser, to `ALTER ROLE`) + `keycloak-db-password` (target pw) — secrets the dbmate-runner is deliberately forbidden to see.

## Narrow exception (not a loosening)
- dedicated `keycloak-db-provision` SA — `automountServiceAccountToken: false`, **no RBAC** (the Job only runs `psql`, never touches the k8s API)
- both `kilobase-jobs-restricted` rules `exclude` resources labelled `kbve.com/job=keycloak-db-provision`
- container-level `runAsNonRoot` added so it still satisfies the hardening it isn't excluded from

Scoped to this **exact label + SA**. Every other kilobase Job stays locked to the dbmate-runner contract.

## After merge
dev→main release → kilobase sync passes admission → the Sync hook runs → role password + schema provisioned → Keycloak self-heals.

> Note: longer-term this provisioning ideally moves to CNPG `managed.roles` (operator-native, no Job, no policy exception) once the CNPG role-password reconcile is reliable on this cluster. Shipping the Job+exception now to resolve Keycloak; tracked for follow-up.