### PR TITLE
fix(cert-manager): add rentearth.com HTTP-01 solver to letsencrypt-http

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -112,6 +112,16 @@ spec:
                             namespace: kbve
                             kind: Gateway
                             group: gateway.networking.k8s.io
+            - selector:
+                  dnsZones:
+                      - rentearth.com
+              http01:
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -221,6 +221,48 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-rentearth
+          protocol: HTTPS
+          port: 443
+          hostname: rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rentearth-www
+          protocol: HTTPS
+          port: 443
+          hostname: www.rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rentearth-play
+          protocol: HTTPS
+          port: 443
+          hostname: play.rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rentearth-tls
+                    namespace: rentearth
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/apps/kube/rentearth/manifest/kustomization.yaml
+++ b/apps/kube/rentearth/manifest/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
     - axum-rentearth-secrets-sealedsecret.yaml
     - axum-rentearth-deployment.yaml
     - axum-rentearth-httproute.yaml
+    - rentearth-reference-grant.yaml
+    - rentearth-certificate.yaml

--- a/apps/kube/rentearth/manifest/rentearth-certificate.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: rentearth-tls
+    namespace: rentearth
+spec:
+    secretName: rentearth-tls
+    dnsNames:
+        - rentearth.com
+        - www.rentearth.com
+        - play.rentearth.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io

--- a/apps/kube/rentearth/manifest/rentearth-reference-grant.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+    name: allow-gateway-tls
+    namespace: rentearth
+spec:
+    from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: kbve
+    to:
+        - group: ''
+          kind: Secret


### PR DESCRIPTION
## Problem

Follow-up to #13669. After the rentearth gateway listeners + `rentearth-tls` Certificate merged, the cert **never issued** — ACME order stuck `pending` 11h, no Challenge, no Secret. Result: the 3 new gateway listeners are `Programmed=False / InvalidCertificateRef`, which **degrades the kbve app** (and rentearth apex HTTPS stays broken → CF 525).

### Root cause
`letsencrypt-http` ClusterIssuer selects HTTP-01 solvers by `selector.dnsZones` allowlist: kbve.com, discord.sh, herbmail.com, meme.sh, cryptothrone.com, chuckrpg.com, rareicon.com, cityvote.com. **`rentearth.com` was not in the list** → cert-manager can't match a solver → order sits pending forever with no challenge presented.

## Fix
Add a `gatewayHTTPRoute` HTTP-01 solver for the `rentearth.com` zone (covers `www` + `play` subdomains), mirroring the other apex zones → kbve-gateway.

## Expected after merge
1. cert-manager matches the solver → creates Challenge + solver HTTPRoute on kbve-gateway :80.
2. LE validates → `rentearth-tls` Secret minted → Certificate `Ready`.
3. Gateway listeners `https-rentearth{,-www,-play}` program → **kbve app un-degrades**.
4. Apex serves axum 200 over HTTPS (525 clears).
5. Legacy prune (separate) → rentearth app Synced.

## Verification
- `yaml.safe_load_all` on cluster-issuer.yaml: OK
- Confirmed live: order `pending` 11h, 3 authorizations, zero challenges; issuer solver list missing rentearth.com; cryptothrone-tls (has a solver) is `Ready=True`.