### PR TITLE
fix(studio): studio-gate → kbve-gate 0.1.6 + register in deploy sync

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -367,7 +367,8 @@
 				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml",
 				"apps/kube/argocd/manifests/argocd-gate-deployment.yaml",
 				"apps/kube/storage/manifests/longhorn-gate-deployment.yaml",
-				"apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml"
+				"apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml",
+				"apps/kube/studio/manifests/studio-gate-deployment.yaml"
 			],
 			"has_test": false
 		},

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -3,7 +3,7 @@ title: KBVE Gate
 description: |
     Reusable auth reverse-proxy sidecar. Validates a Supabase JWT and an
     authz policy (jwt-only or is_staff), then proxies HTTP and WebSocket
-    traffic to an internal upstream. Fronts n8n, Grafana, Longhorn, ArgoCD, and Forgejo.
+    traffic to an internal upstream. Fronts n8n, Grafana, Longhorn, ArgoCD, Forgejo, and Supabase Studio.
 sidebar:
     label: KBVE Gate
     order: 52
@@ -26,6 +26,7 @@ deployment_yamls:
     - apps/kube/argocd/manifests/argocd-gate-deployment.yaml
     - apps/kube/storage/manifests/longhorn-gate-deployment.yaml
     - apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml
+    - apps/kube/studio/manifests/studio-gate-deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kube/studio/manifests/studio-gate-deployment.yaml
+++ b/apps/kube/studio/manifests/studio-gate-deployment.yaml
@@ -42,7 +42,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: kbve-gate
-                  image: ghcr.io/kbve/kbve-gate:0.1.5
+                  image: ghcr.io/kbve/kbve-gate:0.1.6
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: gateway


### PR DESCRIPTION
## What

Two coupled fixes for studio-gate (the kbve-gate sidecar fronting Supabase Studio):

1. Bump the pin `ghcr.io/kbve/kbve-gate:0.1.5` → `0.1.6` ([studio-gate-deployment.yaml:45](apps/kube/studio/manifests/studio-gate-deployment.yaml)).
2. Add `studio-gate-deployment.yaml` to the kbve-gate `deployment_yamls` list in [kbve-gate.mdx](apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx) + regenerate `.github/ci-dispatch-manifest.json`.

## Why

**Image bump (security):** studio-gate is configured `GATE_STAFF_SCHEMA=authz`, `GATE_STAFF_RPC=is_superadmin` to gate Studio on the SUPERADMIN bit. But `GATE_STAFF_RPC` support was added in **0.1.6** (#13387) — on 0.1.5 the RPC name is hardcoded to `is_staff`, so the gate ignores `is_superadmin` and admits **any staff member** (any permission bit) instead of superadmins only. Under-gated, not open (the RPC resolves). 0.1.6 enforces `authz.is_superadmin`. The authz schema/predicates are now live (migration `20260623000000` applied).

**Sync registration (root cause):** studio-gate was the lone gate stranded on 0.1.5 because its manifest was never in the kbve-gate `deployment_yamls` list, so the post-publish image sync skipped it. Registering it means future gate publishes auto-bump studio-gate alongside argocd/forgejo/grafana/longhorn. Manifest regenerated via `astro-kbve:build` → `sync:ci-manifest` (no surgical edit).

## Test

After rollout, Studio (https://supabase.kbve.com/) requires Supabase JWT login + SUPERADMIN: a staff-but-not-superadmin user bounces to login; superadmin passes. Old Kong basic-auth is already removed (#13387).