### PR TITLE
feat(arpg): boot-screen cross-promo ad shared across web + Discord embed

### DIFF
--- a/apps/agones/arpg/web/src/embed/discord.tsx
+++ b/apps/agones/arpg/web/src/embed/discord.tsx
@@ -5,6 +5,7 @@ import {
 } from '@discord/embedded-app-sdk';
 import { mount } from './index';
 import { setArpgAssetBase } from '../game/config';
+import { setExternalOpener } from '../lib/external';
 
 const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 	| string
@@ -389,6 +390,9 @@ async function boot(): Promise<void> {
 	const sdk = new DiscordSDK(CLIENT_ID);
 	await step('Discord SDK ready', () => sdk.ready());
 	activeSdk = sdk;
+	// Let in-game UI (boot-screen ads, CTAs) open links through the Activity SDK
+	// instead of a sandbox-blocked new tab.
+	setExternalOpener(openExternal);
 
 	void sdk.commands.encourageHardwareAcceleration().catch(() => {});
 

--- a/apps/agones/arpg/web/src/game/ArpgBootOverlay.tsx
+++ b/apps/agones/arpg/web/src/game/ArpgBootOverlay.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { onBoot, type BootStatus } from './systems/hud';
 import { arpgAsset } from './config';
 import { authBridge } from '../lib/auth';
+import ArpgChuckAd from './ArpgChuckAd';
 
 // If no boot event arrives for this long while still loading, assume the connect
 // silently wedged (server sim dead, JWT stuck, etc.) and surface an actionable
@@ -264,6 +265,8 @@ export default function ArpgBootOverlay() {
 					})}
 				</div>
 			)}
+
+			{!actionable && <ArpgChuckAd />}
 		</div>
 	);
 }

--- a/apps/agones/arpg/web/src/game/ArpgChuckAd.tsx
+++ b/apps/agones/arpg/web/src/game/ArpgChuckAd.tsx
@@ -1,0 +1,34 @@
+import { AdCard, type AdCreative, pickAd } from '@kbve/laser';
+import { getExternalOpener } from '../lib/external';
+
+// ARPG-side cross-promo creatives. The render + rotation live in @kbve/laser, so
+// promoting another title later is just another entry in this pool — no new code.
+// Shown on the boot/loading screen for both surfaces (kbve.com/arcade/arpg embed
+// and the Discord Activity), since both mount ReactIsoArpgApp -> ArpgBootOverlay.
+const ARPG_ADS: AdCreative[] = [
+	{
+		id: 'chuckrpg',
+		eyebrow: 'While you wait',
+		title: 'Play our MMO —',
+		highlight: 'ChuckRPG',
+		body: 'Open-world co-op adventure. Click to play →',
+		url: 'https://kbve.itch.io/chuckrpg',
+		icon: '⚔️',
+	},
+];
+
+export default function ArpgChuckAd() {
+	const creative = pickAd(ARPG_ADS);
+	if (!creative) return null;
+	// In the Discord Activity an opener is registered; route the click through the
+	// embedded SDK. On the plain web embed it's null, so AdCard's native anchor
+	// (target="_blank") opens a new tab.
+	const opener = getExternalOpener();
+	return (
+		<AdCard
+			creative={creative}
+			onOpen={opener ? (c) => opener(c.url) : undefined}
+			style={{ marginTop: '10px' }}
+		/>
+	);
+}

--- a/apps/agones/arpg/web/src/lib/external.ts
+++ b/apps/agones/arpg/web/src/lib/external.ts
@@ -1,0 +1,14 @@
+// Optional external-link opener. The Discord Activity sandbox can't open a bare
+// new tab — discord.tsx registers an opener backed by the embedded SDK's
+// openExternalLink. The plain web embed leaves this unset, so links fall back to
+// native anchor navigation (target="_blank"). Read at render time on the boot
+// screen, which only mounts after discord.tsx has the SDK ready.
+let opener: ((url: string) => void) | null = null;
+
+export function setExternalOpener(fn: ((url: string) => void) | null): void {
+	opener = fn;
+}
+
+export function getExternalOpener(): ((url: string) => void) | null {
+	return opener;
+}

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -207,6 +207,12 @@ export type {
 	ChatConfig,
 } from './lib/auth/game-auth';
 
+// Ads — framework-agnostic cross-promo model + boot-screen card + rotation pool
+export { AdCard } from './lib/ads/AdCard';
+export type { AdCardProps } from './lib/ads/AdCard';
+export { pickAd, AdRegistry, laserAds } from './lib/ads/registry';
+export type { AdCreative } from './lib/ads/types';
+
 // i18n — framework-agnostic translation store + React provider/hook
 export {
 	I18nStore,

--- a/packages/npm/laser/src/lib/ads/AdCard.tsx
+++ b/packages/npm/laser/src/lib/ads/AdCard.tsx
@@ -1,0 +1,130 @@
+import type { CSSProperties } from 'react';
+import type { AdCreative } from './types';
+
+const ACCENT = '#6ea8ff';
+
+export interface AdCardProps {
+	creative: AdCreative;
+	/**
+	 * Click override. Discord Activities can't open a bare new tab — the host
+	 * passes this to route through the embedded SDK's openExternalLink instead.
+	 * When set, default anchor navigation is suppressed.
+	 */
+	onOpen?: (creative: AdCreative) => void;
+	style?: CSSProperties;
+	className?: string;
+}
+
+/**
+ * Renders one {@link AdCreative} as a compact clickable card. Pure inline styles
+ * so it drops onto any boot/loading screen (Phaser canvas overlay, React shell)
+ * without a stylesheet. Content-agnostic: every label comes from the creative.
+ */
+export function AdCard({ creative, onOpen, style, className }: AdCardProps) {
+	const accent = creative.accent ?? ACCENT;
+	return (
+		<a
+			href={creative.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			className={className}
+			onClick={
+				onOpen
+					? (e) => {
+							e.preventDefault();
+							onOpen(creative);
+						}
+					: undefined
+			}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '12px',
+				maxWidth: '320px',
+				padding: '10px 14px',
+				borderRadius: '8px',
+				border: `1px solid ${accent}59`,
+				background:
+					'linear-gradient(135deg, rgba(20,26,40,0.9), rgba(34,24,48,0.9))',
+				textDecoration: 'none',
+				color: '#e6ebf5',
+				boxShadow: '0 4px 18px rgba(0,0,0,0.45)',
+				...style,
+			}}>
+			<span
+				aria-hidden="true"
+				style={{
+					flex: '0 0 auto',
+					width: '38px',
+					height: '38px',
+					borderRadius: '8px',
+					overflow: 'hidden',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					fontSize: '20px',
+					background: `radial-gradient(120% 120% at 30% 20%, ${accent}, #7c3aed)`,
+				}}>
+				{creative.imageUrl ? (
+					<img
+						src={creative.imageUrl}
+						alt=""
+						style={{
+							width: '100%',
+							height: '100%',
+							objectFit: 'cover',
+						}}
+						onError={(e) => {
+							(
+								e.currentTarget as HTMLImageElement
+							).style.display = 'none';
+						}}
+					/>
+				) : (
+					(creative.icon ?? '★')
+				)}
+			</span>
+			<span
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '2px',
+					minWidth: 0,
+				}}>
+				{creative.eyebrow ? (
+					<span
+						style={{
+							fontSize: '9px',
+							letterSpacing: 1.4,
+							textTransform: 'uppercase',
+							color: '#9fb3d8',
+						}}>
+						{creative.eyebrow}
+					</span>
+				) : null}
+				<span style={{ fontSize: '13px', fontWeight: 700 }}>
+					{creative.title}
+					{creative.highlight ? (
+						<>
+							{' '}
+							<span
+								style={{
+									color:
+										accent === ACCENT ? '#fcd34d' : accent,
+								}}>
+								{creative.highlight}
+							</span>
+						</>
+					) : null}
+				</span>
+				{creative.body ? (
+					<span style={{ fontSize: '11px', color: '#9fb3d8' }}>
+						{creative.body}
+					</span>
+				) : null}
+			</span>
+		</a>
+	);
+}
+
+export default AdCard;

--- a/packages/npm/laser/src/lib/ads/registry.spec.ts
+++ b/packages/npm/laser/src/lib/ads/registry.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { pickAd, AdRegistry } from './registry';
+import type { AdCreative } from './types';
+
+const ad = (id: string, weight?: number): AdCreative => ({
+	id,
+	title: id,
+	url: `https://example.com/${id}`,
+	weight,
+});
+
+describe('pickAd', () => {
+	it('returns null for an empty pool', () => {
+		expect(pickAd([])).toBeNull();
+	});
+
+	it('returns null when every weight is non-positive', () => {
+		expect(pickAd([ad('a', 0), ad('b', -3)])).toBeNull();
+	});
+
+	it('honors weighted boundaries with an injected rng', () => {
+		const pool = [ad('a', 1), ad('b', 3)];
+		expect(pickAd(pool, () => 0)?.id).toBe('a');
+		expect(pickAd(pool, () => 0.2)?.id).toBe('a');
+		expect(pickAd(pool, () => 0.3)?.id).toBe('b');
+		expect(pickAd(pool, () => 0.99)?.id).toBe('b');
+	});
+
+	it('skips zero-weight entries', () => {
+		const pool = [ad('a', 0), ad('b', 1)];
+		expect(pickAd(pool, () => 0)?.id).toBe('b');
+	});
+});
+
+describe('AdRegistry', () => {
+	it('registers, dedupes by id, removes, and picks', () => {
+		const reg = new AdRegistry();
+		reg.register(ad('a'), ad('b'));
+		reg.register({ ...ad('a'), title: 'updated' });
+		expect(reg.list()).toHaveLength(2);
+		expect(reg.list().find((c) => c.id === 'a')?.title).toBe('updated');
+		reg.remove('b');
+		expect(reg.pick(() => 0)?.id).toBe('a');
+		reg.clear();
+		expect(reg.pick()).toBeNull();
+	});
+});

--- a/packages/npm/laser/src/lib/ads/registry.ts
+++ b/packages/npm/laser/src/lib/ads/registry.ts
@@ -1,0 +1,58 @@
+import type { AdCreative } from './types';
+
+/**
+ * Weighted pick from a creative pool. Rotation only (not gameplay state), so the
+ * RNG is injectable but defaults to Math.random — no simgrid determinism contract.
+ * Returns null for an empty/all-zero-weight pool so callers can render nothing.
+ */
+export function pickAd(
+	ads: readonly AdCreative[],
+	rand: () => number = Math.random,
+): AdCreative | null {
+	if (ads.length === 0) return null;
+	const weights = ads.map((a) =>
+		a.weight == null ? 1 : Math.max(0, a.weight),
+	);
+	const total = weights.reduce((s, w) => s + w, 0);
+	if (total <= 0) return null;
+	let roll = rand() * total;
+	for (let i = 0; i < ads.length; i++) {
+		roll -= weights[i];
+		if (roll < 0) return ads[i];
+	}
+	return ads[ads.length - 1];
+}
+
+/**
+ * Mutable cross-promo pool. Games register their creatives once and let the boot
+ * screen pull a weighted pick each load; future ads need only a register() call.
+ */
+export class AdRegistry {
+	private readonly ads = new Map<string, AdCreative>();
+
+	register(...creatives: AdCreative[]): this {
+		for (const c of creatives) this.ads.set(c.id, c);
+		return this;
+	}
+
+	remove(id: string): this {
+		this.ads.delete(id);
+		return this;
+	}
+
+	clear(): this {
+		this.ads.clear();
+		return this;
+	}
+
+	list(): AdCreative[] {
+		return [...this.ads.values()];
+	}
+
+	pick(rand: () => number = Math.random): AdCreative | null {
+		return pickAd(this.list(), rand);
+	}
+}
+
+/** Shared registry instance for games that want a single global ad pool. */
+export const laserAds = new AdRegistry();

--- a/packages/npm/laser/src/lib/ads/types.ts
+++ b/packages/npm/laser/src/lib/ads/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Framework-agnostic cross-promo ad model shared by KBVE Phaser games. A creative
+ * is pure data — the host game supplies the content (its own titles + URLs) and
+ * laser owns the rendering + rotation, so any future ad slots in without new code.
+ */
+export interface AdCreative {
+	/** Stable id — used for rotation bookkeeping and React keys. */
+	id: string;
+	/** Small uppercase kicker above the title, e.g. "While you wait". */
+	eyebrow?: string;
+	/** Main headline line. */
+	title: string;
+	/** Optional trailing word rendered in the accent color (e.g. a product name). */
+	highlight?: string;
+	/** Sub-line beneath the title. */
+	body?: string;
+	/** Click target. Opened in a new tab (or via onClick if the host overrides). */
+	url: string;
+	/** Emoji or short glyph shown in the leading badge when imageUrl is absent. */
+	icon?: string;
+	/** Image source for the leading badge; takes precedence over icon. */
+	imageUrl?: string;
+	/** Selection weight for rotation pools. Defaults to 1; <=0 is never picked. */
+	weight?: number;
+	/** Accent color override (badge + highlight). Defaults to the laser blue. */
+	accent?: string;
+}


### PR DESCRIPTION
## What

Adds a boot/loading-screen cross-promo ad to the ARPG, shown on **both** surfaces — the kbve.com/arcade/arpg embed and the Discord Activity — since both mount `ReactIsoArpgApp -> ArpgBootOverlay`.

First creative pitches **ChuckRPG** ("Play our MMO", → kbve.itch.io/chuckrpg).

## Design — agnostic at the @kbve/laser level

The mechanism lives in `@kbve/laser` so any future ad is data-only:
- `AdCreative` — pure-data model (eyebrow/title/highlight/body/url/icon/imageUrl/weight/accent)
- `AdCard` — inline-styled, content-agnostic card; `onOpen` override for non-anchor hosts
- `pickAd` / `AdRegistry` / `laserAds` — weighted rotation pool

ARPG just supplies content in `ArpgChuckAd` (`ARPG_ADS` pool) — add future ads as array entries.

## Discord embed support

`AdCard.onOpen` lets the Discord Activity route clicks through the embedded SDK's `openExternalLink` (sandbox blocks a bare new tab). `discord.tsx` registers the opener once the SDK is ready via a small `lib/external` bridge; the plain web embed leaves it unset and falls back to a native `target="_blank"` anchor.

## Tests

- New `registry.spec.ts` — 5 tests (weighted boundaries, zero-weight skip, registry dedupe/remove/clear), pass
- `tsc` clean on `apps/agones/arpg/web`