### PR TITLE
feat(forgejo): serve direct.git.kbve.com for large LFS (bypass Cloudflare)

### DIFF
--- a/apps/kube/forgejo/manifest/httproute.yaml
+++ b/apps/kube/forgejo/manifest/httproute.yaml
@@ -16,6 +16,10 @@ spec:
         # at forgejo.kbve.com keeps working while new pushes can target
         # git.kbve.com directly.
         - git.kbve.com
+        # direct.git.kbve.com is DNS-only (grey-cloud, straight to the Cilium
+        # gateway) so large Git LFS pushes bypass Cloudflare's request-body cap.
+        # Same backend rules as git.kbve.com; git/LFS paths still bypass the gate.
+        - direct.git.kbve.com
     rules:
         # Forgejo REST API (token auth, CI, deploy keys) - bypass gate for API token auth
         - matches:

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -41,6 +41,21 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        # direct.git.kbve.com — DNS-only (grey-cloud) host for Forgejo git/LFS,
+        # bypassing Cloudflare's request-body cap so large LFS pushes reach the
+        # gateway. Two labels under kbve.com, so the *.kbve.com wildcard cert
+        # doesn't cover it — own listener + cert-manager-issued cert.
+        - name: https-direct-git
+          protocol: HTTPS
+          port: 443
+          hostname: direct.git.kbve.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - name: direct-git-tls
+          allowedRoutes:
+              namespaces:
+                  from: All
         - name: https-memes
           protocol: HTTPS
           port: 443


### PR DESCRIPTION
Completes the grey-cloud LFS path. `direct.git.kbve.com` DNS is already DNS-only → Cilium gateway `142.132.206.71`, bypassing Cloudflare's request-body cap (100MB non-Enterprise) so 500MB Git LFS pushes can reach Forgejo.

**DNS alone wasn't working** — `curl https://direct.git.kbve.com/` returned `404 + ssl_verify=20`:
- the `*.kbve.com` wildcard cert doesn't cover a two-label host (`direct.git`)
- no gateway listener / HTTPRoute hostname matched it → 404

## Changes
- **kbve-gateway**: new `https-direct-git` listener (hostname `direct.git.kbve.com`, cert `direct-git-tls`). cert-manager's gateway-shim auto-issues the cert via the gateway's `letsencrypt-dns` cluster-issuer (DNS-01 — unaffected by grey-cloud proxy status).
- **forgejo httproute**: add `direct.git.kbve.com` to hostnames — same backend rules as `git.kbve.com`, so git/LFS paths (`/KBVE/`, `/api/`, `/v2/`, `/-/`) still bypass the gate straight to `forgejo-http:3000`.

## Pairs with
#13424 (`LFS_MAX_FILE_SIZE=500MB`) — that lets the app accept 500MB; this lets it actually arrive.

## After release
cert-manager issues `direct-git-tls` (watch the Certificate go Ready), then `https://direct.git.kbve.com` serves Forgejo with TLS. Point LFS remotes there for >100MB objects.