### PR TITLE
feat(postgrest): upgrade to v14 + integration e2e against kilobase

### DIFF
--- a/apps/kube/postgrest/e2e/docker-compose.postgrest-e2e.yml
+++ b/apps/kube/postgrest/e2e/docker-compose.postgrest-e2e.yml
@@ -1,0 +1,24 @@
+services:
+    db:
+        image: ${KILOBASE_IMAGE:-kbve/kilobase:17.6.1.136-local}
+        container_name: pgrst-e2e-db
+        environment:
+            POSTGRES_PASSWORD: e2e
+        healthcheck:
+            test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+            interval: 3s
+            timeout: 5s
+            retries: 40
+
+    rest:
+        image: postgrest/postgrest:${POSTGREST_VERSION:-v14.12}
+        container_name: pgrst-e2e-rest
+        environment:
+            PGRST_DB_URI: postgres://authenticator:e2e@db:5432/postgres
+            PGRST_DB_SCHEMAS: public
+            PGRST_DB_ANON_ROLE: anon
+            PGRST_DB_USE_LEGACY_GUCS: 'false'
+            PGRST_SERVER_PORT: '3000'
+            PGRST_JWT_SECRET: 'e2e-postgrest-kilobase-secret-32chars!!'
+        ports:
+            - '3001:3000'

--- a/apps/kube/postgrest/e2e/run.sh
+++ b/apps/kube/postgrest/e2e/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Integration e2e: PostgREST v14 against our custom kilobase image.
+# Proves the major postgrest upgrade serves REST over kilobase 17.6:
+# schema introspection, anon read, query parsing, JWT role-switch write.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.postgrest-e2e.yml"
+SECRET='e2e-postgrest-kilobase-secret-32chars!!'
+BASE='http://localhost:3001'
+
+fail=0
+pass() { echo "  PASS $*"; }
+bad()  { echo "  FAIL $*"; fail=1; }
+
+cleanup() { $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+wait_db() {
+    for _ in $(seq 1 60); do
+        if $COMPOSE exec -T db psql -U supabase_admin -d postgres -tAc "SELECT 1" >/dev/null 2>&1; then return 0; fi
+        sleep 2
+    done
+    return 1
+}
+wait_rest() {
+    for _ in $(seq 1 40); do
+        if curl -fsS "$BASE/" >/dev/null 2>&1; then return 0; fi
+        sleep 2
+    done
+    return 1
+}
+
+echo "== boot kilobase db =="
+$COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+$COMPOSE up -d db
+wait_db || { echo "db never ready"; $COMPOSE logs --tail=40 db; exit 1; }
+
+echo "== seed test schema/roles (before postgrest caches it) =="
+$COMPOSE exec -T db psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 < setup.sql >/dev/null
+
+echo "== boot postgrest v14 =="
+$COMPOSE up -d rest
+wait_rest || { echo "postgrest never ready"; $COMPOSE logs --tail=40 rest; exit 1; }
+
+echo "== [1] postgrest serves + is v14 =="
+ver=$(curl -fsS -D - "$BASE/" -o /dev/null 2>/dev/null | grep -i '^Server:' | tr -d '\r' | awk '{print $2}')
+echo "    Server: $ver"
+case "$ver" in postgrest/14*|PostgREST/14*) pass "v14 serving over kilobase";; *) bad "unexpected Server header: $ver";; esac
+
+echo "== [2] schema introspection + anon read =="
+rows=$(curl -fsS "$BASE/e2e_items?order=id" 2>/dev/null)
+echo "    $rows"
+if echo "$rows" | grep -q '"name":"alpha"' && echo "$rows" | grep -q '"name":"beta"'; then pass "anon SELECT returns seeded rows"; else bad "anon read wrong: $rows"; fi
+
+echo "== [3] query parsing (filter) =="
+one=$(curl -fsS "$BASE/e2e_items?id=eq.1&select=name" 2>/dev/null)
+if [ "$one" = '[{"name":"alpha"}]' ]; then pass "filter+select works"; else bad "filter wrong: $one"; fi
+
+echo "== [4] JWT role-switch write (service_role insert) =="
+if command -v python3 >/dev/null 2>&1; then
+    tok=$(python3 - "$SECRET" <<'PY'
+import sys,hmac,hashlib,base64,json
+def b64(b): return base64.urlsafe_b64encode(b).rstrip(b'=')
+secret=sys.argv[1].encode()
+h=b64(json.dumps({"alg":"HS256","typ":"JWT"},separators=(',',':')).encode())
+p=b64(json.dumps({"role":"service_role"},separators=(',',':')).encode())
+s=b64(hmac.new(secret,h+b'.'+p,hashlib.sha256).digest())
+print((h+b'.'+p+b'.'+s).decode())
+PY
+)
+    code=$(curl -fsS -o /dev/null -w '%{http_code}' -X POST "$BASE/e2e_items" \
+        -H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
+        -d '{"id":3,"name":"gamma"}' 2>/dev/null || true)
+    cnt=$(curl -fsS "$BASE/e2e_items?select=id" 2>/dev/null | grep -o '"id"' | wc -l | tr -d ' ')
+    if [ "$code" = "201" ] && [ "$cnt" = "3" ]; then pass "service_role JWT insert (role switch works)"; else bad "JWT insert code=$code count=$cnt"; fi
+else
+    echo "  SKIP JWT test (python3 absent)"
+fi
+
+echo
+if [ "$fail" = "0" ]; then echo "POSTGREST E2E PASS"; else echo "POSTGREST E2E FAIL"; fi
+exit "$fail"

--- a/apps/kube/postgrest/e2e/setup.sql
+++ b/apps/kube/postgrest/e2e/setup.sql
@@ -1,0 +1,14 @@
+ALTER ROLE authenticator WITH LOGIN PASSWORD 'e2e';
+GRANT anon TO authenticator;
+
+CREATE TABLE IF NOT EXISTS public.e2e_items (
+    id   int PRIMARY KEY,
+    name text NOT NULL
+);
+TRUNCATE public.e2e_items;
+INSERT INTO public.e2e_items (id, name) VALUES (1, 'alpha'), (2, 'beta');
+
+GRANT USAGE ON SCHEMA public TO anon;
+GRANT SELECT ON public.e2e_items TO anon;
+GRANT INSERT ON public.e2e_items TO service_role;
+GRANT USAGE ON SCHEMA public TO service_role;

--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -23,7 +23,7 @@ spec:
             serviceAccountName: postgrest-sa
             containers:
                 - name: postgrest
-                  image: postgrest/postgrest:v13.0.4
+                  image: postgrest/postgrest:v14.12
                   command:
                       - postgrest
                   ports:


### PR DESCRIPTION
## What

Two birds, one stone: bump **PostgREST v13.0.4 → v14.12** (major) **and** add an integration e2e that proves it serves over our custom kilobase image.

## v14 breaking-change review — our config is clean

| v14 breaking change | Affects us? |
|---|---|
| `jwt-cache-max-lifetime` → `jwt-cache-max-entries` | No — we don't set it |
| `log-query` now boolean | No — we don't set it |
| PostgreSQL 12 support dropped | No — kilobase is 17.6 |
| even-only major versioning | informational |

`PGRST_DB_USE_LEGACY_GUCS=false` is already on the new GUCs. Nothing in `postgrest-deployment.yaml` env needs changing beyond the tag.

## Integration e2e (`apps/kube/postgrest/e2e/`)

Boots our kilobase image + postgrest v14 and asserts the upgrade actually works **against our database**, not a vanilla postgres:

1. `Server: postgrest/14.12` — v14 serving over kilobase
2. schema introspection + **anon SELECT** returns seeded rows
3. query parsing — `?id=eq.1&select=name`
4. **JWT service_role insert** — role switch via `PGRST_JWT_SECRET`, expects 201 + row count 3

Deterministic (2/2 green locally). Seeds roles/table **before** postgrest boots (it caches schema on start) and gates readiness on a real `supabase_admin` connection. `KILOBASE_IMAGE` / `POSTGREST_VERSION` overridable.

```
bash apps/kube/postgrest/e2e/run.sh
```

## Notes

- Depends on the kilobase 17.6 image (PR #13392) being available — e2e defaults to the local `kbve/kilobase:17.6.1.136-local` build; wire `KILOBASE_IMAGE` to the published ghcr tag once #13392 ships.
- ArgoCD tracks main; reaches cluster on next dev→main release. Stateless rollout, rollback = revert tag.