### PR TITLE
release: dev → main — kbve-gate 0.1.7 (ES256, restores Forgejo SSO)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -14,7 +14,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.6"
+version: "0.1.7"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml


### PR DESCRIPTION
Promote `dev` to `main` to trigger the kbve-gate 0.1.7 build.

## Why this is urgent
Forgejo SSO is currently **down** for all users: after the GoTrue HS256→ES256 cutover, the deployed gate 0.1.6 rejects every ES256 session with `invalid token: InvalidAlgorithm`. 0.1.7 ships the jedi JWKS verifier (HS256+ES256) that fixes it.

## Commits
- release(kbve-gate): 0.1.6 → 0.1.7 — ES256 JWT verification (#13612)

## On merge
CI sees mdx `0.1.7` ≠ version.toml `0.1.6` → builds & publishes `kbve-gate:0.1.7` → post-publish PR bumps version.toml / Cargo / the `forgejo-gate` deployment image → Argo rolls the gate → ES256 sessions validate → SSO restored.

> Note: the Forgejo restricted/no-org account defaults (#13610) already reached main in the prior promotion; this PR carries only the gate release.