### PR TITLE
feat(auth): accept-both verifier in metrics/jobboard/rows + edge functions

### DIFF
--- a/apps/jobboard/src/auth.rs
+++ b/apps/jobboard/src/auth.rs
@@ -133,7 +133,13 @@ pub async fn authenticate(app: &AppState, token: &str) -> Result<AuthUser, ApiEr
         .map_err(|_| ApiError::Unauthorized("invalid sub claim".into()))?;
 
     match app.auth_mode {
-        AuthMode::Local => verify_local(token, &app.jwt_secret)?,
+        AuthMode::Local => match &app.verifier {
+            Some(v) => {
+                v.verify::<SupabaseClaims>(token)
+                    .map_err(|e| ApiError::Unauthorized(format!("invalid token: {e}")))?;
+            }
+            None => verify_local(token, &app.jwt_secret)?,
+        },
         AuthMode::Remote => {
             remote_verify(app, token).await?;
             // Dev: prod-issued users have no row in the local auth.users, so

--- a/apps/jobboard/src/state.rs
+++ b/apps/jobboard/src/state.rs
@@ -33,6 +33,9 @@ pub struct AppState {
     pub anon_key: String,
     pub auth_mode: AuthMode,
     pub jwt_secret: Vec<u8>,
+    /// Accept-both verifier (HS256 + ES256/JWKS) for the asymmetric-signing
+    /// transition, used by Local auth mode. `None` → HS256-only.
+    pub verifier: Option<jedi::jwks::JwtVerifier>,
     pub auth_cache: Mutex<LruCache<String, CachedAuth>>,
 }
 
@@ -48,6 +51,25 @@ impl AppState {
             Ok("local") => AuthMode::Local,
             _ => AuthMode::Remote,
         };
+        let verifier = std::env::var("SUPABASE_JWKS_URI")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                let u = supabase_url.trim().trim_end_matches('/');
+                (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+            })
+            .map(|jwks_uri| {
+                let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty());
+                let secret = (!jwt_secret.is_empty()).then_some(jwt_secret.as_slice());
+                let v = jedi::jwks::JwtVerifier::new(jwks_uri, secret, issuer, None);
+                let bg = v.clone();
+                tokio::spawn(async move {
+                    bg.start(std::time::Duration::from_secs(300)).await;
+                });
+                v
+            });
         Arc::new(Self {
             db,
             started_at: Instant::now(),
@@ -57,6 +79,7 @@ impl AppState {
             anon_key,
             auth_mode,
             jwt_secret,
+            verifier,
             auth_cache: Mutex::new(LruCache::new(NonZeroUsize::new(2048).unwrap())),
         })
     }

--- a/apps/kube/functions/manifests/custom-functions/main/index.ts
+++ b/apps/kube/functions/manifests/custom-functions/main/index.ts
@@ -6,6 +6,16 @@ console.log('main function started')
 const JWT_SECRET = Deno.env.get('JWT_SECRET')
 const VERIFY_JWT = Deno.env.get('VERIFY_JWT') === 'true'
 
+// Accept-both for the HS256 -> ES256 migration: ES256 tokens validate against
+// GoTrue's JWKS (SUPABASE_JWKS_URI, else derived from SUPABASE_URL); legacy
+// HS256 tokens against the shared secret. JWKS absent -> HS256 only.
+const JWKS_URI =
+  Deno.env.get('SUPABASE_JWKS_URI') ||
+  (Deno.env.get('SUPABASE_URL')
+    ? `${Deno.env.get('SUPABASE_URL')!.replace(/\/+$/, '')}/auth/v1/.well-known/jwks.json`
+    : undefined)
+const JWKS = JWKS_URI ? jose.createRemoteJWKSet(new URL(JWKS_URI)) : undefined
+
 function getAuthToken(req: Request) {
   const authHeader = req.headers.get('authorization')
   if (!authHeader) {
@@ -19,10 +29,15 @@ function getAuthToken(req: Request) {
 }
 
 async function verifyJWT(jwt: string): Promise<boolean> {
-  const encoder = new TextEncoder()
-  const secretKey = encoder.encode(JWT_SECRET)
   try {
-    await jose.jwtVerify(jwt, secretKey)
+    const { alg } = jose.decodeProtectedHeader(jwt)
+    if (alg === 'HS256') {
+      await jose.jwtVerify(jwt, new TextEncoder().encode(JWT_SECRET))
+    } else if (JWKS) {
+      await jose.jwtVerify(jwt, JWKS)
+    } else {
+      return false
+    }
   } catch (err) {
     console.error(err)
     return false

--- a/apps/metrics/src/auth.rs
+++ b/apps/metrics/src/auth.rs
@@ -4,6 +4,9 @@ use kbve::gate::{AuthError, Claims, StaffGate, extract_token, validate_token};
 pub struct StaffAuth {
     jwt_secret: String,
     staff: Option<StaffGate>,
+    /// Accept-both verifier (HS256 + ES256/JWKS) for the asymmetric-signing
+    /// transition. `None` → HS256-only via `validate_token`.
+    verifier: Option<jedi::jwks::JwtVerifier>,
 }
 
 impl StaffAuth {
@@ -37,7 +40,37 @@ impl StaffAuth {
             None => None,
         };
 
-        Some(Self { jwt_secret, staff })
+        let verifier = std::env::var("SUPABASE_JWKS_URI")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                std::env::var("SUPABASE_URL").ok().and_then(|u| {
+                    let u = u.trim().trim_end_matches('/');
+                    (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+                })
+            })
+            .map(|jwks_uri| {
+                let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty());
+                let v = jedi::jwks::JwtVerifier::new(
+                    jwks_uri,
+                    Some(jwt_secret.as_bytes()),
+                    issuer,
+                    None,
+                );
+                let bg = v.clone();
+                tokio::spawn(async move {
+                    bg.start(std::time::Duration::from_secs(300)).await;
+                });
+                v
+            });
+
+        Some(Self {
+            jwt_secret,
+            staff,
+            verifier,
+        })
     }
 
     pub async fn require_staff(&self, headers: &HeaderMap) -> Result<Claims, AuthError> {
@@ -45,7 +78,13 @@ impl StaffAuth {
         let cookie = headers.get("cookie").and_then(|v| v.to_str().ok());
         let token = extract_token(auth, cookie, None).ok_or(AuthError::MissingToken)?;
 
-        let claims = validate_token(&token, &self.jwt_secret)?.claims;
+        let claims = match &self.verifier {
+            Some(v) => v.verify::<Claims>(&token).map_err(|e| match e {
+                jedi::jwks::VerifyError::Expired => AuthError::TokenExpired,
+                other => AuthError::InvalidToken(other.to_string()),
+            })?,
+            None => validate_token(&token, &self.jwt_secret)?.claims,
+        };
 
         if matches!(claims.role.as_str(), "service_role" | "supabase_admin") {
             return Ok(claims);

--- a/apps/rows/src/supabase.rs
+++ b/apps/rows/src/supabase.rs
@@ -8,15 +8,42 @@ pub struct SupabaseConfig {
     pub url: Option<String>,
     /// Argon2 hash of the service role key (never plaintext).
     pub service_key_hash: Option<String>,
+    /// Accept-both verifier (HS256 + ES256/JWKS) for the asymmetric-signing
+    /// transition. `None` → HS256-only via the local secret.
+    pub verifier: Option<jedi::jwks::JwtVerifier>,
 }
 
 impl SupabaseConfig {
     /// All fields stay optional so ROWS still boots without Supabase (legacy mode).
     pub fn from_env() -> Self {
+        let jwt_secret = std::env::var("SUPABASE_JWT_SECRET").ok();
+        let url = std::env::var("SUPABASE_URL").ok();
+        let verifier = std::env::var("SUPABASE_JWKS_URI")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                url.as_deref().map(str::trim).and_then(|u| {
+                    let u = u.trim_end_matches('/');
+                    (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+                })
+            })
+            .map(|jwks_uri| {
+                let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty());
+                let secret = jwt_secret.as_deref().map(str::as_bytes);
+                let v = jedi::jwks::JwtVerifier::new(jwks_uri, secret, issuer, None);
+                let bg = v.clone();
+                tokio::spawn(async move {
+                    bg.start(std::time::Duration::from_secs(300)).await;
+                });
+                v
+            });
         Self {
-            jwt_secret: std::env::var("SUPABASE_JWT_SECRET").ok(),
-            url: std::env::var("SUPABASE_URL").ok(),
+            jwt_secret,
+            url,
             service_key_hash: std::env::var("SUPABASE_SERVICE_KEY_HASH").ok(),
+            verifier,
         }
     }
 
@@ -66,19 +93,22 @@ pub struct ValidatedUser {
 /// Validates locally with the JWT secret. Revocation is not checked here —
 /// Supabase has no blocklist, so callers that need it must verify the DB session.
 pub fn validate_jwt(token: &str, config: &SupabaseConfig) -> Result<ValidatedUser, JwtError> {
-    let secret = config.jwt_secret.as_ref().ok_or(JwtError::NotConfigured)?;
-
-    let mut validation = Validation::new(Algorithm::HS256);
-    // Supabase tokens carry aud="authenticated", but ROWS authorizes on role/customer_guid, not
-    // audience — leave aud validation off rather than configure an expected value we won't enforce.
-    validation.validate_aud = false;
-
-    let key = DecodingKey::from_secret(secret.as_bytes());
-
-    let token_data = jsonwebtoken::decode::<SupabaseClaims>(token, &key, &validation)
-        .map_err(|e| JwtError::Invalid(e.to_string()))?;
-
-    let claims = token_data.claims;
+    let claims: SupabaseClaims = match &config.verifier {
+        Some(v) => v
+            .verify::<SupabaseClaims>(token)
+            .map_err(|e| JwtError::Invalid(e.to_string()))?,
+        None => {
+            let secret = config.jwt_secret.as_ref().ok_or(JwtError::NotConfigured)?;
+            let mut validation = Validation::new(Algorithm::HS256);
+            // Supabase tokens carry aud="authenticated", but ROWS authorizes on
+            // role/customer_guid, not audience — leave aud validation off.
+            validation.validate_aud = false;
+            let key = DecodingKey::from_secret(secret.as_bytes());
+            jsonwebtoken::decode::<SupabaseClaims>(token, &key, &validation)
+                .map_err(|e| JwtError::Invalid(e.to_string()))?
+                .claims
+        }
+    };
 
     let user_id = Uuid::parse_str(&claims.sub)
         .map_err(|_| JwtError::Invalid("Invalid sub (user_id) in JWT".into()))?;


### PR DESCRIPTION
Phase 1 (cont.) of the Supabase HS256→ES256 JWT migration. Wires the remaining **KBVE-owned** token validators to accept **both** HS256 and ES256/JWKS via the shared `jedi::jwks::JwtVerifier` (added in #715b3d51f on dev).

## What
- **metrics** — `StaffAuth.verifier`, used in `require_staff` (HS256 fallback)
- **jobboard** — `AppState.verifier`, used in the `AuthMode::Local` arm
- **rows** — `SupabaseConfig.verifier`, used in `validate_jwt`
- **edge functions** (Deno) — `verifyJWT` picks HS256 secret vs ES256 JWKS by `alg` (`jose.createRemoteJWKSet`)

Each is **opt-in**: builds the verifier from `SUPABASE_JWKS_URI` (else derived from `SUPABASE_URL`); absent → current HS256-only behavior. GoTrue still signs HS256, so this changes nothing until the env is set + the signer flips.

Compiles: metrics / jobboard / rows green (jobboard's 2 errors are the pre-existing missing `web/dist` embed, unrelated). edge = standard jose API.

## After this
Remaining before the GoTrue ES256 signer flip: **vendor PostgREST / Storage / Realtime** — point their JWT secret at a public JWKS (oct HS256 + EC public). q crate + irc-gateway are dev-only, deferred.