### PR TITLE
fix(forgejo): restrict new accounts + disable org creation by default

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -43,7 +43,7 @@ spec:
                       accessModes:
                           - ReadWriteOnce
                   podAnnotations:
-                      kbve.com/config-revision: 2026-06-21-gc-lfs-cron
+                      kbve.com/config-revision: 2026-06-29-restricted-default-no-org
                   gitea:
                       admin:
                           existingSecret: forgejo-admin
@@ -72,6 +72,15 @@ spec:
                               REQUIRE_SIGNIN_VIEW: true
                               ALLOW_ONLY_EXTERNAL_REGISTRATION: true
                               SHOW_REGISTRATION_BUTTON: false
+                              # New accounts (incl. OAuth auto-registrations) are
+                              # restricted by default: they can only interact with
+                              # repos/orgs where they are explicitly added as a
+                              # collaborator, and cannot access public repos on
+                              # this instance.
+                              DEFAULT_USER_IS_RESTRICTED: true
+                              # New users cannot create organizations by default
+                              # (org creation must be granted per-user by an admin).
+                              DEFAULT_ALLOW_CREATE_ORGANIZATION: false
                           openid:
                               ENABLE_OPENID_SIGNIN: true
                               ENABLE_OPENID_SIGNUP: true


### PR DESCRIPTION
## What
Two `[service]` defaults for newly created Forgejo accounts (including OAuth auto-registrations via 'Sign in with KBVE'):

- **`DEFAULT_USER_IS_RESTRICTED: true`** — new users are restricted: they can only interact with repos/orgs where they're explicitly added as a collaborator, and cannot access public repos on the instance.
- **`DEFAULT_ALLOW_CREATE_ORGANIZATION: false`** — new users cannot create organizations unless an admin grants it per-user.

Bumps `kbve.com/config-revision` so Argo rolls the pod and re-renders `app.ini`.

## Scope
Applies to **new** accounts only; existing users keep their current flags.

## File
`apps/kube/forgejo/application.yaml` (gitea helm `config.service` block)

> Note: ci-atom auto-PR is currently hitting `startup_failure` (0 jobs) on push, so this PR was opened manually.