### PR TITLE
fix(forgejo): bypass SSO gate for OAuth login paths

### DIFF
--- a/apps/kube/forgejo/manifest/httproute.yaml
+++ b/apps/kube/forgejo/manifest/httproute.yaml
@@ -53,6 +53,21 @@ spec:
           backendRefs:
               - name: forgejo-http
                 port: 3000
+        # Forgejo's own auth handshake must bypass the SSO gate — you can't pass
+        # the gate to reach the login that gets you past the gate. /user/login +
+        # /user/oauth2/* (OAuth init + callback) go straight to forgejo so the
+        # "Sign in with KBVE" flow can complete and set the forgejo session.
+        # Gated content (repos, dashboard) still routes through the gate below.
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /user/login
+              - path:
+                    type: PathPrefix
+                    value: /user/oauth2/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
         # Web UI - route through gate for SSO authentication
         - matches:
               - path:


### PR DESCRIPTION
**Bug:** "Sign in with KBVE" never completes — you click Authorize, get redirected to `https://git.kbve.com/user/oauth2/kbve/callback?code=…`, and land back home not logged in.

**Root cause (confirmed in gate logs):**
```
gate deny 401 missing token path=.../user/oauth2/kbve/callback
gate deny 401 missing token path=.../user/login
```
Forgejo's auth endpoints (`/user/login`, `/user/oauth2/*`) fall under the `/` catch-all → `forgejo-gate` (Supabase `is_staff` SSO), which 401s them. The OAuth callback carries the `code` but never reaches forgejo → no token exchange → no session. Chicken-and-egg: you can't pass the gate to reach the login that gets you past the gate. (ENV + Kong + cookies all verified fine — it's purely routing.)

**Fix:** route `/user/login` + `/user/oauth2/` straight to `forgejo-http:3000` (bypass gate), same as `/api/`, `/KBVE/` already do. Gated content (repos, dashboard at `/`) still routes through the gate.

**Note:** after login completes, accessing `/` still requires a gate Supabase session (`is_staff`) — that's the existing edge gate, unchanged. If the OAuth flow should also seed the gate session, that's a follow-up; this PR unblocks the forgejo login itself.