### PR TITLE
feat(rn): marketing sections + rn-astro showcase

### DIFF
--- a/apps/kbve/astro-kbve/src/components/marketing/LiveFeed.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/LiveFeed.astro
@@ -1,0 +1,6 @@
+---
+import { LiveFeed } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<LiveFeed client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/ProcessSteps.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/ProcessSteps.astro
@@ -1,0 +1,6 @@
+---
+import { ProcessSteps } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<ProcessSteps client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/Testimonials.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Testimonials.astro
@@ -1,0 +1,6 @@
+---
+import { Testimonials } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<Testimonials client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
@@ -1,0 +1,104 @@
+---
+title: RN-Astro Showcase
+description: Every @kbve/rn-astro marketing section rendered as an MDX island — mobile and web from one RN core.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+---
+
+import Hero from '@/components/marketing/Hero.astro';
+import FeatureGrid from '@/components/marketing/FeatureGrid.astro';
+import StatStrip from '@/components/marketing/StatStrip.astro';
+import ProcessSteps from '@/components/marketing/ProcessSteps.astro';
+import LiveFeed from '@/components/marketing/LiveFeed.astro';
+import ProjectGrid from '@/components/marketing/ProjectGrid.astro';
+import Testimonials from '@/components/marketing/Testimonials.astro';
+import Cta from '@/components/marketing/Cta.astro';
+
+<Hero
+	eyebrow="component showcase"
+	lead="One RN core, "
+	accent="every surface. "
+	tail="Mobile and web."
+	subtitle="These sections are React Native components from @kbve/rn, re-exported through @kbve/rn-astro and mounted here as client:only islands — the same code that ships in the native app."
+	actions={[
+		{ label: 'Browse the Docs', href: '/docs/' },
+		{ label: 'Star on GitHub', href: 'https://github.com/kbve/kbve', variant: 'outline', external: true },
+	]}
+/>
+
+<StatStrip
+	stats={[
+		{ value: '11', label: 'Marketing sections' },
+		{ value: '1', label: 'Shared RN core' },
+		{ value: '2', label: 'Targets: web + native' },
+		{ value: '0', label: 'Duplicated styles' },
+	]}
+/>
+
+<FeatureGrid
+	title="Section library"
+	subtitle="Composable, token-driven, and identical across platforms."
+	features={[
+		{ title: 'Hero', body: 'Responsive headline with accent span, eyebrow, subtitle, and action buttons.' },
+		{ title: 'FeatureGrid', body: 'Self-contained card grid for capabilities, wrapping fluidly on mobile.' },
+		{ title: 'StatStrip', body: 'A bordered band of social-proof numbers that reflows on narrow screens.' },
+		{ title: 'ProcessSteps', body: 'Numbered how-it-works flow — Connect, Build, Ship.' },
+		{ title: 'LiveFeed', body: 'A terminal-style dashboard mockup — the signature showpiece.' },
+		{ title: 'Testimonials', body: 'Quote cards with avatar initials, name, and role.' },
+	]}
+/>
+
+<ProcessSteps
+	title="How it works"
+	subtitle="Author once in RN, render anywhere."
+	steps={[
+		{ title: 'Author in @kbve/rn', body: 'Build the section with React Native primitives and shared design tokens.' },
+		{ title: 'Re-export via rn-astro', body: 'The web-safe barrel exposes each component for Astro to consume.' },
+		{ title: 'Mount as an island', body: 'Drop it into any MDX file with client:only — no browser-breaking prerender.' },
+	]}
+/>
+
+<LiveFeed
+	title="Signature showpiece"
+	label="kbve — live feed"
+	rows={[
+		{ label: 'deploy · axum-kbve', value: '2.1s', status: 'ok' },
+		{ label: 'build · chuck', value: 'passing', status: 'ok' },
+		{ label: 'sync · ci-manifest', value: 'queued', status: 'warn' },
+		{ label: 'agones · cryptothrone', value: 'ready', status: 'ok' },
+	]}
+	footer="12M events/day · 99.9% uptime"
+/>
+
+<ProjectGrid
+	title="Built in the open"
+	subtitle="A few of the worlds and systems we're shipping."
+	projects={[
+		{ name: 'CryptoThrone', tag: 'Isometric MMO', body: 'A seeded, server-authoritative isometric world with a real in-game economy.', href: '/gaming/' },
+		{ name: 'RareIcon', tag: 'Unity DOTS', body: 'A 2D sci-fi action-RPG bullet-hell roguelite built on Burst-compiled ECS.', href: '/gaming/' },
+		{ name: 'Kilobase', tag: 'Postgres Platform', body: 'Supabase-on-CNPG with migrations, auth, and vault — self-hosted and battle-tested.', href: '/docs/' },
+	]}
+/>
+
+<Testimonials
+	title="What people say"
+	subtitle="Placeholder voices — swap in real quotes anytime."
+	items={[
+		{ quote: 'The whole stack is public and it actually runs. Rare to see infra this honest.', name: 'Dev in Residence', role: 'Contributor' },
+		{ quote: 'One component kit across native and web saved us a rewrite. This is the way.', name: 'Platform Lead', role: 'Community' },
+		{ quote: 'Docs, games, and Kubernetes in one monorepo — chaotic in the best way.', name: 'Open Source Fan', role: 'Discord' },
+	]}
+/>
+
+<Cta
+	title="Come build with us."
+	subtitle="Jump into the docs or hang out in the community."
+	actions={[
+		{ label: 'Read the Docs', href: '/docs/' },
+		{ label: 'Join the Discord', href: '/discord/', variant: 'outline' },
+	]}
+/>

--- a/packages/npm/rn-astro/src/components.ts
+++ b/packages/npm/rn-astro/src/components.ts
@@ -27,6 +27,9 @@ export {
 	ProjectCard,
 	ProjectGrid,
 	CtaSection,
+	ProcessSteps,
+	Testimonials,
+	LiveFeed,
 	useTheme,
 	tokens,
 } from '@kbve/rn/ui';
@@ -54,4 +57,7 @@ export type {
 	FeatureCardProps,
 	StatItem,
 	ProjectItem,
+	StepItem,
+	TestimonialItem,
+	FeedRow,
 } from '@kbve/rn/ui';

--- a/packages/npm/rn/src/ui/marketing/sections.tsx
+++ b/packages/npm/rn/src/ui/marketing/sections.tsx
@@ -314,6 +314,163 @@ export const CtaSection = memo(function CtaSection({
 	);
 });
 
+/* ──────────────────────── Process steps ────────────────────── */
+
+export interface StepItem {
+	title: string;
+	body: string;
+}
+
+export const ProcessSteps = memo(function ProcessSteps({
+	title,
+	subtitle,
+	steps,
+}: {
+	title?: string;
+	subtitle?: string;
+	steps: StepItem[];
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.grid}>
+				{steps.map((s, i) => (
+					<View key={s.title} style={styles.step}>
+						<View style={styles.stepNum}>
+							<Text style={styles.stepNumText}>
+								{String(i + 1).padStart(2, '0')}
+							</Text>
+						</View>
+						<Text style={styles.stepTitle}>{s.title}</Text>
+						<Text style={styles.stepBody}>{s.body}</Text>
+					</View>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ──────────────────────── Testimonials ─────────────────────── */
+
+export interface TestimonialItem {
+	quote: string;
+	name: string;
+	role?: string;
+	initials?: string;
+}
+
+export const Testimonials = memo(function Testimonials({
+	title,
+	subtitle,
+	items,
+}: {
+	title?: string;
+	subtitle?: string;
+	items: TestimonialItem[];
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.grid}>
+				{items.map((t) => (
+					<View key={t.name} style={styles.quoteCard}>
+						<Text style={styles.quoteText}>“{t.quote}”</Text>
+						<View style={styles.quoteFoot}>
+							<View style={styles.avatar}>
+								<Text style={styles.avatarText}>
+									{t.initials ??
+										t.name.slice(0, 2).toUpperCase()}
+								</Text>
+							</View>
+							<View style={styles.quoteMeta}>
+								<Text style={styles.quoteName}>{t.name}</Text>
+								{t.role ? (
+									<Text style={styles.quoteRole}>
+										{t.role}
+									</Text>
+								) : null}
+							</View>
+						</View>
+					</View>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ───────────────────────── Live feed ───────────────────────── */
+
+export interface FeedRow {
+	label: string;
+	value: string;
+	status?: 'ok' | 'warn' | 'error';
+}
+
+const statusColor = {
+	ok: tokens.color.success,
+	warn: tokens.color.warning,
+	error: tokens.color.danger,
+} as const;
+
+export const LiveFeed = memo(function LiveFeed({
+	title,
+	label = 'live feed',
+	rows,
+	footer,
+}: {
+	title?: string;
+	label?: string;
+	rows: FeedRow[];
+	footer?: string;
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? <SectionHeading title={title} /> : null}
+			<View style={styles.feed}>
+				<View style={styles.feedBar}>
+					<View style={styles.feedDots}>
+						<View
+							style={[styles.dot, { backgroundColor: '#ef4444' }]}
+						/>
+						<View
+							style={[styles.dot, { backgroundColor: '#f59e0b' }]}
+						/>
+						<View
+							style={[styles.dot, { backgroundColor: '#22c55e' }]}
+						/>
+					</View>
+					<Text style={styles.feedLabel}>{label}</Text>
+					<View style={styles.feedDots} />
+				</View>
+				<View style={styles.feedBody}>
+					{rows.map((r) => (
+						<View key={r.label} style={styles.feedRow}>
+							<View
+								style={[
+									styles.feedStatus,
+									{
+										backgroundColor:
+											statusColor[r.status ?? 'ok'],
+									},
+								]}
+							/>
+							<Text style={styles.feedRowLabel}>{r.label}</Text>
+							<Text style={styles.feedRowValue}>{r.value}</Text>
+						</View>
+					))}
+					{footer ? (
+						<Text style={styles.feedFooter}>{footer}</Text>
+					) : null}
+				</View>
+			</View>
+		</View>
+	);
+});
+
 /* ─────────────────────────── Styles ────────────────────────── */
 
 const styles = StyleSheet.create({
@@ -501,5 +658,127 @@ const styles = StyleSheet.create({
 		fontSize: 18,
 		color: tokens.color.textMuted,
 		textAlign: 'center',
+	},
+
+	step: {
+		flex: 1,
+		minWidth: 220,
+		gap: tokens.space.sm,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	stepNum: {
+		width: 44,
+		height: 44,
+		borderRadius: tokens.radius.pill,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: tokens.color.surfaceAlt,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		marginBottom: tokens.space.xs,
+	},
+	stepNumText: {
+		fontSize: 16,
+		fontWeight: '800',
+		color: tokens.color.primary,
+	},
+	stepTitle: { fontSize: 18, fontWeight: '700', color: tokens.color.text },
+	stepBody: { fontSize: 14, lineHeight: 21, color: tokens.color.textMuted },
+
+	quoteCard: {
+		flex: 1,
+		minWidth: 280,
+		gap: tokens.space.lg,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	quoteText: {
+		fontSize: 16,
+		lineHeight: 25,
+		color: tokens.color.text,
+	},
+	quoteFoot: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.md,
+	},
+	avatar: {
+		width: 42,
+		height: 42,
+		borderRadius: tokens.radius.pill,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: tokens.color.surfaceAlt,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	avatarText: {
+		fontSize: 13,
+		fontWeight: '800',
+		color: tokens.color.primary,
+	},
+	quoteMeta: { gap: 2 },
+	quoteName: { fontSize: 14, fontWeight: '700', color: tokens.color.text },
+	quoteRole: { fontSize: 12, color: tokens.color.textMuted },
+
+	feed: {
+		width: '100%',
+		maxWidth: 640,
+		alignSelf: 'center',
+		borderRadius: tokens.radius.xl,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		backgroundColor: tokens.color.bg,
+		overflow: 'hidden',
+	},
+	feedBar: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: tokens.space.sm,
+		borderBottomWidth: 1,
+		borderBottomColor: tokens.color.border,
+		backgroundColor: tokens.color.surface,
+	},
+	feedDots: { flexDirection: 'row', gap: 6, width: 52 },
+	dot: { width: 11, height: 11, borderRadius: tokens.radius.pill },
+	feedLabel: {
+		fontSize: 12,
+		letterSpacing: 1,
+		color: tokens.color.textMuted,
+	},
+	feedBody: { padding: tokens.space.lg, gap: tokens.space.sm },
+	feedRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+	},
+	feedStatus: { width: 8, height: 8, borderRadius: tokens.radius.pill },
+	feedRowLabel: {
+		flex: 1,
+		fontSize: 13,
+		color: tokens.color.text,
+	},
+	feedRowValue: {
+		fontSize: 13,
+		fontWeight: '700',
+		color: tokens.color.primary,
+	},
+	feedFooter: {
+		marginTop: tokens.space.xs,
+		paddingTop: tokens.space.sm,
+		borderTopWidth: 1,
+		borderTopColor: tokens.color.border,
+		fontSize: 12,
+		letterSpacing: 1,
+		color: tokens.color.textMuted,
 	},
 });


### PR DESCRIPTION
## Summary
Three new RN marketing sections in `@kbve/rn/ui/marketing`, re-exported through `@kbve/rn-astro`, and a full showcase page.

- **ProcessSteps** — numbered how-it-works flow, wraps on mobile
- **Testimonials** — quote cards with avatar-initials, name, role
- **LiveFeed** — terminal-style dashboard mockup (traffic-light dots, status rows, footer) — the signature showpiece

All token-driven (dark-gold theme), flow through both the native (`index.ts`) and web-safe (`index.web.ts`) barrels.

## Wiring
- `@kbve/rn-astro` barrel: 3 components + `StepItem` / `TestimonialItem` / `FeedRow` types
- Astro wrappers: `ProcessSteps.astro` / `Testimonials.astro` / `LiveFeed.astro` (`client:only`, no nav)
- New page: `/lab/showcase/` renders all 8 sections from one shared RN core (web + native)

## Verify
- `tsc --noEmit` on rn-astro: clean