### PR TITLE
perf(jedi): narrow tokio from `full` to used feature set

### DIFF
--- a/docs/plans/build-optimization/jedi-deps-optimization.md
+++ b/docs/plans/build-optimization/jedi-deps-optimization.md
@@ -92,7 +92,7 @@ valkey      = ["dep:lru"]
 | Gate `fred` (redis) | ✅ done     | #13593 | Folded into `valkey = ["dep:lru", "dep:fred"]` — fred is internal-only, no consumer touches it. |
 | Gate `grpc`         | ✅ done     | (this) | `tonic*` optional behind `grpc`; gated 4 proto service submods + `error.rs` Status impls.       |
 | `reqwest` / `axum`  | ⬜ deferred | —      | Kept core (auth-core + response contract). See findings below.                                  |
-| `tokio = "full"`    | ⬜ deferred | —      | Narrow feature set in separate PR.                                                              |
+| `tokio = "full"`    | ✅ done     | (this) | `full` → `["rt-multi-thread","macros","sync","time","net","fs","io-util"]`. Audited src: no process/signal/io-std/spawn_blocking. |
 | CI feature matrix   | ⬜ todo     | —      | `cargo hack --feature-powerset` smoke build.                                                    |
 | Measure build win   | ⬜ todo     | —      | Wall-time before/after for a trimmed consumer.                                                  |
 

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -36,7 +36,7 @@ tower-http = { version = "0.6.8", features = [
     "fs",
     "cors"
 ] }
-tokio = { version = "1.43", features = ["full", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "sync", "time", "net", "fs", "io-util"] }
 tokio-postgres = { version = "0.7.2", optional = true, features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## What
Replace jedi's `tokio = { features = ["full", "rt-multi-thread"] }` with the explicit set actually used: `["rt-multi-thread", "macros", "sync", "time", "net", "fs", "io-util"]`.

## Why
`full` pulls every Tokio feature (process, signal, io-std, etc.) that jedi never touches — compiled for all 17 consumers for zero benefit. Last concrete dep lever in the jedi-deps-optimization plan after askama/twitch/fred/grpc.

## Audit
Grepped `jedi/src` for tokio surface:
- `rt-multi-thread` — `tokio::spawn`, `tokio::task`
- `macros` — `#[tokio::test]`, `tokio::join!`
- `sync` — `mpsc`, `oneshot`, `broadcast`
- `time` — `timeout`, `sleep`, `interval`
- `net` — `TcpListener`, `TcpStream` (rcon, prometheus pipe)
- `fs` — `read_to_string`
- `io-util` — `AsyncReadExt`/`AsyncWriteExt` (rcon)

Not present: `process`, `signal`, `io-std`, `spawn_blocking`, `runtime::Builder`, `block_on`.

## Validation
- `cargo check -p jedi` clean: `--no-default-features` + each feature (grpc/valkey/postgres/clickhouse/twitch/prometheus).
- Consumers `rows` + `arpg-server` build clean (feature unification holds).