### PR TITLE
fix(seo): repair dev build — MDX escape + docs schema software fields

### DIFF
--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -255,6 +255,14 @@ export const collections = {
 				category: z.string().optional(),
 				tags: z.array(z.string()).optional(),
 				sem: z.number().int().optional(),
+				// Project-page software metadata consumed by Head.astro to
+				// derive SoftwareSourceCode JSON-LD. Without these the docs
+				// schema strips them from entry.data and no node is emitted.
+				source_path: z.string().optional(),
+				app_name: z.string().optional(),
+				version: z.string().optional(),
+				license: z.string().optional(),
+				author: z.string().optional(),
 				// Per-page social-meta overrides consumed by
 				// src/components/navigation/Head.astro. Astro silently strips
 				// nested z.object fields imported across zod-package boundaries

--- a/apps/kbve/astro-kbve/src/content/docs/project/fudster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/fudster.mdx
@@ -37,7 +37,7 @@ Fudster is a composable Python ML library and CLI for haystack-ai and pgvector i
 |---|---|
 | **Package** | `python-fudster` (PyPI `fudster`) |
 | **Version** | 1.0.3 |
-| **Language** | Python (>=3.12,<3.14) |
+| **Language** | Python `>=3.12,<3.14` |
 | **License** | MIT |
 | **Source** | [`packages/python/fudster`](https://github.com/KBVE/kbve/tree/main/packages/python/fudster) |
 | **CLI** | `fudster` |

--- a/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
@@ -37,7 +37,7 @@ The `kbve` Python library is an API layer and complexity handler for async HTTP,
 |---|---|
 | **Package** | `python-kbve` (PyPI `kbve`) |
 | **Version** | 1.0.13 |
-| **Language** | Python (>=3.12,<3.14) |
+| **Language** | Python `>=3.12,<3.14` |
 | **License** | MIT |
 | **Source** | [`packages/python/kbve`](https://github.com/KBVE/kbve/tree/main/packages/python/kbve) |
 | **Core deps** | pydantic, aiohttp, fastapi, uvicorn, grpcio, protobuf |


### PR DESCRIPTION
**Hotfix.** PR #13664 merged before this fix commit landed, so dev currently:
1. Has a bare `<3.14` in python-kbve/fudster tables that MDX parses as JSX → **astro build fails**.
2. Is missing the docs-schema declarations for `source_path`/`app_name`/`version`/`license`/`author`, so Starlight strips them and the SoftwareSourceCode JSON-LD never renders.

This restores both:
- Escapes the version range as inline code.
- Declares the five software fields on the docs schema `extend`.

Verified: `astro-kbve` build green (7332 pages); bevy-cam-crate + agones emit SoftwareSourceCode (codeRepository/version/license) plus FAQPage.