### PR TITLE
fix(forgejo): grant oauth-register SA create on secrets (RBAC)

### DIFF
--- a/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
@@ -18,7 +18,10 @@ metadata:
 rules:
     - apiGroups: ['']
       resources: ['secrets']
-      verbs: ['get', 'create', 'patch', 'update']
+      verbs: ['create']
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'patch', 'update']
       resourceNames: ['forgejo-oauth-credentials']
     - apiGroups: ['']
       resources: ['secrets']


### PR DESCRIPTION
After #13331 unblocked the hook timing + GoTrue v2.191 went live, the `forgejo-oauth-register` job finally ran — and got **one step from done**. Logs:
```
==> Successfully registered OAuth client
==> Creating Kubernetes secret...
Error: secrets is forbidden: User "...:forgejo-oauth-register"
  cannot create resource "secrets" in namespace "kilobase"
```

## Bug
The Role granted `create` on secrets but scoped it with `resourceNames: [forgejo-oauth-credentials]`. **RBAC can't restrict `create` by resourceName** — the name doesn't exist at admission — so create is denied. Side effect: each of the 4 retries re-registered a *new* OAuth client before failing → **12 orphaned "Forgejo KBVE" clients** in `auth.oauth_clients`.

## Fix
Split the secrets rule:
- `create` — name-unscoped (the only form RBAC permits)
- `get/patch/update` — still name-scoped to `forgejo-oauth-credentials`
- `supabase-jwt` read unchanged

## After release
register-job saves `forgejo-oauth-credentials` → ESO syncs to forgejo ns → config-job runs `forgejo admin auth add-oauth --name kbve` → "Sign in with KBVE" button. The 12 orphaned clients (no saved secret → unusable) are cleaned up separately.