### PR TITLE
feat(auth): OAuth consent page for the Supabase OAuth/OIDC server

### DIFF
--- a/apps/kbve/astro-kbve/src/components/auth/AstroConsent.astro
+++ b/apps/kbve/astro-kbve/src/components/auth/AstroConsent.astro
@@ -1,0 +1,78 @@
+---
+import ReactOAuthConsent from './ReactOAuthConsent';
+---
+
+<ReactOAuthConsent client:only="react" />
+
+<style is:global>
+	.auth-container {
+		text-align: center;
+		padding: 3rem 1rem;
+	}
+	.spinner {
+		width: 50px;
+		height: 50px;
+		margin: 0 auto 20px;
+		border: 4px solid var(--sl-color-accent-low);
+		border-top-color: var(--sl-color-accent);
+		border-radius: 50%;
+		animation: spin 1s linear infinite;
+	}
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+	.message {
+		font-size: 18px;
+		margin-bottom: 10px;
+		color: var(--sl-color-text);
+	}
+	.sub-message {
+		font-size: 14px;
+		opacity: 0.8;
+		color: var(--sl-color-text);
+	}
+	.consent-scopes {
+		list-style: none;
+		padding: 0;
+		margin: 16px auto;
+		max-width: 320px;
+		text-align: left;
+	}
+	.consent-scopes li {
+		font-size: 14px;
+		color: var(--sl-color-text);
+		padding: 6px 0 6px 24px;
+		position: relative;
+	}
+	.consent-scopes li::before {
+		content: '✓';
+		position: absolute;
+		left: 0;
+		color: var(--sl-color-accent);
+		font-weight: 700;
+	}
+	.consent-actions {
+		display: flex;
+		gap: 12px;
+		margin-top: 20px;
+	}
+	.consent-btn {
+		padding: 8px 20px;
+		border-radius: 6px;
+		font-size: 14px;
+		font-weight: 600;
+		cursor: pointer;
+		border: 1px solid var(--sl-color-gray-5);
+	}
+	.consent-approve {
+		background: var(--sl-color-accent);
+		color: var(--sl-color-black);
+		border-color: var(--sl-color-accent);
+	}
+	.consent-deny {
+		background: transparent;
+		color: var(--sl-color-text);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/auth/ReactOAuthConsent.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactOAuthConsent.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { authBridge } from '@/components/auth';
+import { SUPABASE_URL } from '@/lib/supa';
+import { cn } from '@/lib/utils';
+
+const OAUTH_BASE = `${SUPABASE_URL}/auth/v1/oauth/authorizations`;
+
+type Phase = 'loading' | 'consent' | 'working' | 'error';
+
+const SCOPE_LABELS: Record<string, string> = {
+	openid: 'Confirm your identity',
+	email: 'Your email address',
+	profile: 'Your basic profile',
+	phone: 'Your phone number',
+};
+
+export default function ReactOAuthConsent() {
+	const [phase, setPhase] = useState<Phase>('loading');
+	const [message, setMessage] = useState('Loading authorization request...');
+	const [subMessage, setSubMessage] = useState('Please wait');
+	const [clientName, setClientName] = useState('an application');
+	const [scopes, setScopes] = useState<string[]>([]);
+	const [authId, setAuthId] = useState('');
+	const [token, setToken] = useState('');
+
+	useEffect(() => {
+		const run = async () => {
+			const id = new URLSearchParams(window.location.search).get(
+				'authorization_id',
+			);
+			if (!id) {
+				setPhase('error');
+				setMessage('Invalid authorization request');
+				setSubMessage('Missing authorization_id.');
+				return;
+			}
+			setAuthId(id);
+
+			let session = null;
+			try {
+				session = await authBridge.getSession();
+			} catch {
+				session = null;
+			}
+			if (!session?.access_token) {
+				const here = window.location.pathname + window.location.search;
+				window.location.href = `/login?redirect_to=${encodeURIComponent(
+					`https://kbve.com${here}`,
+				)}`;
+				return;
+			}
+			setToken(session.access_token);
+
+			const res = await fetch(`${OAUTH_BASE}/${id}`, {
+				headers: { Authorization: `Bearer ${session.access_token}` },
+			});
+			if (!res.ok) {
+				setPhase('error');
+				setMessage('Authorization request not found');
+				setSubMessage('It may have expired — try signing in again.');
+				return;
+			}
+			const data = await res.json();
+			if (data.redirect_url) {
+				setPhase('working');
+				setMessage('Redirecting...');
+				window.location.href = data.redirect_url;
+				return;
+			}
+			setClientName(data.client?.name || 'an application');
+			setScopes(
+				Array.from(
+					new Set(
+						String(data.scope || '')
+							.split(/\s+/)
+							.filter(Boolean),
+					),
+				),
+			);
+			setPhase('consent');
+		};
+		run().catch(() => {
+			setPhase('error');
+			setMessage('Something went wrong');
+			setSubMessage('Please try signing in again.');
+		});
+	}, []);
+
+	const decide = async (action: 'approve' | 'deny') => {
+		setPhase('working');
+		setMessage(action === 'approve' ? 'Authorizing...' : 'Cancelling...');
+		setSubMessage('Please wait');
+		try {
+			const res = await fetch(`${OAUTH_BASE}/${authId}/consent`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ action }),
+			});
+			const data = await res.json();
+			if (data.redirect_url) {
+				window.location.href = data.redirect_url;
+				return;
+			}
+			setPhase('error');
+			setMessage('No redirect from the authorization server');
+			setSubMessage('Please try again.');
+		} catch {
+			setPhase('error');
+			setMessage('Failed to submit your decision');
+			setSubMessage('Please try again.');
+		}
+	};
+
+	if (phase === 'consent') {
+		return (
+			<div
+				className={cn(
+					'auth-container',
+					'min-h-[200px] sm:min-h-[250px] md:min-h-[300px]',
+					'flex flex-col items-center justify-center',
+				)}>
+				<div className="message">Authorize {clientName}</div>
+				<div className="sub-message">
+					{clientName} wants to sign you in with your KBVE account.
+				</div>
+				{scopes.length > 0 && (
+					<ul className="consent-scopes">
+						{scopes.map((s) => (
+							<li key={s}>{SCOPE_LABELS[s] || s}</li>
+						))}
+					</ul>
+				)}
+				<div className="consent-actions">
+					<button
+						type="button"
+						className="consent-btn consent-approve"
+						onClick={() => decide('approve')}>
+						Authorize
+					</button>
+					<button
+						type="button"
+						className="consent-btn consent-deny"
+						onClick={() => decide('deny')}>
+						Cancel
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn(
+				'auth-container',
+				'min-h-[200px] sm:min-h-[250px] md:min-h-[300px]',
+				'flex flex-col items-center justify-center',
+			)}>
+			{(phase === 'loading' || phase === 'working') && (
+				<div className="spinner"></div>
+			)}
+			<div className="message">{message}</div>
+			<div className="sub-message">{subMessage}</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/auth/consent.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/auth/consent.mdx
@@ -1,0 +1,35 @@
+---
+title: Authorize
+description: OAuth 2.1 consent screen for signing into third-party apps with your KBVE account.
+tableOfContents: false
+graph:
+  visible: false
+sidebar:
+  label: Authorize
+  order: 4
+image:
+  src: https://images.unsplash.com/photo-1555066931-4365d14bab8c?fit=crop&w=1400&h=700&q=75
+  alt: Secure authorization interface
+  credit: Unsplash
+tags:
+  - authentication
+  - oauth
+  - consent
+  - security
+  - webmaster
+---
+
+import AstroConsent from '@/components/auth/AstroConsent.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+<AstroConsent />
+
+## OAuth Authorization
+
+This page is the consent screen for KBVE's OAuth 2.1 / OpenID Connect provider (Supabase Auth). When a third-party application — such as Forgejo at [git.kbve.com](https://git.kbve.com) — asks to sign you in with your KBVE account, you are sent here to review and approve the request.
+
+<Aside type="note">
+You must be signed in to your KBVE account to authorize an application. If you are not, you will be redirected to the login page and returned here afterward.
+</Aside>
+
+The authorization server passes an `authorization_id` to this page. The consent screen reads it, shows which application is requesting access and what it will receive, and on approval hands you back to the application with a one-time authorization code.

--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -44,6 +44,8 @@ spec:
                         value: https://kbve.com
                       - name: GOTRUE_OAUTH_SERVER_ENABLED
                         value: 'true'
+                      - name: GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH
+                        value: /auth/consent
                       - name: GOTRUE_JWT_ISSUER
                         value: https://supabase.kbve.com/auth/v1
                       - name: GOTRUE_URI_ALLOW_LIST


### PR DESCRIPTION
The final piece of Supabase-as-OIDC-provider. Forgejo login currently dies at the authorize step with `server_error: oauth authorization path not configured`.

## Why
Self-hosted Supabase's OAuth server ships **no consent UI**. GoTrue's `/oauth/authorize` redirects the user to `SiteURL + GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH?authorization_id=…` and expects *us* to host the "Authorize [App]?" screen there (hosted Supabase has it in their dashboard). The path was unset → error.

## What
- **GoTrue**: `GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH=/auth/consent` (SiteURL is `https://kbve.com`)
- **astro-kbve**: `/auth/consent` page (`content/docs/auth/consent.mdx`) + `ReactOAuthConsent` island, mirroring the existing `ReactAuthCallback` patterns (authBridge, `cn`, Starlight styles)

### Flow
1. `/oauth/authorize` → redirects user to `https://kbve.com/auth/consent?authorization_id=X`
2. Island gets the user's Supabase session; not signed in → `/login?redirect_to=…` and back
3. `GET /auth/v1/oauth/authorizations/{id}` (Bearer) → if already consented returns `{redirect_url}` (auto-redirect); else `{client:{name}, scope}` to render
4. Approve/Deny → `POST …/consent {"action":"approve"|"deny"}` → `{redirect_url}` → navigate (→ Forgejo callback with code)

Calls go through the open `/auth/v1/oauth` Kong route with the user's own Bearer — **no axum-kbve proxy needed**. Component typechecks clean.

## After release
GoTrue redirects to the consent page → approve → Forgejo logs you in. Then: fix the register-job redirect_uri manifest (git.kbve.com) + clean the 12 orphaned oauth_clients.