### PR TITLE
feat(jedi): gate fred behind valkey — drop Redis stack from 10 consumers

### DIFF
--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -59,7 +59,7 @@ webpki-roots = { version = "0.26", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", optional = true, features = ["serde", "v4"] }
 rustls-pemfile = { version = "2", optional = true }
-fred = { version = "10", features = [
+fred = { version = "10", optional = true, features = [
   "i-keys", "i-lists", "i-pubsub", "i-std", "subscriber-client",
   "serde-json", "i-server", "i-scripts", "i-streams",
   "metrics", "enable-rustls", "i-tracking"
@@ -111,7 +111,7 @@ postgres = [
     "dep:url",
     "dep:uuid",
 ]
-valkey = ["dep:lru"]
+valkey = ["dep:lru", "dep:fred"]
 
 [dev-dependencies]
 serial_test = "3"

--- a/packages/rust/jedi/src/entity/error.rs
+++ b/packages/rust/jedi/src/entity/error.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 #[cfg(feature = "postgres")]
 use bb8::ErrorSink;
+#[cfg(feature = "valkey")]
 use fred::error::Error as RedisError;
 use serde::Serialize;
 use std::borrow::Cow;
@@ -168,6 +169,7 @@ impl From<flexbuffers::ReaderError> for JediError {
     }
 }
 
+#[cfg(feature = "valkey")]
 impl From<RedisError> for JediError {
     fn from(err: RedisError) -> Self {
         JediError::Database(Cow::Owned(format!("Redis error: {}", err)))

--- a/packages/rust/jedi/src/entity/mod.rs
+++ b/packages/rust/jedi/src/entity/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod bitwise;
+#[cfg(feature = "valkey")]
 pub mod envelope;
 pub mod error;
 pub mod flex;
@@ -14,6 +15,7 @@ pub mod pipe;
 pub mod pipe_clickhouse;
 #[cfg(feature = "prometheus")]
 pub mod pipe_prometheus;
+#[cfg(feature = "valkey")]
 pub mod pipe_redis;
 pub mod regex;
 pub mod serde_arc_str;

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
@@ -1,9 +1,11 @@
 pub mod alerts;
 pub mod clickhouse_types;
+#[cfg(feature = "valkey")]
 pub mod core;
 pub mod factorio;
 pub mod logs;
 
 pub use clickhouse_types::*;
+#[cfg(feature = "valkey")]
 pub use core::*;
 pub use logs::{LogsQueryParams, LogsResult, LogsStatsParams, run_query, run_stats};

--- a/packages/rust/jedi/src/state/mod.rs
+++ b/packages/rust/jedi/src/state/mod.rs
@@ -1,5 +1,7 @@
 pub mod sidecar;
+#[cfg(feature = "valkey")]
 pub mod temple;
+#[cfg(feature = "valkey")]
 pub mod watchmaster;
 
 #[cfg(feature = "postgres")]

--- a/packages/rust/jedi/src/wrapper/mod.rs
+++ b/packages/rust/jedi/src/wrapper/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "valkey")]
 pub mod redis_wrapper;
 #[cfg(feature = "twitch")]
 pub mod twitch_wrapper;
 
+#[cfg(feature = "valkey")]
 pub use redis_wrapper::*;


### PR DESCRIPTION
Next slice of jedi dependency optimization ([plan](docs/plans/build-optimization/jedi-deps-optimization.md)). Follows #13587 (askama + twitch).

## Finding
Initial audit flagged `fred` as un-gateable core because `TempleState.redis_pool` is a non-optional field threaded through the envelope/Pipe system. Deeper investigation corrected this: **the entire envelope / TempleState / pubsub / pipe_redis machinery is internal jedi plumbing** — no in-repo consumer constructs `TempleState` or uses `JediEnvelope` / `EnvelopePipeline` / wire helpers directly. The only external fred surface is `state::kv::KvCache`, already gated behind `valkey`. The `AppState` hits that suggested otherwise were each consumer's *own* `AppState` struct, not jedi's.

## Change
- `fred` → `optional = true`; `valkey` feature now pulls `dep:fred`.
- Gate internal fred-coupled modules behind `valkey`: `entity::envelope`, `entity::pipe_redis`, `state::temple`, `state::watchmaster`, `wrapper::redis_wrapper`, `pipe_clickhouse::core`, and `error::From<RedisError>`.
- `pipe_clickhouse::{factorio,logs}` take `&ClickHouseConfig` directly (not `TempleState`) so they stay ungated — clickhouse-only consumers keep working without fred.
- **Zero consumer `Cargo.toml` changes** — every fred user already enables `valkey`.

## Validation
- `cargo check -p jedi`: `--no-default-features`, `--features valkey`, `--features clickhouse`, `--all-features` all build (0 errors).
- All 17 in-repo consumers build clean.
- `fred` confirmed **dropped** from clickhouse-only trees (`factorio-ctl`) and **retained** for `KvCache` users (`irc-gateway`).

## Impact
10 of 17 consumers (factorio-ctl, herbmail, metrics, jobboard, rows, axum-memes, axum-discordsh, agones-factorio-relay, axum-rentearth, axum-chuckrpg) no longer compile the fred Redis stack (rustls + ws + 13 features). No behavior change.