### PR TITLE
feat(osrs): v4 enrich ten more high-value thin items

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts-unf.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: Adamant bolts(unf) is a members-only item in Old School RuneScape.
-  mdx_version: 3
-  mdx_updated: "2026-04-10"
+  about:
+    text: "Adamant bolts(unf) are unfeathered adamantite crossbow bolts smithed from an adamantite bar on an anvil. Hammering one bar at 73 Smithing yields 10 bolts for 62.5 Smithing experience, and attaching a feather at 61 Fletching turns each into a finished adamant bolt for 7 Fletching XP."
+    sections:
+      - heading: How to make adamant bolts(unf)
+        anchor: smithing
+        body: "Smith adamant bolts(unf) by using an adamantite bar on an anvil with a hammer in your inventory, requiring 73 Smithing. Each bar produces 10 bolts and grants 62.5 Smithing experience. The action takes 3 game ticks (the first hit is 3 ticks, then 5 ticks thereafter). Because a single bar of adamantite costs more than the 10 bolts sell for, smithing them is a slight loss at Grand Exchange prices, so players generally make them for the Smithing and Fletching experience and the steady demand for finished adamant bolts rather than for profit."
+      - heading: Fletching them into adamant bolts
+        anchor: fletching
+        body: "Use a feather on adamant bolts(unf) to make finished adamant bolts, requiring 61 Fletching and granting 7 Fletching experience per bolt. The unfinished bolts are tradeable and stackable, so fletchers often buy them in bulk to train Fletching toward higher tiers. Adamant bolts(unf) are commonly produced for the high demand of adamant bolts as well as ruby bolts and diamond bolts, which are crafted from the finished adamant bolt by adding gem tips. This makes the unfinished bolt a core intermediate in the bolt-crafting chain."
+  related_items:
+    - item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: component
+      description: Smithed on an anvil to produce 10 adamant bolts(unf) at 73 Smithing
+    - item_name: Adamant bolt
+      slug: adamant-bolt
+      relationship: product
+      description: Made by adding a feather to adamant bolts(unf) at 61 Fletching
+    - item_name: Feather
+      slug: feather
+      relationship: component
+      description: Attached to the unfinished bolt to create a finished adamant bolt
+  recipes:
+    - skill: smithing
+      level: 73
+      xp: 62.5
+      facility: Anvil
+      ticks: 3
+      product: Adamant bolts(unf)
+      materials:
+        - { item_name: Adamantite bar, quantity: 1 }
+    - skill: fletching
+      level: 61
+      xp: 7
+      product: Adamant bolt
+      materials:
+        - { item_name: Adamant bolts(unf), quantity: 1 }
+        - { item_name: Feather, quantity: 1 }
+  drop_table:
+    sources:
+      - { source: Adamant dragon, combat_level: 338, quantity: "20-40", rarity: "11/110", drop_rate: "11/110" }
+      - { source: The Hueycoatl, combat_level: 642, quantity: "15-300", rarity: "3/68", drop_rate: "3/68" }
+      - { source: Martial salvage, quantity: "1-3", rarity: "100/2440", drop_rate: "100/2440" }
+  trivia:
+    - "Unlike other unfinished bolts, adamant bolts(unf) does not have a space before the opening parenthesis."
+    - "They were added on 31 July 2006 as part of the Crossbows update that introduced unfinished bolts to the game."
+  faq:
+    - question: Are adamant bolts(unf) members-only?
+      answer: "Yes. Adamant bolts(unf) are a members-only item and can only be made, traded, and used on members worlds. Free-to-play players cannot smith or fletch them."
+    - question: What level do you need to make adamant bolts(unf)?
+      answer: "You need 73 Smithing to make adamant bolts(unf). Using an adamantite bar on an anvil with a hammer yields 10 unfinished bolts and 62.5 Smithing experience per bar."
+    - question: How do you turn adamant bolts(unf) into adamant bolts?
+      answer: "Use a feather on the adamant bolts(unf), which requires 61 Fletching and grants 7 Fletching experience per bolt. The finished adamant bolts can then have ruby or diamond tips added for enchanted bolts."
+    - question: Is it worth smithing adamant bolts(unf) for profit?
+      answer: "No. One adamantite bar costs around 1,901 coins but produces only 10 bolts worth roughly 1,600, a loss of about 301 coins before tax. Players make them for Smithing and Fletching experience rather than profit."
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Adamant_bolts(unf)"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
   properties:
     tradeable: true
     equipable: false

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-cotton.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-cotton.mdx
@@ -12,9 +12,37 @@ osrs:
   lowalch: 1
   highalch: 1
   limit:
-  about: "Ball of cotton is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "Ball of cotton is an unobtainable item in Old School RuneScape, known only from the game's cache and APIs. It is listed on the Grand Exchange but cannot currently be obtained in normal gameplay, and may be reserved for a future update. It was added alongside the Sailing release on 19 November 2025."
+    sections:
+      - heading: What is the ball of cotton?
+        anchor: overview
+        body: "Ball of cotton is a free-to-play item that exists only in the game APIs or cache, meaning it is not known to be accessible through normal play. The Wiki notes it as unobtainable, though it is listed on the Grand Exchange. It is tradeable and noteable but not stackable, and is examined as 'A neatly wrapped ball of cotton.' Because no obtaining method is currently known, it is likely placeholder content reserved for a possible future update rather than an item players can interact with today."
+  related_items:
+    - item_name: Cotton boll
+      slug: cotton-boll
+      relationship: alternative
+      description: The product harvested from a cotton plant
+    - item_name: Cotton yarn
+      slug: cotton-yarn
+      relationship: alternative
+      description: The processed, spun form of cotton
+  trivia:
+    - "Ball of cotton was added to the game cache on 19 November 2025 alongside the Sailing release, but is not known to be accessible in game."
+    - "Although unobtainable, the item is listed on the Grand Exchange."
+  faq:
+    - question: Is the ball of cotton members-only?
+      answer: "No. Ball of cotton is a free-to-play item. However, it is currently unobtainable through normal gameplay and exists only in the game's cache or APIs, so members status has little practical effect."
+    - question: How do you get a ball of cotton?
+      answer: "You cannot currently obtain a ball of cotton. The OSRS Wiki lists it as an unobtainable item known only from the game cache or APIs, possibly reserved for a future update, though it does appear on the Grand Exchange listings."
+    - question: What is the ball of cotton used for?
+      answer: "Ball of cotton has no known in-game use. It is unobtainable cache content with no documented function, examined simply as 'A neatly wrapped ball of cotton.' Any use it may gain would come with a future update."
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Ball_of_cotton"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-sheet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-sheet.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 64
-  about: "Dragon metal sheet is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 64 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "Dragon metal sheets are a members-only item used in high-level shipbuilding, where the best boat facilities require multiple sheets to build. With the dragon forge unlocked after Dragon Slayer II, players turn sheets into dragon keel parts and dragon nails (15 per sheet) for outfitting skiffs and sloops."
+    sections:
+      - heading: What dragon metal sheets are used for
+        anchor: uses
+        body: "Dragon metal sheets are a core component in high-level shipbuilding. Completion of Dragon Slayer II grants access to the dragon forge, where sheets become dragon keel parts and dragon nails (15 nails per sheet). Two sheets make one keel part, and two keel parts make a set of large dragon keel parts, so a full dragon keel needs 20 sheets on a skiff and 64 sheets on a sloop. Completing the Pandemonium quest is also required to use sheets at the forge; without it you are told 'You probably shouldn't just go messing around with the dragon sheets without knowing what you're doing.' Sheets also feed Sailing builds like the dragon cannon and dragon helm."
+      - heading: How to obtain dragon metal sheets
+        anchor: obtaining
+        body: "The best sources are killing Lava Strykewyrms or frost dragons on a Slayer task, which boosts the drop rate, though both can be tedious and may need Slayer points to skip onto. A slower but more consistent route is completing Sailing bounties for great white sharks, orcas, and high-level krakens such as armoured krakens, since one bounty for each is guaranteed at notice boards across Gielinor. Lost ironwood crates also drop them at 1/8. Since 21 January 2026, receiving a sheet from a lost ironwood crate adds it to the collection log."
+  related_items:
+    - item_name: Dragon nails
+      slug: dragon-nails
+      relationship: product
+      description: Smithed 15 at a time from one dragon metal sheet at 92 Smithing
+    - item_name: Dragon keel parts
+      slug: dragon-keel-parts
+      relationship: product
+      description: Made from 2 dragon metal sheets at 94 Smithing
+    - item_name: Dragon cannon
+      slug: dragon-cannon
+      relationship: product
+      description: A boat facility built using 8 dragon metal sheets
+  recipes:
+    - skill: smithing
+      level: 92
+      xp: 350
+      facility: Dragon forge
+      product: Dragon nails
+      materials:
+        - { item_name: Dragon metal sheet, quantity: 1 }
+    - skill: smithing
+      level: 94
+      xp: 700
+      facility: Dragon forge
+      product: Dragon keel parts
+      materials:
+        - { item_name: Dragon metal sheet, quantity: 2 }
+  drop_table:
+    sources:
+      - { source: Frost dragon, combat_level: 202, quantity: "1", rarity: "1/100", drop_rate: "1/100;1/40" }
+      - { source: Lava Strykewyrm, combat_level: 116, quantity: "1", rarity: "1/115", drop_rate: "1/115;1/45" }
+      - { source: Magma strykewyrm, combat_level: 249, quantity: "1", rarity: "3 × 1/45", drop_rate: "3 × 1/45" }
+      - { source: Great white shark, combat_level: 175, quantity: "1-2", rarity: "1/200", drop_rate: "1/200;1/100" }
+      - { source: Orca, combat_level: 205, quantity: "1-2", rarity: "1/100", drop_rate: "Unknown;1/100" }
+      - { source: Armoured kraken, combat_level: 180, quantity: "1-2", rarity: "1/140", drop_rate: "1/140;1/70" }
+      - { source: Vampyre kraken, combat_level: 211, quantity: "1-2", rarity: "1/150", drop_rate: "1/150;1/75" }
+      - { source: Veiled kraken, combat_level: 210, quantity: "1-2", rarity: "4/500", drop_rate: "4/500;4/350" }
+      - { source: Lost ironwood crate, quantity: "1", rarity: "1/8", drop_rate: "1/8" }
+  trivia:
+    - "Dragon metal sheets were released on 19 November 2025 with the Sailing update, after being added but unobtainable during the 5 November 2025 Sailing Technical Pre-Release."
+    - "Since 21 January 2026, receiving a dragon metal sheet from a lost ironwood crate adds it to the collection log."
+  faq:
+    - question: Are dragon metal sheets members-only?
+      answer: "Yes. Dragon metal sheets are a members-only item used in high-level shipbuilding. They can only be obtained, traded, and forged on members worlds, and require the Sailing skill and related quests to put to use."
+    - question: How do you get dragon metal sheets?
+      answer: "Dragon metal sheets drop from frost dragons and Lava Strykewyrms on Slayer task at boosted rates, from Sailing bounty kills on great white sharks, orcas and krakens, and from lost ironwood crates at 1/8. They can also be bought on the Grand Exchange."
+    - question: What do you need to use dragon metal sheets?
+      answer: "You need access to the dragon forge from completing Dragon Slayer II, plus completion of the Pandemonium quest to forge with the sheets. Without Pandemonium, attempting to use them shows a warning message and fails."
+    - question: How many dragon metal sheets does a dragon keel need?
+      answer: "A dragon keel requires 20 sheets on a skiff and 64 sheets on a sloop. Two sheets make one keel part, two keel parts make a large dragon keel parts set, so four sheets are needed per large keel part."
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Dragon_metal_sheet"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-giant-krill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-giant-krill.mdx
@@ -12,7 +12,43 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: null
-  about: "Fish crate (giant krill) is a members-only Sailing-era container holding giant krill fish, used to transport hauls back to port for processing."
+  about:
+    text: "Fish crate (giant krill) is a members-only fish crate containing 10 raw giant krill. It is obtained by emptying a trawling net holding at least 10 raw giant krill while an empty fish crate sits in the cargo hold, letting players store 10 deep-sea fish per cargo space. It can also be made by using the krill on the crate."
+    sections:
+      - heading: How to obtain and fill the crate
+        anchor: obtaining
+        body: "A fish crate (giant krill) is created by emptying a trawling net that holds at least 10 raw giant krill while an empty fish crate is stored in the ship's cargo hold. This effectively compresses 10 deep-sea fish into a single cargo space, making it the standard way to haul large quantities of krill back from a fishing trip. You can also make one manually by using raw giant krill directly on a fish crate. Each filled crate represents 10 raw giant krill plus the empty crate it was packed into."
+      - heading: Emptying the crate safely
+        anchor: emptying
+        body: "Filled fish crates can only be emptied while standing inside a bank, which returns a camphor crate (an empty fish crate without the ice cooler) along with the 10 raw giant krill. To do this safely you must right-click the 'Empty' option while a banking interface is open. Critically, if you empty the fish crate anywhere else, the crate itself will be lost, so always bank before unpacking. Filling one crate costs an empty crate plus 10 raw krill but the packed crate trades for far more, giving a healthy margin."
+  related_items:
+    - item_name: Raw giant krill
+      slug: raw-giant-krill
+      relationship: component
+      description: Ten of these fill one fish crate (giant krill)
+    - item_name: Fish crate (empty)
+      slug: fish-crate-empty
+      relationship: component
+      description: The empty container packed with krill to make this crate
+  recipes:
+    - skill: sailing
+      ticks: 1
+      product: Fish crate (giant krill)
+      materials:
+        - { item_name: Fish crate (empty), quantity: 1 }
+        - { item_name: Raw giant krill, quantity: 10 }
+  trading_tips:
+    - "Packing costs ~1,264 coins (empty crate + 10 krill) but the filled crate trades for ~3,803, a profit of roughly 2,539 before GE tax"
+  trivia:
+    - "Fish crate (giant krill) was released on 19 November 2025 as part of the Sailing update."
+    - "Each crate stores 10 raw giant krill in a single cargo space, and emptying it outside a bank destroys the crate."
+  faq:
+    - question: Is the fish crate (giant krill) members-only?
+      answer: "Yes. Fish crate (giant krill) is a members-only item tied to the Sailing skill. It can only be filled, traded, and emptied on members worlds using a trawling net and a ship's cargo hold."
+    - question: How do you make a fish crate (giant krill)?
+      answer: "Empty a trawling net containing at least 10 raw giant krill while an empty fish crate is in your cargo hold, or use raw giant krill directly on a fish crate. Each crate packs 10 raw giant krill into one cargo space."
+    - question: How do you empty a fish crate (giant krill)?
+      answer: "Right-click the 'Empty' option while standing inside a bank with a banking interface open. This returns a camphor crate plus the 10 raw giant krill. Emptying it anywhere else destroys the crate, so always bank first."
   properties:
     release_date: "2025-11-19"
     update: "Sailing is OUT TODAY!"
@@ -27,8 +63,12 @@ osrs:
       - Empty
       - Drop
     alchable: true
-  mdx_version: 3
-  mdx_updated: "2026-06-02"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Fish_crate_(giant_krill)"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fried-onions.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fried-onions.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 13000
-  about: "Fried onions is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "Fried onions are a members-only food made by cooking a chopped onion on a fire or range, requiring 42 Cooking and granting 60 experience. When eaten they heal 5 hitpoints, but they are more commonly used as an ingredient to make mushroom & onion topping for mushroom potatoes."
+    sections:
+      - heading: How to cook fried onions
+        anchor: cooking
+        body: "Fried onions are cooked from a chopped onion on a fire or cooking range, requiring 42 Cooking and granting 60 experience per successful cook. The action takes 1 tick the first time, then 3 and 4 ticks for subsequent Make-X cooks. You can burn onions while cooking, producing a burnt onion, but the burn rate falls as your Cooking level rises and stops entirely at level 77 on both fires and ranges. Cooking one is a slight loss at Grand Exchange prices since a chopped onion costs more than the fried onions sells for, so they are made mainly for Cooking experience or as a recipe ingredient."
+      - heading: Healing and cooking uses
+        anchor: uses
+        body: "When eaten, fried onions heal 5 hitpoints. Their more common role is as an ingredient: combine fried onions with fried mushrooms at 57 Cooking to make a mushroom & onion topping. This step grants no Cooking experience, but the topping can then be used at level 64 with a potato with butter to create a mushroom potato for 55 experience. A handy trick is that a sack of onions holds up to 10 onions, so with a knife, a bowl, and a range or fire, a single inventory slot can be turned into 50 hitpoints of healing."
+  food:
+    heals: 5
+    type: bowl
+    cooking_level: 42
+    cooking_xp: 60
+    burn_level: 77
+  recipes:
+    - skill: cooking
+      level: 42
+      xp: 60
+      facility: Cooking range
+      ticks: 1
+      product: Fried onions
+      materials:
+        - { item_name: Chopped onion, quantity: 1 }
+    - skill: cooking
+      level: 57
+      xp: 0
+      product: Mushroom & onion
+      materials:
+        - { item_name: Fried mushrooms, quantity: 1 }
+        - { item_name: Fried onions, quantity: 1 }
+  related_items:
+    - item_name: Chopped onion
+      slug: chopped-onion
+      relationship: component
+      description: Cooked on a fire or range to make fried onions
+    - item_name: Mushroom & onion
+      slug: mushroom-onion
+      relationship: product
+      description: Made by combining fried onions with fried mushrooms at 57 Cooking
+    - item_name: Burnt onion
+      slug: burnt-onion
+      relationship: alternative
+      description: The failed result of burning an onion while cooking
+  trivia:
+    - "Onions are the only ingredient needed to make fried onions, and because a sack holds up to 10 onions, one inventory space can heal 50 hitpoints with a knife, bowl, and access to a range or fire."
+    - "Fried onions were added on 30 January 2006 in the 'Runesquares, Harpie Bugs and new potato recipes!' update."
+  faq:
+    - question: Are fried onions members-only?
+      answer: "Yes. Fried onions are a members-only food. They can only be cooked, traded, and eaten on members worlds, and the recipes they feed into, such as mushroom potatoes, are also members content."
+    - question: How much do fried onions heal?
+      answer: "Fried onions heal 5 hitpoints when eaten. They are a low-tier healing food, so most players use them as an ingredient for mushroom & onion topping rather than as combat food."
+    - question: What level do you need to cook fried onions?
+      answer: "You need 42 Cooking to make fried onions by cooking a chopped onion on a fire or range, gaining 60 experience per cook. The chance to burn one decreases with level and reaches zero at Cooking level 77."
+    - question: What are fried onions used for?
+      answer: "Fried onions are mainly used to make mushroom & onion topping at 57 Cooking by combining them with fried mushrooms. That topping is then used at level 64 with a potato with butter to make a mushroom potato for 55 experience."
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Fried_onions"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-magic-wardrobe-flatpack.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "The mahogany magic wardrobe (flatpack) is a members-only Construction flatpack made at a workbench with level 78 Construction for 560 experience. It is used on the Magic wardrobe space in the Costume Room of a player-owned house, letting players build the storage furniture without needing to make the planks on site."
+    sections:
+      - heading: How do you make the mahogany magic wardrobe flatpack?
+        anchor: making
+        body: "A mahogany magic wardrobe flatpack is made at a workbench in the Workshop of a player-owned house with level 78 Construction, granting 560 Construction experience per flatpack. Building one requires four mahogany planks and uses a bench with a vice as the facility, with a saw and a hammer in your inventory. Each flatpack takes 5 game ticks (3 seconds) to assemble. Because the finished flatpack trades on the Grand Exchange for far less than the cost of four mahogany planks, making them is not profitable, so players generally make flatpacks for Construction experience or for personal use rather than to sell. The flatpack form lets you transport the furniture as a single tradeable item."
+      - heading: How do you use the flatpack in the Costume Room?
+        anchor: usage
+        body: "The mahogany magic wardrobe flatpack is used on the Magic wardrobe space in the Costume Room of a player-owned house, where it becomes a built mahogany magic wardrobe. To build it you must have a hammer and a saw in your inventory. Using a flatpack is a popular way to furnish the Costume Room without first making the mahogany planks at your own workbench, since you can buy ready-made flatpacks from other players via the Grand Exchange. The built mahogany magic wardrobe can later be upgraded into a carved teak magic wardrobe using the relevant flatpack. This makes the flatpack a convenient shortcut for players setting up storage for their costume and holiday items at home."
+  recipes:
+    - skill: construction
+      level: 78
+      xp: 560
+      facility: Bench with vice
+      ticks: 5
+      product: Mahogany magic wardrobe (flatpack)
+      materials:
+        - { item_name: Mahogany plank, quantity: 4 }
+  related_items:
+    - item_name: Mahogany magic wardrobe
+      slug: mahogany-magic-wardrobe
+      relationship: product
+      description: Built furniture made by using the flatpack on a Magic wardrobe space
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Four mahogany planks are used at a workbench to make the flatpack
+  trivia:
+    - "The mahogany magic wardrobe was released on 18 October 2006 with the Player-Owned House Costume Room update."
+    - "On 26 February 2015 the item was renamed from 'Mahogany mw' to 'Mahogany magic wardrobe' alongside the Grand Exchange update."
+    - "Making the flatpack from four mahogany planks costs far more than its Grand Exchange price, so it is built for Construction experience or personal use rather than profit."
+  faq:
+    - question: Is the mahogany magic wardrobe flatpack members-only?
+      answer: "Yes. The mahogany magic wardrobe flatpack is a members-only item. It is made through the Construction skill at a player-owned house workbench and used in the Costume Room, both of which are members-only content, so it cannot be made or used in free-to-play."
+    - question: What Construction level do you need to make it?
+      answer: "You need Construction level 78 to make the mahogany magic wardrobe flatpack at a workbench, which grants 560 Construction experience per flatpack. Building it requires four mahogany planks plus a saw and hammer, and each takes 5 game ticks (3 seconds) to assemble."
+    - question: How do you use the mahogany magic wardrobe flatpack?
+      answer: "You use the flatpack on the Magic wardrobe space in the Costume Room of a player-owned house, where it becomes a built mahogany magic wardrobe. You must have a hammer and a saw in your inventory to build it, letting you furnish the room without making planks on site."
+    - question: What materials does the mahogany magic wardrobe flatpack need?
+      answer: "The flatpack is made from four mahogany planks at a workbench in the Workshop of a player-owned house, using a bench with a vice. You also need a saw and a hammer in your inventory. It grants 560 Construction experience at level 78 Construction."
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Mahogany_magic_wardrobe_(flatpack)"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-cheese.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-cheese.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 13000
-  about: "Potato with cheese is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "Potato with cheese is a members-only food item that heals 16 Hitpoints in a single bite. It is made at Cooking level 47 by using cheese on a potato with butter, with no fire or range needed, and is a popular low-cost food choice for mid-level players."
+    sections:
+      - heading: How much does potato with cheese heal?
+        anchor: healing
+        body: "Potato with cheese heals 16 Hitpoints when eaten and is consumed in one bite, making it a strong single-slot food for mid-level players. Its healing matches several higher-tier foods while costing very little, which is why it is a popular pick among players who fight in places like the Warriors' Guild. Because it is eaten in a single action, it can be used as part of a combo-eat to recover a large amount of health quickly. As a members-only item it cannot be eaten in free-to-play worlds, but on members worlds it offers reliable, cheap healing that is easy to stock up on in bulk through the Grand Exchange or by cooking your own."
+      - heading: How do you make a potato with cheese?
+        anchor: cooking
+        body: "To make a potato with cheese you need Cooking level 47 and must use a piece of cheese on a potato with butter. The process grants 40 Cooking experience and, unusually, does not require a fire or a range, so it can be assembled anywhere in your inventory. Each combine takes 2 game ticks (1.2 seconds). The materials are one potato with butter and one cheese. Because the Grand Exchange price of the finished food is lower than the cost of its ingredients, cooking it for profit is not viable, but it remains a cheap source of healing food and modest Cooking experience for players training the skill while stocking up on food."
+      - heading: Where do you get potato with cheese?
+        anchor: obtaining
+        body: "Potato with cheese can be bought from the Warrior Guild Food Shop, run by Lidio on the ground floor of the Warriors' Guild, which stocks 10 at a time and restocks roughly every minute. This accessibility right beside a popular members combat area is a big part of why the food is favoured by mid-level players. It can also be made yourself at Cooking level 47, or bought on the Grand Exchange where it trades within a 13,000 buy limit per four hours. In addition, it drops in stacks of 3 from the Crazy archaeologist and the Deranged archaeologist as an uncommon drop."
+  food: { heals: 16, type: potato, cooking_level: 47, cooking_xp: 40 }
+  recipes:
+    - skill: cooking
+      level: 47
+      xp: 40
+      ticks: 2
+      product: Potato with cheese
+      materials:
+        - { item_name: Potato with butter, quantity: 1 }
+        - { item_name: Cheese, quantity: 1 }
+  drop_table:
+    sources:
+      - { source: Crazy archaeologist, combat_level: 204, quantity: "3", rarity: "8/128", drop_rate: "8/128" }
+      - { source: Deranged archaeologist, combat_level: 276, quantity: "3", rarity: "8/131", drop_rate: "8/131" }
+  related_items:
+    - item_name: Potato with butter
+      slug: potato-with-butter
+      relationship: component
+      description: Base ingredient combined with cheese to make potato with cheese
+    - item_name: Cheese
+      slug: cheese
+      relationship: component
+      description: Added to a potato with butter to create the finished food
+  trivia:
+    - "Potato with cheese was added on 24 October 2005 in the update that introduced Mogres, Lizards, Pet Fish, Potions and Potatoes."
+    - "On 30 January 2006 the item's value was raised from 0 to 8 coins in the Runesquares, Harpie Bugs and new potato recipes update."
+    - "It is one of the few foods that can be assembled without a fire or range, since cheese is simply used on a potato with butter."
+  faq:
+    - question: Is potato with cheese members-only?
+      answer: "Yes. Potato with cheese is a members-only food, so it can only be eaten and traded on members worlds. It cannot be used in free-to-play. On members worlds it is a cheap, popular healing food, especially among mid-level players training near the Warriors' Guild."
+    - question: How much does potato with cheese heal in OSRS?
+      answer: "Potato with cheese heals 16 Hitpoints and is eaten in a single bite. That single-action healing makes it useful for combo-eating, and its low cost relative to its healing makes it a favourite cheap food for mid-level combat training and bossing on a budget."
+    - question: What Cooking level do you need to make potato with cheese?
+      answer: "You need Cooking level 47 to make potato with cheese. You combine cheese with a potato with butter, gaining 40 Cooking experience per item. No fire or range is required, so the food can be assembled anywhere directly in your inventory."
+    - question: Where can you buy potato with cheese?
+      answer: "Potato with cheese is sold at the Warrior Guild Food Shop by Lidio in the Warriors' Guild, which stocks 10 and restocks about once a minute. It can also be bought on the Grand Exchange or made yourself at Cooking level 47."
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Potato_with_cheese"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mjolnir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mjolnir.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 8
-  about: "Saradomin mjolnir is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "The Saradomin mjolnir is a members-only two-handed crush weapon with no level requirements to wield. It is obtained during The Enchanted Key miniquest or traded from other players, can only be found once per account, and can be equipped for protection against Saradomin followers in the God Wars Dungeon."
+    sections:
+      - heading: How is the Saradomin mjolnir used in combat?
+        anchor: combat
+        body: "The Saradomin mjolnir is a two-handed crush weapon with a +11 crush attack bonus and a +14 strength bonus, attacking at 6 ticks (3.6 seconds) per swing. It has no other attack or defence bonuses. It offers three combat styles: an accurate Bash style training Attack, an aggressive Pound style training Strength, and a defensive Block style training Defence, each also granting Hitpoints experience. Because the mjolnir is aligned with the god Saradomin and tipped with a Saradomin symbol, it can be equipped to count as a Saradomin item, granting protection from Saradomin followers in the God Wars Dungeon. There are no level requirements to wield it, so any member can equip the weapon."
+      - heading: How do you get the Saradomin mjolnir?
+        anchor: obtaining
+        body: "The Saradomin mjolnir is obtained during The Enchanted Key miniquest, where it can be found as one of the treasures, or by trading another player for it. Each mjolnir can only be obtained once per account: once a player has dug up all of the treasure during the miniquest, the Enchanted key disintegrates and cannot be re-obtained, so you cannot dig for a second mjolnir yourself. Because supply is limited to those who complete the miniquest and choose to sell, the weapon trades on the Grand Exchange within a small buy limit of 8 per four hours. Its main value comes from its niche use as a Saradomin-aligned item for God Wars Dungeon access rather than as a combat weapon."
+  equipment:
+    slot: weapon
+    weapon_type: bludgeon
+    attack_speed: 6
+    attack_bonus: { stab: 0, slash: 0, crush: 11, magic: 0, ranged: 0 }
+    defence_bonus: { stab: 0, slash: 0, crush: 0, magic: 0, ranged: 0 }
+    other_bonus: { melee_strength: 14, ranged_strength: 0, magic_damage: 0, prayer: 0 }
+    weight: 2.267
+  related_items:
+    - item_name: Enchanted key
+      slug: enchanted-key
+      relationship: component
+      description: Miniquest key used to dig up treasure, including the Saradomin mjolnir
+    - item_name: Zamorak mjolnir
+      slug: zamorak-mjolnir
+      relationship: alternative
+      description: God-aligned mjolnir variant tied to Zamorak with identical mechanics
+  trivia:
+    - "The Saradomin mjolnir was released on 22 November 2005 in the Making History and minor changes update."
+    - "As its name implies, the mjolnir is affiliated with the god Saradomin and is tipped with a symbol associated with him."
+    - "It can be equipped as a Saradomin item for protection against Saradomin followers in the God Wars Dungeon."
+  faq:
+    - question: Is the Saradomin mjolnir members-only?
+      answer: "Yes. The Saradomin mjolnir is a members-only two-handed weapon, so it can only be wielded and traded on members worlds. It is tied to the members-only Enchanted Key miniquest and the God Wars Dungeon, both of which are members content."
+    - question: How do you get the Saradomin mjolnir in OSRS?
+      answer: "The Saradomin mjolnir is found during The Enchanted Key miniquest or bought from another player. It can only be obtained once per account, because the Enchanted key disintegrates after all treasure is dug up and cannot be re-obtained, so trading is the only way to get a second one."
+    - question: What level do you need to wield the Saradomin mjolnir?
+      answer: "There are no level requirements to wield the Saradomin mjolnir. Any member can equip it. As a two-handed crush weapon it has a +11 crush attack bonus and +14 strength bonus, attacking once every 6 ticks (3.6 seconds)."
+    - question: Why would you use the Saradomin mjolnir?
+      answer: "The Saradomin mjolnir's main use is as a Saradomin-aligned item that grants protection against Saradomin followers in the God Wars Dungeon. It is not a strong combat weapon, but equipping it lets players safely pass Saradomin's followers in the dungeon."
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Saradomin_mjolnir"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skull-piece.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skull-piece.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Skull piece is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "The skull piece is a members-only item obtained as an uncommon drop from Wallasalkis in the Waterbirth Island Dungeon and on Grimstone. It is used to make a skeletal helm through Peer the Seer and can also be exchanged with Askeladden on Waterbirth Island for cooked fish."
+    sections:
+      - heading: How do you get a skull piece?
+        anchor: obtaining
+        body: "Skull pieces are obtained as an uncommon drop from Wallasalkis, which are found in the Waterbirth Island Dungeon and on Grimstone. A Wallasalki has a combat level of 98 and drops a single skull piece at a rate of 2/128. Because they only drop from this one creature in a members-only dungeon, supply is limited, which is reflected in the item being thinly traded. Players farming skeletal helms or simply collecting the drop will spend time killing Wallasalkis on Waterbirth Island. The skull piece can also be bought from other players through the Grand Exchange within an 11,000 buy limit per four hours, though daily trade volume is very low."
+      - heading: What is a skull piece used for?
+        anchor: uses
+        body: "The skull piece is used to make a skeletal helm by giving Peer the Seer one dagannoth hide, 5,000 coins, and one skull piece. Creating the skeletal helm requires completion of The Fremennik Trials quest. Before you have done the quest, the skull piece can instead be exchanged with Askeladden on Waterbirth Island for cooked tuna, and after completing The Fremennik Trials the same exchange gives cooked lobster instead. This dual purpose makes the skull piece both a crafting component for the skeletal helm and a minor source of food, depending on your quest progress and whether you would rather build the helm or trade the piece away on Waterbirth Island."
+  drop_table:
+    sources:
+      - { source: Wallasalki, combat_level: 98, quantity: "1", rarity: "2/128", drop_rate: "2/128" }
+  recipes:
+    - skill: crafting
+      product: Skeletal helm
+      facility: Peer the Seer
+      materials:
+        - { item_name: Dagannoth hide, quantity: 1 }
+        - { item_name: Skull piece, quantity: 1 }
+        - { item_name: Coins, quantity: 5000 }
+  related_items:
+    - item_name: Skeletal helm
+      slug: skeletal-helm
+      relationship: product
+      description: Helmet made from a skull piece, dagannoth hide and 5,000 coins via Peer the Seer
+    - item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: Combined with a skull piece and coins to craft the skeletal helm
+  trivia:
+    - "The skull piece was released on 1 August 2005 in the Waterbirth Island update."
+    - "Building the skeletal helm from a skull piece requires completion of The Fremennik Trials quest."
+    - "Skull pieces can be exchanged with Askeladden for cooked tuna before The Fremennik Trials, or cooked lobster after the quest."
+  faq:
+    - question: Is the skull piece members-only?
+      answer: "Yes. The skull piece is a members-only item. It drops only from Wallasalkis in the members-only Waterbirth Island Dungeon and on Grimstone, and its main use, building the skeletal helm via Peer the Seer, is members content."
+    - question: How do you get a skull piece in OSRS?
+      answer: "Skull pieces are an uncommon drop from Wallasalkis in the Waterbirth Island Dungeon and on Grimstone. A Wallasalki is combat level 98 and drops one skull piece at a rate of 2/128. You can also buy them from other players on the Grand Exchange."
+    - question: What is a skull piece used for?
+      answer: "A skull piece is used to make a skeletal helm by giving Peer the Seer one dagannoth hide, 5,000 coins, and one skull piece, after completing The Fremennik Trials. It can also be exchanged with Askeladden on Waterbirth Island for cooked fish."
+    - question: Do you need a quest to use the skull piece?
+      answer: "You need The Fremennik Trials completed to turn a skull piece into a skeletal helm via Peer the Seer. Without the quest you can still trade the skull piece to Askeladden on Waterbirth Island for cooked tuna instead of building the helm."
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Skull_piece"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tomatoes-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tomatoes-5.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Tomatoes(5) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 3
-  mdx_updated: "2026-06-05"
+  about:
+    text: "Tomatoes(5) is a members-only basket holding five tomatoes. Each tomato eaten heals 2 Hitpoints, so a full basket restores 10 Hitpoints in total. The basket saves inventory space for pizza makers and is also used as payment to farmers to protect oak trees, yanillian hops, and cadavaberry bushes."
+    sections:
+      - heading: How much does Tomatoes(5) heal and what is it for?
+        anchor: usage
+        body: "A basket of five tomatoes lets you carry many tomatoes in a single inventory slot, which is useful for players making pizzas who want to bring lots of tomatoes at once. Each tomato eaten heals 2 Hitpoints, so eating through a full Tomatoes(5) basket restores 10 Hitpoints across the five tomatoes. Beyond food and cooking, Tomatoes(5) is commonly used as farming protection payment. A single basket of five tomatoes can be paid to a farmer to watch over an oak tree or a patch of yanillian hops, while three baskets of tomatoes are the payment to protect a cadavaberry bush. This makes the basket a handy item to keep on hand while training Farming."
+      - heading: How do you make and fill Tomatoes(5)?
+        anchor: making
+        body: "Tomatoes(5) is created by filling a basket with five tomatoes; the basket can hold anywhere between one and five tomatoes. The tomatoes themselves are grown through the Farming skill at level 12, planted by using three tomato seeds on an allotment patch. Filling the basket takes no time (0 ticks) and uses one basket plus five tomatoes. You can later empty the basket to retrieve the tomatoes, and since a 2018 update shift-clicking empties the contents straight into your inventory. Because it stacks five tomatoes into one slot, the basket is mainly a convenience item for transporting tomatoes for pizza-making or for paying farmers, rather than something traded for profit."
+  food: { heals: 10, type: basket }
+  recipes:
+    - skill: farming
+      ticks: 0
+      product: Tomatoes(5)
+      materials:
+        - { item_name: Basket, quantity: 1 }
+        - { item_name: Tomato, quantity: 5 }
+  related_items:
+    - item_name: Tomato
+      slug: tomato
+      relationship: component
+      description: Five tomatoes are placed in a basket to make Tomatoes(5)
+    - item_name: Basket
+      slug: basket
+      relationship: component
+      description: Empty fruit basket filled with up to five tomatoes
+  trivia:
+    - "Tomatoes were released on 11 July 2005 as part of the Farming skill update."
+    - "A single basket of five tomatoes pays a farmer to protect an oak tree or yanillian hops, while three baskets protect a cadavaberry bush."
+    - "On 22 March 2018 an 'Empty' option was added and shift-clicking now empties the basket's contents into the inventory."
+  faq:
+    - question: Is Tomatoes(5) members-only?
+      answer: "Yes. Tomatoes(5) is a members-only item, as it relies on the Farming skill and members content. It can only be filled, used as farming payment, and traded on members worlds. Tomatoes are grown through Farming, which is itself members-only."
+    - question: How much does Tomatoes(5) heal in OSRS?
+      answer: "Each tomato eaten heals 2 Hitpoints, so a full Tomatoes(5) basket heals 10 Hitpoints in total across its five tomatoes. The basket is mainly used to carry tomatoes for pizza-making and as farming payment rather than as a primary combat food."
+    - question: What is Tomatoes(5) used for in farming?
+      answer: "Tomatoes(5) is used as protection payment to farmers. One basket of five tomatoes pays a farmer to watch over an oak tree or yanillian hops, and three baskets of tomatoes pay to protect a cadavaberry bush, reducing the risk of those crops dying."
+    - question: How do you make Tomatoes(5)?
+      answer: "You make Tomatoes(5) by filling an empty basket with five tomatoes. Tomatoes are grown via Farming at level 12 by planting three tomato seeds on an allotment patch. The basket can hold one to five tomatoes and can be emptied again at any time."
+  source:
+    wiki_url: "https://oldschool.runescape.wiki/w/Tomatoes(5)"
+    license: "CC BY-NC-SA 3.0"
+    wiki_fetched_at: "2026-06-29"
+  mdx_version: 4
+  mdx_updated: "2026-06-29"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Second v4 enrichment batch — ten more high-value thin (STUB) OSRS item pages upgraded to `mdx_version: 4` using the [enrichment runbook](docs/plans/osrs/enrichment-runbook.md) + mdream Wiki-prose prefetch.

Items: `adamant-bolts-unf`, `ball-of-cotton`, `dragon-metal-sheet`, `fish-crate-giant-krill`, `fried-onions`, `potato-with-cheese`, `saradomin-mjolnir`, `skull-piece`, `tomatoes-5`, `mahogany-magic-wardrobe-flatpack`.

## What each got
- Answer-first `about.text` + 1–3 `about.sections` (passage-indexable prose)
- Archetype blocks: `food` / `recipes` / `equipment` / `drop_table` as applicable
- `faq[]` (3–4, query-shaped → FAQPage JSON-LD), `trivia[]` (2–3), `related_items[]` (2–3)
- `source` provenance (OSRS Wiki, CC BY-NC-SA 3.0)

## Process / safety
- Facts sourced only from mdream-cached Wiki prose — no fabrication.
- `ball-of-cotton` kept minimal: its Wiki page is cache-only with no mechanics (unsupported blocks omitted, not invented).
- Base identity fields (id/value/alch/limit/examine) preserved verbatim; MDX body unchanged.
- Validated: `astro sync` passes (Zod schema-valid) for all ten.