### PR TITLE
feat(rentearth): ARPG phase 4 — shortcut login + live point

### DIFF
--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/Tests/chuckKbveApiTests.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/Tests/chuckKbveApiTests.cpp
@@ -1,0 +1,52 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "chuckKbveApiClient.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseOkTest,
+	"Chuck.KbveApi.ParseSetUsername.Ok",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseOkTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	const EchuckSetUsernameResult R = UchuckKbveApiClient::ParseSetUsernameResult(
+		200, TEXT("{\"success\":true,\"username\":\"chad\",\"message\":\"ok\"}"), TEXT("chad_req"), Canonical);
+	TestEqual("200 -> Ok", (int32)R, (int32)EchuckSetUsernameResult::Ok);
+	TestEqual("canonical from body", Canonical, FString(TEXT("chad")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseOkNoFieldTest,
+	"Chuck.KbveApi.ParseSetUsername.OkNoField",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseOkNoFieldTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	const EchuckSetUsernameResult R = UchuckKbveApiClient::ParseSetUsernameResult(
+		200, TEXT("{\"success\":true}"), TEXT("chad_req"), Canonical);
+	TestEqual("200 no field -> Ok", (int32)R, (int32)EchuckSetUsernameResult::Ok);
+	TestEqual("canonical falls back to requested", Canonical, FString(TEXT("chad_req")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseCodesTest,
+	"Chuck.KbveApi.ParseSetUsername.Codes",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseCodesTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	TestEqual("400 -> Invalid", (int32)UchuckKbveApiClient::ParseSetUsernameResult(400, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Invalid);
+	TestEqual("401 -> Unauthorized", (int32)UchuckKbveApiClient::ParseSetUsernameResult(401, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Unauthorized);
+	TestEqual("409 -> Taken", (int32)UchuckKbveApiClient::ParseSetUsernameResult(409, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Taken);
+	TestEqual("503 -> ServerError", (int32)UchuckKbveApiClient::ParseSetUsernameResult(503, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::ServerError);
+	TestEqual("500 -> ServerError", (int32)UchuckKbveApiClient::ParseSetUsernameResult(500, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::ServerError);
+	return true;
+}
+
+#endif

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp
@@ -1,6 +1,12 @@
 #include "chuckKbveApiClient.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Engine/GameInstance.h"
+#include "KBVESupabaseSubsystem.h"
 
 EchuckSetUsernameResult UchuckKbveApiClient::ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical)
 {
@@ -37,8 +43,41 @@ EchuckSetUsernameResult UchuckKbveApiClient::ParseSetUsernameResult(int32 HttpCo
 
 void UchuckKbveApiClient::SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult)
 {
-	if (OnResult)
-	{
-		OnResult(EchuckSetUsernameResult::NetworkError, Name);
-	}
+	UGameInstance* GI = GetGameInstance();
+	UKBVESupabaseSubsystem* Supa = GI ? GI->GetSubsystem<UKBVESupabaseSubsystem>() : nullptr;
+	const FString Token = Supa ? Supa->GetAccessToken() : FString();
+
+	TSharedRef<FJsonObject> BodyJson = MakeShared<FJsonObject>();
+	BodyJson->SetStringField(TEXT("username"), Name);
+	FString BodyStr;
+	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&BodyStr);
+	FJsonSerializer::Serialize(BodyJson, Writer);
+
+	const FString Requested = Name;
+
+	const TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Req = FHttpModule::Get().CreateRequest();
+	Req->SetVerb(TEXT("POST"));
+	Req->SetURL(BaseUrl + TEXT("/api/v1/profile/username"));
+	Req->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Req->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Token));
+	Req->SetContentAsString(BodyStr);
+	Req->OnProcessRequestComplete().BindLambda(
+		[OnResult, Requested](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnected)
+		{
+			FString Canonical = Requested;
+			EchuckSetUsernameResult Result;
+			if (!bConnected || !Resp.IsValid())
+			{
+				Result = EchuckSetUsernameResult::NetworkError;
+			}
+			else
+			{
+				Result = ParseSetUsernameResult(Resp->GetResponseCode(), Resp->GetContentAsString(), Requested, Canonical);
+			}
+			if (OnResult)
+			{
+				OnResult(Result, Canonical);
+			}
+		});
+	Req->ProcessRequest();
 }

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp
@@ -1,0 +1,44 @@
+#include "chuckKbveApiClient.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+EchuckSetUsernameResult UchuckKbveApiClient::ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical)
+{
+	OutCanonical = Requested;
+
+	switch (HttpCode)
+	{
+	case 200:
+	{
+		TSharedPtr<FJsonObject> Json;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Body);
+		if (FJsonSerializer::Deserialize(Reader, Json) && Json.IsValid())
+		{
+			FString Canon;
+			if (Json->TryGetStringField(TEXT("username"), Canon) && !Canon.IsEmpty())
+			{
+				OutCanonical = Canon;
+			}
+		}
+		return EchuckSetUsernameResult::Ok;
+	}
+	case 400:
+		return EchuckSetUsernameResult::Invalid;
+	case 401:
+		return EchuckSetUsernameResult::Unauthorized;
+	case 409:
+		return EchuckSetUsernameResult::Taken;
+	case 503:
+		return EchuckSetUsernameResult::ServerError;
+	default:
+		return EchuckSetUsernameResult::ServerError;
+	}
+}
+
+void UchuckKbveApiClient::SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult)
+{
+	if (OnResult)
+	{
+		OnResult(EchuckSetUsernameResult::NetworkError, Name);
+	}
+}

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "chuckKbveApiClient.generated.h"
+
+UENUM()
+enum class EchuckSetUsernameResult : uint8
+{
+	Ok,
+	Taken,
+	Invalid,
+	Unauthorized,
+	ServerError,
+	NetworkError
+};
+
+UCLASS(Config = Game)
+class UchuckKbveApiClient : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Config, EditDefaultsOnly, Category = "Chuck|Api")
+	FString BaseUrl = TEXT("https://kbve.com");
+
+	void SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult);
+
+	static EchuckSetUsernameResult ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical);
+};

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Simgrid")
-	FString ServerUrl = TEXT("ws://localhost:7979/ws");
+	FString ServerUrl = TEXT("wss://arpg.kbve.com/ws");
 
 	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Simgrid")
 	TObjectPtr<UStaticMesh> DefaultEntityMesh;

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp
@@ -83,7 +83,7 @@ FReply SchuckUsernameSetup::HandleConfirm()
 		return FReply::Handled();
 	}
 
-	const FString Name = NameBox.IsValid() ? NameBox->GetText().ToString() : FString();
+	const FString Name = NameBox.IsValid() ? NameBox->GetText().ToString().TrimStartAndEnd() : FString();
 	if (Name.IsEmpty())
 	{
 		SetStatus(LOCTEXT("Empty", "Enter a username"));
@@ -115,7 +115,7 @@ FReply SchuckUsernameSetup::HandleConfirm()
 			{
 				Sub->RefreshSession();
 			}
-			Self->OnUsernameSet.ExecuteIfBound();
+			Self->OnUsernameSet.ExecuteIfBound(Canonical);
 			break;
 		case EchuckSetUsernameResult::Taken:
 			Self->SetStatus(LOCTEXT("Taken", "Username taken - try another"));
@@ -126,6 +126,7 @@ FReply SchuckUsernameSetup::HandleConfirm()
 			Self->SetBusy(false);
 			break;
 		case EchuckSetUsernameResult::Unauthorized:
+			Self->SetBusy(false);
 			Self->OnSessionExpired.ExecuteIfBound();
 			break;
 		default:

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp
@@ -1,0 +1,141 @@
+#include "SchuckUsernameSetup.h"
+#include "Net/chuckKbveApiClient.h"
+#include "KBVESupabaseSubsystem.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBox.h"
+#include "Styling/CoreStyle.h"
+
+#define LOCTEXT_NAMESPACE "SchuckUsernameSetup"
+
+void SchuckUsernameSetup::Construct(const FArguments& InArgs)
+{
+	Subsystem = InArgs._Subsystem;
+	ApiClient = InArgs._ApiClient;
+	OnUsernameSet = InArgs._OnUsernameSet;
+	OnSessionExpired = InArgs._OnSessionExpired;
+
+	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 22);
+	const FSlateFontInfo StatusFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	NameBox = SNew(SEditableTextBox).HintText(LOCTEXT("NameHint", "choose a username"));
+	StatusText = SNew(STextBlock).Font(StatusFont).Text(FText::GetEmpty());
+	ConfirmButton = SNew(SButton)
+		.HAlign(HAlign_Center).VAlign(VAlign_Center)
+		.OnClicked(FOnClicked::CreateSP(this, &SchuckUsernameSetup::HandleConfirm))
+		[
+			SNew(STextBlock).Text(LOCTEXT("Confirm", "Set Username"))
+		];
+
+	ChildSlot
+	.HAlign(HAlign_Center).VAlign(VAlign_Center)
+	[
+		SNew(SBox).WidthOverride(360.f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center).Padding(0.f, 0.f, 0.f, 12.f)
+			[
+				SNew(STextBlock).Font(TitleFont).Text(LOCTEXT("Title", "Pick a username"))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 8.f)
+			[
+				NameBox.ToSharedRef()
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 8.f)
+			[
+				ConfirmButton.ToSharedRef()
+			]
+			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center)
+			[
+				StatusText.ToSharedRef()
+			]
+		]
+	];
+}
+
+void SchuckUsernameSetup::SetStatus(const FText& Text)
+{
+	if (StatusText.IsValid())
+	{
+		StatusText->SetText(Text);
+	}
+}
+
+void SchuckUsernameSetup::SetBusy(bool bInBusy)
+{
+	bBusy = bInBusy;
+	if (NameBox.IsValid())
+	{
+		NameBox->SetEnabled(!bInBusy);
+	}
+	if (ConfirmButton.IsValid())
+	{
+		ConfirmButton->SetEnabled(!bInBusy);
+	}
+}
+
+FReply SchuckUsernameSetup::HandleConfirm()
+{
+	if (bBusy)
+	{
+		return FReply::Handled();
+	}
+
+	const FString Name = NameBox.IsValid() ? NameBox->GetText().ToString() : FString();
+	if (Name.IsEmpty())
+	{
+		SetStatus(LOCTEXT("Empty", "Enter a username"));
+		return FReply::Handled();
+	}
+
+	UchuckKbveApiClient* Api = ApiClient.Get();
+	if (!Api)
+	{
+		SetStatus(LOCTEXT("NoApi", "Client unavailable"));
+		return FReply::Handled();
+	}
+
+	SetBusy(true);
+	SetStatus(LOCTEXT("Setting", "Setting..."));
+
+	TWeakPtr<SchuckUsernameSetup> WeakSelf = SharedThis(this);
+	Api->SetUsername(Name, [WeakSelf](EchuckSetUsernameResult Result, const FString& Canonical)
+	{
+		TSharedPtr<SchuckUsernameSetup> Self = WeakSelf.Pin();
+		if (!Self.IsValid())
+		{
+			return;
+		}
+		switch (Result)
+		{
+		case EchuckSetUsernameResult::Ok:
+			if (UKBVESupabaseSubsystem* Sub = Self->Subsystem.Get())
+			{
+				Sub->RefreshSession();
+			}
+			Self->OnUsernameSet.ExecuteIfBound();
+			break;
+		case EchuckSetUsernameResult::Taken:
+			Self->SetStatus(LOCTEXT("Taken", "Username taken - try another"));
+			Self->SetBusy(false);
+			break;
+		case EchuckSetUsernameResult::Invalid:
+			Self->SetStatus(LOCTEXT("Invalid", "Invalid username"));
+			Self->SetBusy(false);
+			break;
+		case EchuckSetUsernameResult::Unauthorized:
+			Self->OnSessionExpired.ExecuteIfBound();
+			break;
+		default:
+			Self->SetStatus(LOCTEXT("ServerErr", "Server unavailable - try again"));
+			Self->SetBusy(false);
+			break;
+		}
+	});
+
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+class UKBVESupabaseSubsystem;
+class UchuckKbveApiClient;
+class SEditableTextBox;
+class STextBlock;
+class SButton;
+
+class SchuckUsernameSetup : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckUsernameSetup) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+		SLATE_ARGUMENT(TWeakObjectPtr<UchuckKbveApiClient>, ApiClient)
+		SLATE_EVENT(FSimpleDelegate, OnUsernameSet)
+		SLATE_EVENT(FSimpleDelegate, OnSessionExpired)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FReply HandleConfirm();
+	void SetStatus(const FText& Text);
+	void SetBusy(bool bInBusy);
+
+	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
+	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
+	FSimpleDelegate OnUsernameSet;
+	FSimpleDelegate OnSessionExpired;
+	TSharedPtr<SEditableTextBox> NameBox;
+	TSharedPtr<STextBlock> StatusText;
+	TSharedPtr<SButton> ConfirmButton;
+	bool bBusy = false;
+};

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h
@@ -9,13 +9,15 @@ class SEditableTextBox;
 class STextBlock;
 class SButton;
 
+DECLARE_DELEGATE_OneParam(FchuckOnUsernameSet, const FString&);
+
 class SchuckUsernameSetup : public SCompoundWidget
 {
 public:
 	SLATE_BEGIN_ARGS(SchuckUsernameSetup) {}
 		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
 		SLATE_ARGUMENT(TWeakObjectPtr<UchuckKbveApiClient>, ApiClient)
-		SLATE_EVENT(FSimpleDelegate, OnUsernameSet)
+		SLATE_EVENT(FchuckOnUsernameSet, OnUsernameSet)
 		SLATE_EVENT(FSimpleDelegate, OnSessionExpired)
 	SLATE_END_ARGS()
 
@@ -28,7 +30,7 @@ private:
 
 	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
 	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
-	FSimpleDelegate OnUsernameSet;
+	FchuckOnUsernameSet OnUsernameSet;
 	FSimpleDelegate OnSessionExpired;
 	TSharedPtr<SEditableTextBox> NameBox;
 	TSharedPtr<STextBlock> StatusText;

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp
@@ -54,7 +54,7 @@ void AchuckMenuPlayerController::BeginPlay()
 	UsernameWidget = SNew(SchuckUsernameSetup)
 		.Subsystem(SupabaseSubsystem)
 		.ApiClient(ApiClient)
-		.OnUsernameSet(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSet))
+		.OnUsernameSet(FchuckOnUsernameSet::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSet))
 		.OnSessionExpired(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSessionExpired));
 	UsernameWidget->SetVisibility(EVisibility::Collapsed);
 	AccountWidget = SNew(SKBVEAccountPanel).Subsystem(SupabaseSubsystem);
@@ -339,6 +339,7 @@ void AchuckMenuPlayerController::ApplyAccountFromSession(const FKBVESupabaseSess
 
 void AchuckMenuPlayerController::HandleSupabaseSignedOut()
 {
+	LocalUsername.Reset();
 	RefreshAuthVisibility(false);
 	if (UGameInstance* GI = GetGameInstance())
 	{
@@ -349,14 +350,16 @@ void AchuckMenuPlayerController::HandleSupabaseSignedOut()
 	}
 }
 
-void AchuckMenuPlayerController::HandleUsernameSet()
+void AchuckMenuPlayerController::HandleUsernameSet(const FString& Canonical)
 {
+	LocalUsername = Canonical;
 	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
 	RefreshAuthVisibility(Sub && Sub->IsSignedIn());
 }
 
 void AchuckMenuPlayerController::HandleUsernameSessionExpired()
 {
+	LocalUsername.Reset();
 	if (UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get())
 	{
 		Sub->SignOut();
@@ -367,7 +370,7 @@ void AchuckMenuPlayerController::HandleUsernameSessionExpired()
 void AchuckMenuPlayerController::RefreshAuthVisibility(bool bSignedIn)
 {
 	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
-	const bool bHasUsername = Sub && !Sub->GetUser().KbveUsername.IsEmpty();
+	const bool bHasUsername = (Sub && !Sub->GetUser().KbveUsername.IsEmpty()) || !LocalUsername.IsEmpty();
 	const bool bNeedUsername = bSignedIn && !bHasUsername;
 
 	if (LoginWidget.IsValid())

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp
@@ -4,6 +4,8 @@
 #include "SchuckCharacterSelect.h"
 #include "Core/chuckSessionSubsystem.h"
 #include "SKBVELoginWidget.h"
+#include "SchuckUsernameSetup.h"
+#include "Net/chuckKbveApiClient.h"
 #include "SKBVEAccountPanel.h"
 #include "SKBVELoadingPanel.h"
 #include "Engine/GameInstance.h"
@@ -45,6 +47,16 @@ void AchuckMenuPlayerController::BeginPlay()
 		.OnQuitClicked(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleQuit));
 
 	LoginWidget   = SNew(SKBVELoginWidget).Subsystem(SupabaseSubsystem).Title(NSLOCTEXT("chuck", "LoginTitle", "Sign in to ChuckRPG"));
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		ApiClient = GI->GetSubsystem<UchuckKbveApiClient>();
+	}
+	UsernameWidget = SNew(SchuckUsernameSetup)
+		.Subsystem(SupabaseSubsystem)
+		.ApiClient(ApiClient)
+		.OnUsernameSet(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSet))
+		.OnSessionExpired(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSessionExpired));
+	UsernameWidget->SetVisibility(EVisibility::Collapsed);
 	AccountWidget = SNew(SKBVEAccountPanel).Subsystem(SupabaseSubsystem);
 	LoadingWidget = SNew(SKBVELoadingPanel).UnitLabel(TEXT("chunks"));
 	LoadingWidget->SetVisibility(EVisibility::Collapsed);
@@ -64,6 +76,7 @@ void AchuckMenuPlayerController::BeginPlay()
 		Viewport->AddViewportWidgetContent(MenuWidget.ToSharedRef(),    10);
 		Viewport->AddViewportWidgetContent(AccountWidget.ToSharedRef(), 40);
 		Viewport->AddViewportWidgetContent(LoginWidget.ToSharedRef(),   45);
+		Viewport->AddViewportWidgetContent(UsernameWidget.ToSharedRef(), 46);
 		Viewport->AddViewportWidgetContent(CharSelectWidget.ToSharedRef(), 50);
 		Viewport->AddViewportWidgetContent(LoadingWidget.ToSharedRef(), 60);
 	}
@@ -302,6 +315,7 @@ void AchuckMenuPlayerController::HandleSupabaseSessionRefreshed(const FKBVESupab
 			Rows->AdoptSupabaseSession(Session.AccessToken, Session.User.Id, Session.User.KbveUsername);
 		}
 	}
+	RefreshAuthVisibility(true);
 }
 
 void AchuckMenuPlayerController::ApplyAccountFromSession(const FKBVESupabaseSession& Session)
@@ -335,15 +349,38 @@ void AchuckMenuPlayerController::HandleSupabaseSignedOut()
 	}
 }
 
+void AchuckMenuPlayerController::HandleUsernameSet()
+{
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	RefreshAuthVisibility(Sub && Sub->IsSignedIn());
+}
+
+void AchuckMenuPlayerController::HandleUsernameSessionExpired()
+{
+	if (UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get())
+	{
+		Sub->SignOut();
+	}
+	RefreshAuthVisibility(false);
+}
+
 void AchuckMenuPlayerController::RefreshAuthVisibility(bool bSignedIn)
 {
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	const bool bHasUsername = Sub && !Sub->GetUser().KbveUsername.IsEmpty();
+	const bool bNeedUsername = bSignedIn && !bHasUsername;
+
 	if (LoginWidget.IsValid())
 	{
 		LoginWidget->SetVisibility(bSignedIn ? EVisibility::Collapsed : EVisibility::Visible);
 	}
+	if (UsernameWidget.IsValid())
+	{
+		UsernameWidget->SetVisibility(bNeedUsername ? EVisibility::Visible : EVisibility::Collapsed);
+	}
 	if (AccountWidget.IsValid())
 	{
-		AccountWidget->SetVisibility(bSignedIn ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed);
+		AccountWidget->SetVisibility((bSignedIn && bHasUsername) ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed);
 	}
 }
 

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h
@@ -10,6 +10,8 @@ class SKBVELoginWidget;
 class SKBVEAccountPanel;
 class SKBVELoadingPanel;
 class UKBVESupabaseSubsystem;
+class SchuckUsernameSetup;
+class UchuckKbveApiClient;
 struct FKBVESupabaseSession;
 struct FROWSUserCharacter;
 
@@ -41,6 +43,8 @@ private:
 	void TickLoadingTransition(float DeltaSeconds);
 
 	void RefreshAuthVisibility(bool bSignedIn);
+	void HandleUsernameSet();
+	void HandleUsernameSessionExpired();
 
 	UFUNCTION()
 	void HandleSupabaseSignedIn(const FKBVESupabaseSession& Session);
@@ -68,8 +72,10 @@ private:
 	TSharedPtr<SchuckMainMenu>     MenuWidget;
 	TSharedPtr<SchuckCharacterSelect> CharSelectWidget;
 	TSharedPtr<SKBVELoginWidget>  LoginWidget;
+	TSharedPtr<SchuckUsernameSetup> UsernameWidget;
 	TSharedPtr<SKBVEAccountPanel> AccountWidget;
 	TSharedPtr<SKBVELoadingPanel> LoadingWidget;
+	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
 
 	UPROPERTY(Transient)
 	TWeakObjectPtr<UKBVESupabaseSubsystem> SupabaseSubsystem;

--- a/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h
@@ -43,7 +43,7 @@ private:
 	void TickLoadingTransition(float DeltaSeconds);
 
 	void RefreshAuthVisibility(bool bSignedIn);
-	void HandleUsernameSet();
+	void HandleUsernameSet(const FString& Canonical);
 	void HandleUsernameSessionExpired();
 
 	UFUNCTION()
@@ -76,6 +76,7 @@ private:
 	TSharedPtr<SKBVEAccountPanel> AccountWidget;
 	TSharedPtr<SKBVELoadingPanel> LoadingWidget;
 	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
+	FString LocalUsername;
 
 	UPROPERTY(Transient)
 	TWeakObjectPtr<UKBVESupabaseSubsystem> SupabaseSubsystem;

--- a/docs/superpowers/plans/2026-07-01-rentearth-arpg-phase4-shortcut-login.md
+++ b/docs/superpowers/plans/2026-07-01-rentearth-arpg-phase4-shortcut-login.md
@@ -1,0 +1,708 @@
+# RentEarth ARPG Phase 4 — Shortcut Login + Live Point Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-client username-setup gate for first-time players, persist the username via the axum-kbve profile endpoint, refresh the Supabase session so the JWT carries the `kbve_username` claim, and point the rentearth client at the live Agones ARPG ingress.
+
+**Architecture:** All changes live in the rentearth `chuck` fork (`apps/rentearth/unreal-rentearth/Source/chuck`). A new `UchuckKbveApiClient` GameInstanceSubsystem POSTs the chosen name to `/api/v1/profile/username`; a new `SchuckUsernameSetup` Slate widget drives set → refresh → proceed; `AchuckMenuPlayerController` gains a three-state auth gate (login → username → play); `AchuckSimgridController::ServerUrl` defaults to the live ingress.
+
+**Tech Stack:** UE5.8 C++, Slate, `FHttpModule`, `FJsonSerializer`, `UKBVESupabaseSubsystem`, UE automation tests.
+
+## Global Constraints
+
+- All new/edited code lives in the rentearth chuck fork `apps/rentearth/unreal-rentearth/Source/chuck` — do NOT touch main chuck (`apps/chuckrpg/unreal-chuck`).
+- No code comments anywhere (project rule).
+- Endpoint: `POST {BaseUrl}/api/v1/profile/username`, header `Authorization: Bearer <access token>`, body `{"username":"<name>"}`. Responses: 200 ok, 400 invalid, 401 unauthorized, 409 taken, 503 server unavailable.
+- Live ARPG endpoint: `wss://arpg.kbve.com/ws` (fixed ingress). Local dev override: `ws://localhost:7979/ws`.
+- `chuck.Build.cs` already depends on `HTTP`, `Json`, `JsonUtilities`, `KBVESupabase`, `KBVEUIAuth`, `Slate`, `SlateCore`, `KBVESimgrid` — no Build.cs edits needed.
+- Username persistence requires a session refresh afterward: `UKBVESupabaseSubsystem::RefreshSession()` re-mints the JWT with the `kbve_username` claim.
+- Result enum: `enum class EchuckSetUsernameResult : uint8 { Ok, Taken, Invalid, Unauthorized, ServerError, NetworkError }`.
+- Test macro pattern (from `SimgridCobsTests.cpp`): `#if WITH_DEV_AUTOMATION_TESTS` guard, `IMPLEMENT_SIMPLE_AUTOMATION_TEST(Class, "Category.Path", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)`, `bool Class::RunTest(const FString&)`, tests in `Private`/`Tests` co-located `.cpp`.
+- Build/test via UE `Build.sh` + `UnrealEditor-Cmd` automation (nx unavailable in worktree). Before automation runs: `pkill -9 -f UnrealEditor-Cmd; rm -f /tmp/UnrealEditor-Cmd*`.
+
+---
+
+### Task 1: `UchuckKbveApiClient` — enum, config, pure parse + tests
+
+**Files:**
+- Create: `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.h`
+- Create: `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp`
+- Test: `apps/rentearth/unreal-rentearth/Source/chuck/Net/Tests/chuckKbveApiTests.cpp`
+
+**Interfaces:**
+- Consumes: nothing (leaf).
+- Produces:
+  - `enum class EchuckSetUsernameResult : uint8 { Ok, Taken, Invalid, Unauthorized, ServerError, NetworkError };`
+  - `UCLASS(Config=Game) class UchuckKbveApiClient : public UGameInstanceSubsystem` with `UPROPERTY(Config) FString BaseUrl = TEXT("https://kbve.com");`
+  - `static EchuckSetUsernameResult UchuckKbveApiClient::ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical);`
+  - `void SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult);` (declared here, implemented in Task 2)
+
+- [ ] **Step 1: Write the header**
+
+Create `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.h`:
+
+```cpp
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "chuckKbveApiClient.generated.h"
+
+UENUM()
+enum class EchuckSetUsernameResult : uint8
+{
+	Ok,
+	Taken,
+	Invalid,
+	Unauthorized,
+	ServerError,
+	NetworkError
+};
+
+UCLASS(Config = Game)
+class UchuckKbveApiClient : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Config, EditDefaultsOnly, Category = "Chuck|Api")
+	FString BaseUrl = TEXT("https://kbve.com");
+
+	void SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult);
+
+	static EchuckSetUsernameResult ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical);
+};
+```
+
+- [ ] **Step 2: Write the pure-parse implementation (SetUsername left as a stub for Task 2)**
+
+Create `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp`:
+
+```cpp
+#include "chuckKbveApiClient.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+EchuckSetUsernameResult UchuckKbveApiClient::ParseSetUsernameResult(int32 HttpCode, const FString& Body, const FString& Requested, FString& OutCanonical)
+{
+	OutCanonical = Requested;
+
+	switch (HttpCode)
+	{
+	case 200:
+	{
+		TSharedPtr<FJsonObject> Json;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Body);
+		if (FJsonSerializer::Deserialize(Reader, Json) && Json.IsValid())
+		{
+			FString Canon;
+			if (Json->TryGetStringField(TEXT("username"), Canon) && !Canon.IsEmpty())
+			{
+				OutCanonical = Canon;
+			}
+		}
+		return EchuckSetUsernameResult::Ok;
+	}
+	case 400:
+		return EchuckSetUsernameResult::Invalid;
+	case 401:
+		return EchuckSetUsernameResult::Unauthorized;
+	case 409:
+		return EchuckSetUsernameResult::Taken;
+	case 503:
+		return EchuckSetUsernameResult::ServerError;
+	default:
+		return EchuckSetUsernameResult::ServerError;
+	}
+}
+
+void UchuckKbveApiClient::SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult)
+{
+	if (OnResult)
+	{
+		OnResult(EchuckSetUsernameResult::NetworkError, Name);
+	}
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `apps/rentearth/unreal-rentearth/Source/chuck/Net/Tests/chuckKbveApiTests.cpp`:
+
+```cpp
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "chuckKbveApiClient.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseOkTest,
+	"Chuck.KbveApi.ParseSetUsername.Ok",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseOkTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	const EchuckSetUsernameResult R = UchuckKbveApiClient::ParseSetUsernameResult(
+		200, TEXT("{\"success\":true,\"username\":\"chad\",\"message\":\"ok\"}"), TEXT("chad_req"), Canonical);
+	TestEqual("200 -> Ok", (int32)R, (int32)EchuckSetUsernameResult::Ok);
+	TestEqual("canonical from body", Canonical, FString(TEXT("chad")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseOkNoFieldTest,
+	"Chuck.KbveApi.ParseSetUsername.OkNoField",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseOkNoFieldTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	const EchuckSetUsernameResult R = UchuckKbveApiClient::ParseSetUsernameResult(
+		200, TEXT("{\"success\":true}"), TEXT("chad_req"), Canonical);
+	TestEqual("200 no field -> Ok", (int32)R, (int32)EchuckSetUsernameResult::Ok);
+	TestEqual("canonical falls back to requested", Canonical, FString(TEXT("chad_req")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FchuckKbveApiParseCodesTest,
+	"Chuck.KbveApi.ParseSetUsername.Codes",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FchuckKbveApiParseCodesTest::RunTest(const FString& Parameters)
+{
+	FString Canonical;
+	TestEqual("400 -> Invalid", (int32)UchuckKbveApiClient::ParseSetUsernameResult(400, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Invalid);
+	TestEqual("401 -> Unauthorized", (int32)UchuckKbveApiClient::ParseSetUsernameResult(401, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Unauthorized);
+	TestEqual("409 -> Taken", (int32)UchuckKbveApiClient::ParseSetUsernameResult(409, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::Taken);
+	TestEqual("503 -> ServerError", (int32)UchuckKbveApiClient::ParseSetUsernameResult(503, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::ServerError);
+	TestEqual("500 -> ServerError", (int32)UchuckKbveApiClient::ParseSetUsernameResult(500, TEXT(""), TEXT("n"), Canonical), (int32)EchuckSetUsernameResult::ServerError);
+	return true;
+}
+
+#endif
+```
+
+- [ ] **Step 4: Build the editor target and run the tests**
+
+Before running, clear any stale singleton:
+
+```bash
+pkill -9 -f UnrealEditor-Cmd 2>/dev/null; rm -f /tmp/UnrealEditor-Cmd* 2>/dev/null
+```
+
+Build `rentearthEditor` (adjust the engine `Build.sh` path to the machine's UE 5.8 install), then run:
+
+```
+UnrealEditor-Cmd <path>/rentearth.uproject -ExecCmds="Automation RunTests Chuck.KbveApi; Quit" -unattended -nop4 -nullrhi -log
+```
+
+Expected: `Chuck.KbveApi.ParseSetUsername.Ok`, `.OkNoField`, `.Codes` all PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.h \
+        apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp \
+        apps/rentearth/unreal-rentearth/Source/chuck/Net/Tests/chuckKbveApiTests.cpp
+git commit -m "feat(rentearth): kbve api client username result parse + tests"
+```
+
+---
+
+### Task 2: `UchuckKbveApiClient::SetUsername` — HTTP POST
+
+**Files:**
+- Modify: `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp`
+
+**Interfaces:**
+- Consumes: `UKBVESupabaseSubsystem::GetAccessToken()` (returns `FString`), `UGameInstanceSubsystem::GetGameInstance()`, `ParseSetUsernameResult` from Task 1.
+- Produces: working `SetUsername` that issues the POST and invokes `OnResult` with the parsed result + canonical name.
+
+- [ ] **Step 1: Replace the SetUsername stub with the real implementation**
+
+In `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp`, add these includes at the top (below the existing includes):
+
+```cpp
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Engine/GameInstance.h"
+#include "KBVESupabaseSubsystem.h"
+```
+
+Replace the entire stub `SetUsername` body with:
+
+```cpp
+void UchuckKbveApiClient::SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString&)> OnResult)
+{
+	UGameInstance* GI = GetGameInstance();
+	UKBVESupabaseSubsystem* Supa = GI ? GI->GetSubsystem<UKBVESupabaseSubsystem>() : nullptr;
+	const FString Token = Supa ? Supa->GetAccessToken() : FString();
+
+	TSharedRef<FJsonObject> BodyJson = MakeShared<FJsonObject>();
+	BodyJson->SetStringField(TEXT("username"), Name);
+	FString BodyStr;
+	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&BodyStr);
+	FJsonSerializer::Serialize(BodyJson, Writer);
+
+	const FString Requested = Name;
+
+	const TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Req = FHttpModule::Get().CreateRequest();
+	Req->SetVerb(TEXT("POST"));
+	Req->SetURL(BaseUrl + TEXT("/api/v1/profile/username"));
+	Req->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Req->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Token));
+	Req->SetContentAsString(BodyStr);
+	Req->OnProcessRequestComplete().BindLambda(
+		[OnResult, Requested](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnected)
+		{
+			FString Canonical = Requested;
+			EchuckSetUsernameResult Result;
+			if (!bConnected || !Resp.IsValid())
+			{
+				Result = EchuckSetUsernameResult::NetworkError;
+			}
+			else
+			{
+				Result = ParseSetUsernameResult(Resp->GetResponseCode(), Resp->GetContentAsString(), Requested, Canonical);
+			}
+			if (OnResult)
+			{
+				OnResult(Result, Canonical);
+			}
+		});
+	Req->ProcessRequest();
+}
+```
+
+Add the JSON writer include if not already present (it is used for serialization):
+
+```cpp
+#include "Serialization/JsonWriter.h"
+```
+
+- [ ] **Step 2: Rebuild the editor target**
+
+```bash
+pkill -9 -f UnrealEditor-Cmd 2>/dev/null; rm -f /tmp/UnrealEditor-Cmd* 2>/dev/null
+```
+
+Build `rentearthEditor`. Expected: compiles clean. Re-run `Automation RunTests Chuck.KbveApi` — the 3 Task 1 tests still PASS (the pure parse fn is unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckKbveApiClient.cpp
+git commit -m "feat(rentearth): kbve api client SetUsername POST /api/v1/profile/username"
+```
+
+---
+
+### Task 3: `SchuckUsernameSetup` Slate widget
+
+**Files:**
+- Create: `apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h`
+- Create: `apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp`
+
+**Interfaces:**
+- Consumes: `UchuckKbveApiClient::SetUsername` + `EchuckSetUsernameResult` (Task 2), `UKBVESupabaseSubsystem::RefreshSession()`.
+- Produces: `SchuckUsernameSetup` widget with `SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)`, `SLATE_ARGUMENT(TWeakObjectPtr<UchuckKbveApiClient>, ApiClient)`, `SLATE_EVENT(FSimpleDelegate, OnUsernameSet)`, `SLATE_EVENT(FSimpleDelegate, OnSessionExpired)`.
+
+- [ ] **Step 1: Write the header**
+
+Create `apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h`:
+
+```cpp
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+class UKBVESupabaseSubsystem;
+class UchuckKbveApiClient;
+class SEditableTextBox;
+class STextBlock;
+class SButton;
+
+class SchuckUsernameSetup : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckUsernameSetup) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+		SLATE_ARGUMENT(TWeakObjectPtr<UchuckKbveApiClient>, ApiClient)
+		SLATE_EVENT(FSimpleDelegate, OnUsernameSet)
+		SLATE_EVENT(FSimpleDelegate, OnSessionExpired)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FReply HandleConfirm();
+	void SetStatus(const FText& Text);
+	void SetBusy(bool bInBusy);
+
+	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
+	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
+	FSimpleDelegate OnUsernameSet;
+	FSimpleDelegate OnSessionExpired;
+	TSharedPtr<SEditableTextBox> NameBox;
+	TSharedPtr<STextBlock> StatusText;
+	TSharedPtr<SButton> ConfirmButton;
+	bool bBusy = false;
+};
+```
+
+- [ ] **Step 2: Write the implementation**
+
+Create `apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp`:
+
+```cpp
+#include "SchuckUsernameSetup.h"
+#include "Net/chuckKbveApiClient.h"
+#include "KBVESupabaseSubsystem.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBox.h"
+#include "Styling/CoreStyle.h"
+
+#define LOCTEXT_NAMESPACE "SchuckUsernameSetup"
+
+void SchuckUsernameSetup::Construct(const FArguments& InArgs)
+{
+	Subsystem = InArgs._Subsystem;
+	ApiClient = InArgs._ApiClient;
+	OnUsernameSet = InArgs._OnUsernameSet;
+	OnSessionExpired = InArgs._OnSessionExpired;
+
+	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 22);
+	const FSlateFontInfo StatusFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	NameBox = SNew(SEditableTextBox).HintText(LOCTEXT("NameHint", "choose a username"));
+	StatusText = SNew(STextBlock).Font(StatusFont).Text(FText::GetEmpty());
+	ConfirmButton = SNew(SButton)
+		.HAlign(HAlign_Center).VAlign(VAlign_Center)
+		.OnClicked(FOnClicked::CreateSP(this, &SchuckUsernameSetup::HandleConfirm))
+		[
+			SNew(STextBlock).Text(LOCTEXT("Confirm", "Set Username"))
+		];
+
+	ChildSlot
+	.HAlign(HAlign_Center).VAlign(VAlign_Center)
+	[
+		SNew(SBox).WidthOverride(360.f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center).Padding(0.f, 0.f, 0.f, 12.f)
+			[
+				SNew(STextBlock).Font(TitleFont).Text(LOCTEXT("Title", "Pick a username"))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 8.f)
+			[
+				NameBox.ToSharedRef()
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 8.f)
+			[
+				ConfirmButton.ToSharedRef()
+			]
+			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center)
+			[
+				StatusText.ToSharedRef()
+			]
+		]
+	];
+}
+
+void SchuckUsernameSetup::SetStatus(const FText& Text)
+{
+	if (StatusText.IsValid())
+	{
+		StatusText->SetText(Text);
+	}
+}
+
+void SchuckUsernameSetup::SetBusy(bool bInBusy)
+{
+	bBusy = bInBusy;
+	if (NameBox.IsValid())
+	{
+		NameBox->SetEnabled(!bInBusy);
+	}
+	if (ConfirmButton.IsValid())
+	{
+		ConfirmButton->SetEnabled(!bInBusy);
+	}
+}
+
+FReply SchuckUsernameSetup::HandleConfirm()
+{
+	if (bBusy)
+	{
+		return FReply::Handled();
+	}
+
+	const FString Name = NameBox.IsValid() ? NameBox->GetText().ToString() : FString();
+	if (Name.IsEmpty())
+	{
+		SetStatus(LOCTEXT("Empty", "Enter a username"));
+		return FReply::Handled();
+	}
+
+	UchuckKbveApiClient* Api = ApiClient.Get();
+	if (!Api)
+	{
+		SetStatus(LOCTEXT("NoApi", "Client unavailable"));
+		return FReply::Handled();
+	}
+
+	SetBusy(true);
+	SetStatus(LOCTEXT("Setting", "Setting..."));
+
+	TWeakPtr<SchuckUsernameSetup> WeakSelf = SharedThis(this);
+	Api->SetUsername(Name, [WeakSelf](EchuckSetUsernameResult Result, const FString& Canonical)
+	{
+		TSharedPtr<SchuckUsernameSetup> Self = WeakSelf.Pin();
+		if (!Self.IsValid())
+		{
+			return;
+		}
+		switch (Result)
+		{
+		case EchuckSetUsernameResult::Ok:
+			if (UKBVESupabaseSubsystem* Sub = Self->Subsystem.Get())
+			{
+				Sub->RefreshSession();
+			}
+			Self->OnUsernameSet.ExecuteIfBound();
+			break;
+		case EchuckSetUsernameResult::Taken:
+			Self->SetStatus(LOCTEXT("Taken", "Username taken - try another"));
+			Self->SetBusy(false);
+			break;
+		case EchuckSetUsernameResult::Invalid:
+			Self->SetStatus(LOCTEXT("Invalid", "Invalid username"));
+			Self->SetBusy(false);
+			break;
+		case EchuckSetUsernameResult::Unauthorized:
+			Self->OnSessionExpired.ExecuteIfBound();
+			break;
+		default:
+			Self->SetStatus(LOCTEXT("ServerErr", "Server unavailable - try again"));
+			Self->SetBusy(false);
+			break;
+		}
+	});
+
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE
+```
+
+- [ ] **Step 3: Rebuild the editor target**
+
+```bash
+pkill -9 -f UnrealEditor-Cmd 2>/dev/null; rm -f /tmp/UnrealEditor-Cmd* 2>/dev/null
+```
+
+Build `rentearthEditor`. Expected: compiles clean (Slate widget, no automation test for UI).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.h \
+        apps/rentearth/unreal-rentearth/Source/chuck/UI/SchuckUsernameSetup.cpp
+git commit -m "feat(rentearth): username setup slate widget"
+```
+
+---
+
+### Task 4: `AchuckMenuPlayerController` three-state auth gate
+
+**Files:**
+- Modify: `apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h`
+- Modify: `apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp`
+
+**Interfaces:**
+- Consumes: `SchuckUsernameSetup` (Task 3), `UchuckKbveApiClient` (Task 2), `UKBVESupabaseSubsystem::GetUser().KbveUsername`, `IsSignedIn()`, `SignOut()`, `GetSession()`.
+- Produces: three-state `RefreshAuthVisibility(bool bSignedIn)` — login when unauth, username setup when signed-in with empty `KbveUsername`, account/play when signed-in with a username.
+
+- [ ] **Step 1: Edit the header**
+
+In `apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h`:
+
+Add forward declarations alongside the existing widget forward decls (near `class SKBVELoginWidget;`):
+
+```cpp
+class SchuckUsernameSetup;
+class UchuckKbveApiClient;
+```
+
+Add these two private handler declarations next to the existing `HandleSupabase*` UFUNCTIONs (they are plain methods, not UFUNCTIONs — `FSimpleDelegate` binds via `CreateUObject` without requiring UFUNCTION):
+
+```cpp
+	void HandleUsernameSet();
+	void HandleUsernameSessionExpired();
+```
+
+Add these two members next to the existing `TSharedPtr<SKBVELoginWidget> LoginWidget;`:
+
+```cpp
+	TSharedPtr<SchuckUsernameSetup> UsernameWidget;
+	TWeakObjectPtr<UchuckKbveApiClient> ApiClient;
+```
+
+- [ ] **Step 2: Edit the .cpp — includes**
+
+In `apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp`, add includes near the existing widget includes:
+
+```cpp
+#include "SchuckUsernameSetup.h"
+#include "Net/chuckKbveApiClient.h"
+```
+
+- [ ] **Step 3: Edit the .cpp — construct the widget in BeginPlay**
+
+In `BeginPlay`, immediately after the `LoginWidget = SNew(SKBVELoginWidget)...;` construction, add:
+
+```cpp
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		ApiClient = GI->GetSubsystem<UchuckKbveApiClient>();
+	}
+	UsernameWidget = SNew(SchuckUsernameSetup)
+		.Subsystem(SupabaseSubsystem)
+		.ApiClient(ApiClient)
+		.OnUsernameSet(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSet))
+		.OnSessionExpired(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::HandleUsernameSessionExpired));
+	UsernameWidget->SetVisibility(EVisibility::Collapsed);
+```
+
+In the `AddViewportWidgetContent` block, add the username widget between Login (45) and CharSelect (50):
+
+```cpp
+		Viewport->AddViewportWidgetContent(UsernameWidget.ToSharedRef(), 46);
+```
+
+- [ ] **Step 4: Edit the .cpp — three-state RefreshAuthVisibility**
+
+Replace the existing `RefreshAuthVisibility` body with:
+
+```cpp
+void AchuckMenuPlayerController::RefreshAuthVisibility(bool bSignedIn)
+{
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	const bool bHasUsername = Sub && !Sub->GetUser().KbveUsername.IsEmpty();
+	const bool bNeedUsername = bSignedIn && !bHasUsername;
+
+	if (LoginWidget.IsValid())
+	{
+		LoginWidget->SetVisibility(bSignedIn ? EVisibility::Collapsed : EVisibility::Visible);
+	}
+	if (UsernameWidget.IsValid())
+	{
+		UsernameWidget->SetVisibility(bNeedUsername ? EVisibility::Visible : EVisibility::Collapsed);
+	}
+	if (AccountWidget.IsValid())
+	{
+		AccountWidget->SetVisibility((bSignedIn && bHasUsername) ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed);
+	}
+}
+```
+
+- [ ] **Step 5: Edit the .cpp — ensure session-refresh recomputes, add handlers**
+
+Ensure `HandleSupabaseSessionRefreshed` ends by recomputing visibility. Its body should be (preserve any existing `ApplyAccountFromSession` call already there):
+
+```cpp
+void AchuckMenuPlayerController::HandleSupabaseSessionRefreshed(const FKBVESupabaseSession& Session)
+{
+	ApplyAccountFromSession(Session);
+	RefreshAuthVisibility(true);
+}
+```
+
+Add the two new handlers (near the other `HandleSupabase*` definitions):
+
+```cpp
+void AchuckMenuPlayerController::HandleUsernameSet()
+{
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	RefreshAuthVisibility(Sub && Sub->IsSignedIn());
+}
+
+void AchuckMenuPlayerController::HandleUsernameSessionExpired()
+{
+	if (UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get())
+	{
+		Sub->SignOut();
+	}
+	RefreshAuthVisibility(false);
+}
+```
+
+- [ ] **Step 6: Rebuild the editor target**
+
+```bash
+pkill -9 -f UnrealEditor-Cmd 2>/dev/null; rm -f /tmp/UnrealEditor-Cmd* 2>/dev/null
+```
+
+Build `rentearthEditor`. Expected: compiles clean. Re-run `Automation RunTests Chuck.KbveApi` — 3 tests still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.h \
+        apps/rentearth/unreal-rentearth/Source/chuck/UI/chuckMenuPlayerController.cpp
+git commit -m "feat(rentearth): three-state auth gate (login -> username -> play)"
+```
+
+---
+
+### Task 5: Point the client at the live ARPG ingress
+
+**Files:**
+- Modify: `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.h`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ServerUrl` default `wss://arpg.kbve.com/ws`.
+
+- [ ] **Step 1: Edit the default**
+
+In `apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.h`, change the `ServerUrl` default from `ws://localhost:7979/ws` to the live ingress:
+
+```cpp
+	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Simgrid")
+	FString ServerUrl = TEXT("wss://arpg.kbve.com/ws");
+```
+
+- [ ] **Step 2: Rebuild the editor target**
+
+```bash
+pkill -9 -f UnrealEditor-Cmd 2>/dev/null; rm -f /tmp/UnrealEditor-Cmd* 2>/dev/null
+```
+
+Build `rentearthEditor`. Expected: compiles clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.h
+git commit -m "feat(rentearth): point simgrid client at live arpg ingress"
+```
+
+---
+
+## Manual Integration Verification (post-implementation)
+
+Not a task (no automated coverage possible); run once after Task 5:
+
+1. Launch `rentearthEditor`, PIE with a fresh Supabase account (no `kbve_username`).
+2. Sign in → username-setup screen appears (not the play button).
+3. Enter a username → Set → screen dismisses, play path appears.
+4. Enter world → confirm the client connects to `wss://arpg.kbve.com/ws` and renders entities / receives ephemeral events (Phase 2/3 behavior).
+5. Re-launch with the same account → username screen is skipped (goes straight to play).

--- a/docs/superpowers/specs/2026-07-01-rentearth-arpg-phase4-shortcut-login-design.md
+++ b/docs/superpowers/specs/2026-07-01-rentearth-arpg-phase4-shortcut-login-design.md
@@ -1,0 +1,120 @@
+# RentEarth ↔ ARPG Agones Multiplayer — Phase 4: Shortcut Login + Live Point
+
+**Date:** 2026-07-01
+**Status:** Approved (design)
+**Scope:** Phase 4 of the rentearth ARPG multiplayer effort. Adds an in-client username-setup gate for first-time players, refreshes the session so the JWT carries the `kbve_username` claim, and points the client at the live Agones ARPG ingress. Builds on merged KBVESimgrid (transport, #13626), KBVESimgridRender (render, #13629), and Phase 3 ephemeral events (#13632).
+
+## Goal
+
+A signed-in player who already has a username flows straight into the live ARPG. A first-time player (no username) sets one in-client, the client persists it via the axum-kbve profile endpoint, refreshes the Supabase session to mint a JWT carrying the `kbve_username` claim, then enters. The client connects to the live fixed ingress `wss://arpg.kbve.com/ws` instead of localhost.
+
+## Prior Art (do not rewrite)
+
+- **KBVESupabase** (`packages/unreal/KBVESupabase/`) — `UKBVESupabaseSubsystem`:
+  - `FString GetAccessToken() const` — current bearer JWT.
+  - `const FKBVESupabaseUser& GetUser() const` — session user; `FKBVESupabaseUser.KbveUsername` (empty when unset).
+  - `EKBVESupabaseAuthStatus GetStatus()`, `bool IsSignedIn()`, `void RefreshSession()`.
+  - Delegates: `OnSignedIn`, `OnSignedOut`, `OnSessionRefreshed`, `OnAuthStatusChanged`.
+  - `KbveUsername` is populated from the decoded JWT claim (`FKBVESupabaseJWTClaims.KbveUsername`), which the Supabase access-token hook injects from the canonical profile store. Setting a username therefore requires a write to that store **followed by** a session refresh to re-mint the token.
+- **SKBVELoginWidget** (`packages/unreal/KBVEUI/Source/KBVEUIAuth/`) — existing Slate login (email/pass/OAuth/anon). Reference for widget style.
+- **AchuckMenuPlayerController** (`apps/rentearth/unreal-rentearth/Source/chuck/UI/`) — menu PC; `BeginPlay` checks `IsSignedIn()`, `RefreshAuthVisibility()` toggles login vs account widgets in the viewport.
+- **AchuckSimgridController** (`apps/rentearth/unreal-rentearth/Source/chuck/Net/`) — `BeginPlay` calls `USimgridClientSubsystem::ConnectToServer(ServerUrl)`; `ServerUrl` is an `EditDefaultsOnly` `FString`, currently `ws://localhost:7979/ws`.
+- **USimgridClientSubsystem** (`packages/unreal/KBVENet/Source/KBVESimgrid/`) — captures `GetUser().KbveUsername` into `PendingUsername` and `GetAccessToken()` into `PendingJwt` at connect, sends both in `EncodeJoinMatch`.
+
+## axum-kbve Profile Endpoint (wire contract)
+
+`POST /api/v1/profile/username`
+
+- **Auth:** `Authorization: Bearer <access token>` (required).
+- **Body:** `{"username": "<name>"}`.
+- **Responses:**
+  - `200` → `{"success": true, "username": "<canonical>", "message": "..."}` — set OK.
+  - `400` → invalid username format.
+  - `401` → missing/invalid/expired token.
+  - `409` → username already taken.
+  - `503` → auth or profile service unavailable.
+- **Base host:** production `https://kbve.com`; local dev `http://localhost:4321`.
+
+## Live ARPG Endpoint
+
+`wss://arpg.kbve.com/ws` — fixed ingress (Cilium gateway HTTPRoute → `arpg-game:7979`, 3600s WS timeout). Not per-match allocation; the hostname is stable while the Agones fleet scales behind it. Local dev override remains `ws://localhost:7979/ws`.
+
+## Components (all in the rentearth `chuck` fork — do not touch main chuck)
+
+### `UchuckKbveApiClient` (new, `GameInstanceSubsystem`)
+- Wraps `FHttpModule`. Base URL is an `UPROPERTY(EditDefaultsOnly)` / config-backed `FString` (`BaseUrl`, default `https://kbve.com`; set `http://localhost:4321` for local dev).
+- `void SetUsername(const FString& Name, TFunction<void(EchuckSetUsernameResult, const FString& Canonical)> OnResult)` — issues `POST {BaseUrl}/api/v1/profile/username`, header `Authorization: Bearer <UKBVESupabaseSubsystem::GetAccessToken()>`, content-type `application/json`, body `{"username":"<Name>"}`. On completion, maps to a result and invokes `OnResult` on the game thread.
+- **Pure parse function (unit-tested):** `static EchuckSetUsernameResult ParseSetUsernameResult(int32 HttpCode, const FString& Body, FString& OutCanonical)`.
+  - `200` → `Ok`, `OutCanonical` = parsed `username` field (falls back to the requested name if absent).
+  - `400` → `Invalid`.
+  - `401` → `Unauthorized`.
+  - `409` → `Taken`.
+  - `503` → `ServerError`.
+  - any other code → `ServerError`.
+- Transport failure (no HTTP response / `bConnectedSuccessfully == false`) → `NetworkError` (decided in the completion handler, not the pure fn).
+- `enum class EchuckSetUsernameResult : uint8 { Ok, Taken, Invalid, Unauthorized, ServerError, NetworkError }`.
+
+### `SchuckUsernameSetup` (new Slate widget)
+- Editable text box (username), Confirm button, status text block. Styled after `SKBVELoginWidget`.
+- Confirm → disable input + button, set status "Setting…", call `UchuckKbveApiClient::SetUsername`.
+  - `Ok` → call `UKBVESupabaseSubsystem::RefreshSession()`, then fire `OnUsernameSet` delegate (menu proceeds on the subsequent `OnSessionRefreshed`).
+  - `Taken` → status "Username taken — try another", re-enable.
+  - `Invalid` → status "Invalid username", re-enable.
+  - `Unauthorized` → fire `OnSessionExpired` delegate (menu returns to login).
+  - `ServerError` / `NetworkError` → status "Server unavailable — try again", re-enable.
+- Exposes `FSimpleDelegate OnUsernameSet` and `FSimpleDelegate OnSessionExpired` for the menu PC to bind.
+
+### `AchuckMenuPlayerController` gate (extend existing)
+- `RefreshAuthVisibility()` becomes 3-state:
+  - not signed in → show `SKBVELoginWidget`, hide the rest.
+  - signed in **and** `GetUser().KbveUsername.IsEmpty()` → show `SchuckUsernameSetup`, hide login/play.
+  - signed in **and** username present → show the Play/account path.
+- Bind `UKBVESupabaseSubsystem::OnSignedIn` and `OnSessionRefreshed` → `RefreshAuthVisibility()`. Bind `SchuckUsernameSetup::OnSessionExpired` → drop back to the login state (sign-out or re-show login).
+- Construct `SchuckUsernameSetup` lazily alongside the existing login widget in the viewport stack.
+
+### Live server point (edit existing)
+- `AchuckSimgridController::ServerUrl` default → `wss://arpg.kbve.com/ws`. Keep `EditDefaultsOnly` so a local build can override to `ws://localhost:7979/ws` in a Blueprint/instance without code change.
+
+## Data Flow
+
+```
+Menu BeginPlay → UKBVESupabaseSubsystem status
+  Unauth              → SKBVELoginWidget → SignInWithPassword → OnSignedIn ──┐
+  Auth, KbveUsername="" → SchuckUsernameSetup → POST /api/v1/profile/username │
+                          200 → RefreshSession → OnSessionRefreshed ──────────┤
+  Auth, KbveUsername set → Play → OpenLevel(gameplay)                          │
+                          → AchuckSimgridController::BeginPlay                 │
+                          → ConnectToServer("wss://arpg.kbve.com/ws")          │
+                          → EncodeJoinMatch(JWT, KbveUsername)                 │
+        └──────────────────── RefreshAuthVisibility recheck ──────────────────┘
+```
+
+## Error Handling
+
+- `SetUsername` `409` → "taken", re-enable field. `400` → "invalid", re-enable. `401` → session expired → menu returns to login. `503`/transport → "server unavailable — try again", re-enable.
+- `RefreshSession()` failure → `OnSessionRefreshed` still recomputes visibility; if `KbveUsername` is still empty the username widget simply stays shown with a status. No crash.
+- Live connect failure (server down / ns provisioning gaps → `/ws` 503, or a `Reject` frame) surfaces through the existing `USimgridClientSubsystem` `OnRejected` / `OnDisconnected` path; the menu/gameplay HUD shows the existing disconnect messaging. No new handling in this phase.
+
+## Testing
+
+- **`ParseSetUsernameResult` automation tests** (`chuck.KbveApi.*`, guarded `#if WITH_DEV_AUTOMATION_TESTS`) — one assertion per branch:
+  - `200` body `{"success":true,"username":"chad","message":"ok"}` → `Ok`, canonical `"chad"`.
+  - `200` body with no `username` field, requested `"chad"` → `Ok`, canonical `"chad"`.
+  - `400` → `Invalid`. `401` → `Unauthorized`. `409` → `Taken`. `503` → `ServerError`. `500` → `ServerError`.
+- **Widget / menu / live point** — compile-verified in `rentearthEditor` + manual integration: fresh account → username screen → set → enter → confirm connect to `wss://arpg.kbve.com/ws` and render/events live (as in prior phases).
+
+## Out of Scope (Phase 5)
+
+- Packaging / notarize / shippable build (bundle id, `chuckrpg://` scheme, cvar bake pre-sign).
+- Username availability GET pre-check (`GET /api/v1/profile/{username}`) — this phase handles `409` on submit only.
+- Username edit/change UI (only first-time set).
+- Matchmaker / Agones allocation flow (fixed ingress used).
+- Offline / hybrid mode (deferred Phase 2 item).
+
+## Definition of Done
+
+- `UchuckKbveApiClient` posts to `/api/v1/profile/username` with bearer auth; `ParseSetUsernameResult` covers all documented codes; automation tests pass.
+- `SchuckUsernameSetup` widget drives set → refresh → proceed, with the documented error messaging.
+- `AchuckMenuPlayerController` gates login → username → play on the three auth states, bound to the Supabase delegates.
+- `AchuckSimgridController::ServerUrl` defaults to `wss://arpg.kbve.com/ws`.
+- Module compiles in `rentearthEditor`; `chuck.KbveApi.*` tests green.


### PR DESCRIPTION
## Phase 4 — Shortcut Login + Live Point

RentEarth ARPG multiplayer, Phase 4. First-time players set a username in-client; it persists via the axum-kbve profile endpoint and the client points at the live Agones ARPG ingress. All in the rentearth `chuck` fork; main chuck untouched.

### What
- **`UchuckKbveApiClient`** (GameInstanceSubsystem) — `POST /api/v1/profile/username` with the Supabase bearer JWT; pure `ParseSetUsernameResult` maps 200/400/401/409/503 → Ok/Invalid/Unauthorized/Taken/ServerError, transport fail → NetworkError. Config `BaseUrl` (prod `https://kbve.com`, dev override).
- **`SchuckUsernameSetup`** Slate widget — username entry → set → `RefreshSession()` (best-effort JWT re-mint) → advance. Trims input; error messaging per result.
- **`AchuckMenuPlayerController`** — three-state auth gate: login → username setup → play. Advances on the server's canonical username (works for anonymous/implicit-grant sessions where `RefreshSession()` no-ops), so no dead-end loop.
- **`AchuckSimgridController::ServerUrl`** default → `wss://arpg.kbve.com/ws` (fixed ingress). Local dev override retained.

### Auth flow
`kbve_username` JWT claim comes from the auth hook reading the profile store, so setting a username = POST to axum-kbve + refresh. The gate also honors the canonical name returned by the POST, so the session advances even when a token re-mint isn't available.

### Verification
- `chuckEditor` (UE 5.8) builds clean.
- `Chuck.KbveApi.ParseSetUsername.{Ok,OkNoField,Codes}` — **3/3 pass** against the documented response codes.
- Whole-branch opus review: resolved 2 Critical (anon gate dead-end, fragile advance), 2 Important (401 busy-leak, input trim).

### Out of scope (Phase 5)
Packaging/notarize, username availability pre-check, username edit/change, Agones allocation/matchmaker, offline/hybrid mode.

Spec: `docs/superpowers/specs/2026-07-01-rentearth-arpg-phase4-shortcut-login-design.md`
Plan: `docs/superpowers/plans/2026-07-01-rentearth-arpg-phase4-shortcut-login.md`
