### PR TITLE
perf(sitegraph): pan/zoom/hover off React render path + decompose

### DIFF
--- a/apps/kbve/astro-kbve/src/components/sitegraph/SiteGraphHost.tsx
+++ b/apps/kbve/astro-kbve/src/components/sitegraph/SiteGraphHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SiteGraphLoader, createSiteGraphWorker } from '@kbve/astro';
 import {
 	osrsEdgeColors,
@@ -18,13 +18,40 @@ interface Props {
  * tag function, and tag styles. New domains (npcdb, itemdb, ...) wire
  * their own extractor + visuals here.
  *
- * Boots a SharedWorker on mount so the parsed graph is shared across
- * tabs; the loader's cache transparently routes through the worker port.
+ * Defers the heavy SiteGraph (d3-force + fetch + SharedWorker) until the
+ * sidebar slot nears the viewport — on the many docs pages where the graph
+ * is never scrolled into view it costs zero main-thread work.
  */
 export default function SiteGraphHost({ currentSlug }: Props) {
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	const [show, setShow] = useState(false);
+
 	useEffect(() => {
-		createSiteGraphWorker();
+		const el = sentinelRef.current;
+		if (!el || typeof IntersectionObserver === 'undefined') {
+			setShow(true);
+			return;
+		}
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting)) {
+					setShow(true);
+					io.disconnect();
+				}
+			},
+			{ rootMargin: '300px' },
+		);
+		io.observe(el);
+		return () => io.disconnect();
 	}, []);
+
+	useEffect(() => {
+		if (show) createSiteGraphWorker();
+	}, [show]);
+
+	if (!show) {
+		return <div ref={sentinelRef} className="sg-defer" aria-hidden="true" />;
+	}
 
 	return (
 		<SiteGraphLoader

--- a/packages/npm/astro/.verify/.gitignore
+++ b/packages/npm/astro/.verify/.gitignore
@@ -1,0 +1,3 @@
+*.png
+*.log
+node_modules/

--- a/packages/npm/astro/.verify/README.md
+++ b/packages/npm/astro/.verify/README.md
@@ -1,0 +1,17 @@
+# SiteGraph browser verify harness
+
+Standalone Vite page that mounts the real `SiteGraph` React island (real
+d3-force + real DOM paint) without booting the full Astro site, plus a
+Playwright driver that exercises hover-dim, pan, and wheel-zoom.
+
+```bash
+# from packages/npm/astro
+npx vite --config .verify/vite.config.mjs        # serves :4330
+node .verify/drive.mjs                            # drives + asserts, writes shots
+```
+
+`drive.mjs` prints a JSON report and writes `shot-base.png` / `shot-hover.png`.
+Artifacts (`*.png`, `*.log`) are gitignored — the harness source is kept for
+future e2e runs.
+
+`@kbve/droid` is stubbed (`droid-stub.ts`); only the graph is under test.

--- a/packages/npm/astro/.verify/drive.mjs
+++ b/packages/npm/astro/.verify/drive.mjs
@@ -1,0 +1,100 @@
+// Browser-drive the SiteGraph harness: hover-dim, restore, pan, wheel-zoom,
+// console errors. Run the vite server first, then this driver:
+//   npx vite --config .verify/vite.config.mjs    # from packages/npm/astro
+//   node .verify/drive.mjs
+import { chromium } from 'playwright';
+
+const out = (o) => process.stdout.write(JSON.stringify(o, null, 2) + '\n');
+const URL = process.env.URL ?? 'http://localhost:4330/';
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 800, height: 700 } });
+const consoleErrors = [];
+page.on('console', (m) => m.type() === 'error' && consoleErrors.push(m.text()));
+page.on('pageerror', (e) => consoleErrors.push('pageerror: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('.sg-node', { timeout: 10000 });
+await page.waitForTimeout(1500); // let the sim settle so node positions exist
+
+const nodeCount = await page.locator('.sg-node').count();
+
+const styleOf = (id, sel) =>
+	page.evaluate(
+		({ id, sel }) => {
+			const g = document.querySelector(`.sg-node[data-id="${id}"]`);
+			if (!g) return null;
+			if (sel === 'opacity') return g.style.opacity;
+			const el = g.querySelector(sel);
+			return el ? el.getAttribute('fill') : null;
+		},
+		{ id, sel },
+	);
+const linkOpacity = (s, t) =>
+	page.evaluate(
+		({ s, t }) => {
+			const p = document.querySelector(
+				`.sg-link[data-source="${s}"][data-target="${t}"]`,
+			);
+			return p ? p.getAttribute('stroke-opacity') : null;
+		},
+		{ s, t },
+	);
+const groupTransform = () =>
+	page.evaluate(
+		() =>
+			document.querySelector('.sg-link')?.closest('g')?.getAttribute('transform') ??
+			null,
+	);
+
+await page.screenshot({ path: '.verify/shot-base.png' });
+
+// Hover node 'b' (neighbors: a). 'd' is non-adjacent → should dim.
+await page.locator('.sg-node[data-id="b"]').hover({ force: true });
+await page.waitForTimeout(150);
+const hover = {
+	bFill: await styleOf('b', '.sg-node-circle'),
+	dOpacity_nonAdjacent: await styleOf('d', 'opacity'),
+	aOpacity_adjacent: await styleOf('a', 'opacity'),
+	linkAB: await linkOpacity('a', 'b'),
+	linkAD_dimmed: await linkOpacity('a', 'd'),
+};
+await page.screenshot({ path: '.verify/shot-hover.png' });
+
+// Leave → base restored.
+await page.mouse.move(5, 5);
+await page.waitForTimeout(150);
+const afterLeave = {
+	bFill: await styleOf('b', '.sg-node-circle'),
+	dOpacity: await styleOf('d', 'opacity'),
+	linkAD: await linkOpacity('a', 'd'),
+};
+
+// Pan drag on empty SVG space.
+const svg = await page.locator('svg').first().boundingBox();
+const before = await groupTransform();
+const sx = svg.x + svg.width / 2;
+const sy = svg.y + svg.height - 18;
+await page.mouse.move(sx, sy);
+await page.mouse.down();
+await page.mouse.move(sx + 60, sy - 50, { steps: 6 });
+await page.mouse.up();
+await page.waitForTimeout(80);
+const afterPan = await groupTransform();
+
+// Wheel zoom over the center.
+await page.mouse.move(svg.x + svg.width / 2, svg.y + svg.height / 2);
+await page.mouse.wheel(0, -240);
+await page.waitForTimeout(120);
+const afterWheel = await groupTransform();
+
+out({
+	nodeCount,
+	hover,
+	afterLeave,
+	pan: { before, afterPan, panned: before !== afterPan },
+	wheel: { afterWheel, zoomed: afterPan !== afterWheel },
+	consoleErrors,
+});
+
+await browser.close();

--- a/packages/npm/astro/.verify/droid-stub.ts
+++ b/packages/npm/astro/.verify/droid-stub.ts
@@ -1,0 +1,2 @@
+export const openTooltip = (_id?: string) => {};
+export const closeTooltip = (_id?: string) => {};

--- a/packages/npm/astro/.verify/index.html
+++ b/packages/npm/astro/.verify/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>SiteGraph verify</title>
+		<style>
+			:root {
+				--sl-color-accent: #3b82f6;
+				--sl-color-accent-high: #1d4ed8;
+				--sl-color-white: #e6edf3;
+				--sl-color-gray-3: #8b949e;
+				--sl-color-gray-4: #6e7681;
+				--sl-color-gray-5: #262626;
+				--sl-color-gray-6: #1a1a1a;
+				--sl-color-bg-nav: #0d1117;
+				--sl-color-bg: #010409;
+			}
+			body {
+				background: #010409;
+				margin: 0;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/main.tsx"></script>
+	</body>
+</html>

--- a/packages/npm/astro/.verify/main.tsx
+++ b/packages/npm/astro/.verify/main.tsx
@@ -1,0 +1,44 @@
+import { createRoot } from 'react-dom/client';
+import { SiteGraph } from '../src/sitegraph/react/SiteGraph';
+
+const sample = {
+	a: { title: 'Alpha', links: ['b', 'c', 'd'], backlinks: [] },
+	b: { title: 'Beta', links: ['e'], backlinks: ['a'] },
+	c: { title: 'Gamma', links: [], backlinks: ['a'] },
+	d: { title: 'Delta', links: [], backlinks: ['a'] },
+	e: { title: 'Epsilon', links: [], backlinks: ['b'] },
+};
+
+const realFetch = window.fetch;
+window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+	if (String(input).includes('sitegraph')) {
+		return Promise.resolve(
+			new Response(JSON.stringify(sample), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		);
+	}
+	return realFetch(input, init);
+}) as typeof window.fetch;
+
+const tagOf = (slug: string) =>
+	slug === 'a' ? 'root' : slug === 'e' ? 'leaf' : 'mid';
+
+createRoot(document.getElementById('root')!).render(
+	<div style={{ width: 360, padding: 20 }}>
+		<SiteGraph
+			currentSlug="a"
+			width={320}
+			height={320}
+			fixedSize
+			tagOf={tagOf}
+			tagStyles={{
+				root: { fill: '#22d3ee', stroke: '#0891b2', radius: 6 },
+				mid: { fill: '#a3a3a3', stroke: '#525252', radius: 4 },
+				leaf: { fill: '#eab308', stroke: '#a16207', radius: 4 },
+			}}
+			tagLabels={{ root: 'Root', mid: 'Mid', leaf: 'Leaf' }}
+		/>
+	</div>,
+);

--- a/packages/npm/astro/.verify/vite.config.mjs
+++ b/packages/npm/astro/.verify/vite.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+
+// Standalone harness for browser-driving the SiteGraph React island in
+// isolation (real d3-force + real DOM paint), without booting the full Astro
+// site. @kbve/droid is stubbed — only the graph itself is under test.
+export default defineConfig({
+	root: import.meta.dirname,
+	plugins: [react()],
+	resolve: {
+		alias: {
+			'@kbve/droid': fileURLToPath(
+				new URL('./droid-stub.ts', import.meta.url),
+			),
+		},
+	},
+	server: { port: 4330 },
+});

--- a/packages/npm/astro/src/sitegraph/react/GraphControls.tsx
+++ b/packages/npm/astro/src/sitegraph/react/GraphControls.tsx
@@ -1,0 +1,102 @@
+import { memo, type RefObject } from 'react';
+
+interface GraphControlsProps {
+	depth: number;
+	onDepthChange: (depth: number) => void;
+	minDepth: number;
+	maxDepth: number;
+	search: string;
+	onSearchChange: (q: string) => void;
+	searchInputRef: RefObject<HTMLInputElement | null>;
+	isFullscreen: boolean;
+	onFullscreenChange?: (next: boolean) => void;
+}
+
+/** Top control bar: neighborhood depth, title filter, fullscreen toggle. */
+export const GraphControls = memo(function GraphControls({
+	depth,
+	onDepthChange,
+	minDepth,
+	maxDepth,
+	search,
+	onSearchChange,
+	searchInputRef,
+	isFullscreen,
+	onFullscreenChange,
+}: GraphControlsProps) {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '6px',
+				padding: '0 8px 6px',
+				fontSize: '11px',
+				color: 'var(--sl-color-gray-3, #8b949e)',
+			}}>
+			<label
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: '4px',
+				}}>
+				Depth
+				<select
+					value={depth}
+					onChange={(e) => onDepthChange(Number(e.target.value))}
+					style={{
+						background: 'var(--sl-color-bg-nav)',
+						color: 'inherit',
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						borderRadius: 4,
+						padding: '1px 4px',
+						fontSize: '11px',
+					}}>
+					{Array.from(
+						{ length: maxDepth - minDepth + 1 },
+						(_, i) => minDepth + i,
+					).map((d) => (
+						<option key={d} value={d}>
+							{d}
+						</option>
+					))}
+				</select>
+			</label>
+			<input
+				ref={searchInputRef}
+				type="search"
+				value={search}
+				onChange={(e) => onSearchChange(e.target.value)}
+				placeholder="Filter…  (/)"
+				aria-label="Filter nodes by title (press / to focus)"
+				style={{
+					flex: 1,
+					minWidth: 0,
+					background: 'var(--sl-color-bg-nav)',
+					color: 'inherit',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					borderRadius: 4,
+					padding: '2px 6px',
+					fontSize: '11px',
+				}}
+			/>
+			{onFullscreenChange && (
+				<button
+					onClick={() => onFullscreenChange(!isFullscreen)}
+					title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+					aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+					style={{
+						background: 'none',
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						color: 'inherit',
+						borderRadius: 4,
+						padding: '1px 6px',
+						fontSize: '11px',
+						cursor: 'pointer',
+					}}>
+					{isFullscreen ? '×' : '⤢'}
+				</button>
+			)}
+		</div>
+	);
+});

--- a/packages/npm/astro/src/sitegraph/react/GraphLegend.tsx
+++ b/packages/npm/astro/src/sitegraph/react/GraphLegend.tsx
@@ -1,0 +1,95 @@
+import { memo } from 'react';
+
+interface GraphLegendProps {
+	distinctTags: string[];
+	distinctRelationships: string[];
+	tagStyles?: Record<string, { fill: string; stroke: string; radius: number }>;
+	tagLabels?: Record<string, string>;
+	edgeColors?: Record<string, string>;
+	edgeDashes?: Record<string, string>;
+	edgeLabels?: Record<string, string>;
+}
+
+/** Cluster legend: tag swatches + relationship line styles below the SVG. */
+export const GraphLegend = memo(function GraphLegend({
+	distinctTags,
+	distinctRelationships,
+	tagStyles,
+	tagLabels,
+	edgeColors,
+	edgeDashes,
+	edgeLabels,
+}: GraphLegendProps) {
+	if (distinctTags.length < 2 && distinctRelationships.length === 0)
+		return null;
+
+	return (
+		<ul
+			className="sg-legend"
+			aria-label="Graph legend"
+			style={{
+				listStyle: 'none',
+				margin: '6px 0 0',
+				padding: '0 8px',
+				display: 'flex',
+				flexWrap: 'wrap',
+				gap: '4px 10px',
+				fontSize: '10px',
+				color: 'var(--sl-color-gray-3, #8b949e)',
+			}}>
+			{distinctTags.length >= 2 &&
+				distinctTags.map((tag) => {
+					const style = tagStyles?.[tag];
+					return (
+						<li
+							key={`tag-${tag}`}
+							style={{
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: '4px',
+							}}>
+							<span
+								style={{
+									width: 8,
+									height: 8,
+									borderRadius: '50%',
+									background:
+										style?.fill ?? 'var(--sl-color-white)',
+									border: `1px solid ${style?.stroke ?? 'var(--sl-color-gray-4)'}`,
+									display: 'inline-block',
+								}}
+								aria-hidden="true"
+							/>
+							{tagLabels?.[tag] ?? tag}
+						</li>
+					);
+				})}
+			{distinctRelationships.map((rel) => {
+				const dash = edgeDashes?.[rel];
+				const stroke = edgeColors?.[rel] ?? 'var(--sl-color-gray-4)';
+				return (
+					<li
+						key={`rel-${rel}`}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '4px',
+						}}>
+						<svg width={16} height={6} aria-hidden="true">
+							<line
+								x1={0}
+								y1={3}
+								x2={16}
+								y2={3}
+								stroke={stroke}
+								strokeWidth={1.5}
+								strokeDasharray={dash}
+							/>
+						</svg>
+						{edgeLabels?.[rel] ?? rel}
+					</li>
+				);
+			})}
+		</ul>
+	);
+});

--- a/packages/npm/astro/src/sitegraph/react/GraphTooltip.tsx
+++ b/packages/npm/astro/src/sitegraph/react/GraphTooltip.tsx
@@ -1,0 +1,55 @@
+import { memo, type RefObject } from 'react';
+
+interface GraphTooltipProps {
+	tooltipRef: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Floating node tooltip. Content + position are written imperatively (see
+ * `showTooltip`/`moveTooltip` in SiteGraph) so it never re-renders on hover.
+ */
+export const GraphTooltip = memo(function GraphTooltip({
+	tooltipRef,
+}: GraphTooltipProps) {
+	return (
+		<div
+			ref={tooltipRef}
+			role="tooltip"
+			aria-hidden="true"
+			style={{
+				position: 'absolute',
+				transform: 'translate(-50%, -100%) translateY(-12px)',
+				pointerEvents: 'none',
+				zIndex: 10,
+				background: 'var(--sl-color-gray-6, #1a1a1a)',
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				borderRadius: 6,
+				padding: '5px 8px',
+				whiteSpace: 'nowrap',
+				boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+				opacity: 0,
+				visibility: 'hidden',
+				transition: 'opacity 0.1s ease',
+				top: 0,
+				left: 0,
+			}}>
+			<div
+				data-sg-tip-title
+				style={{
+					fontSize: '10px',
+					fontWeight: 600,
+					color: 'var(--sl-color-white, #e6edf3)',
+					lineHeight: 1.3,
+				}}
+			/>
+			<div
+				data-sg-tip-path
+				style={{
+					fontSize: '8.5px',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					lineHeight: 1.3,
+				}}
+			/>
+		</div>
+	);
+});

--- a/packages/npm/astro/src/sitegraph/react/GraphZoomBar.tsx
+++ b/packages/npm/astro/src/sitegraph/react/GraphZoomBar.tsx
@@ -1,0 +1,66 @@
+import { memo } from 'react';
+import { MIN_ZOOM, MAX_ZOOM } from './graph-core';
+
+interface GraphZoomBarProps {
+	zoom: number;
+	onReset: () => void;
+	onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/** Bottom zoom bar: reset-to-100% button + zoom slider. */
+export const GraphZoomBar = memo(function GraphZoomBar({
+	zoom,
+	onReset,
+	onSliderChange,
+}: GraphZoomBarProps) {
+	const pct = ((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100;
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '6px',
+				padding: '6px 8px 0',
+			}}>
+			<button
+				onClick={onReset}
+				title="Reset zoom"
+				style={{
+					background: 'none',
+					border: 'none',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '10px',
+					fontWeight: 600,
+					cursor: 'pointer',
+					padding: '2px 4px',
+					borderRadius: 4,
+					lineHeight: 1,
+					fontVariantNumeric: 'tabular-nums',
+					minWidth: '32px',
+					textAlign: 'center',
+				}}>
+				{Math.round(zoom * 100)}%
+			</button>
+			<input
+				type="range"
+				min={MIN_ZOOM}
+				max={MAX_ZOOM}
+				step={0.05}
+				value={zoom}
+				onChange={onSliderChange}
+				title={`Zoom: ${Math.round(zoom * 100)}%`}
+				aria-label="Zoom level"
+				aria-valuetext={`${Math.round(zoom * 100)}%`}
+				style={{
+					flex: 1,
+					height: '3px',
+					appearance: 'none',
+					WebkitAppearance: 'none',
+					background: `linear-gradient(to right, var(--sl-color-accent, #06b6d4) 0%, var(--sl-color-accent, #06b6d4) ${pct}%, var(--sl-color-gray-5, #262626) ${pct}%, var(--sl-color-gray-5, #262626) 100%)`,
+					borderRadius: '2px',
+					cursor: 'pointer',
+				}}
+			/>
+		</div>
+	);
+});

--- a/packages/npm/astro/src/sitegraph/react/SiteGraph.spec.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraph.spec.tsx
@@ -90,6 +90,48 @@ describe('SiteGraph', () => {
 		expect(screen.getByText('OSRS')).toBeTruthy();
 	});
 
+	it('paints hover-dim imperatively without re-rendering', async () => {
+		stubFetch(sample);
+		const { container } = render(<SiteGraph currentSlug="a" />);
+		await waitFor(() => {
+			expect(container.querySelectorAll('.sg-node').length).toBe(3);
+		});
+
+		const nodeOf = (id: string) =>
+			container.querySelector<SVGGElement>(`.sg-node[data-id="${id}"]`)!;
+		const linkOf = (s: string, t: string) =>
+			container.querySelector<SVGPathElement>(
+				`.sg-link[data-source="${s}"][data-target="${t}"]`,
+			)!;
+
+		// Base state: every filtered-in node at full opacity.
+		expect(nodeOf('b').style.opacity).toBe('1');
+		expect(nodeOf('c').style.opacity).toBe('1');
+
+		// Hover b → set = {b, a}. c is non-adjacent → dims; b highlights.
+		fireEvent.mouseEnter(nodeOf('b'));
+		expect(nodeOf('a').style.opacity).toBe('1');
+		expect(nodeOf('c').style.opacity).toBe('0.18');
+		expect(
+			nodeOf('b')
+				.querySelector('.sg-node-circle')!
+				.getAttribute('fill'),
+		).toBe('var(--sl-color-accent)');
+		// Edge a→b stays lit (both incident); a→c dims.
+		expect(linkOf('a', 'b').getAttribute('stroke-opacity')).toBe('0.4');
+		expect(linkOf('a', 'c').getAttribute('stroke-opacity')).toBe('0.08');
+
+		// Leave → base restored.
+		fireEvent.mouseLeave(nodeOf('b'));
+		expect(nodeOf('c').style.opacity).toBe('1');
+		expect(
+			nodeOf('b')
+				.querySelector('.sg-node-circle')!
+				.getAttribute('fill'),
+		).toBe('var(--sl-color-white)');
+		expect(linkOf('a', 'c').getAttribute('stroke-opacity')).toBe('0.4');
+	});
+
 	it('persists depth changes to localStorage', async () => {
 		stubFetch(sample);
 		const setItem = vi.spyOn(Storage.prototype, 'setItem');

--- a/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
@@ -7,35 +7,24 @@ import {
 	useDeferredValue,
 	type CSSProperties,
 } from 'react';
-import {
-	forceSimulation,
-	forceLink,
-	forceManyBody,
-	forceCenter,
-	forceCollide,
-	forceX,
-	forceY,
-	type Simulation,
-	type SimulationNodeDatum,
-	type SimulationLinkDatum,
-} from 'd3-force';
 import { openTooltip, closeTooltip } from '@kbve/droid';
-import { fetchSiteGraph } from './cache';
-import type { SiteGraphData } from '../types';
-
-interface GraphNode extends SimulationNodeDatum {
-	id: string;
-	title: string;
-	isCurrent: boolean;
-	tag: string | null;
-	degree: number;
-}
-
-interface GraphLink extends SimulationLinkDatum<GraphNode> {
-	source: GraphNode;
-	target: GraphNode;
-	relationship?: string;
-}
+import {
+	type GraphNode,
+	prefersReducedMotion,
+	loadStoredDepth,
+	persistDepth,
+	readUrlState,
+	writeUrlState,
+	radiusForDegree,
+} from './graph-core';
+import { usePanZoom } from './usePanZoom';
+import { useGraphSimulation } from './useGraphSimulation';
+import { useNeighborhood } from './useNeighborhood';
+import { useHoverPaint } from './useHoverPaint';
+import { GraphControls } from './GraphControls';
+import { GraphLegend } from './GraphLegend';
+import { GraphTooltip } from './GraphTooltip';
+import { GraphZoomBar } from './GraphZoomBar';
 
 export interface SiteGraphProps {
 	currentSlug: string;
@@ -90,178 +79,6 @@ export interface SiteGraphProps {
 	onFullscreenChange?: (next: boolean) => void;
 }
 
-const MIN_ZOOM = 0.3;
-const MAX_ZOOM = 3;
-const ZOOM_SENSITIVITY = 0.002;
-
-/** d3-force tick budget — caps long-running simulations on dense neighborhoods. */
-const ALPHA_MIN = 0.05;
-const ALPHA_DECAY = 0.05;
-
-/** localStorage key for the user's preferred neighborhood depth. */
-const DEPTH_STORAGE_KEY = 'kbve-sitegraph-depth';
-
-/** Reads the user's reduced-motion preference. SSR-safe. */
-function prefersReducedMotion(): boolean {
-	if (typeof window === 'undefined') return false;
-	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-}
-
-/** Reads + writes the depth selection to localStorage. */
-function loadStoredDepth(fallback: number, min: number, max: number): number {
-	if (typeof localStorage === 'undefined') return fallback;
-	const raw = localStorage.getItem(DEPTH_STORAGE_KEY);
-	if (!raw) return fallback;
-	const n = Number(raw);
-	return Number.isFinite(n) && n >= min && n <= max ? n : fallback;
-}
-
-function persistDepth(depth: number): void {
-	if (typeof localStorage === 'undefined') return;
-	try {
-		localStorage.setItem(DEPTH_STORAGE_KEY, String(depth));
-	} catch {
-		// quota / disabled — ignore
-	}
-}
-
-/** Reads sg-prefixed query params for shareable graph state. */
-function readUrlState(): { depth: number | null; q: string | null } {
-	if (typeof window === 'undefined') return { depth: null, q: null };
-	const params = new URLSearchParams(window.location.search);
-	const depthRaw = params.get('sg-depth');
-	const depth = depthRaw ? Number(depthRaw) : null;
-	return {
-		depth: depth !== null && Number.isFinite(depth) ? depth : null,
-		q: params.get('sg-q'),
-	};
-}
-
-function writeUrlState(state: { depth: number; q: string }): void {
-	if (typeof window === 'undefined') return;
-	const params = new URLSearchParams(window.location.search);
-	params.set('sg-depth', String(state.depth));
-	if (state.q) params.set('sg-q', state.q);
-	else params.delete('sg-q');
-	const next = `${window.location.pathname}${
-		params.toString() ? '?' + params.toString() : ''
-	}${window.location.hash}`;
-	window.history.replaceState(null, '', next);
-}
-
-function getNeighborhood(
-	graph: SiteGraphData,
-	startSlug: string,
-	maxDepth: number,
-	tagOf: (slug: string) => string | null,
-): { nodes: GraphNode[]; links: GraphLink[] } {
-	const visited = new Set<string>();
-	const queue: Array<{ slug: string; depth: number }> = [
-		{ slug: startSlug, depth: 0 },
-	];
-	visited.add(startSlug);
-
-	while (queue.length > 0) {
-		const { slug, depth } = queue.shift()!;
-		if (depth >= maxDepth) continue;
-
-		const node = graph[slug];
-		if (!node) continue;
-
-		const neighbors = [...node.links, ...node.backlinks];
-		for (const neighbor of neighbors) {
-			if (!visited.has(neighbor) && graph[neighbor]) {
-				visited.add(neighbor);
-				queue.push({ slug: neighbor, depth: depth + 1 });
-			}
-		}
-	}
-
-	const nodeMap = new Map<string, GraphNode>();
-	for (const slug of visited) {
-		const entry = graph[slug];
-		if (!entry) continue;
-		const degree =
-			(entry.links?.length ?? 0) + (entry.backlinks?.length ?? 0);
-		nodeMap.set(slug, {
-			id: slug,
-			title: entry.title,
-			isCurrent: slug === startSlug,
-			tag: tagOf(slug),
-			degree,
-		});
-	}
-
-	const links: GraphLink[] = [];
-	for (const slug of visited) {
-		const entry = graph[slug];
-		if (!entry) continue;
-		for (const target of entry.links) {
-			if (visited.has(target)) {
-				links.push({
-					source: nodeMap.get(slug)!,
-					target: nodeMap.get(target)!,
-					relationship: entry.edges?.[target],
-				});
-			}
-		}
-	}
-
-	return { nodes: [...nodeMap.values()], links };
-}
-
-/**
- * Maps degree (links + backlinks) to a node radius. sqrt-scaled so a 100-link
- * hub doesn't dwarf the rest of the neighborhood.
- */
-function radiusForDegree(degree: number, base: number): number {
-	const extra = Math.min(6, Math.sqrt(Math.max(degree - 1, 0)) * 1.2);
-	return base + extra;
-}
-
-/**
- * Builds the neighbor lookup used for hover-dim. Lets us fade everything
- * except the hovered node + its immediate neighbors without re-running
- * BFS on every mouse-enter.
- */
-/**
- * Returns an SVG path for a quadratic bezier from `s` to `t`. The control
- * point is offset perpendicular to the segment by ~15% of its length so
- * dense graphs read as a fan of curves instead of overlapping lines.
- */
-function curvedEdgePath(
-	s: { x?: number; y?: number },
-	t: { x?: number; y?: number },
-): string {
-	const sx = s.x ?? 0;
-	const sy = s.y ?? 0;
-	const tx = t.x ?? 0;
-	const ty = t.y ?? 0;
-	const dx = tx - sx;
-	const dy = ty - sy;
-	const dist = Math.hypot(dx, dy) || 1;
-	const offset = dist * 0.15;
-	const mx = (sx + tx) / 2;
-	const my = (sy + ty) / 2;
-	// Perpendicular unit vector → control point.
-	const cx = mx + (-dy / dist) * offset;
-	const cy = my + (dx / dist) * offset;
-	return `M${sx} ${sy} Q${cx} ${cy} ${tx} ${ty}`;
-}
-
-function buildAdjacency(links: GraphLink[]): Map<string, Set<string>> {
-	const adj = new Map<string, Set<string>>();
-	for (const l of links) {
-		const a = l.source.id;
-		const b = l.target.id;
-		if (!adj.has(a)) adj.set(a, new Set());
-		if (!adj.has(b)) adj.set(b, new Set());
-		adj.get(a)!.add(b);
-		adj.get(b)!.add(a);
-	}
-	return adj;
-}
-
 export function SiteGraph({
 	currentSlug,
 	depth: depthProp = 2,
@@ -285,12 +102,7 @@ export function SiteGraph({
 	const svgRef = useRef<SVGSVGElement>(null);
 	const tooltipRef = useRef<HTMLDivElement>(null);
 	const searchInputRef = useRef<HTMLInputElement>(null);
-	const [graphData, setGraphData] = useState<SiteGraphData | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const [retryNonce, setRetryNonce] = useState(0);
-	const simulationRef = useRef<Simulation<GraphNode, GraphLink> | null>(null);
 
-	const [hoveredId, setHoveredId] = useState<string | null>(null);
 	const [pinnedId, setPinnedId] = useState<string | null>(null);
 	// Depth seeds from (in order): URL `sg-depth` → localStorage → prop default.
 	const [depth, setDepth] = useState(() => {
@@ -336,34 +148,38 @@ export function SiteGraph({
 	const width = size.width;
 	const height = size.height;
 
-	const [zoom, setZoom] = useState(1);
-	const [panX, setPanX] = useState(0);
-	const [panY, setPanY] = useState(0);
+	// Graph fetch + memoized neighborhood/adjacency/distinct sets for the
+	// current slug + depth. Recomputes only on data/slug/depth change.
+	const {
+		graphData,
+		error,
+		retry,
+		nodes,
+		links,
+		adjacency,
+		distinctTags,
+		distinctRelationships,
+	} = useNeighborhood(currentSlug, depth, tagOf, endpoint);
 
-	const isPointerOverSvg = useRef(false);
+	// The SVG only renders once there's a neighborhood (loading/empty/error
+	// states return earlier), so gesture listeners must (re)attach when this
+	// flips true — otherwise they bind to a not-yet-mounted svg and never fire.
+	const graphReady = nodes.length > 0;
 
-	// Live mirrors of pan/zoom so the once-bound pointer listeners read
-	// current values without re-subscribing on every interaction frame.
-	const panXRef = useRef(panX);
-	panXRef.current = panX;
-	const panYRef = useRef(panY);
-	panYRef.current = panY;
-	const zoomRef = useRef(zoom);
-	zoomRef.current = zoom;
+	// Pan + pinch/wheel zoom, driven through refs + an imperative transform
+	// writer so gestures never re-render the node/link tree. `zoom` is the only
+	// value committed to state (rAF-throttled) for zoom-dependent attributes.
+	const {
+		groupRef,
+		zoom,
+		zoomRef,
+		panXRef,
+		panYRef,
+		isPointerOverSvg,
+		handleSliderChange,
+		handleResetZoom,
+	} = usePanZoom(svgRef, width, height, graphReady);
 
-	// Active pointers on the SVG background, keyed by pointerId.
-	// 1 pointer → pan, 2 pointers → pinch-zoom.
-	const bgPointers = useRef(new Map<number, { x: number; y: number }>());
-	const panStart = useRef<{
-		startX: number;
-		startY: number;
-		startPanX: number;
-		startPanY: number;
-	} | null>(null);
-	const pinchStart = useRef<{
-		startDist: number;
-		startZoom: number;
-	} | null>(null);
 	// Set true once a node pointer-drag passes the move threshold, so the
 	// trailing click doesn't navigate.
 	const draggedRef = useRef(false);
@@ -408,21 +224,9 @@ export function SiteGraph({
 		tip.style.visibility = 'hidden';
 	}, []);
 
-	useEffect(() => {
-		let cancelled = false;
-		setError(null);
-		fetchSiteGraph(endpoint)
-			.then((data) => {
-				if (!cancelled) setGraphData(data);
-			})
-			.catch((err) => {
-				if (!cancelled)
-					setError(err instanceof Error ? err.message : String(err));
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [endpoint, retryNonce]);
+	// Hover-dim painted imperatively from the base styling the render writes to
+	// `data-*` attrs — hovering a node re-renders nothing.
+	const { hoveredIdRef, applyHover } = useHoverPaint(svgRef, adjacency);
 
 	// Persist depth to localStorage and reflect depth + search in the URL so
 	// users can share/refresh into the same view.
@@ -431,310 +235,18 @@ export function SiteGraph({
 		writeUrlState({ depth, q: search });
 	}, [depth, search]);
 
-	// Memoize neighborhood so adjacency + render don't recompute every keystroke.
-	const { nodes, links, adjacency } = useMemo(() => {
-		if (!graphData)
-			return {
-				nodes: [],
-				links: [],
-				adjacency: new Map<string, Set<string>>(),
-			};
-		const result = getNeighborhood(graphData, currentSlug, depth, tagOf);
-		return {
-			...result,
-			adjacency: buildAdjacency(result.links),
-		};
-	}, [graphData, currentSlug, depth, tagOf]);
-
-	// Distinct tags / relationships drive the cluster legend below the SVG.
-	const distinctTags = useMemo(
-		() => [
-			...new Set(nodes.map((n) => n.tag).filter((t): t is string => !!t)),
-		],
-		[nodes],
+	// d3-force layout — ticks straight to the DOM, gated on visibility +
+	// on-screen, hard-stopped on SPA swap. Returns the live sim for dragging.
+	const simulationRef = useGraphSimulation(
+		svgRef,
+		containerRef,
+		!!graphData,
+		nodes,
+		links,
+		width,
+		height,
+		reducedMotion,
 	);
-	const distinctRelationships = useMemo(
-		() => [
-			...new Set(
-				links
-					.map((l) => l.relationship)
-					.filter((r): r is string => !!r),
-			),
-		],
-		[links],
-	);
-
-	useEffect(() => {
-		if (!graphData || !svgRef.current || nodes.length === 0) return;
-
-		const svg = svgRef.current;
-
-		// Group nodes by tag for cluster forces — pulls same-tag nodes toward
-		// the same anchor so users can spot domain clusters at a glance.
-		const tagAnchors = new Map<string, { x: number; y: number }>();
-		const distinctTags = [
-			...new Set(nodes.map((n) => n.tag).filter((t): t is string => !!t)),
-		];
-		distinctTags.forEach((tag, i) => {
-			const angle = (i / Math.max(distinctTags.length, 1)) * Math.PI * 2;
-			const radius = Math.min(width, height) * 0.25;
-			tagAnchors.set(tag, {
-				x: width / 2 + Math.cos(angle) * radius,
-				y: height / 2 + Math.sin(angle) * radius,
-			});
-		});
-
-		const simulation = forceSimulation<GraphNode>(nodes)
-			.alphaMin(reducedMotion ? 0.5 : ALPHA_MIN)
-			.alphaDecay(reducedMotion ? 0.4 : ALPHA_DECAY)
-			.force(
-				'link',
-				forceLink<GraphNode, GraphLink>(links)
-					.id((d) => d.id)
-					.distance(50),
-			)
-			.force('charge', forceManyBody().strength(-120))
-			.force('center', forceCenter(width / 2, height / 2))
-			.force('collide', forceCollide(24));
-
-		if (distinctTags.length >= 2) {
-			simulation
-				.force(
-					'cluster-x',
-					forceX<GraphNode>((d) =>
-						d.tag
-							? (tagAnchors.get(d.tag)?.x ?? width / 2)
-							: width / 2,
-					).strength(0.06),
-				)
-				.force(
-					'cluster-y',
-					forceY<GraphNode>((d) =>
-						d.tag
-							? (tagAnchors.get(d.tag)?.y ?? height / 2)
-							: height / 2,
-					).strength(0.06),
-				);
-		}
-
-		simulationRef.current = simulation;
-
-		// Cache the element lists once. React rendered the nodes/links before
-		// this effect runs, and the effect re-runs whenever nodes/links change,
-		// so a per-tick querySelectorAll (hundreds of nodes × 60fps on a phone)
-		// is pure waste. Snapshot here, index into it on tick.
-		const linkEls = svg.querySelectorAll<SVGPathElement>('.sg-link');
-		const nodeEls = svg.querySelectorAll<SVGGElement>('.sg-node');
-
-		simulation.on('tick', () => {
-			for (let i = 0; i < links.length; i++) {
-				const el = linkEls[i];
-				if (el) {
-					el.setAttribute(
-						'd',
-						curvedEdgePath(links[i].source, links[i].target),
-					);
-				}
-			}
-			for (let i = 0; i < nodes.length; i++) {
-				const el = nodeEls[i];
-				if (el) {
-					el.setAttribute(
-						'transform',
-						`translate(${nodes[i].x ?? 0},${nodes[i].y ?? 0})`,
-					);
-				}
-			}
-		});
-
-		// Battery/CPU: only let the layout tick when the tab is visible AND the
-		// graph is actually on screen. The sidebar graph is frequently scrolled
-		// out of view or backgrounded on mobile — no reason to keep simulating.
-		let docVisible =
-			typeof document === 'undefined' ? true : !document.hidden;
-		let inView = true;
-		const applyRunState = () => {
-			if (docVisible && inView) simulation.restart();
-			else simulation.stop();
-		};
-		const onVisibility = () => {
-			docVisible = !document.hidden;
-			applyRunState();
-		};
-		document.addEventListener('visibilitychange', onVisibility);
-
-		let io: IntersectionObserver | null = null;
-		const container = containerRef.current;
-		if (container && typeof IntersectionObserver !== 'undefined') {
-			io = new IntersectionObserver(
-				(entries) => {
-					inView = entries.some((e) => e.isIntersecting);
-					applyRunState();
-				},
-				{ threshold: 0 },
-			);
-			io.observe(container);
-		}
-
-		// Belt-and-suspenders: if a future Astro/React change ever fails to fire
-		// the island's unmount (which runs this cleanup), still halt the
-		// simulation on SPA swap / page hide so a stale rAF loop can't survive.
-		const killOnSwap = () => simulation.stop();
-		document.addEventListener('astro:before-swap', killOnSwap, {
-			once: true,
-		});
-		window.addEventListener('pagehide', killOnSwap, { once: true });
-
-		return () => {
-			simulation.stop();
-			simulationRef.current = null;
-			document.removeEventListener('visibilitychange', onVisibility);
-			document.removeEventListener('astro:before-swap', killOnSwap);
-			window.removeEventListener('pagehide', killOnSwap);
-			io?.disconnect();
-		};
-	}, [graphData, nodes, links, width, height, reducedMotion]);
-
-	useEffect(() => {
-		const svg = svgRef.current;
-		if (!svg) return;
-
-		const handleWheel = (e: WheelEvent) => {
-			if (!isPointerOverSvg.current) return;
-			e.preventDefault();
-
-			const delta = e.ctrlKey
-				? -e.deltaY * 0.01
-				: -e.deltaY * ZOOM_SENSITIVITY;
-
-			setZoom((prev) => {
-				const next = Math.min(
-					MAX_ZOOM,
-					Math.max(MIN_ZOOM, prev + delta),
-				);
-
-				const rect = svg.getBoundingClientRect();
-				const cursorX = e.clientX - rect.left;
-				const cursorY = e.clientY - rect.top;
-				const svgX = (cursorX - rect.width / 2) / prev;
-				const svgY = (cursorY - rect.height / 2) / prev;
-
-				setPanX((px) => px - svgX * (next - prev));
-				setPanY((py) => py - svgY * (next - prev));
-
-				return next;
-			});
-		};
-
-		const handleEnter = () => {
-			isPointerOverSvg.current = true;
-		};
-		const handleLeave = () => {
-			isPointerOverSvg.current = false;
-		};
-
-		svg.addEventListener('mouseenter', handleEnter);
-		svg.addEventListener('mouseleave', handleLeave);
-		window.addEventListener('wheel', handleWheel, { passive: false });
-		return () => {
-			svg.removeEventListener('mouseenter', handleEnter);
-			svg.removeEventListener('mouseleave', handleLeave);
-			window.removeEventListener('wheel', handleWheel);
-		};
-	}, []);
-
-	// Unified Pointer Events for background pan + pinch-zoom. One code path
-	// for mouse, touch, and pen — iOS Safari (13+) ships Pointer Events, so
-	// this is what makes pan/zoom work on mobile. 1 active pointer pans,
-	// 2 pinch-zoom. Pointers that start inside a node are claimed by
-	// `dragNode` (it stops propagation), so this only sees empty-space drags.
-	useEffect(() => {
-		const svg = svgRef.current;
-		if (!svg) return;
-
-		const pinchDist = (): number => {
-			const pts = [...bgPointers.current.values()];
-			return Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
-		};
-
-		const beginPan = (x: number, y: number) => {
-			panStart.current = {
-				startX: x,
-				startY: y,
-				startPanX: panXRef.current,
-				startPanY: panYRef.current,
-			};
-		};
-
-		const onDown = (e: PointerEvent) => {
-			const target = e.target as Element | null;
-			if (target?.closest('.sg-node')) return;
-			if (e.pointerType === 'mouse' && e.button !== 0) return;
-			try {
-				svg.setPointerCapture(e.pointerId);
-			} catch {
-				// Safari can throw if the element is detaching; ignore.
-			}
-			bgPointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
-			if (bgPointers.current.size === 1) {
-				beginPan(e.clientX, e.clientY);
-				svg.style.cursor = 'grabbing';
-			} else if (bgPointers.current.size === 2) {
-				panStart.current = null;
-				pinchStart.current = {
-					startDist: pinchDist(),
-					startZoom: zoomRef.current,
-				};
-			}
-		};
-
-		const onMove = (e: PointerEvent) => {
-			if (!bgPointers.current.has(e.pointerId)) return;
-			bgPointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
-			if (bgPointers.current.size >= 2 && pinchStart.current) {
-				e.preventDefault();
-				const scale = pinchDist() / pinchStart.current.startDist;
-				const next = Math.min(
-					MAX_ZOOM,
-					Math.max(MIN_ZOOM, pinchStart.current.startZoom * scale),
-				);
-				setZoom(next);
-			} else if (panStart.current) {
-				const p = panStart.current;
-				setPanX(p.startPanX + (e.clientX - p.startX));
-				setPanY(p.startPanY + (e.clientY - p.startY));
-			}
-		};
-
-		const onUp = (e: PointerEvent) => {
-			if (!bgPointers.current.has(e.pointerId)) return;
-			bgPointers.current.delete(e.pointerId);
-			try {
-				svg.releasePointerCapture(e.pointerId);
-			} catch {
-				// Capture may already be gone; ignore.
-			}
-			if (bgPointers.current.size < 2) pinchStart.current = null;
-			if (bgPointers.current.size === 1) {
-				const [only] = [...bgPointers.current.values()];
-				beginPan(only.x, only.y);
-			} else if (bgPointers.current.size === 0) {
-				panStart.current = null;
-				svg.style.cursor = 'grab';
-			}
-		};
-
-		svg.addEventListener('pointerdown', onDown);
-		svg.addEventListener('pointermove', onMove);
-		svg.addEventListener('pointerup', onUp);
-		svg.addEventListener('pointercancel', onUp);
-		return () => {
-			svg.removeEventListener('pointerdown', onDown);
-			svg.removeEventListener('pointermove', onMove);
-			svg.removeEventListener('pointerup', onUp);
-			svg.removeEventListener('pointercancel', onUp);
-		};
-	}, []);
 
 	// Node drag — pin the node's simulation position while dragging by
 	// setting fx/fy, and release with `simulation.alphaTarget` ramping back
@@ -756,11 +268,13 @@ export function SiteGraph({
 
 			const rect = svg.getBoundingClientRect();
 			const toSvg = (clientX: number, clientY: number) => {
-				const relX = clientX - rect.left - rect.width / 2 - panX;
-				const relY = clientY - rect.top - rect.height / 2 - panY;
+				const relX =
+					clientX - rect.left - rect.width / 2 - panXRef.current;
+				const relY =
+					clientY - rect.top - rect.height / 2 - panYRef.current;
 				return {
-					x: relX / zoom + width / 2,
-					y: relY / zoom + height / 2,
+					x: relX / zoomRef.current + width / 2,
+					y: relY / zoomRef.current + height / 2,
 				};
 			};
 
@@ -800,7 +314,7 @@ export function SiteGraph({
 			el.addEventListener('pointerup', onUp);
 			el.addEventListener('pointercancel', onUp);
 		},
-		[panX, panY, zoom, width, height],
+		[width, height],
 	);
 
 	const handleNodeClick = useCallback(
@@ -822,19 +336,6 @@ export function SiteGraph({
 		},
 		[currentSlug],
 	);
-
-	const handleSliderChange = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setZoom(parseFloat(e.target.value));
-		},
-		[],
-	);
-
-	const handleResetZoom = useCallback(() => {
-		setZoom(1);
-		setPanX(0);
-		setPanY(0);
-	}, []);
 
 	// Keyboard shortcuts (only fire when the pointer is over the graph or it's
 	// in fullscreen, so we don't hijack typing in unrelated parts of the page).
@@ -865,7 +366,8 @@ export function SiteGraph({
 				}
 				if (pinnedId) {
 					setPinnedId(null);
-					setHoveredId(null);
+					hoveredIdRef.current = null;
+					applyHover(null);
 					hideTooltip();
 					return;
 				}
@@ -876,7 +378,15 @@ export function SiteGraph({
 		};
 		window.addEventListener('keydown', handler);
 		return () => window.removeEventListener('keydown', handler);
-	}, [isFullscreen, onFullscreenChange, search, pinnedId, hideTooltip]);
+	}, [
+		isFullscreen,
+		onFullscreenChange,
+		search,
+		pinnedId,
+		hideTooltip,
+		applyHover,
+		hoveredIdRef,
+	]);
 
 	// Background tap on the SVG dismisses any pinned tooltip (touch only).
 	useEffect(() => {
@@ -886,12 +396,13 @@ export function SiteGraph({
 			const target = e.target as SVGElement | null;
 			if (target?.closest('.sg-node')) return;
 			setPinnedId(null);
-			setHoveredId(null);
+			hoveredIdRef.current = null;
+			applyHover(null);
 			hideTooltip();
 		};
 		svg.addEventListener('touchstart', onTouch, { passive: true });
 		return () => svg.removeEventListener('touchstart', onTouch);
-	}, [hideTooltip]);
+	}, [hideTooltip, applyHover, hoveredIdRef]);
 
 	if (error) {
 		return (
@@ -921,7 +432,7 @@ export function SiteGraph({
 					{error}
 				</code>
 				<button
-					onClick={() => setRetryNonce((n) => n + 1)}
+					onClick={retry}
 					style={{
 						background: 'var(--sl-color-bg-nav)',
 						color: 'inherit',
@@ -979,14 +490,6 @@ export function SiteGraph({
 		);
 	};
 
-	// Hover-dim adjacency: nodes/links touching the hovered node stay full
-	// opacity; everything else fades. Search-filter dimming layers on top.
-	const isAdjacent = (id: string): boolean => {
-		if (!hoveredId) return true;
-		if (id === hoveredId) return true;
-		return adjacency.get(hoveredId)?.has(id) ?? false;
-	};
-
 	const containerStyle: CSSProperties = isFullscreen
 		? {
 				position: 'fixed',
@@ -1002,83 +505,17 @@ export function SiteGraph({
 	return (
 		<div ref={containerRef} style={containerStyle}>
 			{!hideControls && (
-				<div
-					style={{
-						display: 'flex',
-						alignItems: 'center',
-						gap: '6px',
-						padding: '0 8px 6px',
-						fontSize: '11px',
-						color: 'var(--sl-color-gray-3, #8b949e)',
-					}}>
-					<label
-						style={{
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '4px',
-						}}>
-						Depth
-						<select
-							value={depth}
-							onChange={(e) => setDepth(Number(e.target.value))}
-							style={{
-								background: 'var(--sl-color-bg-nav)',
-								color: 'inherit',
-								border: '1px solid var(--sl-color-gray-5, #262626)',
-								borderRadius: 4,
-								padding: '1px 4px',
-								fontSize: '11px',
-							}}>
-							{Array.from(
-								{ length: maxDepth - minDepth + 1 },
-								(_, i) => minDepth + i,
-							).map((d) => (
-								<option key={d} value={d}>
-									{d}
-								</option>
-							))}
-						</select>
-					</label>
-					<input
-						ref={searchInputRef}
-						type="search"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						placeholder="Filter…  (/)"
-						aria-label="Filter nodes by title (press / to focus)"
-						style={{
-							flex: 1,
-							minWidth: 0,
-							background: 'var(--sl-color-bg-nav)',
-							color: 'inherit',
-							border: '1px solid var(--sl-color-gray-5, #262626)',
-							borderRadius: 4,
-							padding: '2px 6px',
-							fontSize: '11px',
-						}}
-					/>
-					{onFullscreenChange && (
-						<button
-							onClick={() => onFullscreenChange(!isFullscreen)}
-							title={
-								isFullscreen ? 'Exit fullscreen' : 'Fullscreen'
-							}
-							aria-label={
-								isFullscreen ? 'Exit fullscreen' : 'Fullscreen'
-							}
-							style={{
-								background: 'none',
-								border: '1px solid var(--sl-color-gray-5, #262626)',
-								color: 'inherit',
-								borderRadius: 4,
-								padding: '1px 6px',
-								fontSize: '11px',
-								cursor: 'pointer',
-							}}>
-							{isFullscreen ? '×' : '⤢'}
-						</button>
-					)}
-				</div>
+				<GraphControls
+					depth={depth}
+					onDepthChange={setDepth}
+					minDepth={minDepth}
+					maxDepth={maxDepth}
+					search={search}
+					onSearchChange={setSearch}
+					searchInputRef={searchInputRef}
+					isFullscreen={isFullscreen}
+					onFullscreenChange={onFullscreenChange}
+				/>
 			)}
 			<svg
 				ref={svgRef}
@@ -1095,16 +532,11 @@ export function SiteGraph({
 					touchAction: 'none',
 					overflow: 'hidden',
 				}}>
-				<g
-					transform={`translate(${width / 2 + panX},${height / 2 + panY}) scale(${zoom}) translate(${-width / 2},${-height / 2})`}>
+				<g ref={groupRef}>
 					{links.map((l, i) => {
-						const adj =
-							isAdjacent(l.source.id) && isAdjacent(l.target.id);
-						const opacity = adj
-							? l.relationship
-								? 0.6
-								: 0.4
-							: 0.08;
+						// Base stroke-opacity (no hover); the hover overlay
+						// dims non-incident edges imperatively via `data-*`.
+						const opacity = l.relationship ? 0.6 : 0.4;
 						const dash = l.relationship
 							? edgeDashes?.[l.relationship]
 							: undefined;
@@ -1112,6 +544,9 @@ export function SiteGraph({
 							<path
 								key={`link-${i}`}
 								className="sg-link"
+								data-rel={l.relationship ? '1' : '0'}
+								data-source={l.source.id}
+								data-target={l.target.id}
 								fill="none"
 								stroke={
 									l.relationship
@@ -1137,31 +572,29 @@ export function SiteGraph({
 						const radius = node.isCurrent
 							? baseRadius
 							: radiusForDegree(node.degree, baseRadius);
-						const fill = node.isCurrent
+						// Base (no-hover) visuals. The hover overlay swaps these
+						// imperatively via the `data-*` attrs below — see
+						// useHoverPaint — so hovering re-renders nothing.
+						const baseFill = node.isCurrent
 							? 'var(--sl-color-accent)'
-							: hoveredId === node.id
-								? 'var(--sl-color-accent)'
-								: (tagStyle?.fill ?? 'var(--sl-color-white)');
-						const stroke = node.isCurrent
+							: (tagStyle?.fill ?? 'var(--sl-color-white)');
+						const baseStroke = node.isCurrent
 							? 'var(--sl-color-accent-high)'
-							: hoveredId === node.id
-								? 'var(--sl-color-accent-high)'
-								: (tagStyle?.stroke ??
-									'var(--sl-color-gray-4)');
+							: (tagStyle?.stroke ?? 'var(--sl-color-gray-4)');
+						const baseTextFill = node.isCurrent
+							? 'var(--sl-color-white)'
+							: 'var(--sl-color-gray-3)';
 
 						const filterPass = matchesSearch(node);
-						const adjPass = isAdjacent(node.id);
-						const visible = filterPass && adjPass;
-						const opacity = visible ? 1 : filterPass ? 0.18 : 0.05;
+						const opacity = filterPass ? 1 : 0.05;
 
-						// Label-visibility heuristic: always show labels for the
-						// current node, hovered/pinned, search matches; show
-						// degree-≥5 hubs by default; hide other low-signal labels
-						// at low zoom to declutter dense neighborhoods.
-						const labelVisible =
+						// Label-visibility heuristic (no-hover base): current
+						// node, search matches, degree-≥5 hubs always; others
+						// hidden at low zoom to declutter. Hover reveals the
+						// hovered node's label imperatively.
+						const labelBase =
 							node.isCurrent ||
-							hoveredId === node.id ||
-							(deferredSearch && filterPass) ||
+							(!!deferredSearch && filterPass) ||
 							node.degree >= 5 ||
 							zoom >= 1.2;
 
@@ -1169,6 +602,10 @@ export function SiteGraph({
 							<g
 								key={node.id}
 								className="sg-node"
+								data-id={node.id}
+								data-current={node.isCurrent ? '1' : '0'}
+								data-filter={filterPass ? '1' : '0'}
+								data-label-base={labelBase ? '1' : '0'}
 								style={{
 									cursor: 'pointer',
 									opacity,
@@ -1177,20 +614,23 @@ export function SiteGraph({
 								onClick={(e) => handleNodeClick(node.id, e)}
 								onPointerDown={dragNode(node)}
 								onMouseEnter={(e) => {
-									setHoveredId(node.id);
+									hoveredIdRef.current = node.id;
+									applyHover(node.id);
 									showTooltip(node.title, node.id, e);
 									openTooltip(`sg-node-${node.id}`);
 								}}
 								onMouseMove={moveTooltip}
 								onMouseLeave={() => {
 									if (pinnedId === node.id) return;
-									setHoveredId(null);
+									hoveredIdRef.current = null;
+									applyHover(null);
 									hideTooltip();
 									closeTooltip(`sg-node-${node.id}`);
 								}}
 								onTouchStart={(e) => {
 									setPinnedId(node.id);
-									setHoveredId(node.id);
+									hoveredIdRef.current = node.id;
+									applyHover(node.id);
 									const touch = e.touches[0];
 									if (!touch) return;
 									showTooltip(node.title, node.id, {
@@ -1199,31 +639,26 @@ export function SiteGraph({
 									} as React.MouseEvent);
 								}}>
 								<circle
+									className="sg-node-circle"
+									data-fill={baseFill}
+									data-stroke={baseStroke}
 									r={radius}
-									fill={fill}
-									stroke={stroke}
+									fill={baseFill}
+									stroke={baseStroke}
 									strokeWidth={node.isCurrent ? 2 : 1}
 									style={{
 										transition: 'fill 0.15s, stroke 0.15s',
 									}}
 								/>
 								<text
+									className="sg-node-label"
+									data-fill={baseTextFill}
 									dy={node.isCurrent ? -10 : -8}
 									textAnchor="middle"
-									fill={
-										node.isCurrent
-											? 'var(--sl-color-white)'
-											: hoveredId === node.id
-												? 'var(--sl-color-white)'
-												: 'var(--sl-color-gray-3)'
-									}
+									fill={baseTextFill}
 									fontSize={node.isCurrent ? 10 : 8}
-									fontWeight={
-										node.isCurrent || hoveredId === node.id
-											? 600
-											: 400
-									}
-									opacity={labelVisible ? 1 : 0}
+									fontWeight={node.isCurrent ? 600 : 400}
+									opacity={labelBase ? 1 : 0}
 									style={{
 										pointerEvents: 'none',
 										transition: 'fill 0.15s, opacity 0.15s',
@@ -1238,165 +673,23 @@ export function SiteGraph({
 				</g>
 			</svg>
 
-			{(distinctTags.length >= 2 || distinctRelationships.length > 0) && (
-				<ul
-					className="sg-legend"
-					aria-label="Graph legend"
-					style={{
-						listStyle: 'none',
-						margin: '6px 0 0',
-						padding: '0 8px',
-						display: 'flex',
-						flexWrap: 'wrap',
-						gap: '4px 10px',
-						fontSize: '10px',
-						color: 'var(--sl-color-gray-3, #8b949e)',
-					}}>
-					{distinctTags.length >= 2 &&
-						distinctTags.map((tag) => {
-							const style = tagStyles?.[tag];
-							return (
-								<li
-									key={`tag-${tag}`}
-									style={{
-										display: 'inline-flex',
-										alignItems: 'center',
-										gap: '4px',
-									}}>
-									<span
-										style={{
-											width: 8,
-											height: 8,
-											borderRadius: '50%',
-											background:
-												style?.fill ??
-												'var(--sl-color-white)',
-											border: `1px solid ${style?.stroke ?? 'var(--sl-color-gray-4)'}`,
-											display: 'inline-block',
-										}}
-										aria-hidden="true"
-									/>
-									{tagLabels?.[tag] ?? tag}
-								</li>
-							);
-						})}
-					{distinctRelationships.map((rel) => {
-						const dash = edgeDashes?.[rel];
-						const stroke =
-							edgeColors?.[rel] ?? 'var(--sl-color-gray-4)';
-						return (
-							<li
-								key={`rel-${rel}`}
-								style={{
-									display: 'inline-flex',
-									alignItems: 'center',
-									gap: '4px',
-								}}>
-								<svg width={16} height={6} aria-hidden="true">
-									<line
-										x1={0}
-										y1={3}
-										x2={16}
-										y2={3}
-										stroke={stroke}
-										strokeWidth={1.5}
-										strokeDasharray={dash}
-									/>
-								</svg>
-								{edgeLabels?.[rel] ?? rel}
-							</li>
-						);
-					})}
-				</ul>
-			)}
+			<GraphLegend
+				distinctTags={distinctTags}
+				distinctRelationships={distinctRelationships}
+				tagStyles={tagStyles}
+				tagLabels={tagLabels}
+				edgeColors={edgeColors}
+				edgeDashes={edgeDashes}
+				edgeLabels={edgeLabels}
+			/>
 
-			<div
-				ref={tooltipRef}
-				role="tooltip"
-				aria-hidden="true"
-				style={{
-					position: 'absolute',
-					transform: 'translate(-50%, -100%) translateY(-12px)',
-					pointerEvents: 'none',
-					zIndex: 10,
-					background: 'var(--sl-color-gray-6, #1a1a1a)',
-					border: '1px solid var(--sl-color-gray-5, #262626)',
-					borderRadius: 6,
-					padding: '5px 8px',
-					whiteSpace: 'nowrap',
-					boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
-					opacity: 0,
-					visibility: 'hidden',
-					transition: 'opacity 0.1s ease',
-					top: 0,
-					left: 0,
-				}}>
-				<div
-					data-sg-tip-title
-					style={{
-						fontSize: '10px',
-						fontWeight: 600,
-						color: 'var(--sl-color-white, #e6edf3)',
-						lineHeight: 1.3,
-					}}
-				/>
-				<div
-					data-sg-tip-path
-					style={{
-						fontSize: '8.5px',
-						color: 'var(--sl-color-gray-3, #8b949e)',
-						lineHeight: 1.3,
-					}}
-				/>
-			</div>
+			<GraphTooltip tooltipRef={tooltipRef} />
 
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: '6px',
-					padding: '6px 8px 0',
-				}}>
-				<button
-					onClick={handleResetZoom}
-					title="Reset zoom"
-					style={{
-						background: 'none',
-						border: 'none',
-						color: 'var(--sl-color-gray-3, #8b949e)',
-						fontSize: '10px',
-						fontWeight: 600,
-						cursor: 'pointer',
-						padding: '2px 4px',
-						borderRadius: 4,
-						lineHeight: 1,
-						fontVariantNumeric: 'tabular-nums',
-						minWidth: '32px',
-						textAlign: 'center',
-					}}>
-					{Math.round(zoom * 100)}%
-				</button>
-				<input
-					type="range"
-					min={MIN_ZOOM}
-					max={MAX_ZOOM}
-					step={0.05}
-					value={zoom}
-					onChange={handleSliderChange}
-					title={`Zoom: ${Math.round(zoom * 100)}%`}
-					aria-label="Zoom level"
-					aria-valuetext={`${Math.round(zoom * 100)}%`}
-					style={{
-						flex: 1,
-						height: '3px',
-						appearance: 'none',
-						WebkitAppearance: 'none',
-						background: `linear-gradient(to right, var(--sl-color-accent, #06b6d4) 0%, var(--sl-color-accent, #06b6d4) ${((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100}%, var(--sl-color-gray-5, #262626) ${((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100}%, var(--sl-color-gray-5, #262626) 100%)`,
-						borderRadius: '2px',
-						cursor: 'pointer',
-					}}
-				/>
-			</div>
+			<GraphZoomBar
+				zoom={zoom}
+				onReset={handleResetZoom}
+				onSliderChange={handleSliderChange}
+			/>
 		</div>
 	);
 }

--- a/packages/npm/astro/src/sitegraph/react/graph-core.ts
+++ b/packages/npm/astro/src/sitegraph/react/graph-core.ts
@@ -1,0 +1,195 @@
+import type {
+	SimulationNodeDatum,
+	SimulationLinkDatum,
+} from 'd3-force';
+import type { SiteGraphData } from '../types';
+
+export interface GraphNode extends SimulationNodeDatum {
+	id: string;
+	title: string;
+	isCurrent: boolean;
+	tag: string | null;
+	degree: number;
+}
+
+export interface GraphLink extends SimulationLinkDatum<GraphNode> {
+	source: GraphNode;
+	target: GraphNode;
+	relationship?: string;
+}
+
+export const MIN_ZOOM = 0.3;
+export const MAX_ZOOM = 3;
+export const ZOOM_SENSITIVITY = 0.002;
+
+/** d3-force tick budget — caps long-running simulations on dense neighborhoods. */
+export const ALPHA_MIN = 0.05;
+export const ALPHA_DECAY = 0.05;
+
+/** localStorage key for the user's preferred neighborhood depth. */
+const DEPTH_STORAGE_KEY = 'kbve-sitegraph-depth';
+
+/** Reads the user's reduced-motion preference. SSR-safe. */
+export function prefersReducedMotion(): boolean {
+	if (typeof window === 'undefined') return false;
+	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
+
+/** Reads + writes the depth selection to localStorage. */
+export function loadStoredDepth(
+	fallback: number,
+	min: number,
+	max: number,
+): number {
+	if (typeof localStorage === 'undefined') return fallback;
+	const raw = localStorage.getItem(DEPTH_STORAGE_KEY);
+	if (!raw) return fallback;
+	const n = Number(raw);
+	return Number.isFinite(n) && n >= min && n <= max ? n : fallback;
+}
+
+export function persistDepth(depth: number): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(DEPTH_STORAGE_KEY, String(depth));
+	} catch {
+		// quota / disabled — ignore
+	}
+}
+
+/** Reads sg-prefixed query params for shareable graph state. */
+export function readUrlState(): { depth: number | null; q: string | null } {
+	if (typeof window === 'undefined') return { depth: null, q: null };
+	const params = new URLSearchParams(window.location.search);
+	const depthRaw = params.get('sg-depth');
+	const depth = depthRaw ? Number(depthRaw) : null;
+	return {
+		depth: depth !== null && Number.isFinite(depth) ? depth : null,
+		q: params.get('sg-q'),
+	};
+}
+
+export function writeUrlState(state: { depth: number; q: string }): void {
+	if (typeof window === 'undefined') return;
+	const params = new URLSearchParams(window.location.search);
+	params.set('sg-depth', String(state.depth));
+	if (state.q) params.set('sg-q', state.q);
+	else params.delete('sg-q');
+	const next = `${window.location.pathname}${
+		params.toString() ? '?' + params.toString() : ''
+	}${window.location.hash}`;
+	window.history.replaceState(null, '', next);
+}
+
+export function getNeighborhood(
+	graph: SiteGraphData,
+	startSlug: string,
+	maxDepth: number,
+	tagOf: (slug: string) => string | null,
+): { nodes: GraphNode[]; links: GraphLink[] } {
+	const visited = new Set<string>();
+	const queue: Array<{ slug: string; depth: number }> = [
+		{ slug: startSlug, depth: 0 },
+	];
+	visited.add(startSlug);
+
+	while (queue.length > 0) {
+		const { slug, depth } = queue.shift()!;
+		if (depth >= maxDepth) continue;
+
+		const node = graph[slug];
+		if (!node) continue;
+
+		const neighbors = [...node.links, ...node.backlinks];
+		for (const neighbor of neighbors) {
+			if (!visited.has(neighbor) && graph[neighbor]) {
+				visited.add(neighbor);
+				queue.push({ slug: neighbor, depth: depth + 1 });
+			}
+		}
+	}
+
+	const nodeMap = new Map<string, GraphNode>();
+	for (const slug of visited) {
+		const entry = graph[slug];
+		if (!entry) continue;
+		const degree =
+			(entry.links?.length ?? 0) + (entry.backlinks?.length ?? 0);
+		nodeMap.set(slug, {
+			id: slug,
+			title: entry.title,
+			isCurrent: slug === startSlug,
+			tag: tagOf(slug),
+			degree,
+		});
+	}
+
+	const links: GraphLink[] = [];
+	for (const slug of visited) {
+		const entry = graph[slug];
+		if (!entry) continue;
+		for (const target of entry.links) {
+			if (visited.has(target)) {
+				links.push({
+					source: nodeMap.get(slug)!,
+					target: nodeMap.get(target)!,
+					relationship: entry.edges?.[target],
+				});
+			}
+		}
+	}
+
+	return { nodes: [...nodeMap.values()], links };
+}
+
+/**
+ * Maps degree (links + backlinks) to a node radius. sqrt-scaled so a 100-link
+ * hub doesn't dwarf the rest of the neighborhood.
+ */
+export function radiusForDegree(degree: number, base: number): number {
+	const extra = Math.min(6, Math.sqrt(Math.max(degree - 1, 0)) * 1.2);
+	return base + extra;
+}
+
+/**
+ * Returns an SVG path for a quadratic bezier from `s` to `t`. The control
+ * point is offset perpendicular to the segment by ~15% of its length so
+ * dense graphs read as a fan of curves instead of overlapping lines.
+ */
+export function curvedEdgePath(
+	s: { x?: number; y?: number },
+	t: { x?: number; y?: number },
+): string {
+	const sx = s.x ?? 0;
+	const sy = s.y ?? 0;
+	const tx = t.x ?? 0;
+	const ty = t.y ?? 0;
+	const dx = tx - sx;
+	const dy = ty - sy;
+	const dist = Math.hypot(dx, dy) || 1;
+	const offset = dist * 0.15;
+	const mx = (sx + tx) / 2;
+	const my = (sy + ty) / 2;
+	// Perpendicular unit vector → control point.
+	const cx = mx + (-dy / dist) * offset;
+	const cy = my + (dx / dist) * offset;
+	return `M${sx} ${sy} Q${cx} ${cy} ${tx} ${ty}`;
+}
+
+/**
+ * Builds the neighbor lookup used for hover-dim. Lets us fade everything
+ * except the hovered node + its immediate neighbors without re-running
+ * BFS on every mouse-enter.
+ */
+export function buildAdjacency(links: GraphLink[]): Map<string, Set<string>> {
+	const adj = new Map<string, Set<string>>();
+	for (const l of links) {
+		const a = l.source.id;
+		const b = l.target.id;
+		if (!adj.has(a)) adj.set(a, new Set());
+		if (!adj.has(b)) adj.set(b, new Set());
+		adj.get(a)!.add(b);
+		adj.get(b)!.add(a);
+	}
+	return adj;
+}

--- a/packages/npm/astro/src/sitegraph/react/useGraphSimulation.ts
+++ b/packages/npm/astro/src/sitegraph/react/useGraphSimulation.ts
@@ -1,0 +1,180 @@
+import { useEffect, useRef, type RefObject } from 'react';
+import {
+	forceSimulation,
+	forceLink,
+	forceManyBody,
+	forceCenter,
+	forceCollide,
+	forceX,
+	forceY,
+	type Simulation,
+} from 'd3-force';
+import {
+	type GraphNode,
+	type GraphLink,
+	ALPHA_MIN,
+	ALPHA_DECAY,
+	curvedEdgePath,
+} from './graph-core';
+
+/**
+ * Runs the d3-force layout for the current neighborhood and writes node/link
+ * positions straight to the DOM on each tick (cached element lists, no React
+ * re-render). The simulation only ticks while the tab is visible AND the graph
+ * is on screen; it is hard-stopped on SPA swap / page hide so no rAF loop
+ * survives an unmount. Returns the live simulation ref for node dragging.
+ */
+export function useGraphSimulation(
+	svgRef: RefObject<SVGSVGElement | null>,
+	containerRef: RefObject<HTMLDivElement | null>,
+	graphReady: boolean,
+	nodes: GraphNode[],
+	links: GraphLink[],
+	width: number,
+	height: number,
+	reducedMotion: boolean,
+): RefObject<Simulation<GraphNode, GraphLink> | null> {
+	const simulationRef = useRef<Simulation<GraphNode, GraphLink> | null>(null);
+
+	useEffect(() => {
+		if (!graphReady || !svgRef.current || nodes.length === 0) return;
+
+		const svg = svgRef.current;
+
+		// Group nodes by tag for cluster forces — pulls same-tag nodes toward
+		// the same anchor so users can spot domain clusters at a glance.
+		const tagAnchors = new Map<string, { x: number; y: number }>();
+		const distinctTags = [
+			...new Set(nodes.map((n) => n.tag).filter((t): t is string => !!t)),
+		];
+		distinctTags.forEach((tag, i) => {
+			const angle = (i / Math.max(distinctTags.length, 1)) * Math.PI * 2;
+			const radius = Math.min(width, height) * 0.25;
+			tagAnchors.set(tag, {
+				x: width / 2 + Math.cos(angle) * radius,
+				y: height / 2 + Math.sin(angle) * radius,
+			});
+		});
+
+		const simulation = forceSimulation<GraphNode>(nodes)
+			.alphaMin(reducedMotion ? 0.5 : ALPHA_MIN)
+			.alphaDecay(reducedMotion ? 0.4 : ALPHA_DECAY)
+			.force(
+				'link',
+				forceLink<GraphNode, GraphLink>(links)
+					.id((d) => d.id)
+					.distance(50),
+			)
+			.force('charge', forceManyBody().strength(-120))
+			.force('center', forceCenter(width / 2, height / 2))
+			.force('collide', forceCollide(24));
+
+		if (distinctTags.length >= 2) {
+			simulation
+				.force(
+					'cluster-x',
+					forceX<GraphNode>((d) =>
+						d.tag
+							? (tagAnchors.get(d.tag)?.x ?? width / 2)
+							: width / 2,
+					).strength(0.06),
+				)
+				.force(
+					'cluster-y',
+					forceY<GraphNode>((d) =>
+						d.tag
+							? (tagAnchors.get(d.tag)?.y ?? height / 2)
+							: height / 2,
+					).strength(0.06),
+				);
+		}
+
+		simulationRef.current = simulation;
+
+		// Cache the element lists once. React rendered the nodes/links before
+		// this effect runs, and the effect re-runs whenever nodes/links change,
+		// so a per-tick querySelectorAll (hundreds of nodes × 60fps on a phone)
+		// is pure waste. Snapshot here, index into it on tick.
+		const linkEls = svg.querySelectorAll<SVGPathElement>('.sg-link');
+		const nodeEls = svg.querySelectorAll<SVGGElement>('.sg-node');
+
+		simulation.on('tick', () => {
+			for (let i = 0; i < links.length; i++) {
+				const el = linkEls[i];
+				if (el) {
+					el.setAttribute(
+						'd',
+						curvedEdgePath(links[i].source, links[i].target),
+					);
+				}
+			}
+			for (let i = 0; i < nodes.length; i++) {
+				const el = nodeEls[i];
+				if (el) {
+					el.setAttribute(
+						'transform',
+						`translate(${nodes[i].x ?? 0},${nodes[i].y ?? 0})`,
+					);
+				}
+			}
+		});
+
+		// Battery/CPU: only let the layout tick when the tab is visible AND the
+		// graph is actually on screen. The sidebar graph is frequently scrolled
+		// out of view or backgrounded on mobile — no reason to keep simulating.
+		let docVisible =
+			typeof document === 'undefined' ? true : !document.hidden;
+		let inView = true;
+		const applyRunState = () => {
+			if (docVisible && inView) simulation.restart();
+			else simulation.stop();
+		};
+		const onVisibility = () => {
+			docVisible = !document.hidden;
+			applyRunState();
+		};
+		document.addEventListener('visibilitychange', onVisibility);
+
+		let io: IntersectionObserver | null = null;
+		const container = containerRef.current;
+		if (container && typeof IntersectionObserver !== 'undefined') {
+			io = new IntersectionObserver(
+				(entries) => {
+					inView = entries.some((e) => e.isIntersecting);
+					applyRunState();
+				},
+				{ threshold: 0 },
+			);
+			io.observe(container);
+		}
+
+		// Belt-and-suspenders: if a future Astro/React change ever fails to fire
+		// the island's unmount (which runs this cleanup), still halt the
+		// simulation on SPA swap / page hide so a stale rAF loop can't survive.
+		const killOnSwap = () => simulation.stop();
+		document.addEventListener('astro:before-swap', killOnSwap, {
+			once: true,
+		});
+		window.addEventListener('pagehide', killOnSwap, { once: true });
+
+		return () => {
+			simulation.stop();
+			simulationRef.current = null;
+			document.removeEventListener('visibilitychange', onVisibility);
+			document.removeEventListener('astro:before-swap', killOnSwap);
+			window.removeEventListener('pagehide', killOnSwap);
+			io?.disconnect();
+		};
+	}, [
+		svgRef,
+		containerRef,
+		graphReady,
+		nodes,
+		links,
+		width,
+		height,
+		reducedMotion,
+	]);
+
+	return simulationRef;
+}

--- a/packages/npm/astro/src/sitegraph/react/useHoverPaint.ts
+++ b/packages/npm/astro/src/sitegraph/react/useHoverPaint.ts
@@ -1,0 +1,110 @@
+import {
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	type RefObject,
+} from 'react';
+
+const HL_FILL = 'var(--sl-color-accent)';
+const HL_STROKE = 'var(--sl-color-accent-high)';
+const HL_TEXT = 'var(--sl-color-white)';
+
+export interface HoverPaint {
+	/** Live hovered node id — never state, so hovering re-renders nothing. */
+	hoveredIdRef: RefObject<string | null>;
+	/** Paint base + hover overlay onto the cached SVG els. null clears hover. */
+	applyHover: (hoverId: string | null) => void;
+}
+
+/**
+ * Hover-dim without React re-renders. The render writes each node/link's BASE
+ * visual into `data-*` attributes; this painter overlays the hover highlight
+ * (neighbor emphasis, dimming, label reveal) by mutating those elements
+ * directly on mouse-enter/leave — the analog of the imperative pan transform.
+ *
+ * A `useLayoutEffect` re-applies the current hover after every React render so
+ * a base repaint (search/zoom/data change) can't drop the overlay.
+ */
+export function useHoverPaint(
+	svgRef: RefObject<SVGSVGElement | null>,
+	adjacency: Map<string, Set<string>>,
+): HoverPaint {
+	const hoveredIdRef = useRef<string | null>(null);
+
+	const applyHover = useCallback(
+		(hoverId: string | null) => {
+			const svg = svgRef.current;
+			if (!svg) return;
+
+			let set: Set<string> | null = null;
+			if (hoverId) {
+				set = new Set<string>([hoverId]);
+				for (const n of adjacency.get(hoverId) ?? []) set.add(n);
+			}
+
+			const nodeEls = svg.querySelectorAll<SVGGElement>('.sg-node');
+			for (let i = 0; i < nodeEls.length; i++) {
+				const g = nodeEls[i];
+				const id = g.dataset.id ?? '';
+				const filterPass = g.dataset.filter !== '0';
+				const isCurrent = g.dataset.current === '1';
+				const labelBase = g.dataset.labelBase === '1';
+				const inSet = set ? set.has(id) : true;
+				const visible = filterPass && inSet;
+				g.style.opacity = visible
+					? '1'
+					: filterPass
+						? '0.18'
+						: '0.05';
+
+				const isHovered = hoverId != null && id === hoverId;
+				const circle =
+					g.querySelector<SVGCircleElement>('.sg-node-circle');
+				if (circle) {
+					circle.setAttribute(
+						'fill',
+						isHovered ? HL_FILL : (circle.dataset.fill ?? ''),
+					);
+					circle.setAttribute(
+						'stroke',
+						isHovered ? HL_STROKE : (circle.dataset.stroke ?? ''),
+					);
+				}
+				const text = g.querySelector<SVGTextElement>('.sg-node-label');
+				if (text) {
+					text.setAttribute(
+						'fill',
+						isHovered ? HL_TEXT : (text.dataset.fill ?? ''),
+					);
+					text.setAttribute(
+						'opacity',
+						labelBase || isHovered ? '1' : '0',
+					);
+					text.style.fontWeight =
+						isCurrent || isHovered ? '600' : '400';
+				}
+			}
+
+			const linkEls = svg.querySelectorAll<SVGPathElement>('.sg-link');
+			for (let i = 0; i < linkEls.length; i++) {
+				const p = linkEls[i];
+				const baseOp = p.dataset.rel === '1' ? 0.6 : 0.4;
+				let op = baseOp;
+				if (set) {
+					const s = p.dataset.source ?? '';
+					const t = p.dataset.target ?? '';
+					op = set.has(s) && set.has(t) ? baseOp : 0.08;
+				}
+				p.setAttribute('stroke-opacity', String(op));
+			}
+		},
+		[svgRef, adjacency],
+	);
+
+	// Re-apply hover after every render so a base repaint can't drop the overlay.
+	useLayoutEffect(() => {
+		applyHover(hoveredIdRef.current);
+	});
+
+	return { hoveredIdRef, applyHover };
+}

--- a/packages/npm/astro/src/sitegraph/react/useNeighborhood.ts
+++ b/packages/npm/astro/src/sitegraph/react/useNeighborhood.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchSiteGraph } from './cache';
+import type { SiteGraphData } from '../types';
+import {
+	type GraphNode,
+	type GraphLink,
+	getNeighborhood,
+	buildAdjacency,
+} from './graph-core';
+
+export interface Neighborhood {
+	graphData: SiteGraphData | null;
+	error: string | null;
+	/** Re-fetch the graph (used by the error-state retry button). */
+	retry: () => void;
+	nodes: GraphNode[];
+	links: GraphLink[];
+	adjacency: Map<string, Set<string>>;
+	distinctTags: string[];
+	distinctRelationships: string[];
+}
+
+/**
+ * Fetches the site graph (cached, worker-shared) and derives the current
+ * neighborhood for `currentSlug` at `depth`. The BFS + adjacency + distinct
+ * tag/relationship sets are memoized so hover/zoom/search re-renders never
+ * recompute them — they depend only on the graph, slug, depth, and `tagOf`.
+ *
+ * NOTE: `tagOf` is a memo dependency — consumers must pass a stable reference
+ * (module-level fn or `useCallback`), or the neighborhood recomputes on every
+ * render.
+ */
+export function useNeighborhood(
+	currentSlug: string,
+	depth: number,
+	tagOf: (slug: string) => string | null,
+	endpoint?: string,
+): Neighborhood {
+	const [graphData, setGraphData] = useState<SiteGraphData | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [retryNonce, setRetryNonce] = useState(0);
+
+	const retry = useCallback(() => setRetryNonce((n) => n + 1), []);
+
+	useEffect(() => {
+		let cancelled = false;
+		setError(null);
+		fetchSiteGraph(endpoint)
+			.then((data) => {
+				if (!cancelled) setGraphData(data);
+			})
+			.catch((err) => {
+				if (!cancelled)
+					setError(err instanceof Error ? err.message : String(err));
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [endpoint, retryNonce]);
+
+	// Memoize neighborhood so adjacency + render don't recompute every keystroke.
+	const { nodes, links, adjacency } = useMemo(() => {
+		if (!graphData)
+			return {
+				nodes: [] as GraphNode[],
+				links: [] as GraphLink[],
+				adjacency: new Map<string, Set<string>>(),
+			};
+		const result = getNeighborhood(graphData, currentSlug, depth, tagOf);
+		return {
+			...result,
+			adjacency: buildAdjacency(result.links),
+		};
+	}, [graphData, currentSlug, depth, tagOf]);
+
+	// Distinct tags / relationships drive the cluster legend below the SVG.
+	const distinctTags = useMemo(
+		() => [
+			...new Set(nodes.map((n) => n.tag).filter((t): t is string => !!t)),
+		],
+		[nodes],
+	);
+	const distinctRelationships = useMemo(
+		() => [
+			...new Set(
+				links
+					.map((l) => l.relationship)
+					.filter((r): r is string => !!r),
+			),
+		],
+		[links],
+	);
+
+	return {
+		graphData,
+		error,
+		retry,
+		nodes,
+		links,
+		adjacency,
+		distinctTags,
+		distinctRelationships,
+	};
+}

--- a/packages/npm/astro/src/sitegraph/react/usePanZoom.ts
+++ b/packages/npm/astro/src/sitegraph/react/usePanZoom.ts
@@ -1,0 +1,259 @@
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type RefObject,
+} from 'react';
+import { MIN_ZOOM, MAX_ZOOM, ZOOM_SENSITIVITY } from './graph-core';
+
+export interface PanZoom {
+	/** Attach to the `<g>` wrapping all nodes/links. */
+	groupRef: RefObject<SVGGElement | null>;
+	/** Committed zoom — drives zoom-dependent rendered attrs + the slider. */
+	zoom: number;
+	/** Live pan/zoom (imperative source of truth, no re-render on change). */
+	zoomRef: RefObject<number>;
+	panXRef: RefObject<number>;
+	panYRef: RefObject<number>;
+	/** True while a pointer is over the SVG — gates keyboard shortcuts. */
+	isPointerOverSvg: RefObject<boolean>;
+	handleSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	handleResetZoom: () => void;
+}
+
+/**
+ * Pan + pinch/wheel zoom for the SiteGraph SVG, driven entirely through refs
+ * and a single imperative transform writer — high-frequency gestures never
+ * re-render the node/link tree. Only `zoom` is committed to state (rAF-
+ * throttled) so zoom-dependent attributes (stroke width, label decluttering,
+ * the slider) can follow along.
+ */
+export function usePanZoom(
+	svgRef: RefObject<SVGSVGElement | null>,
+	width: number,
+	height: number,
+	ready: boolean,
+): PanZoom {
+	const [zoom, setZoom] = useState(1);
+
+	const groupRef = useRef<SVGGElement>(null);
+	const panXRef = useRef(0);
+	const panYRef = useRef(0);
+	const zoomRef = useRef(1);
+	const zoomCommitRaf = useRef(0);
+	const isPointerOverSvg = useRef(false);
+
+	// Active background pointers, keyed by pointerId. 1 → pan, 2 → pinch-zoom.
+	const bgPointers = useRef(new Map<number, { x: number; y: number }>());
+	const panStart = useRef<{
+		startX: number;
+		startY: number;
+		startPanX: number;
+		startPanY: number;
+	} | null>(null);
+	const pinchStart = useRef<{
+		startDist: number;
+		startZoom: number;
+	} | null>(null);
+
+	const writeTransform = useCallback(() => {
+		const g = groupRef.current;
+		if (!g) return;
+		g.setAttribute(
+			'transform',
+			`translate(${width / 2 + panXRef.current},${height / 2 + panYRef.current}) scale(${zoomRef.current}) translate(${-width / 2},${-height / 2})`,
+		);
+	}, [width, height]);
+
+	// Re-apply after any React render so reconciliation can't reset it.
+	useLayoutEffect(() => {
+		writeTransform();
+	});
+
+	const commitZoom = useCallback(() => {
+		if (zoomCommitRaf.current) return;
+		zoomCommitRaf.current = requestAnimationFrame(() => {
+			zoomCommitRaf.current = 0;
+			setZoom(zoomRef.current);
+		});
+	}, []);
+
+	useEffect(
+		() => () => {
+			if (zoomCommitRaf.current)
+				cancelAnimationFrame(zoomCommitRaf.current);
+		},
+		[],
+	);
+
+	// Wheel zoom (anchored at the cursor) + pointer-over tracking.
+	useEffect(() => {
+		const svg = svgRef.current;
+		if (!svg) return;
+
+		const handleWheel = (e: WheelEvent) => {
+			if (!isPointerOverSvg.current) return;
+			e.preventDefault();
+
+			const delta = e.ctrlKey
+				? -e.deltaY * 0.01
+				: -e.deltaY * ZOOM_SENSITIVITY;
+
+			const prev = zoomRef.current;
+			const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev + delta));
+
+			const rect = svg.getBoundingClientRect();
+			const cursorX = e.clientX - rect.left;
+			const cursorY = e.clientY - rect.top;
+			const svgX = (cursorX - rect.width / 2) / prev;
+			const svgY = (cursorY - rect.height / 2) / prev;
+
+			panXRef.current -= svgX * (next - prev);
+			panYRef.current -= svgY * (next - prev);
+			zoomRef.current = next;
+			writeTransform();
+			commitZoom();
+		};
+
+		const handleEnter = () => {
+			isPointerOverSvg.current = true;
+		};
+		const handleLeave = () => {
+			isPointerOverSvg.current = false;
+		};
+
+		svg.addEventListener('mouseenter', handleEnter);
+		svg.addEventListener('mouseleave', handleLeave);
+		window.addEventListener('wheel', handleWheel, { passive: false });
+		return () => {
+			svg.removeEventListener('mouseenter', handleEnter);
+			svg.removeEventListener('mouseleave', handleLeave);
+			window.removeEventListener('wheel', handleWheel);
+		};
+	}, [svgRef, ready, writeTransform, commitZoom]);
+
+	// Unified Pointer Events for background pan + pinch-zoom. One code path for
+	// mouse, touch, and pen. 1 active pointer pans, 2 pinch-zoom. Pointers that
+	// start inside a node are claimed by the node drag (it stops propagation).
+	useEffect(() => {
+		const svg = svgRef.current;
+		if (!svg) return;
+
+		const pinchDist = (): number => {
+			const pts = [...bgPointers.current.values()];
+			return Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+		};
+
+		const beginPan = (x: number, y: number) => {
+			panStart.current = {
+				startX: x,
+				startY: y,
+				startPanX: panXRef.current,
+				startPanY: panYRef.current,
+			};
+		};
+
+		const onDown = (e: PointerEvent) => {
+			const target = e.target as Element | null;
+			if (target?.closest('.sg-node')) return;
+			if (e.pointerType === 'mouse' && e.button !== 0) return;
+			try {
+				svg.setPointerCapture(e.pointerId);
+			} catch {
+				// Safari can throw if the element is detaching; ignore.
+			}
+			bgPointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+			if (bgPointers.current.size === 1) {
+				beginPan(e.clientX, e.clientY);
+				svg.style.cursor = 'grabbing';
+			} else if (bgPointers.current.size === 2) {
+				panStart.current = null;
+				pinchStart.current = {
+					startDist: pinchDist(),
+					startZoom: zoomRef.current,
+				};
+			}
+		};
+
+		const onMove = (e: PointerEvent) => {
+			if (!bgPointers.current.has(e.pointerId)) return;
+			bgPointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+			if (bgPointers.current.size >= 2 && pinchStart.current) {
+				e.preventDefault();
+				const scale = pinchDist() / pinchStart.current.startDist;
+				const next = Math.min(
+					MAX_ZOOM,
+					Math.max(MIN_ZOOM, pinchStart.current.startZoom * scale),
+				);
+				zoomRef.current = next;
+				writeTransform();
+				commitZoom();
+			} else if (panStart.current) {
+				const p = panStart.current;
+				panXRef.current = p.startPanX + (e.clientX - p.startX);
+				panYRef.current = p.startPanY + (e.clientY - p.startY);
+				writeTransform();
+			}
+		};
+
+		const onUp = (e: PointerEvent) => {
+			if (!bgPointers.current.has(e.pointerId)) return;
+			bgPointers.current.delete(e.pointerId);
+			try {
+				svg.releasePointerCapture(e.pointerId);
+			} catch {
+				// Capture may already be gone; ignore.
+			}
+			if (bgPointers.current.size < 2) pinchStart.current = null;
+			if (bgPointers.current.size === 1) {
+				const [only] = [...bgPointers.current.values()];
+				beginPan(only.x, only.y);
+			} else if (bgPointers.current.size === 0) {
+				panStart.current = null;
+				svg.style.cursor = 'grab';
+			}
+		};
+
+		svg.addEventListener('pointerdown', onDown);
+		svg.addEventListener('pointermove', onMove);
+		svg.addEventListener('pointerup', onUp);
+		svg.addEventListener('pointercancel', onUp);
+		return () => {
+			svg.removeEventListener('pointerdown', onDown);
+			svg.removeEventListener('pointermove', onMove);
+			svg.removeEventListener('pointerup', onUp);
+			svg.removeEventListener('pointercancel', onUp);
+		};
+	}, [svgRef, ready, writeTransform, commitZoom]);
+
+	const handleSliderChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const next = parseFloat(e.target.value);
+			zoomRef.current = next;
+			writeTransform();
+			setZoom(next);
+		},
+		[writeTransform],
+	);
+
+	const handleResetZoom = useCallback(() => {
+		zoomRef.current = 1;
+		panXRef.current = 0;
+		panYRef.current = 0;
+		writeTransform();
+		setZoom(1);
+	}, [writeTransform]);
+
+	return {
+		groupRef,
+		zoom,
+		zoomRef,
+		panXRef,
+		panYRef,
+		isPointerOverSvg,
+		handleSliderChange,
+		handleResetZoom,
+	};
+}


### PR DESCRIPTION
## Why

The right-sidebar site graph drove **INP to ~2,104 ms** on docs pages (e.g. `/application/git/`). Pan, zoom, and hover-dim each ran through React state, re-rendering hundreds of SVG node/link elements per pointer event.

## What

**Perf — move interactions off the React render path:**
- **Pan/zoom** → write the `<g>` transform imperatively via refs + a single writer (`useLayoutEffect` re-applies after each render so reconciliation can't reset it). Only `zoom` commits to state, rAF-throttled, for stroke-width + label decluttering.
- **Hover-dim** → painted imperatively from base styling stored in `data-*` attrs; hovering re-renders nothing.
- **Lazy-mount** the graph via `IntersectionObserver` (`SiteGraphHost`) so docs pages that never scroll it into view pay zero main-thread cost.

**Decompose** the 1430-line `SiteGraph` god-component into focused modules:
- `graph-core.ts` — pure utils (BFS neighborhood, adjacency, curve geometry, depth/URL storage, constants, types)
- hooks: `usePanZoom`, `useGraphSimulation`, `useNeighborhood`, `useHoverPaint`
- `React.memo` UI: `GraphControls`, `GraphLegend`, `GraphTooltip`, `GraphZoomBar`
- `SiteGraph.tsx` → ~640 lines orchestrator

## Verification

- `tsc` clean; `vitest` 31 pass (added a jsdom hover-painter test).
- `@kbve/astro` package builds.
- **Real-browser verify** (Vite + Playwright harness, kept under `.verify/`, artifacts gitignored): confirmed hover highlight + neighbor-dim + restore, pan drag, wheel-zoom, zero console errors. The harness **caught a real regression** — the `usePanZoom` listeners bound to a not-yet-mounted `<svg>` (loading branch returns before it) and never re-attached; fixed with a `graphReady` gate. tsc + unit tests were all green while pan was dead, which is why the browser check mattered.

## Scope

Graph changes only. README/AstroGithubReadme work from the same session is already on `dev` and excluded here.