### PR TITLE
feat(auth): realtime accept-both via API_JWT_JWKS

### DIFF
--- a/apps/kube/realtime/manifests/realtime-statefulset.yaml
+++ b/apps/kube/realtime/manifests/realtime-statefulset.yaml
@@ -71,6 +71,15 @@ spec:
                             secretKeyRef:
                                 name: realtime-jwt-secret
                                 key: API_JWT_SECRET
+                      # Accept-both: seeds.exs sets the tenant's jwt_jwks from
+                      # API_JWT_JWKS so realtime validates ES256 alongside the
+                      # HS256 API_JWT_SECRET. EC-public set, kid matches the
+                      # GoTrue signer. Needs the supabase-jwt-vendor secret.
+                      - name: API_JWT_JWKS
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-jwt-vendor
+                                key: public-jwks
                       - name: JWT_SECRET
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
Last data-plane vendor for the HS256→ES256 transition.

**No image update or Job needed** — our custom realtime `seeds.exs` already reads `API_JWT_JWKS` and sets the tenant `jwt_jwks` on both create and update. (Upstream realtime has no JWKS env at any version; ours injects it via the self-host seed.) So realtime just needs the env.

## Change
`API_JWT_JWKS` → `supabase-jwt-vendor/public-jwks` (EC-public JWKS, kid matches the GoTrue signer). On rollout the seed updates the existing tenant → realtime validates ES256 alongside the HS256 `API_JWT_SECRET`. `SECRET_KEY_BASE` (Elixir enc) untouched.

## Depends on
`supabase-jwt-vendor` secret from the vendor JWKS PR (#13528) — merge/release that first or the `secretKeyRef` won't resolve.

Realtime isn't actively used today; landing it so the whole data plane is accept-both before the GoTrue signer flip.