### PR TITLE
feat(forgejo): upgrade v12 (EOL) -> v15 LTS (preferred_username)

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -25,7 +25,7 @@ spec:
                   image:
                       registry: codeberg.org
                       repository: forgejo/forgejo
-                      tag: '12'
+                      tag: '15'
                   service:
                       http:
                           type: ClusterIP


### PR DESCRIPTION
You were right — latest is **v15.0.3 (LTS, Jun 2026)**; we were pinned to `tag: '12'` (12.0.4, gitea 1.22 base) which is **discontinued** (v12/13/14 all EOL).

## Why
forgejo 12 (gitea 1.22) doesn't support `[oauth2_client] USERNAME=preferred_username` — that source landed in **gitea 1.23**. So "Sign in with KBVE" reached forgejo but auto-register couldn't derive a username (fell back to `nickname`, which Supabase doesn't send) → bounced to login.

forgejo **15** (gitea 1.23+) honors `preferred_username` → your Supabase `preferred_username` (`h0lybyte`) becomes the forgejo username directly. No `email` workaround, and onto the current LTS.

## Change
`tag: '12'` → `'15'`. `USERNAME: preferred_username` unchanged (now actually used). Supersedes #13447 (email) — close it.

## Migration safety (3-major jump)
- forgejo runs **cumulative DB migrations** on first boot — handles multi-version jumps automatically
- **forgejo schema backed up locally** (`forgejo_schema_<ts>.dump`, 125 tables) before rollout
- After release: watch the new pod's startup logs for migration completion + readiness, then verify login → `h0lybyte`
- Rollback: revert tag → 12 + restore the dump if migrations misbehave

⚠️ Majors can drop/rename config keys — watch startup for config warnings.