### PR TITLE
release(kbve-gate): 0.1.7 — ES256 JWT verification (fixes Forgejo SSO outage)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -14,7 +14,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.6"
+version: "0.1.7"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml


### PR DESCRIPTION
## Urgent — fixes Forgejo SSO outage
The GoTrue HS256→ES256 cutover (#13609) made GoTrue sign Supabase **session** tokens with ES256. The deployed **kbve-gate 0.1.6 is HS256-only** and rejects every session with `invalid token: InvalidAlgorithm`, locking all users out of `git.kbve.com` / `forgejo.kbve.com`.

The fix already exists in the codebase — the shared jedi JWKS verifier (HS256+ES256, commit `715b3d51f`, 2026-06-28) — but it landed **after** the 0.1.6 release and was never published. This bumps the mdx `version:` so CI builds and ships it.

## Change
- `kbve-gate.mdx` `version:` **0.1.6 → 0.1.7** (mdx-is-source; CI post-publish owns version.toml / Cargo.toml / deployment image tag).

## What 0.1.7 does
`kbve::gate::serve` builds an accept-both verifier: derives the JWKS URI from `SUPABASE_URL` (already set on the gate), validates ES256 by `kid`, and still accepts legacy HS256. No gate env change needed.

## After merge
dev → main → CI publishes `kbve-gate:0.1.7` → post-publish PR bumps the deployment image → Argo rolls the gate → SSO restored.

> Note: GoTrue ES256 stays ON. Rolling it back would only move the breakage to the OIDC id_token (the original #13609 bug).