### PR TITLE
feat(forgejo): allow up to 500MB Git LFS uploads

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -56,6 +56,7 @@ spec:
                               SSH_LISTEN_PORT: 2222
                               LFS_START_SERVER: true
                               LFS_JWT_SECRET: ''
+                              LFS_MAX_FILE_SIZE: 524288000
                           database:
                               DB_TYPE: postgres
                               HOST: kilobase-rw.kilobase.svc.cluster.local:5432


### PR DESCRIPTION
Sets `[server] LFS_MAX_FILE_SIZE = 524288000` (500 MiB) in the forgejo Helm config (`apps/kube/forgejo/application.yaml`, `gitea.config.server`).

- `LFS_MAX_FILE_SIZE` is the LFS-specific per-file cap (bytes). Default `0` = unlimited at the app layer; this sets an explicit 500MB limit.
- `[repository.upload] FILE_MAX_SIZE` is intentionally untouched — that governs web-UI uploads, not Git LFS.

**Heads-up:** LFS pushes also go through the gateway + `forgejo-gate` proxy. If 500MB pushes still fail at the edge after this, the gateway/gate request-body limit needs raising too — `app.ini` only governs forgejo itself. Tracks `main`, so live after the dev→main release.