### PR TITLE
perf(jedi): replace once_cell with std LazyLock

### DIFF
--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -60,7 +60,6 @@ twitch-irc = { version = "5.0.1", optional = true, default-features = false, fea
 # Replaceable
 crossbeam = "0.8.4"
 regex = "1.10.3"
-once_cell = "1.21.1"
 # Local Supabase JWT verification (HS256 + ES256/JWKS) — rust_crypto for ES256.
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 # ClickHouse (optional)

--- a/packages/rust/jedi/src/entity/bitwise.rs
+++ b/packages/rust/jedi/src/entity/bitwise.rs
@@ -1,5 +1,5 @@
 use crate::proto::jedi::MessageKind;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::collections::HashMap;
 
 impl MessageKind {
@@ -63,7 +63,7 @@ macro_rules! define_multi_flag_checks {
             )*
         }
 
-        pub static MESSAGE_KIND_MULTI_MAP: Lazy<HashMap<i32, &'static [MessageKind]>> = Lazy::new(|| {
+        pub static MESSAGE_KIND_MULTI_MAP: LazyLock<HashMap<i32, &'static [MessageKind]>> = LazyLock::new(|| {
             let mut map = HashMap::new();
             $(
                 const $const_name: &[MessageKind] = &[ $( MessageKind::$variant ),+ ];

--- a/packages/rust/jedi/src/entity/regex/lazyregex.rs
+++ b/packages/rust/jedi/src/entity/regex/lazyregex.rs
@@ -1,52 +1,52 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 
-pub static SANITIZATION_URL_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static SANITIZATION_URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^https:\/\/[A-Z0-9._%+-]{1,63}\.[A-Z]{2,}(\/[A-Z0-9._%+-]*){0,64}$").unwrap()
 });
 
-pub static SANITIZATION_EMAIL_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
+pub static SANITIZATION_EMAIL_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
 
-pub static SANITIZATION_GITHUB_USERNAME_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
+pub static SANITIZATION_GITHUB_USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
 
-pub static SANITIZATION_INSTAGRAM_USERNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static SANITIZATION_INSTAGRAM_USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?:@|(?:www\.)?instagram\.com/)?(?:@)?([a-zA-Z0-9_](?:[a-zA-Z0-9_.]*[a-zA-Z0-9_])?)",
     )
     .unwrap()
 });
 
-pub static SANITIZATION_UNSPLASH_PHOTO_ID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
+pub static SANITIZATION_UNSPLASH_PHOTO_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
 
-pub static SANITIZATION_DISCORD_SERVER_EMBED_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"discord\.com/widget\?id=(\d+)").unwrap());
+pub static SANITIZATION_DISCORD_SERVER_EMBED_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"discord\.com/widget\?id=(\d+)").unwrap());
 
-pub static SANITIZATION_ULID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$").unwrap());
+pub static SANITIZATION_ULID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$").unwrap());
 
-pub static SANITIZATION_USERNAME_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9]{8,255}$").unwrap());
+pub static SANITIZATION_USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{8,255}$").unwrap());
 
-pub static SANITIZATION_HEX_CODE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^#([a-fA-F0-9]{6})$").unwrap());
+pub static SANITIZATION_HEX_CODE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#([a-fA-F0-9]{6})$").unwrap());
 
-pub static SANITIZATION_MARKDOWN_STANDALONE_LINK_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
+pub static SANITIZATION_MARKDOWN_STANDALONE_LINK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
 
-pub static SANITIZATION_MARKDOWN_IMAGE_LINK_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\[\!\[([^\]]+)\]\(([^)]+)\)\]\(([^)]+)\)").unwrap());
+pub static SANITIZATION_MARKDOWN_IMAGE_LINK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[\!\[([^\]]+)\]\(([^)]+)\)\]\(([^)]+)\)").unwrap());
 
-pub static SANITIZATION_GENERAL_INPUT_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9 !.?]{1,255}$").unwrap());
+pub static SANITIZATION_GENERAL_INPUT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9 !.?]{1,255}$").unwrap());
 
-pub static SANITIZATION_SERVICE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9]{3,32}$").unwrap());
+pub static SANITIZATION_SERVICE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{3,32}$").unwrap());
 
-pub static SANITIZATION_CAPTCHA_TOKEN_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$").unwrap());
+pub static SANITIZATION_CAPTCHA_TOKEN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$").unwrap());
 
 // Zero Copy &str
 


### PR DESCRIPTION
## What
`once_cell::sync::Lazy` is now in std as `std::sync::LazyLock` (stable since 1.70/1.80; jedi's `rust-version` is 1.85). Drop-in swap — identical `Deref` semantics. Migrate the 2 users and remove the `once_cell` dependency.

- `entity/regex/lazyregex.rs` — all `SANITIZATION_*_REGEX` statics
- `entity/bitwise.rs` — `MESSAGE_KIND_MULTI_MAP`

## Why
You're right that once_cell graduated into std. Removing the third-party dep trims one more always-on crate from every consumer build, no behavior change.

## Validation
- `cargo check -p jedi` clean: `--all-features` and `--no-default-features` (these statics are core, ungated).
- No external consumer names jedi's `Lazy<T>` statics by type — `packages/rust/kbve` has its **own** copies, not jedi imports.

## Follow-up (separate, not this PR)
`packages/rust/kbve` uses the same once_cell pattern in `utils/sanitization/regex_extractor.rs` — candidate for the same migration.