### PR TITLE
test(kilobase): docker-compose e2e harness for the built image

### DIFF
--- a/apps/kbve/kilobase/Dockerfile
+++ b/apps/kbve/kilobase/Dockerfile
@@ -1,5 +1,5 @@
 ####################
-# Stage 0: Build kilobase extension
+# Stage 0: Build kilobase extension (pgrx, against pgdg server-dev-17)
 ####################
 FROM rust:bookworm AS builder
 
@@ -22,68 +22,31 @@ RUN cargo pgrx package --pg-config /usr/bin/pg_config --features pg17 && \
     echo "=== Build passed ==="
 
 ####################
-# Stage 1: Build Supabase PostgreSQL via Nix
+# Stage 1: Final image = Supabase base (alpine+nix) with kilobase installed
 ####################
-FROM nixos/nix:latest AS supabase-nix-builder
+FROM supabase/postgres:17.6.1.136
 
-RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+USER root
 
-WORKDIR /build
-RUN nix-shell -p git --run "git clone https://github.com/supabase/postgres.git supabase-postgres"
-WORKDIR /build/supabase-postgres
-
-RUN nix flake show . | head -20
-
-RUN echo "=== Building PostgreSQL 17 with Supabase's Nix system ===" && \
-    nix build .#psql_17/bin --out-link /supabase-postgresql && \
-    echo "=== Build completed ===" && \
-    /supabase-postgresql/bin/pg_config --version
-
-####################
-# Stage 2: Combine Supabase PostgreSQL + kilobase artifacts
-####################
-FROM nixos/nix:latest AS custom-postgresql-builder
-
-COPY --from=supabase-nix-builder /supabase-postgresql /supabase-postgresql
 COPY --from=builder /build/target/release/kilobase-pg17 /kilobase-dist
-COPY extend-supabase-postgresql.nix /extend-supabase-postgresql.nix
 
-RUN nix-build /extend-supabase-postgresql.nix --out-link /extended-postgresql && \
-    echo "=== Extended PostgreSQL built ===" && \
-    ls -la /extended-postgresql/lib/ | grep kilobase && \
-    ls -la /extended-postgresql/share/postgresql/extension/ | grep kilobase
-
-####################
-# Stage 3: Final image based on Supabase with kilobase
-####################
-FROM supabase/postgres:17.4.1.068
-
-COPY --from=custom-postgresql-builder /extended-postgresql /nix/store/extended-postgresql
-
-ENV PATH="/nix/store/extended-postgresql/bin:$PATH"
-
-RUN CURRENT_PG_STORE=$(readlink -f $(which pg_config) | sed 's|/bin/pg_config||') && \
-    echo "=== Integrating extended PostgreSQL ===" && \
-    echo "Current PostgreSQL: $CURRENT_PG_STORE" && \
-    echo "Extended PostgreSQL: /nix/store/extended-postgresql" && \
-    \
-    if [ -d "$CURRENT_PG_STORE/lib" ]; then \
-        cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/" 2>/dev/null || \
-        mkdir -p "$CURRENT_PG_STORE/lib" && cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/"; \
-    fi && \
-    \
-    if [ -d "$CURRENT_PG_STORE/share" ]; then \
-        cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/" 2>/dev/null || \
-        mkdir -p "$CURRENT_PG_STORE/share/postgresql/extension" && cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/"; \
-    fi && \
-    \
-    chown -R postgres:postgres "$CURRENT_PG_STORE/lib" "$CURRENT_PG_STORE/share" 2>/dev/null || true
-
-RUN echo "=== Final Verification ===" && \
-    pg_config --version && \
-    PG_LIBDIR=$(pg_config --pkglibdir) && \
-    PG_SHAREDIR=$(pg_config --sharedir) && \
-    ls -la "$PG_LIBDIR" | grep kilobase && \
-    ls -la "$PG_SHAREDIR/extension" | grep kilobase
+RUN set -eux; \
+    SO="$(find /kilobase-dist -name 'kilobase.so' | head -1)"; \
+    CTRL="$(find /kilobase-dist -name 'kilobase.control' | head -1)"; \
+    MERGED_LIB="$(dirname "$(dirname "$(readlink -f "$(command -v pg_config)")")")/lib"; \
+    PROFILE_LIB="$(readlink -f "$(dirname "$(dirname "$(pg_config --sharedir)")")/lib")"; \
+    EXTDIR="$(readlink -f "$(pg_config --sharedir)/extension")"; \
+    for D in "$MERGED_LIB" "$PROFILE_LIB"; do \
+        test -e "$D/plpgsql.so" || continue; \
+        chmod u+w "$D"; cp "$SO" "$D/"; chmod 755 "$D/kilobase.so"; \
+    done; \
+    chmod u+w "$EXTDIR"; \
+    cp "$CTRL" "$EXTDIR/"; \
+    find /kilobase-dist -name 'kilobase*.sql' -exec cp {} "$EXTDIR/" \; ; \
+    rm -rf /kilobase-dist; \
+    echo "=== Final verification ==="; \
+    pg_config --version; \
+    echo "merged_lib=$MERGED_LIB"; echo "profile_lib=$PROFILE_LIB"; echo "extdir=$EXTDIR"; \
+    ls -la "$EXTDIR" | grep kilobase
 
 USER postgres

--- a/apps/kbve/kilobase/docker-compose.e2e.yml
+++ b/apps/kbve/kilobase/docker-compose.e2e.yml
@@ -1,0 +1,16 @@
+services:
+    kilobase-e2e:
+        container_name: kilobase-e2e
+        build:
+            context: .
+            dockerfile: Dockerfile
+        image: kbve/kilobase:e2e
+        environment:
+            POSTGRES_PASSWORD: e2e
+        volumes:
+            - ./e2e/kilobase-preload.conf:/etc/postgresql-custom/conf.d/zz-kilobase.conf:ro
+        healthcheck:
+            test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+            interval: 3s
+            timeout: 5s
+            retries: 30

--- a/apps/kbve/kilobase/e2e/kilobase-preload.conf
+++ b/apps/kbve/kilobase/e2e/kilobase-preload.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'pg_stat_statements,pgaudit,plpgsql,plpgsql_check,pg_cron,pg_net,pgsodium,auto_explain,pg_tle,plan_filter,supabase_vault,kilobase'

--- a/apps/kbve/kilobase/image_e2e.sh
+++ b/apps/kbve/kilobase/image_e2e.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE="docker compose -f docker-compose.e2e.yml"
+SVC=kilobase-e2e
+DB=postgres
+ADMIN=supabase_admin
+WORKER='Smart Matview Refresher'
+PARITY_EXTS="pgsodium supabase_vault wrappers pg_graphql pg_cron pg_net pgaudit pg_stat_statements vector postgis pgmq pg_tle"
+
+fail=0
+pass() { echo "  PASS $*"; }
+bad()  { echo "  FAIL $*"; fail=1; }
+sql()  { $COMPOSE exec -T "$SVC" psql -U "$ADMIN" -d "$DB" -tAc "$1"; }
+
+cleanup() { $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# Gate on a real admin connection: supabase runs a temp init server (roles +
+# migrations) then bounces to the real one, so pg_isready alone races.
+wait_db() {
+    for _ in $(seq 1 60); do
+        if $COMPOSE exec -T "$SVC" psql -U "$ADMIN" -d "$DB" -tAc "SELECT 1" >/dev/null 2>&1; then return 0; fi
+        sleep 2
+    done
+    return 1
+}
+
+echo "== build + boot =="
+$COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+$COMPOSE up -d --build
+
+echo "== wait for ready =="
+wait_db || { echo "server never ready"; $COMPOSE logs --tail=40 "$SVC"; exit 1; }
+
+echo "== [1] kilobase preloaded =="
+if sql "SHOW shared_preload_libraries;" | grep -q kilobase; then pass "shared_preload_libraries has kilobase"; else bad "kilobase not preloaded"; fi
+
+echo "== [2] CREATE EXTENSION kilobase =="
+if sql "CREATE EXTENSION IF NOT EXISTS kilobase;" >/dev/null && [ "$(sql "SELECT 1 FROM pg_extension WHERE extname='kilobase';")" = "1" ]; then
+    pass "extension installed"
+else
+    bad "CREATE EXTENSION kilobase failed"
+fi
+
+echo "== restart so the worker boots with its schema present (models prod) =="
+$COMPOSE restart "$SVC" >/dev/null 2>&1
+wait_db || { echo "server never ready after restart"; exit 1; }
+
+echo "== [3] C function runtime load =="
+if sql "SELECT kilobase_health_check();" >/dev/null 2>&1; then pass "kilobase_health_check() callable"; else bad "health_check call failed (.so load)"; fi
+
+echo "== [4] background worker alive (LISTEN-crash regression guard) =="
+sleep 6
+n1=$(sql "SELECT count(*) FROM pg_stat_activity WHERE backend_type = '$WORKER';")
+sleep 8
+n2=$(sql "SELECT count(*) FROM pg_stat_activity WHERE backend_type = '$WORKER';")
+if [ "$n1" = "1" ] && [ "$n2" = "1" ]; then
+    pass "worker running and stable (no exit-1 crash loop)"
+else
+    bad "worker not stable (count $n1 -> $n2); check for 'cannot execute LISTEN'"
+    $COMPOSE logs "$SVC" 2>&1 | grep -iE "matview|listen|exit code" | tail -10 || true
+fi
+
+echo "== [5] supabase extension parity =="
+for e in $PARITY_EXTS; do
+    if [ "$(sql "SELECT 1 FROM pg_available_extensions WHERE name='$e';")" = "1" ]; then
+        pass "available: $e"
+    else
+        bad "missing extension: $e"
+    fi
+done
+
+echo
+if [ "$fail" = "0" ]; then echo "E2E PASS"; else echo "E2E FAIL"; fi
+exit "$fail"

--- a/apps/kbve/kilobase/project.json
+++ b/apps/kbve/kilobase/project.json
@@ -157,6 +157,14 @@
 				"parallel": false
 			}
 		},
+		"image-e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/kilobase",
+				"commands": ["bash image_e2e.sh"],
+				"parallel": false
+			}
+		},
 		"debug": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/apps/kbve/kilobase/src/lib.rs
+++ b/apps/kbve/kilobase/src/lib.rs
@@ -50,10 +50,6 @@ pub extern "C-unwind" fn smart_matview_worker_main(arg: pg_sys::Datum) {
         max_sleep_secs
     );
 
-    if let Err(e) = setup_notification_listener() {
-        log!("WARNING: Could not set up notifications: {}", e);
-    }
-
     run_worker_loop(max_sleep_secs);
 
     log!("{} shutting down", BackgroundWorker::get_name());
@@ -62,13 +58,6 @@ pub extern "C-unwind" fn smart_matview_worker_main(arg: pg_sys::Datum) {
 // =============================================================================
 // WORKER HELPER FUNCTIONS
 // =============================================================================
-
-fn setup_notification_listener() -> Result<(), pgrx::spi::Error> {
-    BackgroundWorker::transaction(|| {
-        Spi::run("LISTEN matview_refresh_config_changed")?;
-        Ok(())
-    })
-}
 
 fn run_worker_loop(max_sleep_secs: i32) {
     let mut cycle_count: u64 = 0;


### PR DESCRIPTION
Stacked on #13392 (base `trunk/kilobase-17-6`) — retarget to `dev` once that merges.

## What

A fresh-boot e2e that exercises the **actual kilobase image**, not just pgrx unit tests. Catches exactly the bugs we hit while doing the 17.6 upgrade.

- `docker-compose.e2e.yml` — boots the image; kilobase is appended to `shared_preload_libraries` via the supabase `conf.d` include_dir (`e2e/kilobase-preload.conf`). No entrypoint override (that broke supabase init).
- `image_e2e.sh` — assertions, exits non-zero on any failure.
- `nx run kilobase:image-e2e` target.

## Checks (regression guards)

1. **kilobase preloaded** — `SHOW shared_preload_libraries`
2. **CREATE EXTENSION kilobase** — guards the nix `$libdir`/sharedir install-path bug (the wrapped postmaster's real libdir ≠ `pg_config --pkglibdir`)
3. **C function callable at runtime** — `.so` actually dlopens
4. **bgworker stays up** across two samples — direct guard for the `LISTEN within a background process` crash fixed in #13392
5. **supabase extension parity** — vault, wrappers, pg_graphql, pg_cron, pg_net, pgsodium, postgis, vector, pgmq, pg_tle, … all available after the 17.6 base bump

## Notes

- Worker is checked after a **create-then-restart** so it boots with its schema present — mirrors prod (extension exists before postmaster start; CNPG sets the preload).
- Readiness gates on a real `supabase_admin` connection, because supabase's entrypoint runs a temp init server (roles + migrations) before bouncing to the real one — `pg_isready` alone races.
- Verified locally on arm64: two consecutive green runs, all 5 checks pass.

## Out of scope (deliberate)

Not wired into the publish/rollout pipeline — no auto-deploy. A more faithful **prod-level** harness (restore-from-backup, actual refresh-fires, extension `ALTER … UPDATE` upgrade path) comes as a follow-up.