### PR TITLE
feat(observ): keep function names through minification for readable stacks

### DIFF
--- a/apps/agones/arpg/web/vite.config.ts
+++ b/apps/agones/arpg/web/vite.config.ts
@@ -157,6 +157,9 @@ const itemdbSchemaAlias = {
 export default defineConfig(({ mode }) => {
 	const base = {
 		plugins: [stubLaserR3F(), react()],
+		// Keep function/class names through esbuild minification so telemetry
+		// stack traces show real frames (not `t.a.b`) even without a source map.
+		esbuild: { keepNames: true },
 		resolve: {
 			// dedupe bitecs: laser declares it an optional peer, so aliasing
 			// @kbve/laser to source otherwise lets vite resolve laser's `bitecs`
@@ -224,6 +227,7 @@ export default defineConfig(({ mode }) => {
 					: path.join(__dirname, 'dist'),
 				emptyOutDir: false,
 				minify: 'terser',
+				terserOptions: { keep_fnames: true, keep_classnames: true },
 				sourcemap: false,
 				target: 'es2020',
 				lib: {

--- a/apps/chuckrpg/chuck-launcher/vite.config.ts
+++ b/apps/chuckrpg/chuck-launcher/vite.config.ts
@@ -6,6 +6,7 @@ const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig({
 	plugins: [react(), tailwindcss()],
+	esbuild: { keepNames: true },
 	clearScreen: false,
 	server: {
 		port: 1422,

--- a/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
+++ b/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
 	],
 	vite: {
 		plugins: [tailwindcss(), ...coveragePlugins],
+		esbuild: { keepNames: true },
 		resolve: {
 			dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
 		},

--- a/apps/jobboard/web/vite.config.ts
+++ b/apps/jobboard/web/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig(({ mode }) => ({
 		}),
 		tailwindcss(),
 	],
+	esbuild: { keepNames: true },
 	base: '/',
 	resolve: {
 		// @kbve/rn source resolves react from the repo-root node_modules while the

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -373,6 +373,7 @@ export default defineConfig({
 	],
 	vite: {
 		plugins: [tailwindcss()],
+		esbuild: { keepNames: true },
 		define: {
 			'process.env.JEST_WORKER_ID': 'undefined',
 			__DEV__: 'false',


### PR DESCRIPTION
## What

Makes client telemetry stack traces triageable **without shipping source maps**.

Sets `esbuild.keepNames` (and `terserOptions.keep_fnames`/`keep_classnames` on arpg's terser-minified embed/discord lib builds) so prod stacks show real function/class names instead of mangled `t.a.b` identifiers.

## Why this over full source-map de-minification

- **Zero source maps served** — no client-facing weight, no map storage/upload infra.
- Bundle cost is ~1-3% (names retained). Validated: arpg-web builds clean, `@kbve/observ` bundles (833 modules), no size surprise.
- Named frames are usually enough to locate the throwing function. Full `file:line` de-minify (hidden maps + server-side symbolication) is deferred.

## Scope

All bundles that report to metrics.kbve.com via `@kbve/observ`:
- `apps/agones/arpg/web` (esbuild app + terser embed/discord)
- `apps/chuckrpg/chuck-launcher`
- `apps/cryptothrone/astro-cryptothrone`
- `apps/kbve/astro-kbve`
- `apps/jobboard/web`