### PR TITLE
fix(rentearth): name rentearth-web project to unblock nx graph

### DIFF
--- a/apps/rentearth/axum-rentearth/web/project.json
+++ b/apps/rentearth/axum-rentearth/web/project.json
@@ -1,0 +1,41 @@
+{
+	"name": "rentearth-web",
+	"$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/rentearth/axum-rentearth/web/src",
+	"tags": ["vite", "react", "rentearth"],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/rentearth/axum-rentearth/web",
+				"command": "vite"
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{projectRoot}/dist"],
+			"options": {
+				"cwd": "apps/rentearth/axum-rentearth/web",
+				"command": "vite build"
+			},
+			"cache": true
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/rentearth/axum-rentearth/web",
+				"command": "tsc --noEmit"
+			},
+			"cache": true
+		},
+		"preview": {
+			"dependsOn": ["build"],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/rentearth/axum-rentearth/web",
+				"command": "vite preview"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`astro-kbve:build` (and the ci-dispatch-manifest verify) fail on every PR:

```
ProjectsWithNoNameError: The projects in the following directories have no name provided:
- apps/rentearth/axum-rentearth/web
```

The Vite + TanStack web added in `70deb4cc1` ships **no `project.json`**. Under a clean CI `pnpm install`, `@nx/vite/plugin` infers a project at that vite.config root but can't resolve a name (the bare `package.json` name isn't read for inferred vite nodes in CI's nx), so the **whole project graph** fails to build — which kills *every* `nx` command, not just rentearth.

(Locally it can pass on a warm/newer nx that reads the package.json name — CI's clean install is the source of truth.)

## Fix

Add `apps/rentearth/axum-rentearth/web/project.json` with an explicit `name: rentearth-web` + vite `run-commands` targets, mirroring the working sibling `apps/agones/arpg/web/project.json`.

## Validation

Against the installed graph: project resolves as `rentearth-web` (no `@kbve/rentearth-web` duplicate, no collision), `ProjectsWithNoNameError` gone, `nx show projects` clean.

Unrelated to #13387 — this is a latent break in the rentearth web commit that surfaces on any nx graph build.