### PR TITLE
feat(rn): Timeline, TabbedFeatures, TeamGrid, NewsletterCapture marketing sections

### DIFF
--- a/apps/kbve/astro-kbve/src/components/marketing/NewsletterCapture.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/NewsletterCapture.astro
@@ -1,0 +1,6 @@
+---
+import { NewsletterCapture } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<NewsletterCapture client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/TabbedFeatures.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/TabbedFeatures.astro
@@ -1,0 +1,6 @@
+---
+import { TabbedFeatures } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<TabbedFeatures client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/TeamGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/TeamGrid.astro
@@ -1,0 +1,6 @@
+---
+import { TeamGrid } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<TeamGrid client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/components/marketing/Timeline.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Timeline.astro
@@ -1,0 +1,6 @@
+---
+import { Timeline } from '@kbve/rn-astro';
+const props = Astro.props;
+---
+
+<Timeline client:only="react" {...props} />

--- a/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/lab/showcase.mdx
@@ -13,13 +13,17 @@ import Hero from '@/components/marketing/Hero.astro';
 import FeatureGrid from '@/components/marketing/FeatureGrid.astro';
 import StatStrip from '@/components/marketing/StatStrip.astro';
 import ProcessSteps from '@/components/marketing/ProcessSteps.astro';
+import TabbedFeatures from '@/components/marketing/TabbedFeatures.astro';
 import LiveFeed from '@/components/marketing/LiveFeed.astro';
 import BentoGrid from '@/components/marketing/BentoGrid.astro';
+import Timeline from '@/components/marketing/Timeline.astro';
 import ProjectGrid from '@/components/marketing/ProjectGrid.astro';
 import LogoCloud from '@/components/marketing/LogoCloud.astro';
+import TeamGrid from '@/components/marketing/TeamGrid.astro';
 import Testimonials from '@/components/marketing/Testimonials.astro';
 import PricingTiers from '@/components/marketing/PricingTiers.astro';
 import FaqAccordion from '@/components/marketing/FaqAccordion.astro';
+import NewsletterCapture from '@/components/marketing/NewsletterCapture.astro';
 import Cta from '@/components/marketing/Cta.astro';
 
 <Hero
@@ -36,7 +40,7 @@ import Cta from '@/components/marketing/Cta.astro';
 
 <StatStrip
 	stats={[
-		{ value: '15', label: 'Marketing sections' },
+		{ value: '19', label: 'Marketing sections' },
 		{ value: '1', label: 'Shared RN core' },
 		{ value: '2', label: 'Targets: web + native' },
 		{ value: '0', label: 'Duplicated styles' },
@@ -69,7 +73,11 @@ import Cta from '@/components/marketing/Cta.astro';
 		{ title: 'BentoGrid', body: 'Mixed-size feature tiles — wide and standard from one flex grid.' },
 		{ title: 'LogoCloud', body: 'A bordered trust strip of tech and brand names.' },
 		{ title: 'PricingTiers', body: 'Plan cards with a highlighted tier and feature checklists.' },
-		{ title: 'FaqAccordion', body: 'Interactive expand/collapse Q&A — the only stateful section.' },
+		{ title: 'FaqAccordion', body: 'Interactive expand/collapse Q&A.' },
+		{ title: 'TabbedFeatures', body: 'Tabbed panel switcher — stateful, one panel at a time.' },
+		{ title: 'Timeline', body: 'Vertical roadmap with a connecting rail and done markers.' },
+		{ title: 'TeamGrid', body: 'Member cards with avatar initials, role, and bio.' },
+		{ title: 'NewsletterCapture', body: 'Email input band with inline thank-you state.' },
 	]}
 />
 
@@ -95,6 +103,16 @@ import Cta from '@/components/marketing/Cta.astro';
 	]}
 />
 
+<TabbedFeatures
+	title="Explore the stack"
+	subtitle="Tap a tab to switch panels — the active panel is client-side state."
+	tabs={[
+		{ label: 'Games', title: 'Multiplayer worlds', body: 'ARPGs, isometric sims, and engine-native titles shipped across web, desktop, and native.', points: ['Server-authoritative sims', 'Agones multiplayer', 'Shared ECS patterns'] },
+		{ label: 'Engines', title: 'Plugins & crates', body: 'Unreal and Unity plugins plus Bevy/Rust crates and a shared component kit.', points: ['KBVE* Unreal plugins', 'Unity DOTS + Burst', 'Reusable RN kit'] },
+		{ label: 'Cloud', title: 'Declarative infra', body: 'Kubernetes, ArgoCD, ClickHouse, and Supabase — production infra, all in the open.', points: ['GitOps via ArgoCD', 'ClickHouse telemetry', 'Postgres-on-CNPG'] },
+	]}
+/>
+
 <LiveFeed
 	title="Signature showpiece"
 	label="kbve — live feed"
@@ -105,6 +123,17 @@ import Cta from '@/components/marketing/Cta.astro';
 		{ label: 'agones · cryptothrone', value: 'ready', status: 'ok' },
 	]}
 	footer="12M events/day · 99.9% uptime"
+/>
+
+<Timeline
+	title="Roadmap"
+	subtitle="A placeholder changelog — the rail connects each milestone."
+	items={[
+		{ when: '2024 · Q1', title: 'Monorepo goes public', body: 'Games, engine plugins, and infra land in one open repo.', done: true },
+		{ when: '2024 · Q3', title: 'Shared RN kit', body: 'One React Native core drives both native and web surfaces.', done: true },
+		{ when: '2025 · Q2', title: 'Marketing section library', body: 'Theme-parity sections shipped through @kbve/rn-astro.', done: true },
+		{ when: 'Next', title: 'Landing assembly', body: 'Compose the sections into the primary marketing page.' },
+	]}
 />
 
 <ProjectGrid
@@ -127,6 +156,17 @@ import Cta from '@/components/marketing/Cta.astro';
 	]}
 />
 
+<TeamGrid
+	title="The collective"
+	subtitle="Placeholder members — swap in real contributors anytime."
+	members={[
+		{ name: 'Maintainer One', role: 'Infra', bio: 'Kubernetes, ArgoCD, and the pipelines that ship it all.', initials: 'M1', href: '/docs/' },
+		{ name: 'Maintainer Two', role: 'Engines', bio: 'Unreal, Unity, and the shared component kit.', initials: 'M2', href: '/gaming/' },
+		{ name: 'Maintainer Three', role: 'Games', bio: 'Server-authoritative worlds and in-game economies.', initials: 'M3', href: '/gaming/' },
+		{ name: 'You', role: 'Contributor', bio: 'Every issue and PR is open — jump in.', initials: '++', href: 'https://github.com/kbve/kbve' },
+	]}
+/>
+
 <PricingTiers
 	title="Sponsor the work"
 	subtitle="Placeholder tiers — the code stays free and open regardless."
@@ -146,6 +186,14 @@ import Cta from '@/components/marketing/Cta.astro';
 		{ q: 'Why client:only for every section?', a: 'RN-Web uses CommonJS require at module load. client:load or client:visible trigger build-time prerender that runs require before the browser is ready, so client:only is required.' },
 		{ q: 'Can I use these components in my own project?', a: 'The kit lives in the public monorepo. Read the docs to see how the barrels split web-safe and native exports.' },
 	]}
+/>
+
+<NewsletterCapture
+	title="Stay in the loop"
+	subtitle="Placeholder capture — wires to a real list later."
+	placeholder="you@example.com"
+	cta="Subscribe"
+	note="No spam. Unsubscribe anytime."
 />
 
 <Cta

--- a/packages/npm/rn-astro/src/components.ts
+++ b/packages/npm/rn-astro/src/components.ts
@@ -34,6 +34,10 @@ export {
 	FaqAccordion,
 	LogoCloud,
 	BentoGrid,
+	Timeline,
+	TabbedFeatures,
+	TeamGrid,
+	NewsletterCapture,
 	useTheme,
 	tokens,
 } from '@kbve/rn/ui';
@@ -68,4 +72,7 @@ export type {
 	FaqItem,
 	LogoItem,
 	BentoItem,
+	TimelineItem,
+	FeatureTab,
+	TeamMember,
 } from '@kbve/rn/ui';

--- a/packages/npm/rn/src/ui/marketing/sections.tsx
+++ b/packages/npm/rn/src/ui/marketing/sections.tsx
@@ -1,5 +1,11 @@
 import { memo, useState } from 'react';
-import { Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
+import {
+	Pressable,
+	StyleSheet,
+	TextInput,
+	View,
+	useWindowDimensions,
+} from 'react-native';
 import type { ReactNode } from 'react';
 import { tokens } from '../theme';
 import { Text } from '../primitives/Text';
@@ -661,6 +667,229 @@ export const BentoGrid = memo(function BentoGrid({
 	);
 });
 
+/* ───────────────────────── Timeline ────────────────────────── */
+
+export interface TimelineItem {
+	when: string;
+	title: string;
+	body: string;
+	done?: boolean;
+}
+
+export const Timeline = memo(function Timeline({
+	title,
+	subtitle,
+	items,
+}: {
+	title?: string;
+	subtitle?: string;
+	items: TimelineItem[];
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.timeline}>
+				{items.map((it, i) => (
+					<View key={it.title} style={styles.tlRow}>
+						<View style={styles.tlRail}>
+							<View
+								style={[styles.tlDot, it.done && styles.tlDotDone]}
+							/>
+							{i < items.length - 1 ? (
+								<View style={styles.tlLine} />
+							) : null}
+						</View>
+						<View style={styles.tlContent}>
+							<Text style={styles.tlWhen}>{it.when}</Text>
+							<Text style={styles.tlTitle}>{it.title}</Text>
+							<Text style={styles.tlBody}>{it.body}</Text>
+						</View>
+					</View>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ─────────────────────── Tabbed features ───────────────────── */
+
+export interface FeatureTab {
+	label: string;
+	title: string;
+	body: string;
+	points?: string[];
+}
+
+export const TabbedFeatures = memo(function TabbedFeatures({
+	title,
+	subtitle,
+	tabs,
+}: {
+	title?: string;
+	subtitle?: string;
+	tabs: FeatureTab[];
+}) {
+	const [active, setActive] = useState(0);
+	const tab = tabs[active] ?? tabs[0];
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.tabBar}>
+				{tabs.map((t, i) => {
+					const on = i === active;
+					return (
+						<Pressable
+							key={t.label}
+							accessibilityRole="button"
+							onPress={() => setActive(i)}
+							style={[
+								styles.tab,
+								on && styles.tabActive,
+								{ cursor: 'pointer' } as never,
+							]}>
+							<Text
+								style={[
+									styles.tabText,
+									on && styles.tabTextActive,
+								]}>
+								{t.label}
+							</Text>
+						</Pressable>
+					);
+				})}
+			</View>
+			{tab ? (
+				<View style={styles.tabPanel}>
+					<Text style={styles.tabPanelTitle}>{tab.title}</Text>
+					<Text style={styles.tabPanelBody}>{tab.body}</Text>
+					{tab.points && tab.points.length > 0 ? (
+						<View style={styles.tabPoints}>
+							{tab.points.map((p) => (
+								<View key={p} style={styles.tabPoint}>
+									<Text style={styles.tabCheck}>✓</Text>
+									<Text style={styles.tabPointText}>{p}</Text>
+								</View>
+							))}
+						</View>
+					) : null}
+				</View>
+			) : null}
+		</View>
+	);
+});
+
+/* ───────────────────────── Team grid ───────────────────────── */
+
+export interface TeamMember {
+	name: string;
+	role: string;
+	bio?: string;
+	initials?: string;
+	href?: string;
+}
+
+export const TeamGrid = memo(function TeamGrid({
+	title,
+	subtitle,
+	members,
+	onNavigate,
+}: {
+	title?: string;
+	subtitle?: string;
+	members: TeamMember[];
+	onNavigate?: (href: string) => void;
+}) {
+	return (
+		<View style={styles.section}>
+			{title ? (
+				<SectionHeading title={title} subtitle={subtitle} />
+			) : null}
+			<View style={styles.grid}>
+				{members.map((m) => (
+					<Pressable
+						key={m.name}
+						accessibilityRole={m.href ? 'link' : undefined}
+						onPress={() => m.href && onNavigate?.(m.href)}
+						style={[
+							styles.member,
+							m.href ? ({ cursor: 'pointer' } as never) : null,
+						]}>
+						<View style={styles.memberAvatar}>
+							<Text style={styles.memberInitials}>
+								{m.initials ?? m.name.slice(0, 2).toUpperCase()}
+							</Text>
+						</View>
+						<Text style={styles.memberName}>{m.name}</Text>
+						<Text style={styles.memberRole}>{m.role}</Text>
+						{m.bio ? (
+							<Text style={styles.memberBio}>{m.bio}</Text>
+						) : null}
+					</Pressable>
+				))}
+			</View>
+		</View>
+	);
+});
+
+/* ─────────────────────── Newsletter capture ────────────────── */
+
+export const NewsletterCapture = memo(function NewsletterCapture({
+	title,
+	subtitle,
+	placeholder = 'you@example.com',
+	cta = 'Subscribe',
+	note,
+	onSubmit,
+}: {
+	title: string;
+	subtitle?: string;
+	placeholder?: string;
+	cta?: string;
+	note?: string;
+	onSubmit?: (email: string) => void;
+}) {
+	const [email, setEmail] = useState('');
+	const [sent, setSent] = useState(false);
+	const submit = () => {
+		if (!email.trim()) return;
+		onSubmit?.(email.trim());
+		setSent(true);
+	};
+	return (
+		<View style={styles.newsWrap}>
+			<View style={styles.newsInner}>
+				<Text style={styles.newsTitle}>{title}</Text>
+				{subtitle ? (
+					<Text style={styles.newsSub}>{subtitle}</Text>
+				) : null}
+				{sent ? (
+					<Text style={styles.newsThanks}>
+						Thanks — you're on the list.
+					</Text>
+				) : (
+					<View style={styles.newsForm}>
+						<TextInput
+							value={email}
+							onChangeText={setEmail}
+							placeholder={placeholder}
+							placeholderTextColor={tokens.color.textMuted}
+							keyboardType="email-address"
+							autoCapitalize="none"
+							style={styles.newsInput}
+						/>
+						<Button title={cta} variant="primary" onPress={submit} />
+					</View>
+				)}
+				{note ? <Text style={styles.newsNote}>{note}</Text> : null}
+			</View>
+		</View>
+	);
+});
+
 /* ─────────────────────────── Styles ────────────────────────── */
 
 const styles = StyleSheet.create({
@@ -1099,4 +1328,186 @@ const styles = StyleSheet.create({
 	bentoWide: { minWidth: 520, flexBasis: '100%' },
 	bentoTitle: { fontSize: 18, fontWeight: '700', color: tokens.color.primary },
 	bentoBody: { fontSize: 14, lineHeight: 21, color: tokens.color.textMuted },
+
+	timeline: {
+		width: '100%',
+		maxWidth: 760,
+		alignSelf: 'center',
+	},
+	tlRow: { flexDirection: 'row', gap: tokens.space.lg },
+	tlRail: { alignItems: 'center', width: 24 },
+	tlDot: {
+		width: 16,
+		height: 16,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 2,
+		borderColor: tokens.color.border,
+		backgroundColor: tokens.color.surface,
+		marginTop: 4,
+	},
+	tlDotDone: {
+		borderColor: tokens.color.primary,
+		backgroundColor: tokens.color.primary,
+	},
+	tlLine: {
+		flex: 1,
+		width: 2,
+		backgroundColor: tokens.color.border,
+		marginVertical: 4,
+	},
+	tlContent: { flex: 1, gap: 4, paddingBottom: tokens.space.xl },
+	tlWhen: {
+		fontSize: 12,
+		fontWeight: '700',
+		letterSpacing: 1,
+		textTransform: 'uppercase',
+		color: tokens.color.primary,
+	},
+	tlTitle: { fontSize: 18, fontWeight: '700', color: tokens.color.text },
+	tlBody: { fontSize: 14, lineHeight: 21, color: tokens.color.textMuted },
+
+	tabBar: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		justifyContent: 'center',
+		gap: tokens.space.sm,
+		marginBottom: tokens.space.xl,
+	},
+	tab: {
+		paddingHorizontal: tokens.space.lg,
+		paddingVertical: tokens.space.sm,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		backgroundColor: tokens.color.surface,
+	},
+	tabActive: {
+		borderColor: tokens.color.primary,
+		backgroundColor: tokens.color.surfaceAlt,
+	},
+	tabText: { fontSize: 14, fontWeight: '700', color: tokens.color.textMuted },
+	tabTextActive: { color: tokens.color.primary },
+	tabPanel: {
+		width: '100%',
+		maxWidth: 760,
+		alignSelf: 'center',
+		gap: tokens.space.md,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	tabPanelTitle: {
+		fontSize: 22,
+		fontWeight: '800',
+		color: tokens.color.text,
+	},
+	tabPanelBody: {
+		fontSize: 15,
+		lineHeight: 23,
+		color: tokens.color.textMuted,
+	},
+	tabPoints: { gap: tokens.space.sm, marginTop: tokens.space.xs },
+	tabPoint: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+	},
+	tabCheck: { fontSize: 14, fontWeight: '800', color: tokens.color.primary },
+	tabPointText: { flex: 1, fontSize: 14, color: tokens.color.text },
+
+	member: {
+		flex: 1,
+		minWidth: 220,
+		alignItems: 'center',
+		gap: tokens.space.xs,
+		padding: tokens.space.xl,
+		borderRadius: tokens.radius.xl,
+		backgroundColor: tokens.color.surface,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	memberAvatar: {
+		width: 64,
+		height: 64,
+		borderRadius: tokens.radius.pill,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: tokens.color.surfaceAlt,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		marginBottom: tokens.space.xs,
+	},
+	memberInitials: {
+		fontSize: 20,
+		fontWeight: '800',
+		color: tokens.color.primary,
+	},
+	memberName: { fontSize: 16, fontWeight: '700', color: tokens.color.text },
+	memberRole: {
+		fontSize: 12,
+		letterSpacing: 1,
+		textTransform: 'uppercase',
+		color: tokens.color.primary,
+	},
+	memberBio: {
+		fontSize: 13,
+		lineHeight: 20,
+		color: tokens.color.textMuted,
+		textAlign: 'center',
+	},
+
+	newsWrap: {
+		paddingVertical: 72,
+		paddingHorizontal: tokens.space.lg,
+		alignItems: 'center',
+		backgroundColor: tokens.color.bgSubtle,
+		borderTopWidth: 1,
+		borderBottomWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	newsInner: { alignItems: 'center', gap: tokens.space.md, maxWidth: 560 },
+	newsTitle: {
+		fontSize: 30,
+		fontWeight: '800',
+		letterSpacing: -0.5,
+		color: tokens.color.text,
+		textAlign: 'center',
+	},
+	newsSub: {
+		fontSize: 16,
+		color: tokens.color.textMuted,
+		textAlign: 'center',
+	},
+	newsForm: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		justifyContent: 'center',
+		gap: tokens.space.sm,
+		marginTop: tokens.space.xs,
+	},
+	newsInput: {
+		minWidth: 240,
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: tokens.space.sm,
+		borderRadius: tokens.radius.md,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		backgroundColor: tokens.color.surface,
+		color: tokens.color.text,
+		fontSize: 15,
+	},
+	newsThanks: {
+		fontSize: 16,
+		fontWeight: '700',
+		color: tokens.color.primary,
+		marginTop: tokens.space.xs,
+	},
+	newsNote: {
+		fontSize: 12,
+		color: tokens.color.textMuted,
+		textAlign: 'center',
+		marginTop: tokens.space.xs,
+	},
 });


### PR DESCRIPTION
## Summary

Adds four secondary marketing sections to the shared RN core, completing theme parity against the neuron/ethernity template DNA.

- **Timeline** — vertical roadmap with a connecting rail, per-item date/title/body and `done` markers.
- **TabbedFeatures** — tab bar + active panel (`useState`), optional check-listed points. Stateful.
- **TeamGrid** — member cards with avatar initials, role, bio, and optional link.
- **NewsletterCapture** — `TextInput` email band with an inline thank-you state on submit.

All theme-match via existing dark-gold tokens. All web-safe — no @expo/vector-icons. `NewsletterCapture` and `TabbedFeatures` keep state island-local so no functions cross the client:only boundary.

## Wiring
- `@kbve/rn` `ui/marketing/sections.tsx` — 4 components + styles; adds `TextInput` import.
- `@kbve/rn-astro` `components.ts` — named + type exports (`TimelineItem`, `FeatureTab`, `TeamMember`).
- 4 Astro `client:only="react"` island wrappers under `marketing/`.
- `/lab/showcase` MDX extended to render all four (now 19 sections).

## Verify
- `tsc --noEmit` on rn-astro lib: **No errors found**.