### PR TITLE
fix(forgejo): oauth2 USERNAME source preferred_username -> email

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -79,7 +79,12 @@ spec:
                               ENABLE_AUTO_REGISTRATION: true
                               ACCOUNT_LINKING: auto
                               UPDATE_AVATAR: true
-                              USERNAME: preferred_username
+                              # preferred_username needs gitea 1.23+; this build is
+                              # forgejo 12.0.4 (gitea 1.22), which rejects it and
+                              # falls back to `nickname` — a claim Supabase doesn't
+                              # send → auto-register fails. Use `email`, which
+                              # Supabase always provides.
+                              USERNAME: email
                           actions:
                               ENABLED: true
                           repository:


### PR DESCRIPTION
**Bug:** "Sign in with KBVE" now reaches forgejo (after #13436), `SignInOAuthCallback` runs, but it **303s back to `/user/login`** with no session — auto-register silently fails. Looks like "no account" but it's the username source.

**Cause:** this build is **forgejo 12.0.4 (gitea 1.22.0)**. `preferred_username` as a `[oauth2_client] USERNAME` source was added in **gitea 1.23** — so 1.22 rejects it:
```
[W] Username setting is not valid: 'preferred_username', will fallback to 'nickname'
```
It then tries the `nickname` claim, which Supabase's OIDC token doesn't include → no username → new-user creation fails → bounced to login.

**Fix:** `USERNAME: email` — Supabase always provides `email`, and `email` is a valid source in gitea 1.22. forgejo derives a username from it and auto-registers. `ACCOUNT_LINKING=auto` (email-based) is unaffected.

**Alt considered:** upgrade forgejo to gitea 1.23+ to keep `preferred_username` — bigger change; deferred. `email` unblocks login now.

After release: retry — forgejo creates/links the account from your Supabase identity and sets the session.