### PR TITLE
feat(auth): wire Supabase as OIDC provider — issuer + public Kong routes

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -44,6 +44,8 @@ spec:
                         value: https://kbve.com
                       - name: GOTRUE_OAUTH_SERVER_ENABLED
                         value: 'true'
+                      - name: GOTRUE_JWT_ISSUER
+                        value: https://supabase.kbve.com/auth/v1
                       - name: GOTRUE_URI_ALLOW_LIST
                         value: https://kbve.com/**,https://*.kbve.com/**,https://chat.kbve.com/**,https://supabase.kbve.com/**,https://forgejo.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://cryptothrone.com/**,https://*.cryptothrone.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**,http://127.0.0.1:**,kbve://**,kbve://auth/callback,chuckrpg://auth/callback,chuckrpg://**
                       - name: GOTRUE_DISABLE_SIGNUP

--- a/apps/kube/kong/manifests/kong-config.yaml
+++ b/apps/kube/kong/manifests/kong-config.yaml
@@ -37,8 +37,7 @@ data:
         \    routes:\n      - name: auth-v1-open-callback\n        strip_path: true\n\
         \        paths:\n          - /auth/v1/callback\n  - name: auth-v1-open-authorize\n\
         \    url: http://auth:9999/authorize\n    routes:\n      - name: auth-v1-open-authorize\n\
-        \        strip_path: true\n        paths:\n          - /auth/v1/authorize\n\n\
-        \  ## Secure Auth routes\n  - name: auth-v1\n    _comment: 'GoTrue: /auth/v1/*\
+        \        strip_path: true\n        paths:\n          - /auth/v1/authorize\n\n  - name: auth-v1-open-oidc\n    _comment: 'OIDC discovery + OAuth2 server endpoints — public, no apikey'\n    url: http://auth:9999/\n    routes:\n      - name: auth-v1-open-oidc\n        strip_path: true\n        paths:\n          - /auth/v1/.well-known/openid-configuration\n          - /auth/v1/.well-known/oauth-authorization-server\n          - /auth/v1/.well-known/jwks.json\n          - /auth/v1/oauth/\n\n  ## Secure Auth routes\n  - name: auth-v1\n    _comment: 'GoTrue: /auth/v1/*\
         \ -> http://auth:9999/*'\n    url: http://auth:9999/\n    routes:\n      - name:\
         \ auth-v1-all\n        strip_path: true\n        paths:\n          - /auth/v1/\n\
         \    plugins:\n      - name: key-auth\n        config:\n          hide_credentials:\


### PR DESCRIPTION
Phase 2 of the Keycloak→Supabase pivot (after #13363 teardown + #13364 GoTrue v2.191 upgrade, both live). Makes the GoTrue OAuth/OIDC server **reachable + correct** for external clients.

## Two coupled fixes

**1. GoTrue issuer** — discovery was returning `issuer:""` + relative paths (`/oauth/authorize`), unusable by Forgejo. GoTrue builds every discovery endpoint from `config.JWT.Issuer` (`jwks.go` `WellKnownOpenID`: `issuer + "/oauth/authorize"` …), which was unset. Set:
```
GOTRUE_JWT_ISSUER=https://supabase.kbve.com/auth/v1
```
Discovery now emits absolute `https://supabase.kbve.com/auth/v1/oauth/*`.

`JWT.Issuer` also stamps the token `iss`. **Verified safe** — nothing in the stack pins `iss`: no `SUPABASE_JWT_ISSUER`/`JWT_ISSUER`/`PGRST_JWT_ISS` set anywhere; kbve-gate (`gate/auth.rs`) validates issuer only when its env is set; PostgREST/Realtime verify signature + aud, not iss. No flag-day (old + new tokens both pass).

**2. Kong public routes** — Kong fronts `/auth/v1/*` with a `key-auth` catch-all that swallowed discovery + oauth ("No API key found"). Added an **open** (no-plugin) route for the public OIDC surface:
- `/auth/v1/.well-known/openid-configuration`
- `/auth/v1/.well-known/oauth-authorization-server`
- `/auth/v1/.well-known/jwks.json`
- `/auth/v1/oauth/` (authorize / token / userinfo / register)

Secure `auth-v1` catch-all (key-auth + acl) unchanged. Validated: embedded `kong.yml` re-parses, new route has no plugins, secure route still gated.

## After release — verify
- `curl https://supabase.kbve.com/auth/v1/.well-known/openid-configuration` → absolute `/auth/v1/...` URLs, no apikey error
- register Forgejo OAuth client via admin API → point Forgejo OIDC source at `https://supabase.kbve.com/auth/v1`