### PR TITLE
fix(rentearth): add gateway HTTPS listeners + TLS cert for apex

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -221,6 +221,48 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-rentearth
+          protocol: HTTPS
+          port: 443
+          hostname: rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rentearth-www
+          protocol: HTTPS
+          port: 443
+          hostname: www.rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rentearth-play
+          protocol: HTTPS
+          port: 443
+          hostname: play.rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/apps/kube/rentearth/manifest/kustomization.yaml
+++ b/apps/kube/rentearth/manifest/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
     - axum-rentearth-secrets-sealedsecret.yaml
     - axum-rentearth-deployment.yaml
     - axum-rentearth-httproute.yaml
+    - rentearth-reference-grant.yaml
+    - rentearth-certificate.yaml

--- a/apps/kube/rentearth/manifest/rentearth-certificate.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: rentearth-tls
+    namespace: rentearth
+spec:
+    secretName: rentearth-tls
+    dnsNames:
+        - rentearth.com
+        - www.rentearth.com
+        - play.rentearth.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io

--- a/apps/kube/rentearth/manifest/rentearth-reference-grant.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+    name: allow-gateway-tls
+    namespace: rentearth
+spec:
+    from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: kbve
+    to:
+        - group: ''
+          kind: Secret


### PR DESCRIPTION
## Problem

`rentearth.com` returns Cloudflare **525** (SSL handshake CF↔origin) and the `rentearth` Argo app is `OutOfSync/Degraded`. The axum-rentearth migration was left half-done across three layers:

| Layer | State |
|-------|-------|
| Image `axum-rentearth:0.1.1` | ✅ public, healthy — `/`→200, `/api/health`→ok with live itch builds |
| `axum-rentearth-route` | ✅ already claims `rentearth.com` / `www` / `play` → axum-rentearth-service:4323 |
| **kbve-gateway TLS** | ❌ **no HTTPS listener + no cert for rentearth.com** |

Every other apex (cryptothrone, chuckrpg, rareicon, discord.sh…) has a dedicated `https-*` listener + cert. rentearth.com had none, so its routes only attached to the `:80` catch-all → Cloudflare's HTTPS-to-origin handshake failed → 525. (Legacy `rentearth-service` also just returns 404.)

## Fix — mirrors the cryptothrone pattern

- **New** `rentearth-certificate.yaml` — cert-manager `Certificate` `rentearth-tls`, SANs `rentearth.com` / `www.rentearth.com` / `play.rentearth.com`, issuer `letsencrypt-http`.
- **New** `rentearth-reference-grant.yaml` — `ReferenceGrant` letting kbve-gateway (kbve ns) read `rentearth-tls` from the rentearth ns.
- **Edit** `kbve-gateway.yaml` — three `Terminate` HTTPS listeners (exact hostnames; HTTP-01 can't wildcard) → `rentearth-tls`.
- **Edit** `kustomization.yaml` — add the two new resources.

Cloudflare DNS is already correct (525 = origin reached, TLS fails). Once the cert issues and listeners program, the apex serves axum 200.

## Not in this PR
Legacy `rentearth-deployment` / `rentearth-service` / `rentearth-route` (orphaned by commit 0c638e591, returning 404) are left running. Prune them **after** this merges + the cert issues, so `axum-rentearth-route` wins the apex hostnames and the Argo app goes Synced.

## Verification
- `yaml.safe_load_all` on all four files: OK
- `kubectl kustomize apps/kube/rentearth/manifest`: builds — Certificate + ReferenceGrant + 3 HTTPRoutes present
- Gateway listeners confirmed: `https-rentearth`, `https-rentearth-www`, `https-rentearth-play`
- axum verified in-cluster: `/`→200, `/api/health`→`{"status":"ok","version":"0.1.1"}`; legacy →404