### PR TITLE
fix(forgejo): oauth-config-job DB secret name (forgejo-db, not forgejo-db-credentials)

### DIFF
--- a/apps/kube/forgejo/manifest/forgejo-oauth-config-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-config-job.yaml
@@ -68,7 +68,7 @@ spec:
                       - name: FORGEJO__database__PASSWD
                         valueFrom:
                             secretKeyRef:
-                                name: forgejo-db-credentials
+                                name: forgejo-db
                                 key: password
                       - name: OAUTH_CLIENT_ID
                         valueFrom:


### PR DESCRIPTION
The last step of the Forgejo OIDC chain. After #13393 (RBAC) let register-job save the creds, the `forgejo-oauth-config` job ran but its `configure-oauth` container `CreateContainerConfigError`'d:
```
Error: secret "forgejo-db-credentials" not found
```

## Bug
The job pulls `FORGEJO__database__PASSWD` from a secret named **`forgejo-db-credentials`** — which doesn't exist in the forgejo ns. The `forgejo-externalsecret` ESO syncs the DB password into a secret named **`forgejo-db`** (key `password`; the `forgejo-db-credentials` string is the *remoteRef key* in the upstream store, not the local name). So it referenced the remote key as if it were the local secret name.

## Fix
Point the env at `forgejo-db/password` — the secret that already exists and that the Forgejo server itself uses. No new ESO/secret needed.

## After release
config-job runs `forgejo admin auth add-oauth --name kbve --auto-discover-url …/.well-known/openid-configuration` (idempotent — `auth list | grep kbve` guard) → **"Sign in with KBVE"** button on `/user/login`.

Then: clean the 12 orphaned `oauth_clients` from the earlier RBAC-failure retries (keep the one in `forgejo-oauth-credentials`).