### PR TITLE
docs(astro-kbve): SEO audit batch 2 for application docs

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/pocketbase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/pocketbase.mdx
@@ -1,7 +1,9 @@
 ---
 title: Pocketbase
 description: |
-    Pocketbase Database
+    PocketBase is an open-source backend in a single file — an embedded SQLite database with a realtime REST API,
+    authentication, file storage, and an admin dashboard. This guide covers installing it with Docker Compose,
+    the CLI, and Coolify, plus collections, auth, and the realtime API.
 sidebar:
     label: Pocketbase
     order: 1010
@@ -9,6 +11,28 @@ unsplash: 1599507593499-a3f7d7d97667
 img: https://images.unsplash.com/photo-1599507593499-a3f7d7d97667?fit=crop&w=1400&h=700&q=75
 tags:
     - database
+    - backend
+    - self-hosted
+sem: 1
+ogTitle: PocketBase Guide — Self-Hosted Backend with Docker, Auth & Realtime API
+ogDescription: Run PocketBase, the open-source single-file backend — install via Docker Compose, CLI, or Coolify, then use its SQLite database, REST API, authentication, and realtime subscriptions.
+jsonld:
+    type: Article
+    keywords:
+        - pocketbase
+        - self-hosted backend
+        - sqlite
+        - baas
+        - realtime api
+    faq:
+        - question: What is PocketBase?
+          answer: PocketBase is an open-source backend packaged as a single executable. It bundles an embedded SQLite database, a realtime REST API, user authentication, file storage, and an admin dashboard, making it a lightweight self-hosted alternative to Firebase or Supabase.
+        - question: How do I run PocketBase with Docker?
+          answer: Use a docker-compose.yml with a PocketBase image such as ghcr.io/muchobien/pocketbase, expose port 8090, and mount volumes for /pb_data (database) and optionally /pb_public (static files). Then run docker compose up -d and open the admin UI at /_/.
+        - question: Where is the PocketBase admin dashboard?
+          answer: The admin dashboard is served at /_/ on the PocketBase host, for example http://localhost:8090/_/. On first launch you create the initial admin account there, then manage collections, records, users, and settings.
+        - question: Is PocketBase a good alternative to Firebase?
+          answer: For small to medium self-hosted projects, yes. PocketBase offers realtime subscriptions, auth, and file storage with no vendor lock-in and a single-file deployment. It runs on SQLite, so it suits single-node workloads rather than horizontally sharded, massive-scale apps.
 ---
 
 import {
@@ -23,7 +47,15 @@ import {
 import { Giscus, Adsense } from '@/components/astropad';
 
 
-## Information
+## Overview
+
+PocketBase is an open-source backend that ships as a **single executable file**. Inside that one binary you get an embedded SQLite database, a realtime REST API, user authentication (email/password and OAuth2), file storage, and a full admin dashboard. There is nothing else to install — no separate database server, no message broker, no dependency stack.
+
+That makes PocketBase a lightweight, self-hosted alternative to Firebase or Supabase for small and medium projects. You define **collections** (the equivalent of tables) in the admin UI, and PocketBase instantly exposes CRUD endpoints and realtime subscriptions for them. This guide installs PocketBase three ways — Docker Compose, the Docker CLI, and Coolify — then points you at the admin panel to build.
+
+<Aside type="note">
+PocketBase stores everything under `/pb_data` (the SQLite database, uploaded files, and logs). Always mount that directory to a persistent volume so your data survives container restarts and upgrades.
+</Aside>
 
 <Adsense />
 
@@ -86,3 +118,67 @@ Installing Pocketbase through Coolify is extremely easy!
 2. Click `Service`
 3. Select `Pocketbase`
 4. Done! Fill in the URL and then head over the admin panel, `domain.com/_/`.
+
+## First Run
+
+Once the container is up, open the admin dashboard and create your first admin account:
+
+<Steps>
+
+1. **Open the admin UI** — Navigate to `http://your-host:8090/_/`. On first launch PocketBase prompts you to create the initial admin (superuser) account.
+
+2. **Create a collection** — Collections are PocketBase's tables. Click **New collection**, name it (for example `posts`), and add fields (text, number, relation, file, etc.).
+
+3. **Set API rules** — Each collection has list/view/create/update/delete rules written as filter expressions. Leave them empty for public access, or use `@request.auth.id != ""` to require a logged-in user.
+
+4. **Use the API** — PocketBase instantly exposes REST endpoints for the collection.
+
+</Steps>
+
+## REST and Realtime API
+
+Every collection is served under `/api/collections/{name}/records`. Fetching records is a plain HTTP call:
+
+```bash
+# List records
+curl http://localhost:8090/api/collections/posts/records
+
+# Create a record (authenticated)
+curl -X POST http://localhost:8090/api/collections/posts/records \
+  -H "Authorization: TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Hello","body":"First post"}'
+```
+
+The official JavaScript SDK wraps auth and adds **realtime subscriptions** over server-sent events, so clients receive live updates when records change:
+
+```js
+import PocketBase from 'pocketbase';
+
+const pb = new PocketBase('http://localhost:8090');
+await pb.collection('users').authWithPassword('user@example.com', 'password');
+
+pb.collection('posts').subscribe('*', (e) => {
+  console.log(e.action, e.record);
+});
+```
+
+<Aside type="tip">
+PocketBase can also be extended in Go (as a framework) or with JavaScript hooks in the `pb_hooks` directory — useful for custom endpoints, validation, and scheduled jobs without a separate service.
+</Aside>
+
+## FAQ
+
+**What is PocketBase?**
+PocketBase is an open-source backend packaged as a single executable. It bundles an embedded SQLite database, a realtime REST API, user authentication, file storage, and an admin dashboard, making it a lightweight self-hosted alternative to Firebase or Supabase.
+
+**How do I run PocketBase with Docker?**
+Use a `docker-compose.yml` with a PocketBase image such as `ghcr.io/muchobien/pocketbase`, expose port `8090`, and mount volumes for `/pb_data` (database) and optionally `/pb_public` (static files). Then run `docker compose up -d` and open the admin UI at `/_/`.
+
+**Where is the PocketBase admin dashboard?**
+The admin dashboard is served at `/_/` on the PocketBase host, for example `http://localhost:8090/_/`. On first launch you create the initial admin account there, then manage collections, records, users, and settings.
+
+**Is PocketBase a good alternative to Firebase?**
+For small to medium self-hosted projects, yes. PocketBase offers realtime subscriptions, auth, and file storage with no vendor lock-in and a single-file deployment. It runs on SQLite, so it suits single-node workloads rather than horizontally sharded, massive-scale apps.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/portainer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/portainer.mdx
@@ -5,13 +5,36 @@ description: |
     Think of it as a backend panel that helps design and manage container infrastructure within Docker and Kubernetes.
     It simplifies the deployment, monitoring, and scaling of containers, making it easier to manage complex infrastructure.
     Thus, with Portainer, teams can streamline their workflows and gain full control over their containerized ecosystem.
+    This guide covers deploying Portainer on Docker, Docker Swarm, and Kubernetes, plus Edge agents and upgrades.
 sidebar:
     label: Portainer
     order: 105
 unsplash: 1544256718-3bcf237f3974
 img: https://images.unsplash.com/photo-1544256718-3bcf237f3974?fit=crop&w=1400&h=700&q=75
 tags:
-    - emulation
+    - containers
+    - devops
+    - kubernetes
+sem: 1
+ogTitle: Portainer Guide — Docker, Swarm & Kubernetes Container Management
+ogDescription: Deploy and manage Portainer across Docker, Docker Swarm, and Kubernetes — CLI and Compose install, Community vs Business Edition, Edge agents, and upgrade strategies.
+jsonld:
+    type: Article
+    keywords:
+        - portainer
+        - docker management
+        - kubernetes dashboard
+        - container management
+        - docker swarm
+    faq:
+        - question: What is Portainer used for?
+          answer: Portainer is a web-based management UI for containers. It gives a visual dashboard to deploy, monitor, and manage Docker, Docker Swarm, and Kubernetes environments without memorizing CLI commands, with role-based access control for teams.
+        - question: What is the difference between Portainer CE and Business Edition?
+          answer: Community Edition (CE) is free and open-source with core container management. Business Edition (BE/EE) is the commercial version that adds RBAC, registry management, and support. BE requires a license key, though a free tier covers up to a small number of nodes.
+        - question: How do I install Portainer on Docker?
+          answer: Create a portainer_data volume, then run the portainer/portainer-ce image with the Docker socket mounted at /var/run/docker.sock and ports 8000 and 9443 published. Portainer's UI is then reachable over HTTPS on port 9443.
+        - question: What is a Portainer Edge agent?
+          answer: The Edge agent connects remote or air-gapped Docker/Kubernetes hosts back to a central Portainer instance using an EDGE_ID and EDGE_KEY over an outbound tunnel. It lets one Portainer manage many distributed environments without exposing each host's API.
 ---
 
 import {
@@ -48,6 +71,35 @@ Whether you're managing a small development environment or a large-scale product
 <Adsense />
 
 ## Docker
+
+Portainer needs two things on Docker: a persistent volume for its own data, and access to the Docker socket so it can manage the engine. You can deploy it with Compose or the raw CLI.
+
+### Compose
+
+The declarative option — save as `docker-compose.yml` and run `docker compose up -d`:
+
+```yaml
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: always
+    ports:
+      - "8000:8000"
+      - "9443:9443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+
+volumes:
+  portainer_data:
+```
+
+Port `9443` serves the HTTPS UI; `8000` is the tunnel port used by Edge agents. The Docker socket mount is what lets Portainer see and control containers on the host.
+
+<Aside type="caution">
+Mounting `/var/run/docker.sock` grants Portainer root-equivalent control of the host. Restrict who can reach port `9443`, and set a strong admin password on first login — the setup screen locks after a few minutes for security.
+</Aside>
 
 -   For Docker [Compose](/application/portainer#compose)
 
@@ -155,3 +207,21 @@ However these notes are for Portainer Agent 2.16.1 / 11/18/2022. We will update 
 Upgrading Portainer ensures access to the latest features, security patches, and performance improvements.
 Before upgrading, always back up your Portainer data to prevent any potential loss.
 Depending on your environment (Docker, Swarm, or Kubernetes), different upgrade strategies may apply, such as using Docker Compose or Helm charts. It’s recommended to test upgrades in a staging environment before applying them to production. For detailed steps and best practices, refer to the [Official Docs](https://docs.portainer.io/start/upgrade/) on upgrading Portainer.
+
+---
+
+## FAQ
+
+**What is Portainer used for?**
+Portainer is a web-based management UI for containers. It gives a visual dashboard to deploy, monitor, and manage [Docker](/application/docker/), Docker Swarm, and [Kubernetes](/application/kubernetes/) environments without memorizing CLI commands, with role-based access control for teams.
+
+**What is the difference between Portainer CE and Business Edition?**
+Community Edition (CE) is free and open-source with core container management. Business Edition (BE/EE) is the commercial version that adds RBAC, registry management, and support. BE requires a license key, though a free tier covers up to a small number of nodes.
+
+**How do I install Portainer on Docker?**
+Create a `portainer_data` volume, then run the `portainer/portainer-ce` image with the Docker socket mounted at `/var/run/docker.sock` and ports `8000` and `9443` published. Portainer's UI is then reachable over HTTPS on port `9443`.
+
+**What is a Portainer Edge agent?**
+The Edge agent connects remote or air-gapped Docker/Kubernetes hosts back to a central Portainer instance using an `EDGE_ID` and `EDGE_KEY` over an outbound tunnel. It lets one Portainer manage many distributed environments without exposing each host's API.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/python.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/python.mdx
@@ -1,16 +1,40 @@
 ---
 title: Python
 description: |
-    Python is a general-purpose, objected-oriented, high-level programming language.
-    It is known for its simplicity, readability, and versatility.
-    Python is often used for web development, data science, machine learning, and artificial intelligence.
+    Python is a general-purpose, high-level programming language known for its readability and versatility.
+    This guide covers installing Python on Windows, macOS, and Linux, managing virtual environments and pip,
+    and building typed web APIs with FastAPI, Pydantic, and Haystack.
 sidebar:
     label: Python
     order: 420
 unsplash: 1553413077-190dd305871c
 img: https://images.unsplash.com/photo-1553413077-190dd305871c?fit=crop&w=1400&h=700&q=75
 tags:
-    - technology
+    - programming
+    - python
+    - backend
+sem: 1
+ogTitle: Python Guide — Install, Virtual Environments, pip & FastAPI
+ogDescription: A practical Python guide — install on Windows, macOS, and Linux, isolate dependencies with virtual environments and pip, and build typed web APIs using FastAPI and Pydantic.
+jsonld:
+    type: Article
+    keywords:
+        - python
+        - virtual environment
+        - pip
+        - fastapi
+        - pydantic
+    faq:
+        - question: How do I create a Python virtual environment?
+          answer: Run python -m venv .venv to create an isolated environment in a .venv folder, then activate it with source .venv/bin/activate on macOS/Linux or .venv\Scripts\activate on Windows. Packages you install with pip then stay scoped to that project.
+        - question: What is the difference between pip and a virtual environment?
+          answer: pip is Python's package installer; a virtual environment is an isolated directory of Python and its packages. You use pip inside a virtual environment so each project has its own dependency versions without polluting the global system Python.
+        - question: What is FastAPI used for?
+          answer: FastAPI is a modern Python web framework for building APIs. It uses standard type hints and Pydantic models for automatic request validation and generates interactive OpenAPI documentation, while running on ASGI for high async performance.
+        - question: What is Pydantic?
+          answer: Pydantic is a data-validation library that uses Python type hints to parse and validate data at runtime. It powers FastAPI's request and response models, coercing and checking incoming JSON against your declared types and raising clear errors on mismatch.
+        - question: Which Python version should I use?
+          answer: Use the latest stable Python 3 release for new projects to get current syntax, performance, and security fixes. Pin the version per project with a virtual environment or a tool like pyenv so upgrades never break existing work.
 ---
 
 import {
@@ -24,6 +48,11 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
+
+Python is a high-level, interpreted language prized for readable syntax and a vast ecosystem, spanning web development, data science, machine learning, and automation. Its interpreter runs on every major platform, and its package manager (`pip`) plus virtual environments make per-project dependency isolation straightforward.
+
+This guide moves from setup to real APIs: [install Python](#setup) on Windows, macOS, and Linux, isolate dependencies with [virtual environments](#virtual-environments) and [pip](#pip), then build typed web services with [FastAPI](#fastapi), [Pydantic](#pydantic), and [Haystack](#haystack).
 
 ## Information
 
@@ -562,3 +591,24 @@ It leverages natural language processing (NLP) to allow developers to build powe
 With Haystack, users can integrate various NLP models, connect to document stores, and implement sophisticated retrieval mechanisms.
 It supports multiple backends, including Elasticsearch and FAISS, enabling flexible and scalable search solutions.
 Additionally, Haystack offers features like end-to-end pipelines, real-time updates, and integration with external data sources, making it a versatile tool for modern information retrieval tasks.
+
+---
+
+## FAQ
+
+**How do I create a Python virtual environment?**
+Run `python -m venv .venv` to create an isolated environment in a `.venv` folder, then activate it with `source .venv/bin/activate` on macOS/Linux or `.venv\Scripts\activate` on Windows. Packages you install with pip then stay scoped to that project.
+
+**What is the difference between pip and a virtual environment?**
+`pip` is Python's package installer; a virtual environment is an isolated directory of Python and its packages. You use pip inside a virtual environment so each project has its own dependency versions without polluting the global system Python.
+
+**What is FastAPI used for?**
+FastAPI is a modern Python web framework for building APIs. It uses standard type hints and Pydantic models for automatic request validation and generates interactive OpenAPI documentation, while running on ASGI for high async performance.
+
+**What is Pydantic?**
+Pydantic is a data-validation library that uses Python type hints to parse and validate data at runtime. It powers FastAPI's request and response models, coercing and checking incoming JSON against your declared types and raising clear errors on mismatch.
+
+**Which Python version should I use?**
+Use the latest stable Python 3 release for new projects to get current syntax, performance, and security fixes. Pin the version per project with a virtual environment or a tool like `pyenv` so upgrades never break existing work.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/wireguard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/wireguard.mdx
@@ -1,12 +1,40 @@
 ---
 title: WireGuard
 description: |
-    A open source communication protocol that implements encrypted virtual private networks.
+    WireGuard is a fast, modern, open-source VPN protocol that builds encrypted point-to-point tunnels with
+    state-of-the-art cryptography and a tiny codebase. This guide covers the core concepts, a basic peer-to-peer
+    setup, a full Kubernetes DaemonSet deployment, Docker, and Netmaker automation.
 sidebar:
     label: WireGuard
     order: 100
 unsplash: 1649429398909-db7ae841c386
 img: https://images.unsplash.com/photo-1649429398909-db7ae841c386?fit=crop&w=1400&h=700&q=75
+tags:
+    - network
+    - vpn
+    - security
+sem: 1
+ogTitle: WireGuard VPN Guide — Peer-to-Peer, Kubernetes & Netmaker
+ogDescription: Set up WireGuard, the fast modern VPN — understand keys and peers, build a basic point-to-point tunnel, deploy it on Kubernetes as a DaemonSet, and automate meshes with Netmaker.
+jsonld:
+    type: Article
+    keywords:
+        - wireguard
+        - vpn
+        - encrypted tunnel
+        - kubernetes networking
+        - netmaker
+    faq:
+        - question: What is WireGuard?
+          answer: WireGuard is an open-source VPN protocol that creates fast, encrypted point-to-point tunnels. It uses modern cryptography, runs in the Linux kernel for high performance, and has a very small codebase — a few thousand lines — which reduces its attack surface.
+        - question: How does WireGuard differ from OpenVPN?
+          answer: WireGuard is far smaller and faster. It runs in the kernel with modern fixed cryptography and connects almost instantly, whereas OpenVPN runs in userspace with configurable ciphers and higher overhead. WireGuard configs are also much simpler.
+        - question: What are AllowedIPs in a WireGuard config?
+          answer: AllowedIPs serves two roles — it defines which source IPs are accepted from a peer (a cryptographic access control list) and which destination IPs are routed through that peer. Setting 0.0.0.0/0 routes all traffic through the tunnel.
+        - question: What is PersistentKeepalive in WireGuard?
+          answer: PersistentKeepalive sends a small packet every N seconds to keep a NAT or firewall mapping open. It is needed when a peer sits behind NAT and must remain reachable; a value of 25 seconds is the common default.
+        - question: What port does WireGuard use?
+          answer: WireGuard uses a single UDP port, 51820 by default, set with ListenPort. Because it is UDP-only, you must allow that port through firewalls like ufw, iptables, or nftables on the server side.
 ---
 
 import {
@@ -29,6 +57,57 @@ Unlike traditional VPN solutions, WireGuard is lightweight, with a minimal codeb
 It is cross-platform, supporting major operating systems like Linux, Windows, macOS, iOS, and Android, and is known for its ease of configuration and seamless integration into existing network infrastructures.
 WireGuard's efficiency and robust security make it an ideal choice for both personal and enterprise use.
 
+## How WireGuard Works
+
+WireGuard connects **peers**, not clients and servers — the model is symmetric. Each peer has a **key pair**: a private key it keeps secret and a public key it shares. A peer accepts an encrypted packet only if it is signed by a known public key listed in its config, so the public keys themselves form the access control list.
+
+Three fields do most of the work in every config:
+
+| Field | Meaning |
+| ----- | ------- |
+| `PrivateKey` | This peer's secret key (from `wg genkey`) |
+| `PublicKey` | The remote peer's public key, under `[Peer]` |
+| `AllowedIPs` | Which IPs are accepted from and routed to that peer |
+| `Endpoint` | The remote peer's reachable `IP:port` |
+| `PersistentKeepalive` | Seconds between keepalives to hold a NAT mapping open |
+
+## Basic Peer-to-Peer Tunnel
+
+Before the Kubernetes deployment, here is the smallest useful setup — two machines linked over a single UDP port. Generate a key pair on **each** peer:
+
+```bash
+umask 077
+wg genkey | tee privatekey | wg pubkey > publickey
+```
+
+Server (`/etc/wireguard/wg0.conf`):
+
+```ini
+[Interface]
+PrivateKey = <Server_Private_Key>
+Address = 10.0.0.1/24
+ListenPort = 51820
+
+[Peer]
+PublicKey = <Client_Public_Key>
+AllowedIPs = 10.0.0.2/32
+```
+
+Client (`/etc/wireguard/wg0.conf`):
+
+```ini
+[Interface]
+PrivateKey = <Client_Private_Key>
+Address = 10.0.0.2/24
+
+[Peer]
+PublicKey = <Server_Public_Key>
+Endpoint = server.example.com:51820
+AllowedIPs = 10.0.0.0/24
+PersistentKeepalive = 25
+```
+
+Bring the tunnel up on both ends with `wg-quick up wg0` (and down with `wg-quick down wg0`). Check live status and handshake times with `sudo wg`. Setting the client's `AllowedIPs` to `0.0.0.0/0` instead would route **all** its traffic through the server — a full VPN.
 
 <Steps>
 
@@ -307,3 +386,22 @@ Installing WireGuard on Docker!
     -   `RWX` - `Read Write Many` - Storage instance where many nodes can concurrently read and write to the storage volume.
 
 ---
+
+## FAQ
+
+**What is WireGuard?**
+WireGuard is an open-source VPN protocol that creates fast, encrypted point-to-point tunnels. It uses modern cryptography, runs in the Linux kernel for high performance, and has a very small codebase — a few thousand lines — which reduces its attack surface.
+
+**How does WireGuard differ from OpenVPN?**
+WireGuard is far smaller and faster. It runs in the kernel with modern fixed cryptography and connects almost instantly, whereas OpenVPN runs in userspace with configurable ciphers and higher overhead. WireGuard configs are also much simpler.
+
+**What are `AllowedIPs` in a WireGuard config?**
+`AllowedIPs` serves two roles — it defines which source IPs are accepted from a peer (a cryptographic access control list) and which destination IPs are routed through that peer. Setting `0.0.0.0/0` routes all traffic through the tunnel.
+
+**What is `PersistentKeepalive` in WireGuard?**
+It sends a small packet every N seconds to keep a NAT or firewall mapping open. It is needed when a peer sits behind NAT and must stay reachable; a value of `25` seconds is the common default.
+
+**What port does WireGuard use?**
+WireGuard uses a single UDP port, `51820` by default, set with `ListenPort`. Because it is UDP-only, you must allow that port through firewalls like `ufw`, `iptables`, or `nftables` on the server side.
+
+<Adsense />


### PR DESCRIPTION
## Summary

SEO audit **batch 2** for `application/` docs — same locked pattern as [#13645](https://github.com/KBVE/kbve/pull/13645). Four more docs audited, improved, and stamped `sem: 1`.

## Changes

- **pocketbase.mdx** — full build-out from a stub: overview, first-run Steps, REST + realtime API examples with the JS SDK, FAQ.
- **portainer.mdx** — fixed a wrong `emulation` tag, **added the Compose section that was linked (`#compose`) but never existed**, FAQ.
- **wireguard.mdx** — added a concepts table and a basic peer-to-peer tunnel example (the doc previously jumped straight to a Kubernetes DaemonSet), FAQ.
- **python.mdx** — overview with in-page anchor nav, meta polish, FAQ.

Every file: keyword-front-loaded `title`/`description`, real `tags`, `ogTitle`/`ogDescription`, and `jsonld` (keywords + 4-5 entry `faq`, visible MDX + structured for AI/GEO citation).

## Verification

Structural validation PASS — valid YAML, `sem=1`, balanced code fences on all four. Word counts: pocketbase 903, portainer 1361, wireguard 1546, python 2361.

## Progress

Batch 2 of the `application/` sweep. 8 of 45 docs now carry `sem: 1`; 37 remain for future batches.