### PR TITLE
fix(kilobase): dbmate + postgrest connect with sslmode=require

### DIFF
--- a/apps/kube/external-secrets/manifests/postgrest-external-secret.yaml
+++ b/apps/kube/external-secrets/manifests/postgrest-external-secret.yaml
@@ -35,7 +35,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        PGRST_DB_URI: "postgres://authenticator:{{ .password }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=disable"
+        PGRST_DB_URI: "postgres://authenticator:{{ .password }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=require"
   data:
   - secretKey: password
     remoteRef:

--- a/apps/kube/kilobase/manifests/dbmate-runner-secret.yaml
+++ b/apps/kube/kilobase/manifests/dbmate-runner-secret.yaml
@@ -85,8 +85,10 @@ spec:
                 # Service DNS keeps traffic in-cluster, never via the
                 # apiserver tunnel or LoadBalancer. search_path keeps
                 # dbmate's tracker table out of the public schema so it
-                # doesn't get exposed via PostgREST.
-                DATABASE_URL: 'postgresql://postgres:{{ .password }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=disable&search_path=dbmate,public'
+                # doesn't get exposed via PostgREST. sslmode=require
+                # encrypts the wire against in-cluster sniffing; CNPG
+                # serves a TLS cert out of the box (lib/pq honors this).
+                DATABASE_URL: 'postgresql://postgres:{{ .password }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=require&search_path=dbmate,public'
     data:
         - secretKey: password
           remoteRef:


### PR DESCRIPTION
## What

Flip two libpq-based CNPG consumers from `sslmode=disable` to `sslmode=require`:
- [dbmate-runner-secret.yaml:89](apps/kube/kilobase/manifests/dbmate-runner-secret.yaml) — dbmate migration runner (postgres superuser)
- [postgrest-external-secret.yaml:38](apps/kube/external-secrets/manifests/postgrest-external-secret.yaml) — PostgREST (authenticator)

## Why

Both shipped credentials + traffic over an unencrypted in-cluster connection. CNPG serves a TLS server cert out of the box, so requiring SSL encrypts the wire with zero server-side change. dbmate (Go lib/pq) and PostgREST (libpq) both honor the `sslmode` URL param cleanly — safe to flip.

`require` (encrypt, no cert verification) over `verify-full` keeps this minimal; CA-pinning and least-privilege roles are follow-ups.

Closes #13118.

## Scope note — Rust consumers deliberately excluded

arpg, cryptothrone, discordsh connect via jedi (`tokio-postgres-rustls`), which in **release builds** verifies the server cert against **webpki public roots only** ([pg.rs:790-811](packages/rust/jedi/src/state/pg.rs#L790-L811)). CNPG's cert is signed by CNPG's private CA, so flipping those to `require` fails the TLS handshake unless the CNPG CA is mounted and `KBVE_PG_CA_PEM_FILE` is set (as kbve/jobboard already do). That's a separate PR — mount CA, set the env, flip to `verify-full`, and live-test on dev first.