### PR TITLE
feat(seo): kbve.seo Pillar-1 auditor + project-collection POC

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/marketplace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/marketplace.mdx
@@ -1,12 +1,7 @@
 ---
 title: Asset Marketplace
-description: |
-    Asset Marketplace — an open storefront where creators sell game assets (3D, 2D, audio, VFX,
-    tools, complete projects). Strictly game assets. Lead-gen catalog in v1; on-platform checkout
-    with per-sale commission and royalty-free Standard/Extended licensing in a later phase.
-    Decoupled Rust/Axum API with first-party auth, served to a separate frontend. Reuses the
-    existing KBVE protos and adds a new `assetstore` package. References: Fab, itch.io, CraftPix,
-    GameDevMarket.
+description: Open marketplace for game assets — 3D, 2D, audio, VFX, tools, and complete projects — on a decoupled Rust/Axum API sharing KBVE identity with the Job Board.
+sem: 1
 sidebar:
     label: Asset Marketplace
     order: 51

--- a/packages/python/kbve/kbve/seo/__init__.py
+++ b/packages/python/kbve/kbve/seo/__init__.py
@@ -1,0 +1,6 @@
+"""Whole-site SEO/SEM auditing for the astro-kbve content collections.
+
+Static frontmatter + MDX analysis mirroring the kbve.osrs tooling. See
+docs/plans/seo/seo-sem-lighthouse.md for the full 3-pillar plan; this package
+is Pillar 1 (the content/metadata auditor).
+"""

--- a/packages/python/kbve/kbve/seo/_pages.py
+++ b/packages/python/kbve/kbve/seo/_pages.py
@@ -1,0 +1,71 @@
+"""Shared loader for the astro-kbve docs content collections.
+
+Walks apps/kbve/astro-kbve/src/content/docs/<collection>/**.mdx, parses the
+YAML frontmatter and the MDX body, and yields one Page per file. The whole-site
+analog of kbve.osrs._corpus.
+"""
+import os
+import re
+from collections import namedtuple
+
+import yaml
+
+CONTENT_REL = os.path.join(
+    "apps", "kbve", "astro-kbve", "src", "content", "docs",
+)
+
+_FRONTMATTER = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.S)
+
+Page = namedtuple("Page", "collection slug path frontmatter body")
+
+
+def find_content_dir(root):
+    """Resolve the docs content dir from a repo root, or walk up to find it."""
+    if root:
+        candidate = os.path.join(root, CONTENT_REL)
+        if os.path.isdir(candidate):
+            return candidate
+    here = os.path.abspath(os.path.dirname(__file__))
+    while True:
+        candidate = os.path.join(here, CONTENT_REL)
+        if os.path.isdir(candidate):
+            return candidate
+        parent = os.path.dirname(here)
+        if parent == here:
+            raise FileNotFoundError(
+                "Could not locate %s; pass --root <repo>" % CONTENT_REL,
+            )
+        here = parent
+
+
+def split_frontmatter(text):
+    """Return (frontmatter_dict, body_str). Empty dict if no frontmatter."""
+    m = _FRONTMATTER.match(text)
+    if not m:
+        return {}, text
+    try:
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        fm = {}
+    return (fm if isinstance(fm, dict) else {}), m.group(2)
+
+
+def iter_pages(content_dir, only=None):
+    """Yield Page for every .mdx under content_dir.
+
+    only: optional collection name (top-level folder) to restrict the walk.
+    """
+    for dirpath, _dirs, files in os.walk(content_dir):
+        rel = os.path.relpath(dirpath, content_dir)
+        collection = rel.split(os.sep)[0] if rel != "." else ""
+        if only and collection != only:
+            continue
+        for fname in sorted(files):
+            if not fname.endswith(".mdx"):
+                continue
+            path = os.path.join(dirpath, fname)
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+            fm, body = split_frontmatter(text)
+            slug = fname[:-4]
+            yield Page(collection or "docs", slug, path, fm, body)

--- a/packages/python/kbve/kbve/seo/audit.py
+++ b/packages/python/kbve/kbve/seo/audit.py
@@ -1,0 +1,74 @@
+"""Run the SEO rule registry over the docs collections.
+
+    uv run --extra osrs kbve-seo-audit [--root <repo>] [--only <collection>]
+                                       [--json out.json]
+
+Emits findings.json: the shared page-keyed contract other pillars enrich.
+Exit status is non-zero when any error-severity finding is present, so the
+same command gates CI.
+"""
+import argparse
+import json
+import sys
+
+from kbve.seo._pages import find_content_dir, iter_pages
+from kbve.seo.profiles import profile_for
+from kbve.seo.rules import RULES, build_ctx
+
+
+def audit(content_dir, only=None):
+    pages = list(iter_pages(content_dir, only=only))
+    ctx = build_ctx(pages)
+    result = {"pages": {}, "summary": {}}
+    counts = {"error": 0, "warn": 0, "info": 0}
+    per_collection = {}
+    for p in pages:
+        profile = profile_for(p.collection)
+        findings = []
+        for rule in RULES:
+            findings.extend(rule(p, ctx, profile))
+        for f in findings:
+            counts[f.severity] += 1
+        c = per_collection.setdefault(
+            p.collection, {"pages": 0, "error": 0, "warn": 0, "info": 0})
+        c["pages"] += 1
+        for f in findings:
+            c[f.severity] += 1
+        result["pages"]["/%s/%s/" % (p.collection, p.slug)] = {
+            "collection": p.collection,
+            "audit": {
+                "findings": [f._asdict() for f in findings],
+            },
+            "gsc": None,
+            "lhci": None,
+        }
+    result["summary"] = {
+        "pages": len(pages),
+        "collections": per_collection,
+        **counts,
+    }
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit astro-kbve SEO metadata.")
+    parser.add_argument("--root", default=None, help="Repo root path")
+    parser.add_argument("--only", default=None,
+                        help="Restrict to one collection (folder)")
+    parser.add_argument("--json", default=None, help="Write findings to path")
+    args = parser.parse_args()
+
+    content_dir = find_content_dir(args.root)
+    result = audit(content_dir, only=args.only)
+    text = json.dumps(result, indent=2)
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            fh.write(text)
+    s = result["summary"]
+    print("audited %d pages: %d error, %d warn, %d info" % (
+        s["pages"], s["error"], s["warn"], s["info"]))
+    return 1 if s["error"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python/kbve/kbve/seo/profiles.py
+++ b/packages/python/kbve/kbve/seo/profiles.py
@@ -1,0 +1,31 @@
+"""Per-collection SEO profiles.
+
+Thresholds trace to docs/skills/seo-mini.md. Profiles are data: a new
+collection is a new dict entry, no rule code changes. DEFAULT applies to any
+collection without an explicit profile.
+"""
+
+DEFAULT = {
+    "title_min": 15,
+    "title_max": 60,
+    "desc_min": 70,
+    "desc_max": 160,
+    "body_floor": 0,
+    "expect_tags": True,
+}
+
+PROFILES = {
+    # Software/service catalog pages — short, dense, keyword-front-loaded.
+    "project": {
+        "title_min": 10,
+        "title_max": 60,
+        "desc_min": 70,
+        "desc_max": 160,
+        "body_floor": 0,
+        "expect_tags": True,
+    },
+}
+
+
+def profile_for(collection):
+    return {**DEFAULT, **PROFILES.get(collection, {})}

--- a/packages/python/kbve/kbve/seo/report.py
+++ b/packages/python/kbve/kbve/seo/report.py
@@ -1,0 +1,55 @@
+"""Human summary of an SEO audit run.
+
+    uv run --extra osrs kbve-seo-report [--root <repo>] [--only <collection>]
+                                        [--rule <rule-id>]
+
+Prints per-collection health and the worst offenders. Read-only.
+"""
+import argparse
+import sys
+from collections import Counter
+
+from kbve.seo._pages import find_content_dir
+from kbve.seo.audit import audit
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarize astro-kbve SEO audit.")
+    parser.add_argument("--root", default=None, help="Repo root path")
+    parser.add_argument("--only", default=None, help="Restrict to one collection")
+    parser.add_argument("--rule", default=None, help="List pages hitting this rule")
+    args = parser.parse_args()
+
+    content_dir = find_content_dir(args.root)
+    result = audit(content_dir, only=args.only)
+    s = result["summary"]
+
+    print("== SEO audit ==")
+    print("pages %d | error %d | warn %d | info %d\n"
+          % (s["pages"], s["error"], s["warn"], s["info"]))
+
+    print("per collection:")
+    for name, c in sorted(s["collections"].items(),
+                          key=lambda kv: -(kv[1]["error"] + kv[1]["warn"])):
+        print("  %-14s pages %-4d error %-3d warn %-3d info %-3d"
+              % (name, c["pages"], c["error"], c["warn"], c["info"]))
+
+    rule_counts = Counter()
+    for page in result["pages"].values():
+        for f in page["audit"]["findings"]:
+            rule_counts[f["rule"]] += 1
+    print("\nby rule:")
+    for rule, n in rule_counts.most_common():
+        print("  %-18s %d" % (rule, n))
+
+    if args.rule:
+        print("\npages hitting %s:" % args.rule)
+        for url, page in sorted(result["pages"].items()):
+            hits = [f for f in page["audit"]["findings"] if f["rule"] == args.rule]
+            for f in hits:
+                print("  %-40s %s" % (url, f["message"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python/kbve/kbve/seo/rules.py
+++ b/packages/python/kbve/kbve/seo/rules.py
@@ -1,0 +1,106 @@
+"""Pluggable SEO rule registry.
+
+Each rule is a function (page, ctx, profile) -> list[Finding]. Register by
+appending to RULES. ctx carries site-wide state (dup maps) built once per run.
+Adding a check later means appending one function; nothing else changes.
+"""
+from collections import namedtuple
+
+Finding = namedtuple("Finding", "rule severity message")
+
+ERROR, WARN, INFO = "error", "warn", "info"
+
+
+def _desc(page):
+    d = page.frontmatter.get("description")
+    return d.strip() if isinstance(d, str) else None
+
+
+def _title(page):
+    t = page.frontmatter.get("title")
+    return t.strip() if isinstance(t, str) else None
+
+
+def rule_title_length(page, ctx, profile):
+    t = _title(page)
+    if not t:
+        return [Finding("title-length", ERROR, "missing title")]
+    n = len(t)
+    if n < profile["title_min"]:
+        return [Finding("title-length", WARN,
+                        "title %d chars < %d" % (n, profile["title_min"]))]
+    if n > profile["title_max"]:
+        return [Finding("title-length", WARN,
+                        "title %d chars > %d" % (n, profile["title_max"]))]
+    return []
+
+
+def rule_desc_length(page, ctx, profile):
+    d = _desc(page)
+    if not d:
+        return [Finding("desc-length", ERROR, "missing description")]
+    n = len(d)
+    if n < profile["desc_min"]:
+        return [Finding("desc-length", WARN,
+                        "description %d chars < %d" % (n, profile["desc_min"]))]
+    if n > profile["desc_max"]:
+        return [Finding("desc-length", WARN,
+                        "description %d chars > %d (truncated in SERP)"
+                        % (n, profile["desc_max"]))]
+    return []
+
+
+def rule_title_duplicate(page, ctx, profile):
+    t = _title(page)
+    if t and len(ctx["titles"].get(t, ())) > 1:
+        return [Finding("title-duplicate", ERROR,
+                        "title shared with %d other pages"
+                        % (len(ctx["titles"][t]) - 1))]
+    return []
+
+
+def rule_desc_duplicate(page, ctx, profile):
+    d = _desc(page)
+    if d and len(ctx["descs"].get(d, ())) > 1:
+        return [Finding("desc-duplicate", ERROR,
+                        "description shared with %d other pages"
+                        % (len(ctx["descs"][d]) - 1))]
+    return []
+
+
+def rule_tags_present(page, ctx, profile):
+    if not profile["expect_tags"]:
+        return []
+    tags = page.frontmatter.get("tags")
+    if not (isinstance(tags, list) and tags):
+        return [Finding("tags-present", WARN, "no tags")]
+    return []
+
+
+def rule_sem_tracked(page, ctx, profile):
+    if page.frontmatter.get("sem") is None:
+        return [Finding("sem-tracked", INFO, "not yet SEO-audited (sem unset)")]
+    return []
+
+
+RULES = [
+    rule_title_length,
+    rule_desc_length,
+    rule_title_duplicate,
+    rule_desc_duplicate,
+    rule_tags_present,
+    rule_sem_tracked,
+]
+
+
+def build_ctx(pages):
+    """Site-wide state for cross-page rules."""
+    titles, descs = {}, {}
+    for p in pages:
+        t = _title(p)
+        d = _desc(p)
+        if t:
+            titles.setdefault(t, []).append(p.slug)
+        if d:
+            descs.setdefault(d, []).append(p.slug)
+    return {"titles": titles, "descs": descs}

--- a/packages/python/kbve/pyproject.toml
+++ b/packages/python/kbve/pyproject.toml
@@ -28,6 +28,11 @@ sprite = [
 osrs = [
     "pyyaml>=6.0,<7.0",
 ]
+# Whole-site SEO/SEM auditor (kbve.seo.*). Static frontmatter+MDX analysis;
+# only needs PyYAML. Enable with: uv sync --extra seo
+seo = [
+    "pyyaml>=6.0,<7.0",
+]
 
 [project.scripts]
 kbve-skin-variant = "kbve.sprite.skin_variant:main"
@@ -37,6 +42,8 @@ kbve-model-sprites = "kbve.sprite.model_sprites_cli:main"
 kbve-osrs-survey = "kbve.osrs.survey:main"
 kbve-osrs-audit = "kbve.osrs.audit:main"
 kbve-osrs-families = "kbve.osrs.families:main"
+kbve-seo-audit = "kbve.seo.audit:main"
+kbve-seo-report = "kbve.seo.report:main"
 
 [dependency-groups]
 dev = [

--- a/packages/python/kbve/tests/test_seo.py
+++ b/packages/python/kbve/tests/test_seo.py
@@ -1,0 +1,79 @@
+from kbve.seo._pages import Page, split_frontmatter
+from kbve.seo.profiles import profile_for
+from kbve.seo.rules import RULES, build_ctx
+
+
+def _page(slug, fm, collection="project"):
+    return Page(collection, slug, "%s.mdx" % slug, fm, "")
+
+
+def _run(page, ctx):
+    profile = profile_for(page.collection)
+    out = []
+    for rule in RULES:
+        out.extend(rule(page, ctx, profile))
+    return {f.rule: f for f in out}
+
+
+def test_split_frontmatter():
+    fm, body = split_frontmatter("---\ntitle: X\n---\nhello\n")
+    assert fm == {"title": "X"}
+    assert body.strip() == "hello"
+
+
+def test_split_frontmatter_none():
+    fm, body = split_frontmatter("no frontmatter here")
+    assert fm == {}
+    assert body == "no frontmatter here"
+
+
+def test_desc_too_long_flags_warn():
+    p = _page("marketplace", {
+        "title": "KBVE Marketplace",
+        "description": "x" * 300,
+        "tags": ["a"],
+        "sem": 1,
+    })
+    findings = _run(p, build_ctx([p]))
+    assert findings["desc-length"].severity == "warn"
+    assert "> 160" in findings["desc-length"].message
+
+
+def test_desc_too_short_flags_warn():
+    p = _page("api", {"title": "KBVE API Layer", "description": "short",
+                      "tags": ["a"], "sem": 1})
+    findings = _run(p, build_ctx([p]))
+    assert findings["desc-length"].severity == "warn"
+    assert "< 70" in findings["desc-length"].message
+
+
+def test_good_page_passes():
+    p = _page("edge", {
+        "title": "KBVE Edge Worker",
+        "description": ("Cloudflare edge worker that fronts kbve.com, handles "
+                        "routing, caching, and auth token verification at the "
+                        "network boundary before origin."),
+        "tags": ["edge", "cloudflare"],
+        "sem": 1,
+    })
+    findings = _run(p, build_ctx([p]))
+    assert "desc-length" not in findings
+    assert "title-length" not in findings
+    assert "sem-tracked" not in findings
+
+
+def test_missing_sem_is_info():
+    p = _page("api", {"title": "KBVE API Layer",
+                      "description": "x" * 100, "tags": ["a"]})
+    findings = _run(p, build_ctx([p]))
+    assert findings["sem-tracked"].severity == "info"
+
+
+def test_duplicate_description_is_error():
+    a = _page("a", {"title": "Alpha Project", "description": "y" * 100,
+                    "tags": ["t"], "sem": 1})
+    b = _page("b", {"title": "Beta Project", "description": "y" * 100,
+                    "tags": ["t"], "sem": 1})
+    ctx = build_ctx([a, b])
+    findings = _run(a, ctx)
+    assert findings["desc-duplicate"].severity == "error"

--- a/packages/python/kbve/uv.lock
+++ b/packages/python/kbve/uv.lock
@@ -457,6 +457,9 @@ dependencies = [
 osrs = [
     { name = "pyyaml" },
 ]
+seo = [
+    { name = "pyyaml" },
+]
 sprite = [
     { name = "numpy" },
     { name = "pillow" },
@@ -486,9 +489,10 @@ requires-dist = [
     { name = "pydantic", specifier = ">=1.10,<3.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'osrs'", specifier = ">=6.0,<7.0" },
+    { name = "pyyaml", marker = "extra == 'seo'", specifier = ">=6.0,<7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1.0" },
 ]
-provides-extras = ["sprite", "osrs"]
+provides-extras = ["sprite", "osrs", "seo"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Implements **Pillar 1** of `docs/plans/seo/seo-sem-lighthouse.md` (merged) — the reusable content/metadata auditor — and proves it end-to-end on one page.

## The module (`packages/python/kbve/kbve/seo/`, mirrors `kbve.osrs`)
- **`_pages.py`** — walks every `astro-kbve/src/content/docs/**` collection, parses frontmatter + body, yields `Page`. Whole-site analog of `osrs/_corpus.py`.
- **`profiles.py`** — per-collection thresholds (data, not code). New collection = new dict entry.
- **`rules.py`** — pluggable registry: `title-length`, `desc-length`, `title-duplicate`, `desc-duplicate`, `tags-present`, `sem-tracked`. Cross-page `ctx` (dup maps) built once. Adding a check = append one function.
- **`audit.py`** (`kbve-seo-audit`) — runs rules × profiles, emits the page-keyed `findings.json` contract, **exits non-zero on errors** so the same command gates CI.
- **`report.py`** (`kbve-seo-report`) — per-collection + per-rule health, `--rule` to list offenders.

Behind the opt-in `seo` extra. 7 unit tests, flake8-clean.

## POC on `project` (112 pages)
Audit flagged **66 desc-length + 112 sem-tracked + 50 title-length**, cross-validating a manual count exactly. Fixed the worst offender — `marketplace.mdx` description **471 → 156 chars**, keyword-front-loaded, `sem: 1` stamped. Re-audit confirms it drops out of both findings (warn 116→115, info 112→111).

## Not in this PR (future phases)
`stamp.py` writeback + CI gate (P2), GSC→ClickHouse (P3), Lighthouse CI (P4), and the remaining 65 project descriptions. This is the proof-of-concept slice.