### PR TITLE
fix(forgejo): register oauth client with git.kbve.com redirect_uri

### DIFF
--- a/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml
@@ -106,7 +106,7 @@ spec:
                             -d '{
                               "client_name": "Forgejo KBVE",
                               "client_type": "confidential",
-                              "redirect_uris": ["https://forgejo.kbve.com/user/oauth2/kbve/callback"],
+                              "redirect_uris": ["https://git.kbve.com/user/oauth2/kbve/callback", "https://forgejo.kbve.com/user/oauth2/kbve/callback"],
                               "token_endpoint_auth_method": "client_secret_post"
                             }')
 


### PR DESCRIPTION
Persistence fix. Forgejo's `ROOT_URL` is `git.kbve.com`, so its OAuth callback is `https://git.kbve.com/user/oauth2/kbve/callback`. The `forgejo-oauth-register` job hardcoded only `forgejo.kbve.com` → `invalid redirect_uri` on login.

The **live client was already patched** via `PUT /admin/oauth/clients/{id}` (both hosts). This updates the manifest so a re-registration (creds secret deleted → job re-runs) registers the correct URIs instead of reverting to the broken one.

Registers both `git.kbve.com` (primary, ROOT_URL) + `forgejo.kbve.com` (the HTTPRoute serves both). Idempotent job skips if the secret already exists, so this only takes effect on a fresh registration.