### PR TITLE
fix(devops): widen openapi-fetch range to include installed 0.17.0

### DIFF
--- a/packages/npm/devops/package.json
+++ b/packages/npm/devops/package.json
@@ -40,7 +40,7 @@
 		"dompurify": "^3.4.1",
 		"jsdom": "~29.1.0",
 		"marked": "^18.0.2",
-		"openapi-fetch": "^0.15.2",
+		"openapi-fetch": "^0.17.0",
 		"zod": "^4.3.6"
 	},
 	"engines": {


### PR DESCRIPTION
## Problem
`nx run devops:lint` failed with 1 error (`@nx/dependency-checks`):

```
The version specifier does not contain the installed version of "openapi-fetch" package: 0.17.0
```

`packages/npm/devops/package.json` pinned `openapi-fetch: ^0.15.2`, but root installs `0.17.0`. The `^0.15.2` range excludes `0.17.0`.

## Fix
Bump specifier to `^0.17.0`.

## Verify
`nx run devops:lint` → 0 errors (30 pre-existing warnings remain, non-blocking).