### PR TITLE
feat(observ): breadcrumbs, RN native init, metrics dashboard, multi-surface adoption

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/agones/arpg/web/src/main.tsx
+++ b/apps/agones/arpg/web/src/main.tsx
@@ -1,7 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { initObserv } from '@kbve/observ';
 import ReactIsoArpgApp from './game/ReactIsoArpgApp';
 import { setArpgAssetBase } from './game/config';
+
+initObserv({
+	endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+	project: 'arpg',
+	platform: 'web',
+	environment: import.meta.env.MODE,
+});
 
 // Assets (sprites, tilesets) are served from this app's public dir at the site
 // root, the same `/assets/arcade/arpg/...` layout the astro build uses.

--- a/apps/agones/arpg/web/tsconfig.json
+++ b/apps/agones/arpg/web/tsconfig.json
@@ -16,6 +16,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@kbve/laser": ["../../../../packages/npm/laser/src/index.ts"],
+			"@kbve/observ": ["../../../../packages/npm/observ/src/index.ts"],
 			"@kbve/itemdb-data": [
 				"../../../../packages/data/codegen/generated/itemdb.json"
 			],

--- a/apps/agones/arpg/web/vite.config.ts
+++ b/apps/agones/arpg/web/vite.config.ts
@@ -117,6 +117,11 @@ const laserAlias = {
 	replacement: path.join(repoRoot, 'packages/npm/laser/src/index.ts'),
 };
 
+const observAlias = {
+	find: /^@kbve\/observ$/,
+	replacement: path.join(repoRoot, 'packages/npm/observ/src/index.ts'),
+};
+
 const itemdbDataAlias = {
 	find: /^@kbve\/itemdb-data$/,
 	replacement: path.join(
@@ -173,6 +178,7 @@ export default defineConfig(({ mode }) => {
 			],
 			alias: [
 				laserAlias,
+				observAlias,
 				itemdbDataAlias,
 				spelldbDataAlias,
 				itemdbSchemaAlias,

--- a/apps/chuckrpg/chuck-launcher/package.json
+++ b/apps/chuckrpg/chuck-launcher/package.json
@@ -10,6 +10,7 @@
 		"tauri": "tauri"
 	},
 	"dependencies": {
+		"@kbve/observ": "workspace:*",
 		"@kbve/tauri": "workspace:*",
 		"@tauri-apps/api": "^2.0.0",
 		"@tauri-apps/plugin-deep-link": "^2.0.0",

--- a/apps/chuckrpg/chuck-launcher/src/main.tsx
+++ b/apps/chuckrpg/chuck-launcher/src/main.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { initObserv } from '@kbve/observ';
 import App from './App';
 import './app.css';
+
+initObserv({
+	endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+	project: 'chuck-launcher',
+	platform: 'desktop',
+	environment: import.meta.env.MODE,
+});
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useState } from 'react';
 import { KbveUsernameSetup } from '@kbve/astro';
+import { initObserv } from '@kbve/observ';
 import { authBridge, initSupa } from '@/lib/supa';
 import { setCtNetConfig, resolveWsUrl } from '@/lib/net-config';
 import ReactLoginButtons from '../auth/ReactLoginButtons';
 import GameWindowLoader from './GameWindowLoader';
 
 const KBVE_API_BASE = 'https://kbve.com';
+
+initObserv({
+	endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+	project: 'cryptothrone',
+	platform: 'web',
+	environment: import.meta.env.MODE,
+});
 
 type Phase = 'loading' | 'login' | 'username' | 'ready';
 

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -15,6 +15,7 @@
 			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/observ": ["../../../packages/npm/observ/src/index.ts"],
 			"@kbve/laser/ecs": ["../../../packages/npm/laser/src/ecs.ts"],
 			"@kbve/chat/gamechat": [
 				"../../../packages/npm/chat/src/gamechat.ts"

--- a/apps/kbve/kbve-react-native/App.tsx
+++ b/apps/kbve/kbve-react-native/App.tsx
@@ -1,5 +1,7 @@
 import { StatusBar } from 'expo-status-bar';
+import { Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { initObservNative } from '@kbve/observ';
 import {
 	AgentStore,
 	AuthGate,
@@ -14,6 +16,13 @@ import {
 	tsCore,
 } from '@kbve/rn';
 import './WgpuHost';
+
+initObservNative({
+	endpoint: 'https://metrics.kbve.com/api/v1/ingest/errors',
+	project: 'kbve-react-native',
+	platform: Platform.OS === 'ios' ? 'ios' : 'android',
+	environment: __DEV__ ? 'development' : 'production',
+});
 
 const store = new AgentStore(tsCore, createWebSocketExecutor());
 

--- a/apps/kbve/kbve-react-native/metro.config.js
+++ b/apps/kbve/kbve-react-native/metro.config.js
@@ -17,6 +17,7 @@ config.resolver.extraNodeModules = {
 	'@kbve/rn': path.resolve(workspaceRoot, 'packages/npm/rn'),
 	'@kbve/core': path.resolve(workspaceRoot, 'packages/npm/core'),
 	'@kbve/fx': path.resolve(workspaceRoot, 'packages/npm/fx'),
+	'@kbve/observ': path.resolve(workspaceRoot, 'packages/npm/observ'),
 };
 
 config.resolver.disableHierarchicalLookup = false;

--- a/apps/metrics/src/rest/dashboard.html
+++ b/apps/metrics/src/rest/dashboard.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>KBVE Metrics — Errors</title>
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="https://kbve.com/favicon.ico" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: "class" };
+    </script>
+  </head>
+  <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
+    <div class="mx-auto max-w-6xl px-6 py-10">
+      <header class="flex flex-wrap items-center gap-3">
+        <a href="/" class="text-sm text-slate-400 hover:text-slate-200">← home</a>
+        <h1 class="text-lg font-semibold tracking-tight">Error Groups</h1>
+        <div class="ml-auto flex items-center gap-2">
+          <input
+            id="project"
+            placeholder="project filter (optional)"
+            class="w-44 rounded-lg border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm outline-none focus:border-emerald-500"
+          />
+          <button
+            id="refresh"
+            class="rounded-lg bg-emerald-500/15 px-3 py-1.5 text-sm font-medium text-emerald-300 ring-1 ring-emerald-500/30 hover:bg-emerald-500/25"
+          >
+            Load
+          </button>
+        </div>
+      </header>
+
+      <div id="tokenbar" class="mt-5 flex items-center gap-2 rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+        <span class="text-xs text-slate-400">Staff JWT</span>
+        <input
+          id="token"
+          type="password"
+          placeholder="paste supabase access token"
+          class="flex-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm outline-none focus:border-emerald-500"
+        />
+        <label class="flex items-center gap-1 text-xs text-slate-400">
+          <input id="remember" type="checkbox" class="accent-emerald-500" /> remember
+        </label>
+      </div>
+
+      <p id="msg" class="mt-4 text-sm text-slate-400"></p>
+
+      <div class="mt-4 overflow-hidden rounded-xl border border-slate-800">
+        <table class="w-full text-left text-sm">
+          <thead class="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th class="px-4 py-3">Project</th>
+              <th class="px-4 py-3">Type</th>
+              <th class="px-4 py-3">Message</th>
+              <th class="px-4 py-3 text-right">Events</th>
+              <th class="px-4 py-3 text-right">Sessions</th>
+              <th class="px-4 py-3">Last seen</th>
+            </tr>
+          </thead>
+          <tbody id="rows" class="divide-y divide-slate-800/70"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+      const $ = (id) => document.getElementById(id);
+      const KEY = "kbve_metrics_token";
+      const saved = localStorage.getItem(KEY);
+      if (saved) {
+        $("token").value = saved;
+        $("remember").checked = true;
+      }
+
+      function esc(s) {
+        return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+          "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+        }[c]));
+      }
+
+      async function load() {
+        const token = $("token").value.trim();
+        if (!token) {
+          $("msg").textContent = "Paste a staff JWT to load error groups.";
+          return;
+        }
+        if ($("remember").checked) localStorage.setItem(KEY, token);
+        else localStorage.removeItem(KEY);
+
+        const project = $("project").value.trim();
+        const qs = new URLSearchParams({ limit: "100" });
+        if (project) qs.set("project", project);
+        $("msg").textContent = "Loading…";
+        try {
+          const res = await fetch("/api/v1/groups?" + qs.toString(), {
+            headers: { authorization: "Bearer " + token },
+          });
+          if (res.status === 401) return fail("Unauthorized — token invalid or expired.");
+          if (res.status === 403) return fail("Forbidden — account is not staff.");
+          if (!res.ok) return fail("Query failed (" + res.status + ").");
+          const data = await res.json();
+          render(data.groups || []);
+        } catch (e) {
+          fail("Network error.");
+        }
+      }
+
+      function fail(m) {
+        $("msg").textContent = m;
+        $("rows").innerHTML = "";
+      }
+
+      function render(groups) {
+        $("msg").textContent = groups.length
+          ? groups.length + " group(s)"
+          : "No error groups.";
+        $("rows").innerHTML = groups
+          .map(
+            (g) => `
+          <tr class="hover:bg-slate-900/40">
+            <td class="px-4 py-3 font-medium text-slate-200">${esc(g.project)}</td>
+            <td class="px-4 py-3 text-rose-300">${esc(g.error_type) || "—"}</td>
+            <td class="px-4 py-3 max-w-md truncate text-slate-300" title="${esc(g.sample_message)}">${esc(g.sample_message)}</td>
+            <td class="px-4 py-3 text-right tabular-nums">${esc(g.events)}</td>
+            <td class="px-4 py-3 text-right tabular-nums">${esc(g.sessions)}</td>
+            <td class="px-4 py-3 text-slate-400">${esc(g.last_seen)}</td>
+          </tr>`,
+          )
+          .join("");
+      }
+
+      $("refresh").addEventListener("click", load);
+      $("token").addEventListener("keydown", (e) => e.key === "Enter" && load());
+      $("project").addEventListener("keydown", (e) => e.key === "Enter" && load());
+      if (saved) load();
+    </script>
+  </body>
+</html>

--- a/apps/metrics/src/rest/index.html
+++ b/apps/metrics/src/rest/index.html
@@ -54,7 +54,8 @@
         </div>
 
         <div class="mt-6 flex flex-wrap gap-3 text-sm">
-          <a href="/health" class="rounded-lg bg-emerald-500/15 px-4 py-2 font-medium text-emerald-300 ring-1 ring-emerald-500/30 transition hover:bg-emerald-500/25">Health</a>
+          <a href="/dashboard" class="rounded-lg bg-emerald-500/15 px-4 py-2 font-medium text-emerald-300 ring-1 ring-emerald-500/30 transition hover:bg-emerald-500/25">Dashboard</a>
+          <a href="/health" class="rounded-lg bg-slate-800 px-4 py-2 font-medium text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-700">Health</a>
           <a href="/readiness" class="rounded-lg bg-slate-800 px-4 py-2 font-medium text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-700">Readiness</a>
           <a href="https://kbve.com" class="rounded-lg px-4 py-2 font-medium text-slate-400 transition hover:text-slate-200">kbve.com →</a>
         </div>

--- a/apps/metrics/src/rest/mod.rs
+++ b/apps/metrics/src/rest/mod.rs
@@ -12,6 +12,7 @@ use crate::state::AppState;
 pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(system::index))
+        .route("/dashboard", get(system::dashboard))
         .route("/health", get(system::health))
         .route("/readiness", get(system::readiness))
         .route("/api/v1/ingest/errors", post(ingest::ingest_errors))

--- a/apps/metrics/src/rest/system.rs
+++ b/apps/metrics/src/rest/system.rs
@@ -15,6 +15,10 @@ pub async fn index() -> Html<&'static str> {
     Html(include_str!("index.html"))
 }
 
+pub async fn dashboard() -> Html<&'static str> {
+    Html(include_str!("dashboard.html"))
+}
+
 pub async fn health() -> Json<serde_json::Value> {
     Json(json!({
         "status": "healthy",

--- a/packages/npm/observ/src/breadcrumbs.ts
+++ b/packages/npm/observ/src/breadcrumbs.ts
@@ -1,0 +1,105 @@
+export interface Breadcrumb {
+	t: number;
+	kind: 'console' | 'click' | 'nav' | 'fetch' | 'custom';
+	message: string;
+	data?: Record<string, unknown>;
+}
+
+export class BreadcrumbTrail {
+	private buf: Breadcrumb[] = [];
+	private readonly max: number;
+	private readonly clock: () => number;
+
+	constructor(max = 20, clock: () => number = () => Date.now()) {
+		this.max = Math.max(1, max);
+		this.clock = clock;
+	}
+
+	add(kind: Breadcrumb['kind'], message: string, data?: Record<string, unknown>): void {
+		if (!message) return;
+		this.buf.push({ t: this.clock(), kind, message: message.slice(0, 256), data });
+		if (this.buf.length > this.max) this.buf.shift();
+	}
+
+	snapshot(): Breadcrumb[] {
+		return this.buf.slice();
+	}
+}
+
+type ConsoleLevel = 'log' | 'info' | 'warn' | 'error';
+
+export function instrumentConsole(
+	trail: BreadcrumbTrail,
+	levels: ConsoleLevel[] = ['warn', 'error'],
+): void {
+	const c = globalThis.console as unknown as
+		| Record<string, (...a: unknown[]) => void>
+		| undefined;
+	if (!c) return;
+	for (const level of levels) {
+		const original = c[level];
+		if (typeof original !== 'function') continue;
+		c[level] = (...args: unknown[]) => {
+			trail.add('console', `${level}: ${args.map(stringifyArg).join(' ')}`);
+			original.apply(c, args);
+		};
+	}
+}
+
+export function instrumentDom(trail: BreadcrumbTrail): void {
+	if (typeof document === 'undefined' || !document.addEventListener) return;
+	document.addEventListener(
+		'click',
+		(e) => {
+			const el = e.target as Element | null;
+			if (!el || !el.tagName) return;
+			trail.add('click', selector(el));
+		},
+		true,
+	);
+}
+
+export function instrumentFetch(trail: BreadcrumbTrail): void {
+	const g = globalThis as { fetch?: typeof fetch };
+	const original = g.fetch;
+	if (typeof original !== 'function') return;
+	g.fetch = (...args: Parameters<typeof fetch>) => {
+		const url = typeof args[0] === 'string' ? args[0] : (args[0] as Request)?.url ?? '';
+		const method = (args[1]?.method ?? 'GET').toUpperCase();
+		return original(...args).then(
+			(res) => {
+				trail.add('fetch', `${method} ${stripUrl(url)} → ${res.status}`);
+				return res;
+			},
+			(err: unknown) => {
+				trail.add('fetch', `${method} ${stripUrl(url)} → failed`);
+				throw err;
+			},
+		);
+	};
+}
+
+function stringifyArg(a: unknown): string {
+	if (typeof a === 'string') return a;
+	if (a instanceof Error) return a.message;
+	try {
+		return JSON.stringify(a) ?? String(a);
+	} catch {
+		return String(a);
+	}
+}
+
+function selector(el: Element): string {
+	const tag = el.tagName.toLowerCase();
+	const id = el.id ? `#${el.id}` : '';
+	const cls =
+		typeof el.className === 'string' && el.className
+			? `.${el.className.trim().split(/\s+/).slice(0, 2).join('.')}`
+			: '';
+	return `${tag}${id}${cls}`;
+}
+
+function stripUrl(url: string): string {
+	const i = url.indexOf('?');
+	return i === -1 ? url : url.slice(0, i);
+}

--- a/packages/npm/observ/src/client.ts
+++ b/packages/npm/observ/src/client.ts
@@ -1,3 +1,9 @@
+import {
+	BreadcrumbTrail,
+	instrumentConsole,
+	instrumentDom,
+	instrumentFetch,
+} from './breadcrumbs';
 import type { CaptureInput, ErrorEvent, ObservConfig } from './types';
 
 const NOISE = [
@@ -36,6 +42,7 @@ export class Observer {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private session: string;
 	private installed = false;
+	private trail: BreadcrumbTrail;
 
 	constructor(config: ObservConfig) {
 		this.cfg = {
@@ -45,11 +52,59 @@ export class Observer {
 			...config,
 		};
 		this.session = config.sessionId ?? randomId();
+		this.trail = new BreadcrumbTrail(config.maxBreadcrumbs ?? 20);
+	}
+
+	/// Record a manual breadcrumb; surfaces in `extra.breadcrumbs` on the next capture.
+	breadcrumb(message: string, data?: Record<string, unknown>): void {
+		this.trail.add('custom', message, data);
+	}
+
+	private startTimer(): void {
+		this.timer = setInterval(
+			() => this.flush(false),
+			this.cfg.flushIntervalMs,
+		);
+	}
+
+	/// React Native / non-DOM install: global handlers + flush timer, no window.
+	installNative(): this {
+		if (this.installed) return this;
+		this.installed = true;
+		if (this.cfg.captureConsole) instrumentConsole(this.trail);
+		if (this.cfg.captureFetch ?? true) instrumentFetch(this.trail);
+
+		const g = globalThis as {
+			ErrorUtils?: {
+				getGlobalHandler?: () => ((e: unknown, fatal?: boolean) => void) | undefined;
+				setGlobalHandler?: (h: (e: unknown, fatal?: boolean) => void) => void;
+			};
+		};
+		const eu = g.ErrorUtils;
+		if (eu?.setGlobalHandler) {
+			const prev = eu.getGlobalHandler?.();
+			eu.setGlobalHandler((err: unknown, fatal?: boolean) => {
+				this.capture({
+					message: err instanceof Error ? err.message : String(err),
+					stack: err instanceof Error ? err.stack : undefined,
+					error_type: errorType(err),
+					handled: false,
+					extra: { fatal: fatal ?? false },
+				});
+				this.flush(true);
+				prev?.(err, fatal);
+			});
+		}
+		this.startTimer();
+		return this;
 	}
 
 	install(): this {
 		if (this.installed || typeof window === 'undefined') return this;
 		this.installed = true;
+		if (this.cfg.captureConsole) instrumentConsole(this.trail);
+		if (this.cfg.captureClicks ?? true) instrumentDom(this.trail);
+		if (this.cfg.captureFetch ?? true) instrumentFetch(this.trail);
 
 		window.addEventListener('error', (e: ErrorEvent_) => {
 			const err = e.error;
@@ -92,10 +147,7 @@ export class Observer {
 		});
 		window.addEventListener('pagehide', flushNow);
 
-		this.timer = setInterval(
-			() => this.flush(false),
-			this.cfg.flushIntervalMs,
-		);
+		this.startTimer();
 		return this;
 	}
 
@@ -123,6 +175,12 @@ export class Observer {
 			return;
 		if (!input.message || isNoise(input.message)) return;
 
+		const crumbs = this.trail.snapshot();
+		const extra =
+			crumbs.length > 0
+				? { ...input.extra, breadcrumbs: crumbs }
+				: input.extra;
+
 		let event: ErrorEvent = {
 			project: this.cfg.project,
 			platform: this.cfg.platform ?? 'web',
@@ -135,7 +193,7 @@ export class Observer {
 			user_id: this.cfg.getUserId?.() ?? '',
 			session_id: this.session,
 			handled: input.handled ?? false,
-			extra: input.extra,
+			extra,
 		};
 
 		if (this.cfg.beforeSend) {

--- a/packages/npm/observ/src/index.ts
+++ b/packages/npm/observ/src/index.ts
@@ -3,12 +3,22 @@ import type { ObservConfig } from './types';
 
 export { Observer } from './client';
 export type { ErrorEvent, ObservConfig } from './types';
+export type { Breadcrumb } from './breadcrumbs';
 
 let singleton: Observer | null = null;
 
+/// Browser entry: installs window error/rejection handlers + DOM/fetch breadcrumbs.
 export function initObserv(config: ObservConfig): Observer {
 	if (singleton) return singleton;
 	singleton = new Observer(config).install();
+	return singleton;
+}
+
+/// React Native entry: hooks `ErrorUtils.setGlobalHandler`, no DOM/beacon
+/// (flush falls back to fetch keepalive, which RN supports).
+export function initObservNative(config: ObservConfig): Observer {
+	if (singleton) return singleton;
+	singleton = new Observer({ platform: 'android', ...config }).installNative();
 	return singleton;
 }
 
@@ -17,4 +27,11 @@ export function captureException(
 	extra?: Record<string, unknown>,
 ): void {
 	singleton?.captureException(err, extra);
+}
+
+export function addBreadcrumb(
+	message: string,
+	data?: Record<string, unknown>,
+): void {
+	singleton?.breadcrumb(message, data);
 }

--- a/packages/npm/observ/src/types.ts
+++ b/packages/npm/observ/src/types.ts
@@ -22,5 +22,9 @@ export interface ObservConfig {
 	maxBatch?: number;
 	flushIntervalMs?: number;
 	sampleRate?: number;
+	maxBreadcrumbs?: number;
+	captureConsole?: boolean;
+	captureClicks?: boolean;
+	captureFetch?: boolean;
 	beforeSend?: (event: ErrorEvent) => ErrorEvent | null;
 }


### PR DESCRIPTION
## What

Extends the metrics.kbve.com error-telemetry flow to reach more surfaces and capture richer context.

### SDK (`@kbve/observ`)
- **Breadcrumbs** — ring buffer with auto-instrument (console/click/fetch). Rides in `extra.breadcrumbs`; no ClickHouse schema change (server already sanitizes `extra`). Manual `addBreadcrumb()`.
- **React Native** — `initObservNative()` hooks `ErrorUtils.setGlobalHandler`, flush-on-fatal, fetch keepalive (no DOM/beacon). Folded into the main index (single shared singleton) rather than a `/native` subpath, which Metro `extraNodeModules` can't resolve reliably.

### metrics app
- `/dashboard` — live error-groups view; paste staff JWT → `/api/v1/groups` (same-origin, staff-gated server-side).
- `/` landing links to the dashboard.

### Adoption (wired per each app's own resolver convention)
| Surface | Import | Resolver | Verified |
|---|---|---|---|
| arpg-web | `initObserv` | tsconfig path + Vite alias | typecheck ✅ |
| kbve-react-native | `initObservNative` | metro `extraNodeModules` + tsconfig-base path | typecheck ✅ |
| cryptothrone | `initObserv` | tsconfig path (Astro auto-alias) | mirrors laser pattern |
| chuck-launcher | `initObserv` | `@kbve/observ: workspace:*` dep | needs `pnpm install` to link |

## Notes
- observ SDK typecheck clean; metrics app builds.
- chuck-launcher tsc stays red until `pnpm install` links the new `workspace:*` dep (same as existing `@kbve/tauri`).