### PR TITLE
fix(ci): regen ci-dispatch-manifest from MDX — unblock 5 stalled publishes

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -356,7 +356,7 @@
 		{
 			"key": "kbve_gate",
 			"app_name": "kbve-gate",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"version_toml": "apps/kbve/kbve-gate/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
 			"version_target": "apps/kbve/kbve-gate/Cargo.toml",
@@ -474,7 +474,7 @@
 		{
 			"key": "metrics",
 			"app_name": "metrics",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"version_toml": "apps/metrics/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx",
 			"version_target": "apps/metrics/Cargo.toml",
@@ -503,7 +503,7 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.36",
+			"version": "0.1.37",
 			"version_toml": "apps/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/rows/Cargo.toml",
@@ -532,7 +532,7 @@
 		{
 			"key": "devops",
 			"package_name": "devops",
-			"version": "0.0.20",
+			"version": "0.0.19",
 			"version_toml": "packages/npm/devops/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/devops.mdx",
 			"version_target": "packages/npm/devops/package.json"
@@ -556,7 +556,7 @@
 		{
 			"key": "laser",
 			"package_name": "laser",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"version_toml": "packages/npm/laser/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/laser.mdx",
 			"version_target": "packages/npm/laser/package.json"

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-necklace.mdx
@@ -63,7 +63,7 @@ osrs:
 
     | Item | Trigger | Effect | Wilderness |
     |------|---------|--------|-----------|
-    | Phoenix necklace | <20% HP | Heals 30% HP | Lvl 30 |
+    | Phoenix necklace | &lt;20% HP | Heals 30% HP | Lvl 30 |
     | Ring of life | ≤10% HP | Teleport to spawn | Lvl 30 |
 
     Phoenix necklace keeps you in the fight; ring of life removes you.


### PR DESCRIPTION
## Problem
A broken MDX table (bare \`<digit\`, e.g. \`<3.14\`, \`<20%\` parsed as JSX tags) wedged the \`astro-kbve:build\`, so \`sync:ci-manifest\` could never regenerate \`.github/ci-dispatch-manifest.json\`. Five package version bumps sat stranded in MDX but never reached the manifest, so CI never dispatched their publishes.

Discovered while investigating why \`@kbve/laser\` was stuck at 0.1.4 on npm despite MDX declaring 0.1.5.

## Fix
- Escape remaining \`<20%\` in \`osrs/diamond-necklace.mdx\` (fudster/python-kbve already fixed on dev by #13671).
- Regenerate the manifest from MDX source of truth.

## Manifest deltas (MDX-truth)
| package | was | now |
|---|---|---|
| kbve_gate | 0.1.6 | **0.1.7** (Forgejo SSO restore #13613) |
| metrics | 0.1.4 | 0.1.5 |
| rows | 0.1.36 | 0.1.37 |
| laser | 0.1.4 | **0.1.5** |
| devops | 0.0.20 | 0.0.19 (drift cleanup from #13606 revert) |

Publishes track main — these dispatch after dev→main promotion.

## Notes
- \`version.toml\` files untouched — CI post-publish owns those (gate: manifest_version > version.toml → publish).
- devops \`0.0.20\` re-land (\`_\$gha_*\` exports + tracker rewrite) remains a separate #13615 task; this PR only clears the stale drift.
- Related: #13615 (CI outage / publish deadlock).