### PR TITLE
perf(sitegraph): take zoom off the React render path

### DIFF
--- a/packages/npm/astro/.verify/drive.mjs
+++ b/packages/npm/astro/.verify/drive.mjs
@@ -82,18 +82,49 @@ await page.mouse.up();
 await page.waitForTimeout(80);
 const afterPan = await groupTransform();
 
-// Wheel zoom over the center.
+// Label decluttering is now zoom-driven imperatively (no React re-render):
+// 'd' (degree 1, not current) is label-hidden at base zoom; zooming past the
+// reveal threshold must paint its label visible.
+const labelOpacity = (id) =>
+	page.evaluate(
+		(id) =>
+			document
+				.querySelector(`.sg-node[data-id="${id}"] .sg-node-label`)
+				?.getAttribute('opacity') ?? null,
+		id,
+	);
+const zoomPct = () =>
+	page.evaluate(
+		() =>
+			document.querySelector('button[title="Reset zoom"]')?.textContent ??
+			null,
+	);
+const dLabelBase = await labelOpacity('d');
+const zoomPctBase = await zoomPct();
+
+// Wheel zoom over the center (delta ~ +0.48 → ~1.48, past the 1.2 threshold).
 await page.mouse.move(svg.x + svg.width / 2, svg.y + svg.height / 2);
 await page.mouse.wheel(0, -240);
 await page.waitForTimeout(120);
 const afterWheel = await groupTransform();
+const dLabelZoomed = await labelOpacity('d');
+const zoomPctZoomed = await zoomPct();
 
 out({
 	nodeCount,
 	hover,
 	afterLeave,
 	pan: { before, afterPan, panned: before !== afterPan },
-	wheel: { afterWheel, zoomed: afterPan !== afterWheel },
+	wheel: {
+		afterWheel,
+		zoomed: afterPan !== afterWheel,
+		dLabelBase,
+		dLabelZoomed,
+		labelRevealed: dLabelBase === '0' && dLabelZoomed === '1',
+		zoomPctBase,
+		zoomPctZoomed,
+		zoomBarUpdated: zoomPctBase !== zoomPctZoomed,
+	},
 	consoleErrors,
 });
 

--- a/packages/npm/astro/src/sitegraph/react/GraphZoomBar.tsx
+++ b/packages/npm/astro/src/sitegraph/react/GraphZoomBar.tsx
@@ -1,18 +1,26 @@
-import { memo } from 'react';
+import { memo, useEffect, useState, type RefObject } from 'react';
 import { MIN_ZOOM, MAX_ZOOM } from './graph-core';
 
 interface GraphZoomBarProps {
-	zoom: number;
+	zoomRef: RefObject<number>;
+	subscribeZoom: (cb: (zoom: number) => void) => () => void;
 	onReset: () => void;
 	onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-/** Bottom zoom bar: reset-to-100% button + zoom slider. */
+/**
+ * Bottom zoom bar: reset-to-100% button + zoom slider. Subscribes to zoom
+ * itself so a gesture re-renders only this bar — never the node/link tree.
+ */
 export const GraphZoomBar = memo(function GraphZoomBar({
-	zoom,
+	zoomRef,
+	subscribeZoom,
 	onReset,
 	onSliderChange,
 }: GraphZoomBarProps) {
+	const [zoom, setZoom] = useState(() => zoomRef.current ?? 1);
+	useEffect(() => subscribeZoom(setZoom), [subscribeZoom]);
+
 	const pct = ((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100;
 	return (
 		<div

--- a/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
@@ -167,15 +167,16 @@ export function SiteGraph({
 	const graphReady = nodes.length > 0;
 
 	// Pan + pinch/wheel zoom, driven through refs + an imperative transform
-	// writer so gestures never re-render the node/link tree. `zoom` is the only
-	// value committed to state (rAF-throttled) for zoom-dependent attributes.
+	// writer so gestures never re-render the node/link tree. Zoom is broadcast
+	// via `subscribeZoom` (no React state) so only the zoom bar + imperative
+	// label-reveal follow it — the node/link tree never reconciles on zoom.
 	const {
 		groupRef,
-		zoom,
 		zoomRef,
 		panXRef,
 		panYRef,
 		isPointerOverSvg,
+		subscribeZoom,
 		handleSliderChange,
 		handleResetZoom,
 	} = usePanZoom(svgRef, width, height, graphReady);
@@ -225,8 +226,20 @@ export function SiteGraph({
 	}, []);
 
 	// Hover-dim painted imperatively from the base styling the render writes to
-	// `data-*` attrs — hovering a node re-renders nothing.
-	const { hoveredIdRef, applyHover } = useHoverPaint(svgRef, adjacency);
+	// `data-*` attrs — hovering a node re-renders nothing. The painter also owns
+	// zoom-driven label decluttering (reads `zoomRef`).
+	const { hoveredIdRef, applyHover } = useHoverPaint(
+		svgRef,
+		adjacency,
+		zoomRef,
+	);
+
+	// Zoom no longer lives in React state, so repaint labels imperatively when
+	// the committed zoom crosses the reveal threshold during a gesture.
+	useEffect(
+		() => subscribeZoom(() => applyHover(hoveredIdRef.current)),
+		[subscribeZoom, applyHover, hoveredIdRef],
+	);
 
 	// Persist depth to localStorage and reflect depth + search in the URL so
 	// users can share/refresh into the same view.
@@ -554,9 +567,8 @@ export function SiteGraph({
 											'var(--sl-color-gray-4)'
 										: 'var(--sl-color-gray-5)'
 								}
-								strokeWidth={
-									l.relationship ? 1.5 / zoom : 1 / zoom
-								}
+								strokeWidth={l.relationship ? 1.5 : 1}
+								vectorEffect="non-scaling-stroke"
 								strokeOpacity={opacity}
 								strokeDasharray={dash}
 								style={{ transition: 'stroke-opacity 0.12s' }}
@@ -588,15 +600,14 @@ export function SiteGraph({
 						const filterPass = matchesSearch(node);
 						const opacity = filterPass ? 1 : 0.05;
 
-						// Label-visibility heuristic (no-hover base): current
-						// node, search matches, degree-≥5 hubs always; others
-						// hidden at low zoom to declutter. Hover reveals the
-						// hovered node's label imperatively.
+						// Static label-visibility base: current node, search
+						// matches, and degree-≥5 hubs always show. The zoom
+						// threshold + hovered-node reveals are layered on
+						// imperatively (useHoverPaint) so zoom never re-renders.
 						const labelBase =
 							node.isCurrent ||
 							(!!deferredSearch && filterPass) ||
-							node.degree >= 5 ||
-							zoom >= 1.2;
+							node.degree >= 5;
 
 						return (
 							<g
@@ -646,6 +657,7 @@ export function SiteGraph({
 									fill={baseFill}
 									stroke={baseStroke}
 									strokeWidth={node.isCurrent ? 2 : 1}
+									vectorEffect="non-scaling-stroke"
 									style={{
 										transition: 'fill 0.15s, stroke 0.15s',
 									}}
@@ -686,7 +698,8 @@ export function SiteGraph({
 			<GraphTooltip tooltipRef={tooltipRef} />
 
 			<GraphZoomBar
-				zoom={zoom}
+				zoomRef={zoomRef}
+				subscribeZoom={subscribeZoom}
 				onReset={handleResetZoom}
 				onSliderChange={handleSliderChange}
 			/>

--- a/packages/npm/astro/src/sitegraph/react/graph-core.ts
+++ b/packages/npm/astro/src/sitegraph/react/graph-core.ts
@@ -1,7 +1,4 @@
-import type {
-	SimulationNodeDatum,
-	SimulationLinkDatum,
-} from 'd3-force';
+import type { SimulationNodeDatum, SimulationLinkDatum } from 'd3-force';
 import type { SiteGraphData } from '../types';
 
 export interface GraphNode extends SimulationNodeDatum {
@@ -21,6 +18,9 @@ export interface GraphLink extends SimulationLinkDatum<GraphNode> {
 export const MIN_ZOOM = 0.3;
 export const MAX_ZOOM = 3;
 export const ZOOM_SENSITIVITY = 0.002;
+
+/** Zoom at/above which every node label reveals (declutter threshold). */
+export const ZOOM_LABEL_THRESHOLD = 1.2;
 
 /** d3-force tick budget — caps long-running simulations on dense neighborhoods. */
 export const ALPHA_MIN = 0.05;

--- a/packages/npm/astro/src/sitegraph/react/useHoverPaint.ts
+++ b/packages/npm/astro/src/sitegraph/react/useHoverPaint.ts
@@ -1,9 +1,5 @@
-import {
-	useCallback,
-	useLayoutEffect,
-	useRef,
-	type RefObject,
-} from 'react';
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react';
+import { ZOOM_LABEL_THRESHOLD } from './graph-core';
 
 const HL_FILL = 'var(--sl-color-accent)';
 const HL_STROKE = 'var(--sl-color-accent-high)';
@@ -28,6 +24,7 @@ export interface HoverPaint {
 export function useHoverPaint(
 	svgRef: RefObject<SVGSVGElement | null>,
 	adjacency: Map<string, Set<string>>,
+	zoomRef: RefObject<number>,
 ): HoverPaint {
 	const hoveredIdRef = useRef<string | null>(null);
 
@@ -35,6 +32,11 @@ export function useHoverPaint(
 		(hoverId: string | null) => {
 			const svg = svgRef.current;
 			if (!svg) return;
+
+			// Zoom drives label decluttering imperatively (the render no longer
+			// depends on zoom), so reveal every label once zoomed past the
+			// threshold even when it isn't part of the static label-base set.
+			const zoomReveal = (zoomRef.current ?? 1) >= ZOOM_LABEL_THRESHOLD;
 
 			let set: Set<string> | null = null;
 			if (hoverId) {
@@ -51,11 +53,7 @@ export function useHoverPaint(
 				const labelBase = g.dataset.labelBase === '1';
 				const inSet = set ? set.has(id) : true;
 				const visible = filterPass && inSet;
-				g.style.opacity = visible
-					? '1'
-					: filterPass
-						? '0.18'
-						: '0.05';
+				g.style.opacity = visible ? '1' : filterPass ? '0.18' : '0.05';
 
 				const isHovered = hoverId != null && id === hoverId;
 				const circle =
@@ -78,7 +76,7 @@ export function useHoverPaint(
 					);
 					text.setAttribute(
 						'opacity',
-						labelBase || isHovered ? '1' : '0',
+						labelBase || isHovered || zoomReveal ? '1' : '0',
 					);
 					text.style.fontWeight =
 						isCurrent || isHovered ? '600' : '400';
@@ -98,7 +96,7 @@ export function useHoverPaint(
 				p.setAttribute('stroke-opacity', String(op));
 			}
 		},
-		[svgRef, adjacency],
+		[svgRef, adjacency, zoomRef],
 	);
 
 	// Re-apply hover after every render so a base repaint can't drop the overlay.

--- a/packages/npm/astro/src/sitegraph/react/usePanZoom.ts
+++ b/packages/npm/astro/src/sitegraph/react/usePanZoom.ts
@@ -3,7 +3,6 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useRef,
-	useState,
 	type RefObject,
 } from 'react';
 import { MIN_ZOOM, MAX_ZOOM, ZOOM_SENSITIVITY } from './graph-core';
@@ -11,14 +10,18 @@ import { MIN_ZOOM, MAX_ZOOM, ZOOM_SENSITIVITY } from './graph-core';
 export interface PanZoom {
 	/** Attach to the `<g>` wrapping all nodes/links. */
 	groupRef: RefObject<SVGGElement | null>;
-	/** Committed zoom — drives zoom-dependent rendered attrs + the slider. */
-	zoom: number;
 	/** Live pan/zoom (imperative source of truth, no re-render on change). */
 	zoomRef: RefObject<number>;
 	panXRef: RefObject<number>;
 	panYRef: RefObject<number>;
 	/** True while a pointer is over the SVG — gates keyboard shortcuts. */
 	isPointerOverSvg: RefObject<boolean>;
+	/**
+	 * Subscribe to committed-zoom changes (rAF-throttled during gestures). Lets
+	 * the slider + imperative label-reveal follow zoom WITHOUT re-rendering the
+	 * node/link tree. Returns an unsubscribe fn.
+	 */
+	subscribeZoom: (cb: (zoom: number) => void) => () => void;
 	handleSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	handleResetZoom: () => void;
 }
@@ -26,9 +29,9 @@ export interface PanZoom {
 /**
  * Pan + pinch/wheel zoom for the SiteGraph SVG, driven entirely through refs
  * and a single imperative transform writer — high-frequency gestures never
- * re-render the node/link tree. Only `zoom` is committed to state (rAF-
- * throttled) so zoom-dependent attributes (stroke width, label decluttering,
- * the slider) can follow along.
+ * re-render the node/link tree. Zoom is never committed to React state: it
+ * lives in `zoomRef` and is broadcast through `subscribeZoom` (rAF-throttled),
+ * so only the tiny zoom bar + imperative label-reveal react to it.
  */
 export function usePanZoom(
 	svgRef: RefObject<SVGSVGElement | null>,
@@ -36,14 +39,25 @@ export function usePanZoom(
 	height: number,
 	ready: boolean,
 ): PanZoom {
-	const [zoom, setZoom] = useState(1);
-
 	const groupRef = useRef<SVGGElement>(null);
 	const panXRef = useRef(0);
 	const panYRef = useRef(0);
 	const zoomRef = useRef(1);
 	const zoomCommitRaf = useRef(0);
 	const isPointerOverSvg = useRef(false);
+	const zoomSubscribers = useRef(new Set<(zoom: number) => void>());
+
+	const notifyZoom = useCallback(() => {
+		const z = zoomRef.current;
+		for (const cb of zoomSubscribers.current) cb(z);
+	}, []);
+
+	const subscribeZoom = useCallback((cb: (zoom: number) => void) => {
+		zoomSubscribers.current.add(cb);
+		return () => {
+			zoomSubscribers.current.delete(cb);
+		};
+	}, []);
 
 	// Active background pointers, keyed by pointerId. 1 → pan, 2 → pinch-zoom.
 	const bgPointers = useRef(new Map<number, { x: number; y: number }>());
@@ -76,9 +90,9 @@ export function usePanZoom(
 		if (zoomCommitRaf.current) return;
 		zoomCommitRaf.current = requestAnimationFrame(() => {
 			zoomCommitRaf.current = 0;
-			setZoom(zoomRef.current);
+			notifyZoom();
 		});
-	}, []);
+	}, [notifyZoom]);
 
 	useEffect(
 		() => () => {
@@ -233,9 +247,9 @@ export function usePanZoom(
 			const next = parseFloat(e.target.value);
 			zoomRef.current = next;
 			writeTransform();
-			setZoom(next);
+			notifyZoom();
 		},
-		[writeTransform],
+		[writeTransform, notifyZoom],
 	);
 
 	const handleResetZoom = useCallback(() => {
@@ -243,16 +257,16 @@ export function usePanZoom(
 		panXRef.current = 0;
 		panYRef.current = 0;
 		writeTransform();
-		setZoom(1);
-	}, [writeTransform]);
+		notifyZoom();
+	}, [writeTransform, notifyZoom]);
 
 	return {
 		groupRef,
-		zoom,
 		zoomRef,
 		panXRef,
 		panYRef,
 		isPointerOverSvg,
+		subscribeZoom,
 		handleSliderChange,
 		handleResetZoom,
 	};


### PR DESCRIPTION
## Why

Follow-up to #13590. Pan and hover already paint imperatively, but **zoom was still re-rendering the whole graph**. Every wheel/pinch frame committed `zoom` to React state → `links.map` + `nodes.map` recreated and reconciled every `<g class="sg-node">` / `<path class="sg-link">`, plus a per-link `strokeWidth={1.5/zoom}` DOM write. On dense neighborhoods that's the remaining INP/jank source during zoom.

## What

- **`usePanZoom`**: zoom no longer lives in state. It stays in `zoomRef` and is broadcast through a new `subscribeZoom` (rAF-throttled), so only subscribers react — the node/link tree never reconciles on zoom.
- **`GraphZoomBar`**: self-subscribes and holds its own local zoom state, so a gesture re-renders just the tiny bar (slider + %).
- **Label decluttering** moves into `useHoverPaint` (reads `zoomRef`). `SiteGraph` subscribes and repaints labels imperatively when zoom crosses the reveal threshold. `graph-core` exports `ZOOM_LABEL_THRESHOLD`.
- **`vector-effect: non-scaling-stroke`** on links + circles → constant screen-space strokes, dropping the `1/zoom` math entirely (and the zoom dependency it created).

Net: node/link JSX no longer references `zoom`, so wheel/pinch reconciles nothing.

## Verification

- `.verify` browser harness (real d3-force + DOM, extended with label/zoom-bar probes): pan ✓, wheel `100% → 148%` ✓, hover-dim + restore ✓, label reveal `0 → 1` on zoom ✓, zoom bar follows via pub/sub ✓, zero console errors.
- 31 unit tests green (`vitest`), type-clean (`tsc -p tsconfig.lib.json`).