### PR TITLE
fix(studio): set POSTGRES_* so pg-meta queries hit the real DB

### DIFF
--- a/apps/kube/studio/manifests/supabase-studio-dashboard.yaml
+++ b/apps/kube/studio/manifests/supabase-studio-dashboard.yaml
@@ -35,6 +35,18 @@ spec:
                   env:
                       - name: STUDIO_PG_META_URL
                         value: http://meta:8080
+                      # Studio builds the per-request pg-meta connection string from
+                      # these POSTGRES_* vars (x-connection-encrypted). Without them it
+                      # defaults to host `db` / db `postgres` (docker-compose defaults),
+                      # so meta gets `getaddrinfo ENOTFOUND db` and every /query 500s.
+                      - name: POSTGRES_HOST
+                        value: supabase-cluster-rw
+                      - name: POSTGRES_PORT
+                        value: '5432'
+                      - name: POSTGRES_DB
+                        value: supabase
+                      - name: POSTGRES_USER_READ_WRITE
+                        value: supabase_admin
                       - name: DEFAULT_ORGANIZATION_NAME
                         value: KBVE
                       - name: DEFAULT_PROJECT_NAME
@@ -49,10 +61,12 @@ spec:
                         value: 'true'
                       - name: NEXT_ANALYTICS_BACKEND_PROVIDER
                         value: postgres
+                      # Must pair with POSTGRES_USER_READ_WRITE=supabase_admin — same
+                      # superuser secret meta authenticates with (known-good pair).
                       - name: POSTGRES_PASSWORD
                         valueFrom:
                             secretKeyRef:
-                                name: supabase-postgres
+                                name: supabase-superuser
                                 key: password
                       - name: SUPABASE_ANON_KEY
                         valueFrom:


### PR DESCRIPTION
## Problem

`supabase.kbve.com` Studio shell loads, but every SQL/table-editor request returns 500. The errors come from `query`, **not** Kong — Studio talks to pg-meta directly via `STUDIO_PG_META_URL=http://meta:8080`, bypassing Kong entirely. The Kong dashboard catch-all route is fine (it serves the shell).

meta pod logs:
```
{"error":{"code":"ENOTFOUND","message":"getaddrinfo ENOTFOUND db"},"request":{"method":"POST","url":"/query","pg":"db"}}
```

## Root cause

Per the official supabase `docker-compose.yml`, the **studio** service builds the per-request pg-meta connection string from `POSTGRES_HOST/PORT/DB/PASSWORD`. Our deployment set only `POSTGRES_PASSWORD`, so:
- `POSTGRES_HOST` defaulted to `db` (compose default) → DNS `ENOTFOUND db`
- `POSTGRES_DB` defaulted to `postgres` (wrong DB; ours is `supabase`)

meta's own env was correct (`supabase-cluster-rw`); the bad host came from the override Studio sends, so meta was never the problem.

## Fix

Add the missing Studio DB env:
- `POSTGRES_HOST=supabase-cluster-rw` (matches meta, svc exists)
- `POSTGRES_PORT=5432`, `POSTGRES_DB=supabase`
- `POSTGRES_USER_READ_WRITE=supabase_admin` paired with the `supabase-superuser` secret — same known-good credentials meta authenticates with

## Follow-ups (not in this PR)
- Blue-green: migrate both meta and studio off `supabase-cluster-rw` onto the `kilobase-rw` alias (#13413).
- Pin `PG_META_CRYPTO_KEY` to a shared secret on both studio + meta (currently both default → consistent, but implicit).