### PR TITLE
fix(discordsh): resolve Discord mention snowflakes to names in IRC relay

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/mention.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mention.rs
@@ -1,0 +1,91 @@
+//! Resolve a Discord snowflake to the canonical KBVE username.
+//!
+//! Discord rewrites a typed `@name` into the wire token `<@snowflake>`. When
+//! relaying to IRC we want the mentioned user's KBVE handle (so it matches who
+//! they are in-game), not their Discord display name. The
+//! `tracker.find_claim_identity_by_discord_id` RPC joins `auth.identities`
+//! (the linked Discord account) to `profile.username`; we call it over
+//! PostgREST and cache the result in Valkey so a busy channel doesn't hit
+//! Supabase on every message. A miss (unlinked account, or no username set) is
+//! cached too, and the relay falls back to the Discord display name.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use jedi::state::kv::KvCache;
+use serde::Deserialize;
+
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+pub struct MentionResolver {
+    http: reqwest::Client,
+    rpc_url: String,
+    service_key: String,
+    kv: Arc<KvCache>,
+}
+
+#[derive(Deserialize)]
+struct IdentityRow {
+    kbve_username: Option<String>,
+}
+
+impl MentionResolver {
+    /// Build from env. `None` when Supabase isn't configured, in which case
+    /// the relay keeps using the Discord display name.
+    pub fn from_env(kv: Arc<KvCache>) -> Option<Self> {
+        let base = std::env::var("SUPABASE_URL").ok()?;
+        let service_key = std::env::var("SUPABASE_SERVICE_ROLE_KEY").ok()?;
+        if base.trim().is_empty() || service_key.trim().is_empty() {
+            return None;
+        }
+        let rpc_url = format!(
+            "{}/rest/v1/rpc/find_claim_identity_by_discord_id",
+            base.trim_end_matches('/')
+        );
+        Some(Self {
+            http: reqwest::Client::new(),
+            rpc_url,
+            service_key,
+            kv,
+        })
+    }
+
+    /// Return the KBVE username linked to `snowflake`, or `None` when the
+    /// account isn't linked / has no username. Cached (positive and negative)
+    /// in Valkey for [`CACHE_TTL`].
+    pub async fn kbve_username(&self, snowflake: &str) -> Option<String> {
+        if snowflake.is_empty() || !snowflake.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let key = format!("discord:uname:{snowflake}");
+        let sf = snowflake.to_owned();
+        let this = self;
+        this.kv
+            .get_or_fetch_json::<Option<String>, _, _>(&key, Some(CACHE_TTL), || async move {
+                Ok(this.lookup(&sf).await)
+            })
+            .await
+            .ok()
+            .flatten()
+    }
+
+    async fn lookup(&self, snowflake: &str) -> Option<String> {
+        let resp = self
+            .http
+            .post(&self.rpc_url)
+            .header("apikey", &self.service_key)
+            .header("Authorization", format!("Bearer {}", self.service_key))
+            .header("Content-Profile", "tracker")
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "p_discord_id": snowflake }))
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            tracing::warn!(status = %resp.status(), "discord mention lookup failed");
+            return None;
+        }
+        let rows: Vec<IdentityRow> = resp.json().await.ok()?;
+        rows.into_iter().next().and_then(|r| r.kbve_username)
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -10,6 +10,7 @@ pub mod gh_sync;
 pub mod github;
 pub mod github_cache;
 pub mod github_permissions;
+pub mod mention;
 pub mod n8n;
 pub mod relay;
 pub mod scheduler;

--- a/apps/discordsh/discordsh-bot/src/discord/relay.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/relay.rs
@@ -23,7 +23,8 @@ pub async fn handle_discord_message(message: &serenity::Message, app: &Arc<AppSt
         return;
     }
 
-    let content = sanitize(&message.content);
+    let resolved = resolve_user_mentions(&message.content, &message.mentions);
+    let content = sanitize(&resolved);
     if content.is_empty() {
         return;
     }
@@ -134,6 +135,35 @@ fn platform_tag(platform: &str) -> String {
     }
 }
 
+fn resolve_user_mentions(content: &str, mentions: &[serenity::User]) -> String {
+    resolve_mentions_inner(
+        content,
+        mentions.iter().map(|user| {
+            let display = user
+                .global_name
+                .clone()
+                .unwrap_or_else(|| user.name.clone());
+            (user.id.to_string(), display)
+        }),
+    )
+}
+
+fn resolve_mentions_inner<I>(content: &str, pairs: I) -> String
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    if !content.contains("<@") {
+        return content.to_owned();
+    }
+    let mut out = content.to_owned();
+    for (id, display) in pairs {
+        out = out
+            .replace(&format!("<@{id}>"), &format!("@{display}"))
+            .replace(&format!("<@!{id}>"), &format!("@{display}"));
+    }
+    out
+}
+
 fn sanitize(input: &str) -> String {
     let stripped = input.trim();
     if stripped.is_empty() {
@@ -188,6 +218,34 @@ mod tests {
     fn forwarder_passes_chat_from_irc() {
         let msg = ChatMessage::chat("Bob", "irc", "#kbve", "hello there");
         assert!(should_forward_irc(&msg, "#kbve"));
+    }
+
+    fn pair(id: &str, name: &str) -> (String, String) {
+        (id.to_owned(), name.to_owned())
+    }
+
+    #[test]
+    fn resolves_user_mention_to_name() {
+        let out = resolve_mentions_inner(
+            "hey <@123> and <@!456> there",
+            [pair("123", "Alice"), pair("456", "Bob")],
+        );
+        assert_eq!(out, "hey @Alice and @Bob there");
+    }
+
+    #[test]
+    fn resolve_leaves_unknown_mentions_untouched() {
+        let out = resolve_mentions_inner("ping <@999>", [pair("123", "Alice")]);
+        assert_eq!(out, "ping <@999>");
+    }
+
+    #[test]
+    fn resolved_mention_is_neutralised_by_sanitize() {
+        let resolved = resolve_mentions_inner("yo <@123>", [pair("123", "Alice")]);
+        let out = sanitize(&resolved);
+        assert!(!out.contains('@'));
+        assert!(out.contains("Alice"));
+        assert!(!out.contains("<"));
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/relay.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/relay.rs
@@ -23,7 +23,7 @@ pub async fn handle_discord_message(message: &serenity::Message, app: &Arc<AppSt
         return;
     }
 
-    let resolved = resolve_user_mentions(&message.content, &message.mentions);
+    let resolved = resolve_user_mentions(&message.content, &message.mentions, app).await;
     let content = sanitize(&resolved);
     if content.is_empty() {
         return;
@@ -135,17 +135,33 @@ fn platform_tag(platform: &str) -> String {
     }
 }
 
-fn resolve_user_mentions(content: &str, mentions: &[serenity::User]) -> String {
-    resolve_mentions_inner(
-        content,
-        mentions.iter().map(|user| {
-            let display = user
-                .global_name
-                .clone()
-                .unwrap_or_else(|| user.name.clone());
-            (user.id.to_string(), display)
-        }),
-    )
+async fn resolve_user_mentions(
+    content: &str,
+    mentions: &[serenity::User],
+    app: &Arc<AppState>,
+) -> String {
+    if !content.contains("<@") {
+        return content.to_owned();
+    }
+    let mut pairs = Vec::with_capacity(mentions.len());
+    for user in mentions {
+        let discord_name = user
+            .global_name
+            .clone()
+            .unwrap_or_else(|| user.name.clone());
+        let id = user.id.to_string();
+        // Prefer the KBVE username linked to the Discord account; fall back to
+        // the Discord display name when unlinked / no username / no resolver.
+        let display = match app.mentions.as_ref() {
+            Some(resolver) => resolver
+                .kbve_username(&id)
+                .await
+                .unwrap_or(discord_name),
+            None => discord_name,
+        };
+        pairs.push((id, display));
+    }
+    resolve_mentions_inner(content, pairs)
 }
 
 fn resolve_mentions_inner<I>(content: &str, pairs: I) -> String

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -40,6 +40,7 @@ impl RelayConfig {
 use crate::discord::game::{ProfileStore, SessionStore};
 use crate::discord::github_cache::GitHubCache;
 use crate::discord::github_permissions::GitHubCommandGuard;
+use crate::discord::mention::MentionResolver;
 use crate::discord::n8n::N8nConfig;
 use crate::health::HealthMonitor;
 use crate::tracker::ShardTracker;
@@ -106,6 +107,11 @@ pub struct AppState {
     pub irc: Option<ChatClient>,
 
     pub relay: Option<RelayConfig>,
+
+    /// Resolves Discord snowflakes to KBVE usernames for relayed mentions.
+    /// `None` when Supabase isn't configured; the relay then falls back to the
+    /// Discord display name.
+    pub mentions: Option<Arc<MentionResolver>>,
 
     /// Guards against spawning per-`Ready` background workers more than once.
     /// The `Ready` event fires once per shard, so these ensure a single
@@ -242,6 +248,12 @@ impl AppState {
         // Shared L1+L2 cache (Valkey via KBVE_KV_URL when set, else L1-only) for
         // the gh reverse-sync lookups. Same namespace/Valkey as other services.
         let kv_cache = jedi::state::kv::KvCache::from_env().await;
+        let mentions = MentionResolver::from_env(kv_cache.clone()).map(Arc::new);
+        if mentions.is_none() {
+            tracing::info!(
+                "Mention resolver disabled (no Supabase) — relayed mentions use Discord names"
+            );
+        }
 
         Self {
             health_monitor,
@@ -262,6 +274,7 @@ impl AppState {
             github_store: Arc::new(GithubStore::from_env().with_kv(Some(kv_cache))),
             irc,
             relay,
+            mentions,
             irc_forwarder_started: AtomicBool::new(false),
             github_board_scheduler_started: AtomicBool::new(false),
             gh_sync_worker_started: AtomicBool::new(false),


### PR DESCRIPTION
## Problem

When a Discord user types `@name`, Discord rewrites it in `message.content` to the wire token `<@snowflake>` (e.g. `<@123456789>`). The Discord → IRC relay forwarded that raw token, so IRC/game-chat users saw a meaningless numeric id. And a Discord display name is **not** the user's KBVE handle, so we resolve to the canonical KBVE username instead.

## Fix

- `resolve_user_mentions` rewrites `<@id>` / `<@!id>` tokens to `@display`, then `sanitize` neutralises the `@` to a full-width `＠` so the relayed text can't ping IRC users. `resolve_mentions_inner` stays a pure, tested string transform.
- `MentionResolver` maps the snowflake → `profile.username` via `tracker.find_claim_identity_by_discord_id` (PostgREST RPC, service-role), cached in **Valkey for 5 min** (positive *and* negative) via `KvCache::get_or_fetch_json` so a busy channel doesn't hit Supabase per message.
- **Fallback** to the Discord display name when the account is unlinked, has no username set, or Supabase/Valkey isn't configured (resolver is `None`).
- Unknown `<@id>` tokens not in `message.mentions` are left untouched.

## Tests

Unit tests on `resolve_mentions_inner`: name resolution, unknown-id passthrough, sanitize interaction. Full relay suite green (9 passed). Crate compiles with the new resolver + AppState wiring.