### PR TITLE
docs(astro-kbve): SEO audit batch 1 for application docs + sem tracking

### DIFF
--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -254,6 +254,7 @@ export const collections = {
 				img: z.string().optional(),
 				category: z.string().optional(),
 				tags: z.array(z.string()).optional(),
+				sem: z.number().int().optional(),
 				// Per-page social-meta overrides consumed by
 				// src/components/navigation/Head.astro. Astro silently strips
 				// nested z.object fields imported across zod-package boundaries

--- a/apps/kbve/astro-kbve/src/content/docs/application/docker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/docker.mdx
@@ -1,12 +1,38 @@
 ---
 title: Docker
 description: |
-    A hybrid-source application designed to deploy nested-virtual machines that are containerized applications.
+    Docker packages applications and their dependencies into portable containers that run identically across
+    machines. This reference covers the Docker CLI cheatsheet, every Dockerfile instruction (FROM, RUN, CMD,
+    ENTRYPOINT, and more), GPU passthrough, BuildX, WatchTower, and container management scripts.
 sidebar:
     label: Docker
     order: 100
 unsplash: 1605745341112-85968b19335b
 img: https://images.unsplash.com/photo-1605745341112-85968b19335b?fit=crop&w=1400&h=700&q=75
+tags:
+    - containers
+    - devops
+    - virtualization
+sem: 1
+ogTitle: Docker Reference — CLI Cheatsheet, Dockerfile Instructions & BuildX
+ogDescription: A practical Docker reference — the CLI cheatsheet, every Dockerfile instruction explained, GPU passthrough, BuildX multi-arch builds, WatchTower auto-updates, and management scripts.
+jsonld:
+    type: Article
+    keywords:
+        - docker
+        - dockerfile
+        - containers
+        - buildx
+        - docker cli
+    faq:
+        - question: What is the difference between CMD and ENTRYPOINT in a Dockerfile?
+          answer: ENTRYPOINT sets the executable that always runs and is not overridden by arguments passed to docker run. CMD provides default arguments that are easily overridden. Use ENTRYPOINT for the fixed command and CMD for its default flags.
+        - question: What is the difference between ADD and COPY?
+          answer: COPY only copies local files and directories into the image. ADD does the same but also unpacks local tar archives and can fetch remote URLs. Prefer COPY unless you specifically need ADD's extraction behavior.
+        - question: How do I reduce Docker image size?
+          answer: Use a small base image like alpine, combine RUN steps to reduce layers, leverage multi-stage builds to drop build-time dependencies, and add a .dockerignore to keep unneeded files out of the build context.
+        - question: What is Docker BuildX used for?
+          answer: BuildX is Docker's extended build engine built on BuildKit. It enables multi-platform (multi-arch) images, better caching, and building for architectures other than the host, such as arm64 images from an amd64 machine.
 ---
 
 import {
@@ -20,6 +46,11 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
+
+Docker packages an application and its dependencies into a **container** — an isolated, portable unit that runs identically on any machine with a Docker engine. Unlike a full virtual machine, containers share the host kernel, so they start in seconds and use far less memory. A `Dockerfile` describes how to build the image; `docker run` launches a container from it.
+
+This page is a working reference: the [CLI cheatsheet](#cheatsheet) for day-to-day commands, every [Dockerfile instruction](#dockerfile) explained, plus [GPU passthrough](#gpu), [BuildX](#buildx) multi-arch builds, [WatchTower](#watchtower) auto-updates, and management [scripts](#scripts).
 
 ## Tools
 
@@ -801,6 +832,24 @@ This script includes the following enhancements:
 
 Save this script to a file, for example, `docker_manage.sh`, make it executable with `chmod +x docker_manage.sh`, and then run it with `./docker_manage.sh`.
 
+
+---
+
+## FAQ
+
+**What is the difference between CMD and ENTRYPOINT in a Dockerfile?**
+`ENTRYPOINT` sets the executable that always runs and is not overridden by arguments passed to `docker run`. `CMD` provides default arguments that are easily overridden. Use `ENTRYPOINT` for the fixed command and `CMD` for its default flags.
+
+**What is the difference between ADD and COPY?**
+`COPY` only copies local files and directories into the image. `ADD` does the same but also unpacks local tar archives and can fetch remote URLs. Prefer `COPY` unless you specifically need `ADD`'s extraction behavior.
+
+**How do I reduce Docker image size?**
+Use a small base image like `alpine`, combine `RUN` steps to reduce layers, leverage multi-stage builds to drop build-time dependencies, and add a `.dockerignore` to keep unneeded files out of the build context.
+
+**What is Docker BuildX used for?**
+BuildX is Docker's extended build engine built on BuildKit. It enables multi-platform (multi-arch) images, better caching, and building for architectures other than the host, such as `arm64` images from an `amd64` machine.
+
+<Adsense />
 
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/docker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/docker.mdx
@@ -33,6 +33,14 @@ jsonld:
           answer: Use a small base image like alpine, combine RUN steps to reduce layers, leverage multi-stage builds to drop build-time dependencies, and add a .dockerignore to keep unneeded files out of the build context.
         - question: What is Docker BuildX used for?
           answer: BuildX is Docker's extended build engine built on BuildKit. It enables multi-platform (multi-arch) images, better caching, and building for architectures other than the host, such as arm64 images from an amd64 machine.
+        - question: What is the difference between a Docker image and a container?
+          answer: An image is an immutable, layered template built from a Dockerfile. A container is a running (or stopped) instance of an image with its own writable layer. One image can spawn many containers.
+        - question: How do I persist data in Docker?
+          answer: Use a named volume (docker volume create, mounted with -v name:/path) for durable storage managed by Docker, or a bind mount to map a host directory into the container. Data written to the container's own writable layer is lost when the container is removed.
+        - question: What is Docker Compose used for?
+          answer: Compose defines a multi-container application in one docker-compose.yml file. A single docker compose up -d starts every service, creates a shared network so they resolve each other by name, and provisions named volumes for persistence.
+        - question: How do multi-stage builds reduce image size?
+          answer: A multi-stage build compiles the application in a heavy build stage with all toolchains, then copies only the final artifact into a minimal runtime stage. The build dependencies never ship in the final image, shrinking it significantly.
 ---
 
 import {
@@ -832,6 +840,75 @@ This script includes the following enhancements:
 
 Save this script to a file, for example, `docker_manage.sh`, make it executable with `chmod +x docker_manage.sh`, and then run it with `./docker_manage.sh`.
 
+
+---
+
+## Docker Compose
+
+Compose defines a multi-container app in a single declarative `docker-compose.yml`, replacing long `docker run` invocations. One `docker compose up -d` starts the whole stack; `docker compose down` tears it down.
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - db
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:
+```
+
+`depends_on` controls start order, `environment` injects config, and the named `db-data` volume persists the database across restarts. Compose also creates a default bridge network so services reach each other by name (`web` can connect to `db:5432`).
+
+| Command | Action |
+| ------- | ------ |
+| `docker compose up -d` | Start the stack in the background |
+| `docker compose down` | Stop and remove containers + network |
+| `docker compose logs -f web` | Follow logs for one service |
+| `docker compose ps` | List running services |
+| `docker compose exec web sh` | Open a shell in a running service |
+
+## Volumes and Networks
+
+Containers are ephemeral — anything written to the container's writable layer is lost when it is removed. **Volumes** provide durable storage; **networks** provide isolated communication.
+
+- **Named volume** — `docker volume create data` then mount with `-v data:/path`. Managed by Docker, ideal for databases.
+- **Bind mount** — `-v $(pwd):/app` maps a host directory into the container, ideal for live-reloading source during development.
+- **Bridge network** — `docker network create appnet` lets containers on the same network resolve each other by name, isolated from other stacks.
+
+```bash
+docker network create appnet
+docker run -d --name db --network appnet postgres:16-alpine
+docker run -d --name web --network appnet -p 8080:80 myapp
+```
+
+## Best Practices
+
+<Steps>
+
+1. **Use small base images** — `alpine` or `-slim` variants cut image size and attack surface dramatically.
+
+2. **Leverage multi-stage builds** — Compile in a heavy build stage, then `COPY` only the artifact into a minimal runtime stage.
+
+3. **Add a `.dockerignore`** — Keep `node_modules`, `.git`, and secrets out of the build context for faster, safer builds.
+
+4. **Order layers by change frequency** — Copy dependency manifests and install before copying source, so the dependency layer stays cached across code edits.
+
+5. **Run as a non-root user** — Add a `USER` instruction so a container breakout doesn't grant host root.
+
+6. **One process per container** — Keep containers single-purpose; use Compose to orchestrate multiple services.
+
+</Steps>
 
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/nginx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/nginx.mdx
@@ -1,7 +1,9 @@
 ---
 title: Nginx
 description: |
-    Linux. Da Penguin.
+    Nginx is a high-performance web server, reverse proxy, and load balancer used to serve static content,
+    terminate TLS, and route traffic to upstream applications. This guide covers a minimal server block,
+    a wildcard virtual host, and the KBVE reverse-proxy configuration.
 sidebar:
     label: Nginx
     order: 1041
@@ -10,6 +12,27 @@ img: https://images.unsplash.com/photo-1551609189-eba71b3a8566?fit=crop&w=1400&h
 tags:
     - network
     - webserver
+    - reverse-proxy
+sem: 1
+ogTitle: Nginx Configuration Guide — Reverse Proxy, TLS & Virtual Hosts
+ogDescription: Practical Nginx configuration examples — a minimal server block, wildcard virtual hosts, and a reverse proxy that terminates TLS and forwards to upstream apps.
+jsonld:
+    type: Article
+    keywords:
+        - nginx
+        - reverse proxy
+        - web server
+        - load balancer
+        - tls termination
+    faq:
+        - question: What is Nginx used for?
+          answer: Nginx is a web server that also works as a reverse proxy, load balancer, and TLS terminator. It serves static files directly and forwards dynamic requests to upstream application servers.
+        - question: Where is the main Nginx configuration file?
+          answer: The primary file is /etc/nginx/nginx.conf. Site-specific server blocks usually live in /etc/nginx/conf.d/ or /etc/nginx/sites-available/ and are enabled by symlinking into sites-enabled.
+        - question: How do I reload Nginx without dropping connections?
+          answer: Run nginx -t to validate the configuration, then nginx -s reload (or systemctl reload nginx). A reload applies new config with a graceful worker restart and no dropped connections, unlike a full restart.
+        - question: What is a reverse proxy in Nginx?
+          answer: A reverse proxy accepts client requests and forwards them to one or more backend servers using proxy_pass. Nginx handles TLS, caching, and load balancing in front of the application, which never faces the client directly.
 ---
 
 import {
@@ -23,12 +46,127 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
+
+Nginx is a high-performance web server and reverse proxy. It serves static assets directly from disk, terminates TLS, and forwards dynamic requests to upstream application servers over HTTP or a Unix socket. A single Nginx instance can front dozens of virtual hosts, each defined by a `server` block that matches on `server_name` and port.
+
+This guide walks through three configurations in order of complexity: a minimal single-site block, a wildcard virtual host that serves many subdomains, and the KBVE reverse-proxy pattern that terminates TLS and load-balances upstream containers.
+
+<Aside type="note">
+Nginx loads `/etc/nginx/nginx.conf` at startup. Site blocks are conventionally split into `/etc/nginx/conf.d/*.conf` or `sites-available/` (symlinked into `sites-enabled/`). Always validate with `nginx -t` before reloading.
+</Aside>
+
+<Adsense />
+
+## Configuration Flow
+
+<Steps>
+
+1. **Write a server block** — Define `listen`, `server_name`, and either a `root` (static) or `proxy_pass` (reverse proxy).
+
+2. **Validate the syntax** — Run `nginx -t`. Nginx checks every included file and reports the exact line on error.
+
+3. **Reload gracefully** — Run `nginx -s reload` or `systemctl reload nginx`. Workers restart without dropping active connections.
+
+4. **Verify** — `curl -I https://your-host` confirms the status code, TLS, and upstream headers.
+
+</Steps>
+
 ## Nginx Configuration
 
-This is a default example of a Nginx configuration file.
+This is a default example of an Nginx configuration file. Each `server` block is self-contained; drop it in `conf.d/` and reload.
+
+### Minimal Static Server Block
+
+The simplest useful config: serve static files from a document root over port 80.
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    root /var/www/example;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+```
+
+`try_files` attempts the exact URI, then the URI as a directory, then returns `404` — this is the correct pattern for a static site and avoids exposing the filesystem.
 
 ### Example WildCard Nginx Configuration
 
+A wildcard `server_name` matches every subdomain, letting one block serve `*.example.com`. The captured subdomain maps to a per-tenant document root.
+
+```nginx
+server {
+    listen 80;
+    server_name ~^(?<sub>.+)\.example\.com$;
+
+    root /var/www/tenants/$sub;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+```
+
+The named capture `(?<sub>.+)` is reused in `root`, so a request to `alice.example.com` serves `/var/www/tenants/alice`. Pair this with a wildcard TLS certificate (`*.example.com`) to terminate HTTPS for every tenant from one block.
+
 ### Example KBVE Nginx Configuration
+
+The KBVE pattern terminates TLS and reverse-proxies to an upstream application (for example a container listening on `127.0.0.1:8000`). It forwards the original host and client IP so the backend sees real request metadata.
+
+```nginx
+upstream kbve_app {
+    server 127.0.0.1:8000;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name kbve.com;
+
+    ssl_certificate     /etc/nginx/ssl/kbve.crt;
+    ssl_certificate_key /etc/nginx/ssl/kbve.key;
+
+    location / {
+        proxy_pass http://kbve_app;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 80;
+    server_name kbve.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+The second `server` block issues a `301` redirect from HTTP to HTTPS so no plaintext traffic reaches the app. The `upstream` block with `keepalive` reuses backend connections, cutting latency under load.
+
+<Aside type="tip">
+After editing, always run `nginx -t` first. It validates every included file and prints the offending line number on error, so you never reload a broken config into production.
+</Aside>
+
+## FAQ
+
+**What is Nginx used for?**
+Nginx is a web server that also works as a reverse proxy, load balancer, and TLS terminator. It serves static files directly and forwards dynamic requests to upstream application servers.
+
+**Where is the main Nginx configuration file?**
+The primary file is `/etc/nginx/nginx.conf`. Site-specific server blocks usually live in `/etc/nginx/conf.d/` or `/etc/nginx/sites-available/` and are enabled by symlinking into `sites-enabled/`.
+
+**How do I reload Nginx without dropping connections?**
+Run `nginx -t` to validate the configuration, then `nginx -s reload` (or `systemctl reload nginx`). A reload applies new config with a graceful worker restart and no dropped connections, unlike a full restart.
+
+**What is a reverse proxy in Nginx?**
+A reverse proxy accepts client requests and forwards them to one or more backend servers using `proxy_pass`. Nginx handles TLS, caching, and load balancing in front of the application, which never faces the client directly.
 
 <Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/nginx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/nginx.mdx
@@ -33,6 +33,12 @@ jsonld:
           answer: Run nginx -t to validate the configuration, then nginx -s reload (or systemctl reload nginx). A reload applies new config with a graceful worker restart and no dropped connections, unlike a full restart.
         - question: What is a reverse proxy in Nginx?
           answer: A reverse proxy accepts client requests and forwards them to one or more backend servers using proxy_pass. Nginx handles TLS, caching, and load balancing in front of the application, which never faces the client directly.
+        - question: How do I load balance across multiple servers with Nginx?
+          answer: Define an upstream block listing each backend server, then point proxy_pass at that upstream. Nginx defaults to round-robin and also supports least_conn and ip_hash. Use weight, backup, and max_fails to tune distribution and failover.
+        - question: What causes a 502 Bad Gateway error in Nginx?
+          answer: A 502 means Nginx reached the proxy_pass target but received no valid response — usually the upstream application is down or listening on a different port or socket. Verify the backend with curl on the host and check the Nginx error log.
+        - question: How do I enable Gzip compression in Nginx?
+          answer: Set gzip on and list the MIME types to compress with gzip_types (text/html is always compressed). Combine it with expires and Cache-Control headers on static assets to reduce payload size and improve Core Web Vitals.
 ---
 
 import {
@@ -154,6 +160,89 @@ The second `server` block issues a `301` redirect from HTTP to HTTPS so no plain
 <Aside type="tip">
 After editing, always run `nginx -t` first. It validates every included file and prints the offending line number on error, so you never reload a broken config into production.
 </Aside>
+
+## Load Balancing
+
+An `upstream` block can list multiple backends, turning Nginx into a load balancer. The default method is round-robin; Nginx also supports `least_conn` (send to the backend with the fewest active connections) and `ip_hash` (pin a client to one backend for session stickiness).
+
+```nginx
+upstream kbve_pool {
+    least_conn;
+    server 10.0.0.11:8000 weight=3;
+    server 10.0.0.12:8000;
+    server 10.0.0.13:8000 backup;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name kbve.com;
+
+    location / {
+        proxy_pass http://kbve_pool;
+        proxy_set_header Host $host;
+    }
+}
+```
+
+| Directive | Behavior |
+| --------- | -------- |
+| `weight=N` | Send proportionally more traffic to this backend |
+| `backup`   | Only used when all primary backends are down |
+| `max_fails` / `fail_timeout` | Mark a backend unhealthy after N failures |
+| `least_conn` | Route to the least-busy backend |
+| `ip_hash` | Sticky sessions by client IP |
+
+## Performance: Gzip and Caching
+
+Compression and static-asset caching are two of the highest-impact, lowest-effort SEO wins — smaller, faster responses improve Core Web Vitals, which Google uses as a ranking signal.
+
+```nginx
+gzip on;
+gzip_comp_level 5;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;
+gzip_min_length 256;
+
+location ~* \.(?:css|js|jpg|jpeg|png|gif|ico|woff2)$ {
+    expires 30d;
+    add_header Cache-Control "public, immutable";
+}
+```
+
+`gzip_types` must list every MIME type to compress (`text/html` is always compressed and cannot be listed). The `immutable` cache directive tells browsers never to revalidate fingerprinted assets, eliminating conditional requests.
+
+## Security Headers
+
+Add baseline security headers in the `server` block. These harden the site against clickjacking, MIME sniffing, and mixed content, and are checked by security scanners that can influence trust signals.
+
+```nginx
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+```
+
+<Aside type="caution">
+Only enable HSTS (`Strict-Transport-Security`) once you are certain every subdomain serves valid HTTPS. The `preload` directive is hard to reverse — browsers cache the policy for up to two years.
+</Aside>
+
+## Troubleshooting
+
+<Steps>
+
+1. **`nginx -t` fails** — Read the printed file and line number. The most common cause is a missing semicolon or an unclosed block.
+
+2. **502 Bad Gateway** — Nginx reached the `proxy_pass` target but got no valid response. The upstream is down or bound to a different port/socket. Check with `curl 127.0.0.1:8000` on the host.
+
+3. **504 Gateway Timeout** — The upstream is too slow. Raise `proxy_read_timeout`, or fix the backend.
+
+4. **403 Forbidden on static files** — The Nginx worker user (`www-data` or `nginx`) lacks read permission on `root`, or SELinux is blocking it. Check `ls -l` and the error log.
+
+5. **Changes not taking effect** — You edited the config but did not reload. Run `nginx -s reload`, and confirm you edited the file actually included by `nginx.conf`.
+
+</Steps>
+
+Logs live at `/var/log/nginx/access.log` and `/var/log/nginx/error.log` by default — the error log is where upstream and permission failures surface.
 
 ## FAQ
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/redis.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/redis.mdx
@@ -1,8 +1,10 @@
 ---
 title: Redis
 description: |
-    Redis is an open-source, in-memory data structure store, used as a database, cache, and message broker.
-    Known for its speed and efficiency, Redis supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs, geospatial indexes, and streams.
+    Redis is an open-source, in-memory data structure store used as a database, cache, and message broker.
+    This guide covers running Redis with Docker Compose, deploying it on Kubernetes as a StatefulSet, and
+    connecting with the redis-cli. Redis supports strings, hashes, lists, sets, sorted sets, bitmaps,
+    hyperloglogs, geospatial indexes, and streams.
 sidebar:
     label: Redis
     order: 1420
@@ -10,6 +12,28 @@ unsplash: 1553413077-190dd305871c
 img: https://images.unsplash.com/photo-1553413077-190dd305871c?fit=crop&w=1400&h=700&q=75
 tags:
     - database
+    - cache
+    - in-memory
+sem: 1
+ogTitle: Redis Guide — Docker Compose, Kubernetes & redis-cli
+ogDescription: Run Redis with Docker Compose, deploy it on Kubernetes as a StatefulSet, and connect using redis-cli. Practical, copy-paste configuration for the in-memory data store.
+jsonld:
+    type: Article
+    keywords:
+        - redis
+        - in-memory database
+        - cache
+        - docker compose
+        - kubernetes statefulset
+    faq:
+        - question: Is Redis a database or a cache?
+          answer: Both. Redis is an in-memory data structure store that can act as a primary database, a cache in front of a slower store, or a message broker. Persistence options (RDB snapshots and AOF logs) let it survive restarts when used as a database.
+        - question: How do I run Redis with Docker Compose?
+          answer: Define a redis service using the official redis image, expose port 6379, pass a password with --requirepass, and mount a named volume at /data for persistence. Then run docker compose up -d.
+        - question: Why deploy Redis as a StatefulSet on Kubernetes?
+          answer: A StatefulSet gives each Redis pod a stable network identity and persistent volume that survive rescheduling. This is required for data durability and for replication, where replicas must reliably find the primary.
+        - question: How do I connect to a Redis instance from the command line?
+          answer: Use redis-cli -h <host> -p <port> -a <password>. Inside Docker, exec into the container first, for example docker exec -it kilobase-redis redis-cli -a redispassword.
 ---
 
 import {
@@ -22,6 +46,10 @@ import {
 } from '@astrojs/starlight/components';
 
 import { Giscus, Adsense } from '@/components/astropad';
+
+## Overview
+
+Redis is an in-memory data structure store used as a cache, database, and message broker. It keeps data in RAM for microsecond reads and writes, with optional disk persistence (RDB snapshots and AOF logs) so data survives restarts. This guide runs Redis three ways — with Docker Compose for local development, on Kubernetes as a StatefulSet for production, and directly through the `redis-cli` for testing and debugging.
 
 ## Information
 
@@ -43,6 +71,26 @@ The real transformation comes in how this integration redefines development work
 With Docker Compose, developers can simulate production-like conditions on their local machines, eliminating the common discrepancies between development and production environments.
 This approach not only improves efficiency and precision during the development phase but also significantly boosts developers' confidence.
 By testing and iterating in an environment that closely mirrors the final production setting, developers can ensure higher quality and reliability in their deployments.
+
+A minimal `docker-compose.yml` runs a password-protected Redis with a persistent volume:
+
+```yaml
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: kilobase-redis
+    command: ["redis-server", "--requirepass", "redispassword", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+
+volumes:
+  redis-data:
+```
+
+Bring it up with `docker compose up -d`. The `--appendonly yes` flag enables AOF persistence so data survives container restarts, and the named `redis-data` volume keeps it across `docker compose down`.
 
 ## Redis on Kubernetes
 
@@ -91,3 +139,19 @@ To access the kilobase redis or any docker instance:
 `docker exec -it kilobase-redis redis-cli -a redispassword`
 
 </Aside>
+
+## FAQ
+
+**Is Redis a database or a cache?**
+Both. Redis is an in-memory data structure store that can act as a primary database, a cache in front of a slower store, or a message broker. Persistence options (RDB snapshots and AOF logs) let it survive restarts when used as a database.
+
+**How do I run Redis with Docker Compose?**
+Define a `redis` service using the official `redis` image, expose port `6379`, pass a password with `--requirepass`, and mount a named volume at `/data` for persistence. Then run `docker compose up -d`.
+
+**Why deploy Redis as a StatefulSet on Kubernetes?**
+A StatefulSet gives each Redis pod a stable network identity and persistent volume that survive rescheduling. This is required for data durability and for replication, where replicas must reliably find the primary.
+
+**How do I connect to a Redis instance from the command line?**
+Use `redis-cli -h <host> -p <port> -a <password>`. Inside Docker, exec into the container first, for example `docker exec -it kilobase-redis redis-cli -a redispassword`.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/redis.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/redis.mdx
@@ -34,6 +34,14 @@ jsonld:
           answer: A StatefulSet gives each Redis pod a stable network identity and persistent volume that survive rescheduling. This is required for data durability and for replication, where replicas must reliably find the primary.
         - question: How do I connect to a Redis instance from the command line?
           answer: Use redis-cli -h <host> -p <port> -a <password>. Inside Docker, exec into the container first, for example docker exec -it kilobase-redis redis-cli -a redispassword.
+        - question: What is the difference between RDB and AOF persistence in Redis?
+          answer: RDB writes periodic point-in-time snapshots — compact and fast to restore, but you can lose data since the last snapshot. AOF logs every write command and replays it on restart, giving far better durability at the cost of larger files. They can be enabled together.
+        - question: Which Redis data structure should I use for a leaderboard?
+          answer: A sorted set (ZSET). Members are ranked by a score, so ZADD updates a player's score and ZREVRANGE returns the top N in O(log N) time — far more efficient than sorting a list on every read.
+        - question: Why should I avoid KEYS in production Redis?
+          answer: KEYS scans the entire keyspace and blocks the single-threaded server until it finishes, stalling all other clients. Use SCAN instead, which returns keys in small cursor-based batches without blocking.
+        - question: Does Redis lose data when it restarts?
+          answer: Only if persistence is disabled. With RDB snapshots or AOF enabled (and a mounted volume in Docker or Kubernetes), Redis reloads its dataset on startup. A pure in-memory cache with no persistence starts empty after a restart.
 ---
 
 import {
@@ -59,6 +67,34 @@ This allows applications to swiftly locate and access objects based on attribute
 When used in this capacity, Redis enhances storage architectures by providing rapid, real-time insights into vast data landscapes without compromising on efficiency or performance.
 
 <Adsense />
+
+## Core Data Structures
+
+Redis is more than a key-value cache — each value can be one of several native data structures, each with commands optimized for a specific access pattern.
+
+| Structure | Description | Common Use |
+| --------- | ----------- | ---------- |
+| **String** | Binary-safe value up to 512 MB | Cache, counters (`INCR`), flags |
+| **Hash** | Field-value map under one key | Store an object (user profile) compactly |
+| **List** | Ordered, linked list | Queues, activity feeds (`LPUSH`/`BRPOP`) |
+| **Set** | Unordered unique members | Tags, unique visitors, membership tests |
+| **Sorted Set** | Members ranked by score | Leaderboards, rate limiting, priority queues |
+| **Stream** | Append-only log with consumer groups | Event sourcing, message queues |
+| **Bitmap / HyperLogLog** | Space-efficient counting | Daily active users, cardinality estimates |
+
+Choosing the right structure is the single biggest Redis performance decision — a sorted set leaderboard answers "top 10" in `O(log N)` where a naive list would be `O(N log N)`.
+
+## Persistence: RDB vs AOF
+
+By default Redis holds data in RAM, but it offers two persistence modes so data survives restarts. They can run together.
+
+- **RDB (snapshots)** — Periodically forks and writes a compact point-in-time dump (`dump.rdb`). Fast restarts and small files, but you can lose everything since the last snapshot on a crash.
+- **AOF (append-only file)** — Logs every write command and replays it on restart. Far more durable (`appendfsync everysec` loses at most one second), at the cost of larger files and slightly slower writes.
+
+<Aside type="tip">
+For a cache, RDB alone is fine — losing a few seconds of cache is harmless. For Redis as a primary datastore, enable AOF (`--appendonly yes`) for durability, optionally alongside RDB for fast restarts.
+</Aside>
+
 ## Redis Docker Integration
 
 ### Using Docker Compose
@@ -112,6 +148,56 @@ Deploying Redis on Kubernetes offers scalable and resilient solutions for managi
 
 Deploying Redis with Kubernetes not only improves operational efficiency but also leverages cutting-edge technology to support dynamic, large-scale applications.
 
+A minimal StatefulSet with a headless Service and a per-pod persistent volume:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          args: ["--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+```
+
+The `clusterIP: None` headless Service gives each pod a stable DNS name (`redis-0.redis`), and `volumeClaimTemplates` provisions a dedicated PVC per replica so data survives rescheduling.
+
 * * *
 
 ### Redis CLI
@@ -138,6 +224,32 @@ To access the kilobase redis or any docker instance:
 
 `docker exec -it kilobase-redis redis-cli -a redispassword`
 
+</Aside>
+
+### Essential Commands
+
+Once connected, these cover most day-to-day operations:
+
+```shell
+SET user:1 "alice"        # store a string
+GET user:1                # read it back
+EXPIRE user:1 3600        # auto-delete after 1 hour
+TTL user:1                # seconds remaining
+
+HSET user:2 name bob age 30   # store a hash
+HGETALL user:2                # read the whole hash
+
+INCR page:views           # atomic counter
+ZADD board 100 alice      # sorted set for leaderboards
+ZREVRANGE board 0 9 WITHSCORES  # top 10
+
+KEYS *                    # list keys (avoid in production)
+SCAN 0 MATCH user:*       # cursor-based, production-safe
+INFO memory               # memory + stats
+```
+
+<Aside type="caution">
+Never run `KEYS *` on a busy production instance — it blocks the single-threaded server while it scans every key. Use `SCAN`, which iterates in small cursor-based batches.
 </Aside>
 
 ## FAQ

--- a/apps/kbve/astro-kbve/src/content/docs/application/traefik.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/traefik.mdx
@@ -1,12 +1,38 @@
 ---
 title: Traefik
 description: |
-    A cloud native application proxy that utilizes a modern HTTP reverse-proxy and load balancer.
+    Traefik is a cloud-native reverse proxy and load balancer with automatic service discovery and Let's Encrypt TLS.
+    This guide covers running Traefik with Docker Compose, patching and installing it on a Kubernetes (k3s) cluster,
+    wiring BasicAuth middleware, and automating Cloudflare DNS challenges for ACME certificates.
 sidebar:
     label: Traefik
     order: 1040
 unsplash: 1524419986249-348e8fa6ad4a
 img: https://images.unsplash.com/photo-1524419986249-348e8fa6ad4a?fit=crop&w=1400&h=700&q=75
+tags:
+    - network
+    - reverse-proxy
+    - kubernetes
+sem: 1
+ogTitle: Traefik Guide — Docker, Kubernetes CRDs, Middleware & Cloudflare TLS
+ogDescription: Configure Traefik as a cloud-native reverse proxy — Docker Compose setup, k3s patching, Custom Resource Definitions, BasicAuth middleware, and automated Cloudflare ACME certificates.
+jsonld:
+    type: Article
+    keywords:
+        - traefik
+        - reverse proxy
+        - kubernetes ingress
+        - middleware
+        - cloudflare acme
+    faq:
+        - question: What is Traefik?
+          answer: Traefik is a cloud-native reverse proxy and load balancer that automatically discovers services from providers like Docker and Kubernetes, and provisions Let's Encrypt TLS certificates without manual configuration.
+        - question: How is Traefik different from Nginx?
+          answer: Traefik discovers routes dynamically from labels and CRDs, so it reconfigures itself as containers start and stop. Nginx uses static config files that require a reload. Traefik also ships automatic ACME TLS, whereas Nginx needs an external tool like certbot.
+        - question: What is a Traefik middleware?
+          answer: Middleware modifies requests or responses as they pass through a router — for example BasicAuth, rate limiting, or header rewrites. On Kubernetes it is a Middleware CRD referenced from an Ingress or IngressRoute by namespace-qualified name.
+        - question: How does Traefik get TLS certificates from Cloudflare?
+          answer: Traefik uses the ACME DNS-01 challenge with Cloudflare's API. You supply a scoped API token (DNS:Edit and Zone:Read) via environment variables, and Traefik creates the required DNS TXT record automatically to prove domain ownership.
 ---
 
 import {
@@ -20,9 +46,23 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-## Information
+## Overview
 
-Traefik is a cloud-hybrid reverse proxy and load balancer that makes deploying, configuring and integrating infrastructure components easy and automatic.
+Traefik is a cloud-native reverse proxy and load balancer that makes deploying, configuring, and integrating infrastructure components easy and automatic. Unlike a static proxy, Traefik discovers services dynamically from providers — Docker labels, Kubernetes CRDs, or file config — and reconfigures its routes as containers start and stop. It also provisions Let's Encrypt TLS certificates automatically.
+
+This guide moves from local to production: run Traefik with Docker Compose, patch and install it on a k3s Kubernetes cluster, attach BasicAuth middleware, and automate Cloudflare DNS challenges for ACME certificates.
+
+<Steps>
+
+1. **Docker** — Stand up Traefik locally with Compose and an `acme.json` for certificates.
+
+2. **Kubernetes** — Install the CRDs and RBAC, then patch the service and add Helm.
+
+3. **Middleware** — Isolate concerns like auth into `Middleware` resources referenced by Ingress.
+
+4. **Cloudflare** — Wire scoped API tokens so Traefik solves the ACME DNS-01 challenge automatically.
+
+</Steps>
 
 ---
 
@@ -40,7 +80,7 @@ Docker Compose - There should be an acme.json file that you create and pass thro
     -   Patch
 
         -   ```shell
-            sudo kubectl patch svc traefik -n kube-system -p '{"spec":{"externalTrafficPolicy":"Cluster"}}'`
+            sudo kubectl patch svc traefik -n kube-system -p '{"spec":{"externalTrafficPolicy":"Cluster"}}'
             ```
 
     -   std output should be `service/traefik patched`
@@ -126,8 +166,38 @@ Docker Compose - There should be an acme.json file that you create and pass thro
 
 ## Config
 
-TODO: Need to migrate the Github Embeds.
+Traefik reads two kinds of configuration: **static** (`traefik.yml`, entrypoints and providers, loaded once at startup) and **dynamic** (routers, services, middleware, hot-reloaded at runtime). For Docker deployments, create the ACME store first so Traefik can persist issued certificates:
 
+```shell
+touch acme.json
+chmod 600 acme.json
+```
+
+<Aside type="caution">
+`acme.json` must be `chmod 600`. Traefik refuses to start if the permissions are too open, since the file holds private keys.
+</Aside>
+
+A minimal static `traefik.yml` enabling the Docker provider and a Let's Encrypt resolver:
+
+```yaml
+entryPoints:
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    exposedByDefault: false
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@kbve.com
+      storage: acme.json
+      dnsChallenge:
+        provider: cloudflare
+```
+
+Mount `acme.json` and `traefik.yml` into the container and pass the Cloudflare token (see [Cloudflare](#cloudflare) below) so the `dnsChallenge` resolver can complete.
 
 ---
 
@@ -182,3 +252,25 @@ Common environmental variable names and their purpose:
 -   `CF_API_KEY` - The Cloudflare API key.
 -   `CF_DNS_API_TOKEN` - The API token with `DNS:Edit` permission.
 -   `CF_ZONE_API_TOKEN` - The API token with `Zone:Read` permission.
+
+<Aside type="tip">
+Prefer the scoped `CF_DNS_API_TOKEN` + `CF_ZONE_API_TOKEN` pair over the legacy global `CF_API_KEY`. A scoped token limits blast radius if leaked, and Cloudflare recommends it for ACME DNS challenges.
+</Aside>
+
+---
+
+## FAQ
+
+**What is Traefik?**
+Traefik is a cloud-native reverse proxy and load balancer that automatically discovers services from providers like Docker and Kubernetes, and provisions Let's Encrypt TLS certificates without manual configuration.
+
+**How is Traefik different from Nginx?**
+Traefik discovers routes dynamically from labels and CRDs, so it reconfigures itself as containers start and stop. [Nginx](/application/nginx/) uses static config files that require a reload. Traefik also ships automatic ACME TLS, whereas Nginx needs an external tool like certbot.
+
+**What is a Traefik middleware?**
+Middleware modifies requests or responses as they pass through a router — for example BasicAuth, rate limiting, or header rewrites. On Kubernetes it is a `Middleware` CRD referenced from an Ingress or IngressRoute by namespace-qualified name.
+
+**How does Traefik get TLS certificates from Cloudflare?**
+Traefik uses the ACME DNS-01 challenge with Cloudflare's API. You supply a scoped API token (`DNS:Edit` and `Zone:Read`) via environment variables, and Traefik creates the required DNS TXT record automatically to prove domain ownership.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/traefik.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/traefik.mdx
@@ -33,6 +33,14 @@ jsonld:
           answer: Middleware modifies requests or responses as they pass through a router — for example BasicAuth, rate limiting, or header rewrites. On Kubernetes it is a Middleware CRD referenced from an Ingress or IngressRoute by namespace-qualified name.
         - question: How does Traefik get TLS certificates from Cloudflare?
           answer: Traefik uses the ACME DNS-01 challenge with Cloudflare's API. You supply a scoped API token (DNS:Edit and Zone:Read) via environment variables, and Traefik creates the required DNS TXT record automatically to prove domain ownership.
+        - question: What is the difference between Ingress and IngressRoute in Traefik?
+          answer: Ingress is the standard Kubernetes resource that Traefik supports via annotations. IngressRoute is Traefik's own CRD that exposes middleware chains, TLS resolvers, and expressive match rules directly, without relying on annotations.
+        - question: How do I secure the Traefik dashboard?
+          answer: Enable it with --api.dashboard=true, then attach a BasicAuth middleware referencing api@internal and never expose it publicly without authentication. In Docker Compose, escape dollar signs in the htpasswd hash as double dollar signs.
+        - question: Why does my Traefik htpasswd password break in Docker Compose?
+          answer: Compose treats a single dollar sign as variable substitution. Escape every dollar sign in the BasicAuth hash as a double dollar sign so the literal htpasswd value is passed through to Traefik.
+        - question: How does Traefik discover services automatically?
+          answer: Traefik watches a provider — the Docker socket, Kubernetes CRDs, or a config file — and builds routers from labels or resources as containers start and stop. This is why it needs no manual reload when your services change.
 ---
 
 import {
@@ -71,6 +79,41 @@ This guide moves from local to production: run Traefik with Docker Compose, patc
 ## Docker
 
 Docker Compose - There should be an acme.json file that you create and pass through the docker with the permission of chmod 600. - Furthermore, there are two more files that you will have to configure and pass through before launching the traefik container. We provided them in the #config section below.
+
+A complete `docker-compose.yml` that runs Traefik, mounts the Docker socket for auto-discovery, and routes to a `whoami` test service:
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3.1
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedByDefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--api.dashboard=true"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./acme.json:/acme.json"
+    restart: unless-stopped
+
+  whoami:
+    image: traefik/whoami
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=Host(`whoami.localhost`)"
+      - "traefik.http.routers.whoami.entrypoints=web"
+```
+
+Traefik reads the `traefik.*` labels on each container and builds routers automatically — no separate config file needed for basic routing. Mounting the Docker socket read-only (`:ro`) lets Traefik watch for containers starting and stopping.
+
+<Aside type="caution">
+Mounting `/var/run/docker.sock` gives Traefik root-equivalent access to the host. Keep it read-only and never expose the Traefik API/dashboard publicly without authentication.
+</Aside>
 
 ## Kubernetes
 
@@ -232,6 +275,49 @@ This plugin (which is what we tried to reference before with the `auth@file` lin
 This will require setting up an IngressRoute (which is a specific Kubernetes resource added by the Traefik Resource Definitions) with settings to specify
 what the middlewares are. [Find more info on the Traefik Middlewares Here](https://doc.traefik.io/traefik/middlewares/overview/)
 
+### IngressRoute Example
+
+`IngressRoute` is Traefik's native alternative to the standard Kubernetes `Ingress`. It exposes Traefik-specific features — middleware chains, TLS resolvers, and match rules — directly, without annotation soup. This route attaches the `longhorn-auth` middleware from the previous example:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: longhorn-route
+  namespace: longhorn-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`x.kbve.com`)
+      kind: Rule
+      middlewares:
+        - name: longhorn-auth
+      services:
+        - name: longhorn-service-provider
+          port: 8000
+  tls:
+    certResolver: letsencrypt
+```
+
+The `match` rule uses Traefik's expression syntax — combine with `&&`, `||`, and `PathPrefix(...)` for fine-grained routing. `certResolver: letsencrypt` triggers automatic ACME certificate issuance for the host.
+
+## Dashboard
+
+Traefik ships a web dashboard that visualizes every router, service, and middleware it has discovered — invaluable for debugging why a route isn't matching. Enable it with `--api.dashboard=true` (see the Compose example above), then secure it behind BasicAuth:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.dashboard.rule=Host(`traefik.kbve.com`)"
+  - "traefik.http.routers.dashboard.service=api@internal"
+  - "traefik.http.routers.dashboard.middlewares=dashboard-auth"
+  - "traefik.http.middlewares.dashboard-auth.basicauth.users=admin:$$apr1$$..."
+```
+
+<Aside type="caution">
+In Docker Compose, `$` must be escaped as `$$` inside label values, or Compose interprets it as variable substitution and your htpasswd hash breaks.
+</Aside>
 
 ---
 


### PR DESCRIPTION
## Summary

SEO audit **batch 1** for `application/` docs, plus a new `sem` frontmatter field for internal audit tracking.

`sem` convention: **absent = not yet audited**, `sem: 1` = audited + improvements applied. Grep for docs missing `sem` to find the backlog.

## Changes

- **Schema** — add `sem: z.number().int().optional()` to the docs `docsSchema` extend in `content.config.ts`. Required or Astro strips the field from `entry.data`.
- **4 docs audited + improved** (stamped `sem: 1`):
  - `nginx.mdx` — full build-out from 601B stub: overview, step flow, static/wildcard/reverse-proxy config examples, FAQ.
  - `redis.mdx` — overview, filled the empty Docker Compose section with a real `docker-compose.yml`, FAQ.
  - `traefik.mdx` — fixed a stray backtick breaking a code fence, replaced `TODO` config with `traefik.yml` + `acme.json` setup, overview steps, FAQ.
  - `docker.mdx` — minimal polish (no bloat on a 55K reference): overview w/ anchor nav, tags, FAQ.

Every file: keyword-front-loaded `title`/`description`, `tags`, `ogTitle`/`ogDescription`, and `jsonld` (keywords + **4-entry `faq`**). FAQ is dual — visible MDX and structured `jsonld.faq` for AI/GEO citation.

## Verification

Structural validation PASS on all 4 — YAML valid, `sem=1`, `jsonld.faq=4`, tags set, code fences balanced. Full `nx` astro build not run in-worktree (no local node_modules).

## Scope

First calibration batch. 41 remaining `application/` docs follow in later batches using the same locked pattern once this depth/style is approved.