### PR TITLE
fix(kubevirt): idle-shutdown fail-closed + hardened win_vm_boot (#13100)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1048,12 +1048,15 @@ jobs:
                   }
                   request_start() {
                     echo "Requesting start..."
-                    curl -sS --max-time 15 --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
+                    if ! curl -sS --max-time 15 --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
                       -X PUT -H "Content-Type: application/json" -d '{}' \
-                      "$API/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM/start" || true
+                      "$API/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM/start"; then
+                      echo "::warning::start request failed (already running, RBAC, or API error) — will retry on next poll"
+                    fi
                   }
                   S=$(status); echo "::notice::$VM status: $S"
                   [ "$S" != "Running" ] && request_start
+                  unknown_streak=0
                   for i in $(seq 1 48); do
                     S=$(status)
                     if [ "$S" = "Running" ]; then
@@ -1064,6 +1067,16 @@ jobs:
                     if [ "$S" = "Stopped" ]; then
                       echo "$VM is Stopped (idle-shutdown race or lost start) — re-requesting start"
                       request_start
+                      unknown_streak=0
+                    elif [ "$S" = "Unknown" ]; then
+                      unknown_streak=$((unknown_streak + 1))
+                      if [ "$unknown_streak" -ge 4 ]; then
+                        echo "::warning::$VM status Unknown for $unknown_streak checks — re-requesting start defensively"
+                        request_start
+                        unknown_streak=0
+                      fi
+                    else
+                      unknown_streak=0
                     fi
                     echo "waiting for $VM to reach Running ($i/48): $S"
                     sleep 15

--- a/apps/kube/kubevirt/keda/vm-idle-shutdown-script.yaml
+++ b/apps/kube/kubevirt/keda/vm-idle-shutdown-script.yaml
@@ -49,13 +49,19 @@ data:
 
         # ── Check 3: Is a runner carrying RUNNER_LABEL currently busy? ──
         if [ -n "${GITHUB_TOKEN}" ]; then
-            RUNNERS_JSON=$(curl -sf \
+            if ! RUNNERS_JSON=$(curl -sf \
                 -H "Authorization: token ${GITHUB_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \
-                "https://api.github.com/orgs/${GITHUB_ORG}/actions/runners?per_page=100" 2>/dev/null || echo '{}')
+                "https://api.github.com/orgs/${GITHUB_ORG}/actions/runners?per_page=100"); then
+                echo "KEEP: GitHub API unreachable — fail closed"
+                exit 0
+            fi
 
-            BUSY_LABELED=$(printf '%s' "${RUNNERS_JSON}" | jq -r --arg L "${RUNNER_LABEL}" \
-                '[.runners[]? | select(.busy == true) | select(any(.labels[]?; .name == $L))] | length' 2>/dev/null || echo "0")
+            if ! BUSY_LABELED=$(printf '%s' "${RUNNERS_JSON}" | jq -e -r --arg L "${RUNNER_LABEL}" \
+                '[.runners[] | select(.busy == true) | select(any(.labels[]?; .name == $L))] | length'); then
+                echo "KEEP: runners payload missing/unparseable — fail closed"
+                exit 0
+            fi
 
             echo "GitHub: busy runners with label ${RUNNER_LABEL} = ${BUSY_LABELED}"
 
@@ -68,12 +74,18 @@ data:
         fi
 
         # ── Check 4: Any active VNC/RDP connections? ──
-        POD_NAME=$(kubectl get pods -n "${NAMESPACE}" -l "vm.kubevirt.io/name=${VM_NAME}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if ! POD_NAME=$(kubectl get pods -n "${NAMESPACE}" -l "vm.kubevirt.io/name=${VM_NAME}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null); then
+            echo "KEEP: pod lookup failed — fail closed"
+            exit 0
+        fi
         if [ -n "${POD_NAME}" ]; then
-            VNC_CONNS=$(kubectl exec "${POD_NAME}" -n "${NAMESPACE}" -c compute -- \
-                sh -c "ss -tn state established 2>/dev/null | grep -c ':5900' || echo 0" 2>/dev/null || echo "0")
-            RDP_CONNS=$(kubectl exec "${POD_NAME}" -n "${NAMESPACE}" -c compute -- \
-                sh -c "ss -tn state established 2>/dev/null | grep -c ':3389' || echo 0" 2>/dev/null || echo "0")
+            if ! SS_OUT=$(kubectl exec "${POD_NAME}" -n "${NAMESPACE}" -c compute -- \
+                ss -tn state established 2>/dev/null); then
+                echo "KEEP: VNC/RDP session probe failed — fail closed"
+                exit 0
+            fi
+            VNC_CONNS=$(printf '%s' "${SS_OUT}" | grep -c ':5900' || true)
+            RDP_CONNS=$(printf '%s' "${SS_OUT}" | grep -c ':3389' || true)
 
             echo "Sessions: VNC=${VNC_CONNS}, RDP=${RDP_CONNS}"
 


### PR DESCRIPTION
## Summary

Two coupled reliability bugs around the `windows-builder` KubeVirt VM used by the UE5-Win Actions runner.

### 1. Idle-shutdown fails OPEN on transient error (#13100)

`vm-idle-shutdown-script.yaml` ran under `set -e` but masked every failure:
- Check 3: `curl … || echo '{}'` + `jq … || echo "0"` → a transient GitHub API blip yielded 0 busy runners → VM **stopped mid-build**.
- Check 4: `kubectl exec … || echo "0"` → a probe failure read as "no VNC/RDP session" → also stopped.

Now **fail closed** — any unreachable/unparseable check keeps the VM running:
- `curl -sf` failure → `KEEP: GitHub API unreachable`
- `jq -e` on missing/malformed `.runners` → `KEEP: payload unparseable`
- pod lookup / session-probe failure → `KEEP: … fail closed`

### 2. `win_vm_boot` startup flakiness

The dispatch-time boot job (`ci-unreal-build.yml`) only re-requested start on `Stopped` and hid start-request failures with `|| true`. A persistent `Unknown` status (transient API/token blip) looped the full ~12m then **skipped the Win64 build**.

- Re-request start defensively after 4 consecutive `Unknown` polls.
- Surface start-request HTTP failures as `::warning::` instead of swallowing them.

### Why coupled
The fail-open shutdown killed the VM mid-build; the boot job didn't reliably self-heal → observed "Windows KVM sometimes doesn't start." Fix 1 stops the spurious kills, Fix 2 makes boot recover.

## Not in scope (follow-up)
Idle-shutdown checks *busy runners* only, not *queued jobs* — a job queued before the UE5-Win runner registers can still race. The >30min age gate protects fresh boots, so low risk.

## Verification
- `sh -n` on both extracted scripts: OK
- YAML parse of both files: OK

Closes #13100