### PR TITLE
fix(unreal): migrate Mass ForEachEntityChunk to UE 5.6+ API

### DIFF
--- a/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatDotProcessor.cpp
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatDotProcessor.cpp
@@ -36,7 +36,7 @@ void UKBVECombatDotProcessor::Execute(FMassEntityManager& EntityManager, FMassEx
 		return;
 	}
 
-	EntityQuery.ParallelForEachEntityChunk(EntityManager, Context,
+	EntityQuery.ParallelForEachEntityChunk(Context,
 		[DeltaSeconds, Batch](FMassExecutionContext& Chunk)
 		{
 			const TArrayView<FKBVECombatDotFragment> DotViews = Chunk.GetMutableFragmentView<FKBVECombatDotFragment>();

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatStatics.cpp
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatStatics.cpp
@@ -167,7 +167,7 @@ int32 UKBVECombatStatics::DamageMassStatTargetsInSphere(const UObject* WorldCont
 
 	int32 Hits = 0;
 	FMassExecutionContext Context(EM);
-	Query.ForEachEntityChunk(EM, Context, [&Hits, Center, RadiusSq, Amount](FMassExecutionContext& Chunk)
+	Query.ForEachEntityChunk(Context, [&Hits, Center, RadiusSq, Amount](FMassExecutionContext& Chunk)
 	{
 		const TConstArrayView<FTransformFragment> Xforms = Chunk.GetFragmentView<FTransformFragment>();
 		const TArrayView<FKBVEStatFragment> Stats = Chunk.GetMutableFragmentView<FKBVEStatFragment>();

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
@@ -22,7 +22,7 @@ void UKBVEStatRegenProcessor::Execute(FMassEntityManager& EntityManager, FMassEx
 
 	const float DeltaSeconds = Context.GetDeltaTimeSeconds();
 
-	EntityQuery.ParallelForEachEntityChunk(EntityManager, Context,
+	EntityQuery.ParallelForEachEntityChunk(Context,
 		[DeltaSeconds](FMassExecutionContext& Chunk)
 		{
 			const TArrayView<FKBVEStatFragment> Stats = Chunk.GetMutableFragmentView<FKBVEStatFragment>();


### PR DESCRIPTION
## What

Migrate deprecated Mass `ForEachEntityChunk` / `ParallelForEachEntityChunk` calls to the UE 5.6+ API, which drops the `FMassEntityManager` parameter and switches the parallel variant to `EParallelExecutionFlags`.

Surfaced as a `-Wdeprecated-declarations` warning building against UE_5.8:

> 'ParallelForEachEntityChunk' is deprecated ... New version doesn't require the FMassEntityManager parameter.

## Files

- `KBVEGameplay/.../KBVEStatRegenProcessor.cpp` — `ParallelForEachEntityChunk`
- `KBVECombat/.../KBVECombatDotProcessor.cpp` — `ParallelForEachEntityChunk`
- `KBVECombat/.../KBVECombatStatics.cpp` — `ForEachEntityChunk`

`KBVEWorld/.../KBVEWorldGrassMass.cpp` already used the new signature — no change.

The `EntityManager` params on the `Execute` overrides are kept (virtual signature).