### PR TITLE
fix(kilobase): repair container target so Docker publish loads image

### DIFF
--- a/apps/kbve/kilobase/project.json
+++ b/apps/kbve/kilobase/project.json
@@ -182,27 +182,25 @@
 				"engine": "docker",
 				"context": "apps/kbve/kilobase",
 				"file": "apps/kbve/kilobase/Dockerfile",
-				"metadata": {
-					"images": ["kbve/kilobase"],
+				"load": true,
+				"tags": ["kbve/kilobase:latest"]
+			},
+			"configurations": {
+				"local": {
 					"load": true,
-					"tags": ["17.4.15", "17.4"]
+					"push": false,
+					"tags": ["kbve/kilobase:latest"]
 				},
-				"configurations": {
-					"local": {
-						"tags": ["17.4.15", "17.4"],
-						"push": false
-					},
-					"production": {
-						"tags": ["17.4.15", "17.4"],
-						"push": true,
-						"customBuildOptions": "--push",
-						"cache-from": [
-							"type=registry,ref=kbve/kilobase:buildcache"
-						],
-						"cache-to": [
-							"type=registry,ref=kbve/kilobase:buildcache,mode=max"
-						]
-					}
+				"production": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/kilobase:latest"],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/kilobase:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/kilobase:buildcache,mode=max"
+					]
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

CI [run #28322311352](https://github.com/KBVE/kbve/actions/runs/28322311352) (`CI - Docker / kilobase`) failed at **Push Docker Images**:

```
##[error]No images found matching 'kbve/kilobase'. Listing all images:
REPOSITORY          TAG               ...
tonistiigi/binfmt   latest            ...
moby/buildkit       buildx-stable-1   ...
```

The local Docker daemon had no `kbve/kilobase` image at all.

## Root cause

Two bugs in `apps/kbve/kilobase/project.json` `container` target:

1. **Hardcoded tags** `["17.4.15", "17.4"]` via `metadata` — the build tagged `kbve/kilobase:17.4.15`, but the publish workflow derives the version from the MDX source (`17.6.1`) and looks for `kbve/kilobase:17.6.1` / `:latest`. Never matched, and no `:latest` existed for the workflow fallback to catch.
2. **`configurations` nested inside `options`** plus `production` using `push:true` / `--push` with no `--load` — buildx exported straight to a registry, nothing was loaded into the local daemon, so the workflow's tag/push step found nothing.

## Fix

Mirror the canonical working pattern (arpg-server): `load:true`, `push:false`, `tags:["kbve/kilobase:latest"]`, `configurations` as a sibling of `options`, buildcache on `ghcr.io`. The publish workflow then retags the loaded `:latest` to `ghcr.io/kbve/kilobase:<version>` + `:latest` and pushes — producing the `ghcr.io/kbve/kilobase:17.6.1` image the blue-green epic needs.

Local-only change (project.json); no live cluster touched.

Closes #13509. Refs #13506.