### PR TITLE
fix(rn): run vitest via nx target using root deps

### DIFF
--- a/packages/npm/rn/package.json
+++ b/packages/npm/rn/package.json
@@ -88,16 +88,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"scripts": {
-		"test": "vitest run",
-		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage"
-	},
-	"devDependencies": {
-		"@types/react": "^18.3.18",
-		"@types/react-native": "^0.76.0",
-		"vitest": "^3.0.2",
-		"@vitest/coverage-v8": "^3.0.2"
 	}
 }

--- a/packages/npm/rn/project.json
+++ b/packages/npm/rn/project.json
@@ -13,6 +13,13 @@
 			"options": {
 				"command": "tsc --noEmit -p packages/npm/rn/tsconfig.lib.json"
 			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "packages/npm/rn",
+				"command": "vitest run"
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

```
nx run rn:test
> @kbve/rn@0.0.1 test
> vitest run
sh: 1: vitest: not found
WARN Local package.json exists, but node_modules missing
```

nx fell back to the package.json `test` script, which ran a local `vitest` binary. But vitest was declared **only** in rn's devDependencies and never installed — this monorepo hoists deps at the root (root-deps-only). Confirmed: `@kbve/rn` has **no importer entry** in `pnpm-lock.yaml` and no `vitest@3` anywhere — the devDeps were phantom, never locked or installed.

On top of the failure, the phantom devDeps were a version-leakage hazard: vitest `^3.0.2` vs root `4.0.9`, `@vitest/coverage-v8` `^3` vs root `4`, `@types/react` `^18` vs root `19.2.9`, plus deprecated `@types/react-native`.

## Fix

Match the canonical `fx` package pattern:

- **project.json** — add an explicit `test` target (`nx:run-commands`, `cwd: packages/npm/rn`, `vitest run`) that resolves the **root** vitest binary via PATH.
- **package.json** — drop the phantom `devDependencies` and the local `test`/`test:watch`/`test:coverage` scripts.

`vitest.config.ts` already existed (node env) and is unchanged. No lockfile change needed — rn was never in the lockfile, so package.json now matches installed reality.