### PR TITLE
fix(husky): stop tracking machine-generated .husky/_ hooks

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"


### PR DESCRIPTION
## Problem
Every worktree/clone setup left a dirty tree:
```
 M .husky/_/post-checkout
 M .husky/_/post-commit
 M .husky/_/post-merge
 M .husky/_/pre-push
```

## Root cause
`.husky/_/` hooks are machine-generated by husky (`prepare: husky`) + `git-lfs install` on every clone. Four were committed before the `.husky/_/.gitignore` (`*`) convention. Tracked files override gitignore, so each setup regenerated them (echo→printf formatting drift) and flagged them modified.

## Fix
`git rm --cached` the four files. `.husky/_/.gitignore` already ignores the dir, so they no longer leak. Hooks still regenerate locally per clone — actual hook logic lives in tracked top-level `.husky/pre-push` / `.husky/pre-commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)