### PR TITLE
docs(application): SEO/SEM audit batch 8 — intel-nuc-talos, ansible, ios, android

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/android.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/android.mdx
@@ -15,6 +15,31 @@ unsplash: 1607252650355-f7fd0460ccdb
 img: https://images.unsplash.com/photo-1607252650355-f7fd0460ccdb?fit=crop&w=1400&h=700&q=75
 tags:
     - os
+    - android
+    - mobile
+sem: 1
+ogTitle: Android Guide — ADB Cheatsheet, Data Storage & React Native
+ogDescription: A practical Android reference — the ADB (Android Debug Bridge) command cheatsheet for device control and debugging, on-device data storage, and Android-specific React Native notes.
+jsonld:
+    type: Article
+    keywords:
+        - android
+        - adb
+        - android debug bridge
+        - android development
+        - android data storage
+        - react native android
+    faq:
+        - question: What is ADB (Android Debug Bridge)?
+          answer: ADB is a command-line tool that lets a computer control an Android device over USB or Wi-Fi. It is used to install and uninstall apps, push and pull files, read device logs with logcat, open a device shell, and debug applications during development.
+        - question: How do I connect a device with ADB?
+          answer: Enable Developer Options and USB debugging on the device, connect it over USB, and run adb devices to confirm it is listed. Some commands need root access, and certain Android versions may require slightly different command syntax.
+        - question: What languages are used for Android development?
+          answer: Native Android apps are written in Kotlin (now preferred) or Java against the Android SDK. Cross-platform options include React Native and Flutter. KBVE's Android apps use React Native with Expo, with native modules added when a feature needs platform-specific code.
+        - question: Is Android open source?
+          answer: Yes. Android is built on the open-source Android Open Source Project (AOSP) on top of a modified Linux kernel. Vendors customize drivers and UI layers on top, while Project Treble and mainline modules allow more consistent updates and faster security patches.
+        - question: What is Android used for beyond phones?
+          answer: Android extends well past phones and tablets into specialized distributions — Android TV for televisions, Android Auto for vehicles, and Wear OS for smartwatches — plus growing use in embedded, desktop, and server-adjacent devices thanks to its modular architecture.
 ---
 
 import {
@@ -35,6 +60,8 @@ Unleash your creativity and make your smartphone, tablet, or smartwatch truly yo
 Our job at KBVE will be to provide you with everything you need to deploy your own Android application on almost any device!
 
 This one page guide is meant to serve as your resource manual moving forward, we will start with the cheat sheet below, that makes it easy to reference back in the future.
+
+Jump to the [ADB cheatsheet](#cheatsheet), [data storage](#android-data-storage), or [React Native](#react-native) notes.
 
 <Adsense />
 
@@ -453,6 +480,23 @@ cursor.close();
 ## React Native
 
 This part of the guide goes into the specific parts of React Native and Android, we do try to keep all our react native notes into one area.
-We recommend going to the rn section as well, but there might be double notes in this section.
+We recommend going to the React Native section as well, but there might be double notes in this section.
+
+## FAQ
+
+**What is ADB (Android Debug Bridge)?**
+ADB is a command-line tool that lets a computer control an Android device over USB or Wi-Fi. It is used to install and uninstall apps, push and pull files, read device logs with `logcat`, open a device shell, and debug applications during development.
+
+**How do I connect a device with ADB?**
+Enable Developer Options and USB debugging on the device, connect it over USB, and run `adb devices` to confirm it is listed. Some commands need root access, and certain Android versions may require slightly different command syntax.
+
+**What languages are used for Android development?**
+Native Android apps are written in Kotlin (now preferred) or Java against the Android SDK. Cross-platform options include React Native and [Flutter](/application/flutter/). KBVE's Android apps use React Native with Expo, with native modules added when a feature needs platform-specific code.
+
+**Is Android open source?**
+Yes. Android is built on the open-source Android Open Source Project (AOSP) on top of a modified Linux kernel. Vendors customize drivers and UI layers on top, while Project Treble and mainline modules allow more consistent updates and faster security patches.
+
+**What is Android used for beyond phones?**
+Android extends well past phones and tablets into specialized distributions — Android TV for televisions, Android Auto for vehicles, and Wear OS for smartwatches — plus growing use in embedded, desktop, and server-adjacent devices thanks to its modular architecture.
 
 <Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/application/ansible.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/ansible.mdx
@@ -10,6 +10,31 @@ unsplash: 1549605659-32d82da3a059
 img: https://images.unsplash.com/photo-1549605659-32d82da3a059?fit=crop&w=1400&h=700&q=75
 tags:
     - iac
+    - devops
+    - ansible
+sem: 1
+ogTitle: Ansible Guide — Agentless Automation, Playbooks & Modules
+ogDescription: Learn Ansible, the agentless IT automation tool — how it uses SSH and Python modules, writing YAML playbooks, the inventory, common modules, AWX, and a command cheatsheet.
+jsonld:
+    type: Article
+    keywords:
+        - ansible
+        - configuration management
+        - infrastructure as code
+        - ansible playbook
+        - ansible modules
+        - awx
+    faq:
+        - question: What is Ansible?
+          answer: Ansible is an open-source IT automation tool for configuration management, application deployment, and orchestration. It is agentless — it connects to hosts over SSH and pushes small programs called modules to do work, then removes them — so managed machines need no special software beyond Python and SSH.
+        - question: What is an Ansible playbook?
+          answer: A playbook is a YAML file that describes a set of plays, each mapping a group of hosts to an ordered list of tasks. Playbooks are declarative and idempotent — running one repeatedly converges hosts to the same desired state without repeating changes that are already applied.
+        - question: Why is Ansible agentless?
+          answer: Ansible does not install a daemon on managed nodes. It uses existing SSH access and Python to run modules on demand, which lowers setup overhead, reduces attack surface, and means any reachable host can be managed without provisioning an agent first.
+        - question: What is an Ansible module?
+          answer: A module is a self-contained unit of work — like apt, copy, service, or template — that Ansible ships to a host to perform one task idempotently. Tasks in a playbook call modules with parameters, and Ansible reports whether each run changed the system.
+        - question: What is AWX?
+          answer: AWX is the open-source upstream of Ansible Tower (Red Hat Ansible Automation Platform). It adds a web UI, REST API, role-based access control, job scheduling, and centralized credential management on top of core Ansible for team-scale automation.
 ---
 
 import {
@@ -37,6 +62,8 @@ It simplifies system management, application deployment, and workflow orchestrat
 Powered by open source, Python, and SSH, Ansible connects seamlessly to your devices—no agents required.
 It sends lightweight programs called **modules** to perform tasks precisely where they are needed, then removes them once finished.
 From provisioning servers to configuring networks and deploying applications, Ansible turns manual, error-prone processes into consistent, repeatable automation.
+
+Jump to [install](#install), [playbooks](#playbook), [modules](#modules), [AWX](#awx), or the [cheatsheet](#cheatsheet).
 
 <Adsense />
 
@@ -560,3 +587,22 @@ Video -> https://www.youtube.com/watch?v=EcnqJbxBcM0
 ## Notes
 
 Notes for Ansible
+
+## FAQ
+
+**What is Ansible?**
+Ansible is an open-source IT automation tool for configuration management, application deployment, and orchestration. It is agentless — it connects to hosts over SSH and pushes small programs called modules to do work, then removes them — so managed machines need no special software beyond Python and SSH.
+
+**What is an Ansible playbook?**
+A playbook is a YAML file that describes a set of plays, each mapping a group of hosts to an ordered list of tasks. Playbooks are declarative and idempotent — running one repeatedly converges hosts to the same desired state without repeating changes that are already applied.
+
+**Why is Ansible agentless?**
+Ansible does not install a daemon on managed nodes. It uses existing SSH access and Python to run modules on demand, which lowers setup overhead, reduces attack surface, and means any reachable host can be managed without provisioning an agent first.
+
+**What is an Ansible module?**
+A module is a self-contained unit of work — like `apt`, `copy`, `service`, or `template` — that Ansible ships to a host to perform one task idempotently. Tasks in a playbook call modules with parameters, and Ansible reports whether each run changed the system.
+
+**What is AWX?**
+AWX is the open-source upstream of Ansible Tower (Red Hat Ansible Automation Platform). It adds a web UI, REST API, role-based access control, job scheduling, and centralized credential management on top of core Ansible for team-scale automation.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/application/intel-nuc-talos.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/intel-nuc-talos.mdx
@@ -7,6 +7,33 @@ sidebar:
     order: 150
 unsplash: 1518834107796-18cc03584b9a
 img: https://images.unsplash.com/photo-1518834107796-18cc03584b9a?fit=crop&w=1400&h=700&q=75
+tags:
+    - kubernetes
+    - talos
+    - homelab
+sem: 1
+ogTitle: Intel NUC Talos Worker Nodes — Add Bare-Metal Workers to Kubernetes
+ogDescription: Step-by-step guide to add Intel NUC devices as Talos Linux worker nodes on an existing Kubernetes cluster over WireGuard — hardware prep, Talos install, key generation, joining, and troubleshooting.
+jsonld:
+    type: Article
+    keywords:
+        - talos linux
+        - intel nuc
+        - kubernetes worker node
+        - bare metal kubernetes
+        - wireguard
+        - homelab cluster
+    faq:
+        - question: What is Talos Linux?
+          answer: Talos Linux is a minimal, immutable, API-driven operating system purpose-built for Kubernetes. It has no shell or SSH — every node is managed declaratively through talosctl and a machine config — which makes bare-metal nodes like Intel NUCs reproducible and secure.
+        - question: Can I add bare-metal Intel NUCs to a cloud Kubernetes cluster?
+          answer: Yes. This guide joins Intel NUC workers to an existing Talos control plane running on Hetzner by tunneling cluster traffic over WireGuard. Each NUC gets a unique WireGuard key and IP, applies a worker machine config, and registers as a standard worker node.
+        - question: Why use WireGuard to join remote worker nodes?
+          answer: WireGuard creates an encrypted overlay network so home-based NUCs and cloud control-plane nodes communicate securely across the public internet as if on one private subnet. It is lightweight, fast, and integrates directly into the Talos machine network config.
+        - question: What are the minimum hardware requirements for a Talos NUC worker?
+          answer: An Intel NUC 11th gen or newer with at least 8GB RAM (16GB recommended), a 256GB+ SSD (NVMe preferred), and gigabit Ethernet. Enable UEFI boot, disable Secure Boot, and turn on Intel VT-x/VT-d in the BIOS before installing Talos.
+        - question: How do I troubleshoot a NUC that will not join the cluster?
+          answer: Check WireGuard connectivity with wg show and ping the control-plane endpoint, inspect kubelet logs via talosctl logs --nodes, and confirm the cluster secrets and keys match. Most join failures trace back to an incorrect WireGuard key or an unreachable endpoint.
 ---
 
 import {
@@ -23,6 +50,8 @@ import { Giscus, Adsense } from '@/components/astropad';
 ## Overview
 
 This guide covers adding Intel NUC devices as worker nodes to the existing Talos Linux cluster running on Hetzner with WireGuard networking.
+
+Flow: [hardware prep](#phase-1-hardware-preparation) → [Talos install](#phase-2-talos-linux-installation) → [cluster config](#phase-3-cluster-configuration) → [join](#phase-4-join-nucs-to-cluster) → [troubleshooting](#troubleshooting).
 
 ## Hardware Requirements
 
@@ -275,6 +304,23 @@ To add additional Intel NUC worker nodes:
 - Monitor cluster access logs
 
 <Adsense />
+
+## FAQ
+
+**What is Talos Linux?**
+Talos Linux is a minimal, immutable, API-driven operating system purpose-built for Kubernetes. It has no shell or SSH — every node is managed declaratively through `talosctl` and a machine config — which makes bare-metal nodes like Intel NUCs reproducible and secure.
+
+**Can I add bare-metal Intel NUCs to a cloud Kubernetes cluster?**
+Yes. This guide joins Intel NUC workers to an existing Talos control plane running on Hetzner by tunneling cluster traffic over [WireGuard](/application/wireguard/). Each NUC gets a unique WireGuard key and IP, applies a worker machine config, and registers as a standard worker node.
+
+**Why use WireGuard to join remote worker nodes?**
+WireGuard creates an encrypted overlay network so home-based NUCs and cloud control-plane nodes communicate securely across the public internet as if on one private subnet. It is lightweight, fast, and integrates directly into the Talos machine network config.
+
+**What are the minimum hardware requirements for a Talos NUC worker?**
+An Intel NUC 11th gen or newer with at least 8GB RAM (16GB recommended), a 256GB+ SSD (NVMe preferred), and gigabit Ethernet. Enable UEFI boot, disable Secure Boot, and turn on Intel VT-x/VT-d in the BIOS before installing Talos.
+
+**How do I troubleshoot a NUC that will not join the cluster?**
+Check WireGuard connectivity with `wg show` and ping the control-plane endpoint, inspect kubelet logs via `talosctl logs --nodes`, and confirm the cluster secrets and keys match. Most join failures trace back to an incorrect WireGuard key or an unreachable endpoint.
 
 ## References
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/ios.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/ios.mdx
@@ -15,6 +15,30 @@ img: https://images.unsplash.com/photo-1611472173362-3f53dbd65d80?fit=crop&w=140
 tags:
     - os
     - mobile
+    - ios
+sem: 1
+ogTitle: iOS Development Guide — Code Signing, Provisioning & CI/CD
+ogDescription: Build and ship iOS apps at KBVE — Apple code signing, certificates and provisioning profiles, GitHub Actions CI/CD with macOS runners, exportOptions.plist, and UE5 iOS builds.
+jsonld:
+    type: Article
+    keywords:
+        - ios development
+        - code signing
+        - provisioning profile
+        - apple developer
+        - ios ci cd
+        - react native ios
+    faq:
+        - question: What do I need to develop and distribute iOS apps?
+          answer: A macOS machine with Xcode, and enrollment in the Apple Developer Program at $99/year. Membership is required to test on physical devices and distribute through the App Store. You also need a signing certificate, a provisioning profile, and a unique bundle identifier such as com.kbve.app.
+        - question: What is the difference between a certificate and a provisioning profile?
+          answer: A signing certificate proves your identity to Apple and signs the app binary. A provisioning profile links that certificate, the app ID, and (for development/ad-hoc) allowed device UDIDs, authorizing where the app can run. App Store profiles do not need device registration.
+        - question: How do I sign an iOS build in CI/CD?
+          answer: Store the .p12 certificate and .mobileprovision profile as base64 GitHub secrets, then in the workflow create a temporary keychain, import the decoded certificate, install the profile, and build with xcodebuild archive plus exportArchive using an exportOptions.plist. Never commit certificates to the repo.
+        - question: Can I build an unsigned iOS app for testing?
+          answer: Yes. A simulator build for the iphonesimulator SDK does not require signing, so CI can produce an unsigned x86_64 build for testing. Signing is only required for device installs, TestFlight, and App Store submission using the iphoneos SDK.
+        - question: Do Unreal Engine 5 iOS builds use the same Apple setup?
+          answer: Yes. UE5 iOS builds reuse the same Apple Developer certificates, provisioning profiles, and Team ID as React Native builds. The difference is the build system — UE5 uses UnrealBuildTool and RunUAT instead of xcodebuild directly, and produces larger binaries with precompiled Metal shaders.
 ---
 
 import {
@@ -34,6 +58,8 @@ import { Giscus, Adsense } from '@/components/astropad';
 
 iOS development requires a macOS environment and enrollment in the Apple Developer Program ($99/year) to deploy applications to physical devices and distribute through the App Store.
 This guide covers code signing, provisioning profiles, CI/CD setup, and best practices for building iOS applications at KBVE.
+
+Jump to [code signing](#code-signing-setup), [GitHub secrets](#github-secrets-configuration), the [CI/CD workflow](#cicd-workflow), [troubleshooting](#troubleshooting), or [UE5 iOS builds](#unreal-engine-5-ios-builds).
 
 Our React Native iOS applications use Expo for streamlined development and deployment workflows, with custom native modules when needed for advanced features.
 
@@ -491,6 +517,23 @@ UE5 iOS builds require significant disk space (30GB+ for engine + project) and b
 </Steps>
 
 <Adsense />
+
+## FAQ
+
+**What do I need to develop and distribute iOS apps?**
+A macOS machine with Xcode, and enrollment in the Apple Developer Program at $99/year. Membership is required to test on physical devices and distribute through the App Store. You also need a signing certificate, a provisioning profile, and a unique bundle identifier such as `com.kbve.app`.
+
+**What is the difference between a certificate and a provisioning profile?**
+A signing certificate proves your identity to Apple and signs the app binary. A provisioning profile links that certificate, the app ID, and (for development/ad-hoc) allowed device UDIDs, authorizing where the app can run. App Store profiles do not need device registration.
+
+**How do I sign an iOS build in CI/CD?**
+Store the `.p12` certificate and `.mobileprovision` profile as base64 GitHub secrets, then in the workflow create a temporary keychain, import the decoded certificate, install the profile, and build with `xcodebuild archive` plus `exportArchive` using an `exportOptions.plist`. Never commit certificates to the repo.
+
+**Can I build an unsigned iOS app for testing?**
+Yes. A simulator build for the `iphonesimulator` SDK does not require signing, so CI can produce an unsigned x86_64 build for testing. Signing is only required for device installs, TestFlight, and App Store submission using the `iphoneos` SDK.
+
+**Do Unreal Engine 5 iOS builds use the same Apple setup?**
+Yes. UE5 iOS builds reuse the same Apple Developer certificates, provisioning profiles, and Team ID as React Native builds. The difference is the build system — UE5 uses UnrealBuildTool and RunUAT instead of `xcodebuild` directly, and produces larger binaries with precompiled Metal shaders.
 
 ---
 


### PR DESCRIPTION
## SEO/SEM audit — batch 8 (4 files)

Stamps `sem: 1` and applies inline content + metadata improvements. All four were already content-rich; this pass is mostly metadata + FAQ + navigation.

| File | Work | FAQ | ~words |
|------|------|-----|--------|
| intel-nuc-talos | **had zero tags** → kubernetes/talos/homelab; meta + jsonld; phase-flow nav | 5 | 1100 |
| ansible | tag iac→+devops/ansible; meta + jsonld; section nav; FAQ | 5 | 3166 |
| ios | tag +ios; meta + jsonld; section nav (already 1.8k-word signing/CI guide) | 5 | 1818 |
| android | tag os→+android/mobile; meta + jsonld; section nav; FAQ | 5 | 2659 |

Each: keyword-front-loaded title/description, tags fixed/added, ogTitle/ogDescription, jsonld (Article + keywords + faq mirrored as visible MDX).

Note: android's React Native links left as plain text (not `/application/rn/`) to avoid a transient 404 — the `rn` page lands in batch 6 (#13659), merge order independent.

Validation (python/PyYAML): frontmatter parses, sem=1, code-fence parity EVEN — **PASS** all 4. Full nx astro build not run (worktree lacks hoisted node_modules).

**32 / 45** application docs now `sem: 1`; 13 remain.