### PR TITLE
fix(KBVESQLite): cross-platform symbol isolation + bump SQLite 3.51.3→3.53.3

### DIFF
--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -18,14 +18,35 @@ public class KBVESQLite : ModuleRules
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 
+		// Enable the column-metadata APIs (sqlite3_column_{database,table,origin}_name).
+		// Without this, the amalgamation's #ifndef SQLITE_ENABLE_COLUMN_METADATA branch
+		// redefines those 6 names as `0` macros, clashing with the kbve_ renames already
+		// established by sqlite3_prefix.h. MSVC tolerates the macro redefinition, but Mac
+		// clang compiles third-party code with -Werror,-Wmacro-redefined and fails the
+		// build. Enabling the feature skips that branch entirely (no redefinition on any
+		// platform) and makes the prefixed symbols — which the prefix header already
+		// enumerates — real exported functions.
+		PrivateDefinitions.Add("SQLITE_ENABLE_COLUMN_METADATA=1");
+
+		// Export the sqlite3 entry points from THIS module so consumer modules
+		// (e.g. KBVEWorld) can link directly against sqlite3_open/...etc without
+		// re-bundling the amalgamation.
+		//
+		// These defines must apply only when compiling the amalgamation itself
+		// (PrivateDefinitions), not to consumers. sqlite3.c/.h are plain C and
+		// never include UE's platform headers, so we expand to the raw compiler
+		// construct rather than UE's DLLEXPORT/KBVESQLITE_API macros (which would
+		// leave bare tokens). Consumers get no SQLITE_API define and fall back to
+		// sqlite3.h's built-in empty default — plain extern function decls link
+		// fine against this module's import library (consumers call sqlite
+		// functions only, no exported data globals).
 		if (Target.Platform == UnrealTargetPlatform.Win64)
 		{
 			PrivateDefinitions.Add("SQLITE_API=__declspec(dllexport)");
 		}
 		else
 		{
-			PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
-			PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");
+			PrivateDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
 		}
 	}
 }

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteConnection.cpp
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteConnection.cpp
@@ -1,6 +1,7 @@
 #include "KBVESQLiteConnection.h"
 
 #include "HAL/PlatformFileManager.h"
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "Misc/Paths.h"
 
 THIRD_PARTY_INCLUDES_START

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteThirdParty.c
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteThirdParty.c
@@ -10,7 +10,6 @@
  * - SQLITE_ENABLE_FTS5: full-text search v5
  * - SQLITE_ENABLE_JSON1: JSON functions
  * - SQLITE_ENABLE_RTREE: R*Tree index for spatial queries
- * - SQLITE_ENABLE_COLUMN_METADATA: sqlite3_column_{database,table,origin}_name
  * - SQLITE_DQS=0: disable double-quoted strings (SQL standard compliance)
  * - SQLITE_DEFAULT_WAL_SYNCHRONOUS=1: WAL mode with NORMAL sync (fast + safe)
  */
@@ -19,9 +18,15 @@
 #define SQLITE_ENABLE_FTS5 1
 #define SQLITE_ENABLE_JSON1 1
 #define SQLITE_ENABLE_RTREE 1
-#define SQLITE_ENABLE_COLUMN_METADATA 1
 #define SQLITE_DQS 0
 #define SQLITE_DEFAULT_WAL_SYNCHRONOUS 1
 
+/**
+ * Prefix every exported sqlite3_* symbol with kbve_ so this threadsafe copy can
+ * coexist with the engine's game-thread SQLiteCore in a monolithic binary. Must
+ * be included BEFORE sqlite3.c so the renames apply to the definitions. See the
+ * header for the full rationale (UE 5.8 upgrade).
+ */
 #include "sqlite3_prefix.h"
+
 #include "sqlite3.c"

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteThirdParty.c
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteThirdParty.c
@@ -1,5 +1,5 @@
 /**
- * Compilation unit for SQLite 3.51.3 (Public Domain).
+ * Compilation unit for SQLite 3.53.3 (Public Domain).
  * https://sqlite.org
  *
  * This file MUST remain .c (not .cpp) because sqlite3.c uses "new" as a

--- a/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3.h
+++ b/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3.h
@@ -152,12 +152,12 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.51.3"
-#define SQLITE_VERSION_NUMBER 3051003
-#define SQLITE_SOURCE_ID      "2026-03-13 10:38:09 737ae4a34738ffa0c3ff7f9bb18df914dd1cad163f28fd6b6e114a344fe6d618"
-#define SQLITE_SCM_BRANCH     "branch-3.51"
-#define SQLITE_SCM_TAGS       "release version-3.51.3"
-#define SQLITE_SCM_DATETIME   "2026-03-13T10:38:09.694Z"
+#define SQLITE_VERSION        "3.53.3"
+#define SQLITE_VERSION_NUMBER 3053003
+#define SQLITE_SOURCE_ID      "2026-06-26 20:14:12 d4c0e51e4aeb96955b99185ab9cde75c339e2c29c3f3f12428d364a10d782c62"
+#define SQLITE_SCM_BRANCH     "branch-3.53"
+#define SQLITE_SCM_TAGS       "release version-3.53.3"
+#define SQLITE_SCM_DATETIME   "2026-06-26T20:14:12.354Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -584,7 +584,7 @@ SQLITE_API int sqlite3_exec(
 #define SQLITE_WARNING_AUTOINDEX       (SQLITE_WARNING | (1<<8))
 #define SQLITE_AUTH_USER               (SQLITE_AUTH | (1<<8))
 #define SQLITE_OK_LOAD_PERMANENTLY     (SQLITE_OK | (1<<8))
-#define SQLITE_OK_SYMLINK              (SQLITE_OK | (2<<8)) /* internal use only */
+#define SQLITE_OK_SYMLINK              (SQLITE_OK | (2<<8)) /* internal only */
 
 /*
 ** CAPI3REF: Flags For File Open Operations
@@ -1296,6 +1296,12 @@ struct sqlite3_io_methods {
 #define SQLITE_SET_LOCKPROXYFILE      SQLITE_FCNTL_SET_LOCKPROXYFILE
 #define SQLITE_LAST_ERRNO             SQLITE_FCNTL_LAST_ERRNO
 
+/* reserved file-control numbers:
+**                                         101
+**                                         102
+**                                         103
+*/
+
 
 /*
 ** CAPI3REF: Mutex Handle
@@ -1496,7 +1502,7 @@ typedef const char *sqlite3_filename;
 ** greater and the function pointer is not NULL) and will fall back
 ** to xCurrentTime() if xCurrentTimeInt64() is unavailable.
 **
-** ^The xSetSystemCall(), xGetSystemCall(), and xNestSystemCall() interfaces
+** ^The xSetSystemCall(), xGetSystemCall(), and xNextSystemCall() interfaces
 ** are not used by the SQLite core.  These optional interfaces are provided
 ** by some VFSes to facilitate testing of the VFS code. By overriding
 ** system calls with functions under its control, a test program can
@@ -1717,7 +1723,8 @@ SQLITE_API int sqlite3_os_end(void);
 ** are called "anytime configuration options".
 ** ^If sqlite3_config() is called after [sqlite3_initialize()] and before
 ** [sqlite3_shutdown()] with a first argument that is not an anytime
-** configuration option, then the sqlite3_config() call will return SQLITE_MISUSE.
+** configuration option, then the sqlite3_config() call will
+** return SQLITE_MISUSE.
 ** Note, however, that ^sqlite3_config() can be called as part of the
 ** implementation of an application-defined [sqlite3_os_init()].
 **
@@ -2283,9 +2290,10 @@ struct sqlite3_mem_methods {
 ** is less than 8.  The "sz" argument should be a multiple of 8 less than
 ** 65536.  If "sz" does not meet this constraint, it is reduced in size until
 ** it does.
-** <li><p>The third argument ("cnt") is the number of slots. Lookaside is disabled
-** if "cnt"is less than 1.  The "cnt" value will be reduced, if necessary, so
-** that the product of "sz" and "cnt" does not exceed 2,147,418,112.  The "cnt"
+** <li><p>The third argument ("cnt") is the number of slots.
+** Lookaside is disabled if "cnt"is less than 1.
+*  The "cnt" value will be reduced, if necessary, so
+** that the product of "sz" and "cnt" does not exceed 2,147,418,112. The "cnt"
 ** parameter is usually chosen so that the product of "sz" and "cnt" is less
 ** than 1,000,000.
 ** </ol>
@@ -2573,12 +2581,15 @@ struct sqlite3_mem_methods {
 ** [[SQLITE_DBCONFIG_STMT_SCANSTATUS]]
 ** <dt>SQLITE_DBCONFIG_STMT_SCANSTATUS</dt>
 ** <dd>The SQLITE_DBCONFIG_STMT_SCANSTATUS option is only useful in
-** SQLITE_ENABLE_STMT_SCANSTATUS builds. In this case, it sets or clears
-** a flag that enables collection of the sqlite3_stmt_scanstatus_v2()
-** statistics. For statistics to be collected, the flag must be set on
-** the database handle both when the SQL statement is prepared and when it
-** is stepped. The flag is set (collection of statistics is enabled)
-** by default. <p>This option takes two arguments: an integer and a pointer to
+** [SQLITE_ENABLE_STMT_SCANSTATUS] builds. In this case, it sets or clears
+** a flag that enables collection of run-time performance statistics
+** used by [sqlite3_stmt_scanstatus_v2()] and the [nexec and ncycle]
+** columns of the [bytecode virtual table].
+** For statistics to be collected, the flag must be set on
+** the database handle both when the SQL statement is
+** [sqlite3_prepare|prepared] and when it is [sqlite3_step|stepped].
+** The flag is set (collection of statistics is enabled) by default.
+** <p>This option takes two arguments: an integer and a pointer to
 ** an integer.  The first argument is 1, 0, or -1 to enable, disable, or
 ** leave unchanged the statement scanstatus option.  If the second argument
 ** is not NULL, then the value of the statement scanstatus setting after
@@ -2651,16 +2662,34 @@ struct sqlite3_mem_methods {
 ** comments are allowed in SQL text after processing the first argument.
 ** </dd>
 **
+** [[SQLITE_DBCONFIG_FP_DIGITS]]
+** <dt>SQLITE_DBCONFIG_FP_DIGITS</dt>
+** <dd>The SQLITE_DBCONFIG_FP_DIGITS setting is a small integer that determines
+** the number of significant digits that SQLite will attempt to preserve when
+** converting floating point numbers (IEEE 754 "doubles") into text.  The
+** default value 17, as of SQLite version 3.52.0.  The value was 15 in all
+** prior versions.<p>
+** This option takes two arguments which are an integer and a pointer
+** to an integer.  The first argument is a small integer, between 3 and 23, or
+** zero.  The FP_DIGITS setting is changed to that small integer, or left
+** unaltered if the first argument is zero or out of range. The second argument
+** is a pointer to an integer.  If the pointer is not NULL, then the value of
+** the FP_DIGITS setting, after possibly being modified by the first
+** arguments, is written into the integer to which the second argument points.
+** </dd>
+**
 ** </dl>
 **
 ** [[DBCONFIG arguments]] <h3>Arguments To SQLITE_DBCONFIG Options</h3>
 **
 ** <p>Most of the SQLITE_DBCONFIG options take two arguments, so that the
 ** overall call to [sqlite3_db_config()] has a total of four parameters.
-** The first argument (the third parameter to sqlite3_db_config()) is an integer.
-** The second argument is a pointer to an integer.  If the first argument is 1,
-** then the option becomes enabled.  If the first integer argument is 0, then the
-** option is disabled.  If the first argument is -1, then the option setting
+** The first argument (the third parameter to sqlite3_db_config()) is
+** an integer.
+** The second argument is a pointer to an integer. If the first argument is 1,
+** then the option becomes enabled.  If the first integer argument is 0,
+** then the option is disabled.
+** If the first argument is -1, then the option setting
 ** is unchanged.  The second argument, the pointer to an integer, may be NULL.
 ** If the second argument is not NULL, then a value of 0 or 1 is written into
 ** the integer to which the second argument points, depending on whether the
@@ -2668,9 +2697,10 @@ struct sqlite3_mem_methods {
 ** the first argument.
 **
 ** <p>While most SQLITE_DBCONFIG options use the argument format
-** described in the previous paragraph, the [SQLITE_DBCONFIG_MAINDBNAME]
-** and [SQLITE_DBCONFIG_LOOKASIDE] options are different.  See the
-** documentation of those exceptional options for details.
+** described in the previous paragraph, the [SQLITE_DBCONFIG_MAINDBNAME],
+** [SQLITE_DBCONFIG_LOOKASIDE], and [SQLITE_DBCONFIG_FP_DIGITS] options
+** are different.  See the documentation of those exceptional options for
+** details.
 */
 #define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
 #define SQLITE_DBCONFIG_LOOKASIDE             1001 /* void* int int */
@@ -2695,7 +2725,8 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_ENABLE_ATTACH_CREATE  1020 /* int int* */
 #define SQLITE_DBCONFIG_ENABLE_ATTACH_WRITE   1021 /* int int* */
 #define SQLITE_DBCONFIG_ENABLE_COMMENTS       1022 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1022 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_FP_DIGITS             1023 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1023 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -4177,6 +4208,7 @@ SQLITE_API void sqlite3_free_filename(sqlite3_filename);
 ** <li> sqlite3_errmsg()
 ** <li> sqlite3_errmsg16()
 ** <li> sqlite3_error_offset()
+** <li> sqlite3_db_handle()
 ** </ul>
 **
 ** ^The sqlite3_errmsg() and sqlite3_errmsg16() return English-language
@@ -4223,7 +4255,7 @@ SQLITE_API const char *sqlite3_errstr(int);
 SQLITE_API int sqlite3_error_offset(sqlite3 *db);
 
 /*
-** CAPI3REF: Set Error Codes And Message
+** CAPI3REF: Set Error Code And Message
 ** METHOD: sqlite3
 **
 ** Set the error code of the database handle passed as the first argument
@@ -4340,7 +4372,12 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 ** or in an ORDER BY or GROUP BY clause.</dd>)^
 **
 ** [[SQLITE_LIMIT_EXPR_DEPTH]] ^(<dt>SQLITE_LIMIT_EXPR_DEPTH</dt>
-** <dd>The maximum depth of the parse tree on any expression.</dd>)^
+** <dd>The maximum depth of the parse tree on any expression and
+** the maximum nesting depth for subqueries and VIEWs</dd>)^
+**
+** [[SQLITE_LIMIT_PARSER_DEPTH]] ^(<dt>SQLITE_LIMIT_PARSER_DEPTH</dt>
+** <dd>The maximum depth of the LALR(1) parser stack used to analyze
+** input SQL statements.</dd>)^
 **
 ** [[SQLITE_LIMIT_COMPOUND_SELECT]] ^(<dt>SQLITE_LIMIT_COMPOUND_SELECT</dt>
 ** <dd>The maximum number of terms in a compound SELECT statement.</dd>)^
@@ -4367,7 +4404,8 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 ** <dd>The maximum index number of any [parameter] in an SQL statement.)^
 **
 ** [[SQLITE_LIMIT_TRIGGER_DEPTH]] ^(<dt>SQLITE_LIMIT_TRIGGER_DEPTH</dt>
-** <dd>The maximum depth of recursion for triggers.</dd>)^
+** <dd>The maximum depth of recursion for triggers, and the maximum
+** nesting depth for separate triggers.</dd>)^
 **
 ** [[SQLITE_LIMIT_WORKER_THREADS]] ^(<dt>SQLITE_LIMIT_WORKER_THREADS</dt>
 ** <dd>The maximum number of auxiliary worker threads that a single
@@ -4386,6 +4424,7 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 #define SQLITE_LIMIT_VARIABLE_NUMBER           9
 #define SQLITE_LIMIT_TRIGGER_DEPTH            10
 #define SQLITE_LIMIT_WORKER_THREADS           11
+#define SQLITE_LIMIT_PARSER_DEPTH             12
 
 /*
 ** CAPI3REF: Prepare Flags
@@ -4430,12 +4469,29 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 ** fails, the sqlite3_prepare_v3() call returns the same error indications
 ** with or without this flag; it just omits the call to [sqlite3_log()] that
 ** logs the error.
+**
+** [[SQLITE_PREPARE_FROM_DDL]] <dt>SQLITE_PREPARE_FROM_DDL</dt>
+** <dd>The SQLITE_PREPARE_FROM_DDL flag causes the SQL compiler to enforce
+** security constraints that would otherwise only be enforced when parsing
+** the database schema.  In other words, the SQLITE_PREPARE_FROM_DDL flag
+** causes the SQL compiler to treat the SQL statement being prepared as if
+** it had come from an attacker.  When SQLITE_PREPARE_FROM_DDL is used and
+** [SQLITE_DBCONFIG_TRUSTED_SCHEMA] is off, SQL functions may only be called
+** if they are tagged with [SQLITE_INNOCUOUS] and virtual tables may only
+** be used if they are tagged with [SQLITE_VTAB_INNOCUOUS].  Best practice
+** is to use the SQLITE_PREPARE_FROM_DDL option when preparing any SQL that
+** is derived from parts of the database schema. In particular, virtual
+** table implementations that run SQL statements that are derived from
+** arguments to their CREATE VIRTUAL TABLE statement should always use
+** [sqlite3_prepare_v3()] and set the SQLITE_PREPARE_FROM_DDL flag to
+** prevent bypass of the [SQLITE_DBCONFIG_TRUSTED_SCHEMA] security checks.
 ** </dl>
 */
 #define SQLITE_PREPARE_PERSISTENT              0x01
 #define SQLITE_PREPARE_NORMALIZE               0x02
 #define SQLITE_PREPARE_NO_VTAB                 0x04
 #define SQLITE_PREPARE_DONT_LOG                0x10
+#define SQLITE_PREPARE_FROM_DDL                0x20
 
 /*
 ** CAPI3REF: Compiling An SQL Statement
@@ -4449,8 +4505,9 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 **
 ** The preferred routine to use is [sqlite3_prepare_v2()].  The
 ** [sqlite3_prepare()] interface is legacy and should be avoided.
-** [sqlite3_prepare_v3()] has an extra "prepFlags" option that is used
-** for special purposes.
+** [sqlite3_prepare_v3()] has an extra
+** [SQLITE_PREPARE_FROM_DDL|"prepFlags" option] that is sometimes
+** needed for special purpose or to pass along security restrictions.
 **
 ** The use of the UTF-8 interfaces is preferred, as SQLite currently
 ** does all parsing using UTF-8.  The UTF-16 interfaces are provided
@@ -4855,8 +4912,8 @@ typedef struct sqlite3_context sqlite3_context;
 ** it should be a pointer to well-formed UTF16 text.
 ** ^If the third parameter to sqlite3_bind_text64() is not NULL, then
 ** it should be a pointer to a well-formed unicode string that is
-** either UTF8 if the sixth parameter is SQLITE_UTF8, or UTF16
-** otherwise.
+** either UTF8 if the sixth parameter is SQLITE_UTF8 or SQLITE_UTF8_ZT,
+** or UTF16 otherwise.
 **
 ** [[byte-order determination rules]] ^The byte-order of
 ** UTF16 input text is determined by the byte-order mark (BOM, U+FEFF)
@@ -4902,10 +4959,15 @@ typedef struct sqlite3_context sqlite3_context;
 ** object and pointer to it must remain valid until then. ^SQLite will then
 ** manage the lifetime of its private copy.
 **
-** ^The sixth argument to sqlite3_bind_text64() must be one of
-** [SQLITE_UTF8], [SQLITE_UTF16], [SQLITE_UTF16BE], or [SQLITE_UTF16LE]
-** to specify the encoding of the text in the third parameter.  If
-** the sixth argument to sqlite3_bind_text64() is not one of the
+** ^The sixth argument (the E argument)
+** to sqlite3_bind_text64(S,K,Z,N,D,E) must be one of
+** [SQLITE_UTF8], [SQLITE_UTF8_ZT], [SQLITE_UTF16], [SQLITE_UTF16BE],
+** or [SQLITE_UTF16LE] to specify the encoding of the text in the
+** third parameter, Z.  The special value [SQLITE_UTF8_ZT] means that the
+** string argument is both UTF-8 encoded and is zero-terminated.  In other
+** words, SQLITE_UTF8_ZT means that the Z array is allocated to hold at
+** least N+1 bytes and that the Z&#91;N&#93; byte is zero.  If
+** the E argument to sqlite3_bind_text64(S,K,Z,N,D,E) is not one of the
 ** allowed values shown above, or if the text encoding is different
 ** from the encoding specified by the sixth parameter, then the behavior
 ** is undefined.
@@ -5772,6 +5834,52 @@ SQLITE_API int sqlite3_create_window_function(
 **
 ** These constants define integer codes that represent the various
 ** text encodings supported by SQLite.
+**
+** <dl>
+** [[SQLITE_UTF8]] <dt>SQLITE_UTF8</dt><dd>Text is encoding as UTF-8</dd>
+**
+** [[SQLITE_UTF16LE]] <dt>SQLITE_UTF16LE</dt><dd>Text is encoding as UTF-16
+** with each code point being expressed "little endian" - the least significant
+** byte first.  This is the usual encoding, for example on Windows.</dd>
+**
+** [[SQLITE_UTF16BE]] <dt>SQLITE_UTF16BE</dt><dd>Text is encoding as UTF-16
+** with each code point being expressed "big endian" - the most significant
+** byte first.  This encoding is less common, but is still sometimes seen,
+** specially on older systems.
+**
+** [[SQLITE_UTF16]] <dt>SQLITE_UTF16</dt><dd>Text is encoding as UTF-16
+** with each code point being expressed either little endian or as big
+** endian, according to the native endianness of the host computer.
+**
+** [[SQLITE_ANY]] <dt>SQLITE_ANY</dt><dd>This encoding value may only be used
+** to declare the preferred text for [application-defined SQL functions]
+** created using [sqlite3_create_function()] and similar.  If the preferred
+** encoding (the 4th parameter to sqlite3_create_function() - the eTextRep
+** parameter) is SQLITE_ANY, that indicates that the function does not have
+** a preference regarding the text encoding of its parameters and can take
+** any text encoding that the SQLite core find convenient to supply.  This
+** option is deprecated.  Please do not use it in new applications.
+**
+** [[SQLITE_UTF16_ALIGNED]] <dt>SQLITE_UTF16_ALIGNED</dt><dd>This encoding
+** value may be used as the 3rd parameter (the eTextRep parameter) to
+** [sqlite3_create_collation()] and similar.  This encoding value means
+** that the application-defined collating sequence created expects its
+** input strings to be in UTF16 in native byte order, and that the start
+** of the strings must be aligned to a 2-byte boundary.
+**
+** [[SQLITE_UTF8_ZT]] <dt>SQLITE_UTF8_ZT</dt><dd>This option can only be
+** used to specify the text encoding to strings input to
+** [sqlite3_result_text64()] and [sqlite3_bind_text64()].
+** The SQLITE_UTF8_ZT encoding means that the input string (call it "z")
+** is UTF-8 encoded and that it is zero-terminated.  If the length parameter
+** (call it "n") is non-negative, this encoding option means that the caller
+** guarantees that z array contains at least n+1 bytes and that the z&#91;n&#93;
+** byte has a value of zero.
+** This option gives the same output as SQLITE_UTF8, but can be more efficient
+** by avoiding the need to make a copy of the input string, in some cases.
+** However, if z is allocated to hold fewer than n+1 bytes or if the
+** z&#91;n&#93; byte is not zero, undefined behavior may result.
+** </dl>
 */
 #define SQLITE_UTF8           1    /* IMP: R-37514-35566 */
 #define SQLITE_UTF16LE        2    /* IMP: R-03371-37637 */
@@ -5779,6 +5887,7 @@ SQLITE_API int sqlite3_create_window_function(
 #define SQLITE_UTF16          4    /* Use native byte order */
 #define SQLITE_ANY            5    /* Deprecated */
 #define SQLITE_UTF16_ALIGNED  8    /* sqlite3_create_collation only */
+#define SQLITE_UTF8_ZT       16    /* Zero-terminated UTF8 */
 
 /*
 ** CAPI3REF: Function Flags
@@ -6013,26 +6122,22 @@ SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int6
 ** the SQL function that supplied the [sqlite3_value*] parameters.
 **
 ** As long as the input parameter is correct, these routines can only
-** fail if an out-of-memory error occurs during a format conversion.
-** Only the following subset of interfaces are subject to out-of-memory
-** errors:
-**
-** <ul>
-** <li> sqlite3_value_blob()
-** <li> sqlite3_value_text()
-** <li> sqlite3_value_text16()
-** <li> sqlite3_value_text16le()
-** <li> sqlite3_value_text16be()
-** <li> sqlite3_value_bytes()
-** <li> sqlite3_value_bytes16()
-** </ul>
-**
+** fail if an out-of-memory error occurs while trying to do a
+** UTF8&rarr;UTF16 or UTF16&rarr;UTF8 conversion.
 ** If an out-of-memory error occurs, then the return value from these
 ** routines is the same as if the column had contained an SQL NULL value.
-** Valid SQL NULL returns can be distinguished from out-of-memory errors
-** by invoking the [sqlite3_errcode()] immediately after the suspect
+** If the input sqlite3_value was not obtained from [sqlite3_value_dup()],
+** then valid SQL NULL returns can also be distinguished from
+** out-of-memory errors after extracting the value
+** by invoking the [sqlite3_errcode()] immediately after the suspicious
 ** return value is obtained and before any
 ** other SQLite interface is called on the same [database connection].
+** If the input sqlite3_value was obtained from sqlite3_value_dup() then
+** it is disconnected from the database connection and so sqlite3_errcode()
+** will not work.
+** In that case, the only way to distinguish an out-of-memory
+** condition from a true SQL NULL is to invoke sqlite3_value_type() on the
+** input to see if it is NULL prior to trying to extract the value.
 */
 SQLITE_API const void *sqlite3_value_blob(sqlite3_value*);
 SQLITE_API double sqlite3_value_double(sqlite3_value*);
@@ -6059,7 +6164,8 @@ SQLITE_API int sqlite3_value_frombind(sqlite3_value*);
 ** of the value X, assuming that X has type TEXT.)^  If sqlite3_value_type(X)
 ** returns something other than SQLITE_TEXT, then the return value from
 ** sqlite3_value_encoding(X) is meaningless.  ^Calls to
-** [sqlite3_value_text(X)], [sqlite3_value_text16(X)], [sqlite3_value_text16be(X)],
+** [sqlite3_value_text(X)], [sqlite3_value_text16(X)],
+** [sqlite3_value_text16be(X)],
 ** [sqlite3_value_text16le(X)], [sqlite3_value_bytes(X)], or
 ** [sqlite3_value_bytes16(X)] might change the encoding of the value X and
 ** thus change the return from subsequent calls to sqlite3_value_encoding(X).
@@ -6190,17 +6296,17 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 ** query execution, under some circumstances the associated auxiliary data
 ** might be preserved.  An example of where this might be useful is in a
 ** regular-expression matching function. The compiled version of the regular
-** expression can be stored as auxiliary data associated with the pattern string.
-** Then as long as the pattern string remains the same,
+** expression can be stored as auxiliary data associated with the pattern
+** string. Then as long as the pattern string remains the same,
 ** the compiled regular expression can be reused on multiple
 ** invocations of the same function.
 **
-** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the auxiliary data
-** associated by the sqlite3_set_auxdata(C,N,P,X) function with the Nth argument
-** value to the application-defined function.  ^N is zero for the left-most
-** function argument.  ^If there is no auxiliary data
-** associated with the function argument, the sqlite3_get_auxdata(C,N) interface
-** returns a NULL pointer.
+** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the auxiliary
+** data associated by the sqlite3_set_auxdata(C,N,P,X) function with the
+** Nth argument value to the application-defined function.  ^N is zero
+** for the left-most function argument.  ^If there is no auxiliary data
+** associated with the function argument, the sqlite3_get_auxdata(C,N)
+** interface returns a NULL pointer.
 **
 ** ^The sqlite3_set_auxdata(C,N,P,X) interface saves P as auxiliary data for the
 ** N-th argument of the application-defined function.  ^Subsequent
@@ -6284,10 +6390,14 @@ SQLITE_API void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void (*)(voi
 **
 ** There is no limit (other than available memory) on the number of different
 ** client data pointers (with different names) that can be attached to a
-** single database connection.  However, the implementation is optimized
-** for the case of having only one or two different client data names.
-** Applications and wrapper libraries are discouraged from using more than
-** one client data name each.
+** single database connection.  However, the current implementation stores
+** the content on a linked list.  Insert and retrieval performance will
+** be proportional to the number of entries.  The design use case, and
+** the use case for which the implementation is optimized, is
+** that an application will store only small number of client data names,
+** typically just one or two.  This interface is not intended to be a
+** generalized key/value store for thousands or millions of keys.  It
+** will work for that, but performance might be disappointing.
 **
 ** There is no way to enumerate the client data pointers
 ** associated with a database connection.  The N parameter can be thought
@@ -6395,10 +6505,14 @@ typedef void (*sqlite3_destructor_type)(void*);
 ** set the return value of the application-defined function to be
 ** a text string which is represented as UTF-8, UTF-16 native byte order,
 ** UTF-16 little endian, or UTF-16 big endian, respectively.
-** ^The sqlite3_result_text64() interface sets the return value of an
+** ^The sqlite3_result_text64(C,Z,N,D,E) interface sets the return value of an
 ** application-defined function to be a text string in an encoding
-** specified by the fifth (and last) parameter, which must be one
-** of [SQLITE_UTF8], [SQLITE_UTF16], [SQLITE_UTF16BE], or [SQLITE_UTF16LE].
+** specified the E parameter, which must be one
+** of [SQLITE_UTF8], [SQLITE_UTF8_ZT], [SQLITE_UTF16], [SQLITE_UTF16BE],
+** or [SQLITE_UTF16LE].  ^The special value [SQLITE_UTF8_ZT] means that
+** the result text is both UTF-8 and zero-terminated.  In other words,
+** SQLITE_UTF8_ZT means that the Z array holds at least N+1 bytes and that
+** the Z&#91;N&#93; is zero.
 ** ^SQLite takes the text result from the application from
 ** the 2nd parameter of the sqlite3_result_text* interfaces.
 ** ^If the 3rd parameter to any of the sqlite3_result_text* interfaces
@@ -6485,7 +6599,7 @@ SQLITE_API void sqlite3_result_int(sqlite3_context*, int);
 SQLITE_API void sqlite3_result_int64(sqlite3_context*, sqlite3_int64);
 SQLITE_API void sqlite3_result_null(sqlite3_context*);
 SQLITE_API void sqlite3_result_text(sqlite3_context*, const char*, int, void(*)(void*));
-SQLITE_API void sqlite3_result_text64(sqlite3_context*, const char*,sqlite3_uint64,
+SQLITE_API void sqlite3_result_text64(sqlite3_context*, const char *z, sqlite3_uint64 n,
                            void(*)(void*), unsigned char encoding);
 SQLITE_API void sqlite3_result_text16(sqlite3_context*, const void*, int, void(*)(void*));
 SQLITE_API void sqlite3_result_text16le(sqlite3_context*, const void*, int,void(*)(void*));
@@ -7424,7 +7538,7 @@ SQLITE_API int sqlite3_table_column_metadata(
 ** ^The sqlite3_load_extension() interface attempts to load an
 ** [SQLite extension] library contained in the file zFile.  If
 ** the file cannot be loaded directly, attempts are made to load
-** with various operating-system specific extensions added.
+** with various operating-system specific filename extensions added.
 ** So for example, if "samplelib" cannot be loaded, then names like
 ** "samplelib.so" or "samplelib.dylib" or "samplelib.dll" might
 ** be tried also.
@@ -7432,10 +7546,10 @@ SQLITE_API int sqlite3_table_column_metadata(
 ** ^The entry point is zProc.
 ** ^(zProc may be 0, in which case SQLite will try to come up with an
 ** entry point name on its own.  It first tries "sqlite3_extension_init".
-** If that does not work, it constructs a name "sqlite3_X_init" where
-** X consists of the lower-case equivalent of all ASCII alphabetic
-** characters in the filename from the last "/" to the first following
-** "." and omitting any initial "lib".)^
+** If that does not work, it tries names of the form "sqlite3_X_init"
+** where X consists of the lower-case equivalent of all ASCII alphabetic
+** characters or all ASCII alphanumeric characters in the filename from
+** the last "/" to the first following "." and omitting any initial "lib".)^
 ** ^The sqlite3_load_extension() interface returns
 ** [SQLITE_OK] on success and [SQLITE_ERROR] if something goes wrong.
 ** ^If an error occurs and pzErrMsg is not 0, then the
@@ -7509,7 +7623,7 @@ SQLITE_API int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
 ** <blockquote><pre>
 ** &nbsp;  int xEntryPoint(
 ** &nbsp;    sqlite3 *db,
-** &nbsp;    const char **pzErrMsg,
+** &nbsp;    char **pzErrMsg,
 ** &nbsp;    const struct sqlite3_api_routines *pThunk
 ** &nbsp;  );
 ** </pre></blockquote>)^
@@ -8259,13 +8373,6 @@ SQLITE_API int sqlite3_vfs_unregister(sqlite3_vfs*);
 ** SQLITE_MUTEX_W32 implementations are appropriate for use on Unix
 ** and Windows.
 **
-** If SQLite is compiled with the SQLITE_MUTEX_APPDEF preprocessor
-** macro defined (with "-DSQLITE_MUTEX_APPDEF=1"), then no mutex
-** implementation is included with the library. In this case the
-** application must supply a custom mutex implementation using the
-** [SQLITE_CONFIG_MUTEX] option of the sqlite3_config() function
-** before calling sqlite3_initialize() or any other public sqlite3_
-** function that calls sqlite3_initialize().
 **
 ** ^The sqlite3_mutex_alloc() routine allocates a new
 ** mutex and returns a pointer to it. ^The sqlite3_mutex_alloc()
@@ -8620,6 +8727,7 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_TUNE                    32
 #define SQLITE_TESTCTRL_LOGEST                  33
 #define SQLITE_TESTCTRL_USELONGDOUBLE           34  /* NOT USED */
+#define SQLITE_TESTCTRL_ATOF                    34
 #define SQLITE_TESTCTRL_LAST                    34  /* Largest TESTCTRL */
 
 /*
@@ -8728,17 +8836,22 @@ SQLITE_API sqlite3_str *sqlite3_str_new(sqlite3*);
 ** pass the returned value to [sqlite3_free()] to avoid a memory leak.
 ** ^The [sqlite3_str_finish(X)] interface may return a NULL pointer if any
 ** errors were encountered during construction of the string.  ^The
-** [sqlite3_str_finish(X)] interface will also return a NULL pointer if the
+** [sqlite3_str_finish(X)] interface might also return a NULL pointer if the
 ** string in [sqlite3_str] object X is zero bytes long.
+**
+** ^The [sqlite3_str_free(X)] interface destroys both the sqlite3_str object
+** X and the string content it contains.  Calling sqlite3_str_free(X) is
+** the equivalent of calling [sqlite3_free](sqlite3_str_finish(X)).
 */
 SQLITE_API char *sqlite3_str_finish(sqlite3_str*);
+SQLITE_API void sqlite3_str_free(sqlite3_str*);
 
 /*
 ** CAPI3REF: Add Content To A Dynamic String
 ** METHOD: sqlite3_str
 **
-** These interfaces add content to an sqlite3_str object previously obtained
-** from [sqlite3_str_new()].
+** These interfaces add or remove content to an sqlite3_str object
+** previously obtained from [sqlite3_str_new()].
 **
 ** ^The [sqlite3_str_appendf(X,F,...)] and
 ** [sqlite3_str_vappendf(X,F,V)] interfaces uses the [built-in printf]
@@ -8761,6 +8874,10 @@ SQLITE_API char *sqlite3_str_finish(sqlite3_str*);
 ** ^The [sqlite3_str_reset(X)] method resets the string under construction
 ** inside [sqlite3_str] object X back to zero bytes in length.
 **
+** ^The [sqlite3_str_truncate(X,N)] method changes the length of the string
+** under construction to be N bytes or less.  This routine is a no-op if
+** N is negative or if the string is already N bytes or smaller in size.
+**
 ** These methods do not return a result code.  ^If an error occurs, that fact
 ** is recorded in the [sqlite3_str] object and can be recovered by a
 ** subsequent call to [sqlite3_str_errcode(X)].
@@ -8771,6 +8888,7 @@ SQLITE_API void sqlite3_str_append(sqlite3_str*, const char *zIn, int N);
 SQLITE_API void sqlite3_str_appendall(sqlite3_str*, const char *zIn);
 SQLITE_API void sqlite3_str_appendchar(sqlite3_str*, int N, char C);
 SQLITE_API void sqlite3_str_reset(sqlite3_str*);
+SQLITE_API void sqlite3_str_truncate(sqlite3_str*,int N);
 
 /*
 ** CAPI3REF: Status Of A Dynamic String
@@ -10301,7 +10419,8 @@ SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info*,int);
 ** <tr>
 ** <td valign="top">sqlite3_vtab_distinct() return value
 ** <td valign="top">Rows are returned in aOrderBy order
-** <td valign="top">Rows with the same value in all aOrderBy columns are adjacent
+** <td valign="top">Rows with the same value in all aOrderBy columns are
+**                  adjacent
 ** <td valign="top">Duplicates over all colUsed columns may be omitted
 ** <tr><td>0<td>yes<td>yes<td>no
 ** <tr><td>1<td>no<td>yes<td>no
@@ -10310,8 +10429,8 @@ SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info*,int);
 ** </table>
 **
 ** ^For the purposes of comparing virtual table output values to see if the
-** values are the same value for sorting purposes, two NULL values are considered
-** to be the same.  In other words, the comparison operator is "IS"
+** values are the same value for sorting purposes, two NULL values are
+** considered to be the same.  In other words, the comparison operator is "IS"
 ** (or "IS NOT DISTINCT FROM") and not "==".
 **
 ** If a virtual table implementation is unable to meet the requirements
@@ -10604,9 +10723,9 @@ SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info*, int, sqlite3_value **
 ** a variable pointed to by the "pOut" parameter.
 **
 ** The "flags" parameter must be passed a mask of flags. At present only
-** one flag is defined - SQLITE_SCANSTAT_COMPLEX. If SQLITE_SCANSTAT_COMPLEX
+** one flag is defined - [SQLITE_SCANSTAT_COMPLEX]. If SQLITE_SCANSTAT_COMPLEX
 ** is specified, then status information is available for all elements
-** of a query plan that are reported by "EXPLAIN QUERY PLAN" output. If
+** of a query plan that are reported by "[EXPLAIN QUERY PLAN]" output. If
 ** SQLITE_SCANSTAT_COMPLEX is not specified, then only query plan elements
 ** that correspond to query loops (the "SCAN..." and "SEARCH..." elements of
 ** the EXPLAIN QUERY PLAN output) are available. Invoking API
@@ -10620,7 +10739,8 @@ SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info*, int, sqlite3_value **
 ** elements used to implement the statement - a non-zero value is returned and
 ** the variable that pOut points to is unchanged.
 **
-** See also: [sqlite3_stmt_scanstatus_reset()]
+** See also: [sqlite3_stmt_scanstatus_reset()] and the
+** [nexec and ncycle] columns of the [bytecode virtual table].
 */
 SQLITE_API int sqlite3_stmt_scanstatus(
   sqlite3_stmt *pStmt,      /* Prepared statement for which info desired */
@@ -11162,19 +11282,42 @@ SQLITE_API int sqlite3_deserialize(
 /*
 ** CAPI3REF: Bind array values to the CARRAY table-valued function
 **
-** The sqlite3_carray_bind(S,I,P,N,F,X) interface binds an array value to
-** one of the first argument of the [carray() table-valued function].  The
-** S parameter is a pointer to the [prepared statement] that uses the carray()
-** functions.  I is the parameter index to be bound.  P is a pointer to the
-** array to be bound, and N is the number of eements in the array.  The
-** F argument is one of constants [SQLITE_CARRAY_INT32], [SQLITE_CARRAY_INT64],
-** [SQLITE_CARRAY_DOUBLE], [SQLITE_CARRAY_TEXT], or [SQLITE_CARRAY_BLOB] to
-** indicate the datatype of the array being bound.  The X argument is not a
-** NULL pointer, then SQLite will invoke the function X on the P parameter
-** after it has finished using P, even if the call to
-** sqlite3_carray_bind() fails. The special-case finalizer
-** SQLITE_TRANSIENT has no effect here.
+** The sqlite3_carray_bind_v2(S,I,P,N,F,X,D) interface binds an array value to
+** parameter that is the first argument of the [carray() table-valued function].
+** The S parameter is a pointer to the [prepared statement] that uses the
+** carray() functions.  I is the parameter index to be bound.  I must be the
+** index of the parameter that is the first argument to the carray()
+** table-valued function. P is a pointer to the array to be bound, and N
+** is the number of elements in the array.  The F argument is one of
+** constants [SQLITE_CARRAY_INT32], [SQLITE_CARRAY_INT64],
+** [SQLITE_CARRAY_DOUBLE], [SQLITE_CARRAY_TEXT],
+** or [SQLITE_CARRAY_BLOB] to indicate the datatype of the array P.
+**
+** If the X argument is not a NULL pointer or one of the special
+** values [SQLITE_STATIC] or [SQLITE_TRANSIENT], then SQLite will invoke
+** the function X with argument D when it is finished using the data in P.
+** The call to X(D) is a destructor for the array P. The destructor X(D)
+** is invoked even if the call to sqlite3_carray_bind_v2() fails. If the X
+** parameter is the special-case value [SQLITE_STATIC], then SQLite assumes
+** that the data static and the destructor is never invoked.  If the X
+** parameter is the special-case value [SQLITE_TRANSIENT], then
+** sqlite3_carray_bind_v2() makes its own private copy of the data prior
+** to returning and never invokes the destructor X.
+**
+** The sqlite3_carray_bind() function works the same as sqlite3_carray_bind_v2()
+** with a D parameter set to P.  In other words,
+** sqlite3_carray_bind(S,I,P,N,F,X) is same as
+** sqlite3_carray_bind_v2(S,I,P,N,F,X,P).
 */
+SQLITE_API int sqlite3_carray_bind_v2(
+  sqlite3_stmt *pStmt,        /* Statement to be bound */
+  int i,                      /* Parameter index */
+  void *aData,                /* Pointer to array data */
+  int nData,                  /* Number of data elements */
+  int mFlags,                 /* CARRAY flags */
+  void (*xDel)(void*),        /* Destructor for aData */
+  void *pDel                  /* Optional argument to xDel() */
+);
 SQLITE_API int sqlite3_carray_bind(
   sqlite3_stmt *pStmt,        /* Statement to be bound */
   int i,                      /* Parameter index */
@@ -12718,11 +12861,23 @@ SQLITE_API int sqlite3changeset_apply_v3(
 **   database behave as if they were declared with "ON UPDATE NO ACTION ON
 **   DELETE NO ACTION", even if they are actually CASCADE, RESTRICT, SET NULL
 **   or SET DEFAULT.
+**
+** <dt>SQLITE_CHANGESETAPPLY_NOUPDATELOOP <dd>
+**   Sometimes, a changeset contains two or more update statements such that
+**   although after applying all updates the database will contain no
+**   constraint violations, no single update can be applied before the others.
+**   The simplest example of this is a pair of UPDATEs that have "swapped"
+**   two column values with a UNIQUE constraint.
+**   <p>
+**   Usually, sqlite3changeset_apply() and similar functions work hard to try
+**   to find a way to apply such a changeset. However, if this flag is set,
+**   then all such updates are considered CONSTRAINT conflicts.
 */
 #define SQLITE_CHANGESETAPPLY_NOSAVEPOINT   0x0001
 #define SQLITE_CHANGESETAPPLY_INVERT        0x0002
 #define SQLITE_CHANGESETAPPLY_IGNORENOOP    0x0004
 #define SQLITE_CHANGESETAPPLY_FKNOACTION    0x0008
+#define SQLITE_CHANGESETAPPLY_NOUPDATELOOP  0x0010
 
 /*
 ** CAPI3REF: Constants Passed To The Conflict Handler
@@ -13204,6 +13359,232 @@ SQLITE_API int sqlite3session_config(int op, void *pArg);
 ** CAPI3REF: Values for sqlite3session_config().
 */
 #define SQLITE_SESSION_CONFIG_STRMSIZE 1
+
+/*
+** CAPI3REF: Configure a changegroup object
+**
+** Configure the changegroup object passed as the first argument.
+** At present the only valid value for the second parameter is
+** [SQLITE_CHANGEGROUP_CONFIG_PATCHSET].
+*/
+SQLITE_API int sqlite3changegroup_config(sqlite3_changegroup*, int, void *pArg);
+
+/*
+** CAPI3REF: Options for sqlite3changegroup_config().
+**
+** The following values may be passed as the 2nd parameter to
+** sqlite3changegroup_config().
+**
+** <dt>SQLITE_CHANGEGROUP_CONFIG_PATCHSET <dd>
+**   A changegroup object generates either a changeset or patchset. Usually,
+**   this is determined by whether the first call to sqlite3changegroup_add()
+**   is passed a changeset or a patchset. Or, if the first changes are added
+**   to the changegroup object using the sqlite3changegroup_change_xxx()
+**   APIs, then this option may be used to configure whether the changegroup
+**   object generates a changeset or patchset.
+**
+**   When this option is invoked, parameter pArg must point to a value of
+**   type int. If the changegroup currently contains zero changes, and the
+**   value of the int variable is zero or greater than zero, then the
+**   changegroup is configured to generate a changeset or patchset,
+**   respectively. It is a no-op, not an error, if the changegroup is not
+**   configured because it has already started accumulating changes.
+**
+**   Before returning, the int variable is set to 0 if the changegroup is
+**   configured to generate a changeset, or 1 if it is configured to generate
+**   a patchset.
+*/
+#define SQLITE_CHANGEGROUP_CONFIG_PATCHSET 1
+
+
+/*
+** CAPI3REF: Begin adding a change to a changegroup
+**
+** This API is used, in concert with other sqlite3changegroup_change_xxx()
+** APIs, to add changes to a changegroup object one at a time. To add a
+** single change, the caller must:
+**
+**   1. Invoke sqlite3changegroup_change_begin() to indicate the type of
+**      change (INSERT, UPDATE or DELETE), the affected table and whether
+**      or not the change should be marked as indirect.
+**
+**   2. Invoke sqlite3changegroup_change_int64() or one of the other four
+**      value functions - _null(), _double(), _text() or _blob() - one or
+**      more times to specify old.* and new.* values for the change being
+**      constructed.
+**
+**   3. Invoke sqlite3changegroup_change_finish() to either finish adding
+**      the change to the group, or to discard the change altogether.
+**
+** The first argument to this function must be a pointer to the existing
+** changegroup object that the change will be added to. The second argument
+** must be SQLITE_INSERT, SQLITE_UPDATE or SQLITE_DELETE. The third is the
+** name of the table that the change affects, and the fourth is a boolean
+** flag specifying whether the change should be marked as "indirect" (if
+** bIndirect is non-zero) or not indirect (if bIndirect is zero).
+**
+** Following a successful call to this function, this function may not be
+** called again on the same changegroup object until after
+** sqlite3changegroup_change_finish() has been called. Doing so is an
+** SQLITE_MISUSE error.
+**
+** The changegroup object passed as the first argument must be already
+** configured with schema data for the specified table. It may be configured
+** either by calling sqlite3changegroup_schema() with a database that contains
+** the table, or sqlite3changegroup_add() with a changeset that contains the
+** table. If the changegroup object has not been configured with a schema for
+** the specified table when this function is called, SQLITE_ERROR is returned.
+**
+** If successful, SQLITE_OK is returned. Otherwise, if an error occurs, an
+** SQLite error code is returned. In this case, if argument pzErr is non-NULL,
+** then (*pzErr) may be set to point to a buffer containing a utf-8 formated,
+** nul-terminated, English language error message. It is the responsibility
+** of the caller to eventually free this buffer using sqlite3_free().
+*/
+SQLITE_API int sqlite3changegroup_change_begin(
+  sqlite3_changegroup*,
+  int eOp,
+  const char *zTab,
+  int bIndirect,
+  char **pzErr
+);
+
+/*
+** CAPI3REF: Add a 64-bit integer to a changegroup
+**
+** This function may only be called between a successful call to
+** sqlite3changegroup_change_begin() and its matching
+** sqlite3changegroup_change_finish() call. If it is called at any
+** other time, it is an SQLITE_MISUSE error. Calling this function
+** specifies a 64-bit integer value to be used in the change currently being
+** added to the changegroup object passed as the first argument.
+**
+** The second parameter, bNew, specifies whether the value is to be part of
+** the new.* (if bNew is non-zero) or old.* (if bNew is zero) record of
+** the change under construction. If this does not match the type of change
+** specified by the preceding call to sqlite3changegroup_change_begin() (i.e.
+** an old.* value for an SQLITE_INSERT change, or a new.* value for an
+** SQLITE_DELETE), then SQLITE_ERROR is returned.
+**
+** The third parameter specifies the column of the old.* or new.* record that
+** the value will be a part of. If the specified table has an explicit primary
+** key, then this is the index of the table column, numbered from 0 in the order
+** specified within the CREATE TABLE statement. Or, if the table uses an
+** implicit rowid key, then the column 0 is the rowid and the explicit columns
+** are numbered starting from 1. If the iCol parameter is less than 0 or greater
+** than the index of the last column in the table, SQLITE_RANGE is returned.
+**
+** The fourth parameter is the integer value to use as part of the old.* or
+** new.* record.
+**
+** If this call is successful, SQLITE_OK is returned. Otherwise, if an
+** error occurs, an SQLite error code is returned.
+*/
+SQLITE_API int sqlite3changegroup_change_int64(
+  sqlite3_changegroup*,
+  int bNew,
+  int iCol,
+  sqlite3_int64 iVal
+);
+
+/*
+** CAPI3REF: Add a NULL to a changegroup
+**
+** This function is similar to sqlite3changegroup_change_int64(). Except that
+** it configures the change currently under construction with a NULL value
+** instead of a 64-bit integer.
+*/
+SQLITE_API int sqlite3changegroup_change_null(sqlite3_changegroup*, int, int);
+
+/*
+** CAPI3REF: Add an double to a changegroup
+**
+** This function is similar to sqlite3changegroup_change_int64(). Except that
+** it configures the change currently being constructed with a real value
+** instead of a 64-bit integer.
+*/
+SQLITE_API int sqlite3changegroup_change_double(sqlite3_changegroup*, int, int, double);
+
+/*
+** CAPI3REF: Add a text value to a changegroup
+**
+** This function is similar to sqlite3changegroup_change_int64(). It configures
+** the currently accumulated change with a text value instead of a 64-bit
+** integer. Parameter pVal points to a buffer containing the text encoded using
+** utf-8. Parameter nVal may either be the size of the text value in bytes, or
+** else a negative value, in which case the buffer pVal points to is assumed to
+** be nul-terminated.
+*/
+SQLITE_API int sqlite3changegroup_change_text(
+  sqlite3_changegroup*, int, int, const char *pVal, int nVal
+);
+
+/*
+** CAPI3REF: Add a blob to a changegroup
+**
+** This function is similar to sqlite3changegroup_change_int64(). It configures
+** the currently accumulated change with a blob value instead of a 64-bit
+** integer. Parameter pVal points to a buffer containing the blob. Parameter
+** nVal is the size of the blob in bytes.
+*/
+SQLITE_API int sqlite3changegroup_change_blob(
+    sqlite3_changegroup*, int, int, const void *pVal, int nVal
+);
+
+/*
+** CAPI3REF: Finish adding one-at-at-time changes to a changegroup
+**
+** This function may only be called following a successful call to
+** sqlite3changegroup_change_begin(). Otherwise, it is an SQLITE_MISUSE error.
+**
+** If parameter bDiscard is non-zero, then the current change is simply
+** discarded. In this case this function is always successful and SQLITE_OK
+** returned.
+**
+** If parameter bDiscard is zero, then an attempt is made to add the current
+** change to the changegroup. Assuming the changegroup is configured to
+** produce a changeset (not a patchset), this requires that:
+**
+**   *  If the change is an INSERT or DELETE, then a value must be specified
+**      for all columns of the new.* or old.* record, respectively.
+**
+**   *  If the change is an UPDATE record, then values must be provided for
+**      the PRIMARY KEY columns of the old.* record, but must not be provided
+**      for PRIMARY KEY columns of the new.* record.
+**
+**   *  If the change is an UPDATE record, then for each non-PRIMARY KEY
+**      column in the old.* record for which a value has been provided, a
+**      value must also be provided for the same column in the new.* record.
+**      Similarly, for each non-PK column in the old.* record for which
+**      a value is not provided, a value must not be provided for the same
+**      column in the new.* record.
+**
+**   *  All values specified for PRIMARY KEY columns must be non-NULL.
+**
+** Otherwise, it is an error.
+**
+** If the changegroup already contains a change for the same row (identified
+** by PRIMARY KEY columns), then the current change is combined with the
+** existing change in the same way as for sqlite3changegroup_add().
+**
+** For a patchset, all of the above rules apply except that it doesn't matter
+** whether or not values are provided for the non-PK old.* record columns
+** for an UPDATE or DELETE change. This means that code used to produce
+** a changeset using the sqlite3changegroup_change_xxx() APIs may also
+** be used to produce patchsets.
+**
+** If the call is successful, SQLITE_OK is returned. Otherwise, if an error
+** occurs, an SQLite error code is returned. If an error is returned and
+** parameter pzErr is not NULL, then (*pzErr) may be set to point to a buffer
+** containing a nul-terminated, utf-8 encoded, English language error message.
+** It is the responsibility of the caller to eventually free any such error
+** message buffer using sqlite3_free().
+*/
+SQLITE_API int sqlite3changegroup_change_finish(
+  sqlite3_changegroup*,
+  int bDiscard,
+  char **pzErr
+);
 
 /*
 ** Make sure we can call this stuff from C++.

--- a/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3.h
+++ b/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3.h
@@ -32,8 +32,13 @@
 */
 #ifndef SQLITE3_H
 #define SQLITE3_H
-#include "sqlite3_prefix.h"
 #include <stdarg.h>     /* Needed for the definition of va_list */
+
+/* KBVESQLite: rename the public API to kbve_sqlite3_* so consumers (e.g.
+** KBVEWorld) link against this threadsafe copy and never collide with the
+** engine's SQLiteCore in a monolithic build. Mirror of the force-include in
+** KBVESQLiteThirdParty.c. Added during the UE 5.8 upgrade. */
+#include "sqlite3_prefix.h"
 
 /*
 ** Make sure we can call this stuff from C++.

--- a/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3_prefix.h
+++ b/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3_prefix.h
@@ -61,6 +61,7 @@
 #define sqlite3_callback kbve_sqlite3_callback
 #define sqlite3_cancel_auto_extension kbve_sqlite3_cancel_auto_extension
 #define sqlite3_carray_bind kbve_sqlite3_carray_bind
+#define sqlite3_carray_bind_v2 kbve_sqlite3_carray_bind_v2
 #define sqlite3_changegroup kbve_sqlite3_changegroup
 #define sqlite3_changegroup_new kbve_sqlite3_changegroup_new
 #define sqlite3_changegroup_schema kbve_sqlite3_changegroup_schema
@@ -334,9 +335,11 @@
 #define sqlite3_str_appendf kbve_sqlite3_str_appendf
 #define sqlite3_str_errcode kbve_sqlite3_str_errcode
 #define sqlite3_str_finish kbve_sqlite3_str_finish
+#define sqlite3_str_free kbve_sqlite3_str_free
 #define sqlite3_str_length kbve_sqlite3_str_length
 #define sqlite3_str_new kbve_sqlite3_str_new
 #define sqlite3_str_reset kbve_sqlite3_str_reset
+#define sqlite3_str_truncate kbve_sqlite3_str_truncate
 #define sqlite3_str_value kbve_sqlite3_str_value
 #define sqlite3_str_vappendf kbve_sqlite3_str_vappendf
 #define sqlite3_strglob kbve_sqlite3_strglob

--- a/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3_prefix.h
+++ b/packages/unreal/KBVESQLite/ThirdParty/sqlite/sqlite3_prefix.h
@@ -1,29 +1,26 @@
-/*
- * sqlite3_prefix.h — GENERATED. Do not edit by hand.
- *
- * Renames KBVESQLite's bundled SQLite C API (sqlite3_*) to a kbve_sqlite3_*
- * symbol prefix so this plugin's amalgamation (3.51.3, SQLITE_THREADSAFE=1,
- * off-thread async access) can coexist in a single monolithic binary with the
- * engine's SQLiteCore (SQLITE_OS_OTHER / game-thread-serialized) without
- * LNK2005 duplicate-symbol errors.
- *
- * Force-included in two places (both required — the amalgamation comments out
- * its own `#include "sqlite3.h"`, so prefixing one file is not enough):
- *   1. KBVESQLiteThirdParty.c, before #include "sqlite3.c"  (prefixes definitions)
- *   2. top of sqlite3.h                                     (prefixes consumer decls)
- *
- * Regenerate when SQLite is updated:
- *   grep -hoE 'sqlite3_[A-Za-z0-9_]+' sqlite3.h sqlite3ext.h | sort -u \
- *     | grep -vE '^(sqlite3_XXX|sqlite3_xxx|sqlite3_X_init|sqlite3_bind_)$' \
- *     | awk '{printf "#define %s kbve_%s\n", $0, $0}'
- */
+// GENERATED — do not hand-edit. Regenerate from the bundled amalgamation:
+//   cd ThirdParty/sqlite
+//   { grep -hoE 'sqlite3_[A-Za-z0-9_]+' sqlite3.h; grep -E 'SQLITE_API' sqlite3.c \
+//       | grep -oE 'sqlite3_[A-Za-z0-9_]+'; } | sort -u \
+//       | grep -vE '^(sqlite3_XXX|sqlite3_xxx|sqlite3_X_init|sqlite3_bind_|sqlite3_prefix)$'
+//
+// Renames KBVESQLite's bundled SQLite (SQLITE_THREADSAFE=1, off-thread) exported C
+// API to a kbve_ prefix so it coexists in a MONOLITHIC client/server binary with the
+// engine's game-thread SQLiteCore (pulled in transitively via MassGameplay) without
+// LNK2005 duplicate-symbol errors. The editor build is modular so it never collided.
+//
+// Sourced from BOTH sqlite3.h and sqlite3.c SQLITE_API exports: the .c carries
+// extension-init symbols (fts3/fts5/rtree/icu _init) that are NOT declared in
+// sqlite3.h; omitting them lets them collide with SQLiteCore's copies. Over-inclusion
+// is a harmless no-op (whole-token #define); under-inclusion is a link error.
+//
+// Force-included from KBVESQLiteThirdParty.c (prefixes definitions) and the top of
+// sqlite3.h (prefixes consumer declarations, e.g. KBVEWorld).
 #ifndef KBVE_SQLITE3_PREFIX_H
 #define KBVE_SQLITE3_PREFIX_H
-
 #define sqlite3_activate_cerod kbve_sqlite3_activate_cerod
 #define sqlite3_aggregate_context kbve_sqlite3_aggregate_context
 #define sqlite3_aggregate_count kbve_sqlite3_aggregate_count
-#define sqlite3_api kbve_sqlite3_api
 #define sqlite3_api_routines kbve_sqlite3_api_routines
 #define sqlite3_authorizer kbve_sqlite3_authorizer
 #define sqlite3_auto_extension kbve_sqlite3_auto_extension
@@ -108,15 +105,16 @@
 #define sqlite3_context kbve_sqlite3_context
 #define sqlite3_context_db_handle kbve_sqlite3_context_db_handle
 #define sqlite3_create_collation kbve_sqlite3_create_collation
-#define sqlite3_create_collation16 kbve_sqlite3_create_collation16
 #define sqlite3_create_collation_v2 kbve_sqlite3_create_collation_v2
+#define sqlite3_create_collation16 kbve_sqlite3_create_collation16
 #define sqlite3_create_filename kbve_sqlite3_create_filename
 #define sqlite3_create_function kbve_sqlite3_create_function
-#define sqlite3_create_function16 kbve_sqlite3_create_function16
 #define sqlite3_create_function_v2 kbve_sqlite3_create_function_v2
+#define sqlite3_create_function16 kbve_sqlite3_create_function16
 #define sqlite3_create_module kbve_sqlite3_create_module
 #define sqlite3_create_module_v2 kbve_sqlite3_create_module_v2
 #define sqlite3_create_window_function kbve_sqlite3_create_window_function
+#define sqlite3_current_time kbve_sqlite3_current_time
 #define sqlite3_data_count kbve_sqlite3_data_count
 #define sqlite3_data_directory kbve_sqlite3_data_directory
 #define sqlite3_database_file_object kbve_sqlite3_database_file_object
@@ -133,6 +131,8 @@
 #define sqlite3_declare_vtab kbve_sqlite3_declare_vtab
 #define sqlite3_deserialize kbve_sqlite3_deserialize
 #define sqlite3_destructor_type kbve_sqlite3_destructor_type
+#define sqlite3_diskfull kbve_sqlite3_diskfull
+#define sqlite3_diskfull_pending kbve_sqlite3_diskfull_pending
 #define sqlite3_drop_modules kbve_sqlite3_drop_modules
 #define sqlite3_enable_load_extension kbve_sqlite3_enable_load_extension
 #define sqlite3_enable_shared_cache kbve_sqlite3_enable_shared_cache
@@ -155,9 +155,17 @@
 #define sqlite3_filename_journal kbve_sqlite3_filename_journal
 #define sqlite3_filename_wal kbve_sqlite3_filename_wal
 #define sqlite3_finalize kbve_sqlite3_finalize
+#define sqlite3_found_count kbve_sqlite3_found_count
 #define sqlite3_free kbve_sqlite3_free
 #define sqlite3_free_filename kbve_sqlite3_free_filename
 #define sqlite3_free_table kbve_sqlite3_free_table
+#define sqlite3_fts_init kbve_sqlite3_fts_init
+#define sqlite3_fts3_enable_parentheses kbve_sqlite3_fts3_enable_parentheses
+#define sqlite3_fts3_init kbve_sqlite3_fts3_init
+#define sqlite3_fts3_may_be_corrupt kbve_sqlite3_fts3_may_be_corrupt
+#define sqlite3_fts5_init kbve_sqlite3_fts5_init
+#define sqlite3_fts5_may_be_corrupt kbve_sqlite3_fts5_may_be_corrupt
+#define sqlite3_fullsync_count kbve_sqlite3_fullsync_count
 #define sqlite3_get_autocommit kbve_sqlite3_get_autocommit
 #define sqlite3_get_auxdata kbve_sqlite3_get_auxdata
 #define sqlite3_get_clientdata kbve_sqlite3_get_clientdata
@@ -165,6 +173,8 @@
 #define sqlite3_global_recover kbve_sqlite3_global_recover
 #define sqlite3_hard_heap_limit kbve_sqlite3_hard_heap_limit
 #define sqlite3_hard_heap_limit64 kbve_sqlite3_hard_heap_limit64
+#define sqlite3_hostid_num kbve_sqlite3_hostid_num
+#define sqlite3_icu_init kbve_sqlite3_icu_init
 #define sqlite3_index_constraint kbve_sqlite3_index_constraint
 #define sqlite3_index_constraint_usage kbve_sqlite3_index_constraint_usage
 #define sqlite3_index_info kbve_sqlite3_index_info
@@ -172,6 +182,12 @@
 #define sqlite3_initialize kbve_sqlite3_initialize
 #define sqlite3_int64 kbve_sqlite3_int64
 #define sqlite3_interrupt kbve_sqlite3_interrupt
+#define sqlite3_interrupt_count kbve_sqlite3_interrupt_count
+#define sqlite3_io_error_benign kbve_sqlite3_io_error_benign
+#define sqlite3_io_error_hardhit kbve_sqlite3_io_error_hardhit
+#define sqlite3_io_error_hit kbve_sqlite3_io_error_hit
+#define sqlite3_io_error_pending kbve_sqlite3_io_error_pending
+#define sqlite3_io_error_persist kbve_sqlite3_io_error_persist
 #define sqlite3_io_methods kbve_sqlite3_io_methods
 #define sqlite3_is_interrupted kbve_sqlite3_is_interrupted
 #define sqlite3_keyword_check kbve_sqlite3_keyword_check
@@ -180,13 +196,15 @@
 #define sqlite3_last_insert_rowid kbve_sqlite3_last_insert_rowid
 #define sqlite3_libversion kbve_sqlite3_libversion
 #define sqlite3_libversion_number kbve_sqlite3_libversion_number
+#define sqlite3_like_count kbve_sqlite3_like_count
 #define sqlite3_limit kbve_sqlite3_limit
 #define sqlite3_load_extension kbve_sqlite3_load_extension
-#define sqlite3_loadext_entry kbve_sqlite3_loadext_entry
 #define sqlite3_log kbve_sqlite3_log
 #define sqlite3_malloc kbve_sqlite3_malloc
 #define sqlite3_malloc64 kbve_sqlite3_malloc64
+#define sqlite3_max_blobsize kbve_sqlite3_max_blobsize
 #define sqlite3_mem_methods kbve_sqlite3_mem_methods
+#define sqlite3_memdebug_vfs_oom_test kbve_sqlite3_memdebug_vfs_oom_test
 #define sqlite3_memory_alarm kbve_sqlite3_memory_alarm
 #define sqlite3_memory_highwater kbve_sqlite3_memory_highwater
 #define sqlite3_memory_used kbve_sqlite3_memory_used
@@ -205,21 +223,27 @@
 #define sqlite3_next_stmt kbve_sqlite3_next_stmt
 #define sqlite3_normalized_sql kbve_sqlite3_normalized_sql
 #define sqlite3_open kbve_sqlite3_open
-#define sqlite3_open16 kbve_sqlite3_open16
+#define sqlite3_open_file_count kbve_sqlite3_open_file_count
 #define sqlite3_open_v2 kbve_sqlite3_open_v2
+#define sqlite3_open16 kbve_sqlite3_open16
+#define sqlite3_opentemp_count kbve_sqlite3_opentemp_count
 #define sqlite3_os_end kbve_sqlite3_os_end
 #define sqlite3_os_init kbve_sqlite3_os_init
+#define sqlite3_os_type kbve_sqlite3_os_type
 #define sqlite3_overload_function kbve_sqlite3_overload_function
+#define sqlite3_pager_readdb_count kbve_sqlite3_pager_readdb_count
+#define sqlite3_pager_writedb_count kbve_sqlite3_pager_writedb_count
+#define sqlite3_pager_writej_count kbve_sqlite3_pager_writej_count
 #define sqlite3_pcache kbve_sqlite3_pcache
 #define sqlite3_pcache_methods kbve_sqlite3_pcache_methods
 #define sqlite3_pcache_methods2 kbve_sqlite3_pcache_methods2
 #define sqlite3_pcache_page kbve_sqlite3_pcache_page
 #define sqlite3_prepare kbve_sqlite3_prepare
+#define sqlite3_prepare_v2 kbve_sqlite3_prepare_v2
+#define sqlite3_prepare_v3 kbve_sqlite3_prepare_v3
 #define sqlite3_prepare16 kbve_sqlite3_prepare16
 #define sqlite3_prepare16_v2 kbve_sqlite3_prepare16_v2
 #define sqlite3_prepare16_v3 kbve_sqlite3_prepare16_v3
-#define sqlite3_prepare_v2 kbve_sqlite3_prepare_v2
-#define sqlite3_prepare_v3 kbve_sqlite3_prepare_v3
 #define sqlite3_preupdate_blobwrite kbve_sqlite3_preupdate_blobwrite
 #define sqlite3_preupdate_count kbve_sqlite3_preupdate_count
 #define sqlite3_preupdate_depth kbve_sqlite3_preupdate_depth
@@ -240,10 +264,10 @@
 #define sqlite3_result_blob64 kbve_sqlite3_result_blob64
 #define sqlite3_result_double kbve_sqlite3_result_double
 #define sqlite3_result_error kbve_sqlite3_result_error
-#define sqlite3_result_error16 kbve_sqlite3_result_error16
 #define sqlite3_result_error_code kbve_sqlite3_result_error_code
 #define sqlite3_result_error_nomem kbve_sqlite3_result_error_nomem
 #define sqlite3_result_error_toobig kbve_sqlite3_result_error_toobig
+#define sqlite3_result_error16 kbve_sqlite3_result_error16
 #define sqlite3_result_int kbve_sqlite3_result_int
 #define sqlite3_result_int64 kbve_sqlite3_result_int64
 #define sqlite3_result_null kbve_sqlite3_result_null
@@ -263,9 +287,11 @@
 #define sqlite3_rtree_dbl kbve_sqlite3_rtree_dbl
 #define sqlite3_rtree_geometry kbve_sqlite3_rtree_geometry
 #define sqlite3_rtree_geometry_callback kbve_sqlite3_rtree_geometry_callback
+#define sqlite3_rtree_init kbve_sqlite3_rtree_init
 #define sqlite3_rtree_query kbve_sqlite3_rtree_query
 #define sqlite3_rtree_query_callback kbve_sqlite3_rtree_query_callback
 #define sqlite3_rtree_query_info kbve_sqlite3_rtree_query_info
+#define sqlite3_search_count kbve_sqlite3_search_count
 #define sqlite3_serialize kbve_sqlite3_serialize
 #define sqlite3_session kbve_sqlite3_session
 #define sqlite3_set_authorizer kbve_sqlite3_set_authorizer
@@ -285,6 +311,7 @@
 #define sqlite3_snprintf kbve_sqlite3_snprintf
 #define sqlite3_soft_heap_limit kbve_sqlite3_soft_heap_limit
 #define sqlite3_soft_heap_limit64 kbve_sqlite3_soft_heap_limit64
+#define sqlite3_sort_count kbve_sqlite3_sort_count
 #define sqlite3_sourceid kbve_sqlite3_sourceid
 #define sqlite3_sql kbve_sqlite3_sql
 #define sqlite3_status kbve_sqlite3_status
@@ -293,6 +320,7 @@
 #define sqlite3_stmt kbve_sqlite3_stmt
 #define sqlite3_stmt_busy kbve_sqlite3_stmt_busy
 #define sqlite3_stmt_explain kbve_sqlite3_stmt_explain
+#define sqlite3_stmt_init kbve_sqlite3_stmt_init
 #define sqlite3_stmt_isexplain kbve_sqlite3_stmt_isexplain
 #define sqlite3_stmt_readonly kbve_sqlite3_stmt_readonly
 #define sqlite3_stmt_scanstatus kbve_sqlite3_stmt_scanstatus
@@ -315,6 +343,7 @@
 #define sqlite3_stricmp kbve_sqlite3_stricmp
 #define sqlite3_strlike kbve_sqlite3_strlike
 #define sqlite3_strnicmp kbve_sqlite3_strnicmp
+#define sqlite3_sync_count kbve_sqlite3_sync_count
 #define sqlite3_syscall_ptr kbve_sqlite3_syscall_ptr
 #define sqlite3_system_errno kbve_sqlite3_system_errno
 #define sqlite3_table_column_metadata kbve_sqlite3_table_column_metadata
@@ -335,7 +364,6 @@
 #define sqlite3_uri_int64 kbve_sqlite3_uri_int64
 #define sqlite3_uri_key kbve_sqlite3_uri_key
 #define sqlite3_uri_parameter kbve_sqlite3_uri_parameter
-#define sqlite3_uri_vsnprintf kbve_sqlite3_uri_vsnprintf
 #define sqlite3_user_data kbve_sqlite3_user_data
 #define sqlite3_value kbve_sqlite3_value
 #define sqlite3_value_blob kbve_sqlite3_value_blob
@@ -379,8 +407,22 @@
 #define sqlite3_wal_checkpoint kbve_sqlite3_wal_checkpoint
 #define sqlite3_wal_checkpoint_v2 kbve_sqlite3_wal_checkpoint_v2
 #define sqlite3_wal_hook kbve_sqlite3_wal_hook
+#define sqlite3_win_test_unc_locking kbve_sqlite3_win_test_unc_locking
+#define sqlite3_win32_compact_heap kbve_sqlite3_win32_compact_heap
+#define sqlite3_win32_is_nt kbve_sqlite3_win32_is_nt
+#define sqlite3_win32_mbcs_to_utf8 kbve_sqlite3_win32_mbcs_to_utf8
+#define sqlite3_win32_mbcs_to_utf8_v2 kbve_sqlite3_win32_mbcs_to_utf8_v2
+#define sqlite3_win32_reset_heap kbve_sqlite3_win32_reset_heap
 #define sqlite3_win32_set_directory kbve_sqlite3_win32_set_directory
 #define sqlite3_win32_set_directory16 kbve_sqlite3_win32_set_directory16
 #define sqlite3_win32_set_directory8 kbve_sqlite3_win32_set_directory8
-
-#endif /* KBVE_SQLITE3_PREFIX_H */
+#define sqlite3_win32_sleep kbve_sqlite3_win32_sleep
+#define sqlite3_win32_unicode_to_utf8 kbve_sqlite3_win32_unicode_to_utf8
+#define sqlite3_win32_utf8_to_mbcs kbve_sqlite3_win32_utf8_to_mbcs
+#define sqlite3_win32_utf8_to_mbcs_v2 kbve_sqlite3_win32_utf8_to_mbcs_v2
+#define sqlite3_win32_utf8_to_unicode kbve_sqlite3_win32_utf8_to_unicode
+#define sqlite3_win32_write_debug kbve_sqlite3_win32_write_debug
+#define sqlite3_wsd_find kbve_sqlite3_wsd_find
+#define sqlite3_wsd_init kbve_sqlite3_wsd_init
+#define sqlite3_xferopt_count kbve_sqlite3_xferopt_count
+#endif // KBVE_SQLITE3_PREFIX_H


### PR DESCRIPTION
Two commits on **KBVESQLite**, first plugin in the Chuck ↔ monorepo plugin-drift sync (#13464). Validated in the Chuck game project; lands on the canonical monorepo source.

## 1. Cross-platform symbol isolation (Mac/Linux/Win)

Make the bundled SQLite amalgamation coexist with the engine's `SQLiteCore` in **monolithic (client/server)** builds without link/compile failures.

- **Windows `LNK2005`** — the old `sqlite3_prefix.h` under-included `sqlite3.c`-only `SQLITE_API` exports (`fts3_init`, `fts5_init`, `rtree_init`, `icu_init`, …). UE's `SQLiteCore` also compiles FTS/RTree → collision.
- **Mac clang `-Werror,-Wmacro-redefined`** — the amalgamation's `#ifndef SQLITE_ENABLE_COLUMN_METADATA` branch redefines the 6 `sqlite3_column_*_name` names as `0`, clashing with `kbve_` renames; and defining `COLUMN_METADATA` in both `Build.cs` and the `.c` was itself a redefinition.

Changes: `Build.cs` adds `SQLITE_ENABLE_COLUMN_METADATA=1` (Private; module-only is correct — the redefine lives in `sqlite3.c`, `sqlite3.h` declares the funcs unconditionally), moves `SQLITE_API` to Private on Mac/Linux, drops `SQLITE_EXTERN`. `.c` drops the duplicate define. `sqlite3_prefix.h` regenerated canonically from **both** `sqlite3.h` and `sqlite3.c` `SQLITE_API` lines (over-inclusion = harmless no-op, under-inclusion = link error); junk placeholders + the `sqlite3_prefix` self-include false-positive filtered.

## 2. Bump bundled SQLite 3.51.3 → 3.53.3

The bundle was on the back-patched **3.51.3** (2026-03-13) maintenance branch; **3.53.3** (2026-06-26) is current mainline. Replaced the amalgamation, re-applied the prefix force-include, regenerated `sqlite3_prefix.h` (**410 symbols**). 3.53.3 adds 3 exported symbols (`sqlite3_carray_bind_v2`, `str_free`, `str_truncate`), removes none. Compile flags unchanged.

## Verification

`ci-unreal-plugins.yml` Tier-1 compile (Linux + Win64) on this PR; Mac at release. Symbol-isolation logic already proven in the Chuck client/server cook.

Refs #13464.
