### PR TITLE
docs(application): SEO/SEM audit batch 4 — terraform, nomad, authelia, nmap

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/authelia.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/authelia.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authelia
-description: Open-source auth software as a middleware. Authelia handles the authentication and authorization of the user/entity, allowing to secure access outside the scope of the application and provides a unique firewall-like access terminal.
+description: Authelia is an open-source authentication and authorization server that adds two-factor authentication (2FA) and single sign-on (SSO) to your applications through a reverse proxy. It acts as a firewall-like access portal, securing services outside the scope of the application itself.
 sidebar:
     label: Authelia
     order: 5
@@ -9,7 +9,30 @@ img: https://images.unsplash.com/photo-1549605659-32d82da3a059?fit=crop&w=1400&h
 tags:
   - security
   - auth
-  - firewall
+  - sso
+sem: 1
+ogTitle: Authelia Guide — 2FA & Single Sign-On via Reverse Proxy
+ogDescription: Secure your web apps with Authelia, an open-source authentication and authorization server. Learn how forward auth works with Nginx and Traefik, prerequisites, Docker deployment, and 2FA/SSO setup.
+jsonld:
+    type: Article
+    keywords:
+        - authelia
+        - two-factor authentication
+        - single sign-on
+        - sso
+        - forward auth
+        - reverse proxy authentication
+    faq:
+        - question: What is Authelia?
+          answer: Authelia is an open-source authentication and authorization server that provides two-factor authentication (2FA) and single sign-on (SSO) for your web applications. It sits behind a reverse proxy like Nginx or Traefik and validates every request before it reaches the protected service, acting like an application-layer firewall.
+        - question: How does Authelia integrate with a reverse proxy?
+          answer: Authelia uses forward auth (also called external or auth_request). The reverse proxy intercepts each request and asks Authelia whether the user is authenticated and authorized. If yes, the request passes through; if not, the user is redirected to Authelia's login portal. Nginx uses auth_request, and Traefik uses a forwardAuth middleware.
+        - question: What port does Authelia run on?
+          answer: Authelia listens on port 9091 by default, but this is configurable. It must operate under SSL/TLS, so in practice you terminate HTTPS at your reverse proxy and forward authenticated traffic to Authelia and your backend services.
+        - question: Does Authelia support single sign-on across multiple domains?
+          answer: Yes. Once a user authenticates through Authelia's portal, a session cookie scoped to your root domain grants access to every protected subdomain and service without logging in again, delivering true single sign-on across your ecosystem.
+        - question: What do I need before deploying Authelia?
+          answer: A working reverse proxy (Nginx, Traefik, or HAProxy), a domain with valid SSL certificates, and a session/storage backend. If Cloudflare sits in front of your domain, verify your forwarded headers configuration so Authelia receives the correct original request details.
 ---
 
 import {
@@ -26,26 +49,48 @@ import { Giscus, Adsense } from '@/components/astropad';
 
 <Aside title="TLDR">
 
-Tldr; Authelia is an authentication and authorization application that provides a backend server and frontend portal through various core features and plugins.
+Tldr; Authelia is an authentication and authorization application that provides a backend server and frontend portal, adding 2FA and SSO to any app through your reverse proxy.
 
 </Aside>
 
 
 ## Information
 
-Have you ever wondered how to secure your web applications with a simple, secure and elegant solution?
-Do you want to offer your users a seamless and convenient login experience across multiple domains and services?
-If so, you might be interested in Autheila, an open-source authentication and authorization server that provides two-factor authentication and single sign-on (SSO) for your applications via a web portal.
-In this document, KBVE will introduce you and your dev team to the features and benefits of Autheila, and show you how to set it up with some common reverse proxies like [Nginx](/application/nginx/), [Traefik](/application/traefik/), or HAProxy.
-By the end of this reference document, you will be able to protect your web applications with Autheila and enjoy a secure and hassle-free authentication process.
+Have you ever wondered how to secure your web applications with a simple, secure, and elegant solution?
+Do you want to offer your users a seamless login experience across multiple domains and services?
+If so, you might be interested in **Authelia**, an open-source authentication and authorization server that provides two-factor authentication (2FA) and single sign-on (SSO) for your applications via a web portal.
+In this document, KBVE introduces you and your dev team to the features and benefits of Authelia, and shows you how to set it up with common reverse proxies like [Nginx](/application/nginx/), [Traefik](/application/traefik/), or HAProxy.
+By the end of this reference, you will be able to protect your web applications with Authelia and enjoy a secure, hassle-free authentication process.
 
 ---
 
 <Adsense />
 
+## How It Works
+
+Authelia does not modify your applications. Instead, it plugs into your **reverse proxy** using a pattern called **forward auth** (also called external auth or `auth_request`):
+
+<Steps>
+
+1. A user requests a protected service, e.g. `https://app.kbve.com`.
+2. The reverse proxy pauses and asks Authelia: *is this session authenticated and authorized?*
+3. If **yes**, the proxy forwards the request to the backend as normal.
+4. If **no**, the user is redirected to Authelia's login portal, completes 2FA, and is sent back — now with a valid session cookie.
+
+</Steps>
+
+Because the session cookie is scoped to your **root domain**, one login unlocks every protected subdomain — that is the single sign-on (SSO) experience.
+
+| Concept | Meaning |
+| ------- | ------- |
+| **Authentication** | Proving *who* the user is (password + 2FA) |
+| **Authorization** | Deciding *what* the user may access (access control rules) |
+| **Forward auth** | Reverse proxy delegates the auth decision to Authelia |
+| **SSO** | One authenticated session grants access across services |
+
 ## Install
 
-There are a couple ways we can install Autheila, here are the official deployment notes for each:
+There are a couple of ways to install Authelia. Here are the official deployment notes for each:
 
 - [Docker](https://www.authelia.com/integration/deployment/docker/)
 - [Kubernetes](https://www.authelia.com/integration/kubernetes/introduction/)
@@ -55,23 +100,71 @@ There are a couple ways we can install Autheila, here are the official deploymen
 
 ### Prerequisites
 
-Having a decent understanding of the operating system, networking and containerization will be extremely helpful!
+A decent understanding of your operating system, networking, and containerization will be extremely helpful.
 
-One of the fundamental situations that you have to account for is that Autheila has to operate under SSL!
-The default port that Autheila runs on is 9091, but this can be changed as well.
+One fundamental requirement: **Authelia has to operate under SSL/TLS**.
+The default port that Authelia runs on is `9091`, but this can be changed.
 
-Finally, if you have Cloudflare sitting infront of your domain, then we recommend double checking your forwarded headers, Autheila provides a guide on that [here](https://www.authelia.com/integration/proxies/fowarded-headers/).
+Finally, if you have Cloudflare sitting in front of your domain, double-check your forwarded headers — Authelia provides a guide on that [here](https://www.authelia.com/integration/proxies/fowarded-headers/).
 
 ---
 
 ### Docker
 
-This section will cover the deployment of Autheila via Docker!
+This section covers deploying Authelia via Docker.
 
-We are currently using the DockerHub image, `authelia/authelia` but you can also opt to use their Github image as well.
+We use the DockerHub image `authelia/authelia`, but you can opt for their GitHub image as well.
 
-Since our eco-system currently uses `Traefik` to manage, we recommend that you follow the documentation related to its [integration](https://www.authelia.com/integration/proxies/traefik/).
+Since our ecosystem uses **Traefik**, we recommend following the documentation for its [integration](https://www.authelia.com/integration/proxies/traefik/).
 
----
+A minimal `docker-compose.yml` service:
+
+```yaml
+services:
+  authelia:
+    image: authelia/authelia
+    container_name: authelia
+    volumes:
+      - ./authelia:/config
+    ports:
+      - "9091:9091"
+    environment:
+      - TZ=America/New_York
+    restart: unless-stopped
+```
+
+<Aside type="caution">
+Authelia must sit behind HTTPS. Terminate TLS at your reverse proxy and never expose port `9091` directly to the internet — it is meant to be reached only by the proxy's forward-auth request.
+</Aside>
+
+### Traefik forwardAuth
+
+Wire Authelia into Traefik with a `forwardAuth` middleware, then attach it to any protected router:
+
+```yaml
+labels:
+  - "traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://auth.kbve.com"
+  - "traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true"
+  - "traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User,Remote-Groups,Remote-Name,Remote-Email"
+```
+
+## FAQ
+
+**What is Authelia?**
+Authelia is an open-source authentication and authorization server that provides 2FA and SSO for your web applications. It sits behind a reverse proxy like Nginx or Traefik and validates every request before it reaches the protected service — like an application-layer firewall.
+
+**How does Authelia integrate with a reverse proxy?**
+It uses forward auth. The reverse proxy intercepts each request and asks Authelia whether the user is authenticated and authorized. If yes, the request passes through; if not, the user is redirected to the login portal. Nginx uses `auth_request`; Traefik uses a `forwardAuth` middleware.
+
+**What port does Authelia run on?**
+Authelia listens on port `9091` by default, but it is configurable. It must operate under SSL/TLS, so you terminate HTTPS at your reverse proxy and forward authenticated traffic to Authelia and your backend services.
+
+**Does Authelia support single sign-on across multiple domains?**
+Yes. Once a user authenticates, a session cookie scoped to your root domain grants access to every protected subdomain and service without logging in again.
+
+**What do I need before deploying Authelia?**
+A working reverse proxy (Nginx, Traefik, or HAProxy), a domain with valid SSL certificates, and a session/storage backend. If Cloudflare sits in front of your domain, verify your forwarded headers configuration.
 
 ## Videos
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/nmap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/nmap.mdx
@@ -11,6 +11,9 @@ img: https://images.unsplash.com/photo-1551609189-eba71b3a8566?fit=crop&w=1400&h
 tags:
     - network
     - security
+sem: 1
+ogTitle: Nmap Cheatsheet — Port Scanning, Service Detection & NSE
+ogDescription: Practical Nmap cheatsheet — host discovery, SYN vs connect scans, scanning all 65535 ports, service/OS fingerprinting, the Nmap Scripting Engine (NSE), and firewall evasion with copy-paste recipes.
 jsonld:
     type: Article
     section: Security

--- a/apps/kbve/astro-kbve/src/content/docs/application/nomad.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/nomad.mdx
@@ -1,15 +1,41 @@
 ---
 title: Nomad
 description: |
-    Nomad by HashiCorp is an orchestration swiss army knife that makes container management extremely flexible and easy.
+    Nomad by HashiCorp is a lightweight, flexible workload orchestrator that deploys and manages containers,
+    binaries, and batch jobs across a cluster from a single binary. This guide covers the architecture,
+    installation, job specification, and the essential CLI compared to Kubernetes.
 sidebar:
     label: Nomad
     order: 103
 unsplash: 1572511443032-a3cfe6823872
 img: https://images.unsplash.com/photo-1572511443032-a3cfe6823872?fit=crop&w=1400&h=700&q=75
 tags:
-    - network
+    - orchestration
     - cloud
+    - nomad
+sem: 1
+ogTitle: Nomad Guide — HashiCorp Workload Orchestrator, Jobs & CLI
+ogDescription: Learn Nomad, HashiCorp's lightweight workload orchestrator — how it compares to Kubernetes, the client/server architecture, writing a job specification, and the essential nomad CLI commands.
+jsonld:
+    type: Article
+    keywords:
+        - nomad
+        - hashicorp nomad
+        - workload orchestration
+        - container orchestration
+        - nomad vs kubernetes
+        - job scheduler
+    faq:
+        - question: What is HashiCorp Nomad?
+          answer: Nomad is a lightweight, single-binary workload orchestrator from HashiCorp that schedules and manages containers, standalone binaries, Java apps, and batch jobs across a cluster. It pairs naturally with Consul for service discovery and Vault for secrets.
+        - question: How is Nomad different from Kubernetes?
+          answer: Nomad is a single ~100MB binary that orchestrates more than just containers (raw executables, Java, QEMU VMs), with far less operational overhead than Kubernetes. Kubernetes is a larger, container-focused platform with a bigger built-in ecosystem. Nomad favors simplicity and flexible workload types; Kubernetes favors breadth and a rich API surface.
+        - question: What is an allocation in Nomad?
+          answer: An allocation (alloc) is a set of tasks from a job placed and running on a single client node — the rough equivalent of a Pod in Kubernetes. Each allocation gets a unique ID you use to inspect status and stream logs with nomad alloc logs.
+        - question: How many servers does a Nomad cluster need for high availability?
+          answer: A production HA control plane needs an odd number of server nodes to hold quorum, typically 3 or 5. A full HashiCorp stack with Vault and Consul also at HA means 3 instances of each, for 9 total, though Nomad itself can run standalone.
+        - question: What is a Nomad job specification?
+          answer: A job spec is an HCL (or JSON) file that declares what to run — the job, its groups, tasks, driver (docker, exec, java), resources, and count. You submit it with nomad job run, and the scheduler places allocations onto healthy clients that meet the constraints.
 ---
 
 import {
@@ -23,29 +49,144 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
 
-## Information
+**Nomad** is HashiCorp's easy, flexible, and powerful workload orchestrator. It ships as a **single binary** that can schedule and scale containers, plain executables, Java applications, and batch jobs across a cluster — often with a fraction of the operational overhead of Kubernetes.
 
--   Nomad is an easy, flexible and powerful orchestration software that can operate and scale various applications, micro-services and complex architectures.
--   It should be noted that the quorum for HA is 3 separated instances of each: `Vault` , `Consul` and `Nomad`, thus requiring a total of 9 instances.
+Nomad slots into the HashiCorp stack: **Consul** for service discovery, **Vault** for secrets. A production high-availability control plane holds quorum with an odd number of server nodes (3 or 5); a full HA stack of Vault, Consul, and Nomad means 3 instances of each — 9 total — though Nomad runs standalone too.
+
+This guide covers the [architecture](#architecture), [installation](#install), [job specs](#jobs), and the [CLI cheatsheet](#cheatsheet).
 
 <Adsense />
 
+## Architecture
+
+Nomad has two node roles running from the same binary:
+
+| Role | Responsibility |
+| ---- | -------------- |
+| **Server** | Holds cluster state, runs the scheduler, elects a leader via Raft. Run 3 or 5 for HA. |
+| **Client** | Registers with servers, runs allocations, reports health and resource usage. |
+
+Key terms:
+
+- **Job** — your declarative desired state (what to run, how many).
+- **Task** — a single unit of work run by a driver (`docker`, `exec`, `java`, `qemu`).
+- **Group** — a set of tasks scheduled together on one node.
+- **Allocation (alloc)** — a group's tasks placed on a specific client. The rough equivalent of a **Pod** in Kubernetes.
+
 ## Install
 
+Nomad is a single binary — download it or use a package manager.
 
-## Terms
+<Steps>
 
+1. **Install the binary**
 
--   Allocations / alloc - A collection of tasks that run on a node.
-    -   Alias of `Pod` in k8s.
+   ```bash
+   # macOS
+   brew tap hashicorp/tap && brew install hashicorp/tap/nomad
 
+   # Linux (Debian/Ubuntu)
+   wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+   echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+   sudo apt update && sudo apt install nomad
+   ```
+
+2. **Verify the install**
+
+   ```bash
+   nomad version
+   ```
+
+3. **Start a dev agent**
+   A single node acting as both server and client — perfect for local testing.
+
+   ```bash
+   sudo nomad agent -dev
+   ```
+
+   Open the UI at `http://localhost:4646`.
+
+</Steps>
+
+## Jobs
+
+Nomad workloads are declared in an **HCL job specification**. A minimal Docker service:
+
+```hcl
+job "web" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "app" {
+    count = 3
+
+    network {
+      port "http" { to = 8080 }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "nginx:alpine"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}
+```
+
+Submit and inspect it:
+
+```bash
+nomad job run web.nomad.hcl
+nomad job status web
+```
+
+<Aside type="tip">
+`type = "service"` keeps a job running and reschedules it on failure. Use `type = "batch"` for run-to-completion tasks and `type = "system"` to run one alloc on every client (like a Kubernetes DaemonSet).
+</Aside>
 
 ## Cheatsheet
 
--   `nomad alloc logs {$allocation}`
+| Command | Purpose |
+| ------- | ------- |
+| `nomad agent -dev` | Start a local single-node agent |
+| `nomad job run <file>` | Submit or update a job |
+| `nomad job status <job>` | Show job, group, and allocation state |
+| `nomad alloc logs <alloc>` | Stream logs from an allocation |
+| `nomad alloc logs -f <alloc>` | Follow logs live |
+| `nomad status <id>` | Look up any object by its 8-char ID |
+| `nomad node status` | List client nodes and health |
+| `nomad job stop <job>` | Stop and garbage-collect a job |
+| `nomad server members` | List server peers and the Raft leader |
 
-    -   `{$allocation}` - unique id that is the default reference to a group of tasks within a specific node.
+<Aside type="note">
+The `{$allocation}` ID is a unique reference to a group of tasks on a node; the `{$identifier}` used by `nomad status` is an 8-character alphanumeric prefix — you only need enough characters to be unambiguous.
+</Aside>
 
--   `nomad status {$identifier}`
-    -   `{$identifier}` - The id is an 8 digit alphanumeric reference.
+## FAQ
+
+**What is HashiCorp Nomad?**
+Nomad is a lightweight, single-binary workload orchestrator that schedules and manages containers, standalone binaries, Java apps, and batch jobs across a cluster. It pairs naturally with Consul for service discovery and Vault for secrets.
+
+**How is Nomad different from Kubernetes?**
+Nomad is a single ~100MB binary that orchestrates more than just containers, with far less operational overhead than Kubernetes. Kubernetes is a larger, container-focused platform with a bigger built-in ecosystem. Nomad favors simplicity and flexible workload types; Kubernetes favors breadth.
+
+**What is an allocation in Nomad?**
+An allocation (alloc) is a set of tasks from a job placed and running on a single client node — the rough equivalent of a Pod in Kubernetes. Each allocation gets a unique ID you use to inspect status and stream logs.
+
+**How many servers does a Nomad cluster need for high availability?**
+A production HA control plane needs an odd number of server nodes to hold quorum, typically 3 or 5. A full HashiCorp stack with Vault and Consul also at HA means 3 instances of each, for 9 total.
+
+**What is a Nomad job specification?**
+A job spec is an HCL (or JSON) file that declares what to run — the job, its groups, tasks, driver, resources, and count. You submit it with `nomad job run`, and the scheduler places allocations onto healthy clients that meet the constraints.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/terraform.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/terraform.mdx
@@ -1,8 +1,9 @@
 ---
 title: Terraform
 description: |
-    Terraform is an open-source infrastructure as code tool that automates the provisioning of hardware and software resources across multiple providers.
-    It ensures consistent environments through declarative configuration files
+    Terraform is HashiCorp's open-source infrastructure as code (IaC) tool that provisions and manages cloud
+    resources across AWS, Azure, GCP, and hundreds of providers from declarative HCL configuration files.
+    This guide covers the core workflow, HCL basics, state management, and reusable modules.
 sidebar:
     label: Terraform
     order: 120
@@ -10,6 +11,31 @@ unsplash: 1524439188326-e47322d1cef2
 img: https://images.unsplash.com/photo-1524439188326-e47322d1cef2?fit=crop&w=1400&h=700&q=75
 tags:
     - iac
+    - devops
+    - terraform
+sem: 1
+ogTitle: Terraform Guide — Infrastructure as Code Workflow, State & Modules
+ogDescription: Learn Terraform, HashiCorp's infrastructure as code tool — the init/plan/apply workflow, HCL configuration basics, remote state management, and building reusable modules across cloud providers.
+jsonld:
+    type: Article
+    keywords:
+        - terraform
+        - infrastructure as code
+        - hashicorp
+        - hcl
+        - terraform state
+        - terraform modules
+    faq:
+        - question: What is Terraform used for?
+          answer: Terraform is an infrastructure as code tool that provisions and manages cloud and on-prem resources through declarative configuration files. You describe the desired end state in HCL, and Terraform figures out the create, update, and destroy actions needed to reach it across providers like AWS, Azure, and GCP.
+        - question: What is the difference between terraform plan and terraform apply?
+          answer: terraform plan is a dry run that shows what changes Terraform would make without touching any infrastructure, so you can review adds, changes, and destroys. terraform apply executes those changes against real providers after an optional confirmation prompt.
+        - question: What is Terraform state and why does it matter?
+          answer: State is a JSON file that maps your configuration to the real resources Terraform manages, tracking metadata and dependencies. It lets Terraform detect drift and plan minimal changes. In teams, store it remotely (e.g. an S3 bucket with locking) so no two people apply at once against a shared, stale state.
+        - question: What is a Terraform module?
+          answer: A module is a reusable, parameterized package of Terraform configuration. The root module is your working directory; child modules are called with a module block and inputs. Modules let you package a VPC, cluster, or service once and reuse it across environments with different variables.
+        - question: Is Terraform free?
+          answer: Terraform CLI is open source and free. HashiCorp also offers HCP Terraform (formerly Terraform Cloud) with paid tiers for remote state, run pipelines, and policy. OpenTofu is a community-driven, MPL-licensed fork of Terraform maintained under the Linux Foundation.
 ---
 
 import {
@@ -23,29 +49,167 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-## Information
+## Overview
+
+**Terraform** is HashiCorp's open-source **infrastructure as code (IaC)** tool. Instead of clicking through cloud consoles, you declare the resources you want — servers, networks, DNS records, databases — in `.tf` configuration files, and Terraform provisions them to match. The same config reproduces an environment identically every time, and version control gives you a full history of infrastructure changes.
+
+Terraform is **provider-agnostic**: one workflow drives AWS, Azure, GCP, Kubernetes, Cloudflare, and hundreds more via a plugin ecosystem.
+
+This guide covers the [core workflow](#workflow), [HCL basics](#configuration), [state management](#state), and [reusable modules](#modules).
 
 <Adsense />
 
----
+## Workflow
 
-## Setup
+Terraform's day-to-day loop is four commands:
 
----
+<Steps>
 
-## Wrapper
+1. **`terraform init`**
+   Downloads the providers and modules your config references and prepares the working directory. Run it once per project and again whenever providers or backends change.
+
+   ```bash
+   terraform init
+   ```
+
+2. **`terraform plan`**
+   A dry run. Terraform reads current state, compares it to your config, and prints exactly what it would add, change, or destroy — without touching anything.
+
+   ```bash
+   terraform plan -out=tfplan
+   ```
+
+3. **`terraform apply`**
+   Executes the plan against real providers. With a saved plan file it applies without re-prompting; otherwise it shows the diff and waits for `yes`.
+
+   ```bash
+   terraform apply tfplan
+   ```
+
+4. **`terraform destroy`**
+   Tears down everything the configuration manages. Useful for ephemeral environments and test stacks.
+
+   ```bash
+   terraform destroy
+   ```
+
+</Steps>
+
+<Aside type="tip">
+Always review `terraform plan` output before applying — the "destroy" and "replace (`-/+`)" lines are where accidental data loss hides.
+</Aside>
+
+## Configuration
+
+Terraform files are written in **HCL (HashiCorp Configuration Language)**. A minimal AWS example:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0abcdef1234567890"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "kbve-web"
+  }
+}
+
+output "public_ip" {
+  value = aws_instance.web.public_ip
+}
+```
+
+| Block | Purpose |
+| ----- | ------- |
+| `terraform` | Provider requirements and backend config |
+| `provider` | Configure a target platform (region, credentials) |
+| `resource` | A managed piece of infrastructure |
+| `variable` | Parameterize a configuration |
+| `output` | Export values after apply |
+| `data` | Read existing resources you don't manage |
+
+## State
+
+Terraform records what it manages in a **state file** (`terraform.tfstate`). State maps your config to real resource IDs so Terraform can detect drift and compute minimal changes.
+
+For teams, **never** commit local state to git — store it **remotely** with locking so two applies can't race:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "kbve-tfstate"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "tf-locks"
+    encrypt        = true
+  }
+}
+```
+
+<Aside type="caution">
+State can contain secrets (passwords, keys) in plaintext. Use a remote backend with encryption at rest and restrict access — treat the state file as sensitive.
+</Aside>
+
+## Modules
+
+A **module** is a reusable bundle of Terraform config. Package infrastructure once, call it many times with different inputs:
+
+```hcl
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+
+  name = "kbve-prod"
+  cidr = "10.0.0.0/16"
+}
+```
+
+The [Terraform Registry](https://registry.terraform.io/) hosts thousands of community and verified modules. Wrap your own patterns into local modules under a `modules/` directory to keep environments DRY.
+
+## Wrappers
 
 -   [PreTF](https://github.com/raymondbutcher/pretf)
 -   [TerraformJS](https://github.com/mdawar/terraformjs)
 
----
-
 ## References
 
 -   [Terraform The Hard Way](https://github.com/AdminTurnedDevOps/Terraform-The-Hard-Way)
-
--   [TerraForm Sentry](https://github.com/jianyuan/terraform-provider-sentry)
-
+-   [Terraform Sentry Provider](https://github.com/jianyuan/terraform-provider-sentry)
 -   [Awesome Terraform](https://github.com/shuaibiyy/awesome-terraform)
+-   [Terraform Scalable Self-Hosted GitHub Runners](https://github.com/philips-labs/terraform-aws-github-runner)
 
--   [Terraform Scalable Self Hosted Github Action](https://github.com/philips-labs/terraform-aws-github-runner)
+## FAQ
+
+**What is Terraform used for?**
+Terraform is an infrastructure as code tool that provisions and manages cloud and on-prem resources through declarative configuration files. You describe the desired end state in HCL, and Terraform figures out the create, update, and destroy actions needed to reach it across providers like AWS, Azure, and GCP.
+
+**What is the difference between `terraform plan` and `terraform apply`?**
+`terraform plan` is a dry run that shows what changes Terraform would make without touching any infrastructure. `terraform apply` executes those changes against real providers after an optional confirmation prompt.
+
+**What is Terraform state and why does it matter?**
+State is a JSON file that maps your configuration to the real resources Terraform manages. It lets Terraform detect drift and plan minimal changes. In teams, store it remotely (e.g. an S3 bucket with locking) so no two people apply at once against a shared, stale state.
+
+**What is a Terraform module?**
+A module is a reusable, parameterized package of Terraform configuration. Modules let you package a VPC, cluster, or service once and reuse it across environments with different variables.
+
+**Is Terraform free?**
+The Terraform CLI is open source and free. HashiCorp also offers HCP Terraform with paid tiers for remote state and run pipelines. OpenTofu is a community-driven, MPL-licensed fork maintained under the Linux Foundation.
+
+<Adsense />


### PR DESCRIPTION
## SEO/SEM audit — batch 4 (4 files)

Stamps `sem: 1` and applies inline content + metadata improvements.

| File | Work | FAQ |
|------|------|-----|
| terraform | stub → full: workflow (init/plan/apply/destroy Steps), HCL basics + block table, remote state, modules | 5 |
| nomad | stub → full: architecture (server/client + terms table), install Steps, HCL job spec, CLI cheatsheet table | 5 |
| authelia | fixed `Autheila` typo throughout; added How-It-Works forward-auth flow + concept table, docker-compose, Traefik forwardAuth | 5 |
| nmap | already rich (jsonld+6 FAQ); stamped sem + added ogTitle/ogDescription | 6 |

Each: keyword-front-loaded title/description, tags fixed, ogTitle/ogDescription, jsonld (Article + keywords + faq mirrored as visible MDX).

Validation (python/PyYAML): frontmatter parses, sem=1, code-fence parity EVEN — **PASS** all 4. Full nx astro build not run (worktree lacks hoisted node_modules).

**16 / 45** application docs now `sem: 1`; 29 remain.