### PR TITLE
fix(arc-runner): bake zip into runner image + sync UE values

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -1,7 +1,7 @@
 ---
 title: ARC Runner
 description: |
-    Custom GitHub Actions Runner image for the arc-runner-set scale set. Bakes git-lfs, unzip, jq, xz, and the GitHub CLI into the upstream actions/runner base so workflows stop installing them at job runtime.
+    Custom GitHub Actions Runner image for the arc-runner-set scale set. Bakes git-lfs, unzip, zip, jq, xz, and the GitHub CLI into the upstream actions/runner base so workflows stop installing them at job runtime.
 sidebar:
     label: ARC Runner
     order: 57
@@ -12,7 +12,7 @@ tags:
 key: arc_runner
 pipeline: docker
 app_name: arc-runner
-version: "0.1.5"
+version: "0.1.6"
 source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest
@@ -20,6 +20,7 @@ image: kbve/arc-runner
 deployment_yamls:
     - apps/kube/github/runners/manifests/values-kbve.yaml
     - apps/kube/github/runners/manifests/values.yaml
+    - apps/kube/github/runners/manifests/values-ue.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -10,7 +10,7 @@ FROM --platform=linux/amd64 mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-
 FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:${ACTIONS_RUNNER_VERSION} AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/kbve/kbve"
-LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client + node/pnpm/playwright."
+LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/zip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client + node/pnpm/playwright."
 LABEL org.opencontainers.image.licenses="MIT"
 
 USER root
@@ -22,6 +22,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         git-lfs \
         unzip \
+        zip \
         jq \
         xz-utils \
         ca-certificates \

--- a/packages/docker/arc-runner/project.json
+++ b/packages/docker/arc-runner/project.json
@@ -43,6 +43,7 @@
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'git-lfs --version' | grep -q 'git-lfs/' && echo 'PASS: git-lfs on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'jq --version' | grep -q 'jq-' && echo 'PASS: jq on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'unzip -v' | grep -q 'UnZip' && echo 'PASS: unzip on PATH'",
+					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'zip -v' | grep -q 'Zip ' && echo 'PASS: zip on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'xz --version' | grep -q 'xz (XZ Utils)' && echo 'PASS: xz on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'gh --version' | grep -q 'gh version' && echo 'PASS: gh on PATH'",
 					"echo '=== arc-runner image OK ==='"


### PR DESCRIPTION
## Problem

`Build Plugin Linux (KBVEAgones)` failed on PR #13382 (run 28223012721). The misleading "build error" is actually a **packaging** failure — UE BuildPlugin reported `BUILD SUCCESSFUL ExitCode=0` (StrictInclude cascade is fixed), then the next step died:

```
/.../sh: line 2: zip: command not found
##[error]Process completed with exit code 127.
```

The custom `ghcr.io/kbve/arc-runner` image bakes `unzip` but never `zip`. `arc-runner-ue` (where the plugin job runs) uses the same image, so `zip -r` in the package step has no binary.

## Fix

- Add `zip` to the Dockerfile apt bundle (symmetric with `unzip`); update label/description.
- Add a `zip` on-PATH smoke test to `project.json`.
- Bump arc-runner `0.1.5 → 0.1.6` to publish the new image.
- Add `values-ue.yaml` to `deployment_yamls` — it was missing, so the post-publish atom PR would have bumped `values.yaml` + `values-kbve.yaml` but left the **UE** scale set pinned to the zip-less `0.1.5`.

## Rollout

Lands on dev → rides the next dev→main release → publish pipeline ships `arc-runner:0.1.6` → atom PR bumps all three values files → Argo rolls the scale sets. UE plugin packaging works once the UE runner picks up 0.1.6.