### PR TITLE
fix(buildkitd): add no-duration GC tier as hard cache ceiling

### DIFF
--- a/apps/kube/github/runners/manifests/buildkitd.yaml
+++ b/apps/kube/github/runners/manifests/buildkitd.yaml
@@ -45,8 +45,13 @@ data:
           # pnpm store + layer cache across every app.
           gckeepstorage = "110GB"
           [[worker.oci.gcpolicy]]
-            keepBytes = "110GB"
+            keepBytes = "80GB"
             keepDuration = "336h"
+          # Final tier has no keepDuration: a hard ceiling that evicts oldest
+          # regardless of age. Without it, a burst of builds inside the 336h
+          # window protects every entry and the cache fills to the PVC (ENOSPC).
+          [[worker.oci.gcpolicy]]
+            keepBytes = "120GB"
 
         [worker.containerd]
           enabled = false


### PR DESCRIPTION
## Problem

arpg `container-web` build failed with:
```
ERROR: failed to solve: ResourceExhausted: failed to add snapshot ... to lease: write /var/lib/buildkit/runc-overlayfs/containerdmeta.db: no space left on device
```

`buildkitd-cache` PVC was full — **149.9 GiB / 150 GiB**.

## Root cause

The custom `[[worker.oci.gcpolicy]]` had a single rule with `keepDuration = "336h"` (14d). Specifying any explicit gcpolicy **replaces** buildkit's default multi-tier policy, whose final tier has no keepDuration and acts as the hard ceiling. With only the 336h rule, a burst of builds inside the 14d window protected every cache entry, so GC could evict nothing and the cache filled to the PVC.

## Fix

Add a final gcpolicy with **no keepDuration** — a hard 120GB ceiling that evicts oldest-first regardless of age:

```toml
[[worker.oci.gcpolicy]]
  keepBytes = "80GB"
  keepDuration = "336h"
[[worker.oci.gcpolicy]]
  keepBytes = "120GB"
```

## Deploy note

ConfigMap change needs a pod restart (Deployment uses `Recreate`) to reload the toml. Live cache already manually pruned to ~80GB to unwedge current builds.