### PR TITLE
fix(simgrid,arpg): resolve clippy lint failures

### DIFF
--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -457,10 +457,10 @@ fn mechamutt_team(species: &simgrid::NpcDef) -> Vec<simgrid::Combatant> {
 /// the strongest damaging move that still has PP (falling back to any PP move).
 fn ai_action(side: &simgrid::BattleSide) -> simgrid::BattleAction {
     let active = side.active();
-    if !active.is_alive() {
-        if let Some(i) = side.team.iter().position(simgrid::Combatant::is_alive) {
-            return simgrid::BattleAction::Swap { to: i };
-        }
+    if !active.is_alive()
+        && let Some(i) = side.team.iter().position(simgrid::Combatant::is_alive)
+    {
+        return simgrid::BattleAction::Swap { to: i };
     }
     let slot = active
         .moves

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -293,7 +293,7 @@ pub struct EquipmentEffects(pub HashMap<String, EquipBonus>);
 
 /// Worn gear: handles to the equipped item entities (not in the owner's [`Inventory`]
 /// while worn, no `GridPos`). `None` = slot empty. The item entity keeps its instance id
-/// + (later) durability/affix components while equipped. The per-slot bonus is cached so
+/// plus (later) durability/affix components while equipped. The per-slot bonus is cached so
 /// the combat hot path reads it without touching the item entities.
 #[derive(Component, Clone, Default)]
 pub struct Equipped {
@@ -1856,6 +1856,8 @@ pub struct ItemDefs<'w> {
     pub equipment: Res<'w, EquipmentEffects>,
 }
 
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
 fn drain_inputs(
     queue: Res<InputQueue>,
     map: Res<WalkableMap>,
@@ -2881,6 +2883,7 @@ pub const PLACE_RANGE: i32 = 4;
 /// Validate and consume one deployable item for placement. On success the item is
 /// already removed from `inv` and the caller queues the env spawn. Failure leaves
 /// the inventory untouched and returns a short reason for the client.
+#[allow(clippy::too_many_arguments)]
 fn place_item(
     deployables: &Deployables,
     map: &WalkableMap,


### PR DESCRIPTION
## What

Resolve failing lint tasks: `simgrid:lint`, `arpg-server:lint`, `cryptothrone-server:lint`.

## Changes

**simgrid** (`packages/rust/simgrid/src/sim.rs`)
- `doc_lazy_continuation`: reworded doc comment — clippy read leading `+` as a list bullet
- `drain_inputs`: `#[allow(too_many_arguments)]` + `#[allow(type_complexity)]` (repo convention for Bevy systems)
- `place_item`: `#[allow(too_many_arguments)]`

**arpg-server** (`apps/agones/arpg/server/src/game.rs`)
- `collapsible_if`: merged nested `if` / `if let` into `if … && let …` in `ai_action`

**cryptothrone-server** — no own errors; failed only because simgrid (dep) failed. Now green.

## Verify

All three pass:
- `./kbve.sh -nx simgrid:lint`
- `./kbve.sh -nx arpg-server:lint`
- `./kbve.sh -nx cryptothrone-server:lint`