### PR TITLE
chore(kilobase): publish 17.6.1 image (version bump)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kilobase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kilobase.mdx
@@ -11,7 +11,7 @@ tags:
 key: kilobase
 pipeline: docker
 app_name: kilobase
-version: "17.4.1"
+version: "17.6.1"
 source_path: apps/kbve/kilobase
 runner: ubuntu-latest
 image: kbve/kilobase


### PR DESCRIPTION
One-line version bump so CI publishes `ghcr.io/kbve/kilobase:17.6.1` from the merged 17.6 Dockerfile (supabase 17.6.1.136 + kilobase + pg_failover_slots).

Re-lands the bump that **stranded** off #13412 — the squash-merge + branch-delete dropped the follow-up commit, leaving main/dev at `17.4.1` while the Dockerfile is already the complete 17.6 image. Without this the image would publish under the wrong `17.4.1` tag.

`ci-docker` reads the tag straight from this MDX `version:`; kilobase has no `deployment_yamls` in ci-dispatch, so publishing **does not touch the live prod cluster** — the image just becomes available for the blue-green v2 cluster to pull.