### PR TITLE
ci(unreal): scope concurrency group by target_platform

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -220,7 +220,7 @@ on:
                 value: ${{ jobs.plugin_check.outputs.should_release }}
 
 concurrency:
-    group: ci-unreal-${{ inputs.mode }}-${{ inputs.shell_path }}${{ inputs.app_name }}${{ inputs.plugin_name }}${{ github.ref }}
+    group: ci-unreal-${{ inputs.mode }}-${{ inputs.shell_path }}${{ inputs.app_name }}${{ inputs.plugin_name }}-${{ inputs.target_platforms }}-${{ github.ref }}
     cancel-in-progress: false
 
 permissions: {}


### PR DESCRIPTION
## Problem

Plugin-mode callers in ci-unreal-plugins.yml invoke ci-unreal-build.yml three times per plugin (Verify Mac/Linux/Win64). All three share `inputs.mode`, `inputs.plugin_name`, and `github.ref`; `shell_path`/`app_name` are empty in plugin mode. So every platform caller resolved to the **same** concurrency group:

```
ci-unreal-plugin-<plugin>-<ref>
```

`cancel-in-progress: false` only governs cancellation across separate runs. Within one run GitHub cannot let two jobs hold the same concurrency group, so it keeps one and **cancels** the others. Those cancelled callers surface as red ✗ in `gh pr checks` / the PR checks UI — fake warnings that should have been clean skips. Observed on #13574 (run 28399571994): Win64 pending, Mac + Linux cancelled.

## Fix

Add `inputs.target_platforms` to the concurrency group key so each platform caller gets a distinct group. No eviction; all three run.

```diff
- group: ci-unreal-${{ inputs.mode }}-...${{ inputs.plugin_name }}${{ github.ref }}
+ group: ci-unreal-${{ inputs.mode }}-...${{ inputs.plugin_name }}-${{ inputs.target_platforms }}-${{ github.ref }}
```