### PR TITLE
debug(arpg): box spell bolt travel (green) + impact (yellow)

### DIFF
--- a/apps/agones/arpg/web/src/game/entities/projectiles/spells/spellVfx.ts
+++ b/apps/agones/arpg/web/src/game/entities/projectiles/spells/spellVfx.ts
@@ -142,8 +142,22 @@ function castBolt(
 	trail.setDepth(DEPTH_PROJECTILE);
 	trail.startFollow(core);
 
+	// DEBUG: GREEN box follows the travelling bolt (its origin/travel animation);
+	// YELLOW box marks the destination (the impact/burst animation). Remove once the
+	// offset is diagnosed.
+	const dbgTravel = scene.add
+		.rectangle(a.x, a.y, 30, 30)
+		.setStrokeStyle(2, 0x22c55e)
+		.setFillStyle(0, 0)
+		.setDepth(DEPTH_PROJECTILE + 5);
+	const dbgImpact = scene.add
+		.rectangle(b.x, b.y, 30, 30)
+		.setStrokeStyle(2, 0xeab308)
+		.setFillStyle(0, 0)
+		.setDepth(DEPTH_PROJECTILE + 5);
+
 	scene.tweens.add({
-		targets: core,
+		targets: [core, dbgTravel],
 		x: b.x,
 		y: b.y,
 		duration,
@@ -153,6 +167,10 @@ function castBolt(
 			burst(scene, b.x, b.y, style.ramp);
 			core.destroy();
 			scene.time.delayedCall(400, () => trail.destroy());
+			scene.time.delayedCall(900, () => {
+				dbgTravel.destroy();
+				dbgImpact.destroy();
+			});
 		},
 	});
 }


### PR DESCRIPTION
Temporary debug instrumentation to diagnose the remaining spell-VFX offset (follows the origin fix in #13527).

Draws two stroked boxes in `castBolt`:
- **GREEN** — follows the travelling bolt (its origin / travel animation).
- **YELLOW** — marks the destination (the impact / burst animation).

Both auto-clean ~900ms after impact. Pull this branch, cast a spell, and report which box sits where it shouldn't:
- green not on the caster → origin still off
- yellow not on the cursor/target → destination off
- boxes correct but glow visually off → it's the sprite/trail anchor

Will be removed once the offset is identified.