### PR TITLE
fix(kube): wire base rows Application into root app-of-apps (#13117)

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -57,6 +57,12 @@ resources:
     - metrics/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
+    # rows = shared ROWS infra (ns `rows`): ows-valkey, externalsecrets, servicemonitor,
+    # and the `rows-agones-allocator-binding` Kyverno ClusterPolicy that grants every
+    # tenant's rows-instancelauncher SA GameServerAllocation rights (without it tenants 403).
+    # Live in-cluster but was applied out-of-band; declare it here so app-of-apps owns it
+    # and a rebuild-from-git reproduces it. Tenant overlays below layer on top.
+    - rows/application.yaml
     - rows/tenants/overlays/chuckrpg-dev/application.yaml
     - rows/tenants/overlays/chuckrpg-beta/application.yaml
     - agones/application.yaml


### PR DESCRIPTION
## Issue
Closes #13117 — base `rows/application.yaml` not wired into root app-of-apps.

## Investigation (kubectl, read-only)
| Check | Result |
|---|---|
| `rows` Application in cluster | **Synced / Healthy**, no ownerRefs → applied **out-of-band**, not via app-of-apps |
| ns `rows` (41d) | `ows-valkey` 1/1, 4 ExternalSecrets, `rows-metrics` ServiceMonitor, `rows` deploy 0/0 (vestigial) |
| Kyverno `rows-agones-allocator-binding` | live 8d, Ready — generates each tenant's GameServerAllocation RoleBinding |

## Correction to issue premise
The overlays' `../../base` = `rows/tenants/base` (per-tenant deploy, ns `rows-<slug>`), **not** `rows/manifest` (shared infra, ns `rows`). They are different dirs — the base app is **not** redundant.

## Why wire-in, not delete
The base app owns cluster-scoped + shared infra nothing else provides — most importantly the Kyverno policy that grants `rows-<slug>:rows-instancelauncher` allocation rights (without it tenants 403). It's just **undeclared in GitOps**, so a rebuild-from-git would drop it and break tenant gameserver allocation.

## Change
Add `rows/application.yaml` to `apps/kube/kustomization.yaml` before the tenant overlays. ArgoCD adopts the already-Synced resources — no recreation. `kubectl kustomize apps/kube` builds clean.

## Follow-up (not in this PR)
`rows` deploy in ns `rows` is `0/0` (vestigial pre-multi-tenant shared instance). Left in place because the post-publish atom still bumps its image tag; removing it needs coordinating with that flow.