### PR TITLE
fix(auth): wire GOTRUE_JWT_KEYS for OIDC id_token signing (HS256->ES256 Phase 2)

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -133,6 +133,18 @@ spec:
                             secretKeyRef:
                                 name: supabase-jwt
                                 key: secret
+                      # ES256 signer (HS256->ES256 migration Phase 2). Required
+                      # for the OAuth2 server to sign OIDC id_tokens — GoTrue
+                      # rejects HS256 for id_token signing, so without this the
+                      # Forgejo "Sign in with KBVE" /oauth/token call 500s with
+                      # "Error generating ID token". JWKS = ES256 signer + HS256
+                      # verify-only; downstream (postgrest/realtime/storage/gate)
+                      # already accept both via supabase-jwt-vendor.
+                      - name: GOTRUE_JWT_KEYS
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-jwt-keys
+                                key: jwt-keys
                       - name: POSTGRES_PASSWORD
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Problem
Forgejo 'Sign in with KBVE' failed at token exchange:
```
OAuth2 RetrieveError: 500 ... "msg":"Error generating ID token","error_code":"unexpected_failure"
```
GoTrue log (live cluster) showed the real cause:
```
"error":"HS256 is not supported for ID token signing"
```
The OAuth2 server (`GOTRUE_OAUTH_SERVER_ENABLED=true`) must sign an OIDC `id_token`, but the deployment only provided the symmetric `GOTRUE_JWT_SECRET` (HS256). The ES256 signer (`supabase-jwt-keys`) was generated in Phase 0 (`gen-supabase-jwt-keys.sh`) but never wired into GoTrue — Phase 2 was missing.

## Fix
Reference the existing sealed ES256 JWKS via `GOTRUE_JWT_KEYS`. GoTrue then signs id_tokens with ES256 (published at `/.well-known/jwks.json`) and keeps the HS256 oct key for verifying already-issued tokens.

## Safe because downstream already accepts both algs
- postgrest: `PGRST_JWT_SECRET` <- `supabase-jwt-vendor/postgrest-jwks`
- realtime: `API_JWT_JWKS` <- `supabase-jwt-vendor`
- storage-api: `JWT_JWKS` <- `supabase-jwt-vendor`
- kbve-gate (jedi/jwks.rs): verifies HS256 secret + ES256 JWKS

## Validation
Patched live (selfHeal temporarily off), retried login: `/oauth/token` -> **200**, zero id-token-signing errors. The custom_access_token_hook logged success (not implicated).

> Argo `auth` app tracks `main`; self-heal stays OFF until this reaches main, else it reverts the live patch.