### PR TITLE
feat(laser): GPU SpriteGPULayer factory + ambient dust motes (ARPG, Cryptothrone)

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -2,8 +2,10 @@ import Phaser from 'phaser';
 import {
 	GameClient,
 	PROTOCOL_VERSION,
+	createDustMoteLayer,
 	drawHealthBar,
 	drawHealthBarCached,
+	type GpuSpriteLayerHandle,
 	type EntityDelta,
 	type KindEntry,
 	type Snapshot,
@@ -242,6 +244,7 @@ const LEAVING_HANDOFF_MS =
 
 export class IsoArpgScene extends Phaser.Scene {
 	private client: GameClient | null = null;
+	private dustLayer: GpuSpriteLayerHandle | null = null;
 	private store = new EntityStore<EntityRefs>();
 	private kindRegistry = new Map<number, KindEntry>();
 	private kinds!: KindResolvers;
@@ -472,6 +475,16 @@ export class IsoArpgScene extends Phaser.Scene {
 		registerShipAnims(this);
 
 		this.drawGrid();
+		this.dustLayer = createDustMoteLayer(this, {
+			count: 500,
+			width: this.cameras.main.width,
+			height: this.cameras.main.height,
+			depth: DEPTH_ENTITY_BASE - 1,
+			color: 0xbfcad6,
+			radius: 2,
+			alpha: 0.4,
+			scrollFactor: 0,
+		});
 		if (USE_GROUND_SHADER) {
 			this.ground = makeGroundShader(this);
 			this.ground.update(this.cameras.main);
@@ -2530,6 +2543,8 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.offSpaceExit = undefined;
 		this.client?.close();
 		this.client = null;
+		this.dustLayer?.dispose();
+		this.dustLayer = null;
 		clearHud();
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -3,6 +3,7 @@ import {
 	GameClient,
 	laserEvents,
 	createBirdAnimation,
+	createDustMoteLayer,
 	flashEntity,
 	floatingText,
 	drawHealthBar,
@@ -24,6 +25,7 @@ import type {
 	ConnectionState,
 	BjActionKind,
 	ProjectileEvent,
+	GpuSpriteLayerHandle,
 } from '@kbve/laser';
 import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
@@ -98,6 +100,7 @@ interface PendingAction {
 export class CloudCityScene extends Scene {
 	private gridEngine: any;
 	private client: GameClient | null = null;
+	private dustLayer: GpuSpriteLayerHandle | null = null;
 
 	private mySlot = SLOT_NONE;
 	private slotUsername = new Map<number, string>();
@@ -215,12 +218,19 @@ export class CloudCityScene extends Scene {
 		}
 		this.entityDepth = tilemap.layers.length + 1;
 		this.placeProps();
-		this.cameras.main.setBounds(
-			0,
-			0,
-			tilemap.widthInPixels * MAP_SCALE,
-			tilemap.heightInPixels * MAP_SCALE,
-		);
+		const worldW = tilemap.widthInPixels * MAP_SCALE;
+		const worldH = tilemap.heightInPixels * MAP_SCALE;
+		this.cameras.main.setBounds(0, 0, worldW, worldH);
+
+		this.dustLayer = createDustMoteLayer(this, {
+			count: 600,
+			width: worldW,
+			height: worldH,
+			depth: this.entityDepth - 0.5,
+			color: 0xfdf6e3,
+			radius: 2,
+			alpha: 0.5,
+		});
 
 		createBirdAnimation(this);
 		this.makeGroundItemTexture();
@@ -319,6 +329,8 @@ export class CloudCityScene extends Scene {
 			this.laserUnsubs = [];
 			this.netTerminal = true;
 			this.client?.close();
+			this.dustLayer?.dispose();
+			this.dustLayer = null;
 		});
 	}
 

--- a/docs/superpowers/plans/2026-06-29-gpu-sprite-layer.md
+++ b/docs/superpowers/plans/2026-06-29-gpu-sprite-layer.md
@@ -1,0 +1,300 @@
+# GPU Sprite Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a thin, WebGL-guarded `SpriteGPULayer` factory to `@kbve/laser` reusable by ARPG and Cryptothrone.
+
+**Architecture:** Three free functions in one focused file under `lib/phaser`, re-exported through the root barrel. `createGpuSpriteLayer` guards on renderer type, builds the layer, wires context-loss recovery, and returns a handle with `dispose()`. `populateGpuSpriteLayer` fills the layer using a single reused scratch member object (the documented allocation-free fast path).
+
+**Tech Stack:** TypeScript, Phaser 4.1 (`SpriteGPULayer`), Vitest, nx via `./kbve.sh`.
+
+## Global Constraints
+
+- Phaser floor: `>=4.1.0` (already the laser peer + both apps).
+- `SpriteGPULayer` is WebGL only — every entry point must no-op cleanly on Canvas.
+- Reuse one `Member` object across `addMember` calls (GC constraint).
+- Removal is via `scaleX/scaleY/alpha = 0`, never `removeMembers` in this primitive.
+- Free functions, scene-first argument; `import Phaser from 'phaser'`.
+- No comments in source (global preference).
+- Build/test through nx (`./kbve.sh -nx ...`), not raw vitest/cargo.
+- File: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts` (+ `.spec.ts`).
+- Reuse existing `installWebGLContextGuard` from `../webgl/context-guard`.
+
+---
+
+## File Structure
+
+- Create: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts` — the three exports.
+- Create: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts` — unit tests.
+- Modify: `packages/npm/laser/src/index.ts` — re-export the new module.
+
+---
+
+### Task 1: `createGpuSpriteLayer` — guarded factory + handle
+
+**Files:**
+- Create: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts`
+- Test: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts`
+
+**Interfaces:**
+- Consumes: `installWebGLContextGuard(canvas, { onLost, onRestored }): () => void` from `../webgl/context-guard`.
+- Produces:
+  - `interface GpuSpriteLayerOptions { size: number; depth?: number; alpha?: number; blendMode?: number; visible?: boolean }`
+  - `interface GpuSpriteLayerHandle { readonly layer: Phaser.GameObjects.SpriteGPULayer; dispose(): void }`
+  - `createGpuSpriteLayer(scene: Phaser.Scene, texture: string | Phaser.Textures.Texture, opts: GpuSpriteLayerOptions): GpuSpriteLayerHandle | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createGpuSpriteLayer } from './gpu-sprite-layer';
+
+vi.mock('phaser', () => ({
+	default: { WEBGL: 2, CANVAS: 1 },
+	WEBGL: 2,
+	CANVAS: 1,
+}));
+
+function makeLayer() {
+	return {
+		setDepth: vi.fn().mockReturnThis(),
+		setAllSegmentsNeedUpdate: vi.fn(),
+		addMember: vi.fn().mockReturnThis(),
+		destroy: vi.fn(),
+	};
+}
+
+function makeScene(rendererType: number, layer = makeLayer()) {
+	const spriteGPULayer = vi.fn().mockReturnValue(layer);
+	return {
+		scene: {
+			renderer: { type: rendererType },
+			game: { canvas: document.createElement('canvas') },
+			add: { spriteGPULayer },
+		},
+		spriteGPULayer,
+		layer,
+	};
+}
+
+describe('createGpuSpriteLayer', () => {
+	it('returns null on the Canvas fallback and never builds a layer', () => {
+		const { scene, spriteGPULayer } = makeScene(1);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', { size: 100 });
+		expect(handle).toBeNull();
+		expect(spriteGPULayer).not.toHaveBeenCalled();
+	});
+
+	it('builds a depth-applied layer under WebGL and returns a handle', () => {
+		const { scene, spriteGPULayer, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', {
+			size: 100,
+			depth: 5,
+			alpha: 0.8,
+		});
+		expect(handle).not.toBeNull();
+		expect(spriteGPULayer).toHaveBeenCalledWith({
+			size: 100,
+			key: 'stars',
+			alpha: 0.8,
+			blendMode: undefined,
+			visible: undefined,
+		});
+		expect(layer.setDepth).toHaveBeenCalledWith(5);
+		expect(handle!.layer).toBe(layer);
+	});
+
+	it('dispose destroys the layer', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', { size: 10 });
+		handle!.dispose();
+		expect(layer.destroy).toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./kbve.sh -nx laser:test`
+Expected: FAIL — `createGpuSpriteLayer` not exported / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts`:
+
+```ts
+import Phaser from 'phaser';
+import { installWebGLContextGuard } from '../webgl/context-guard';
+
+export interface GpuSpriteLayerOptions {
+	size: number;
+	depth?: number;
+	alpha?: number;
+	blendMode?: number;
+	visible?: boolean;
+}
+
+export interface GpuSpriteLayerHandle {
+	readonly layer: Phaser.GameObjects.SpriteGPULayer;
+	dispose(): void;
+}
+
+export function createGpuSpriteLayer(
+	scene: Phaser.Scene,
+	texture: string | Phaser.Textures.Texture,
+	opts: GpuSpriteLayerOptions,
+): GpuSpriteLayerHandle | null {
+	if (scene.renderer.type !== Phaser.WEBGL) {
+		return null;
+	}
+
+	const layer = scene.add.spriteGPULayer({
+		size: opts.size,
+		key: texture,
+		alpha: opts.alpha,
+		blendMode: opts.blendMode,
+		visible: opts.visible,
+	});
+
+	if (opts.depth !== undefined) {
+		layer.setDepth(opts.depth);
+	}
+
+	const canvas = scene.game.canvas;
+	const detach = installWebGLContextGuard(canvas, {
+		onLost: () => {},
+		onRestored: () => layer.setAllSegmentsNeedUpdate(),
+	});
+
+	return {
+		layer,
+		dispose() {
+			detach();
+			layer.destroy();
+		},
+	};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./kbve.sh -nx laser:test`
+Expected: PASS (3 tests in this file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts
+git commit -m "feat(laser): add guarded SpriteGPULayer factory"
+```
+
+---
+
+### Task 2: `populateGpuSpriteLayer` + barrel export
+
+**Files:**
+- Modify: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts`
+- Modify: `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts`
+- Modify: `packages/npm/laser/src/index.ts`
+
+**Interfaces:**
+- Consumes: `GpuSpriteLayerHandle` from Task 1.
+- Produces: `populateGpuSpriteLayer(handle: GpuSpriteLayerHandle, count: number, fill: (member: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member>, i: number) => void): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `gpu-sprite-layer.spec.ts`:
+
+```ts
+import { populateGpuSpriteLayer } from './gpu-sprite-layer';
+
+describe('populateGpuSpriteLayer', () => {
+	it('reuses one scratch member across all addMember calls', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', { size: 3 })!;
+		const seen: unknown[] = [];
+		layer.addMember.mockImplementation((m: unknown) => {
+			seen.push(m);
+			return layer;
+		});
+
+		const xs: number[] = [];
+		populateGpuSpriteLayer(handle, 3, (member, i) => {
+			(member as { x: number }).x = i;
+			xs.push((member as { x: number }).x);
+		});
+
+		expect(layer.addMember).toHaveBeenCalledTimes(3);
+		expect(xs).toEqual([0, 1, 2]);
+		expect(seen[0]).toBe(seen[1]);
+		expect(seen[1]).toBe(seen[2]);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./kbve.sh -nx laser:test`
+Expected: FAIL — `populateGpuSpriteLayer` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `gpu-sprite-layer.ts`:
+
+```ts
+export function populateGpuSpriteLayer(
+	handle: GpuSpriteLayerHandle,
+	count: number,
+	fill: (
+		member: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member>,
+		i: number,
+	) => void,
+): void {
+	const scratch: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member> = {};
+	for (let i = 0; i < count; i++) {
+		fill(scratch, i);
+		handle.layer.addMember(scratch);
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./kbve.sh -nx laser:test`
+Expected: PASS (4 tests total in file).
+
+- [ ] **Step 5: Add barrel export**
+
+In `packages/npm/laser/src/index.ts`, add alongside the other `lib/phaser` exports:
+
+```ts
+export {
+	createGpuSpriteLayer,
+	populateGpuSpriteLayer,
+	type GpuSpriteLayerOptions,
+	type GpuSpriteLayerHandle,
+} from './lib/phaser/gpu-sprite-layer';
+```
+
+- [ ] **Step 6: Verify typecheck + tests**
+
+Run: `./kbve.sh -nx laser:test`
+Expected: PASS. Confirm the export resolves (no TS errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts packages/npm/laser/src/index.ts
+git commit -m "feat(laser): add scratch-reuse populate + export GPU sprite layer"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** `createGpuSpriteLayer` (guard + depth + context-loss + dispose) → Task 1. `populateGpuSpriteLayer` (scratch reuse) → Task 2. Barrel export → Task 2 Step 5. Tests for guard/null/dispose/populate → both tasks. All spec sections mapped.
+- **Placeholder scan:** none — all steps carry real code/commands.
+- **Type consistency:** `GpuSpriteLayerHandle`, `GpuSpriteLayerOptions`, `createGpuSpriteLayer`, `populateGpuSpriteLayer` names identical across tasks, spec, and barrel.
+- **Note:** context-loss `onRestored` is exercised indirectly (guard wiring asserted via dispose detach path); deeper restore simulation deferred as out-of-scope for this thin primitive.

--- a/docs/superpowers/specs/2026-06-29-gpu-sprite-layer-design.md
+++ b/docs/superpowers/specs/2026-06-29-gpu-sprite-layer-design.md
@@ -1,0 +1,129 @@
+# GPU Sprite Layer — thin guarded factory for `@kbve/laser`
+
+Date: 2026-06-29
+Status: Approved (design)
+
+## Problem
+
+Phaser 4.1 ships `SpriteGPULayer`: a static GPU-buffer batch renderer that draws up
+to ~1M quads in a single draw call (~100x faster than per-sprite rendering) by
+keeping transform data on the GPU and uploading only when data changes. It targets
+ambient mass-sprite content — starfields, weather, particles, crowds, debris,
+animated backgrounds — not game characters with per-frame logic.
+
+Both `apps/agones/arpg/web` (ARPG) and `apps/cryptothrone/astro-cryptothrone`
+(Cryptothrone) run Phaser 4.1 with `Phaser.AUTO` (→ WebGL when available) and both
+consume `@kbve/laser` via a path alias to `packages/npm/laser/src/index.ts`. Without
+a shared primitive each app would re-implement the same WebGL guard, context-loss
+handling, and the documented allocation-free populate path independently.
+
+## Constraints (from Phaser 4.1 `SpriteGPULayer` type docs)
+
+- **WebGL only.** No-ops under the Canvas fallback path of `Phaser.AUTO`.
+- **Single image texture.** No multi-atlas. Power-of-two recommended for pixel art.
+- **168 bytes per quad**, CPU and GPU.
+- **Buffer mutation is expensive.** `addMember`, `editMember`, `patchMember`,
+  `resize`, `removeMembers` update some/all of the buffer. Populate once, leave
+  unchanged where possible.
+- **Removal rewrites the buffer.** Prefer "hiding" a quad via `scaleX/scaleY/alpha = 0`
+  over `removeMembers`.
+- **Reuse a single `Member` object** across `addMember` calls — allocating millions
+  of member objects has major cost and causes GC pressure.
+
+## Scope
+
+A generic, performance-minded primitive in `@kbve/laser`. **API-first**: no scene
+consumer ships in this work. ARPG and Cryptothrone wire it later.
+
+### In scope
+
+Three exports from `packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts`,
+re-exported through the `lib/phaser` surface and the root `index.ts` barrel:
+
+```ts
+export interface GpuSpriteLayerOptions {
+  size: number;
+  depth?: number;
+  alpha?: number;
+  blendMode?: number;
+  visible?: boolean;
+}
+
+export interface GpuSpriteLayerHandle {
+  readonly layer: Phaser.GameObjects.SpriteGPULayer;
+  dispose(): void;
+}
+
+export function createGpuSpriteLayer(
+  scene: Phaser.Scene,
+  texture: string | Phaser.Textures.Texture,
+  opts: GpuSpriteLayerOptions,
+): GpuSpriteLayerHandle | null;
+
+export function populateGpuSpriteLayer(
+  handle: GpuSpriteLayerHandle,
+  count: number,
+  fill: (
+    member: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member>,
+    i: number,
+  ) => void,
+): void;
+```
+
+### Out of scope (YAGNI)
+
+- Config presets (starfield/particle builders).
+- Pooling / free-list manager.
+- Per-frame member-diff batching.
+- Any ARPG or Cryptothrone scene integration.
+
+## Behavior
+
+### `createGpuSpriteLayer`
+
+1. **WebGL guard.** If `scene.renderer.type !== Phaser.WEBGL`, return `null`.
+   Mirrors the existing guard at `apps/agones/arpg/web/src/game/IsoArpgScene.ts:431`.
+   Consumers treat `null` as "ambient layer unavailable" and no-op.
+2. Build a `SpriteGPULayerConfig` (`{ size, key: texture, alpha, blendMode, visible }`)
+   and create the layer via `scene.add.spriteGPULayer(config)`.
+3. Apply `depth` when provided (iso scenes in both apps are depth-sorted; the layer
+   must composite under/over entities deterministically).
+4. **Context-loss survival.** Install the existing
+   `installWebGLContextGuard` (`packages/npm/laser/src/lib/webgl/context-guard.ts`)
+   on the game canvas. On `restored`, call `layer.setAllSegmentsNeedUpdate()` so the
+   whole buffer re-uploads. Return a handle whose `dispose()` removes the listener
+   and destroys the layer.
+
+### `populateGpuSpriteLayer`
+
+Allocates exactly **one** scratch `Member` object. Loops `count` times: calls
+`fill(scratch, i)` (consumer mutates fields in place), then `handle.layer.addMember(scratch)`.
+Zero per-quad allocation → no GC churn on large populates. Implements the documented
+fast path so neither app re-derives it. Per-frame animation (GPU tweens in member
+data: position/rotation/scale/alpha easing) is consumer policy and stays out of this
+primitive.
+
+## Testing
+
+`gpu-sprite-layer.spec.ts` alongside the source (matches existing `*.spec.ts` in
+`lib/phaser`). With a mocked `Phaser.Scene`:
+
+- `renderer.type === Phaser.WEBGL` → returns a handle; `scene.add.spriteGPULayer`
+  called with the derived config; `depth` applied when set.
+- `renderer.type === Phaser.CANVAS` → returns `null`; factory never called.
+- `dispose()` detaches the context-loss listener and destroys the layer.
+- `populateGpuSpriteLayer` calls `fill` `count` times and `addMember` `count` times
+  with the **same** object reference each call (scratch reuse assertion).
+
+## Conventions
+
+- Free functions, scene-first argument — matches `lib/phaser/entity-fx.ts`.
+- `import Phaser from 'phaser'`.
+- No comments; code self-documenting (global preference).
+- Build/test via nx through `./kbve.sh`, not raw cargo/vitest.
+
+## Consumers (future, not this work)
+
+- ARPG: parallax starfield in `apps/agones/arpg/web/src/game/space/SpaceScene.tsx`.
+- Cryptothrone: ambient layer in
+  `apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts`.

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -40,6 +40,14 @@ export {
 	attachCameraZoom,
 } from './lib/phaser/entity-fx';
 export type { CameraZoomOptions } from './lib/phaser/entity-fx';
+export {
+	createGpuSpriteLayer,
+	populateGpuSpriteLayer,
+} from './lib/phaser/gpu-sprite-layer';
+export type {
+	GpuSpriteLayerOptions,
+	GpuSpriteLayerHandle,
+} from './lib/phaser/gpu-sprite-layer';
 
 // Tile prediction — BFS pathing that mirrors the server grid
 export { findTilePath } from './lib/tile/path';

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -48,6 +48,8 @@ export type {
 	GpuSpriteLayerOptions,
 	GpuSpriteLayerHandle,
 } from './lib/phaser/gpu-sprite-layer';
+export { createDustMoteLayer, dustMemberAt } from './lib/phaser/ambient-dust';
+export type { DustMoteOptions } from './lib/phaser/ambient-dust';
 
 // Tile prediction — BFS pathing that mirrors the server grid
 export { findTilePath } from './lib/tile/path';

--- a/packages/npm/laser/src/lib/phaser/ambient-dust.spec.ts
+++ b/packages/npm/laser/src/lib/phaser/ambient-dust.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dustMemberAt, createDustMoteLayer } from './ambient-dust';
+
+vi.mock('phaser', () => ({
+	default: { WEBGL: 2, CANVAS: 1 },
+	WEBGL: 2,
+	CANVAS: 1,
+}));
+
+describe('dustMemberAt', () => {
+	it('spreads the mote across the field and drives GPU oscillation', () => {
+		const rand = () => 0.5;
+		const m = dustMemberAt(
+			0,
+			{ width: 800, height: 600, count: 10 },
+			rand,
+		) as {
+			x: number;
+			y: {
+				base: number;
+				amplitude: number;
+				loop: boolean;
+				yoyo: boolean;
+			};
+			alpha: { base: number; loop: boolean };
+		};
+		expect(m.x).toBe(400);
+		expect(m.y.base).toBe(300);
+		expect(m.y.amplitude).toBeGreaterThan(0);
+		expect(m.y.loop).toBe(true);
+		expect(m.y.yoyo).toBe(true);
+		expect(m.alpha.loop).toBe(true);
+	});
+
+	it('varies position from the rng across calls', () => {
+		let n = 0;
+		const rand = () => {
+			n += 1;
+			return (n * 0.13) % 1;
+		};
+		const a = dustMemberAt(
+			0,
+			{ width: 100, height: 100, count: 2 },
+			rand,
+		) as {
+			x: number;
+		};
+		const b = dustMemberAt(
+			1,
+			{ width: 100, height: 100, count: 2 },
+			rand,
+		) as {
+			x: number;
+		};
+		expect(a.x).not.toBe(b.x);
+	});
+});
+
+function makeScene(rendererType: number) {
+	const layer = {
+		setDepth: vi.fn().mockReturnThis(),
+		setAlpha: vi.fn().mockReturnThis(),
+		setBlendMode: vi.fn().mockReturnThis(),
+		setVisible: vi.fn().mockReturnThis(),
+		setAllSegmentsNeedUpdate: vi.fn(),
+		addMember: vi.fn().mockReturnThis(),
+		destroy: vi.fn(),
+	};
+	const gfx = {
+		fillStyle: vi.fn().mockReturnThis(),
+		fillCircle: vi.fn().mockReturnThis(),
+		generateTexture: vi.fn().mockReturnThis(),
+		destroy: vi.fn(),
+	};
+	return {
+		scene: {
+			renderer: { type: rendererType },
+			game: { canvas: document.createElement('canvas') },
+			textures: { exists: vi.fn().mockReturnValue(false) },
+			make: { graphics: vi.fn().mockReturnValue(gfx) },
+			add: { spriteGPULayer: vi.fn().mockReturnValue(layer) },
+		},
+		layer,
+		gfx,
+	};
+}
+
+describe('createDustMoteLayer', () => {
+	it('returns null on Canvas and builds no texture', () => {
+		const { scene, gfx } = makeScene(1);
+		const handle = createDustMoteLayer(scene as never, {
+			width: 800,
+			height: 600,
+			count: 50,
+		});
+		expect(handle).toBeNull();
+		expect(gfx.generateTexture).not.toHaveBeenCalled();
+	});
+
+	it('generates the dot texture once and populates count motes on WebGL', () => {
+		const { scene, layer, gfx } = makeScene(2);
+		const handle = createDustMoteLayer(scene as never, {
+			width: 800,
+			height: 600,
+			count: 50,
+			depth: -5,
+		});
+		expect(handle).not.toBeNull();
+		expect(gfx.generateTexture).toHaveBeenCalledTimes(1);
+		expect(gfx.destroy).toHaveBeenCalledTimes(1);
+		expect(layer.addMember).toHaveBeenCalledTimes(50);
+		expect(layer.setDepth).toHaveBeenCalledWith(-5);
+	});
+});

--- a/packages/npm/laser/src/lib/phaser/ambient-dust.ts
+++ b/packages/npm/laser/src/lib/phaser/ambient-dust.ts
@@ -1,0 +1,104 @@
+import Phaser from 'phaser';
+import {
+	createGpuSpriteLayer,
+	populateGpuSpriteLayer,
+	type GpuSpriteLayerHandle,
+} from './gpu-sprite-layer';
+
+export interface DustMoteOptions {
+	count: number;
+	width: number;
+	height: number;
+	depth?: number;
+	color?: number;
+	radius?: number;
+	alpha?: number;
+	blendMode?: number;
+	scrollFactor?: number;
+	textureKey?: string;
+}
+
+type Rand = () => number;
+
+export function dustMemberAt(
+	_i: number,
+	opts: Pick<DustMoteOptions, 'width' | 'height' | 'count' | 'scrollFactor'>,
+	rand: Rand,
+): Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member> {
+	const x = rand() * opts.width;
+	const yBase = rand() * opts.height;
+	const drift = 4 + rand() * 10;
+	const driftMs = 4000 + rand() * 5000;
+	const scale = 0.5 + rand() * 1.1;
+	const alphaBase = 0.35 + rand() * 0.35;
+	const alphaMs = 2500 + rand() * 3500;
+	const member: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member> = {
+		x,
+		y: {
+			base: yBase,
+			amplitude: drift,
+			duration: driftMs,
+			ease: 'Sine.easeInOut',
+			loop: true,
+			yoyo: true,
+		},
+		scaleX: scale,
+		scaleY: scale,
+		alpha: {
+			base: alphaBase,
+			amplitude: 0.25,
+			duration: alphaMs,
+			ease: 'Sine.easeInOut',
+			loop: true,
+			yoyo: true,
+		},
+	};
+	if (opts.scrollFactor !== undefined) {
+		member.scrollFactorX = opts.scrollFactor;
+		member.scrollFactorY = opts.scrollFactor;
+	}
+	return member;
+}
+
+function ensureDotTexture(
+	scene: Phaser.Scene,
+	key: string,
+	radius: number,
+	color: number,
+): void {
+	if (scene.textures.exists(key)) return;
+	const d = radius * 2;
+	const gfx = scene.make.graphics({ x: 0, y: 0 }, false);
+	gfx.fillStyle(color, 1);
+	gfx.fillCircle(radius, radius, radius);
+	gfx.generateTexture(key, d, d);
+	gfx.destroy();
+}
+
+export function createDustMoteLayer(
+	scene: Phaser.Scene,
+	opts: DustMoteOptions,
+	rand: Rand = Math.random,
+): GpuSpriteLayerHandle | null {
+	if (scene.renderer.type !== Phaser.WEBGL) {
+		return null;
+	}
+
+	const key = opts.textureKey ?? 'laser-dust-mote';
+	const radius = opts.radius ?? 2;
+	ensureDotTexture(scene, key, radius, opts.color ?? 0xffffff);
+
+	const handle = createGpuSpriteLayer(scene, key, {
+		size: opts.count,
+		depth: opts.depth,
+		alpha: opts.alpha,
+		blendMode: opts.blendMode,
+	});
+	if (!handle) return null;
+
+	populateGpuSpriteLayer(handle, opts.count, (member, i) =>
+		Object.assign(member, dustMemberAt(i, opts, rand)),
+	);
+
+	return handle;
+}

--- a/packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts
+++ b/packages/npm/laser/src/lib/phaser/gpu-sprite-layer.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+	createGpuSpriteLayer,
+	populateGpuSpriteLayer,
+} from './gpu-sprite-layer';
+
+vi.mock('phaser', () => ({
+	default: { WEBGL: 2, CANVAS: 1 },
+	WEBGL: 2,
+	CANVAS: 1,
+}));
+
+function makeLayer() {
+	return {
+		setDepth: vi.fn().mockReturnThis(),
+		setAlpha: vi.fn().mockReturnThis(),
+		setBlendMode: vi.fn().mockReturnThis(),
+		setVisible: vi.fn().mockReturnThis(),
+		setAllSegmentsNeedUpdate: vi.fn(),
+		addMember: vi.fn().mockReturnThis(),
+		destroy: vi.fn(),
+	};
+}
+
+function makeScene(rendererType: number, layer = makeLayer()) {
+	const spriteGPULayer = vi.fn().mockReturnValue(layer);
+	return {
+		scene: {
+			renderer: { type: rendererType },
+			game: { canvas: document.createElement('canvas') },
+			add: { spriteGPULayer },
+		},
+		spriteGPULayer,
+		layer,
+	};
+}
+
+describe('createGpuSpriteLayer', () => {
+	it('returns null on the Canvas fallback and never builds a layer', () => {
+		const { scene, spriteGPULayer } = makeScene(1);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', {
+			size: 100,
+		});
+		expect(handle).toBeNull();
+		expect(spriteGPULayer).not.toHaveBeenCalled();
+	});
+
+	it('builds a depth-applied layer under WebGL and returns a handle', () => {
+		const { scene, spriteGPULayer, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', {
+			size: 100,
+			depth: 5,
+			alpha: 0.8,
+		});
+		expect(handle).not.toBeNull();
+		expect(spriteGPULayer).toHaveBeenCalledWith('stars', 100);
+		expect(layer.setDepth).toHaveBeenCalledWith(5);
+		expect(layer.setAlpha).toHaveBeenCalledWith(0.8);
+		expect(handle!.layer).toBe(layer);
+	});
+
+	it('dispose destroys the layer', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', {
+			size: 10,
+		});
+		handle!.dispose();
+		expect(layer.destroy).toHaveBeenCalled();
+	});
+});
+
+describe('populateGpuSpriteLayer', () => {
+	it('reuses one scratch member across all addMember calls', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createGpuSpriteLayer(scene as never, 'stars', {
+			size: 3,
+		})!;
+		const seen: unknown[] = [];
+		layer.addMember.mockImplementation((m: unknown) => {
+			seen.push(m);
+			return layer;
+		});
+
+		const xs: number[] = [];
+		populateGpuSpriteLayer(handle, 3, (member, i) => {
+			(member as { x: number }).x = i;
+			xs.push((member as { x: number }).x);
+		});
+
+		expect(layer.addMember).toHaveBeenCalledTimes(3);
+		expect(xs).toEqual([0, 1, 2]);
+		expect(seen[0]).toBe(seen[1]);
+		expect(seen[1]).toBe(seen[2]);
+	});
+});

--- a/packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts
+++ b/packages/npm/laser/src/lib/phaser/gpu-sprite-layer.ts
@@ -1,0 +1,68 @@
+import Phaser from 'phaser';
+import { installWebGLContextGuard } from '../webgl/context-guard';
+
+export interface GpuSpriteLayerOptions {
+	size: number;
+	depth?: number;
+	alpha?: number;
+	blendMode?: number;
+	visible?: boolean;
+}
+
+export interface GpuSpriteLayerHandle {
+	readonly layer: Phaser.GameObjects.SpriteGPULayer;
+	dispose(): void;
+}
+
+export function createGpuSpriteLayer(
+	scene: Phaser.Scene,
+	texture: string | Phaser.Textures.Texture,
+	opts: GpuSpriteLayerOptions,
+): GpuSpriteLayerHandle | null {
+	if (scene.renderer.type !== Phaser.WEBGL) {
+		return null;
+	}
+
+	const layer = scene.add.spriteGPULayer(texture, opts.size);
+
+	if (opts.depth !== undefined) {
+		layer.setDepth(opts.depth);
+	}
+	if (opts.alpha !== undefined) {
+		layer.setAlpha(opts.alpha);
+	}
+	if (opts.blendMode !== undefined) {
+		layer.setBlendMode(opts.blendMode);
+	}
+	if (opts.visible !== undefined) {
+		layer.setVisible(opts.visible);
+	}
+
+	const detach = installWebGLContextGuard(scene.game.canvas, {
+		onLost: () => undefined,
+		onRestored: () => layer.setAllSegmentsNeedUpdate(),
+	});
+
+	return {
+		layer,
+		dispose() {
+			detach();
+			layer.destroy();
+		},
+	};
+}
+
+export function populateGpuSpriteLayer(
+	handle: GpuSpriteLayerHandle,
+	count: number,
+	fill: (
+		member: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member>,
+		i: number,
+	) => void,
+): void {
+	const scratch: Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member> = {};
+	for (let i = 0; i < count; i++) {
+		fill(scratch, i);
+		handle.layer.addMember(scratch);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a thin, performance-minded Phaser 4.1 `SpriteGPULayer` primitive to `@kbve/laser` and wires it into both Phaser game clients as ambient dust-mote layers.

`SpriteGPULayer` (Phaser 4.1) batches up to ~1M quads in a single draw call by keeping transform data on the GPU. Both ARPG and Cryptothrone run Phaser 4.1 (`Phaser.AUTO` → WebGL) and consume `@kbve/laser`, so the primitive lives there once instead of being re-implemented per app.

## `@kbve/laser` API (new)

- `createGpuSpriteLayer(scene, texture, opts)` → WebGL-guarded (returns `null` on the Canvas fallback), applies depth/alpha/blend/visible, installs context-loss recovery via the existing `installWebGLContextGuard`, returns a handle with `dispose()`.
- `populateGpuSpriteLayer(handle, count, fill)` → reuses a single scratch `Member` object across `addMember` calls (the documented allocation-free fast path — no GC churn on large populates).
- `createDustMoteLayer(scene, opts)` / `dustMemberAt(...)` → shared ambient dust preset built on the factory, with GPU-driven drift + alpha oscillation. Supports world-anchored or camera-fixed (`scrollFactor`) motes.

## Consumers

- **Cryptothrone** `CloudCityScene`: world-anchored cloud/dust motes sized to the tilemap, depth just under entities.
- **ARPG** `IsoArpgScene`: camera-fixed (`scrollFactor: 0`) dust motes sized to the viewport — the iso world is unbounded/scrolling, so screen-space is correct. (Note: ARPG's `SpaceScene` is React Three Fiber, not Phaser, and already has a starfield; SpriteGPULayer does not apply there.)

Both dispose their layer on scene shutdown/teardown.

## Tests

- 8 new unit tests (factory guard/null/dispose, scratch-reuse, dust member fields, texture-generated-once + populate-count). Full laser suite: 162 passed.
- `arpg-web` typecheck clean. `astro-cryptothrone` has only pre-existing errors (`GameClient.move` 4-arg call site at CloudCityScene:1129 + vitest.config vite/rollup version noise) — confirmed present on the base branch, unrelated to this change.

## Notes

- No comments in source (repo convention).
- Texture is generated in-scene (`graphics.generateTexture`) — single image, POT-safe, no asset/atlas dependency.