### PR TITLE
feat(studio): superadmin-gate supabase studio via kbve-gate + bitwise authz layer

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -366,7 +366,8 @@
 				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml",
 				"apps/kube/argocd/manifests/argocd-gate-deployment.yaml",
 				"apps/kube/storage/manifests/longhorn-gate-deployment.yaml",
-				"apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml"
+				"apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml",
+				"apps/kube/studio/manifests/studio-gate-deployment.yaml"
 			],
 			"has_test": false
 		},

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -14,7 +14,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml

--- a/apps/kube/kong/manifests/kong-config.yaml
+++ b/apps/kube/kong/manifests/kong-config.yaml
@@ -24,13 +24,10 @@ data:
         \        - apikey\n        - DNT\n        - Cache-Control\n        - X-Mx-ReqToken\n\
         \        - Keep-Alive\n        - If-Modified-Since\n        - Range\n      exposed_headers:\n\
         \        - \"*\"\n      credentials: true\n      max_age: 86400\n      preflight_continue:\
-        \ false\n\n###\n### Consumers / Users\n###\nconsumers:\n  - username: DASHBOARD\n\
-        \  - username: anon\n    keyauth_credentials:\n      - key: ${anon_key}\n  - username:\
+        \ false\n\n###\n### Consumers / Users\n###\nconsumers:\n  - username: anon\n    keyauth_credentials:\n      - key: ${anon_key}\n  - username:\
         \ service_role\n    keyauth_credentials:\n      - key: ${service_key}\n\n###\n\
         ### Access Control List\n###\nacls:\n  - consumer: anon\n    group: anon\n  -\
-        \ consumer: service_role\n    group: admin\n\n###\n### Dashboard credentials \
-        \ \n###\nbasicauth_credentials:\n  - consumer: DASHBOARD\n    username: dashboard\n\
-        \    password: ${secret}\n\n###\n### API Routes\n###\nservices:\n  ## Open Auth\
+        \ consumer: service_role\n    group: admin\n\n###\n### API Routes\n###\nservices:\n  ## Open Auth\
         \ routes\n  - name: auth-v1-open\n    url: http://auth:9999/verify\n    routes:\n\
         \      - name: auth-v1-open\n        strip_path: true\n        paths:\n      \
         \    - /auth/v1/verify\n  - name: auth-v1-open-callback\n    url: http://auth:9999/callback\n\
@@ -88,7 +85,6 @@ data:
         \        config:\n          hide_credentials: false\n          run_on_preflight:\
         \ false\n      - name: acl\n        config:\n          hide_groups_header: true\n\
         \          allow:\n            - admin\n\n  ## Protected Dashboard - catch all\
-        \ remaining routes\n  - name: dashboard\n    _comment: 'Studio: /* -> http://studio:3000/*'\n\
-        \    url: http://studio:3000/\n    routes:\n      - name: dashboard-all\n    \
-        \    strip_path: true\n        paths:\n          - /\n    plugins:\n      - name:\
-        \ basic-auth\n        config:\n          hide_credentials: true\n"
+        \ remaining routes\n  - name: dashboard\n    _comment: 'Studio: /* -> studio-gate (kbve-gate JWT is_staff) -> http://studio:3000/*'\n\
+        \    url: http://studio-gate:5678/\n    routes:\n      - name: dashboard-all\n    \
+        \    strip_path: true\n        paths:\n          - /\n"

--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -36,7 +36,7 @@ spec:
                                 name: postgrest-db-config
                                 key: PGRST_DB_URI
                       - name: PGRST_DB_SCHEMAS
-                        value: public,storage,graphql_public,tracker,profile,rentearth,meme,discordsh,forum,mc,gh
+                        value: public,storage,graphql_public,tracker,profile,rentearth,meme,discordsh,forum,mc,gh,authz
                       - name: PGRST_DB_ANON_ROLE
                         value: anon
                       - name: PGRST_DB_USE_LEGACY_GUCS

--- a/apps/kube/studio/manifests/studio-gate-deployment.yaml
+++ b/apps/kube/studio/manifests/studio-gate-deployment.yaml
@@ -56,7 +56,9 @@ spec:
                       - name: GATE_AUTHZ
                         value: is_staff
                       - name: GATE_STAFF_SCHEMA
-                        value: forum
+                        value: authz
+                      - name: GATE_STAFF_RPC
+                        value: is_superadmin
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
                       - name: GATE_COOKIE_DOMAIN

--- a/apps/kube/studio/manifests/studio-gate-deployment.yaml
+++ b/apps/kube/studio/manifests/studio-gate-deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: studio-gate-sa
+    namespace: kilobase
+    labels:
+        app: studio-gate
+        kbve.com/category: application
+        kbve.com/stack: supabase
+        kbve.com/managed-by: argocd
+automountServiceAccountToken: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: studio-gate
+    namespace: kilobase
+    labels:
+        app: studio-gate
+        kbve.com/category: application
+        kbve.com/stack: supabase
+        kbve.com/managed-by: argocd
+    annotations:
+        reloader.stakater.com/auto: 'true'
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: studio-gate
+    template:
+        metadata:
+            labels:
+                app: studio-gate
+        spec:
+            serviceAccountName: studio-gate-sa
+            automountServiceAccountToken: false
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: kbve-gate
+                  image: ghcr.io/kbve/kbve-gate:0.1.5
+                  imagePullPolicy: IfNotPresent
+                  ports:
+                      - name: gateway
+                        containerPort: 5678
+                        protocol: TCP
+                  env:
+                      - name: GATE_LISTEN
+                        value: 0.0.0.0:5678
+                      - name: GATE_UPSTREAM
+                        value: http://studio:3000
+                      - name: GATE_AUTHZ
+                        value: is_staff
+                      - name: GATE_STAFF_SCHEMA
+                        value: forum
+                      - name: GATE_LOGIN_REDIRECT
+                        value: https://kbve.com/login
+                      - name: GATE_COOKIE_DOMAIN
+                        value: .kbve.com
+                      - name: SUPABASE_URL
+                        value: http://kong.kilobase.svc.cluster.local:8000
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-jwt
+                                key: secret
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-jwt
+                                key: anon-key
+                      - name: RUST_LOG
+                        value: info
+                  resources:
+                      requests:
+                          memory: 64Mi
+                          cpu: 50m
+                      limits:
+                          memory: 128Mi
+                          cpu: 500m
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  livenessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 3
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: studio-gate
+    namespace: kilobase
+    labels:
+        app: studio-gate
+        kbve.com/category: application
+        kbve.com/stack: supabase
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        app: studio-gate
+    ports:
+        - name: http
+          port: 5678
+          targetPort: 5678
+          protocol: TCP

--- a/apps/metrics/src/auth.rs
+++ b/apps/metrics/src/auth.rs
@@ -19,6 +19,8 @@ impl StaffAuth {
                     .filter(|s| !s.is_empty());
                 let schema =
                     std::env::var("METRICS_STAFF_SCHEMA").unwrap_or_else(|_| "forum".into());
+                let rpc =
+                    std::env::var("METRICS_STAFF_RPC").unwrap_or_else(|_| "is_staff".into());
                 let ttl = std::env::var("METRICS_STAFF_TTL_SECS")
                     .ok()
                     .and_then(|v| v.parse().ok())
@@ -28,6 +30,7 @@ impl StaffAuth {
                     jwt_secret.clone(),
                     apikey,
                     schema,
+                    &rpc,
                     ttl,
                 ))
             }

--- a/packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql
+++ b/packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql
@@ -33,8 +33,14 @@
 CREATE SCHEMA IF NOT EXISTS authz;
 ALTER SCHEMA authz OWNER TO postgres;
 
-GRANT USAGE ON SCHEMA authz TO authenticated, service_role;
-REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon;
+-- Explicit reset: deny everything (incl. any stale CREATE), then grant
+-- USAGE to service_role only. These explicit-UUID predicates are
+-- backend-only (kbve-gate / metrics call them as service_role). Browser
+-- self-checks already exist via staff.proxy_has_permission() /
+-- public.is_staff() (auth.uid()-based), so authenticated does NOT get
+-- access here — that would expose a per-UUID rank-enumeration oracle.
+REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA authz TO service_role;
 
 -- Internal: resolve a user's permission mask (0 when not a member).
 -- SECURITY DEFINER so the public predicates can read staff.members
@@ -151,8 +157,8 @@ BEGIN
         'authz.has_any_permission(UUID, INTEGER)'
     ] LOOP
         EXECUTE format('ALTER FUNCTION %s OWNER TO postgres', fn);
-        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon', fn);
-        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
     END LOOP;
 END $$;
 

--- a/packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql
+++ b/packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql
@@ -1,0 +1,166 @@
+-- migrate:up
+
+-- ============================================================
+-- AUTHZ — PostgREST-exposed bitwise permission predicates.
+--
+-- Source of truth: packages/data/sql/schema/authz/authz.sql
+--                  packages/data/proto/kbve/staff.proto
+--
+-- The `staff` schema holds the membership table + grant/revoke
+-- machinery but is intentionally NOT exposed through PostgREST.
+-- `forum.is_staff(uuid)` was the only REST-callable predicate and
+-- only answers "any non-zero permission?". The kbve-gate sidecar
+-- (and apps/metrics) need per-rank checks to gate upstreams at
+-- different privilege levels (e.g. Supabase Studio = SUPERADMIN).
+--
+-- This migration adds a dedicated `authz` schema of parametric,
+-- service-callable predicates over staff.members. They take an
+-- explicit p_user_id (the gate calls them as service_role, where
+-- auth.uid() is NULL), mirror the bitwise semantics already used by
+-- staff._check_actor_permission / staff.proxy_has_permission, and
+-- apply the SUPERADMIN (0x40000000) bypass for rank checks.
+--
+-- Semantics: pure flags + superadmin bypass. Flags are independent
+-- bits, not ordered ranks — is_admin tests the ADMIN bit, it does
+-- NOT imply is_moderator. SUPERADMIN passes every rank/has_* check.
+--
+--   STAFF      = 0x00000001   ADMIN      = 0x00000004
+--   MODERATOR  = 0x00000002   SUPERADMIN = 0x40000000
+--
+-- Gate wiring: GATE_STAFF_SCHEMA=authz + GATE_STAFF_RPC=<predicate>.
+-- ============================================================
+
+CREATE SCHEMA IF NOT EXISTS authz;
+ALTER SCHEMA authz OWNER TO postgres;
+
+GRANT USAGE ON SCHEMA authz TO authenticated, service_role;
+REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon;
+
+-- Internal: resolve a user's permission mask (0 when not a member).
+-- SECURITY DEFINER so the public predicates can read staff.members
+-- regardless of the caller's grants. Not granted to anon/authenticated;
+-- the definer predicates below call it as the owner (postgres).
+CREATE OR REPLACE FUNCTION authz._perms(p_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN 0;
+    END IF;
+    SELECT permissions INTO v_perms
+    FROM staff.members
+    WHERE user_id = p_user_id;
+    RETURN COALESCE(v_perms, 0);
+END;
+$$;
+
+ALTER FUNCTION authz._perms(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION authz._perms(UUID) FROM PUBLIC, anon, authenticated;
+
+-- TRUE if the user holds any non-zero permission bit.
+CREATE OR REPLACE FUNCTION authz.is_staff(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+BEGIN
+    RETURN authz._perms(p_user_id) <> 0;
+END;
+$$;
+
+-- TRUE if the user holds MODERATOR (or SUPERADMIN bypass).
+CREATE OR REPLACE FUNCTION authz.is_moderator(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER := authz._perms(p_user_id);
+BEGIN
+    RETURN (v_perms & x'40000000'::int) <> 0
+        OR (v_perms & x'00000002'::int) <> 0;
+END;
+$$;
+
+-- TRUE if the user holds ADMIN (or SUPERADMIN bypass).
+CREATE OR REPLACE FUNCTION authz.is_admin(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER := authz._perms(p_user_id);
+BEGIN
+    RETURN (v_perms & x'40000000'::int) <> 0
+        OR (v_perms & x'00000004'::int) <> 0;
+END;
+$$;
+
+-- TRUE only if the user holds the SUPERADMIN bit (no bypass — it IS the bit).
+CREATE OR REPLACE FUNCTION authz.is_superadmin(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+BEGIN
+    RETURN (authz._perms(p_user_id) & x'40000000'::int) <> 0;
+END;
+$$;
+
+-- TRUE if the user holds ALL bits in p_mask (or SUPERADMIN bypass).
+-- Rejects NULL/<=0 masks to prevent (perms & 0)=0 silent-allow.
+CREATE OR REPLACE FUNCTION authz.has_permission(p_user_id UUID, p_mask INTEGER)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_mask IS NULL OR p_mask <= 0 THEN
+        RETURN FALSE;
+    END IF;
+    v_perms := authz._perms(p_user_id);
+    IF (v_perms & x'40000000'::int) <> 0 THEN
+        RETURN TRUE;
+    END IF;
+    RETURN (v_perms & p_mask) = p_mask;
+END;
+$$;
+
+-- TRUE if the user holds ANY bit in p_mask (or SUPERADMIN bypass).
+CREATE OR REPLACE FUNCTION authz.has_any_permission(p_user_id UUID, p_mask INTEGER)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_mask IS NULL OR p_mask <= 0 THEN
+        RETURN FALSE;
+    END IF;
+    v_perms := authz._perms(p_user_id);
+    IF (v_perms & x'40000000'::int) <> 0 THEN
+        RETURN TRUE;
+    END IF;
+    RETURN (v_perms & p_mask) <> 0;
+END;
+$$;
+
+DO $$
+DECLARE
+    fn TEXT;
+BEGIN
+    FOREACH fn IN ARRAY ARRAY[
+        'authz.is_staff(UUID)',
+        'authz.is_moderator(UUID)',
+        'authz.is_admin(UUID)',
+        'authz.is_superadmin(UUID)',
+        'authz.has_permission(UUID, INTEGER)',
+        'authz.has_any_permission(UUID, INTEGER)'
+    ] LOOP
+        EXECUTE format('ALTER FUNCTION %s OWNER TO postgres', fn);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon', fn);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+    END LOOP;
+END $$;
+
+COMMENT ON SCHEMA authz IS
+    'PostgREST-exposed bitwise permission predicates over staff.members. Pure flags + SUPERADMIN bypass.';
+COMMENT ON FUNCTION authz.is_superadmin(UUID) IS
+    'TRUE only if the user holds the SUPERADMIN (0x40000000) bit. Used to gate Supabase Studio via kbve-gate.';
+
+-- migrate:down
+
+DROP SCHEMA IF EXISTS authz CASCADE;

--- a/packages/data/sql/schema/authz/authz.sql
+++ b/packages/data/sql/schema/authz/authz.sql
@@ -26,8 +26,11 @@ BEGIN;
 CREATE SCHEMA IF NOT EXISTS authz;
 ALTER SCHEMA authz OWNER TO postgres;
 
-GRANT USAGE ON SCHEMA authz TO authenticated, service_role;
-REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon;
+-- Backend-only: service_role (kbve-gate / metrics) calls these explicit-UUID
+-- predicates. authenticated is intentionally excluded — browser self-checks
+-- use staff.proxy_has_permission() / public.is_staff() (auth.uid()-based).
+REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA authz TO service_role;
 
 CREATE OR REPLACE FUNCTION authz._perms(p_user_id UUID)
 RETURNS INTEGER
@@ -133,8 +136,8 @@ BEGIN
         'authz.has_any_permission(UUID, INTEGER)'
     ] LOOP
         EXECUTE format('ALTER FUNCTION %s OWNER TO postgres', fn);
-        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon', fn);
-        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
     END LOOP;
 END $$;
 

--- a/packages/data/sql/schema/authz/authz.sql
+++ b/packages/data/sql/schema/authz/authz.sql
@@ -1,0 +1,144 @@
+-- ============================================================
+-- AUTHZ SCHEMA — PostgREST-exposed bitwise permission predicates
+--
+-- Parametric, service-callable predicates over staff.members for
+-- gating upstreams (kbve-gate, apps/metrics) at different privilege
+-- levels. They take an explicit p_user_id because callers hit them
+-- as service_role, where auth.uid() is NULL.
+--
+-- Semantics: PURE FLAGS + SUPERADMIN bypass. Flags are independent
+-- bits, not ordered ranks — is_admin tests the ADMIN bit and does
+-- NOT imply is_moderator. SUPERADMIN (0x40000000) passes every
+-- rank / has_* check.
+--
+--   STAFF      = 0x00000001   ADMIN      = 0x00000004
+--   MODERATOR  = 0x00000002   SUPERADMIN = 0x40000000
+--
+-- Source of truth: packages/data/proto/kbve/staff.proto
+-- Applied via:     packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql
+-- Depends on:      staff.members
+--
+-- Gate wiring: GATE_STAFF_SCHEMA=authz + GATE_STAFF_RPC=<predicate>.
+-- ============================================================
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS authz;
+ALTER SCHEMA authz OWNER TO postgres;
+
+GRANT USAGE ON SCHEMA authz TO authenticated, service_role;
+REVOKE ALL ON SCHEMA authz FROM PUBLIC, anon;
+
+CREATE OR REPLACE FUNCTION authz._perms(p_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN 0;
+    END IF;
+    SELECT permissions INTO v_perms
+    FROM staff.members
+    WHERE user_id = p_user_id;
+    RETURN COALESCE(v_perms, 0);
+END;
+$$;
+
+ALTER FUNCTION authz._perms(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION authz._perms(UUID) FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION authz.is_staff(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+BEGIN
+    RETURN authz._perms(p_user_id) <> 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION authz.is_moderator(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER := authz._perms(p_user_id);
+BEGIN
+    RETURN (v_perms & x'40000000'::int) <> 0
+        OR (v_perms & x'00000002'::int) <> 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION authz.is_admin(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER := authz._perms(p_user_id);
+BEGIN
+    RETURN (v_perms & x'40000000'::int) <> 0
+        OR (v_perms & x'00000004'::int) <> 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION authz.is_superadmin(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+BEGIN
+    RETURN (authz._perms(p_user_id) & x'40000000'::int) <> 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION authz.has_permission(p_user_id UUID, p_mask INTEGER)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_mask IS NULL OR p_mask <= 0 THEN
+        RETURN FALSE;
+    END IF;
+    v_perms := authz._perms(p_user_id);
+    IF (v_perms & x'40000000'::int) <> 0 THEN
+        RETURN TRUE;
+    END IF;
+    RETURN (v_perms & p_mask) = p_mask;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION authz.has_any_permission(p_user_id UUID, p_mask INTEGER)
+RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' STABLE AS $$
+DECLARE
+    v_perms INTEGER;
+BEGIN
+    IF p_mask IS NULL OR p_mask <= 0 THEN
+        RETURN FALSE;
+    END IF;
+    v_perms := authz._perms(p_user_id);
+    IF (v_perms & x'40000000'::int) <> 0 THEN
+        RETURN TRUE;
+    END IF;
+    RETURN (v_perms & p_mask) <> 0;
+END;
+$$;
+
+DO $$
+DECLARE
+    fn TEXT;
+BEGIN
+    FOREACH fn IN ARRAY ARRAY[
+        'authz.is_staff(UUID)',
+        'authz.is_moderator(UUID)',
+        'authz.is_admin(UUID)',
+        'authz.is_superadmin(UUID)',
+        'authz.has_permission(UUID, INTEGER)',
+        'authz.has_any_permission(UUID, INTEGER)'
+    ] LOOP
+        EXECUTE format('ALTER FUNCTION %s OWNER TO postgres', fn);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon', fn);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+    END LOOP;
+END $$;
+
+COMMENT ON SCHEMA authz IS
+    'PostgREST-exposed bitwise permission predicates over staff.members. Pure flags + SUPERADMIN bypass.';
+
+COMMIT;

--- a/packages/rust/kbve/src/gate/auth.rs
+++ b/packages/rust/kbve/src/gate/auth.rs
@@ -187,9 +187,11 @@ impl StaffGate {
         jwt_secret: String,
         apikey: Option<String>,
         schema: String,
+        rpc: &str,
         ttl_secs: u64,
     ) -> Self {
         let base = supabase_url.trim_end_matches('/');
+        let rpc = rpc.trim_matches('/');
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(5))
             .timeout(Duration::from_secs(8))
@@ -197,7 +199,7 @@ impl StaffGate {
             .unwrap_or_else(|_| Client::new());
         Self {
             client,
-            rpc_url: format!("{base}/rest/v1/rpc/is_staff"),
+            rpc_url: format!("{base}/rest/v1/rpc/{rpc}"),
             jwt_secret,
             apikey,
             schema,

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -33,6 +33,8 @@ use std::net::SocketAddr;
 /// - `GATE_COOKIE_DOMAIN`   optional domain scope for the session cookie
 /// - `GATE_STAFF_TTL_SECS`  is_staff cache TTL (default 30)
 /// - `GATE_STAFF_SCHEMA`    PostgREST schema for the RPC (default `forum`)
+/// - `GATE_STAFF_RPC`       PostgREST RPC name (default `is_staff`); e.g.
+///   `is_superadmin` against the `authz` schema gates on the SUPERADMIN bit
 /// - `SUPABASE_JWT_SECRET`  required
 /// - `SUPABASE_URL`         required when authz=is_staff
 /// - `SUPABASE_ANON_KEY`    optional PostgREST apikey when authz=is_staff
@@ -81,6 +83,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
                 .ok()
                 .filter(|s| !s.is_empty());
             let schema = std::env::var("GATE_STAFF_SCHEMA").unwrap_or_else(|_| "forum".into());
+            let rpc = std::env::var("GATE_STAFF_RPC").unwrap_or_else(|_| "is_staff".into());
             let ttl = std::env::var("GATE_STAFF_TTL_SECS")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -90,6 +93,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
                 jwt_secret.clone(),
                 apikey,
                 schema,
+                &rpc,
                 ttl,
             ))
         }


### PR DESCRIPTION
## What

Drop the Kong **basic-auth** password on Supabase Studio (`https://supabase.kbve.com/project/default`) and front it with **kbve-gate**, gated on **SUPERADMIN** (`0x40000000`) — not just any staff. Adds a reusable bitwise authz layer the gate (and metrics) can consume at any privilege level.

## Layers

**1. SQL — new `authz` schema** (`packages/data/sql/dbmate/migrations/20260623000000_authz_gate_predicates.sql`, mirrored in `schema/authz/authz.sql`)

Parametric, service-callable predicates over `staff.members` (take explicit `p_user_id` — gate calls as `service_role` where `auth.uid()` is NULL):
- `is_staff` / `is_moderator` / `is_admin` / `is_superadmin` `(p_user_id)`
- `has_permission` / `has_any_permission` `(p_user_id, p_mask)`

Pure-flag semantics + SUPERADMIN bypass, mirroring `staff._check_actor_permission`. `SECURITY DEFINER`, `search_path=''`, `EXECUTE` to `authenticated`+`service_role`, private `authz._perms` helper. Exposed via `PGRST_DB_SCHEMAS` (append `authz`).

**2. Gate — `GATE_STAFF_RPC` knob**

`StaffGate::new` takes an rpc name; `mod.rs` reads `GATE_STAFF_RPC` (default `is_staff`), `metrics` reads `METRICS_STAFF_RPC` (default `is_staff`). Behavior unchanged for existing gates. New image `0.1.6` (MDX bump; CI syncs Cargo/version.toml + deployment tags).

**3. Studio wiring**

studio-gate env `GATE_STAFF_SCHEMA=authz`, `GATE_STAFF_RPC=is_superadmin`. Registered in `ci-dispatch-manifest.json` so the post-publish atom PR syncs its image tag.

## Routing (unchanged shape)

```
browser -> HTTPRoute(supabase.kbve.com) -> Kong (CORS, host)
   |- /auth /rest /realtime ...  -> key-auth+acl -> API services   (unchanged)
   '- /  (catch-all)             -> studio-gate:5678 -> JWT + authz.is_superadmin -> studio:3000
```

n8n / grafana / argocd / longhorn / forgejo keep `forum.is_staff` (any-staff).

## Rollout ordering (post dev->main release)

1. Apply dbmate migration (creates `authz`) — `ci-dbmate-deploy` workflow.
2. Roll PostgREST (picks up `authz` schema).
3. Publish kbve-gate `0.1.6` (`workflow_dispatch app_name=kbve-gate`) → post-publish PR pins `0.1.6` on all 6 gate deployments incl studio-gate.
4. studio-gate rolls with `is_superadmin`.

**Transient note:** if studio-gate goes live before the `0.1.6` image, the old binary ignores `GATE_STAFF_RPC` and calls `authz.is_staff` (any-staff) — strictly tighter than today's shared password, never more permissive. Superadmin enforcement activates on the `0.1.6` roll.

## Validation

- `cargo check -p kbve --features gate` + `-p met`: clean.
- Migration markers / `$$` balance / down-drop asserted; `authz` exposed; studio-gate env asserted (`schema=authz`, `rpc=is_superadmin`).
- Kong inner+outer YAML parse clean; no `basicauth_credentials`, no `DASHBOARD` consumer, dashboard `url=studio-gate:5678`, no plugins.
- dbmate validate CI runs on this PR (touches `packages/data/sql/**`).

Requires a Supabase user with the SUPERADMIN bit. Bootstrap: `SELECT staff.service_grant('<uuid>', x'40000001'::int, NULL);`