### PR TITLE
fix(agones): wire SUPABASE_URL into arpg + cryptothrone fleets for ES256 JWKS auth

### DIFF
--- a/apps/kube/agones/arpg/manifests/fleet.yaml
+++ b/apps/kube/agones/arpg/manifests/fleet.yaml
@@ -63,6 +63,15 @@ spec:
                                     secretKeyRef:
                                         name: supabase-shared
                                         key: SUPABASE_JWT_SECRET
+                              # Enables the jedi JWKS verifier (accept-both
+                              # HS256 + ES256). Without it the server falls back
+                              # to HS256-only and rejects ES256 tokens GoTrue
+                              # now issues.
+                              - name: SUPABASE_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: SUPABASE_URL
                               # jedi PgCluster (pooled Postgres) + KvCache
                               # (Valkey). All optional so a GameServer still
                               # starts before the ExternalSecrets render; jedi

--- a/apps/kube/agones/cryptothrone/manifests/fleet.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet.yaml
@@ -63,6 +63,15 @@ spec:
                                     secretKeyRef:
                                         name: supabase-shared
                                         key: SUPABASE_JWT_SECRET
+                              # Enables the jedi JWKS verifier (accept-both
+                              # HS256 + ES256). Without it the server falls back
+                              # to HS256-only and rejects ES256 tokens GoTrue
+                              # now issues.
+                              - name: SUPABASE_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: SUPABASE_URL
                               # jedi PgCluster (pooled Postgres) + KvCache
                               # (Valkey). All optional so a GameServer still
                               # starts before the ExternalSecrets render; jedi


### PR DESCRIPTION
## Problem

The arpg and cryptothrone simgrid game servers reject every real player JWT with:

```
auth rejected: invalid token: InvalidAlgorithm
```

Root-caused from a live Unreal client (rentearth) PIE session: the WS handshake completes, the server receives the JoinMatch, then rejects on algorithm mismatch. No `Welcome` → client shows default camera + no player entity.

## Cause

Both server binaries verify player JWTs with jedi's dual-key verifier (accept-both HS256 + ES256). `jwks_verifier()` only engages when it can derive a JWKS URI from `SUPABASE_JWKS_URI` or `SUPABASE_URL`. Both fleets set `SUPABASE_JWT_SECRET` but **not** `SUPABASE_URL`, so the verifier bailed and the server fell back to the local **HS256-only** path (`verify_supabase_jwt`, `Validation::new(HS256)`).

Fine until GoTrue switched to **ES256** signing (HS256→ES256/JWKS migration). Since then, HS256-only validation rejects every ES256 token with `InvalidAlgorithm`.

## Fix

Map `SUPABASE_URL` into both fleet containers from the existing `supabase-shared` secret (already carries `http://kong.kilobase.svc.cluster.local:8000`). The verifier then derives `$SUPABASE_URL/auth/v1/.well-known/jwks.json`, loads the ES256 JWKS, and accepts **both** HS256 and ES256 — matching the accept-both migration design.

Server code unchanged; client unchanged. Env-only.

## Impact / rollout

- ArgoCD (`agones-arpg`, cryptothrone) tracks `main` — deploys on merge to main.
- RollingUpdate replaces the running GameServer; active sessions reconnect.
- No secret changes (`SUPABASE_URL` already rendered by both ExternalSecrets).