### PR TITLE
docs(astro-kbve): SEO audit batch 3 for application docs

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/flutter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/flutter.mdx
@@ -1,7 +1,9 @@
 ---
 title: Flutter
 description: |
-    Open-source cross platform UI/UX software development kit based upon Dart and created by Google.
+    Flutter is Google's open-source UI toolkit for building natively compiled apps for mobile, web, and desktop
+    from a single Dart codebase. This guide covers installing the SDK, running flutter doctor, the essential CLI
+    cheatsheet, the widget model, and where to find packages on pub.dev.
 sidebar:
     label: Flutter
     order: 475
@@ -9,6 +11,30 @@ unsplash: 1628277613967-6abca504d0ac
 img: https://images.unsplash.com/photo-1628277613967-6abca504d0ac?fit=crop&w=1400&h=700&q=75
 tags:
     - dart
+    - mobile
+    - cross-platform
+sem: 1
+ogTitle: Flutter Guide — Install the SDK, CLI Cheatsheet & Widget Basics
+ogDescription: Get started with Flutter, Google's cross-platform UI toolkit — install the SDK, verify with flutter doctor, learn the core CLI commands, and understand the widget-based build model.
+jsonld:
+    type: Article
+    keywords:
+        - flutter
+        - dart
+        - cross-platform
+        - mobile development
+        - flutter widgets
+    faq:
+        - question: What is Flutter?
+          answer: Flutter is Google's open-source UI toolkit for building natively compiled applications for mobile (iOS and Android), web, and desktop from a single Dart codebase. It renders its own widgets, so the UI looks and behaves consistently across platforms.
+        - question: What language does Flutter use?
+          answer: Flutter apps are written in Dart, an object-oriented, strongly typed language by Google. Dart compiles ahead-of-time to native machine code for release builds and just-in-time during development to enable hot reload.
+        - question: What is flutter doctor?
+          answer: flutter doctor is a diagnostic command that checks your environment for everything Flutter needs — the SDK, platform toolchains (Android SDK, Xcode), connected devices, and IDE plugins — and reports what is missing with fix suggestions.
+        - question: What is a widget in Flutter?
+          answer: In Flutter everything on screen is a widget — a lightweight, immutable description of part of the UI. Widgets compose into a tree; StatelessWidget describes UI that never changes, while StatefulWidget rebuilds when its state updates.
+        - question: Where do I find Flutter packages?
+          answer: pub.dev is the official package repository for Dart and Flutter. Add a package with flutter pub add <name>, which updates pubspec.yaml and downloads it, then import it in your Dart code.
 ---
 
 import {
@@ -21,6 +47,12 @@ import {
 } from '@astrojs/starlight/components';
 
 import { Giscus, Adsense } from '@/components/astropad';
+
+## Overview
+
+Flutter is Google's open-source UI toolkit for building natively compiled apps for mobile, web, and desktop from **one** Dart codebase. Instead of wrapping native controls, Flutter ships its own rendering engine and widget set, so a single design looks and behaves identically on every platform. Its standout developer feature is **hot reload** — code changes appear in the running app in under a second.
+
+This guide gets you productive fast: [install the SDK](#install), verify it with `flutter doctor`, learn the [essential CLI commands](#cheatsheet), understand the [widget model](#widgets), and find [packages](#packages) on pub.dev.
 
 ## Information
 
@@ -50,6 +82,28 @@ You can install Flutter on Windows by following these steps:
 5. Extract the zip file and place it in your desired location.
 6. Add Flutter to your path.
 7. Run `flutter doctor` to verify that Flutter has been installed correctly.
+
+### macOS / Linux
+
+On macOS and Linux the fastest route is to clone the SDK and add it to your `PATH`:
+
+```bash
+git clone https://github.com/flutter/flutter.git -b stable ~/flutter
+export PATH="$PATH:$HOME/flutter/bin"
+flutter doctor
+```
+
+`flutter doctor` inspects your toolchain and lists anything missing — Android SDK, Xcode, or IDE plugins — with a checkmark or an `✗` plus a fix hint. Resolve every `✗` before building.
+
+### Create and Run Your First App
+
+```bash
+flutter create my_app
+cd my_app
+flutter run
+```
+
+`flutter create` scaffolds a counter demo app. `flutter run` builds it and launches on a connected device or emulator — then edit `lib/main.dart` and save to see hot reload in action.
 
 ---
 
@@ -81,6 +135,54 @@ You can install Flutter on Windows by following these steps:
 
 ---
 
+## Widgets
+
+In Flutter, **everything is a widget** — text, padding, buttons, and even the app itself. A widget is an immutable description of part of the UI; Flutter composes them into a tree and renders it. There are two core kinds:
+
+- **StatelessWidget** — describes UI that never changes on its own (a label, an icon).
+- **StatefulWidget** — holds mutable state and rebuilds when that state changes (a counter, a form).
+
+```dart
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Hello Flutter')),
+        body: const Center(child: Text('Welcome to KBVE')),
+      ),
+    );
+  }
+}
+```
+
+The `build` method returns a widget tree. When state changes, Flutter calls `build` again and efficiently updates only what differs — the foundation of its reactive UI model.
+
 ## Packages
 
-[Pub.dev](https://pub.dev) is the official package repository for Dart / Flutter apps!
+[Pub.dev](https://pub.dev) is the official package repository for Dart / Flutter apps! Add one with `flutter pub add <package>`, which records it in `pubspec.yaml` and downloads it, then `import` it in your Dart code.
+
+## FAQ
+
+**What is Flutter?**
+Flutter is Google's open-source UI toolkit for building natively compiled applications for mobile (iOS and Android), web, and desktop from a single Dart codebase. It renders its own widgets, so the UI looks and behaves consistently across platforms.
+
+**What language does Flutter use?**
+Flutter apps are written in Dart, an object-oriented, strongly typed language by Google. Dart compiles ahead-of-time to native machine code for release builds and just-in-time during development to enable hot reload.
+
+**What is `flutter doctor`?**
+`flutter doctor` is a diagnostic command that checks your environment for everything Flutter needs — the SDK, platform toolchains (Android SDK, Xcode), connected devices, and IDE plugins — and reports what is missing with fix suggestions.
+
+**What is a widget in Flutter?**
+Everything on screen is a widget — a lightweight, immutable description of part of the UI. Widgets compose into a tree; `StatelessWidget` describes UI that never changes, while `StatefulWidget` rebuilds when its state updates.
+
+**Where do I find Flutter packages?**
+[pub.dev](https://pub.dev) is the official package repository for Dart and Flutter. Add a package with `flutter pub add <name>`, which updates `pubspec.yaml` and downloads it, then import it in your Dart code.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/linux.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/linux.mdx
@@ -12,6 +12,28 @@ unsplash: 1695820716792-bb317bc02822
 img: https://images.unsplash.com/photo-1695820716792-bb317bc02822?fit=crop&w=1400&h=700&q=75
 tags:
     - os
+    - linux
+    - sysadmin
+sem: 1
+ogTitle: Linux Guide — LVM Storage, ZSH Setup & Essential Commands
+ogDescription: Practical Linux administration — extend storage with LVM, set up ZSH with Oh My Zsh and Powerlevel10k, and reference the essential command-line toolkit for servers and desktops.
+jsonld:
+    type: Article
+    keywords:
+        - linux
+        - lvm
+        - zsh
+        - command line
+        - system administration
+    faq:
+        - question: How do I extend a disk partition on Linux with LVM?
+          answer: Grow the partition with growpart, update the physical volume with pvresize, extend the logical volume using lvextend -l +100%FREE, then resize the filesystem with resize2fs (EXT4) or xfs_growfs (XFS). Verify with df -h.
+        - question: What is LVM in Linux?
+          answer: Logical Volume Management is a storage abstraction layer that lets you resize, extend, or move volumes without repartitioning. It is especially useful in virtualized environments like Proxmox where disk size can grow dynamically.
+        - question: How do I change my default shell to ZSH?
+          answer: Install ZSH with your package manager, then run chsh -s $(which zsh) and log out and back in. Many users add Oh My Zsh and a theme like Powerlevel10k for autocompletion, history, and prompt customization.
+        - question: What is the difference between ext4 and XFS when resizing?
+          answer: Both are Linux filesystems, but they grow with different tools. Use resize2fs to expand an ext4 filesystem and xfs_growfs to expand XFS. XFS can only grow, never shrink, so plan capacity accordingly.
 ---
 
 import {
@@ -32,7 +54,30 @@ From the servers that power your favorite websites to the Kubernetes clusters or
 Its open-source roots have created a culture of collaboration and curiosity, where anyone can peek under the hood, make changes, and share improvements with the world.
 Whether you're deploying containers, managing infrastructure, or just exploring the command line, understanding Linux means understanding the language of modern computing.
 
+This page focuses on two everyday sysadmin skills — extending storage with [LVM](#lvm) and setting up a productive [ZSH](#zsh) shell — plus an [essential command reference](#essential-commands) for navigating any Linux system.
+
 <Adsense />
+
+## Essential Commands
+
+A quick reference for the commands you reach for constantly on any Linux box:
+
+| Command | Purpose |
+| ------- | ------- |
+| `ls -lah` | List files with sizes, permissions, and hidden entries |
+| `cd` / `pwd` | Change directory / print working directory |
+| `cp` / `mv` / `rm` | Copy, move, remove files |
+| `chmod` / `chown` | Change file permissions / ownership |
+| `sudo` | Run a command as root |
+| `ps aux` / `top` | List / monitor running processes |
+| `systemctl status <svc>` | Inspect a systemd service |
+| `journalctl -u <svc> -f` | Follow a service's logs |
+| `df -h` / `du -sh *` | Disk free / directory sizes |
+| `grep -r "text" .` | Recursively search file contents |
+
+<Aside type="tip">
+Permissions are the most common source of "it works for root but not the app" bugs. `ls -l` shows the owner and mode; fix access with `chown user:group file` and `chmod` rather than running everything as root.
+</Aside>
 
 ## LVM
 
@@ -225,3 +270,21 @@ If you're using VS Code's integrated terminal or Windows Terminal, make sure you
 -   [Oh My Zsh Official Page](https://ohmyz.sh/)
 -   [Powerlevel10K Repository](https://github.com/romkatv/powerlevel10k)
 -   [One of the Best Tutorials by dev.to (Dec 2020)](https://dev.to/abdfnx/oh-my-zsh-powerlevel10k-cool-terminal-1no0)
+
+---
+
+## FAQ
+
+**How do I extend a disk partition on Linux with LVM?**
+Grow the partition with `growpart`, update the physical volume with `pvresize`, extend the logical volume using `lvextend -l +100%FREE`, then resize the filesystem with `resize2fs` (EXT4) or `xfs_growfs` (XFS). Verify with `df -h`.
+
+**What is LVM in Linux?**
+Logical Volume Management is a storage abstraction layer that lets you resize, extend, or move volumes without repartitioning. It is especially useful in virtualized environments like [Proxmox](/application/proxmox/) where disk size can grow dynamically.
+
+**How do I change my default shell to ZSH?**
+Install ZSH with your package manager, then run `chsh -s $(which zsh)` and log out and back in. Many users add Oh My Zsh and a theme like Powerlevel10k for autocompletion, history, and prompt customization.
+
+**What is the difference between ext4 and XFS when resizing?**
+Both are Linux filesystems, but they grow with different tools. Use `resize2fs` to expand an ext4 filesystem and `xfs_growfs` to expand XFS. XFS can only grow, never shrink, so plan capacity accordingly.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/proxmox.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/proxmox.mdx
@@ -1,14 +1,38 @@
 ---
 title: Proxmox
 description: |
-    A complete open source software platform for virtualization management.
+    Proxmox VE is an open-source virtualization platform built on Debian that runs KVM virtual machines and LXC
+    containers with a web UI, CLI, and REST API. This guide covers the qm and pct command cheatsheet, container
+    networking with netplan, Windows VM setup with VirtIO drivers, and theming.
 sidebar:
     label: Proxmox
     order: 110
 unsplash: 1558494949-ef010cbdcc31
 img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
 tags:
-    - technology
+    - virtualization
+    - homelab
+    - linux
+sem: 1
+ogTitle: Proxmox VE Guide — qm & pct CLI, Networking & Windows VMs
+ogDescription: Manage Proxmox VE virtual machines and containers — the qm and pct command cheatsheet, container networking with netplan, Windows KVM setup with VirtIO drivers, and dark-mode theming.
+jsonld:
+    type: Article
+    keywords:
+        - proxmox
+        - kvm
+        - lxc
+        - virtualization
+        - homelab
+    faq:
+        - question: What is Proxmox VE?
+          answer: Proxmox Virtual Environment is an open-source server virtualization platform based on Debian Linux. It runs KVM/QEMU virtual machines and LXC containers under one web interface, with clustering, high availability, Ceph storage, and backups built in.
+        - question: What is the difference between qm and pct in Proxmox?
+          answer: qm manages KVM/QEMU virtual machines (full hardware virtualization), while pct manages LXC containers (lightweight OS-level virtualization). For example qm start <id> boots a VM and pct start <id> starts a container.
+        - question: What port is the Proxmox web interface on?
+          answer: The Proxmox web panel listens on port 8006 over HTTPS, and the PVEDaemon uses port 85. You log in with PAM or Proxmox PVE authentication. Confirm the open ports with nmap 127.0.0.1 -p- or netstat.
+        - question: How do I install VirtIO drivers on a Windows VM in Proxmox?
+          answer: Download the VirtIO ISO into /var/lib/vz/template/iso with wget, attach it to the Windows KVM as a second CD drive, reboot, and run the installer from the ISO so Windows recognizes the paravirtualized disk and network devices.
 ---
 
 import {
@@ -31,6 +55,8 @@ Proxmox offers a web interface for easy administration, as well as command-line 
 The objective of this software is provide a base-line to build your own paradigm style hybrid cloud through HA (High Avalibity), CEPH and load balancing built-in.
 
 > Hint: Utilize the PAM/PVE settings within Proxmox to secure and abstract the system authentication.
+
+This page is a working reference: the [command cheatsheet](#cheatsheet) for `qm` (VMs) and `pct` (containers), [container networking](#network) with netplan, [Windows VM setup](#windows) including VirtIO drivers, and [theming](#style).
 
 <Adsense />
 
@@ -237,3 +263,21 @@ Dock Swarm
 #In case you aren't in the know like cool guy Jones, Rick Deckard is from Bladerunner and he hunts stray replicants, the premise here don't let replicants go stray.
 ### 4.d. Creating Reverse Proxies for your Nodes
 ```
+
+---
+
+## FAQ
+
+**What is Proxmox VE?**
+Proxmox Virtual Environment is an open-source server virtualization platform based on Debian Linux. It runs KVM/QEMU virtual machines and LXC containers under one web interface, with clustering, high availability, Ceph storage, and backups built in.
+
+**What is the difference between `qm` and `pct` in Proxmox?**
+`qm` manages KVM/QEMU virtual machines (full hardware virtualization), while `pct` manages LXC containers (lightweight OS-level virtualization). For example `qm start <id>` boots a VM and `pct start <id>` starts a container.
+
+**What port is the Proxmox web interface on?**
+The Proxmox web panel listens on port `8006` over HTTPS, and the PVEDaemon uses port `85`. You log in with PAM or Proxmox PVE authentication. Confirm the open ports with `nmap 127.0.0.1 -p-` or `netstat`.
+
+**How do I install VirtIO drivers on a Windows VM in Proxmox?**
+Download the VirtIO ISO into `/var/lib/vz/template/iso` with `wget`, attach it to the Windows KVM as a second CD drive, reboot, and run the installer from the ISO so Windows recognizes the paravirtualized disk and network devices.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/sql.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/sql.mdx
@@ -1,7 +1,9 @@
 ---
 title: SQL
 description: |
-    SQL is the standard language for managing data in relational databases like MySQL and PostgreSQL, enabling robust and scalable operations.
+    SQL is the standard language for managing data in relational databases like MySQL, MariaDB, and PostgreSQL.
+    This guide covers the MySQL/MariaDB cheatsheet, PostgreSQL with PSQL and extensions, CloudNativePG (CNPG)
+    and Barman on Kubernetes, plus Supabase schemas and backups.
 sidebar:
     label: SQL
     order: 409
@@ -9,6 +11,28 @@ unsplash: 1567604713218-36a0f5841046
 img: https://images.unsplash.com/photo-1567604713218-36a0f5841046?fit=crop&w=1400&h=700&q=75
 tags:
     - database
+    - sql
+    - postgresql
+sem: 1
+ogTitle: SQL Guide — MySQL/MariaDB, PostgreSQL, CNPG & Supabase
+ogDescription: A practical SQL reference — MySQL and MariaDB command cheatsheet, PostgreSQL with PSQL and extensions, CloudNativePG and Barman on Kubernetes, and Supabase schemas and backups.
+jsonld:
+    type: Article
+    keywords:
+        - sql
+        - mysql
+        - postgresql
+        - cloudnativepg
+        - supabase
+    faq:
+        - question: What is the difference between SQL and MySQL?
+          answer: SQL is the standard query language for relational databases. MySQL is a specific database system that implements SQL. PostgreSQL, MariaDB, and SQLite are other systems that also speak SQL with their own extensions.
+        - question: What is the difference between MySQL and PostgreSQL?
+          answer: Both are open-source relational databases. MySQL is known for simplicity and read-heavy speed, while PostgreSQL offers richer SQL compliance, advanced types (JSONB, arrays), and extensions. PostgreSQL is often preferred for complex, write-heavy, or analytical workloads.
+        - question: What is CloudNativePG (CNPG)?
+          answer: CloudNativePG is a Kubernetes operator that runs PostgreSQL clusters as native resources. It handles provisioning, failover, rolling updates, and backups (often via Barman), managing high-availability Postgres declaratively inside a cluster.
+        - question: How do I reset a MySQL root password?
+          answer: Log into the MySQL shell and run ALTER USER 'root'@'localhost' IDENTIFIED BY 'newpassword'. On a fresh Ubuntu install that never prompted for a password, you may first need to authenticate through the auth_socket plugin.
 ---
 
 import {
@@ -27,6 +51,8 @@ import { Giscus, Adsense } from '@/components/astropad';
 SQL (Structured Query Language) is the standard programming language used for managing relational databases and performing various operations on the data they contain.
 The SQL ecosystem includes a wide array of database systems such as MySQL and PostgreSQL, which are known for their robustness, scalability, and support for complex queries.
 These systems are integral to many applications, providing transactional support, ACID compliance, and advanced data management capabilities to ensure data integrity and performance across numerous industries.
+
+This page collects working references across engines: the [MySQL/MariaDB cheatsheet](#cheatsheet), [PostgreSQL](#postgresql) with PSQL and extensions, [CloudNativePG](#cnpg) and [Barman](#barman) for Postgres on Kubernetes, and [Supabase schemas](#supabase-schemas) and [backups](#backup).
 
 ---
 
@@ -395,3 +421,21 @@ More information on [AWX](/application/ansible/#awx) and [Docker](/application/d
 -   #### What to do if you've never used this foreign and vaguely antiquated technology before and you wish you had a time machine that would let you go back in time so you could sit with the pioneers of this dying technology and learn from them what drugs they were smoking when they decided on the syntax?
 
     -   [Well here's a cool link](https://devhints.io/mysql) that will help in your journey to understand the aforementioned topics.
+
+---
+
+## FAQ
+
+**What is the difference between SQL and MySQL?**
+SQL is the standard query language for relational databases. MySQL is a specific database system that implements SQL. PostgreSQL, MariaDB, and SQLite are other systems that also speak SQL with their own extensions.
+
+**What is the difference between MySQL and PostgreSQL?**
+Both are open-source relational databases. MySQL is known for simplicity and read-heavy speed, while PostgreSQL offers richer SQL compliance, advanced types (JSONB, arrays), and extensions. PostgreSQL is often preferred for complex, write-heavy, or analytical workloads.
+
+**What is CloudNativePG (CNPG)?**
+CloudNativePG is a Kubernetes operator that runs PostgreSQL clusters as native resources. It handles provisioning, failover, rolling updates, and backups (often via Barman), managing high-availability Postgres declaratively inside a cluster.
+
+**How do I reset a MySQL root password?**
+Log into the MySQL shell and run `ALTER USER 'root'@'localhost' IDENTIFIED BY 'newpassword'`. On a fresh Ubuntu install that never prompted for a password, you may first need to authenticate through the `auth_socket` plugin.
+
+<Adsense />


### PR DESCRIPTION
## Summary

SEO audit **batch 3** for `application/` docs — same locked pattern as [#13645](https://github.com/KBVE/kbve/pull/13645) and [#13648](https://github.com/KBVE/kbve/pull/13648). Four more docs audited, improved, stamped `sem: 1`.

## Changes

- **flutter.mdx** — built out install (macOS/Linux SDK clone, create + run first app), added a Widgets section with a Dart example and the Stateless/Stateful distinction, FAQ.
- **linux.mdx** — added an Essential Commands reference table, overview with anchor nav, FAQ.
- **proxmox.mdx** — fixed a weak `technology` tag, overview nav, FAQ (qm vs pct, ports, VirtIO).
- **sql.mdx** — fixed a weak `technology`→domain tag, cross-engine overview nav, FAQ (SQL vs MySQL, MySQL vs Postgres, CNPG).

Every file: keyword-front-loaded `title`/`description`, real `tags`, `ogTitle`/`ogDescription`, and `jsonld` (keywords + 4-5 entry `faq`, visible MDX + structured for AI/GEO citation).

## Verification

Structural validation PASS — valid YAML, `sem=1`, balanced fences. Word counts: flutter 1195, linux 1347, proxmox 1293, sql 2562.

## Progress

Batch 3 of the `application/` sweep. **12 of 45** docs now carry `sem: 1`; 33 remain.