### PR TITLE
feat(edge): accept-both JWT (HS256 + ES256/JWKS) — v0.1.46

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.45"
+version: "0.1.46"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -14,6 +14,15 @@ const JWT_SECRET = VERIFY_JWT
   : Deno.env.get("JWT_SECRET");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+// Accept-both for the HS256 -> ES256 migration: ES256 tokens validate against
+// GoTrue's JWKS (SUPABASE_JWKS_URI, else derived from SUPABASE_URL); legacy
+// HS256 against the shared secret. JWKS absent -> HS256 only.
+const JWKS_URI =
+  Deno.env.get("SUPABASE_JWKS_URI") ||
+  (SUPABASE_URL
+    ? `${SUPABASE_URL.replace(/\/+$/, "")}/auth/v1/.well-known/jwks.json`
+    : "");
+const JWKS = JWKS_URI ? jose.createRemoteJWKSet(new URL(JWKS_URI)) : undefined;
 const PUBLIC_ROUTES = new Set(["health", "gh-webhook"]);
 const STAFF_ROUTES = new Set(["argo"]);
 
@@ -51,10 +60,15 @@ function getAuthToken(req: Request) {
 }
 
 async function verifyJWT(jwt: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const secretKey = encoder.encode(JWT_SECRET);
   try {
-    await jose.jwtVerify(jwt, secretKey);
+    const { alg } = jose.decodeProtectedHeader(jwt);
+    if (alg === "HS256") {
+      await jose.jwtVerify(jwt, new TextEncoder().encode(JWT_SECRET));
+    } else if (JWKS) {
+      await jose.jwtVerify(jwt, JWKS);
+    } else {
+      return false;
+    }
   } catch (err) {
     logError("main.verifyJWT", err);
     return false;


### PR DESCRIPTION
Edge functions for the HS256→ES256 transition — **the image needs a rebuild** (your call was right).

## Key correction
The running main service is the **baked** `apps/kbve/edge/functions/main/index.ts` (`--main-service /home/deno/functions/main` in `ghcr.io/kbve/edge`). The earlier #13475 edit hit `apps/kube/functions/.../custom-functions/main/index.ts` — a **stale copy that isn't running**. Fixed the real one here.

## Change
- `verifyJWT` picks the key by `alg`: HS256 → `JWT_SECRET`; ES256 → GoTrue JWKS via `jose.createRemoteJWKSet` (`SUPABASE_JWKS_URI`, else derived from `SUPABASE_URL`). `jose@v4.14.4` already imported (has `createRemoteJWKSet` + `decodeProtectedHeader`) — no new dep. JWKS absent → HS256-only.
- `edge.mdx` version `0.1.45` → `0.1.46` (MDX source of truth) → CI rebuilds the image + syncs the `functions-deployment` tag.

## Follow-up
The stale `apps/kube/functions/.../custom-functions/main/index.ts` (my #13475 edit) is a no-op; can be cleaned up separately.