### PR TITLE
ci(unreal): verify Agones + KBVEAgones plugins on zip-capable runner

### DIFF
--- a/packages/unreal/Agones/VENDORING.md
+++ b/packages/unreal/Agones/VENDORING.md
@@ -22,3 +22,10 @@ git clone --depth 1 --branch release-1.58.0 --filter=blob:none --sparse https://
 cd agones && git sparse-checkout set sdks/unreal
 # diff sdks/unreal/Agones against packages/unreal/Agones, re-apply the TargetAllowList line
 ```
+
+## CI
+
+Linux-only, server target. Covered by the per-plugin verify pipeline
+(`ci-unreal-plugins.yml`). A change here selects `Agones` plus its dependent
+`KBVEAgones` via the changed-plugin cascade; the Linux verify stage runs on
+release PRs into `main` or any PR labeled `ci-full-plugins`.


### PR DESCRIPTION
## Why

The runner image now ships `zip` (#13389), so Unreal plugin verify can package on Linux. Two plugins have **never** run through the per-plugin verify pipeline:

- `Agones` (vendored SDK, Linux-only, server target) — added in #12759, before the per-plugin pipeline (#12770)
- `KBVEAgones` (ROWS bridge, Linux-only, server target) — depends on `Agones` + `KBVEROWS`

Neither was touched after the pipeline landed, so the changed-plugin matrix never selected them.

## What

Adds a CI note to `Agones/VENDORING.md` — a harmless touch of the `Agones` plugin path so the changed-plugin cascade selects **Agones** and its dependent **KBVEAgones**.

On the dev→main release PR (`base.ref == main`) the Linux verify stage runs, producing two verify jobs. The `KBVEAgones` job also pulls `Agones` + `KBVEROWS` as build deps, so this smoke-tests the full server bridge compile on the new runner. No label needed — the normal release flow opens the gate.

No source or behavior change.