### PR TITLE
chore(jedi): feature-gate heavy deps — drop askama, gate twitch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8777,7 +8777,6 @@ name = "jedi"
 version = "0.2.2"
 dependencies = [
  "ammonia",
- "askama 0.15.6",
  "async-trait",
  "axum 0.8.9",
  "axum-extra",

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -51,7 +51,6 @@ axum-extra = { version = "0.12.1", features = [
     "form",
     "file-stream"
 ]}
-askama = "0.15.4"
 bb8 = { version = "0.9.0", optional = true }
 bb8-postgres = { version = "0.9.0", optional = true }
 tokio-postgres-rustls = { version = "0.13", optional = true }

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -79,7 +79,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 rustc-hash = "2.1.1"
 flexbuffers = "25.2.10"
 # Twitch
-twitch-irc = { version = "5.0.1", default-features = false, features = ["with-serde", "refreshing-token-rustls-webpki-roots", "transport-tcp", "transport-tcp-rustls-webpki-roots", "transport-ws", "transport-ws-rustls-webpki-roots"] }
+twitch-irc = { version = "5.0.1", optional = true, default-features = false, features = ["with-serde", "refreshing-token-rustls-webpki-roots", "transport-tcp", "transport-tcp-rustls-webpki-roots", "transport-ws", "transport-ws-rustls-webpki-roots"] }
 # Replaceable
 crossbeam = "0.8.4"
 regex = "1.10.3"
@@ -99,6 +99,7 @@ clickhouse = ["dep:clickhouse"]
 prometheus = ["dep:axum-prometheus", "dep:metrics"]
 forgejo = []
 itch = []
+twitch = ["dep:twitch-irc"]
 postgres = [
     "dep:tokio-postgres",
     "dep:bb8",

--- a/packages/rust/jedi/src/proto/mod.rs
+++ b/packages/rust/jedi/src/proto/mod.rs
@@ -5,4 +5,5 @@ pub mod github;
 pub mod groq;
 pub mod jedi;
 pub mod redis;
+#[cfg(feature = "twitch")]
 pub mod twitch;

--- a/packages/rust/jedi/src/wrapper/mod.rs
+++ b/packages/rust/jedi/src/wrapper/mod.rs
@@ -1,4 +1,5 @@
 pub mod redis_wrapper;
+#[cfg(feature = "twitch")]
 pub mod twitch_wrapper;
 
 pub use redis_wrapper::*;


### PR DESCRIPTION
First slice of jedi dependency optimization ([plan](docs/plans/build-optimization/jedi-deps-optimization.md)). Goal: stop compiling heavy deps for consumers that don't use them.

## Step 1 — drop dead `askama` ✅
- `askama` had **0 usages** across `jedi/src` yet compiled unconditionally for all 17 downstream consumers.
- Pure subtraction. `cargo check -p jedi` passes `--no-default-features` (62 crates) and `--all-features` (412 crates).

## Step 2 — gate `twitch` (incoming on this branch)
- `twitch-irc` (full rustls/ws TLS stack) used only in `wrapper/twitch_wrapper.rs` + `proto/twitch.rs`. No in-repo consumer enables it.
- Make `twitch-irc` optional; gate behind a `twitch` feature.

Both steps are strictly build-cost reductions — no behavior change.