### PR TITLE
fix(npcdb): UE 5.8 compile breaks in KBVENPCSprite render subsystem

### DIFF
--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
@@ -8,6 +8,7 @@
 #include "Materials/Material.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Materials/MaterialInterface.h"
+#include "MaterialDomain.h"
 #include "UObject/StrongObjectPtr.h"
 
 #if WITH_EDITOR
@@ -302,7 +303,7 @@ UInstancedStaticMeshComponent* UKBVENpcSpriteRenderSubsystem::GetOrCreateHISM(UK
 		{
 			if (Def->Atlas)
 			{
-				MID->SetTextureParameterValue(TEXT("Atlas"), Def->Atlas);
+				MID->SetTextureParameterValue(TEXT("Atlas"), Def->Atlas.Get());
 			}
 			MID->SetScalarParameterValue(TEXT("WorldSizeX"), Def->WorldSize.X);
 			MID->SetScalarParameterValue(TEXT("WorldSizeY"), Def->WorldSize.Y);


### PR DESCRIPTION
## Problem

The Unreal plugin verify pipeline now builds against **UE_5.8** (`dev-5.8.0`). The Mac verify of `KBVENPCDB` fails to compile `KBVENpcSpriteRenderSubsystem.cpp` with two 5.7→5.8 API-drift errors:

```
error: use of undeclared identifier 'MD_Surface'
  140 |   M->MaterialDomain = MD_Surface;

error: no viable conversion from 'TObjectPtr<UTexture2D>' to 'class UTexture *'
  305 |   MID->SetTextureParameterValue(TEXT("Atlas"), Def->Atlas);
```

Surfaced by the pets PR (`trunk/arpg-pets-1782642622`), which changed the NPC proto/schema and re-triggered the changed-plugin cascade — but the sprite module itself is **unchanged** there; this is a pre-existing break on `dev` that only the 5.8 verify catches.

## Fix

- `EMaterialDomain` (`MD_Surface`) is no longer transitively included under 5.8 → `#include "MaterialDomain.h"`.
- `UMaterialInstanceDynamic::SetTextureParameterValue` takes `UTexture*`; `TObjectPtr<UTexture2D>` no longer converts implicitly → pass `Def->Atlas.Get()`.

Two-line change, no behavior change. Unblocks `KBVENPCDB` plugin verify (and the pets PR once it picks up dev).

ref run: https://github.com/KBVE/kbve/actions/runs/28320856294