### PR TITLE
fix(clickhouse): nudge keeper CHK to finalize Completed status

### DIFF
--- a/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-keeper.yaml
@@ -16,6 +16,9 @@ spec:
     templates:
         podTemplates:
             - name: clickhouse-keeper-pod
+              metadata:
+                  annotations:
+                      kbve.com/reconcile-nonce: "2026-07-01"
               spec:
                   containers:
                       - name: clickhouse-keeper


### PR DESCRIPTION
## Problem

The `clickhouse` Argo app has been `OutOfSync / Progressing` for ~7d. Sync operation blocks on:

> waiting for healthy state of clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/clickhouse-keeper

### Root cause
The keeper is **fully healthy** — STS `1/1`, pod `Running` 7d, CHI `Completed`, CH 25.8.4 serving. Only the CHK `status.status` lies (`InProgress`, all sub-fields null).

Operator logs show why:
```
worker-reconciler-chk.go: reconcileCR(): ActionPlan has no actions - abort reconcile
```
On a no-op reconcile the Altinity operator aborts **before** `finalizeReconcileAndMarkCompleted()`, so a healthy CHK never gets marked `Completed`. Argo's CHK health check keys on `Completed` → app wedges. Restarting the operator doesn't help — every pass finds "no actions" and aborts identically.

## Fix
Add a pod-template annotation (`kbve.com/reconcile-nonce`) to `clickhouse-keeper.yaml`. This changes the operator-computed object version → produces a real ActionPlan → reconcile runs to completion → CHK marked `Completed` → Argo goes Synced/Healthy.

Keeper STS/pod stay healthy; the single-replica keeper pod rolls once on apply (brief).

## Verification
- `yaml.safe_load` on the manifest: OK
- Root cause confirmed live: CHK status `InProgress` + operator "ActionPlan has no actions" abort; keeper workload healthy.

## Related triage (not in this PR)
- **arc-runners** — self-resolved to Synced/Healthy.
- **rentearth** — OutOfSync/Degraded because commit 0c638e591 deleted `rentearth-deployment`/`-service`/`-route` from git while they still serve production `rentearth.com`. Left as-is per owner decision; needs a deliberate call (restore-to-git vs. finish decommission by repointing the apex route to axum-rentearth).