### PR TITLE
fix(rust): clear pre-existing rows/workspace lint debt (#13540)

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,33 +61,9 @@ exclude = [
 [profile.dev]
 opt-level = 1
 
-[profile.dev.overrides.kilobase]
-panic = 'unwind'
-
-[profile.dev.overrides.isometric-game]
-panic = 'unwind'
-
 [profile.release]
 opt-level = 3
 lto = true
 strip = true
 codegen-units = 1
 panic = 'abort'
-
-[profile.release.overrides.kilobase]
-panic = 'unwind'
-opt-level = 3
-lto = 'fat'
-codegen-units = 1
-
-[profile.release.overrides.isometric-game]
-panic = 'unwind'
-opt-level = 3
-lto = 'fat'
-codegen-units = 1
-
-[profile.release.overrides.uniti]
-panic = 'unwind'
-opt-level = 3
-lto = 'fat'
-codegen-units = 1

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -29,10 +29,20 @@ name = "isometric-game"
 path = "src/main.rs"
 
 [features]
-default = []
+default = ["desktop"]
 # Native mobile (iOS/Android) build: drops the Tauri desktop shell and exposes
 # `mobile::init_game` for hosting on an externally-provided wgpu surface.
+# Build with `--no-default-features --features mobile`.
 mobile = []
+# Tauri desktop shell. On the default build; mobile builds opt out via
+# --no-default-features. The deps are also target-gated to non-wasm.
+desktop = [
+    "dep:tauri",
+    "dep:tauri-plugin-opener",
+    "dep:tauri-plugin-deep-link",
+    "dep:tauri-plugin-window-state",
+    "dep:urlencoding",
+]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
@@ -101,13 +111,13 @@ ureq = { version = "3", features = ["json"] }
 # Dedicated runtime that hosts the chat IRC-WS connection (all native targets).
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
-# --- Tauri desktop shell — excluded from the `mobile` feature build ---
-[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "mobile")))'.dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
-tauri-plugin-opener = "2"
-tauri-plugin-deep-link = "2"
-tauri-plugin-window-state = "2"
-urlencoding = "2"
+# Tauri desktop shell — gated by the `desktop` feature (on by default, off for
+# mobile builds via --no-default-features). Optional so mobile drops them.
+tauri = { version = "2", features = ["macos-private-api"], optional = true }
+tauri-plugin-opener = { version = "2", optional = true }
+tauri-plugin-deep-link = { version = "2", optional = true }
+tauri-plugin-window-state = { version = "2", optional = true }
+urlencoding = { version = "2", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/apps/rows/src/jobs.rs
+++ b/apps/rows/src/jobs.rs
@@ -159,8 +159,7 @@ impl AdvisoryLockGuard {
     /// Borrow the held connection as a `&mut PgConnection` (what sqlx's `Executor` wants) for the
     /// explicit unlock query — `PoolConnection` derefs to the inner `PgConnection`.
     fn conn_mut(&mut self) -> &mut sqlx::PgConnection {
-        &mut **self
-            .conn
+        self.conn
             .as_mut()
             .expect("advisory-lock connection already released")
     }

--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -134,12 +134,3 @@ wry = { version = "0.54.2", features = ["transparent", "devtools"] }
 raw-window-handle = "0.6.2"
 http = "1.4.0"
 infer = "0.19.0"
-
-# -----------------------------------------------------------------------------
-# Profiles
-# -----------------------------------------------------------------------------
-[profile.release]
-opt-level = 'z'
-lto = "fat"
-codegen-units = 1
-debug = false


### PR DESCRIPTION
Closes #13540.

Pre-existing lint debt surfaced on `dev` with stable toolchain (rustc/clippy ≥1.91; verified locally on 1.94). Four fixes, all behavior-preserving except #4 (which makes a previously-dead gate actually work).

## Changes

1. **`apps/rows/src/jobs.rs:162`** — drop `&mut **`; `PoolConnection` auto-derefs to `&mut PgConnection`. Fixes `clippy::explicit_auto_deref` that goes red under `-D warnings` on rust ≥1.91.
2. **root `Cargo.toml`** — delete dead `profile.{dev,release}.overrides.*` keys. `overrides` is not a valid profile key (silently ignored), and per-package `panic` is not a supportable override anyway. No behavior change.
3. **`packages/rust/q/Cargo.toml`** — delete the non-root `[profile.release]` block; profiles only apply at the workspace root, so it was already inert. The root release profile applies.
4. **`apps/kbve/isometric/src-tauri/Cargo.toml`** — the tauri desktop deps were gated by `cfg(not(feature = "mobile"))` in a `[target.*]` table, which Cargo silently ignores → they were pulled into *every* non-wasm build. Moved them to optional deps behind a new default-on `desktop` feature. Mobile builds now correctly drop the shell via `--no-default-features --features mobile`.

## Verification

- `cargo clippy -p rows --bins -- -D warnings` → Finished, no `explicit_auto_deref` (rustc 1.94).
- `cargo metadata` → no `unused manifest key` / non-root-profile warnings.
- `cargo tree -p isometric-game` → 4 tauri crates (default/desktop); `--no-default-features --features mobile` → 0 tauri crates.