### PR TITLE
docs(application): SEO/SEM audit batch 7 — appwrite, argocd, flipperzero, v01d

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/appwrite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/appwrite.mdx
@@ -7,7 +7,32 @@ sidebar:
 unsplash: 1549605659-32d82da3a059
 img: https://images.unsplash.com/photo-1549605659-32d82da3a059?fit=crop&w=1400&h=700&q=75
 tags:
-    - auth
+    - backend
+    - baas
+    - serverless
+sem: 1
+ogTitle: Appwrite Guide — Open-Source Backend, Cloud Functions & SDKs
+ogDescription: Learn Appwrite, the open-source, self-hosted backend server (BaaS) — core APIs for auth, databases, and storage, writing serverless Cloud Functions, and using the JavaScript and Python SDKs.
+jsonld:
+    type: Article
+    keywords:
+        - appwrite
+        - backend as a service
+        - baas
+        - cloud functions
+        - self-hosted backend
+        - appwrite sdk
+    faq:
+        - question: What is Appwrite?
+          answer: Appwrite is an open-source, self-hosted backend server (a Backend-as-a-Service) that gives developers a set of core APIs — authentication, databases, storage, messaging, and serverless functions — plus a management console. It runs on any OS via Docker and removes the need to build common backend plumbing from scratch.
+        - question: What is an Appwrite Cloud Function?
+          answer: A Cloud Function is a piece of code that runs in response to an event (Function-as-a-Service). In Appwrite, functions run inside Docker containers, support runtimes like Node.js, Python, and Deno, and can be triggered by events such as user registration or document creation, or executed manually.
+        - question: Which SDKs does Appwrite provide?
+          answer: Appwrite ships official SDKs for many platforms including JavaScript/TypeScript, Python, Flutter/Dart, Android, Apple, and more. Each SDK wraps the REST API so you configure a Client with an endpoint, project ID, and key, then call typed service methods instead of raw HTTP.
+        - question: Is Appwrite self-hosted or cloud?
+          answer: Both. Appwrite is open source and can be self-hosted on your own infrastructure with Docker, and there is also Appwrite Cloud, a managed offering. Self-hosting gives you full data control; the cloud removes operational overhead.
+        - question: How do I connect the Appwrite Python SDK?
+          answer: Install it with pip install appwrite, then create a Client and chain set_endpoint (your API endpoint), set_project (project ID), and set_key (a secret API key). From there you instantiate services like Users or Databases with that client and call their methods.
 ---
 
 import {
@@ -20,6 +45,12 @@ import {
 } from '@astrojs/starlight/components';
 
 import { Giscus, Adsense } from '@/components/astropad';
+
+## Overview
+
+**Appwrite** is an open-source, self-hosted **backend server** (Backend-as-a-Service) that hands developers a ready-made set of core APIs — **auth, databases, storage, messaging, and serverless functions** — behind a clean management console. It runs on any OS via Docker, so you skip building common backend plumbing yourself.
+
+This guide covers [Cloud Functions](#javascript) (Init/Core/Extra) and the [Python SDK](#python).
 
 ## Information
 
@@ -176,7 +207,7 @@ Step aside traditional backends, the Appwrite Python SDK is in town, rolling out
 This snazzy toolkit doesn't just connect Python applications to the Appwrite server; it's a golden ticket to a carnival of backend delights.
 From the tantalizing whirlwind of user authentication to the magic show of database operations and the high-flying trapeze of storage management, the SDK transforms mundane backend tasks into a spectacle.
 No more wrestling with manual API requests – just harness the SDK's sleek methods and watch as Appwrite's vast services dance harmoniously with your Python code.
-Whether you're orchestrating a symphony of user data or choreographing a ballet of notifications, the Appwrite Python SDK ensures every act is a showstopper or a stormtrooper muhahaha.
+Whether you're orchestrating user data or wiring up notifications, the Appwrite Python SDK keeps backend integration clean and readable.
 
 ### Appwrite Python SDK Install
 
@@ -229,3 +260,22 @@ user = users.create(
 )
 
 ```
+
+## FAQ
+
+**What is Appwrite?**
+Appwrite is an open-source, self-hosted backend server (a Backend-as-a-Service) that gives developers core APIs — authentication, databases, storage, messaging, and serverless functions — plus a management console. It runs on any OS via Docker and removes the need to build common backend plumbing from scratch.
+
+**What is an Appwrite Cloud Function?**
+A Cloud Function is a piece of code that runs in response to an event (Function-as-a-Service). In Appwrite, functions run inside Docker containers, support runtimes like Node.js, Python, and Deno, and can be triggered by events such as user registration or document creation, or executed manually.
+
+**Which SDKs does Appwrite provide?**
+Appwrite ships official SDKs for many platforms including JavaScript/TypeScript, Python, [Flutter](/application/flutter/)/Dart, Android, Apple, and more. Each SDK wraps the REST API so you configure a `Client` with an endpoint, project ID, and key, then call typed service methods instead of raw HTTP.
+
+**Is Appwrite self-hosted or cloud?**
+Both. Appwrite is open source and can be self-hosted on your own infrastructure with Docker, and there is also Appwrite Cloud, a managed offering. Self-hosting gives you full data control; the cloud removes operational overhead.
+
+**How do I connect the Appwrite Python SDK?**
+Install it with `pip install appwrite`, then create a `Client` and chain `set_endpoint`, `set_project`, and `set_key`. From there you instantiate services like `Users` or `Databases` with that client and call their methods.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/argocd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/argocd.mdx
@@ -1,12 +1,41 @@
 ---
 title: ArgoCD
 description: |
-    ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes.
+    ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes that syncs the desired state in Git
+    with the live cluster. This guide covers the architecture, CLI, sync policies, the KBVE annotation standard,
+    and troubleshooting.
 sidebar:
     label: ArgoCD
     order: 12
 unsplash: 1667372459726-a8fb4f5e4a5b
 img: https://images.unsplash.com/photo-1667372459726-a8fb4f5e4a5b?fit=crop&w=1400&h=700&q=75
+tags:
+    - kubernetes
+    - gitops
+    - ci-cd
+sem: 1
+ogTitle: ArgoCD Guide — GitOps Continuous Delivery for Kubernetes
+ogDescription: Learn ArgoCD, the declarative GitOps CD tool for Kubernetes — architecture, the argocd CLI, automated sync with self-heal and prune, ignoreDifferences, finalizers, and troubleshooting stuck syncs.
+jsonld:
+    type: Article
+    keywords:
+        - argocd
+        - gitops
+        - continuous delivery
+        - kubernetes deployment
+        - argo cd sync
+        - declarative cd
+    faq:
+        - question: What is ArgoCD?
+          answer: ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes. It treats a Git repository as the source of truth for the desired application state and continuously syncs the live cluster to match, automating deployments and detecting drift.
+        - question: What is GitOps?
+          answer: GitOps is an operational model where the desired state of infrastructure and applications is declared in Git, and an automated agent reconciles the running system to match. Git becomes the single source of truth, so every change is version-controlled, reviewable, and auditable.
+        - question: What is the difference between prune and self-heal in ArgoCD?
+          answer: prune deletes cluster resources that were removed from Git, keeping the cluster from accumulating orphans. selfHeal reverts manual kubectl changes back to the Git-defined state. Together they enforce that the live cluster always matches the repository.
+        - question: How do I fix an ArgoCD application stuck in Progressing?
+          answer: Check the operation with argocd app get, terminate a stuck sync using argocd app terminate-op, then force a fresh sync with argocd app sync --force. A hard refresh (--hard-refresh) bypasses the cache when an app shows out of sync despite matching Git.
+        - question: What are ignoreDifferences used for in ArgoCD?
+          answer: ignoreDifferences tells ArgoCD to skip specific resource fields when comparing live and desired state, so it does not fight controllers that own those fields — for example an autoscaler managing an Agones Fleet's spec.replicas would otherwise be reverted on every sync.
 ---
 
 import {
@@ -25,6 +54,8 @@ import { Giscus, Adsense } from '@/components/astropad';
 ## Information
 
 ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes. It automates the deployment of applications by synchronizing the desired state defined in Git repositories with the actual state in Kubernetes clusters.
+
+Jump to the [architecture](#architecture), [CLI commands](#cli-commands), [sync policies](#application-management), or [troubleshooting](#troubleshooting).
 
 <Adsense />
 
@@ -458,5 +489,22 @@ kubectl logs -n argocd -l app.kubernetes.io/name=argocd-repo-server -f
 - [GitHub Actions](/application/git/) - CI/CD integration with ArgoCD
 
 ---
+
+## FAQ
+
+**What is ArgoCD?**
+ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes. It treats a Git repository as the source of truth for the desired application state and continuously syncs the live cluster to match, automating deployments and detecting drift.
+
+**What is GitOps?**
+GitOps is an operational model where the desired state of infrastructure and applications is declared in Git, and an automated agent reconciles the running system to match. Git becomes the single source of truth, so every change is version-controlled, reviewable, and auditable.
+
+**What is the difference between prune and self-heal in ArgoCD?**
+`prune` deletes cluster resources that were removed from Git, keeping the cluster from accumulating orphans. `selfHeal` reverts manual `kubectl` changes back to the Git-defined state. Together they enforce that the live cluster always matches the repository.
+
+**How do I fix an ArgoCD application stuck in Progressing?**
+Check the operation with `argocd app get`, terminate a stuck sync using `argocd app terminate-op`, then force a fresh sync with `argocd app sync --force`. A hard refresh (`--hard-refresh`) bypasses the cache when an app shows out of sync despite matching Git.
+
+**What are `ignoreDifferences` used for in ArgoCD?**
+`ignoreDifferences` tells ArgoCD to skip specific resource fields when comparing live and desired state, so it does not fight controllers that own those fields — for example an autoscaler managing an Agones Fleet's `spec.replicas` would otherwise be reverted on every sync.
 
 <Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/application/flipperzero.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/flipperzero.mdx
@@ -11,6 +11,30 @@ tags:
     - security
     - redteam
     - nfc
+sem: 1
+ogTitle: Flipper Zero Guide — Firmware, Sub-GHz, NFC & pyFlipper
+ogDescription: Learn the Flipper Zero pentest multi-tool — installing official and custom firmware (Unleashed, RogueMaster), the Sub-GHz CC1101 radio, NFC read/emulate at 13.56 MHz, and the pyFlipper CLI.
+jsonld:
+    type: Article
+    keywords:
+        - flipper zero
+        - flipperzero firmware
+        - sub-ghz
+        - nfc
+        - rfid
+        - unleashed firmware
+        - pentest multi-tool
+    faq:
+        - question: What is the Flipper Zero?
+          answer: Flipper Zero is a portable, open-source multi-tool for pentesters and hardware hobbyists. It reads, saves, and emulates a range of wireless and access-control signals — Sub-GHz radio, NFC and RFID cards, infrared, iButton, and GPIO — behind a playful Tamagotchi-like interface.
+        - question: What is custom firmware for the Flipper Zero?
+          answer: Custom firmware replaces the official firmware to unlock extra features, protocols, and plugins the stock build restricts. Popular forks include Unleashed and its RogueMaster fork. The chip stores a New and Old firmware slot, which lowers (but does not remove) the risk of bricking when flashing.
+        - question: What frequencies does the Flipper Zero Sub-GHz radio use?
+          answer: The Sub-GHz module uses the CC1101 chipset and operates in the 300-348 MHz, 387-464 MHz, and 779-928 MHz bands. Common targets include 315 MHz and 433 MHz car key fobs and remotes, within the limits of local radio regulations.
+        - question: How does NFC work on the Flipper Zero?
+          answer: The NFC module operates at 13.56 MHz (ISO/IEC 18000-3) and can read, save, and emulate NFC cards, capturing data like UID, ATQA, and SAK. It supports many card types, though full ISO 15693 (NFC-V) support is limited. A microSD stores saved cards for later emulation.
+        - question: How do I update Flipper Zero firmware?
+          answer: The most reliable method is a direct USB cable update via the qFlipper desktop app, which avoids the corruption risk of wireless flashing. You can also update over the Flipper Mobile App or the web updater, but a wired qFlipper upgrade is recommended.
 ---
 
 import {
@@ -29,6 +53,12 @@ import { Giscus, Adsense } from '@/components/astropad';
 Flipper Zero is a portable multi-tool device for geeks that can interact with various digital systems in real life, such as RFID, radio protocols, access control systems and more.
 It gives you full access to its source code and design, so you can tailor it to your own needs and preferences.
 Your cyber-buddy, Flipper Zero, is a cybernetic companion with a Tamagotchi-like personality that enjoys exploring and manipulating digital and analog systems.
+
+This guide covers [firmware](#firmware) (official and custom), [updating](#update), the [Sub-GHz radio](#ghz), the [NFC module](#nfc), and the [pyFlipper CLI](#pyflipper).
+
+<Aside type="caution">
+Only interact with radio signals, NFC/RFID cards, and access-control systems you own or are explicitly authorized to test. Cloning or replaying signals against systems you don't own is illegal in most jurisdictions.
+</Aside>
 
 <Adsense />
 ---
@@ -79,7 +109,7 @@ There are other methods of updating, including Mobile and Web but from experienc
 
 ## GHz
 
--   The frequencies that FlipperZero operates in are `300-348 MMHz`, `387-464 MHz` and `770-928 MHz` bands through the `CC1101` chipset.
+-   The frequencies that FlipperZero operates in are `300-348 MHz`, `387-464 MHz` and `779-928 MHz` bands through the `CC1101` chipset.
 
 -   ### GHz Sub Menu
 
@@ -88,9 +118,9 @@ There are other methods of updating, including Mobile and Web but from experienc
         -   Lower right side will display the remaining slots of scanned signals.
     -   `Read RAW` - Records the radio signal in RAW format.
         -   Requires a microSD for the storage of the RAW.
-    -   `Saved` -
-    -   `Add Manually` -
-    -   `Frequency Analyzer` -
+    -   `Saved` - Lists previously captured signals stored on the microSD, ready to replay or inspect.
+    -   `Add Manually` - Create a signal by picking a known protocol and entering its parameters by hand.
+    -   `Frequency Analyzer` - Scans the bands to detect the strongest nearby transmitter's frequency — point it at a remote and hold its button to identify the frequency in use.
 
 #### GHZ InfoSec
 
@@ -132,3 +162,22 @@ These are notes on the `NFC` aspect of the device.
 This is an unofficial cli wrapper for the Flipper Zero device and we will integrate it with our current eco-system, including the possible future expansion into our core IoT project.
 
 ---
+
+## FAQ
+
+**What is the Flipper Zero?**
+Flipper Zero is a portable, open-source multi-tool for pentesters and hardware hobbyists. It reads, saves, and emulates a range of wireless and access-control signals — Sub-GHz radio, NFC and RFID cards, infrared, iButton, and GPIO — behind a playful Tamagotchi-like interface.
+
+**What is custom firmware for the Flipper Zero?**
+Custom firmware replaces the official firmware to unlock extra features, protocols, and plugins the stock build restricts. Popular forks include [Unleashed](https://github.com/DarkFlippers/unleashed-firmware) and its RogueMaster fork. The chip stores a New and Old firmware slot, which lowers (but does not remove) the risk of bricking when flashing.
+
+**What frequencies does the Flipper Zero Sub-GHz radio use?**
+The Sub-GHz module uses the CC1101 chipset and operates in the `300-348 MHz`, `387-464 MHz`, and `779-928 MHz` bands. Common targets include 315 MHz and 433 MHz car key fobs and remotes, within the limits of local radio regulations.
+
+**How does NFC work on the Flipper Zero?**
+The NFC module operates at 13.56 MHz (ISO/IEC 18000-3) and can read, save, and emulate NFC cards, capturing data like UID, ATQA, and SAK. It supports many card types, though full ISO 15693 (NFC-V) support is limited.
+
+**How do I update Flipper Zero firmware?**
+The most reliable method is a direct USB cable update via the qFlipper desktop app, which avoids the corruption risk of wireless flashing. You can also update over the Flipper Mobile App or web updater, but a wired qFlipper upgrade is recommended.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/v01d.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/v01d.mdx
@@ -9,6 +9,29 @@ unsplash: 1537158345907-c4fb34477bd6
 img: https://images.unsplash.com/photo-1537158345907-c4fb34477bd6?fit=crop&w=1400&h=700&q=75
 tags:
     - software
+    - virtualization
+    - automation
+sem: 1
+ogTitle: v01d (VOID) — Virtualization & Automation Operator Daemon
+ogDescription: v01d is the Virtualized Object Intelligence Daemon (VOID), an operator that manages servers, nested machines, and clustered instances with soft-scripting automation and RBAC across the KBVE ecosystem.
+jsonld:
+    type: Article
+    keywords:
+        - v01d
+        - void
+        - virtualization
+        - automation
+        - orchestration
+        - operator daemon
+    faq:
+        - question: What is v01d?
+          answer: v01d (VOID — Virtualized Object Intelligence Daemon) is an operator application that manages servers, nested machines, and clustered instances across the KBVE ecosystem. It focuses on soft-scripting automation with fine-grained RBAC over virtual environments and containers, from small-scale testing to production.
+        - question: What is an environ in v01d?
+          answer: An environ is an entity that helps balance and regulate the digital environment managed by VOID. Examples include tr33 (a collection of timers for micro tasks), s33d (data seeding), bl0ck (micro storage), and r00t (an OS-level embed, currently disabled).
+        - question: What is tr33 in v01d?
+          answer: tr33 is an environ — a collection of timers that handle micro tasks on the host machine. The stable branch, tr33._04, targets Ubuntu 22 LTS, Debian 9, and Windows 10/11, while the YAML- and JSON-based v5 and v6 lines are unstable and slated for deprecation.
+        - question: Which platforms does v01d install on?
+          answer: VOID ships install scripts for Linux (Ubuntu 24+ and Debian 11+, which self-delete after running) and a Windows 11 installer that needs admin privileges. On Apple Silicon Macs (M1/M2), the ARM architecture may require isolation from Intel Macs, with Homebrew as a likely path.
 ---
 
 import {
@@ -22,7 +45,13 @@ import {
 
 import { Adsense } from '@/components/astropad';
 
-## Information.
+## Overview
+
+**v01d** (VOID — *Virtualized Object Intelligence Daemon*) is an internal operator that manages servers, nested machines, and clustered instances across the KBVE ecosystem. It leans on **soft-scripting automation** with fine-grained RBAC, orchestrating virtual environments and containers without heavy configuration.
+
+Its behavior is organized into **environs** — regulating entities such as [tr33](#tr33) (timers), [s33d](#s33d) (data seeding), [bl0ck](#bl0ck) (micro storage), and [r00t](#r00t) (OS-level embed).
+
+## Information
 
 Virtualization soft scripting for automation.
 
@@ -84,3 +113,19 @@ By leveraging **v01d**, teams can reduce overhead and enhance operational effici
 
 -   `r00t` - (environ) - an embed that sits on-top of the operating system.
     -   `r00t` - Disabled as of `tr33._02` because the design induced significant flaws and exploits; uncle ben does not approve of such power for any man.
+
+## FAQ
+
+**What is v01d?**
+v01d (VOID — Virtualized Object Intelligence Daemon) is an operator application that manages servers, nested machines, and clustered instances across the KBVE ecosystem. It focuses on soft-scripting automation with fine-grained RBAC over virtual environments and containers, from small-scale testing to production.
+
+**What is an environ in v01d?**
+An environ is an entity that helps balance and regulate the digital environment managed by VOID. Examples include `tr33` (timers for micro tasks), `s33d` (data seeding), `bl0ck` (micro storage), and `r00t` (an OS-level embed, currently disabled).
+
+**What is `tr33` in v01d?**
+`tr33` is an environ — a collection of timers that handle micro tasks on the host machine. The stable branch, `tr33._04`, targets Ubuntu 22 LTS, Debian 9, and Windows 10/11, while the YAML- and JSON-based v5 and v6 lines are unstable and slated for deprecation.
+
+**Which platforms does v01d install on?**
+VOID ships install scripts for Linux (Ubuntu 24+ and Debian 11+, which self-delete after running) and a Windows 11 installer that needs admin privileges. On Apple Silicon Macs (M1/M2), the ARM architecture may require isolation from Intel Macs, with Homebrew as a likely path.
+
+<Adsense />


### PR DESCRIPTION
## SEO/SEM audit — batch 7 (4 files)

Stamps `sem: 1` and applies inline content + metadata improvements. Built thicker per feedback — targets 1000+ words on real apps (v01d is internal lore, kept concise).

| File | Work | FAQ | ~words |
|------|------|-----|--------|
| appwrite | fixed tag (auth→backend/baas/serverless), Overview nav, trimmed filler prose | 5 | 1479 |
| argocd | **had zero tags** → kubernetes/gitops/ci-cd; meta + jsonld; nav (already rich 2k-word doc) | 5 | 1669 |
| flipperzero | Overview nav, authorization caution, fixed `MMHz`→`MHz` + `770`→`779`, filled empty Sub-GHz menu bullets | 5 | 1197 |
| v01d | internal VOID operator doc; Overview + environ nav, meta | 4 | 767 |

Each: keyword-front-loaded title/description, tags fixed/added, ogTitle/ogDescription, jsonld (Article + keywords + faq mirrored as visible MDX).

Validation (python/PyYAML): frontmatter parses, sem=1, code-fence parity EVEN — **PASS** all 4. Full nx astro build not run (worktree lacks hoisted node_modules).

**28 / 45** application docs now `sem: 1`; 17 remain.