### PR TITLE
feat(auth): upgrade GoTrue to v2.191.0 + enable OAuth/OIDC server

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
             containers:
                 - name: gotrue
-                  image: supabase/gotrue:v2.177.0
+                  image: supabase/gotrue:v2.191.0
                   ports:
                       - containerPort: 9999
                         name: http
@@ -42,6 +42,8 @@ spec:
                                 key: database-url
                       - name: GOTRUE_SITE_URL
                         value: https://kbve.com
+                      - name: GOTRUE_OAUTH_SERVER_ENABLED
+                        value: 'true'
                       - name: GOTRUE_URI_ALLOW_LIST
                         value: https://kbve.com/**,https://*.kbve.com/**,https://chat.kbve.com/**,https://supabase.kbve.com/**,https://forgejo.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://cryptothrone.com/**,https://*.cryptothrone.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**,http://127.0.0.1:**,kbve://**,kbve://auth/callback,chuckrpg://auth/callback,chuckrpg://**
                       - name: GOTRUE_DISABLE_SIGNUP


### PR DESCRIPTION
Makes Supabase the central OAuth/OIDC provider, replacing Keycloak (torn down in #13363).

## What
- `supabase/gotrue` **v2.177.0 → v2.191.0**
- `GOTRUE_OAUTH_SERVER_ENABLED=true`

## Why this version
Supabase Auth's OAuth server landed incrementally:

| Version | Milestone |
|---|---|
| v2.180.0 | OAuth client type (server begins) |
| **v2.183.0** | **OIDC support** (required for Forgejo OIDC client) |
| v2.190.0 | authorize/consent row-level lock hardening |
| **v2.191.0** | latest stable — target |

Our v2.177.0 predates all of it (so *"GoTrue can't be an OAuth server"* was true then, stale now).

## ⚠️ Migrations — backup first
GoTrue auto-applies its baked-in migrations on boot. v2.177→v2.191 adds `oauth_clients`, `oauth_authorizations`, `oauth_consents`, `oauth_client_states` to the `auth` schema (these hold **clients + consent grants, not users** — identities stay in `auth.users`).

**Before this releases to main: back up the `auth` schema.** 14 minor versions of migrations apply in one boot; backup = rollback path.

## After release — verify
- `GET https://supabase.kbve.com/auth/v1/.well-known/openid-configuration` resolves
- login still works (existing flows unaffected)
- register the Forgejo OAuth client via the admin API, point Forgejo's OIDC source at `https://supabase.kbve.com/auth/v1`

Dynamic client registration left off (static clients via admin API).