### PR TITLE
fix(rn): hero accent scaling + not-content wrappers + card hover polish + green dash tests

### DIFF
--- a/apps/kbve/astro-kbve/src/components/marketing/BentoGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/BentoGrid.astro
@@ -3,4 +3,6 @@ import { BentoGrid } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<BentoGrid client:only="react" {...props} />
+<div class="not-content">
+	<BentoGrid client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/Cta.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Cta.astro
@@ -3,4 +3,6 @@ import CtaIsland from './CtaIsland';
 const props = Astro.props;
 ---
 
-<CtaIsland client:only="react" {...props} />
+<div class="not-content">
+	<CtaIsland client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/FaqAccordion.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/FaqAccordion.astro
@@ -3,4 +3,6 @@ import { FaqAccordion } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<FaqAccordion client:only="react" {...props} />
+<div class="not-content">
+	<FaqAccordion client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/FeatureGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/FeatureGrid.astro
@@ -3,4 +3,6 @@ import { FeatureGrid } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<FeatureGrid client:only="react" {...props} />
+<div class="not-content">
+	<FeatureGrid client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/Hero.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Hero.astro
@@ -3,4 +3,6 @@ import HeroIsland from './HeroIsland';
 const props = Astro.props;
 ---
 
-<HeroIsland client:only="react" {...props} />
+<div class="not-content">
+	<HeroIsland client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/LiveFeed.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/LiveFeed.astro
@@ -3,4 +3,6 @@ import { LiveFeed } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<LiveFeed client:only="react" {...props} />
+<div class="not-content">
+	<LiveFeed client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/LogoCloud.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/LogoCloud.astro
@@ -3,4 +3,6 @@ import { LogoCloud } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<LogoCloud client:only="react" {...props} />
+<div class="not-content">
+	<LogoCloud client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/NewsletterCapture.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/NewsletterCapture.astro
@@ -3,4 +3,6 @@ import { NewsletterCapture } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<NewsletterCapture client:only="react" {...props} />
+<div class="not-content">
+	<NewsletterCapture client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/PricingTiers.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/PricingTiers.astro
@@ -3,4 +3,6 @@ import { PricingTiers } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<PricingTiers client:only="react" {...props} />
+<div class="not-content">
+	<PricingTiers client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/ProcessSteps.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/ProcessSteps.astro
@@ -3,4 +3,6 @@ import { ProcessSteps } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<ProcessSteps client:only="react" {...props} />
+<div class="not-content">
+	<ProcessSteps client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/ProjectGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/ProjectGrid.astro
@@ -3,4 +3,6 @@ import ProjectGridIsland from './ProjectGridIsland';
 const props = Astro.props;
 ---
 
-<ProjectGridIsland client:only="react" {...props} />
+<div class="not-content">
+	<ProjectGridIsland client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/StatStrip.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/StatStrip.astro
@@ -3,4 +3,6 @@ import { StatStrip } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<StatStrip client:only="react" {...props} />
+<div class="not-content">
+	<StatStrip client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/TabbedFeatures.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/TabbedFeatures.astro
@@ -3,4 +3,6 @@ import { TabbedFeatures } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<TabbedFeatures client:only="react" {...props} />
+<div class="not-content">
+	<TabbedFeatures client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/TeamGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/TeamGrid.astro
@@ -3,4 +3,6 @@ import { TeamGrid } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<TeamGrid client:only="react" {...props} />
+<div class="not-content">
+	<TeamGrid client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/Testimonials.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Testimonials.astro
@@ -3,4 +3,6 @@ import { Testimonials } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<Testimonials client:only="react" {...props} />
+<div class="not-content">
+	<Testimonials client:only="react" {...props} />
+</div>

--- a/apps/kbve/astro-kbve/src/components/marketing/Timeline.astro
+++ b/apps/kbve/astro-kbve/src/components/marketing/Timeline.astro
@@ -3,4 +3,6 @@ import { Timeline } from '@kbve/rn-astro';
 const props = Astro.props;
 ---
 
-<Timeline client:only="react" {...props} />
+<div class="not-content">
+	<Timeline client:only="react" {...props} />
+</div>

--- a/packages/npm/rn/src/dash/StatGrid.tsx
+++ b/packages/npm/rn/src/dash/StatGrid.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import { Stack, Text, tokens } from '../ui';
+import { Stack, Text, tokens } from './_ui';
 import type { StatModel } from './types';
 
 const TONE_COLOR: Record<string, string> = {

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -1,14 +1,10 @@
 import { memo, useMemo, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
-import {
-	ErrorState,
-	LoadingState,
-	Stack,
-	Text,
-	VirtualList,
-	tokens,
-} from '../ui';
+import { Stack, Text, tokens } from './_ui';
+import { ErrorState } from '../ui/feedback/ErrorState';
+import { LoadingState } from '../ui/feedback/LoadingState';
+import { VirtualList } from '../ui/lists/VirtualList';
 import { StatGrid } from './StatGrid';
 import { useStream, useStreamLifecycle, useStreamSelector } from './useStream';
 import type {

--- a/packages/npm/rn/src/dash/_ui.ts
+++ b/packages/npm/rn/src/dash/_ui.ts
@@ -1,0 +1,6 @@
+export { Text } from '../ui/primitives/Text';
+export { Stack } from '../ui/primitives/Stack';
+export { Surface } from '../ui/primitives/Surface';
+export { Badge } from '../ui/primitives/Badge';
+export type { BadgeTone } from '../ui/primitives/Badge';
+export { tokens } from '../ui/theme';

--- a/packages/npm/rn/src/dash/adapters/__tests__/clickhouse.test.ts
+++ b/packages/npm/rn/src/dash/adapters/__tests__/clickhouse.test.ts
@@ -43,7 +43,7 @@ describe('ClickHouse Adapter', () => {
 				namespace: 'test-ns',
 			});
 
-			await stream.load();
+			await stream.refresh();
 
 			expect(mockFetch).toHaveBeenCalledWith(
 				expect.stringContaining('/dashboard/clickhouse/proxy'),
@@ -80,8 +80,8 @@ describe('ClickHouse Adapter', () => {
 				getToken: mockGetToken,
 			});
 
-			await stream.load();
-			const items = stream.items.get();
+			await stream.refresh();
+			const items = stream.get().items;
 
 			expect(items).toHaveLength(1);
 			expect(items[0]).toMatchObject({
@@ -105,9 +105,9 @@ describe('ClickHouse Adapter', () => {
 				getToken: mockGetToken,
 			});
 
-			await stream.load();
+			await stream.refresh();
 
-			expect(stream.error.get()).toMatch(/access restricted/i);
+			expect(stream.get().error).toMatch(/access restricted/i);
 		});
 	});
 

--- a/packages/npm/rn/src/dash/adapters/argo.tsx
+++ b/packages/npm/rn/src/dash/adapters/argo.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { StyleSheet, View, Pressable, ActivityIndicator } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamAction, StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/clickhouse.tsx
+++ b/packages/npm/rn/src/dash/adapters/clickhouse.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/deployment.tsx
+++ b/packages/npm/rn/src/dash/adapters/deployment.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/edge.tsx
+++ b/packages/npm/rn/src/dash/adapters/edge.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/factorio.tsx
+++ b/packages/npm/rn/src/dash/adapters/factorio.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/forgejo.tsx
+++ b/packages/npm/rn/src/dash/adapters/forgejo.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/grafana.tsx
+++ b/packages/npm/rn/src/dash/adapters/grafana.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/minecraft.tsx
+++ b/packages/npm/rn/src/dash/adapters/minecraft.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/rows.tsx
+++ b/packages/npm/rn/src/dash/adapters/rows.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/adapters/vm.tsx
+++ b/packages/npm/rn/src/dash/adapters/vm.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { Badge, Stack, Surface, Text, tokens } from '../../ui';
-import type { BadgeTone } from '../../ui';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import type { StreamLens, StreamStore } from '../types';
 

--- a/packages/npm/rn/src/dash/createStreamSource.ts
+++ b/packages/npm/rn/src/dash/createStreamSource.ts
@@ -124,6 +124,7 @@ export function createStreamSource<TRaw, TItem>(
 	return {
 		subscribe: signal.subscribe,
 		get: signal.get,
+		key,
 		id,
 		refresh: runFetch,
 		start: () => {

--- a/packages/npm/rn/src/dash/shared.tsx
+++ b/packages/npm/rn/src/dash/shared.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
-import { Stack, Text, tokens } from '../ui';
-import type { BadgeTone } from '../ui';
+import { Stack, Text, tokens } from './_ui';
+import type { BadgeTone } from './_ui';
 
 // ---------------------------------------------------------------------------
 // Shared Components

--- a/packages/npm/rn/src/dash/types.ts
+++ b/packages/npm/rn/src/dash/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { BadgeTone } from '../ui';
+import type { BadgeTone } from './_ui';
 
 /**
  * The generic dashboard contract: `<T> of <t> of <n>`.
@@ -56,6 +56,8 @@ export interface StreamStore<TItem> {
 	subscribe: (listener: () => void) => () => void;
 	/** Current immutable snapshot. */
 	get: () => StreamState<TItem>;
+	/** Cache key prefix this store was created with. */
+	key: string;
 	/** Stable identity for an item — the view keys rows off this. */
 	id: (item: TItem) => string;
 	/** Force a fetch now (bypasses poll cadence; keeps cache write). */

--- a/packages/npm/rn/src/ui/marketing/sections.tsx
+++ b/packages/npm/rn/src/ui/marketing/sections.tsx
@@ -14,6 +14,17 @@ import { openExternal } from '../../platform/openExternal';
 
 const CONTENT_MAX = 1120;
 
+function useHover() {
+	const [hover, setHover] = useState(false);
+	return {
+		hover,
+		bind: {
+			onHoverIn: () => setHover(true),
+			onHoverOut: () => setHover(false),
+		},
+	};
+}
+
 const container = (extra?: object) => ({
 	width: '100%' as const,
 	maxWidth: CONTENT_MAX,
@@ -51,6 +62,7 @@ export const Hero = memo(function Hero({
 }: HeroProps) {
 	const { width } = useWindowDimensions();
 	const titleSize = width < 600 ? 38 : width < 960 ? 52 : 64;
+	const titleSize2 = { fontSize: titleSize, lineHeight: titleSize * 1.06 };
 
 	const fire = (a: HeroAction) =>
 		a.external ? openExternal(a.href) : onNavigate?.(a.href);
@@ -63,14 +75,15 @@ export const Hero = memo(function Hero({
 						<Text style={styles.eyebrowText}>{eyebrow}</Text>
 					</View>
 				) : null}
-				<Text
-					style={[
-						styles.heroTitle,
-						{ fontSize: titleSize, lineHeight: titleSize * 1.06 },
-					]}>
+				<Text style={[styles.heroTitle, titleSize2]}>
 					{lead}
 					{accent ? (
-						<Text style={[styles.heroTitle, styles.heroAccent]}>
+						<Text
+							style={[
+								styles.heroTitle,
+								styles.heroAccent,
+								titleSize2,
+							]}>
 							{accent}
 						</Text>
 					) : null}
@@ -130,12 +143,13 @@ export const FeatureCard = memo(function FeatureCard({
 	body,
 	icon,
 }: FeatureCardProps) {
+	const { hover, bind } = useHover();
 	return (
-		<View style={styles.card}>
+		<Pressable {...bind} style={[styles.card, hover && styles.hoverLift]}>
 			{icon ? <View style={styles.cardIcon}>{icon}</View> : null}
 			<Text style={styles.cardTitle}>{title}</Text>
 			<Text style={styles.cardBody}>{body}</Text>
-		</View>
+		</Pressable>
 	);
 });
 
@@ -327,6 +341,27 @@ export interface StepItem {
 	body: string;
 }
 
+const StepCard = memo(function StepCard({
+	index,
+	step,
+}: {
+	index: number;
+	step: StepItem;
+}) {
+	const { hover, bind } = useHover();
+	return (
+		<Pressable {...bind} style={[styles.step, hover && styles.hoverLift]}>
+			<View style={styles.stepNum}>
+				<Text style={styles.stepNumText}>
+					{String(index + 1).padStart(2, '0')}
+				</Text>
+			</View>
+			<Text style={styles.stepTitle}>{step.title}</Text>
+			<Text style={styles.stepBody}>{step.body}</Text>
+		</Pressable>
+	);
+});
+
 export const ProcessSteps = memo(function ProcessSteps({
 	title,
 	subtitle,
@@ -343,15 +378,7 @@ export const ProcessSteps = memo(function ProcessSteps({
 			) : null}
 			<View style={styles.grid}>
 				{steps.map((s, i) => (
-					<View key={s.title} style={styles.step}>
-						<View style={styles.stepNum}>
-							<Text style={styles.stepNumText}>
-								{String(i + 1).padStart(2, '0')}
-							</Text>
-						</View>
-						<Text style={styles.stepTitle}>{s.title}</Text>
-						<Text style={styles.stepBody}>{s.body}</Text>
-					</View>
+					<StepCard key={s.title} index={i} step={s} />
 				))}
 			</View>
 		</View>
@@ -366,6 +393,34 @@ export interface TestimonialItem {
 	role?: string;
 	initials?: string;
 }
+
+const QuoteCard = memo(function QuoteCard({
+	item,
+}: {
+	item: TestimonialItem;
+}) {
+	const { hover, bind } = useHover();
+	return (
+		<Pressable
+			{...bind}
+			style={[styles.quoteCard, hover && styles.hoverLift]}>
+			<Text style={styles.quoteText}>“{item.quote}”</Text>
+			<View style={styles.quoteFoot}>
+				<View style={styles.avatar}>
+					<Text style={styles.avatarText}>
+						{item.initials ?? item.name.slice(0, 2).toUpperCase()}
+					</Text>
+				</View>
+				<View style={styles.quoteMeta}>
+					<Text style={styles.quoteName}>{item.name}</Text>
+					{item.role ? (
+						<Text style={styles.quoteRole}>{item.role}</Text>
+					) : null}
+				</View>
+			</View>
+		</Pressable>
+	);
+});
 
 export const Testimonials = memo(function Testimonials({
 	title,
@@ -383,25 +438,7 @@ export const Testimonials = memo(function Testimonials({
 			) : null}
 			<View style={styles.grid}>
 				{items.map((t) => (
-					<View key={t.name} style={styles.quoteCard}>
-						<Text style={styles.quoteText}>“{t.quote}”</Text>
-						<View style={styles.quoteFoot}>
-							<View style={styles.avatar}>
-								<Text style={styles.avatarText}>
-									{t.initials ??
-										t.name.slice(0, 2).toUpperCase()}
-								</Text>
-							</View>
-							<View style={styles.quoteMeta}>
-								<Text style={styles.quoteName}>{t.name}</Text>
-								{t.role ? (
-									<Text style={styles.quoteRole}>
-										{t.role}
-									</Text>
-								) : null}
-							</View>
-						</View>
-					</View>
+					<QuoteCard key={t.name} item={t} />
 				))}
 			</View>
 		</View>
@@ -489,6 +526,59 @@ export interface PricingTier {
 	featured?: boolean;
 }
 
+const TierCard = memo(function TierCard({
+	tier,
+	onAction,
+}: {
+	tier: PricingTier;
+	onAction: (a: HeroAction) => void;
+}) {
+	const { hover, bind } = useHover();
+	return (
+		<Pressable
+			{...bind}
+			style={[
+				styles.tier,
+				tier.featured && styles.tierFeatured,
+				hover && styles.hoverLift,
+			]}>
+			{tier.featured ? (
+				<View style={styles.tierBadge}>
+					<Text style={styles.tierBadgeText}>Popular</Text>
+				</View>
+			) : null}
+			<Text style={styles.tierName}>{tier.name}</Text>
+			<View style={styles.tierPriceRow}>
+				<Text style={styles.tierPrice}>{tier.price}</Text>
+				{tier.period ? (
+					<Text style={styles.tierPeriod}>/{tier.period}</Text>
+				) : null}
+			</View>
+			{tier.body ? (
+				<Text style={styles.tierBody}>{tier.body}</Text>
+			) : null}
+			<View style={styles.tierFeatures}>
+				{tier.features.map((f) => (
+					<View key={f} style={styles.tierFeature}>
+						<Text style={styles.tierCheck}>✓</Text>
+						<Text style={styles.tierFeatureText}>{f}</Text>
+					</View>
+				))}
+			</View>
+			{tier.action ? (
+				<Button
+					title={tier.action.label}
+					variant={
+						tier.action.variant ??
+						(tier.featured ? 'primary' : 'outline')
+					}
+					onPress={() => onAction(tier.action as HeroAction)}
+				/>
+			) : null}
+		</Pressable>
+	);
+});
+
 export const PricingTiers = memo(function PricingTiers({
 	title,
 	subtitle,
@@ -509,43 +599,7 @@ export const PricingTiers = memo(function PricingTiers({
 			) : null}
 			<View style={styles.grid}>
 				{tiers.map((t) => (
-					<View
-						key={t.name}
-						style={[styles.tier, t.featured && styles.tierFeatured]}>
-						{t.featured ? (
-							<View style={styles.tierBadge}>
-								<Text style={styles.tierBadgeText}>Popular</Text>
-							</View>
-						) : null}
-						<Text style={styles.tierName}>{t.name}</Text>
-						<View style={styles.tierPriceRow}>
-							<Text style={styles.tierPrice}>{t.price}</Text>
-							{t.period ? (
-								<Text style={styles.tierPeriod}>/{t.period}</Text>
-							) : null}
-						</View>
-						{t.body ? (
-							<Text style={styles.tierBody}>{t.body}</Text>
-						) : null}
-						<View style={styles.tierFeatures}>
-							{t.features.map((f) => (
-								<View key={f} style={styles.tierFeature}>
-									<Text style={styles.tierCheck}>✓</Text>
-									<Text style={styles.tierFeatureText}>{f}</Text>
-								</View>
-							))}
-						</View>
-						{t.action ? (
-							<Button
-								title={t.action.label}
-								variant={
-									t.action.variant ??
-									(t.featured ? 'primary' : 'outline')
-								}
-								onPress={() => fire(t.action as HeroAction)}
-							/>
-						) : null}
-					</View>
+					<TierCard key={t.name} tier={t} onAction={fire} />
 				))}
 			</View>
 		</View>
@@ -639,6 +693,22 @@ export interface BentoItem {
 	wide?: boolean;
 }
 
+const BentoTile = memo(function BentoTile({ item }: { item: BentoItem }) {
+	const { hover, bind } = useHover();
+	return (
+		<Pressable
+			{...bind}
+			style={[
+				styles.bento,
+				item.wide && styles.bentoWide,
+				hover && styles.hoverLift,
+			]}>
+			<Text style={styles.bentoTitle}>{item.title}</Text>
+			<Text style={styles.bentoBody}>{item.body}</Text>
+		</Pressable>
+	);
+});
+
 export const BentoGrid = memo(function BentoGrid({
 	title,
 	subtitle,
@@ -655,12 +725,7 @@ export const BentoGrid = memo(function BentoGrid({
 			) : null}
 			<View style={styles.grid}>
 				{items.map((b) => (
-					<View
-						key={b.title}
-						style={[styles.bento, b.wide && styles.bentoWide]}>
-						<Text style={styles.bentoTitle}>{b.title}</Text>
-						<Text style={styles.bentoBody}>{b.body}</Text>
-					</View>
+					<BentoTile key={b.title} item={b} />
 				))}
 			</View>
 		</View>
@@ -792,6 +857,38 @@ export interface TeamMember {
 	href?: string;
 }
 
+const MemberCard = memo(function MemberCard({
+	member,
+	onNavigate,
+}: {
+	member: TeamMember;
+	onNavigate?: (href: string) => void;
+}) {
+	const { hover, bind } = useHover();
+	return (
+		<Pressable
+			{...bind}
+			accessibilityRole={member.href ? 'link' : undefined}
+			onPress={() => member.href && onNavigate?.(member.href)}
+			style={[
+				styles.member,
+				hover && styles.hoverLift,
+				member.href ? ({ cursor: 'pointer' } as never) : null,
+			]}>
+			<View style={styles.memberAvatar}>
+				<Text style={styles.memberInitials}>
+					{member.initials ?? member.name.slice(0, 2).toUpperCase()}
+				</Text>
+			</View>
+			<Text style={styles.memberName}>{member.name}</Text>
+			<Text style={styles.memberRole}>{member.role}</Text>
+			{member.bio ? (
+				<Text style={styles.memberBio}>{member.bio}</Text>
+			) : null}
+		</Pressable>
+	);
+});
+
 export const TeamGrid = memo(function TeamGrid({
 	title,
 	subtitle,
@@ -810,25 +907,11 @@ export const TeamGrid = memo(function TeamGrid({
 			) : null}
 			<View style={styles.grid}>
 				{members.map((m) => (
-					<Pressable
+					<MemberCard
 						key={m.name}
-						accessibilityRole={m.href ? 'link' : undefined}
-						onPress={() => m.href && onNavigate?.(m.href)}
-						style={[
-							styles.member,
-							m.href ? ({ cursor: 'pointer' } as never) : null,
-						]}>
-						<View style={styles.memberAvatar}>
-							<Text style={styles.memberInitials}>
-								{m.initials ?? m.name.slice(0, 2).toUpperCase()}
-							</Text>
-						</View>
-						<Text style={styles.memberName}>{m.name}</Text>
-						<Text style={styles.memberRole}>{m.role}</Text>
-						{m.bio ? (
-							<Text style={styles.memberBio}>{m.bio}</Text>
-						) : null}
-					</Pressable>
+						member={m}
+						onNavigate={onNavigate}
+					/>
 				))}
 			</View>
 		</View>
@@ -899,7 +982,7 @@ const styles = StyleSheet.create({
 		paddingBottom: 72,
 		alignItems: 'center',
 	},
-	heroInner: { alignItems: 'center', gap: tokens.space.lg, maxWidth: 760 },
+	heroInner: { alignItems: 'center', gap: tokens.space.lg, maxWidth: 920 },
 	eyebrow: {
 		paddingHorizontal: tokens.space.md,
 		paddingVertical: 6,
@@ -945,6 +1028,10 @@ const styles = StyleSheet.create({
 		paddingVertical: 80,
 	},
 	grid: { flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.lg },
+	hoverLift: {
+		borderColor: tokens.color.primary,
+		transform: [{ translateY: -3 }],
+	},
 
 	headingWrap: {
 		alignItems: 'center',

--- a/packages/npm/rn/vitest.config.ts
+++ b/packages/npm/rn/vitest.config.ts
@@ -1,10 +1,34 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	resolve: {
+		extensions: [
+			'.web.tsx',
+			'.web.ts',
+			'.web.jsx',
+			'.web.js',
+			'.tsx',
+			'.ts',
+			'.jsx',
+			'.js',
+			'.json',
+		],
+		alias: {
+			'react-native': 'react-native-web',
+			'react-native-reanimated': fileURLToPath(
+				new URL('./vitest/reanimated-stub.ts', import.meta.url),
+			),
+			'@kbve/core': fileURLToPath(
+				new URL('../core/src/index.ts', import.meta.url),
+			),
+		},
+	},
 	test: {
-		environment: 'node',
+		environment: 'jsdom',
 		include: ['**/*.test.ts', '**/*.test.tsx'],
 		globals: true,
+		server: { deps: { inline: ['react-native-web'] } },
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json', 'html'],

--- a/packages/npm/rn/vitest/reanimated-stub.ts
+++ b/packages/npm/rn/vitest/reanimated-stub.ts
@@ -1,0 +1,30 @@
+import { View } from 'react-native-web';
+
+const passthrough = (v?: unknown) => v;
+const chain = (): unknown => {
+	const p: unknown = new Proxy(() => p, { get: () => p });
+	return p;
+};
+
+export const useSharedValue = (initial: unknown) => ({ value: initial });
+export const useAnimatedStyle = (factory: () => unknown) =>
+	typeof factory === 'function' ? factory() : {};
+export const useAnimatedProps = (factory: () => unknown) =>
+	typeof factory === 'function' ? factory() : {};
+export const withTiming = passthrough;
+export const withSpring = passthrough;
+export const withRepeat = passthrough;
+export const withSequence = (...steps: unknown[]) => steps[steps.length - 1];
+export const runOnJS =
+	(fn: (...a: unknown[]) => unknown) =>
+	(...a: unknown[]) =>
+		fn(...a);
+export const Easing = new Proxy({}, { get: () => () => 0 });
+export const LinearTransition = chain();
+
+const Animated = {
+	View,
+	createAnimatedComponent: (c: unknown) => c,
+};
+
+export default Animated;


### PR DESCRIPTION
## Summary

Fixes the reported hero bug, isolates the marketing islands from Starlight, adds a polish pass, and gets `nx run rn:test` green.

### Hero accent scaling
The ` every surface. ` accent rendered tiny — a nested RNW `<Text>` doesn't inherit the parent's inline `fontSize`. The dynamic `titleSize` is now applied to the accent span too, so it scales with the headline. Also widened the hero content column (760 → 920).

### Starlight isolation
Every marketing wrapper is now wrapped in `<div class="not-content">` so Starlight's `.sl-markdown-content` prose styles stop leaking into the RN components.

### Polish
Shared `useHover` lift (border → gold + `translateY(-3)`) on the Feature / Bento / Tier / Step / Quote / Member card families; inline-mapped tiles extracted into memoized subcomponents so each can own hover state.

### rn tests (were failing on dev)
`nx run rn:test` was red — vitest couldn't parse react-native's Flow `import typeof`, then hit reanimated / @kbve/core / the whole UI barrel.
- vitest: alias `react-native` → `react-native-web`, prefer `.web` resolution, jsdom env, stub reanimated, resolve `@kbve/core` to source.
- Isolate dash from the full UI kit via a minimal leaf `_ui` barrel (Text/Stack/Surface/Badge/tokens); `StreamView` imports its heavy feedback/list deps directly.
- Correct the clickhouse adapter tests to the real `StreamStore` API (`refresh()`, `get().items`, `get().error`) and expose `key` on the store.

## Verify
- `nx run rn:test` → **2 files, 16 tests passed**.
- `tsc` rn-astro lib → **No errors**; rn lib → only the 11 pre-existing dash type errors, zero new.