### PR TITLE
feat(devops): CI failure tracker via @kbve/devops pure fns

### DIFF
--- a/.github/workflows/utils-ci-failure-tracker.yml
+++ b/.github/workflows/utils-ci-failure-tracker.yml
@@ -30,216 +30,131 @@ jobs:
         timeout-minutes: 5
         permissions:
             issues: write
+            actions: read
 
         steps:
-            - name: Search for existing failure issue
-              id: search
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  WORKFLOW_NAME: ${{ inputs.workflow_name }}
-                  JOB_NAME: ${{ inputs.job_name }}
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Install @kbve/devops
               run: |
                   set -euo pipefail
-                  TITLE="[CI] ${WORKFLOW_NAME} / ${JOB_NAME} — Failed"
-                  ISSUE=$(gh issue list --repo "${{ github.repository }}" \
-                    --search "\"$TITLE\" in:title" \
-                    --state open --json number,title \
-                    --jq "[.[] | select(.title == \"$TITLE\")][0].number // empty")
-                  echo "issue_number=${ISSUE:-}" >> "$GITHUB_OUTPUT"
-                  echo "title=$TITLE" >> "$GITHUB_OUTPUT"
-                  if [ -n "${ISSUE:-}" ]; then
-                    echo "Found open issue #$ISSUE"
-                  else
-                    echo "No open issue found"
-                  fi
+                  mkdir -p /tmp/devops
+                  cd /tmp/devops
+                  npm init -y >/dev/null 2>&1
+                  npm install --silent @kbve/devops@latest
 
-            - name: Extract failed step logs
-              if: inputs.status == 'failure'
-              id: logs
+            - name: Track CI failure
+              uses: actions/github-script@v9
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  JOB_NAME: ${{ inputs.job_name }}
-                  RUN_ID: ${{ inputs.run_id }}
-              run: |
-                  set -euo pipefail
-                  # Find the job ID by name
-                  JOB_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
-                    --jq ".jobs[] | select(.name | contains(\"${JOB_NAME}\")) | .id" \
-                    2>/dev/null | head -1 || echo "")
-
-                  FAILED_STEP=""
-                  if [ -n "$JOB_ID" ]; then
-                    FAILED_STEP=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
-                      --jq ".jobs[] | select(.id == ${JOB_ID}) | .steps[] | select(.conclusion == \"failure\") | .name" \
-                      2>/dev/null | head -1 || echo "")
-                  fi
-
-                  # Try to get log snippet — logs may not be available yet
-                  RAW_LOG=""
-                  LOG_SNIPPET="See [run logs](${{ inputs.run_url }}) for details."
-                  if [ -n "$JOB_ID" ]; then
-                    RAW_LOG=$(gh api "repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" \
-                      2>/dev/null || echo "")
-                    if [ -n "$RAW_LOG" ]; then
-                      LOG_SNIPPET=$(echo "$RAW_LOG" | tail -50 | head -50)
-                    fi
-                  fi
-
-                  # Classify a likely cause from the logs so the issue states WHY, not just where.
-                  REASON=""
-                  if printf '%s' "${RAW_LOG}${LOG_SNIPPET}" | grep -qiE 'Forgejo LFS auth failed|Authentication required|Authorization error|info/lfs/objects/batch'; then
-                    REASON="🔑 Forgejo LFS authentication failed — FORGEJO_TOKEN is likely invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."
-                  fi
-
-                  # Write to file to avoid delimiter issues
-                  echo "$LOG_SNIPPET" > /tmp/log_snippet.txt
-                  echo "failed_step=${FAILED_STEP:-unknown}" >> "$GITHUB_OUTPUT"
-                  echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
-
-            - name: Create new failure issue
-              if: inputs.status == 'failure' && steps.search.outputs.issue_number == ''
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  TITLE: ${{ steps.search.outputs.title }}
+                  STATUS: ${{ inputs.status }}
                   WORKFLOW_NAME: ${{ inputs.workflow_name }}
                   JOB_NAME: ${{ inputs.job_name }}
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
-                  FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
-                  REASON: ${{ steps.logs.outputs.reason }}
                   VERSION: ${{ inputs.version }}
-              run: |
-                  set -euo pipefail
-                  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  LOG_SNIPPET=$(cat /tmp/log_snippet.txt 2>/dev/null || echo "Logs unavailable")
-                  VERSION_LINE=""
-                  VERSION_MARKER=""
-                  if [ -n "${VERSION:-}" ]; then
-                    VERSION_LINE="**Version:** ${VERSION}"
-                    VERSION_MARKER="<!-- ci-tracker:version=${VERSION} -->"
-                  fi
-                  REASON_LINE=""
-                  if [ -n "${REASON:-}" ]; then
-                    REASON_LINE="**Likely cause:** ${REASON}"
-                  fi
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const devops = await import('/tmp/devops/node_modules/@kbve/devops/devops.es.js');
+                      const {
+                        _$gha_failureIssueTitle,
+                        _$gha_parseFailureLog,
+                        _$gha_classifyCIFailure,
+                        _$gha_buildFailureIssueBody,
+                        _$gha_buildFailureComment,
+                        _$gha_buildResolveComment,
+                        _$gha_incrementFailureHistory,
+                      } = devops;
 
-                  cat > /tmp/issue-body.md << ISSUEEOF
-                  ## ${TITLE}
-                  ${VERSION_MARKER}
+                      const { owner, repo } = context.repo;
+                      const status = process.env.STATUS;
+                      const workflowName = process.env.WORKFLOW_NAME;
+                      const jobName = process.env.JOB_NAME;
+                      const runId = process.env.RUN_ID;
+                      const runUrl = process.env.RUN_URL;
+                      const version = process.env.VERSION || '';
+                      const ref = context.ref;
+                      const eventName = context.eventName;
+                      const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 
-                  **Workflow:** ${WORKFLOW_NAME}
-                  **Job:** ${JOB_NAME}
-                  ${VERSION_LINE}
-                  **Failed step:** ${FAILED_STEP}
-                  ${REASON_LINE}
-                  **Status:** Failing since ${TIMESTAMP}
-                  **Consecutive failures:** 1
+                      const title = _$gha_failureIssueTitle(workflowName, jobName);
 
-                  ### Latest Failure
+                      const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                        owner, repo, state: 'open', labels: 'ci', per_page: 100,
+                      });
+                      const existing = openIssues.find((i) => i.title === title);
 
-                  - **Run:** [#${RUN_ID}](${RUN_URL})
-                  - **Trigger:** ${{ github.event_name }}
-                  - **Ref:** ${{ github.ref }}
+                      if (status === 'failure') {
+                        let failedStep = 'unknown';
+                        let snippet = `See [run logs](${runUrl}) for details.`;
+                        let nxTargets = '';
+                        let reason = null;
 
-                  ### Error Summary
+                        try {
+                          const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                            owner, repo, run_id: Number(runId), per_page: 100,
+                          });
+                          const job = jobs.find((j) => j.name.includes(jobName));
+                          if (job) {
+                            const failed = (job.steps || []).find((s) => s.conclusion === 'failure');
+                            if (failed) failedStep = failed.name;
+                            try {
+                              const log = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                                owner, repo, job_id: job.id,
+                              });
+                              const raw = typeof log.data === 'string'
+                                ? log.data
+                                : Buffer.from(log.data).toString('utf8');
+                              const parsed = _$gha_parseFailureLog(raw);
+                              if (parsed.snippet) snippet = parsed.snippet;
+                              nxTargets = parsed.nxTargets;
+                              reason = _$gha_classifyCIFailure(raw);
+                            } catch (e) {
+                              core.info(`Logs unavailable: ${e.message}`);
+                            }
+                          }
+                        } catch (e) {
+                          core.warning(`Job lookup failed: ${e.message}`);
+                        }
 
-                  \`\`\`
-                  ${LOG_SNIPPET}
-                  \`\`\`
-
-                  ### Failure History
-
-                  | # | Date | Run | Ref | Trigger |
-                  |---|------|-----|-----|---------|
-                  | 1 | ${TIMESTAMP} | [#${RUN_ID}](${RUN_URL}) | ${{ github.ref }} | ${{ github.event_name }} |
-
-                  ---
-                  *Auto-generated by ci-failure-tracker*
-                  ISSUEEOF
-
-                  sed 's/^                  //' /tmp/issue-body.md > /tmp/issue-body-clean.md
-
-                  gh issue create --repo "${{ github.repository }}" \
-                    --title "$TITLE" \
-                    --label "bug,ci,6" \
-                    --body-file /tmp/issue-body-clean.md
-
-            - name: Comment on existing failure issue
-              if: inputs.status == 'failure' && steps.search.outputs.issue_number != ''
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ISSUE_NUMBER: ${{ steps.search.outputs.issue_number }}
-                  RUN_ID: ${{ inputs.run_id }}
-                  RUN_URL: ${{ inputs.run_url }}
-                  FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
-                  REASON: ${{ steps.logs.outputs.reason }}
-                  VERSION: ${{ inputs.version }}
-              run: |
-                  set -euo pipefail
-                  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  LOG_SNIPPET=$(cat /tmp/log_snippet.txt 2>/dev/null || echo "Logs unavailable")
-                  VERSION_LINE=""
-                  if [ -n "${VERSION:-}" ]; then
-                    VERSION_LINE="- **Version:** ${VERSION}"
-                  fi
-                  REASON_LINE=""
-                  if [ -n "${REASON:-}" ]; then
-                    REASON_LINE="- **Likely cause:** ${REASON}"
-                  fi
-
-                  cat > /tmp/comment-body.md << COMMENTEOF
-                  ## Failure — ${TIMESTAMP}
-
-                  - **Run:** [#${RUN_ID}](${RUN_URL})
-                  - **Failed step:** ${FAILED_STEP}
-                  ${REASON_LINE}
-                  ${VERSION_LINE}
-                  - **Ref:** ${{ github.ref }}
-                  - **Trigger:** ${{ github.event_name }}
-
-                  \`\`\`
-                  ${LOG_SNIPPET}
-                  \`\`\`
-                  COMMENTEOF
-
-                  sed 's/^                  //' /tmp/comment-body.md > /tmp/comment-body-clean.md
-
-                  gh issue comment "$ISSUE_NUMBER" \
-                    --repo "${{ github.repository }}" \
-                    --body-file /tmp/comment-body-clean.md
-
-            - name: Close resolved issue
-              if: inputs.status == 'success' && steps.search.outputs.issue_number != ''
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ISSUE_NUMBER: ${{ steps.search.outputs.issue_number }}
-                  RUN_ID: ${{ inputs.run_id }}
-                  RUN_URL: ${{ inputs.run_url }}
-                  VERSION: ${{ inputs.version }}
-              run: |
-                  set -euo pipefail
-                  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  RESOLVE_TITLE="## Resolved — ${TIMESTAMP}"
-                  if [ -n "${VERSION:-}" ]; then
-                    RESOLVE_TITLE="## Resolved — shipped v${VERSION} — ${TIMESTAMP}"
-                  fi
-
-                  cat > /tmp/resolve-body.md << RESOLVEEOF
-                  ${RESOLVE_TITLE}
-
-                  - **Run:** [#${RUN_ID}](${RUN_URL})
-                  - **Ref:** ${{ github.ref }}
-                  - **Trigger:** ${{ github.event_name }}
-
-                  Auto-closing this issue.
-                  RESOLVEEOF
-
-                  sed 's/^                  //' /tmp/resolve-body.md > /tmp/resolve-body-clean.md
-
-                  gh issue comment "$ISSUE_NUMBER" \
-                    --repo "${{ github.repository }}" \
-                    --body-file /tmp/resolve-body-clean.md
-
-                  gh issue close "$ISSUE_NUMBER" \
-                    --repo "${{ github.repository }}" \
-                    --reason completed
+                        if (existing) {
+                          const comment = _$gha_buildFailureComment({
+                            failedStep, runId, runUrl, ref, eventName, timestamp,
+                            logSnippet: snippet, version, reason, nxTargets,
+                          });
+                          await github.rest.issues.createComment({
+                            owner, repo, issue_number: existing.number, body: comment,
+                          });
+                          const newBody = _$gha_incrementFailureHistory(existing.body || '', {
+                            runId, runUrl, ref, eventName, timestamp,
+                          });
+                          await github.rest.issues.update({
+                            owner, repo, issue_number: existing.number, body: newBody,
+                          });
+                          core.info(`Updated issue #${existing.number}`);
+                        } else {
+                          const body = _$gha_buildFailureIssueBody({
+                            title, workflowName, jobName, failedStep, runId, runUrl,
+                            ref, eventName, timestamp, logSnippet: snippet, version, reason, nxTargets,
+                          });
+                          const created = await github.rest.issues.create({
+                            owner, repo, title, labels: ['bug', 'ci', '6'], body,
+                          });
+                          core.info(`Created issue #${created.data.number}`);
+                        }
+                      } else if (status === 'success' && existing) {
+                        const comment = _$gha_buildResolveComment({
+                          runId, runUrl, ref, eventName, timestamp, version,
+                        });
+                        await github.rest.issues.createComment({
+                          owner, repo, issue_number: existing.number, body: comment,
+                        });
+                        await github.rest.issues.update({
+                          owner, repo, issue_number: existing.number,
+                          state: 'closed', state_reason: 'completed',
+                        });
+                        core.info(`Closed issue #${existing.number}`);
+                      }

--- a/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
@@ -11,7 +11,7 @@ tags:
 key: devops
 pipeline: npm
 package_name: devops
-version: "0.0.19"
+version: "0.0.20"
 source_path: packages/npm/devops
 version_toml: packages/npm/devops/version.toml
 author: h0lybyte

--- a/packages/npm/devops/src/index.ts
+++ b/packages/npm/devops/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/sanitization';
 export * from './lib/api';
 export * from './lib/client/kbve';
+export * from './lib/client/github/ci-failure';
 export * from './lib/ci';
 export * from './lib/forum';
 export * as telemetry from './lib/telemetry';

--- a/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest';
+import {
+  _$gha_failureIssueTitle,
+  _$gha_classifyCIFailure,
+  _$gha_parseFailureLog,
+  _$gha_buildFailureIssueBody,
+  _$gha_buildFailureComment,
+  _$gha_buildResolveComment,
+  _$gha_incrementFailureHistory,
+  CI_FAILURE_PATTERNS,
+  ci,
+} from './ci-failure';
+
+describe('ci namespace', () => {
+  it('exposes the canonical API', () => {
+    expect(ci.issueTitle('CI Main', 'build')).toBe(
+      '[CI] CI Main / build — Failed',
+    );
+    expect(ci.parseFailureLog('').nxTargets).toBe('');
+    expect(ci.classifyFailure('nothing')).toBeNull();
+    expect(ci.failurePatterns).toBe(CI_FAILURE_PATTERNS);
+  });
+
+  it('deprecated _$gha_* aliases point to the same functions', () => {
+    expect(_$gha_failureIssueTitle).toBe(ci.issueTitle);
+    expect(_$gha_classifyCIFailure).toBe(ci.classifyFailure);
+    expect(_$gha_parseFailureLog).toBe(ci.parseFailureLog);
+    expect(_$gha_buildFailureIssueBody).toBe(ci.buildIssueBody);
+    expect(_$gha_buildFailureComment).toBe(ci.buildComment);
+    expect(_$gha_buildResolveComment).toBe(ci.buildResolveComment);
+    expect(_$gha_incrementFailureHistory).toBe(ci.incrementHistory);
+  });
+});
+
+describe('_$gha_failureIssueTitle', () => {
+  it('formats the canonical tracker title', () => {
+    expect(_$gha_failureIssueTitle('CI Main', 'build')).toBe(
+      '[CI] CI Main / build — Failed',
+    );
+  });
+});
+
+describe('_$gha_classifyCIFailure', () => {
+  it('classifies Forgejo LFS auth failures', () => {
+    const log = 'batch response: Authentication required: ... info/lfs/objects/batch';
+    const reason = _$gha_classifyCIFailure(log);
+    expect(reason).toContain('Forgejo LFS');
+    expect(reason).toContain('FORGEJO_TOKEN');
+  });
+
+  it('classifies out-of-memory kills', () => {
+    expect(_$gha_classifyCIFailure('Killed signal 9 - JavaScript heap out of memory')).toContain(
+      'memory',
+    );
+  });
+
+  it('returns null when no pattern matches', () => {
+    expect(_$gha_classifyCIFailure('some unrelated output')).toBeNull();
+  });
+
+  it('matches the first pattern in registry order', () => {
+    expect(CI_FAILURE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('_$gha_parseFailureLog', () => {
+  it('strips ANSI escapes and GH timestamp prefixes', () => {
+    const raw =
+      '2026-06-29T10:00:00.123Z [31mError: boom[0m';
+    const { snippet } = _$gha_parseFailureLog(raw);
+    expect(snippet).toContain('Error: boom');
+    expect(snippet).not.toContain('');
+    expect(snippet).not.toContain('2026-06-29');
+  });
+
+  it('drops cargo/npm progress noise and group markers', () => {
+    const raw = [
+      '##[group]Run build',
+      '   Compiling foo v0.1.0',
+      'Downloading bar',
+      'real failure here',
+      '##[endgroup]',
+    ].join('\n');
+    const { snippet } = _$gha_parseFailureLog(raw);
+    expect(snippet).toContain('real failure here');
+    expect(snippet).not.toContain('Compiling foo');
+    expect(snippet).not.toContain('##[group]');
+  });
+
+  it('windows around the last error marker', () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 100; i++) lines.push(`line ${i}`);
+    lines.push('error: the real one');
+    lines.push('trailing 1');
+    lines.push('trailing 2');
+    const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+    expect(snippet).toContain('error: the real one');
+    expect(snippet).toContain('trailing 1');
+    expect(snippet).not.toContain('line 10');
+    expect(snippet).toContain('line 80');
+  });
+
+  it('falls back to the tail when no error marker present', () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i++) lines.push(`plain ${i}`);
+    const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+    expect(snippet).toContain('plain 49');
+    expect(snippet).not.toContain('plain 10');
+  });
+
+  it('extracts failing Nx targets', () => {
+    const raw = [
+      'Failed tasks:',
+      '  - devops:lint',
+      '  - api:build',
+      '',
+      'other text',
+    ].join('\n');
+    const { nxTargets } = _$gha_parseFailureLog(raw);
+    expect(nxTargets).toBe('devops:lint api:build');
+  });
+
+  it('returns empty nxTargets when none present', () => {
+    expect(_$gha_parseFailureLog('nothing here').nxTargets).toBe('');
+  });
+});
+
+describe('_$gha_buildFailureIssueBody', () => {
+  it('includes title, metadata, log and history table', () => {
+    const body = _$gha_buildFailureIssueBody({
+      title: '[CI] CI Main / build — Failed',
+      workflowName: 'CI Main',
+      jobName: 'build',
+      failedStep: 'nx build',
+      runId: '123',
+      runUrl: 'https://example/run/123',
+      ref: 'refs/heads/dev',
+      eventName: 'push',
+      timestamp: '2026-06-29T10:00:00Z',
+      logSnippet: 'error: boom',
+    });
+    expect(body).toContain('[CI] CI Main / build — Failed');
+    expect(body).toContain('**Failed step:** nx build');
+    expect(body).toContain('**Consecutive failures:** 1');
+    expect(body).toContain('error: boom');
+    expect(body).toContain('[#123](https://example/run/123)');
+    expect(body).toContain('| 1 |');
+  });
+
+  it('embeds version marker and reason when provided', () => {
+    const body = _$gha_buildFailureIssueBody({
+      title: 't',
+      workflowName: 'w',
+      jobName: 'j',
+      failedStep: 's',
+      runId: '1',
+      runUrl: 'u',
+      ref: 'r',
+      eventName: 'push',
+      timestamp: 'ts',
+      logSnippet: 'l',
+      version: '1.2.3',
+      reason: 'token expired',
+      nxTargets: 'devops:lint',
+    });
+    expect(body).toContain('<!-- ci-tracker:version=1.2.3 -->');
+    expect(body).toContain('**Version:** 1.2.3');
+    expect(body).toContain('**Likely cause:** token expired');
+    expect(body).toContain('**Failed Nx targets:** `devops:lint`');
+  });
+
+  it('omits optional lines when absent', () => {
+    const body = _$gha_buildFailureIssueBody({
+      title: 't',
+      workflowName: 'w',
+      jobName: 'j',
+      failedStep: 's',
+      runId: '1',
+      runUrl: 'u',
+      ref: 'r',
+      eventName: 'push',
+      timestamp: 'ts',
+      logSnippet: 'l',
+    });
+    expect(body).not.toContain('**Version:**');
+    expect(body).not.toContain('**Likely cause:**');
+    expect(body).not.toContain('**Failed Nx targets:**');
+  });
+});
+
+describe('_$gha_buildFailureComment', () => {
+  it('renders a failure comment with run and log', () => {
+    const c = _$gha_buildFailureComment({
+      failedStep: 'nx test',
+      runId: '9',
+      runUrl: 'u9',
+      ref: 'refs/heads/dev',
+      eventName: 'push',
+      timestamp: 'ts',
+      logSnippet: 'boom',
+    });
+    expect(c).toContain('## Failure — ts');
+    expect(c).toContain('**Failed step:** nx test');
+    expect(c).toContain('boom');
+  });
+});
+
+describe('_$gha_buildResolveComment', () => {
+  it('notes plain resolution', () => {
+    const c = _$gha_buildResolveComment({
+      runId: '5',
+      runUrl: 'u5',
+      ref: 'r',
+      eventName: 'push',
+      timestamp: 'ts',
+    });
+    expect(c).toContain('## Resolved — ts');
+    expect(c).toContain('Auto-closing');
+  });
+
+  it('notes shipped version when provided', () => {
+    const c = _$gha_buildResolveComment({
+      runId: '5',
+      runUrl: 'u5',
+      ref: 'r',
+      eventName: 'push',
+      timestamp: 'ts',
+      version: '2.0.0',
+    });
+    expect(c).toContain('shipped v2.0.0');
+  });
+});
+
+describe('_$gha_incrementFailureHistory', () => {
+  const base = _$gha_buildFailureIssueBody({
+    title: '[CI] CI Main / build — Failed',
+    workflowName: 'CI Main',
+    jobName: 'build',
+    failedStep: 'nx build',
+    runId: '100',
+    runUrl: 'https://example/run/100',
+    ref: 'refs/heads/dev',
+    eventName: 'push',
+    timestamp: '2026-06-29T10:00:00Z',
+    logSnippet: 'error: boom',
+  });
+
+  it('bumps the consecutive failure count', () => {
+    const next = _$gha_incrementFailureHistory(base, {
+      runId: '101',
+      runUrl: 'https://example/run/101',
+      ref: 'refs/heads/dev',
+      eventName: 'push',
+      timestamp: '2026-06-29T11:00:00Z',
+    });
+    expect(next).toContain('**Consecutive failures:** 2');
+  });
+
+  it('appends a new history table row', () => {
+    const next = _$gha_incrementFailureHistory(base, {
+      runId: '101',
+      runUrl: 'https://example/run/101',
+      ref: 'refs/heads/dev',
+      eventName: 'push',
+      timestamp: '2026-06-29T11:00:00Z',
+    });
+    expect(next).toContain('| 2 | 2026-06-29T11:00:00Z |');
+    expect(next).toContain('[#101](https://example/run/101)');
+    expect(next).toContain('| 1 |');
+  });
+
+  it('is idempotent on count formatting across multiple increments', () => {
+    let body = base;
+    for (let i = 0; i < 3; i++) {
+      body = _$gha_incrementFailureHistory(body, {
+        runId: `${200 + i}`,
+        runUrl: `u${i}`,
+        ref: 'r',
+        eventName: 'push',
+        timestamp: `t${i}`,
+      });
+    }
+    expect(body).toContain('**Consecutive failures:** 4');
+    expect((body.match(/\*\*Consecutive failures:\*\*/g) || []).length).toBe(1);
+  });
+});

--- a/packages/npm/devops/src/lib/client/github/ci-failure.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.ts
@@ -1,0 +1,274 @@
+export interface CIFailurePattern {
+  test: RegExp;
+  reason: string;
+}
+
+export const CI_FAILURE_PATTERNS: CIFailurePattern[] = [
+  {
+    test: /Forgejo LFS auth failed|Authentication required|Authorization error|info\/lfs\/objects\/batch/i,
+    reason:
+      '🔑 Forgejo LFS authentication failed — FORGEJO_TOKEN is likely invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret.',
+  },
+  {
+    test: /JavaScript heap out of memory|Killed signal 9|out of memory|oom-kill/i,
+    reason:
+      '🧠 Job ran out of memory — the runner was OOM-killed. Reduce parallelism, raise the runner size, or cap Node/Nx memory.',
+  },
+  {
+    test: /The job running on runner .* has exceeded the maximum execution time|timed out after|cancel.*timeout/i,
+    reason:
+      '⏱️ Job exceeded its timeout — a step hung or ran long. Inspect the slowest step and raise timeout-minutes or fix the hang.',
+  },
+];
+
+const NOISE_PREFIXES =
+  /^\s*(Checking|Compiling|Downloaded|Downloading|Finished|Fresh|Updating|Locking|Building|Installing|Adding|Removing) /;
+const GROUP_MARKER = /^##\[(group|endgroup)\]/;
+const ANSI = new RegExp(String.fromCharCode(27) + '\\[[0-9;?]*[ -/]*[@-~]', 'g');
+const GH_TIMESTAMP = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\s?/;
+const ERROR_MARKER =
+  /error|failed tasks|process completed with exit code|panic|✖|assertion/i;
+
+export interface ParsedFailureLog {
+  snippet: string;
+  nxTargets: string;
+}
+
+export interface FailureIssueMeta {
+  title: string;
+  workflowName: string;
+  jobName: string;
+  failedStep: string;
+  runId: string;
+  runUrl: string;
+  ref: string;
+  eventName: string;
+  timestamp: string;
+  logSnippet: string;
+  version?: string;
+  reason?: string;
+  nxTargets?: string;
+}
+
+export interface FailureEventMeta {
+  failedStep: string;
+  runId: string;
+  runUrl: string;
+  ref: string;
+  eventName: string;
+  timestamp: string;
+  logSnippet: string;
+  version?: string;
+  reason?: string;
+  nxTargets?: string;
+}
+
+export interface ResolveMeta {
+  runId: string;
+  runUrl: string;
+  ref: string;
+  eventName: string;
+  timestamp: string;
+  version?: string;
+}
+
+export interface HistoryEntry {
+  runId: string;
+  runUrl: string;
+  ref: string;
+  eventName: string;
+  timestamp: string;
+}
+
+function issueTitle(workflowName: string, jobName: string): string {
+  return `[CI] ${workflowName} / ${jobName} — Failed`;
+}
+
+function classifyFailure(log: string): string | null {
+  for (const pattern of CI_FAILURE_PATTERNS) {
+    if (pattern.test.test(log)) {
+      return pattern.reason;
+    }
+  }
+  return null;
+}
+
+function extractNxTargets(lines: string[]): string {
+  const idx = lines.findIndex((l) => /Failed tasks:/i.test(l));
+  if (idx < 0) {
+    return '';
+  }
+  const targets: string[] = [];
+  for (let i = idx + 1; i < Math.min(lines.length, idx + 21); i++) {
+    const match = lines[i].match(/^\s*-\s+(\S+:\S+)/);
+    if (match) {
+      targets.push(match[1]);
+    }
+  }
+  return targets.join(' ');
+}
+
+function parseFailureLog(rawLog: string): ParsedFailureLog {
+  if (!rawLog) {
+    return { snippet: '', nxTargets: '' };
+  }
+
+  const clean = rawLog
+    .split('\n')
+    .map((line) => line.replace(ANSI, '').replace(GH_TIMESTAMP, ''))
+    .filter((line) => !NOISE_PREFIXES.test(line) && !GROUP_MARKER.test(line));
+
+  let lastErr = -1;
+  for (let i = 0; i < clean.length; i++) {
+    if (ERROR_MARKER.test(clean[i])) {
+      lastErr = i;
+    }
+  }
+
+  let snippet: string;
+  if (lastErr >= 0) {
+    const start = Math.max(0, lastErr - 30);
+    const end = Math.min(clean.length, lastErr + 4);
+    snippet = clean.slice(start, end).join('\n');
+  } else {
+    snippet = clean.slice(Math.max(0, clean.length - 30)).join('\n');
+  }
+
+  return { snippet, nxTargets: extractNxTargets(clean) };
+}
+
+function buildIssueBody(meta: FailureIssueMeta): string {
+  const lines: string[] = [];
+  lines.push(`## ${meta.title}`);
+  if (meta.version) {
+    lines.push(`<!-- ci-tracker:version=${meta.version} -->`);
+  }
+  lines.push('');
+  lines.push(`**Workflow:** ${meta.workflowName}`);
+  lines.push(`**Job:** ${meta.jobName}`);
+  if (meta.version) {
+    lines.push(`**Version:** ${meta.version}`);
+  }
+  lines.push(`**Failed step:** ${meta.failedStep}`);
+  if (meta.nxTargets) {
+    lines.push(`**Failed Nx targets:** \`${meta.nxTargets}\``);
+  }
+  if (meta.reason) {
+    lines.push(`**Likely cause:** ${meta.reason}`);
+  }
+  lines.push(`**Status:** Failing since ${meta.timestamp}`);
+  lines.push(`**Consecutive failures:** 1`);
+  lines.push('');
+  lines.push('### Latest Failure');
+  lines.push('');
+  lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+  lines.push(`- **Trigger:** ${meta.eventName}`);
+  lines.push(`- **Ref:** ${meta.ref}`);
+  lines.push('');
+  lines.push('### Error Summary');
+  lines.push('');
+  lines.push('```');
+  lines.push(meta.logSnippet);
+  lines.push('```');
+  lines.push('');
+  lines.push('### Failure History');
+  lines.push('');
+  lines.push('| # | Date | Run | Ref | Trigger |');
+  lines.push('|---|------|-----|-----|---------|');
+  lines.push(
+    `| 1 | ${meta.timestamp} | [#${meta.runId}](${meta.runUrl}) | ${meta.ref} | ${meta.eventName} |`,
+  );
+  lines.push('');
+  lines.push('---');
+  lines.push('*Auto-generated by ci-failure-tracker*');
+  return lines.join('\n');
+}
+
+function buildComment(meta: FailureEventMeta): string {
+  const lines: string[] = [];
+  lines.push(`## Failure — ${meta.timestamp}`);
+  lines.push('');
+  lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+  lines.push(`- **Failed step:** ${meta.failedStep}`);
+  if (meta.nxTargets) {
+    lines.push(`- **Failed Nx targets:** \`${meta.nxTargets}\``);
+  }
+  if (meta.reason) {
+    lines.push(`- **Likely cause:** ${meta.reason}`);
+  }
+  if (meta.version) {
+    lines.push(`- **Version:** ${meta.version}`);
+  }
+  lines.push(`- **Ref:** ${meta.ref}`);
+  lines.push(`- **Trigger:** ${meta.eventName}`);
+  lines.push('');
+  lines.push('```');
+  lines.push(meta.logSnippet);
+  lines.push('```');
+  return lines.join('\n');
+}
+
+function buildResolveComment(meta: ResolveMeta): string {
+  const heading = meta.version
+    ? `## Resolved — shipped v${meta.version} — ${meta.timestamp}`
+    : `## Resolved — ${meta.timestamp}`;
+  const lines: string[] = [];
+  lines.push(heading);
+  lines.push('');
+  lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+  lines.push(`- **Ref:** ${meta.ref}`);
+  lines.push(`- **Trigger:** ${meta.eventName}`);
+  lines.push('');
+  lines.push('Auto-closing this issue.');
+  return lines.join('\n');
+}
+
+function incrementHistory(oldBody: string, entry: HistoryEntry): string {
+  const countRe = /(\*\*Consecutive failures:\*\* )(\d+)/;
+  const match = oldBody.match(countRe);
+  const count = match ? parseInt(match[2], 10) + 1 : 1;
+
+  let body = match ? oldBody.replace(countRe, `$1${count}`) : oldBody;
+
+  const row = `| ${count} | ${entry.timestamp} | [#${entry.runId}](${entry.runUrl}) | ${entry.ref} | ${entry.eventName} |`;
+
+  const lines = body.split('\n');
+  let lastRow = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\|\s*\d+\s*\|/.test(lines[i])) {
+      lastRow = i;
+    }
+  }
+  if (lastRow >= 0) {
+    lines.splice(lastRow + 1, 0, row);
+    body = lines.join('\n');
+  }
+
+  return body;
+}
+
+export const ci = {
+  failurePatterns: CI_FAILURE_PATTERNS,
+  issueTitle,
+  classifyFailure,
+  parseFailureLog,
+  buildIssueBody,
+  buildComment,
+  buildResolveComment,
+  incrementHistory,
+};
+
+/** @deprecated Use `ci.issueTitle`. */
+export const _$gha_failureIssueTitle = issueTitle;
+/** @deprecated Use `ci.classifyFailure`. */
+export const _$gha_classifyCIFailure = classifyFailure;
+/** @deprecated Use `ci.parseFailureLog`. */
+export const _$gha_parseFailureLog = parseFailureLog;
+/** @deprecated Use `ci.buildIssueBody`. */
+export const _$gha_buildFailureIssueBody = buildIssueBody;
+/** @deprecated Use `ci.buildComment`. */
+export const _$gha_buildFailureComment = buildComment;
+/** @deprecated Use `ci.buildResolveComment`. */
+export const _$gha_buildResolveComment = buildResolveComment;
+/** @deprecated Use `ci.incrementHistory`. */
+export const _$gha_incrementFailureHistory = incrementHistory;

--- a/packages/npm/devops/src/lib/client/github/index.ts
+++ b/packages/npm/devops/src/lib/client/github/index.ts
@@ -3,3 +3,4 @@ export * from './issues';
 export * from './pulls';
 export * from './docker';
 export * from './actions';
+export * from './ci-failure';


### PR DESCRIPTION
## Summary

Rewrites `utils-ci-failure-tracker.yml` (reusable `workflow_call`, ~20 callers) from ~280 lines of inline bash to a single `actions/github-script` step that installs `@kbve/devops` and calls pure, unit-tested helpers.

## What moved into `@kbve/devops` (`ci-failure.ts`)

- `_$gha_parseFailureLog` — ANSI/timestamp strip, noise filter, error-window snippet, Nx target extraction
- `_$gha_classifyCIFailure` — pattern registry (Forgejo LFS auth, OOM, timeout); extensible vs the old single hardcoded bash regex
- `_$gha_buildFailureIssueBody` / `_$gha_buildFailureComment` / `_$gha_buildResolveComment` — one templating source (drops heredoc + `sed` dedent hack, de-dups create/comment bodies)
- `_$gha_incrementFailureHistory` — bumps **Consecutive failures** count + appends a history row on repeat failures (the old bash hardcoded `1` and never grew the table)
- `_$gha_failureIssueTitle`

22 unit tests; full devops suite green; lint clean.

## Workflow

- `workflow_call` inputs unchanged → callers untouched
- Added `actions: read` permission (job-log download)
- octokit handles search / create / comment / close; devops handles parse + format

## Versioning / ship order

Bumps `devops.mdx` `0.0.19 → 0.0.20` (`version_source`) so devops republishes with the new module. The manifest (`0.0.20`) already landed on dev via the CI manifest bot. **The workflow imports `@kbve/devops@latest`, so devops must publish 0.0.20 before the tracker is live** — merge order: this PR → devops publishes → tracker works.