### PR TITLE
fix(seo): unblock astro build — escape MDX version range + declare software schema fields

### DIFF
--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -255,6 +255,14 @@ export const collections = {
 				category: z.string().optional(),
 				tags: z.array(z.string()).optional(),
 				sem: z.number().int().optional(),
+				// Project-page software metadata consumed by Head.astro to
+				// derive SoftwareSourceCode JSON-LD. Without these the docs
+				// schema strips them from entry.data and no node is emitted.
+				source_path: z.string().optional(),
+				app_name: z.string().optional(),
+				version: z.string().optional(),
+				license: z.string().optional(),
+				author: z.string().optional(),
 				// Per-page social-meta overrides consumed by
 				// src/components/navigation/Head.astro. Astro silently strips
 				// nested z.object fields imported across zod-package boundaries

--- a/apps/kbve/astro-kbve/src/content/docs/project/fudster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/fudster.mdx
@@ -37,7 +37,7 @@ Fudster is a composable Python ML library and CLI for haystack-ai and pgvector i
 |---|---|
 | **Package** | `python-fudster` (PyPI `fudster`) |
 | **Version** | 1.0.3 |
-| **Language** | Python (>=3.12,<3.14) |
+| **Language** | Python `>=3.12,<3.14` |
 | **License** | MIT |
 | **Source** | [`packages/python/fudster`](https://github.com/KBVE/kbve/tree/main/packages/python/fudster) |
 | **CLI** | `fudster` |

--- a/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
@@ -37,7 +37,7 @@ The `kbve` Python library is an API layer and complexity handler for async HTTP,
 |---|---|
 | **Package** | `python-kbve` (PyPI `kbve`) |
 | **Version** | 1.0.13 |
-| **Language** | Python (>=3.12,<3.14) |
+| **Language** | Python `>=3.12,<3.14` |
 | **License** | MIT |
 | **Source** | [`packages/python/kbve`](https://github.com/KBVE/kbve/tree/main/packages/python/kbve) |
 | **Core deps** | pydantic, aiohttp, fastapi, uvicorn, grpcio, protobuf |


### PR DESCRIPTION
Follow-up to #13664 (merged). That PR broke the astro build on dev:

```
[ERROR] [vite] ✗ Build failed
Unexpected character `3` (U+0033) before name
  @mdx-js/rolldown .../project/python-kbve.mdx:40:34
```

## Fixes
1. **MDX JSX hazard** — `Python (>=3.12,<3.14)` in the Key-facts table of `python-kbve.mdx` and `fudster.mdx` parsed `<3.14` as a JSX tag. Wrapped the version range in inline code.
2. **SoftwareSourceCode not rendering** — the `docs` schema stripped `source_path`/`app_name`/`version`/`license`/`author` from `entry.data`, so Head.astro derived no software node. Declared them in the `docsSchema` extend.

## Verified
`nx build astro-kbve` green — **7332 pages**. Rendered JSON-LD on `project/bevy-cam-crate` now includes `SoftwareSourceCode` (codeRepository, programmingLanguage `["rust"]`, version, license) **and** `FAQPage`.