### PR TITLE
chore(supabase): bump studio + postgres-meta to current

### DIFF
--- a/apps/kube/meta/manifests/supabase-meta-admin-restful.yaml
+++ b/apps/kube/meta/manifests/supabase-meta-admin-restful.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
             containers:
                 - name: postgres-meta
-                  image: supabase/postgres-meta:v0.91.0
+                  image: supabase/postgres-meta:v0.96.6
                   ports:
                       - containerPort: 8080
                         name: http

--- a/apps/kube/studio/manifests/supabase-studio-dashboard.yaml
+++ b/apps/kube/studio/manifests/supabase-studio-dashboard.yaml
@@ -25,7 +25,7 @@ spec:
                   emptyDir: {}
             containers:
                 - name: studio
-                  image: supabase/studio:2025.06.30-sha-6f5982d
+                  image: supabase/studio:2026.06.03-sha-0bca601
                   ports:
                       - containerPort: 3000
                         name: http


### PR DESCRIPTION
## What

Bump two stateless supabase components to supabase's current pinned versions (from their official docker-compose):

| Component | From | To |
|---|---|---|
| studio | 2025.06.30-sha-6f5982d | 2026.06.03-sha-0bca601 |
| postgres-meta | v0.91.0 | v0.96.6 |

## Why these two together

Both are **stateless** — studio is the dashboard UI, postgres-meta is a REST shim over the pg catalog. No DB schema, no boot migrations, no persistent state. Pure image tag bumps; rollback = revert the tag.

## Deliberately not in this PR

- **gotrue**: ours (v2.191.0) is intentionally **ahead** of supabase's v2.189.0 for the in-house OAuth server — left as-is.
- **postgrest** v13→**v14**: major version, breaking config/behavior — separate PR after changelog review.
- **storage-api** v1.25→v1.60: runs boot migrations on the `storage` schema — separate, backup-aware PR.
- **realtime**: runs as our own `ghcr.io/kbve/realtime` fork (no build source in-repo) — separate investigation.

ArgoCD apps track main; reaches the cluster on the next dev→main release.