### PR TITLE
fix(arpg): spell VFX launches from the caster, not an offset tile

### DIFF
--- a/apps/agones/arpg/web/src/game/entities/projectiles/spells/spellVfx.ts
+++ b/apps/agones/arpg/web/src/game/entities/projectiles/spells/spellVfx.ts
@@ -114,7 +114,7 @@ function castBolt(
 ): void {
 	ensureSpellTextures(scene);
 	const a = worldToScreen(from.x, from.y);
-	a.y -= 24;
+	a.y -= 32; // launch near the caster's body/hands, not the ground tile
 	const b = worldToScreen(to.x, to.y);
 	b.y -= 16;
 	const dist = Math.hypot(b.x - a.x, b.y - a.y);

--- a/apps/agones/arpg/web/src/game/systems/spells.ts
+++ b/apps/agones/arpg/web/src/game/systems/spells.ts
@@ -70,7 +70,11 @@ function playSpellVfxAt(
 	aim: TileXY,
 ): void {
 	if (!meta) return;
-	const from = deps.predicted();
+	// Launch the VFX from the player's actual sub-tile float position (where the sprite
+	// is drawn), NOT the rounded predicted tile — otherwise the bolt starts offset from
+	// the caster whenever they're between tiles. Mirrors the bow muzzle origin.
+	const pos = deps.floatState.pos;
+	const from: TileXY = { x: pos.x, y: pos.y };
 	const targeted = meta.effect === 'damage' || meta.effect === 'status';
 	const to = targeted
 		? ((target != null ? deps.store.tile(target) : null) ?? aim)


### PR DESCRIPTION
## Bug

Casting a spell in the 2D overworld: the projectile **resolves** on the cursor aim correctly, but the **bolt animation** is visibly offset from the caster.

## Cause

`playSpellVfxAt` started the VFX from `deps.predicted()` — the rounded predicted **tile** — while the player sprite is drawn at the **sub-tile float position**. Standing between tiles, the bolt launched from the wrong spot. (The bow doesn't have this — it launches from `floatPos()`.)

## Fix

- VFX origin now uses the player's float position (`floatState.pos`), exactly like the bow muzzle.
- Lift the launch to body height (24 → 32px) so the bolt leaves the caster's hands, not the ground tile.
- The server-targeting `from` still uses the predicted tile — only the **visual** origin changed.

## Verified
- arpg-web typecheck clean.