### PR TITLE
feat(profile): unify username banlist as the chat filter source

### DIFF
--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -43,7 +43,7 @@ pub use osrs::{get_osrs_cache, init_osrs_cache};
 pub use pg_cluster::{get_pg_cluster, init_pg_cluster};
 pub use profile::{
     DiscordInfo, GithubInfo, TwitchInfo, UserProfile, UserProvider, get_profile_service,
-    init_profile_service, validate_username,
+    init_profile_service, spawn_chat_blocklist_mirror, validate_username,
 };
 pub use referral::{get_referral_client, init_referral_client};
 pub use rentearth::{RentEarthProfile, get_rentearth_service, init_rentearth_service};

--- a/apps/kbve/axum-kbve/src/db/profile.rs
+++ b/apps/kbve/axum-kbve/src/db/profile.rs
@@ -658,6 +658,90 @@ impl ProfileService {
 
         Ok(Some(username))
     }
+
+    /// Fetch the chat-applicable ban patterns (profanity + slurs) from
+    /// profile.username_banlist. The reserved-name terms (admin/mod/staff/…)
+    /// are deliberately excluded — they're username-only and would over-block
+    /// ordinary chat.
+    pub async fn get_chat_blocklist(&self) -> Result<Vec<String>, String> {
+        let url = format!("{}/username_banlist", self.client.config().rest_url());
+        let headers = self.client.rpc_headers("profile")?;
+
+        let response = self
+            .client
+            .client()
+            .get(&url)
+            .headers(headers)
+            .query(&[
+                ("select", "pattern"),
+                ("is_active", "eq.true"),
+                ("category", "in.(profanity,slur)"),
+            ])
+            .send()
+            .await
+            .map_err(|e| format!("username_banlist network error: {}", e))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("username_banlist {} → {}", status, body));
+        }
+
+        #[derive(Deserialize)]
+        struct Row {
+            pattern: String,
+        }
+        let rows: Vec<Row> = response
+            .json()
+            .await
+            .map_err(|e| format!("username_banlist parse: {}", e))?;
+        Ok(rows.into_iter().map(|r| r.pattern).collect())
+    }
+}
+
+/// Valkey key the irc-gateway chat filter reads its word blocklist from.
+const CHAT_BLOCKLIST_KEY: &str = "chat:filter:words";
+/// How often the banlist is mirrored from Postgres into Valkey.
+const CHAT_BLOCKLIST_REFRESH: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Mirror the profanity/slur ban patterns into Valkey on a fixed interval so
+/// the irc-gateway chat filter (and any other Valkey consumer) shares one
+/// Postgres-authoritative source. No-op when the profile service or KvCache is
+/// unconfigured.
+pub fn spawn_chat_blocklist_mirror() {
+    tokio::spawn(async {
+        let mut tick = tokio::time::interval(CHAT_BLOCKLIST_REFRESH);
+        loop {
+            tick.tick().await;
+            sync_chat_blocklist_once().await;
+        }
+    });
+}
+
+async fn sync_chat_blocklist_once() {
+    let Some(service) = get_profile_service() else {
+        return;
+    };
+    let Some(cache) = super::kv_cache::get_kv_cache() else {
+        return;
+    };
+    let words = match service.get_chat_blocklist().await {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!("chat blocklist mirror: fetch failed: {}", e);
+            return;
+        }
+    };
+    match serde_json::to_string(&words) {
+        Ok(json) => {
+            if cache.kv_set_str(CHAT_BLOCKLIST_KEY, &json).await.is_some() {
+                tracing::info!(count = words.len(), "chat blocklist mirrored to Valkey");
+            } else {
+                tracing::warn!("chat blocklist mirror: Valkey write failed");
+            }
+        }
+        Err(e) => tracing::warn!("chat blocklist mirror: serialize failed: {}", e),
+    }
 }
 
 // Global singleton for ProfileService

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -121,6 +121,8 @@ async fn main() -> anyhow::Result<()> {
         warn!("KvCache init failed - read-through cache disabled");
     }
 
+    db::spawn_chat_blocklist_mirror();
+
     if db::init_wallet_client().await {
         info!("Wallet client initialized - /api/v1/wallet/me/* routes enabled");
     } else {

--- a/packages/data/sql/dbmate/migrations/20260626120000_profile_username_banlist_category.sql
+++ b/packages/data/sql/dbmate/migrations/20260626120000_profile_username_banlist_category.sql
@@ -1,20 +1,34 @@
 -- migrate:up
 
-ALTER TABLE profile.username_banlist
-    ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'reserved';
+-- profile.* tables are provisioned from the schema files, not from dbmate, so
+-- the bare prod-replica CI database has no profile.username_banlist. Guard the
+-- DDL on the table's existence: apply the column + backfill on real databases,
+-- no-op on the schema-less migration runner.
+DO $$
+BEGIN
+    IF to_regclass('profile.username_banlist') IS NOT NULL THEN
+        ALTER TABLE profile.username_banlist
+            ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'reserved';
 
-COMMENT ON COLUMN profile.username_banlist.category IS
-    'Why the pattern is banned: profanity/slur apply to chat too; reserved is username-only.';
+        COMMENT ON COLUMN profile.username_banlist.category IS
+            'Why the pattern is banned: profanity/slur apply to chat too; reserved is username-only.';
 
-UPDATE profile.username_banlist
-    SET category = 'profanity'
-    WHERE pattern IN ('fuck', 'shit', 'bitch', 'cunt');
+        UPDATE profile.username_banlist
+            SET category = 'profanity'
+            WHERE pattern IN ('fuck', 'shit', 'bitch', 'cunt');
 
-UPDATE profile.username_banlist
-    SET category = 'slur'
-    WHERE pattern IN ('nigg');
+        UPDATE profile.username_banlist
+            SET category = 'slur'
+            WHERE pattern IN ('nigg');
+    END IF;
+END $$;
 
 -- migrate:down
 
-ALTER TABLE profile.username_banlist
-    DROP COLUMN IF EXISTS category;
+DO $$
+BEGIN
+    IF to_regclass('profile.username_banlist') IS NOT NULL THEN
+        ALTER TABLE profile.username_banlist
+            DROP COLUMN IF EXISTS category;
+    END IF;
+END $$;

--- a/packages/data/sql/dbmate/migrations/20260626120000_profile_username_banlist_category.sql
+++ b/packages/data/sql/dbmate/migrations/20260626120000_profile_username_banlist_category.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+
+ALTER TABLE profile.username_banlist
+    ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'reserved';
+
+COMMENT ON COLUMN profile.username_banlist.category IS
+    'Why the pattern is banned: profanity/slur apply to chat too; reserved is username-only.';
+
+UPDATE profile.username_banlist
+    SET category = 'profanity'
+    WHERE pattern IN ('fuck', 'shit', 'bitch', 'cunt');
+
+UPDATE profile.username_banlist
+    SET category = 'slur'
+    WHERE pattern IN ('nigg');
+
+-- migrate:down
+
+ALTER TABLE profile.username_banlist
+    DROP COLUMN IF EXISTS category;

--- a/packages/data/sql/schema/profile/username.sql
+++ b/packages/data/sql/schema/profile/username.sql
@@ -187,13 +187,20 @@ CREATE TABLE IF NOT EXISTS profile.username_banlist (
     id          bigserial PRIMARY KEY,
     pattern     text NOT NULL UNIQUE,   -- regex or literal fragment (unique to prevent duplicates)
     description text,
+    category    text NOT NULL DEFAULT 'reserved',  -- 'profanity' | 'slur' | 'reserved'
     is_active   boolean NOT NULL DEFAULT TRUE
 );
 
+-- Idempotent add for databases created before the category column existed.
+ALTER TABLE profile.username_banlist
+    ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'reserved';
+
 COMMENT ON TABLE profile.username_banlist IS
-    'List of banned username patterns (regex or fragments), enforced in normalize_username().';
+    'List of banned username patterns (regex or fragments), enforced in normalize_username(). The profanity/slur rows are also mirrored into Valkey for the chat content filter.';
 COMMENT ON COLUMN profile.username_banlist.pattern IS
     'Regex or literal fragment checked against canonical username.';
+COMMENT ON COLUMN profile.username_banlist.category IS
+    'Why the pattern is banned: profanity/slur apply to chat too; reserved is username-only.';
 COMMENT ON COLUMN profile.username_banlist.is_active IS
     'Soft flag so ban rules can be disabled without deleting rows.';
 
@@ -212,21 +219,24 @@ CREATE POLICY "service_role_full_access"
 REVOKE ALL ON TABLE profile.username_banlist
     FROM PUBLIC, anon, authenticated;
 
--- Optional seed entries (tune this list as you like)
-INSERT INTO profile.username_banlist (pattern, description)
+-- Optional seed entries (tune this list as you like). ON CONFLICT updates the
+-- category so re-applying this file backfills rows seeded before the column.
+INSERT INTO profile.username_banlist (pattern, description, category)
 VALUES
-    ('fuck',         'Generic profanity'),
-    ('shit',         'Generic profanity'),
-    ('bitch',        'Generic profanity'),
-    ('cunt',         'Generic profanity'),
-    ('nigg',         'Racial slur fragment'),
-    ('admin',        'Reserved administrative term'),
-    ('administrator','Reserved administrative term'),
-    ('moderator',    'Reserved staff term'),
-    ('mod',          'Reserved staff term'),
-    ('support',      'Reserved support term'),
-    ('staff',        'Reserved staff term')
-ON CONFLICT DO NOTHING;  -- in case this is re-run in dev
+    ('fuck',         'Generic profanity',           'profanity'),
+    ('shit',         'Generic profanity',           'profanity'),
+    ('bitch',        'Generic profanity',           'profanity'),
+    ('cunt',         'Generic profanity',           'profanity'),
+    ('nigg',         'Racial slur fragment',        'slur'),
+    ('admin',        'Reserved administrative term','reserved'),
+    ('administrator','Reserved administrative term','reserved'),
+    ('moderator',    'Reserved staff term',         'reserved'),
+    ('mod',          'Reserved staff term',         'reserved'),
+    ('support',      'Reserved support term',       'reserved'),
+    ('staff',        'Reserved staff term',         'reserved')
+ON CONFLICT (pattern) DO UPDATE
+    SET description = EXCLUDED.description,
+        category    = EXCLUDED.category;
 
 
 -- ===========================================


### PR DESCRIPTION
## What

Make `profile.username_banlist` the single source of truth for both username validation and chat content moderation.

- Add a `category` column (`profanity` | `slur` | `reserved`) to `profile.username_banlist`; backfill the seed rows. Idempotent `ADD COLUMN IF NOT EXISTS` + `ON CONFLICT DO UPDATE` so re-applying the schema categorizes pre-existing rows.
- `axum-kbve` mirrors the **profanity + slur** patterns into the Valkey key `chat:filter:words` every 5 minutes (`ProfileService::get_chat_blocklist` over PostgREST → `KvCache::kv_set_str`).
- The irc-gateway chat filter already reads `chat:filter:words`, so no gateway change is needed — it now gets a Postgres-authoritative list.

## Why

Two blocklists were drifting: the SQL username banlist and the gateway's static/Valkey chat list. Unifying them means staff edit one table and both username signup and live chat honor it.

The reserved-name terms (`admin`/`mod`/`support`/`staff`) are deliberately **excluded** from chat — they're username-only and would over-block ordinary chat ("ask a mod", "need support").

## Notes

- Depends on the irc-gateway chat filter already on dev (reads `chat:filter:words`).
- Builds clean (`nx run axum-kbve:build`).