### PR TITLE
feat(rn): PricingTiers, FaqAccordion, LogoCloud, BentoGrid marketing sections

### DIFF
--- a/apps/kbve/astro-kbve/src/components/marketing/BentoGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/BentoGrid.astro
@@ -1,0 +1,6 @@
+---
+import { BentoGrid } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<BentoGrid client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/FaqAccordion.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/FaqAccordion.astro
@@ -1,0 +1,6 @@
+---
+import { FaqAccordion } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<FaqAccordion client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/LogoCloud.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/LogoCloud.astro
@@ -1,0 +1,6 @@
+---
+import { LogoCloud } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<LogoCloud client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/PricingTiers.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/PricingTiers.astro
@@ -1,0 +1,6 @@
+---
+import { PricingTiers } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<PricingTiers client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
@@ -14,8 +14,12 @@ import FeatureGrid from '@/components/marketing/FeatureGrid.astro';
 import StatStrip from '@/components/marketing/StatStrip.astro';
 import ProcessSteps from '@/components/marketing/ProcessSteps.astro';
 import LiveFeed from '@/components/marketing/LiveFeed.astro';
+import BentoGrid from '@/components/marketing/BentoGrid.astro';
 import ProjectGrid from '@/components/marketing/ProjectGrid.astro';
+import LogoCloud from '@/components/marketing/LogoCloud.astro';
 import Testimonials from '@/components/marketing/Testimonials.astro';
+import PricingTiers from '@/components/marketing/PricingTiers.astro';
+import FaqAccordion from '@/components/marketing/FaqAccordion.astro';
 import Cta from '@/components/marketing/Cta.astro';
 
 <Hero
@@ -32,10 +36,23 @@ import Cta from '@/components/marketing/Cta.astro';
 
 <StatStrip
 	stats={[
-		{ value: '11', label: 'Marketing sections' },
+		{ value: '15', label: 'Marketing sections' },
 		{ value: '1', label: 'Shared RN core' },
 		{ value: '2', label: 'Targets: web + native' },
 		{ value: '0', label: 'Duplicated styles' },
+	]}
+/>
+
+<LogoCloud
+	title="Powering every layer of the stack"
+	logos={[
+		{ name: 'Rust' },
+		{ name: 'Astro' },
+		{ name: 'Kubernetes' },
+		{ name: 'ClickHouse' },
+		{ name: 'Supabase' },
+		{ name: 'Unreal' },
+		{ name: 'Unity' },
 	]}
 />
 
@@ -49,6 +66,22 @@ import Cta from '@/components/marketing/Cta.astro';
 		{ title: 'ProcessSteps', body: 'Numbered how-it-works flow — Connect, Build, Ship.' },
 		{ title: 'LiveFeed', body: 'A terminal-style dashboard mockup — the signature showpiece.' },
 		{ title: 'Testimonials', body: 'Quote cards with avatar initials, name, and role.' },
+		{ title: 'BentoGrid', body: 'Mixed-size feature tiles — wide and standard from one flex grid.' },
+		{ title: 'LogoCloud', body: 'A bordered trust strip of tech and brand names.' },
+		{ title: 'PricingTiers', body: 'Plan cards with a highlighted tier and feature checklists.' },
+		{ title: 'FaqAccordion', body: 'Interactive expand/collapse Q&A — the only stateful section.' },
+	]}
+/>
+
+<BentoGrid
+	title="Mixed-size tiles"
+	subtitle="A modern bento layout — wide and standard tiles from one flex grid."
+	items={[
+		{ title: 'Open monorepo', body: 'Games, engines, Rust services, and Kubernetes infra — every line public on GitHub.', wide: true },
+		{ title: 'Native + web', body: 'One RN core renders on both.' },
+		{ title: 'Token-driven', body: 'Shared dark-gold design tokens.' },
+		{ title: 'Declarative infra', body: 'ArgoCD, ESO, sealed secrets.' },
+		{ title: 'Battle-tested', body: 'Postgres-on-CNPG with vault + auth.' },
 	]}
 />
 
@@ -91,6 +124,27 @@ import Cta from '@/components/marketing/Cta.astro';
 		{ quote: 'The whole stack is public and it actually runs. Rare to see infra this honest.', name: 'Dev in Residence', role: 'Contributor' },
 		{ quote: 'One component kit across native and web saved us a rewrite. This is the way.', name: 'Platform Lead', role: 'Community' },
 		{ quote: 'Docs, games, and Kubernetes in one monorepo — chaotic in the best way.', name: 'Open Source Fan', role: 'Discord' },
+	]}
+/>
+
+<PricingTiers
+	title="Sponsor the work"
+	subtitle="Placeholder tiers — the code stays free and open regardless."
+	tiers={[
+		{ name: 'Community', price: '$0', period: 'forever', body: 'Everything, in the open.', features: ['Full monorepo access', 'All docs pages', 'Discord community', 'Open issues & PRs'], action: { label: 'Get started', href: '/docs/', variant: 'outline' } },
+		{ name: 'Supporter', price: '$9', period: 'mo', body: 'Back the roadmap.', features: ['Everything in Community', 'Name in credits', 'Priority issue triage', 'Early feature previews'], action: { label: 'Become a supporter', href: '/support/' }, featured: true },
+		{ name: 'Patron', price: '$49', period: 'mo', body: 'Fund a whole lane.', features: ['Everything in Supporter', 'Logo on the site', 'Roadmap input', 'Direct maintainer chat'], action: { label: 'Sponsor a lane', href: '/support/', variant: 'outline' } },
+	]}
+/>
+
+<FaqAccordion
+	title="Frequently asked"
+	subtitle="Tap a question to expand."
+	items={[
+		{ q: 'Is everything really open source?', a: 'Yes — the entire monorepo is public on GitHub, including games, engine plugins, Rust services, and the Kubernetes infrastructure.' },
+		{ q: 'Do the web and native apps share code?', a: 'These sections are React Native components from @kbve/rn, re-exported through @kbve/rn-astro and mounted here as client:only islands — the same code ships in the native app.' },
+		{ q: 'Why client:only for every section?', a: 'RN-Web uses CommonJS require at module load. client:load or client:visible trigger build-time prerender that runs require before the browser is ready, so client:only is required.' },
+		{ q: 'Can I use these components in my own project?', a: 'The kit lives in the public monorepo. Read the docs to see how the barrels split web-safe and native exports.' },
 	]}
 />
 

--- a/packages/npm/rn-astro/src/components.ts
+++ b/packages/npm/rn-astro/src/components.ts
@@ -30,6 +30,10 @@ export {
 	ProcessSteps,
 	Testimonials,
 	LiveFeed,
+	PricingTiers,
+	FaqAccordion,
+	LogoCloud,
+	BentoGrid,
 	useTheme,
 	tokens,
 } from '@kbve/rn/ui';
@@ -60,4 +64,8 @@ export type {
 	StepItem,
 	TestimonialItem,
 	FeedRow,
+	PricingTier,
+	FaqItem,
+	LogoItem,
+	BentoItem,
 } from '@kbve/rn/ui';

--- a/packages/npm/rn/src/ui/marketing/sections.tsx
+++ b/packages/npm/rn/src/ui/marketing/sections.tsx
@@ -471,6 +471,196 @@ export const LiveFeed = memo(function LiveFeed({
 	);
 });
 
+/* ──────────────────────── Pricing tiers ────────────────────── */
+
+export interface PricingTier {
+	name: string;
+	price: string;
+	period?: string;
+	body?: string;
+	features: string[];
+	action?: HeroAction;
+	featured?: boolean;
+}
+
+export const PricingTiers = memo(function PricingTiers({
+	title,
+	subtitle,
+	tiers,
+	onNavigate,
+}: {
+	title?: string;
+	subtitle?: string;
+	tiers: PricingTier[];
+	onNavigate?: (href: string) => void;
+}) {
+	const fire = (a: HeroAction) =>
+		a.external ? openExternal(a.href) : onNavigate?.(a.href);
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.grid}>
+				{tiers.map((t) => (
+					<View
+						key={t.name}
+						style={[styles.tier, t.featured && styles.tierFeatured]}>
+						{t.featured ? (
+							<View style={styles.tierBadge}>
+								<Text style={styles.tierBadgeText}>Popular</Text>
+							</View>
+						) : null}
+						<Text style={styles.tierName}>{t.name}</Text>
+						<View style={styles.tierPriceRow}>
+							<Text style={styles.tierPrice}>{t.price}</Text>
+							{t.period ? (
+								<Text style={styles.tierPeriod}>/{t.period}</Text>
+							) : null}
+						</View>
+						{t.body ? (
+							<Text style={styles.tierBody}>{t.body}</Text>
+						) : null}
+						<View style={styles.tierFeatures}>
+							{t.features.map((f) => (
+								<View key={f} style={styles.tierFeature}>
+									<Text style={styles.tierCheck}>✓</Text>
+									<Text style={styles.tierFeatureText}>{f}</Text>
+								</View>
+							))}
+						</View>
+						{t.action ? (
+							<Button
+								title={t.action.label}
+								variant={
+									t.action.variant ??
+									(t.featured ? 'primary' : 'outline')
+								}
+								onPress={() => fire(t.action as HeroAction)}
+							/>
+						) : null}
+					</View>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ───────────────────────── FAQ accordion ───────────────────── */
+
+export interface FaqItem {
+	q: string;
+	a: string;
+}
+
+export const FaqAccordion = memo(function FaqAccordion({
+	title,
+	subtitle,
+	items,
+}: {
+	title?: string;
+	subtitle?: string;
+	items: FaqItem[];
+}) {
+	const [open, setOpen] = useState<number | null>(null);
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.faqList}>
+				{items.map((f, i) => {
+					const isOpen = open === i;
+					return (
+						<Pressable
+							key={f.q}
+							accessibilityRole="button"
+							onPress={() => setOpen(isOpen ? null : i)}
+							style={[
+								styles.faqItem,
+								isOpen && styles.faqItemOpen,
+								{ cursor: 'pointer' } as never,
+							]}>
+							<View style={styles.faqHead}>
+								<Text style={styles.faqQ}>{f.q}</Text>
+								<Text style={styles.faqSign}>
+									{isOpen ? '−' : '+'}
+								</Text>
+							</View>
+							{isOpen ? (
+								<Text style={styles.faqA}>{f.a}</Text>
+							) : null}
+						</Pressable>
+					);
+				})}
+			</View>
+		</View>
+	);
+});
+
+/* ───────────────────────── Logo cloud ──────────────────────── */
+
+export interface LogoItem {
+	name: string;
+}
+
+export const LogoCloud = memo(function LogoCloud({
+	title,
+	logos,
+}: {
+	title?: string;
+	logos: LogoItem[];
+}) {
+	return (
+		<View style={styles.logoBand}>
+			{title ? <Text style={styles.logoTitle}>{title}</Text> : null}
+			<View style={[container(), styles.logoRow]}>
+				{logos.map((l) => (
+					<Text key={l.name} style={styles.logoItem}>
+						{l.name}
+					</Text>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ───────────────────────── Bento grid ──────────────────────── */
+
+export interface BentoItem {
+	title: string;
+	body: string;
+	wide?: boolean;
+}
+
+export const BentoGrid = memo(function BentoGrid({
+	title,
+	subtitle,
+	items,
+}: {
+	title?: string;
+	subtitle?: string;
+	items: BentoItem[];
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.grid}>
+				{items.map((b) => (
+					<View
+						key={b.title}
+						style={[styles.bento, b.wide && styles.bentoWide]}>
+						<Text style={styles.bentoTitle}>{b.title}</Text>
+						<Text style={styles.bentoBody}>{b.body}</Text>
+					</View>
+				))}
+			</View>
+		</View>
+	);
+});
+
 /* ─────────────────────────── Styles ────────────────────────── */
 
 const styles = StyleSheet.create({
@@ -781,4 +971,132 @@ const styles = StyleSheet.create({
 		letterSpacing: 1,
 		color: tokens.color.textMuted,
 	},
+
+	tier: {
+		flex: 1,
+		minWidth: 240,
+		gap: tokens.space.md,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	tierFeatured: { borderColor: tokens.color.primary },
+	tierBadge: {
+		alignSelf: 'flex-start',
+		paddingHorizontal: tokens.space.sm,
+		paddingVertical: 3,
+		borderRadius: tokens.radius.pill,
+		backgroundColor: tokens.color.surfaceAlt,
+		borderWidth: 1,
+		borderColor: tokens.color.primary,
+	},
+	tierBadgeText: {
+		fontSize: 11,
+		fontWeight: '700',
+		letterSpacing: 1,
+		textTransform: 'uppercase',
+		color: tokens.color.primary,
+	},
+	tierName: { fontSize: 18, fontWeight: '700', color: tokens.color.text },
+	tierPriceRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 4 },
+	tierPrice: {
+		fontSize: 40,
+		fontWeight: '800',
+		letterSpacing: -1,
+		color: tokens.color.primary,
+	},
+	tierPeriod: {
+		fontSize: 14,
+		color: tokens.color.textMuted,
+		marginBottom: 6,
+	},
+	tierBody: { fontSize: 14, lineHeight: 21, color: tokens.color.textMuted },
+	tierFeatures: { gap: tokens.space.sm, marginVertical: tokens.space.sm },
+	tierFeature: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+	},
+	tierCheck: { fontSize: 14, fontWeight: '800', color: tokens.color.primary },
+	tierFeatureText: { flex: 1, fontSize: 14, color: tokens.color.text },
+
+	faqList: {
+		width: '100%',
+		maxWidth: 760,
+		alignSelf: 'center',
+		gap: tokens.space.sm,
+	},
+	faqItem: {
+		padding: tokens.space.lg,
+		borderRadius: tokens.radius.lg,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	faqItemOpen: { borderColor: tokens.color.primary },
+	faqHead: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		gap: tokens.space.md,
+	},
+	faqQ: { flex: 1, fontSize: 16, fontWeight: '700', color: tokens.color.text },
+	faqSign: {
+		fontSize: 22,
+		fontWeight: '800',
+		color: tokens.color.primary,
+	},
+	faqA: {
+		marginTop: tokens.space.sm,
+		fontSize: 14,
+		lineHeight: 22,
+		color: tokens.color.textMuted,
+	},
+
+	logoBand: {
+		borderTopWidth: 1,
+		borderBottomWidth: 1,
+		borderColor: tokens.color.border,
+		backgroundColor: tokens.color.bgSubtle,
+		paddingVertical: tokens.space.xl,
+		paddingHorizontal: tokens.space.lg,
+		gap: tokens.space.lg,
+		alignItems: 'center',
+	},
+	logoTitle: {
+		fontSize: 12,
+		letterSpacing: 2,
+		textTransform: 'uppercase',
+		color: tokens.color.textMuted,
+		textAlign: 'center',
+	},
+	logoRow: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		justifyContent: 'center',
+		alignItems: 'center',
+		gap: tokens.space.xl,
+	},
+	logoItem: {
+		fontSize: 20,
+		fontWeight: '800',
+		letterSpacing: -0.5,
+		color: tokens.color.textMuted,
+	},
+
+	bento: {
+		flex: 1,
+		minWidth: 240,
+		gap: tokens.space.sm,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	bentoWide: { minWidth: 520, flexBasis: '100%' },
+	bentoTitle: { fontSize: 18, fontWeight: '700', color: tokens.color.primary },
+	bentoBody: { fontSize: 14, lineHeight: 21, color: tokens.color.textMuted },
 });


### PR DESCRIPTION
## Summary

Adds four theme-parity marketing sections to the shared RN core, closing gaps against the neuron/ethernity template DNA.

- **PricingTiers** — plan cards with a highlighted `featured` tier, price/period, feature checklist, and per-tier action button.
- **FaqAccordion** — interactive expand/collapse Q&A (single-open, `useState`). The only stateful section.
- **LogoCloud** — bordered trust strip of tech/brand names.
- **BentoGrid** — mixed-size feature tiles (`wide` flag spans the row).

All theme-match automatically via existing dark-gold tokens. All web-safe — no @expo/vector-icons.

## Wiring
- `@kbve/rn` `ui/marketing/sections.tsx` — 4 components + styles, following existing memo/token/StyleSheet conventions.
- `@kbve/rn-astro` `components.ts` — explicit named + type exports (`PricingTier`, `FaqItem`, `LogoItem`, `BentoItem`).
- 4 Astro `client:only="react"` island wrappers under `marketing/`.
- `/lab/showcase` MDX extended to render all four (now 15 sections).

## Verify
- `tsc --noEmit` on rn-astro lib: **No errors**.
- rn lib pre-existing `src/dash/*` errors are unrelated to this change.