### PR TITLE
docs(application): SEO/SEM audit batch 5 — obs, rn-web, n8n, php

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/n8n.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/n8n.mdx
@@ -1,14 +1,41 @@
 ---
-title: N8N
+title: n8n
 description: |
-    n8n Automation Software
+    n8n is a fair-code, node-based workflow automation tool that connects APIs, databases, and services without
+    writing glue code. This guide covers core concepts, self-hosting with Docker, building your first workflow,
+    and using AI agent nodes.
 sidebar:
     label: N8N
     order: 1040
 unsplash: 1615014672571-461f4f80db5a
 img: https://images.unsplash.com/photo-1615014672571-461f4f80db5a?fit=crop&w=1400&h=700&q=75
 tags:
-    - technology
+    - automation
+    - workflow
+    - self-hosted
+sem: 1
+ogTitle: n8n Guide — Workflow Automation, Self-Hosting & AI Agents
+ogDescription: Learn n8n, the fair-code node-based automation tool — core concepts (nodes, triggers, workflows), self-hosting with Docker, building your first workflow, and connecting AI agent nodes.
+jsonld:
+    type: Article
+    keywords:
+        - n8n
+        - workflow automation
+        - node-based automation
+        - self-hosted automation
+        - n8n docker
+        - ai agents
+    faq:
+        - question: What is n8n?
+          answer: n8n is a fair-code, node-based workflow automation tool that connects apps, APIs, databases, and services into automated workflows. You build flows visually by wiring nodes together on a canvas, with the option to drop into JavaScript or Python for custom logic. It can be self-hosted or used as a managed cloud service.
+        - question: Is n8n free and open source?
+          answer: n8n is fair-code, released under the Sustainable Use License. You can self-host it for free, including commercial internal use. It is source-available rather than strictly OSI open source, and n8n also offers a paid cloud and enterprise tier.
+        - question: How do I self-host n8n?
+          answer: The simplest route is Docker. Run the n8nio/n8n image with a persisted volume for the SQLite or Postgres database, set N8N_HOST and a webhook URL, and expose port 5678 behind a reverse proxy with TLS. For production, use Postgres and, at scale, queue mode with a Redis-backed worker pool.
+        - question: What is the difference between a node and a workflow in n8n?
+          answer: A node is a single step — a trigger, an API call, a transformation, or a condition. A workflow is the connected graph of nodes that runs start to finish. Data flows between nodes as JSON items, and each node operates on the items it receives from the previous one.
+        - question: Can n8n run AI agents?
+          answer: Yes. n8n ships AI/LangChain nodes including an AI Agent node that can call language models, use tools, and query vector stores. You can wire an agent to your workflow data and other nodes, letting it take actions across your connected services.
 ---
 
 import {
@@ -22,21 +49,102 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-## Information
+## Overview
 
-In a world where seamless digital integration is no longer a luxury but a necessity, businesses and developers alike grapple with myriad tools to streamline processes and enhance productivity.
-Enter n8n—an open-source, node-based tool that promises to revolutionize the way we think about workflow automation.
-Imagine a world where your CRM, email platform, social media, and even IoT devices can effortlessly talk to each other, where manual data transfer becomes a relic of the past, and where workflows become as customizable as a Lego set.
-This isn't a vision from a distant future; this is the present brought to life by n8n.
-In this article, we will embark on a journey through n8n's innovative landscape, exploring its game-changing features, its flexible node-based architecture, and how it empowers both businesses and developers to craft automation like never before.
+**n8n** is a fair-code, **node-based workflow automation** tool. Instead of writing glue code to connect your CRM, email, databases, and IoT devices, you wire **nodes** together on a visual canvas — and drop into JavaScript or Python whenever a step needs custom logic.
+
+Because it is **self-hostable**, your data and credentials stay on your own infrastructure, unlike fully managed SaaS automation platforms.
+
+This guide covers [core concepts](#concepts), [self-hosting](#self-host), your [first workflow](#first-workflow), and [AI agents](#agents).
 
 <Adsense />
 
+## Information
+
+In a world where seamless digital integration is no longer a luxury but a necessity, businesses and developers alike grapple with myriad tools to streamline processes and enhance productivity.
+Enter n8n — an open-source, node-based tool that promises to revolutionize the way we think about workflow automation.
+Imagine a world where your CRM, email platform, social media, and even IoT devices can effortlessly talk to each other, where manual data transfer becomes a relic of the past, and where workflows become as customizable as a Lego set.
+This isn't a vision from a distant future; this is the present brought to life by n8n.
+
+## Concepts
+
+| Term | Meaning |
+| ---- | ------- |
+| **Node** | A single step — a trigger, API call, transform, or condition |
+| **Trigger** | The node that starts a workflow (schedule, webhook, app event) |
+| **Workflow** | The connected graph of nodes that runs start to finish |
+| **Item** | A JSON object of data passed between nodes |
+| **Credential** | Stored, reusable auth for a connected service |
+| **Execution** | One run of a workflow, with a full log of node inputs/outputs |
+
+Data flows node to node as **JSON items** — each node operates on the items it receives from the previous one.
+
+## Self-Host
+
+The simplest deployment is **Docker**:
+
+```yaml
+services:
+  n8n:
+    image: n8nio/n8n
+    container_name: n8n
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_HOST=n8n.kbve.com
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=https
+      - WEBHOOK_URL=https://n8n.kbve.com/
+      - GENERIC_TIMEZONE=America/New_York
+    volumes:
+      - ./n8n-data:/home/node/.n8n
+    restart: unless-stopped
+```
+
+<Aside type="tip">
+The default SQLite store is fine for a home lab. For production, point n8n at **Postgres** and, at scale, enable **queue mode** with a Redis-backed worker pool so executions run concurrently.
+</Aside>
+
+## First Workflow
+
+<Steps>
+
+1. **Add a trigger**
+   Every workflow starts with a trigger node — a **Schedule** (cron), a **Webhook**, or an app event like "new row in a database."
+
+2. **Add action nodes**
+   Search the node panel for the service you want (HTTP Request, Slack, Postgres, Gmail) and connect it to the trigger.
+
+3. **Map the data**
+   Use expressions like `{{ $json.email }}` to pull fields from the previous node's items into the next node's parameters.
+
+4. **Test and activate**
+   Click **Execute Workflow** to test with live data, inspect each node's output, then toggle **Active** to run it automatically on the trigger.
+
+</Steps>
+
 ## Agents
 
-This is a section for all the AI Agents
+n8n ships **AI / LangChain** nodes, including an **AI Agent** node that can call language models, use tools, and query vector stores — letting an agent take actions across your connected services.
 
 - [Video 1](https://www.youtube.com/watch?v=61rl_lQZZFo)
 - [Video 2](https://www.youtube.com/watch?v=9FuNtfsnRNo)
 
-I will come back around and include better n8n configurations + edge runtimes after the godot code updates.
+## FAQ
+
+**What is n8n?**
+n8n is a fair-code, node-based workflow automation tool that connects apps, APIs, databases, and services into automated workflows. You build flows visually by wiring nodes together, with the option to drop into JavaScript or Python for custom logic.
+
+**Is n8n free and open source?**
+n8n is fair-code under the Sustainable Use License. You can self-host it for free, including commercial internal use. It is source-available rather than strictly OSI open source, and also offers a paid cloud and enterprise tier.
+
+**How do I self-host n8n?**
+The simplest route is Docker — run the `n8nio/n8n` image with a persisted volume, set `N8N_HOST` and a webhook URL, and expose port 5678 behind a TLS reverse proxy. For production use Postgres and, at scale, queue mode with a Redis worker pool.
+
+**What is the difference between a node and a workflow?**
+A node is a single step; a workflow is the connected graph of nodes that runs start to finish. Data flows between nodes as JSON items.
+
+**Can n8n run AI agents?**
+Yes. n8n ships AI/LangChain nodes including an AI Agent node that can call language models, use tools, and query vector stores, wired to your workflow data and other nodes.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/obs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/obs.mdx
@@ -1,7 +1,9 @@
 ---
-title: OBS
+title: OBS Studio
 description: |
-    Open Broadcast System - an open source screencasting and streaming application.
+    OBS Studio (Open Broadcaster Software) is a free, open-source application for screen recording and live
+    streaming to Twitch, YouTube, and beyond. This guide covers scenes and sources, encoder settings, streaming
+    setup, and extending OBS with plugins.
 sidebar:
     label: OBS
     order: 1100
@@ -9,6 +11,31 @@ unsplash: 1572511443032-a3cfe6823872
 img: https://images.unsplash.com/photo-1572511443032-a3cfe6823872?fit=crop&w=1400&h=700&q=75
 tags:
     - media
+    - streaming
+    - video
+sem: 1
+ogTitle: OBS Studio Guide — Screen Recording, Live Streaming & Plugins
+ogDescription: Get started with OBS Studio, the free open-source broadcaster — understand scenes and sources, configure encoder and bitrate settings, stream to Twitch or YouTube, and extend OBS with plugins.
+jsonld:
+    type: Article
+    keywords:
+        - obs studio
+        - open broadcaster software
+        - screen recording
+        - live streaming
+        - twitch streaming
+        - obs plugins
+    faq:
+        - question: What is OBS Studio?
+          answer: OBS Studio (Open Broadcaster Software) is a free, open-source application for screen recording and live streaming. It composites multiple sources — screen captures, webcams, images, and audio — into scenes and encodes them for local recording or streaming to platforms like Twitch and YouTube.
+        - question: Is OBS Studio free?
+          answer: Yes. OBS Studio is completely free and open source under the GPLv2 license, with no watermarks, time limits, or paid tiers. It runs on Windows, macOS, and Linux.
+        - question: What is the difference between a scene and a source in OBS?
+          answer: A source is a single input such as a display capture, webcam, image, or audio device. A scene is a named arrangement of one or more sources with their positions and sizes. You switch between scenes live to change your layout during a stream or recording.
+        - question: What bitrate should I use for streaming in OBS?
+          answer: For 1080p60 streaming, 6000 kbps with the x264 or NVENC encoder is a common baseline for Twitch, and higher for YouTube. Match your bitrate to your upload bandwidth — leave headroom so network spikes do not drop frames. Use CBR for streaming and a quality-based rate control for local recording.
+        - question: How do I add plugins to OBS?
+          answer: Download a plugin compatible with your OBS version and operating system, then place its files in the OBS plugins directory (or run its installer). Restart OBS, and the plugin's filters, sources, or docks appear in the relevant menus.
 ---
 
 import {
@@ -22,16 +49,77 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
 
-## Information
+**OBS Studio** (Open Broadcaster Software) is a free, open-source tool for **screen recording** and **live streaming**. It composites multiple inputs — display captures, webcams, images, browser sources, and audio — into **scenes**, encodes them in real time, and either records locally or streams to Twitch, YouTube, and any RTMP endpoint.
 
+It runs on Windows, macOS, and Linux under the GPLv2 license — no watermarks, no time limits.
+
+This guide covers [core concepts](#concepts), [streaming setup](#streaming), and [plugins](#plugins).
 
 <Adsense />
 
+## Concepts
+
+| Term | Meaning |
+| ---- | ------- |
+| **Source** | A single input — display capture, webcam, image, browser, audio device |
+| **Scene** | A named arrangement of sources with their positions and sizes |
+| **Scene collection** | A saved set of scenes you can switch between |
+| **Filter** | A per-source effect — chroma key, noise gate, color correction |
+| **Profile** | A saved bundle of encoder and streaming settings |
+
+You build scenes for each layout you need (Starting Soon, Gameplay, Just Chatting) and switch between them live.
+
+<Aside type="tip">
+Right-click any source to add **filters** — a Chroma Key filter removes a green-screen background, and a Noise Suppression filter on your mic cleans up background hum.
+</Aside>
+
+## Streaming
+
+<Steps>
+
+1. **Set your stream key**
+   In **Settings → Stream**, pick your service (Twitch, YouTube, Custom) and paste the stream key from that platform's dashboard.
+
+2. **Configure the encoder**
+   In **Settings → Output**, choose an encoder — `NVENC` (NVIDIA GPU) or `x264` (CPU). Set rate control to **CBR** and a bitrate matched to your upload speed (≈6000 kbps for 1080p60 on Twitch).
+
+3. **Set resolution and FPS**
+   In **Settings → Video**, set the base (canvas) and output (scaled) resolution and a frame rate of 30 or 60.
+
+4. **Build a scene and go live**
+   Add your sources, arrange them, then click **Start Streaming** (or **Start Recording** for local capture).
+
+</Steps>
+
+<Aside type="caution">
+Streaming bitrate is capped by your **upload** bandwidth, not download. Run a speed test and stay well under your upload ceiling — sustained over-subscription drops frames and stutters the stream.
+</Aside>
+
 ## Plugins
 
-Information and guides on additional plugins for OBS.
+Plugins extend OBS with extra sources, filters, and docks. Install by dropping the plugin files into the OBS plugins directory (or running its installer), then restart OBS. Popular examples:
 
-#### Banana
+- **StreamFX** — advanced filters, shaders, and 3D transforms.
+- **Move Transition** — animate sources between scenes.
+- **obs-websocket** — remote-control OBS over WebSocket for automation and stream decks.
 
-#### Potato
+## FAQ
+
+**What is OBS Studio?**
+OBS Studio is a free, open-source application for screen recording and live streaming. It composites multiple sources into scenes and encodes them for local recording or streaming to platforms like Twitch and YouTube.
+
+**Is OBS Studio free?**
+Yes. It is completely free and open source under GPLv2, with no watermarks, time limits, or paid tiers, on Windows, macOS, and Linux.
+
+**What is the difference between a scene and a source?**
+A source is a single input such as a display capture, webcam, or audio device. A scene is a named arrangement of one or more sources with their positions and sizes. You switch between scenes live.
+
+**What bitrate should I use for streaming?**
+For 1080p60 on Twitch, 6000 kbps with x264 or NVENC is a common baseline. Match your bitrate to your upload bandwidth and use CBR for streaming.
+
+**How do I add plugins to OBS?**
+Download a plugin compatible with your OBS version and OS, place its files in the OBS plugins directory (or run its installer), and restart OBS. Its filters, sources, or docks then appear in the menus.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/php.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/php.mdx
@@ -1,13 +1,41 @@
 ---
 title: PHP
 description: |
-    Dat PHP
+    PHP (Hypertext Preprocessor) is a widely-used, dynamic, server-side scripting language for web development
+    that embeds directly into HTML and powers the classic LAMP stack. This guide covers install, syntax basics,
+    and reusable functions.
 sidebar:
     label: PHP
     order: 409
 unsplash: 1599507593499-a3f7d7d97667
 img: https://images.unsplash.com/photo-1599507593499-a3f7d7d97667?fit=crop&w=1400&h=700&q=75
-
+tags:
+    - programming
+    - php
+    - backend
+sem: 1
+ogTitle: PHP Guide — Server-Side Scripting, LAMP Stack & Syntax Basics
+ogDescription: Learn PHP, the server-side scripting language behind the LAMP stack — install with a package manager, understand variables and functions, embed PHP in HTML, and reuse practical string helpers.
+jsonld:
+    type: Article
+    keywords:
+        - php
+        - hypertext preprocessor
+        - server-side scripting
+        - lamp stack
+        - web development
+        - php functions
+    faq:
+        - question: What is PHP used for?
+          answer: PHP is a server-side scripting language used mainly for web development. It runs on the server, generates HTML sent to the browser, and powers dynamic, data-driven applications and content management systems like WordPress, Drupal, and Laravel apps. It is the P in the classic LAMP stack.
+        - question: What does PHP stand for?
+          answer: PHP is a recursive acronym for PHP Hypertext Preprocessor. It originally stood for Personal Home Page, reflecting its origins, but was renamed as it grew into a general-purpose web scripting language.
+        - question: Is PHP still relevant in modern web development?
+          answer: Yes. PHP powers a large share of the web, including WordPress. Modern PHP 8.x brings the JIT compiler, strong typing, attributes, enums, and major performance gains, and frameworks like Laravel and Symfony keep it a productive, well-supported choice for backends.
+        - question: How do I embed PHP in HTML?
+          answer: Wrap PHP code in <?php ... ?> tags anywhere inside an .php file. The server executes the code between the tags and replaces it with its output, while everything outside the tags is sent to the browser as plain HTML.
+        - question: What is the LAMP stack?
+          answer: LAMP is a classic web hosting stack of Linux (OS), Apache (web server), MySQL (database), and PHP (scripting language). It is a fully open-source foundation that has powered countless websites and web applications for decades.
 ---
 
 import {
@@ -21,6 +49,13 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
+## Overview
+
+**PHP** (Hypertext Preprocessor) is a dynamic, server-side scripting language famed for embedding directly into HTML and powering the classic **LAMP** stack. It runs on the server, generates HTML for the browser, and drives a huge share of the web — including WordPress, Laravel, and Symfony applications.
+
+This guide covers the [background](#information), [install](#install), [syntax basics](#syntax), and reusable [functions](#functions).
+
+<Adsense />
 
 ## Information
 
@@ -32,13 +67,57 @@ PHP supports a wide range of databases, has rich built-in functions, and can int
 It's also part of the classic LAMP ([Linux](/application/linux/), Apache, [MySQL](/application/sql/), PHP) stack which powers countless servers across the globe.
 PHP continues to evolve with regular updates that improve its performance, security features, and modern language capabilities.
 
-<Adsense />
+## Install
+
+PHP is packaged for every major OS. Install the CLI and verify the version:
+
+```bash
+# Debian / Ubuntu
+sudo apt install php-cli -y
+
+# macOS (Homebrew)
+brew install php
+
+# Check the version
+php -v
+```
+
+Run a script or start the built-in dev server (never for production):
+
+```bash
+php script.php
+php -S localhost:8000
+```
+
+## Syntax
+
+PHP code lives between `<?php ... ?>` tags; everything outside is sent to the browser as plain HTML:
+
+```php
+<?php
+$name = "KBVE";
+$count = 3;
+
+function greet(string $who): string {
+    return "Hello, {$who}!";
+}
+
+echo greet($name);
+
+for ($i = 0; $i < $count; $i++) {
+    echo "Row {$i}\n";
+}
+```
+
+<Aside type="tip">
+Variables start with `$` and are loosely typed, but modern PHP (8.x) supports type declarations, enums, and the JIT compiler. Declare `declare(strict_types=1);` at the top of a file to enforce strict typing.
+</Aside>
 
 ## Functions
 
 ### SS_BETWEEN
 
-    - This is an exmaple of the `ss_between` function written in `php`.
+    - This is an example of the `ss_between` function written in `php`.
 
         ```php
 
@@ -66,3 +145,22 @@ PHP continues to evolve with regular updates that improve its performance, secur
             echo $u;
             // return username
         ```
+
+## FAQ
+
+**What is PHP used for?**
+PHP is a server-side scripting language used mainly for web development. It runs on the server, generates HTML sent to the browser, and powers dynamic, data-driven applications and content management systems like WordPress, Drupal, and Laravel apps. It is the P in the classic LAMP stack.
+
+**What does PHP stand for?**
+PHP is a recursive acronym for PHP Hypertext Preprocessor. It originally stood for Personal Home Page, but was renamed as it grew into a general-purpose web scripting language.
+
+**Is PHP still relevant in modern web development?**
+Yes. PHP powers a large share of the web, including WordPress. Modern PHP 8.x brings the JIT compiler, strong typing, attributes, enums, and major performance gains, and frameworks like Laravel and Symfony keep it productive and well-supported.
+
+**How do I embed PHP in HTML?**
+Wrap PHP code in `<?php ... ?>` tags anywhere inside a `.php` file. The server executes the code between the tags and replaces it with its output, while everything outside the tags is sent to the browser as plain HTML.
+
+**What is the LAMP stack?**
+LAMP is a classic web hosting stack of [Linux](/application/linux/) (OS), Apache (web server), [MySQL](/application/sql/) (database), and PHP (scripting language) — a fully open-source foundation that has powered countless web applications for decades.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/rn-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/rn-web.mdx
@@ -1,20 +1,53 @@
 ---
 title: React Native on the Web
 description: |
-  Proof of concept rendering @kbve/rn (React Native) components on the web via
-  react-native-web as a Starlight-themed Astro island.
+    A proof of concept rendering @kbve/rn (React Native) components on the web via react-native-web as a
+    Starlight-themed Astro island — sharing one component codebase between the native app and the docs site.
 sidebar:
   label: RN on Web
 tags:
   - react-native
   - web
+  - astro
+sem: 1
+ogTitle: React Native on the Web — react-native-web in an Astro Island
+ogDescription: Proof of concept rendering @kbve/rn React Native components on the web with react-native-web, hydrated as a Starlight-themed Astro client island that tracks light/dark theme tokens.
+jsonld:
+    type: Article
+    keywords:
+        - react native web
+        - react-native-web
+        - astro island
+        - starlight
+        - cross-platform ui
+    faq:
+        - question: What is react-native-web?
+          answer: react-native-web is a library that maps React Native primitives — View, Text, Pressable, StyleSheet — to their DOM equivalents, so the same React Native component code renders in a browser. It is how frameworks like Expo ship a web target from one codebase.
+        - question: How does the @kbve/rn component render inside Astro?
+          answer: The React Native component is aliased to react-native-web and mounted as a client:only Astro island, so it hydrates in the browser rather than at build time. Its colors are wired to Starlight's theme tokens, so it follows the docs site's light and dark modes.
+        - question: Why share one component between native and web?
+          answer: A single @kbve/rn component codebase renders in the native app and in the docs via react-native-web, so a UI primitive is written and styled once, then reused across platforms — reducing drift between the app and its documentation.
 ---
 
 import RnWebDemo from '@/components/rnweb/AstroRnWebDemo.astro';
 
-The block below is the same `@kbve/rn` component the native app renders —
-`View` / `Text` / `Pressable` / `StyleSheet` primitives aliased to
+## Overview
+
+This page is a **proof of concept**: the exact same `@kbve/rn` (React Native) component the native app renders is displayed here on the web via **react-native-web**, hydrated as a Starlight-themed Astro island.
+
+The block below uses `View` / `Text` / `Pressable` / `StyleSheet` primitives aliased to
 `react-native-web` and hydrated as a `client:only` island. Its colors are wired
 to Starlight's theme tokens, so it tracks light/dark with the rest of the docs.
 
 <RnWebDemo />
+
+## FAQ
+
+**What is react-native-web?**
+react-native-web maps React Native primitives — `View`, `Text`, `Pressable`, `StyleSheet` — to their DOM equivalents, so the same React Native component code renders in a browser. It is how frameworks like Expo ship a web target from one codebase.
+
+**How does the `@kbve/rn` component render inside Astro?**
+The component is aliased to react-native-web and mounted as a `client:only` Astro island, so it hydrates in the browser. Its colors are wired to Starlight's theme tokens, so it follows the docs site's light and dark modes.
+
+**Why share one component between native and web?**
+A single `@kbve/rn` component codebase renders in the native app and in the docs via react-native-web, so a UI primitive is written and styled once, then reused across platforms — reducing drift between the app and its documentation.


### PR DESCRIPTION
## SEO/SEM audit — batch 5 (4 files)

Stamps `sem: 1` and applies inline content + metadata improvements.

| File | Work | FAQ |
|------|------|-----|
| obs | stub (Banana/Potato placeholders) → full: Overview, concept table, streaming Steps, real plugin list | 5 |
| n8n | stub → full: Overview, concept table, Docker self-host compose, first-workflow Steps, AI agents | 5 |
| php | added missing tags; Overview, install, syntax basics + example; kept SS_BETWEEN; fixed `exmaple` typo | 5 |
| rn-web | POC demo page — added Overview + meta; kept live island demo | 3 |

Each: keyword-front-loaded title/description, tags fixed/added, ogTitle/ogDescription, jsonld (Article + keywords + faq mirrored as visible MDX).

Validation (python/PyYAML): frontmatter parses, sem=1, code-fence parity EVEN — **PASS** all 4. Verified internal links (removed a broken `/application/astro/` link; astro.mdx doesn't exist). Full nx astro build not run (worktree lacks hoisted node_modules).

**20 / 45** application docs now `sem: 1`; 25 remain.