### PR TITLE
feat(kilobase): upgrade to supabase/postgres 17.6.1.136, drop nix build

### DIFF
--- a/apps/kbve/kilobase/Dockerfile
+++ b/apps/kbve/kilobase/Dockerfile
@@ -1,5 +1,5 @@
 ####################
-# Stage 0: Build kilobase extension
+# Stage 0: Build kilobase extension (pgrx, against pgdg server-dev-17)
 ####################
 FROM rust:bookworm AS builder
 
@@ -22,68 +22,31 @@ RUN cargo pgrx package --pg-config /usr/bin/pg_config --features pg17 && \
     echo "=== Build passed ==="
 
 ####################
-# Stage 1: Build Supabase PostgreSQL via Nix
+# Stage 1: Final image = Supabase base (alpine+nix) with kilobase installed
 ####################
-FROM nixos/nix:latest AS supabase-nix-builder
+FROM supabase/postgres:17.6.1.136
 
-RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+USER root
 
-WORKDIR /build
-RUN nix-shell -p git --run "git clone https://github.com/supabase/postgres.git supabase-postgres"
-WORKDIR /build/supabase-postgres
-
-RUN nix flake show . | head -20
-
-RUN echo "=== Building PostgreSQL 17 with Supabase's Nix system ===" && \
-    nix build .#psql_17/bin --out-link /supabase-postgresql && \
-    echo "=== Build completed ===" && \
-    /supabase-postgresql/bin/pg_config --version
-
-####################
-# Stage 2: Combine Supabase PostgreSQL + kilobase artifacts
-####################
-FROM nixos/nix:latest AS custom-postgresql-builder
-
-COPY --from=supabase-nix-builder /supabase-postgresql /supabase-postgresql
 COPY --from=builder /build/target/release/kilobase-pg17 /kilobase-dist
-COPY extend-supabase-postgresql.nix /extend-supabase-postgresql.nix
 
-RUN nix-build /extend-supabase-postgresql.nix --out-link /extended-postgresql && \
-    echo "=== Extended PostgreSQL built ===" && \
-    ls -la /extended-postgresql/lib/ | grep kilobase && \
-    ls -la /extended-postgresql/share/postgresql/extension/ | grep kilobase
-
-####################
-# Stage 3: Final image based on Supabase with kilobase
-####################
-FROM supabase/postgres:17.4.1.068
-
-COPY --from=custom-postgresql-builder /extended-postgresql /nix/store/extended-postgresql
-
-ENV PATH="/nix/store/extended-postgresql/bin:$PATH"
-
-RUN CURRENT_PG_STORE=$(readlink -f $(which pg_config) | sed 's|/bin/pg_config||') && \
-    echo "=== Integrating extended PostgreSQL ===" && \
-    echo "Current PostgreSQL: $CURRENT_PG_STORE" && \
-    echo "Extended PostgreSQL: /nix/store/extended-postgresql" && \
-    \
-    if [ -d "$CURRENT_PG_STORE/lib" ]; then \
-        cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/" 2>/dev/null || \
-        mkdir -p "$CURRENT_PG_STORE/lib" && cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/"; \
-    fi && \
-    \
-    if [ -d "$CURRENT_PG_STORE/share" ]; then \
-        cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/" 2>/dev/null || \
-        mkdir -p "$CURRENT_PG_STORE/share/postgresql/extension" && cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/"; \
-    fi && \
-    \
-    chown -R postgres:postgres "$CURRENT_PG_STORE/lib" "$CURRENT_PG_STORE/share" 2>/dev/null || true
-
-RUN echo "=== Final Verification ===" && \
-    pg_config --version && \
-    PG_LIBDIR=$(pg_config --pkglibdir) && \
-    PG_SHAREDIR=$(pg_config --sharedir) && \
-    ls -la "$PG_LIBDIR" | grep kilobase && \
-    ls -la "$PG_SHAREDIR/extension" | grep kilobase
+RUN set -eux; \
+    SO="$(find /kilobase-dist -name 'kilobase.so' | head -1)"; \
+    CTRL="$(find /kilobase-dist -name 'kilobase.control' | head -1)"; \
+    MERGED_LIB="$(dirname "$(dirname "$(readlink -f "$(command -v pg_config)")")")/lib"; \
+    PROFILE_LIB="$(readlink -f "$(dirname "$(dirname "$(pg_config --sharedir)")")/lib")"; \
+    EXTDIR="$(readlink -f "$(pg_config --sharedir)/extension")"; \
+    for D in "$MERGED_LIB" "$PROFILE_LIB"; do \
+        test -e "$D/plpgsql.so" || continue; \
+        chmod u+w "$D"; cp "$SO" "$D/"; chmod 755 "$D/kilobase.so"; \
+    done; \
+    chmod u+w "$EXTDIR"; \
+    cp "$CTRL" "$EXTDIR/"; \
+    find /kilobase-dist -name 'kilobase*.sql' -exec cp {} "$EXTDIR/" \; ; \
+    rm -rf /kilobase-dist; \
+    echo "=== Final verification ==="; \
+    pg_config --version; \
+    echo "merged_lib=$MERGED_LIB"; echo "profile_lib=$PROFILE_LIB"; echo "extdir=$EXTDIR"; \
+    ls -la "$EXTDIR" | grep kilobase
 
 USER postgres

--- a/apps/kbve/kilobase/src/lib.rs
+++ b/apps/kbve/kilobase/src/lib.rs
@@ -50,10 +50,6 @@ pub extern "C-unwind" fn smart_matview_worker_main(arg: pg_sys::Datum) {
         max_sleep_secs
     );
 
-    if let Err(e) = setup_notification_listener() {
-        log!("WARNING: Could not set up notifications: {}", e);
-    }
-
     run_worker_loop(max_sleep_secs);
 
     log!("{} shutting down", BackgroundWorker::get_name());
@@ -62,13 +58,6 @@ pub extern "C-unwind" fn smart_matview_worker_main(arg: pg_sys::Datum) {
 // =============================================================================
 // WORKER HELPER FUNCTIONS
 // =============================================================================
-
-fn setup_notification_listener() -> Result<(), pgrx::spi::Error> {
-    BackgroundWorker::transaction(|| {
-        Spi::run("LISTEN matview_refresh_config_changed")?;
-        Ok(())
-    })
-}
 
 fn run_worker_loop(max_sleep_secs: i32) {
     let mut cycle_count: u64 = 0;


### PR DESCRIPTION
## What

Upgrade kilobase to **supabase/postgres 17.6.1.136** (from 17.4.1.068) and rip out the three nix build stages.

## Why the nix stages went

They rebuilt all of supabase-postgres from source (~17 min, fragile — broke on supabase's own `cargo-pgrx-0.12.9-vendor` derivation), then the final stage `FROM supabase/postgres` discarded everything except the `kilobase.so`/`.control`/`.sql` that **stage 0 already produced**. Pure no-op. The supabase base image already ships every supabase extension prebuilt.

## New build

- Stage 0 `rust:bookworm`: build kilobase ext (pgrx 0.16.1, pgdg `postgresql-server-dev-17`).
- Final `FROM supabase/postgres:17.6.1.136`: install `kilobase.so` into the **wrapped** postmaster's real `$libdir` (merged plugins-env lib + profile lib — `pg_config --pkglibdir` lies for the wrapped binary) and control/sql into the profile extension dir.

## Worker fix

Removed `setup_notification_listener()`. `LISTEN` is illegal in a background worker on **every** PG version (`ERROR: cannot execute LISTEN within a background process`); the PG ERROR longjmps past the Rust `if let Err`, so the "Smart Matview Refresher" crashed (exit code 1) on every boot where kilobase is in `shared_preload_libraries`. The worker already polls via `wait_latch`, so this loses nothing and the daemon now stays up.

## Verified locally (arm64)

- ✅ image builds (~3 min, no nix)
- ✅ `CREATE EXTENSION kilobase` + C functions execute (ABI good under supabase nix pg)
- ✅ worker preloads, **stays alive** in its poll loop, runs refresh cycles

## Not in this PR (deliberate — no publish yet)

MDX `version:`, ci-dispatch image/version, project.json/compose tags, prod cluster manifest, external `kbve/postgres` repo retirement.

## Caveats

- Could not A/B the prod image: `ghcr.io/kbve/postgres:17.4.1.069-kilobase` is amd64-only, tested host is arm64. The LISTEN bug is version-independent → **prod's worker may be silently crash-looping today** unless the external repo ships older source. Worth a separate check.
- `shared_preload_libraries=kilobase` stays a CNPG concern (postgres-cluster.yaml), unchanged.