### PR TITLE
feat(jedi): gate gRPC transport behind `grpc` feature

### DIFF
--- a/docs/plans/build-optimization/jedi-deps-optimization.md
+++ b/docs/plans/build-optimization/jedi-deps-optimization.md
@@ -83,6 +83,21 @@ valkey      = ["dep:lru"]
 - crates.io consumers: feature changes are semver-additive if `default = []` stays empty, but trimming what a _named_ feature pulls can break external users — bump minor and document.
 - Coordinate with [proto-distribution.md](./proto-distribution.md): the `grpc` feature and `src/proto` codegen are coupled.
 
+## Execution Status (2026-06-29)
+
+| Step                | Status      | PR     | Notes                                                                                          |
+| ------------------- | ----------- | ------ | ---------------------------------------------------------------------------------------------- |
+| Remove `askama`     | ✅ done     | #13587 | Dead dep dropped.                                                                               |
+| Gate `twitch`       | ✅ done     | #13587 | `twitch = ["dep:twitch-irc"]`; gated `wrapper/twitch_wrapper` + `proto/twitch`.                 |
+| Gate `fred` (redis) | ✅ done     | #13593 | Folded into `valkey = ["dep:lru", "dep:fred"]` — fred is internal-only, no consumer touches it. |
+| Gate `grpc`         | ✅ done     | (this) | `tonic*` optional behind `grpc`; gated 4 proto service submods + `error.rs` Status impls.       |
+| `reqwest` / `axum`  | ⬜ deferred | —      | Kept core (auth-core + response contract). See findings below.                                  |
+| `tokio = "full"`    | ⬜ deferred | —      | Narrow feature set in separate PR.                                                              |
+| CI feature matrix   | ⬜ todo     | —      | `cargo hack --feature-powerset` smoke build.                                                    |
+| Measure build win   | ⬜ todo     | —      | Wall-time before/after for a trimmed consumer.                                                  |
+
+**grpc finding (verified):** jedi's tonic transport is internal/unused — no consumer references jedi's grpc service mods or `From<JediError> for tonic::Status`. jobboard + rows carry their **own** `tonic` dep + proto, not jedi's. `prost` message types stay **core** (every proto struct derives `prost::Message`); only `tonic`/`tonic-prost`/`tonic-health`/`tonic-reflection` go optional. tonic-health + tonic-reflection had **0 src usages** but are kept under `grpc` for the server-bootstrap story. Service codegen lives in 4 vendored submods (`{click_house,redis}_service_{client,server}`) gated with `#[cfg(feature = "grpc")]`; `build.rs` codegen is manual (`BUILD_PROTO`) so the gates are hand-maintained.
+
 ## Investigation Findings (2026-06-29, verified against code)
 
 ### Confirmed

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -66,10 +66,10 @@ fred = { version = "10", optional = true, features = [
 ] }
 prost = { version = "0.14", features = ["derive"] }
 papaya = "0.2.1"
-tonic = "0.14.5"
-tonic-health = "0.14.5"
-tonic-prost = "0.14.5"
-tonic-reflection = "0.14.5"
+tonic = { version = "0.14.5", optional = true }
+tonic-health = { version = "0.14.5", optional = true }
+tonic-prost = { version = "0.14.5", optional = true }
+tonic-reflection = { version = "0.14.5", optional = true }
 http-body-util = "0.1"
 ulid = { version = "1", features = ["serde", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -100,6 +100,7 @@ prometheus = ["dep:axum-prometheus", "dep:metrics"]
 forgejo = []
 itch = []
 twitch = ["dep:twitch-irc"]
+grpc = ["dep:tonic", "dep:tonic-prost", "dep:tonic-health", "dep:tonic-reflection"]
 postgres = [
     "dep:tokio-postgres",
     "dep:bb8",

--- a/packages/rust/jedi/src/entity/error.rs
+++ b/packages/rust/jedi/src/entity/error.rs
@@ -99,6 +99,7 @@ impl From<tokio_postgres::Error> for JediError {
     }
 }
 
+#[cfg(feature = "grpc")]
 impl From<JediError> for tonic::Status {
     fn from(err: JediError) -> tonic::Status {
         match err {
@@ -118,6 +119,7 @@ impl From<JediError> for tonic::Status {
     }
 }
 
+#[cfg(feature = "grpc")]
 impl From<tonic::Status> for JediError {
     fn from(status: tonic::Status) -> Self {
         JediError::Grpc(status.to_string())

--- a/packages/rust/jedi/src/proto/clickhouse.rs
+++ b/packages/rust/jedi/src/proto/clickhouse.rs
@@ -212,6 +212,7 @@ impl SeverityLevel {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod click_house_service_client {
     #![allow(
         unused_variables,
@@ -406,6 +407,7 @@ pub mod click_house_service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod click_house_service_server {
     #![allow(
         unused_variables,

--- a/packages/rust/jedi/src/proto/redis.rs
+++ b/packages/rust/jedi/src/proto/redis.rs
@@ -216,6 +216,7 @@ pub struct Field {
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod redis_service_client {
     #![allow(
         unused_variables,
@@ -322,6 +323,7 @@ pub mod redis_service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod redis_service_server {
     #![allow(
         unused_variables,


### PR DESCRIPTION
## What

Makes jedi's tonic gRPC transport stack optional behind a new `grpc` feature. Continues the jedi dependency optimization (after #13587 askama/twitch, #13593 fred/valkey).

## Why

`tonic`, `tonic-prost`, `tonic-health`, `tonic-reflection` compiled **unconditionally** for all 17 in-repo consumers — but **none use jedi's gRPC services**. jobboard and rows have their **own** `tonic` dependency + proto codegen; they never touch jedi's service mods or `From<JediError> for tonic::Status`. So the entire transport stack was pure dead weight on every consumer's build.

## Changes

- `Cargo.toml`: `tonic*` → `optional = true`; new `grpc = ["dep:tonic", "dep:tonic-prost", "dep:tonic-health", "dep:tonic-reflection"]`.
- `proto/clickhouse.rs`, `proto/redis.rs`: gate the 4 generated service submodules (`{click_house,redis}_service_{client,server}`) behind `#[cfg(feature = "grpc")]`.
- `error.rs`: gate `From<JediError> for tonic::Status` + `From<tonic::Status>` behind `grpc`.
- `prost` message types stay **core** (every proto struct derives `prost::Message`) — only transport moves.
- Plan doc: execution-status table + grpc finding.

## Notes

- tonic-health + tonic-reflection have **0 src usages** today; kept under `grpc` for the server-bootstrap story rather than dropped.
- `build.rs` codegen is manual (`BUILD_PROTO`-gated), so the service-mod `#[cfg]` attrs are hand-maintained on the vendored files.
- No consumer Cargo.toml changes — nobody needs `grpc`.

## Validation

- `cargo check -p jedi --no-default-features` → 0 errors
- `cargo check -p jedi --no-default-features --features grpc` → 0 errors
- `cargo check -p jedi --all-features` → 0 errors
- `rows`, `jobboard` build unchanged (own tonic; jobboard's only errors are the pre-existing missing `web/dist` embed artifact)