### PR TITLE
feat(kilobase): stable DB service aliases for blue-green cutover

### DIFF
--- a/apps/kube/kilobase/manifests/stable-db-services.yaml
+++ b/apps/kube/kilobase/manifests/stable-db-services.yaml
@@ -1,0 +1,58 @@
+# Stable DB service aliases — decouple consumers from CNPG-generated cluster
+# service names so a future blue-green cutover is a one-line selector flip
+# (cnpg.io/cluster: supabase-cluster -> supabase-cluster-v2) with zero consumer
+# changes. Selectors mirror the CNPG -rw/-ro/-r services exactly. Additive and
+# harmless: currently resolve to the same pods as supabase-cluster-{rw,ro,r}.
+apiVersion: v1
+kind: Service
+metadata:
+    name: kilobase-rw
+    namespace: kilobase
+    labels:
+        app: kilobase-db-alias
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        cnpg.io/cluster: supabase-cluster
+        cnpg.io/instanceRole: primary
+    ports:
+        - name: postgres
+          port: 5432
+          targetPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: kilobase-ro
+    namespace: kilobase
+    labels:
+        app: kilobase-db-alias
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        cnpg.io/cluster: supabase-cluster
+        cnpg.io/instanceRole: replica
+    ports:
+        - name: postgres
+          port: 5432
+          targetPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: kilobase-r
+    namespace: kilobase
+    labels:
+        app: kilobase-db-alias
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        cnpg.io/cluster: supabase-cluster
+        cnpg.io/podRole: instance
+    ports:
+        - name: postgres
+          port: 5432
+          targetPort: 5432


### PR DESCRIPTION
## What

Adds `kilobase-rw` / `kilobase-ro` / `kilobase-r` Services in ns `kilobase`, selectors mirroring the CNPG-generated `supabase-cluster-{rw,ro,r}`.

Validated against the live cluster (server dry-run):
- `kilobase-rw` → `supabase-cluster-2` (primary)
- `kilobase-ro` → `supabase-cluster-8`, `-9` (replicas)

Additive and harmless today — they point at the same pods as the existing services.

## Why

The 17.6 upgrade can't be in-place (`postgresUID` is immutable — webhook-confirmed), so it needs a **new cluster** (blue-green). A new cluster gets new CNPG service DNS, which would break the **~18 consumers** that hardcode `supabase-cluster-rw.kilobase.svc`.

These stable aliases let consumers depend on a name we own. After consumers repoint to `kilobase-rw/ro`, the eventual cutover is a **one-line selector flip** (`cnpg.io/cluster: supabase-cluster` → `supabase-cluster-v2`) — instant, zero consumer edits.

## Not in this PR

The consumer repoint (~22 files across ~18 apps, mostly ExternalSecret `DATABASE_URL` templates) is a separate, staged change — each app re-renders its secret and needs a pod reload. Sequencing TBD.