### PR TITLE
fix(rentearth): drop play.rentearth.com to unblock apex cert

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -249,20 +249,6 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
-        - name: https-rentearth-play
-          protocol: HTTPS
-          port: 443
-          hostname: play.rentearth.com
-          tls:
-              mode: Terminate
-              certificateRefs:
-                  - kind: Secret
-                    group: ''
-                    name: rentearth-tls
-                    namespace: rentearth
-          allowedRoutes:
-              namespaces:
-                  from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/apps/kube/rentearth/manifest/axum-rentearth-httproute.yaml
+++ b/apps/kube/rentearth/manifest/axum-rentearth-httproute.yaml
@@ -10,7 +10,6 @@ spec:
     hostnames:
         - rentearth.com
         - www.rentearth.com
-        - play.rentearth.com
     rules:
         - matches:
               - path:

--- a/apps/kube/rentearth/manifest/rentearth-certificate.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-certificate.yaml
@@ -8,7 +8,6 @@ spec:
     dnsNames:
         - rentearth.com
         - www.rentearth.com
-        - play.rentearth.com
     issuerRef:
         name: letsencrypt-http
         kind: ClusterIssuer


### PR DESCRIPTION
## Problem

After the solver landed (#13673), the `rentearth-tls` HTTP-01 challenges ran:

| host | challenge |
|------|-----------|
| rentearth.com | ✅ valid |
| www.rentearth.com | ✅ valid |
| play.rentearth.com | ❌ pending — `wrong status code '530'` |

`play.rentearth.com` returns Cloudflare **530** (no origin routing configured for that hostname — it was newly introduced by this migration and never wired at CF). The ACME order is **all-or-nothing**, so the stuck play challenge blocks issuance for the apex + www too → rentearth.com stays offline (525) and the kbve gateway stays degraded.

## Fix
Remove `play.rentearth.com` from:
- `rentearth-certificate.yaml` (SANs)
- `kbve-gateway.yaml` (`https-rentearth-play` listener)
- `axum-rentearth-httproute.yaml` (hostnames)

Cert reissues for `rentearth.com` + `www.rentearth.com` (both already validated) → issues immediately → listeners program → apex online, kbve un-degrades.

`play.rentearth.com` can be re-added once its Cloudflare origin is set up.

## Verification
- `yaml.safe_load_all` on all 3 files: OK
- No `play.rentearth` refs remain in kbve/rentearth manifests
- Live: rentearth.com + www challenges `valid`, play `pending 530`