### PR TITLE
fix(unreal): declare KBVEYYJson plugin dep in KBVEQuestDB

### DIFF
--- a/packages/unreal/KBVEQuestDB/KBVEQuestDB.uplugin
+++ b/packages/unreal/KBVEQuestDB/KBVEQuestDB.uplugin
@@ -13,5 +13,11 @@
 	"IsExperimentalVersion": false,
 	"Installed": false,
 	"EnabledByDefault": false,
-	"Modules": [ { "Name": "KBVEQuestDB", "Type": "Runtime", "LoadingPhase": "Default" } ]
+	"Modules": [ { "Name": "KBVEQuestDB", "Type": "Runtime", "LoadingPhase": "Default" } ],
+	"Plugins": [
+		{
+			"Name": "KBVEYYJson",
+			"Enabled": true
+		}
+	]
 }


### PR DESCRIPTION
## Problem

UBT warning:
```
Warning: Plugin 'KBVEQuestDB' does not list plugin 'KBVEYYJson' as a dependency, but module 'KBVEQuestDB' depends on module 'KBVEYYJson'.
```

The KBVEQuestDB module depends on the KBVEYYJson module (Build.cs), but the plugin manifest did not declare the plugin-level dependency.

## Fix

Add a `Plugins` array to `KBVEQuestDB.uplugin` with a KBVEYYJson entry, matching the module dependency and clearing the warning.