### PR TITLE
feat(kilobase): bundle pg_failover_slots in the 17.6 image

### DIFF
--- a/apps/kbve/kilobase/Dockerfile
+++ b/apps/kbve/kilobase/Dockerfile
@@ -1,10 +1,10 @@
 ####################
-# Stage 0: Build kilobase extension (pgrx, against pgdg server-dev-17)
+# Stage 0: Build kilobase extension (pgrx) + pg_failover_slots, against pgdg dev-17
 ####################
 FROM rust:bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl gnupg2 lsb-release ca-certificates \
+    curl gnupg2 lsb-release ca-certificates git make \
     libclang-dev pkg-config libssl-dev && \
     echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg && \
@@ -19,34 +19,50 @@ WORKDIR /build
 COPY . .
 
 RUN cargo pgrx package --pg-config /usr/bin/pg_config --features pg17 && \
-    echo "=== Build passed ==="
+    echo "=== kilobase build passed ==="
+
+# pg_failover_slots: vanilla supabase does NOT ship it, but it is in our
+# shared_preload_libraries (HA logical-slot failover) so the image must carry
+# the .so. v1.1.0 matches the version the prod image bundles.
+RUN git clone --depth 1 --branch v1.1.0 \
+        https://github.com/EnterpriseDB/pg_failover_slots.git /pgfs && \
+    make -C /pgfs PG_CONFIG=/usr/bin/pg_config && \
+    make -C /pgfs install PG_CONFIG=/usr/bin/pg_config && \
+    mkdir -p /pgfs-dist && \
+    cp "$(/usr/bin/pg_config --pkglibdir)/pg_failover_slots.so" /pgfs-dist/ && \
+    (cp "$(/usr/bin/pg_config --sharedir)/extension/"pg_failover_slots* /pgfs-dist/ 2>/dev/null || true) && \
+    echo "=== pg_failover_slots build passed ===" && ls -la /pgfs-dist
 
 ####################
-# Stage 1: Final image = Supabase base (alpine+nix) with kilobase installed
+# Stage 1: Final image = Supabase base (alpine+nix) with our extensions installed
 ####################
 FROM supabase/postgres:17.6.1.136
 
 USER root
 
 COPY --from=builder /build/target/release/kilobase-pg17 /kilobase-dist
+COPY --from=builder /pgfs-dist /pgfs-dist
 
 RUN set -eux; \
-    SO="$(find /kilobase-dist -name 'kilobase.so' | head -1)"; \
-    CTRL="$(find /kilobase-dist -name 'kilobase.control' | head -1)"; \
     MERGED_LIB="$(dirname "$(dirname "$(readlink -f "$(command -v pg_config)")")")/lib"; \
     PROFILE_LIB="$(readlink -f "$(dirname "$(dirname "$(pg_config --sharedir)")")/lib")"; \
     EXTDIR="$(readlink -f "$(pg_config --sharedir)/extension")"; \
+    KILO_SO="$(find /kilobase-dist -name 'kilobase.so' | head -1)"; \
+    KILO_CTRL="$(find /kilobase-dist -name 'kilobase.control' | head -1)"; \
+    PGFS_SO="$(find /pgfs-dist -name 'pg_failover_slots.so' | head -1)"; \
     for D in "$MERGED_LIB" "$PROFILE_LIB"; do \
         test -e "$D/plpgsql.so" || continue; \
-        chmod u+w "$D"; cp "$SO" "$D/"; chmod 755 "$D/kilobase.so"; \
+        chmod u+w "$D"; \
+        cp "$KILO_SO" "$D/"; chmod 755 "$D/kilobase.so"; \
+        cp "$PGFS_SO" "$D/"; chmod 755 "$D/pg_failover_slots.so"; \
     done; \
     chmod u+w "$EXTDIR"; \
-    cp "$CTRL" "$EXTDIR/"; \
+    cp "$KILO_CTRL" "$EXTDIR/"; \
     find /kilobase-dist -name 'kilobase*.sql' -exec cp {} "$EXTDIR/" \; ; \
-    rm -rf /kilobase-dist; \
+    find /pgfs-dist \( -name 'pg_failover_slots*.control' -o -name 'pg_failover_slots*.sql' \) -exec cp {} "$EXTDIR/" \; ; \
+    rm -rf /kilobase-dist /pgfs-dist; \
     echo "=== Final verification ==="; \
     pg_config --version; \
-    echo "merged_lib=$MERGED_LIB"; echo "profile_lib=$PROFILE_LIB"; echo "extdir=$EXTDIR"; \
-    ls -la "$EXTDIR" | grep kilobase
+    ls -la "$MERGED_LIB" | grep -E 'kilobase|failover'
 
 USER postgres

--- a/apps/kbve/kilobase/scripts/upgrade_rehearsal.sh
+++ b/apps/kbve/kilobase/scripts/upgrade_rehearsal.sh
@@ -103,7 +103,10 @@ verify() {
     if [ "$uid" = "$img_uid" ] && [ "$gid" = "$img_gid" ]; then
         echo "  ok   uid/gid match"
     else
-        echo "  MISMATCH -> set postgresUID:$img_uid postgresGID:$img_gid in postgres-cluster.yaml AND chown the PGDATA volume $uid:$gid -> $img_uid:$img_gid at cutover"
+        echo "  MISMATCH -> postgresUID/GID are IMMUTABLE on an existing CNPG cluster (webhook"
+        echo "             rejects edits). Image needs $img_uid:$img_gid, cluster locked at $uid:$gid"
+        echo "             -> requires a NEW cluster (blue-green) + data migration + service flip,"
+        echo "             NOT an in-place edit."
     fi
 }
 


### PR DESCRIPTION
## What

Builds **pg_failover_slots v1.1.0** into the kilobase 17.6 image — the one remaining image-level blocker for replacing the prod `ghcr.io/kbve/postgres:17.4.1.069-kilobase` with an in-house build.

## Why

Vanilla `supabase/postgres` does **not** ship `pg_failover_slots`, but it's in our `shared_preload_libraries` (HA logical-slot failover — confirmed a live logical slot `cainophile_…` rides on it in prod). Without the `.so`, the postmaster **FATALs** on boot. The prod image bundles v1.1.0; we now build the same from source (pgdg server-dev-17) and install it alongside `kilobase.so` into the wrapped postmaster's real `$libdir`.

Verified — rehearsal `verify` against the new image reports full preload coverage:
```
ok pg_stat_statements … ok kilobase  ok pg_failover_slots
```

## The uid blocker is NOT in this PR — it can't be a manifest edit

Server-side dry-run proved `postgresUID`/`postgresGID` are **immutable**:
```
spec.postgresUID: Invalid value: 100: UID is an immutable field in the spec
```
Supabase moved the postgres user 101:102 → 100:101 between 17.4 and 17.6, so the in-house 17.6 image needs uid 100, but the existing cluster is locked at 101. **In-place upgrade is impossible** → requires a **new cluster (blue-green) + data migration**. The rehearsal's guidance is updated to say so. The blue-green rollout is a separate change.

## Status

Image is now a complete drop-in (preload-wise) for the 17.4 prod image. Remaining work is the blue-green cluster cutover (new cluster, uid 100, data migration, service-alias flip), tracked separately.