### PR TITLE
feat(devops): re-land CI-failure pure fns + publish 0.0.20 (source only)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -532,7 +532,7 @@
 		{
 			"key": "devops",
 			"package_name": "devops",
-			"version": "0.0.19",
+			"version": "0.0.20",
 			"version_toml": "packages/npm/devops/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/devops.mdx",
 			"version_target": "packages/npm/devops/package.json"

--- a/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
@@ -11,7 +11,7 @@ tags:
 key: devops
 pipeline: npm
 package_name: devops
-version: "0.0.19"
+version: "0.0.20"
 source_path: packages/npm/devops
 version_toml: packages/npm/devops/version.toml
 author: h0lybyte

--- a/packages/npm/devops/src/index.ts
+++ b/packages/npm/devops/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/sanitization';
 export * from './lib/api';
 export * from './lib/client/kbve';
+export * from './lib/client/github/ci-failure';
 export * from './lib/ci';
 export * from './lib/forum';
 export * as telemetry from './lib/telemetry';

--- a/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import {
+	_$gha_failureIssueTitle,
+	_$gha_classifyCIFailure,
+	_$gha_parseFailureLog,
+	_$gha_buildFailureIssueBody,
+	_$gha_buildFailureComment,
+	_$gha_buildResolveComment,
+	_$gha_incrementFailureHistory,
+	CI_FAILURE_PATTERNS,
+	ci,
+} from './ci-failure';
+
+describe('ci namespace', () => {
+	it('exposes the canonical API', () => {
+		expect(ci.issueTitle('CI Main', 'build')).toBe(
+			'[CI] CI Main / build — Failed',
+		);
+		expect(ci.parseFailureLog('').nxTargets).toBe('');
+		expect(ci.classifyFailure('nothing')).toBeNull();
+		expect(ci.failurePatterns).toBe(CI_FAILURE_PATTERNS);
+	});
+
+	it('deprecated _$gha_* aliases point to the same functions', () => {
+		expect(_$gha_failureIssueTitle).toBe(ci.issueTitle);
+		expect(_$gha_classifyCIFailure).toBe(ci.classifyFailure);
+		expect(_$gha_parseFailureLog).toBe(ci.parseFailureLog);
+		expect(_$gha_buildFailureIssueBody).toBe(ci.buildIssueBody);
+		expect(_$gha_buildFailureComment).toBe(ci.buildComment);
+		expect(_$gha_buildResolveComment).toBe(ci.buildResolveComment);
+		expect(_$gha_incrementFailureHistory).toBe(ci.incrementHistory);
+	});
+});
+
+describe('_$gha_failureIssueTitle', () => {
+	it('formats the canonical tracker title', () => {
+		expect(_$gha_failureIssueTitle('CI Main', 'build')).toBe(
+			'[CI] CI Main / build — Failed',
+		);
+	});
+});
+
+describe('_$gha_classifyCIFailure', () => {
+	it('classifies Forgejo LFS auth failures', () => {
+		const log =
+			'batch response: Authentication required: ... info/lfs/objects/batch';
+		const reason = _$gha_classifyCIFailure(log);
+		expect(reason).toContain('Forgejo LFS');
+		expect(reason).toContain('FORGEJO_TOKEN');
+	});
+
+	it('classifies out-of-memory kills', () => {
+		expect(
+			_$gha_classifyCIFailure(
+				'Killed signal 9 - JavaScript heap out of memory',
+			),
+		).toContain('memory');
+	});
+
+	it('returns null when no pattern matches', () => {
+		expect(_$gha_classifyCIFailure('some unrelated output')).toBeNull();
+	});
+
+	it('matches the first pattern in registry order', () => {
+		expect(CI_FAILURE_PATTERNS.length).toBeGreaterThan(0);
+	});
+});
+
+describe('_$gha_parseFailureLog', () => {
+	it('strips ANSI escapes and GH timestamp prefixes', () => {
+		const raw = '2026-06-29T10:00:00.123Z [31mError: boom[0m';
+		const { snippet } = _$gha_parseFailureLog(raw);
+		expect(snippet).toContain('Error: boom');
+		expect(snippet).not.toContain('');
+		expect(snippet).not.toContain('2026-06-29');
+	});
+
+	it('drops cargo/npm progress noise and group markers', () => {
+		const raw = [
+			'##[group]Run build',
+			'   Compiling foo v0.1.0',
+			'Downloading bar',
+			'real failure here',
+			'##[endgroup]',
+		].join('\n');
+		const { snippet } = _$gha_parseFailureLog(raw);
+		expect(snippet).toContain('real failure here');
+		expect(snippet).not.toContain('Compiling foo');
+		expect(snippet).not.toContain('##[group]');
+	});
+
+	it('windows around the last error marker', () => {
+		const lines: string[] = [];
+		for (let i = 0; i < 100; i++) lines.push(`line ${i}`);
+		lines.push('error: the real one');
+		lines.push('trailing 1');
+		lines.push('trailing 2');
+		const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+		expect(snippet).toContain('error: the real one');
+		expect(snippet).toContain('trailing 1');
+		expect(snippet).not.toContain('line 10');
+		expect(snippet).toContain('line 80');
+	});
+
+	it('falls back to the tail when no error marker present', () => {
+		const lines: string[] = [];
+		for (let i = 0; i < 50; i++) lines.push(`plain ${i}`);
+		const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+		expect(snippet).toContain('plain 49');
+		expect(snippet).not.toContain('plain 10');
+	});
+
+	it('extracts failing Nx targets', () => {
+		const raw = [
+			'Failed tasks:',
+			'  - devops:lint',
+			'  - api:build',
+			'',
+			'other text',
+		].join('\n');
+		const { nxTargets } = _$gha_parseFailureLog(raw);
+		expect(nxTargets).toBe('devops:lint api:build');
+	});
+
+	it('returns empty nxTargets when none present', () => {
+		expect(_$gha_parseFailureLog('nothing here').nxTargets).toBe('');
+	});
+});
+
+describe('_$gha_buildFailureIssueBody', () => {
+	it('includes title, metadata, log and history table', () => {
+		const body = _$gha_buildFailureIssueBody({
+			title: '[CI] CI Main / build — Failed',
+			workflowName: 'CI Main',
+			jobName: 'build',
+			failedStep: 'nx build',
+			runId: '123',
+			runUrl: 'https://example/run/123',
+			ref: 'refs/heads/dev',
+			eventName: 'push',
+			timestamp: '2026-06-29T10:00:00Z',
+			logSnippet: 'error: boom',
+		});
+		expect(body).toContain('[CI] CI Main / build — Failed');
+		expect(body).toContain('**Failed step:** nx build');
+		expect(body).toContain('**Consecutive failures:** 1');
+		expect(body).toContain('error: boom');
+		expect(body).toContain('[#123](https://example/run/123)');
+		expect(body).toContain('| 1 |');
+	});
+
+	it('embeds version marker and reason when provided', () => {
+		const body = _$gha_buildFailureIssueBody({
+			title: 't',
+			workflowName: 'w',
+			jobName: 'j',
+			failedStep: 's',
+			runId: '1',
+			runUrl: 'u',
+			ref: 'r',
+			eventName: 'push',
+			timestamp: 'ts',
+			logSnippet: 'l',
+			version: '1.2.3',
+			reason: 'token expired',
+			nxTargets: 'devops:lint',
+		});
+		expect(body).toContain('<!-- ci-tracker:version=1.2.3 -->');
+		expect(body).toContain('**Version:** 1.2.3');
+		expect(body).toContain('**Likely cause:** token expired');
+		expect(body).toContain('**Failed Nx targets:** `devops:lint`');
+	});
+
+	it('omits optional lines when absent', () => {
+		const body = _$gha_buildFailureIssueBody({
+			title: 't',
+			workflowName: 'w',
+			jobName: 'j',
+			failedStep: 's',
+			runId: '1',
+			runUrl: 'u',
+			ref: 'r',
+			eventName: 'push',
+			timestamp: 'ts',
+			logSnippet: 'l',
+		});
+		expect(body).not.toContain('**Version:**');
+		expect(body).not.toContain('**Likely cause:**');
+		expect(body).not.toContain('**Failed Nx targets:**');
+	});
+});
+
+describe('_$gha_buildFailureComment', () => {
+	it('renders a failure comment with run and log', () => {
+		const c = _$gha_buildFailureComment({
+			failedStep: 'nx test',
+			runId: '9',
+			runUrl: 'u9',
+			ref: 'refs/heads/dev',
+			eventName: 'push',
+			timestamp: 'ts',
+			logSnippet: 'boom',
+		});
+		expect(c).toContain('## Failure — ts');
+		expect(c).toContain('**Failed step:** nx test');
+		expect(c).toContain('boom');
+	});
+});
+
+describe('_$gha_buildResolveComment', () => {
+	it('notes plain resolution', () => {
+		const c = _$gha_buildResolveComment({
+			runId: '5',
+			runUrl: 'u5',
+			ref: 'r',
+			eventName: 'push',
+			timestamp: 'ts',
+		});
+		expect(c).toContain('## Resolved — ts');
+		expect(c).toContain('Auto-closing');
+	});
+
+	it('notes shipped version when provided', () => {
+		const c = _$gha_buildResolveComment({
+			runId: '5',
+			runUrl: 'u5',
+			ref: 'r',
+			eventName: 'push',
+			timestamp: 'ts',
+			version: '2.0.0',
+		});
+		expect(c).toContain('shipped v2.0.0');
+	});
+});
+
+describe('_$gha_incrementFailureHistory', () => {
+	const base = _$gha_buildFailureIssueBody({
+		title: '[CI] CI Main / build — Failed',
+		workflowName: 'CI Main',
+		jobName: 'build',
+		failedStep: 'nx build',
+		runId: '100',
+		runUrl: 'https://example/run/100',
+		ref: 'refs/heads/dev',
+		eventName: 'push',
+		timestamp: '2026-06-29T10:00:00Z',
+		logSnippet: 'error: boom',
+	});
+
+	it('bumps the consecutive failure count', () => {
+		const next = _$gha_incrementFailureHistory(base, {
+			runId: '101',
+			runUrl: 'https://example/run/101',
+			ref: 'refs/heads/dev',
+			eventName: 'push',
+			timestamp: '2026-06-29T11:00:00Z',
+		});
+		expect(next).toContain('**Consecutive failures:** 2');
+	});
+
+	it('appends a new history table row', () => {
+		const next = _$gha_incrementFailureHistory(base, {
+			runId: '101',
+			runUrl: 'https://example/run/101',
+			ref: 'refs/heads/dev',
+			eventName: 'push',
+			timestamp: '2026-06-29T11:00:00Z',
+		});
+		expect(next).toContain('| 2 | 2026-06-29T11:00:00Z |');
+		expect(next).toContain('[#101](https://example/run/101)');
+		expect(next).toContain('| 1 |');
+	});
+
+	it('is idempotent on count formatting across multiple increments', () => {
+		let body = base;
+		for (let i = 0; i < 3; i++) {
+			body = _$gha_incrementFailureHistory(body, {
+				runId: `${200 + i}`,
+				runUrl: `u${i}`,
+				ref: 'r',
+				eventName: 'push',
+				timestamp: `t${i}`,
+			});
+		}
+		expect(body).toContain('**Consecutive failures:** 4');
+		expect(
+			(body.match(/\*\*Consecutive failures:\*\*/g) || []).length,
+		).toBe(1);
+	});
+});

--- a/packages/npm/devops/src/lib/client/github/ci-failure.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.ts
@@ -1,0 +1,276 @@
+export interface CIFailurePattern {
+	test: RegExp;
+	reason: string;
+}
+
+export const CI_FAILURE_PATTERNS: CIFailurePattern[] = [
+	{
+		test: /Forgejo LFS auth failed|Authentication required|Authorization error|info\/lfs\/objects\/batch/i,
+		reason: '🔑 Forgejo LFS authentication failed — FORGEJO_TOKEN is likely invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret.',
+	},
+	{
+		test: /JavaScript heap out of memory|Killed signal 9|out of memory|oom-kill/i,
+		reason: '🧠 Job ran out of memory — the runner was OOM-killed. Reduce parallelism, raise the runner size, or cap Node/Nx memory.',
+	},
+	{
+		test: /The job running on runner .* has exceeded the maximum execution time|timed out after|cancel.*timeout/i,
+		reason: '⏱️ Job exceeded its timeout — a step hung or ran long. Inspect the slowest step and raise timeout-minutes or fix the hang.',
+	},
+];
+
+const NOISE_PREFIXES =
+	/^\s*(Checking|Compiling|Downloaded|Downloading|Finished|Fresh|Updating|Locking|Building|Installing|Adding|Removing) /;
+const GROUP_MARKER = /^##\[(group|endgroup)\]/;
+const ANSI = new RegExp(
+	String.fromCharCode(27) + '\\[[0-9;?]*[ -/]*[@-~]',
+	'g',
+);
+const GH_TIMESTAMP = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\s?/;
+const ERROR_MARKER =
+	/error|failed tasks|process completed with exit code|panic|✖|assertion/i;
+
+export interface ParsedFailureLog {
+	snippet: string;
+	nxTargets: string;
+}
+
+export interface FailureIssueMeta {
+	title: string;
+	workflowName: string;
+	jobName: string;
+	failedStep: string;
+	runId: string;
+	runUrl: string;
+	ref: string;
+	eventName: string;
+	timestamp: string;
+	logSnippet: string;
+	version?: string;
+	reason?: string;
+	nxTargets?: string;
+}
+
+export interface FailureEventMeta {
+	failedStep: string;
+	runId: string;
+	runUrl: string;
+	ref: string;
+	eventName: string;
+	timestamp: string;
+	logSnippet: string;
+	version?: string;
+	reason?: string;
+	nxTargets?: string;
+}
+
+export interface ResolveMeta {
+	runId: string;
+	runUrl: string;
+	ref: string;
+	eventName: string;
+	timestamp: string;
+	version?: string;
+}
+
+export interface HistoryEntry {
+	runId: string;
+	runUrl: string;
+	ref: string;
+	eventName: string;
+	timestamp: string;
+}
+
+function issueTitle(workflowName: string, jobName: string): string {
+	return `[CI] ${workflowName} / ${jobName} — Failed`;
+}
+
+function classifyFailure(log: string): string | null {
+	for (const pattern of CI_FAILURE_PATTERNS) {
+		if (pattern.test.test(log)) {
+			return pattern.reason;
+		}
+	}
+	return null;
+}
+
+function extractNxTargets(lines: string[]): string {
+	const idx = lines.findIndex((l) => /Failed tasks:/i.test(l));
+	if (idx < 0) {
+		return '';
+	}
+	const targets: string[] = [];
+	for (let i = idx + 1; i < Math.min(lines.length, idx + 21); i++) {
+		const match = lines[i].match(/^\s*-\s+(\S+:\S+)/);
+		if (match) {
+			targets.push(match[1]);
+		}
+	}
+	return targets.join(' ');
+}
+
+function parseFailureLog(rawLog: string): ParsedFailureLog {
+	if (!rawLog) {
+		return { snippet: '', nxTargets: '' };
+	}
+
+	const clean = rawLog
+		.split('\n')
+		.map((line) => line.replace(ANSI, '').replace(GH_TIMESTAMP, ''))
+		.filter(
+			(line) => !NOISE_PREFIXES.test(line) && !GROUP_MARKER.test(line),
+		);
+
+	let lastErr = -1;
+	for (let i = 0; i < clean.length; i++) {
+		if (ERROR_MARKER.test(clean[i])) {
+			lastErr = i;
+		}
+	}
+
+	let snippet: string;
+	if (lastErr >= 0) {
+		const start = Math.max(0, lastErr - 30);
+		const end = Math.min(clean.length, lastErr + 4);
+		snippet = clean.slice(start, end).join('\n');
+	} else {
+		snippet = clean.slice(Math.max(0, clean.length - 30)).join('\n');
+	}
+
+	return { snippet, nxTargets: extractNxTargets(clean) };
+}
+
+function buildIssueBody(meta: FailureIssueMeta): string {
+	const lines: string[] = [];
+	lines.push(`## ${meta.title}`);
+	if (meta.version) {
+		lines.push(`<!-- ci-tracker:version=${meta.version} -->`);
+	}
+	lines.push('');
+	lines.push(`**Workflow:** ${meta.workflowName}`);
+	lines.push(`**Job:** ${meta.jobName}`);
+	if (meta.version) {
+		lines.push(`**Version:** ${meta.version}`);
+	}
+	lines.push(`**Failed step:** ${meta.failedStep}`);
+	if (meta.nxTargets) {
+		lines.push(`**Failed Nx targets:** \`${meta.nxTargets}\``);
+	}
+	if (meta.reason) {
+		lines.push(`**Likely cause:** ${meta.reason}`);
+	}
+	lines.push(`**Status:** Failing since ${meta.timestamp}`);
+	lines.push(`**Consecutive failures:** 1`);
+	lines.push('');
+	lines.push('### Latest Failure');
+	lines.push('');
+	lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+	lines.push(`- **Trigger:** ${meta.eventName}`);
+	lines.push(`- **Ref:** ${meta.ref}`);
+	lines.push('');
+	lines.push('### Error Summary');
+	lines.push('');
+	lines.push('```');
+	lines.push(meta.logSnippet);
+	lines.push('```');
+	lines.push('');
+	lines.push('### Failure History');
+	lines.push('');
+	lines.push('| # | Date | Run | Ref | Trigger |');
+	lines.push('|---|------|-----|-----|---------|');
+	lines.push(
+		`| 1 | ${meta.timestamp} | [#${meta.runId}](${meta.runUrl}) | ${meta.ref} | ${meta.eventName} |`,
+	);
+	lines.push('');
+	lines.push('---');
+	lines.push('*Auto-generated by ci-failure-tracker*');
+	return lines.join('\n');
+}
+
+function buildComment(meta: FailureEventMeta): string {
+	const lines: string[] = [];
+	lines.push(`## Failure — ${meta.timestamp}`);
+	lines.push('');
+	lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+	lines.push(`- **Failed step:** ${meta.failedStep}`);
+	if (meta.nxTargets) {
+		lines.push(`- **Failed Nx targets:** \`${meta.nxTargets}\``);
+	}
+	if (meta.reason) {
+		lines.push(`- **Likely cause:** ${meta.reason}`);
+	}
+	if (meta.version) {
+		lines.push(`- **Version:** ${meta.version}`);
+	}
+	lines.push(`- **Ref:** ${meta.ref}`);
+	lines.push(`- **Trigger:** ${meta.eventName}`);
+	lines.push('');
+	lines.push('```');
+	lines.push(meta.logSnippet);
+	lines.push('```');
+	return lines.join('\n');
+}
+
+function buildResolveComment(meta: ResolveMeta): string {
+	const heading = meta.version
+		? `## Resolved — shipped v${meta.version} — ${meta.timestamp}`
+		: `## Resolved — ${meta.timestamp}`;
+	const lines: string[] = [];
+	lines.push(heading);
+	lines.push('');
+	lines.push(`- **Run:** [#${meta.runId}](${meta.runUrl})`);
+	lines.push(`- **Ref:** ${meta.ref}`);
+	lines.push(`- **Trigger:** ${meta.eventName}`);
+	lines.push('');
+	lines.push('Auto-closing this issue.');
+	return lines.join('\n');
+}
+
+function incrementHistory(oldBody: string, entry: HistoryEntry): string {
+	const countRe = /(\*\*Consecutive failures:\*\* )(\d+)/;
+	const match = oldBody.match(countRe);
+	const count = match ? parseInt(match[2], 10) + 1 : 1;
+
+	let body = match ? oldBody.replace(countRe, `$1${count}`) : oldBody;
+
+	const row = `| ${count} | ${entry.timestamp} | [#${entry.runId}](${entry.runUrl}) | ${entry.ref} | ${entry.eventName} |`;
+
+	const lines = body.split('\n');
+	let lastRow = -1;
+	for (let i = 0; i < lines.length; i++) {
+		if (/^\|\s*\d+\s*\|/.test(lines[i])) {
+			lastRow = i;
+		}
+	}
+	if (lastRow >= 0) {
+		lines.splice(lastRow + 1, 0, row);
+		body = lines.join('\n');
+	}
+
+	return body;
+}
+
+export const ci = {
+	failurePatterns: CI_FAILURE_PATTERNS,
+	issueTitle,
+	classifyFailure,
+	parseFailureLog,
+	buildIssueBody,
+	buildComment,
+	buildResolveComment,
+	incrementHistory,
+};
+
+/** @deprecated Use `ci.issueTitle`. */
+export const _$gha_failureIssueTitle = issueTitle;
+/** @deprecated Use `ci.classifyFailure`. */
+export const _$gha_classifyCIFailure = classifyFailure;
+/** @deprecated Use `ci.parseFailureLog`. */
+export const _$gha_parseFailureLog = parseFailureLog;
+/** @deprecated Use `ci.buildIssueBody`. */
+export const _$gha_buildFailureIssueBody = buildIssueBody;
+/** @deprecated Use `ci.buildComment`. */
+export const _$gha_buildFailureComment = buildComment;
+/** @deprecated Use `ci.buildResolveComment`. */
+export const _$gha_buildResolveComment = buildResolveComment;
+/** @deprecated Use `ci.incrementHistory`. */
+export const _$gha_incrementFailureHistory = incrementHistory;

--- a/packages/npm/devops/src/lib/client/github/index.ts
+++ b/packages/npm/devops/src/lib/client/github/index.ts
@@ -3,3 +3,4 @@ export * from './issues';
 export * from './pulls';
 export * from './docker';
 export * from './actions';
+export * from './ci-failure';


### PR DESCRIPTION
## Step 1 of the #13615 re-land (publish-before-depend)

#13606 added the CI-failure pure fns to \`@kbve/devops\` and rewired the failure-tracker to import them. That created a deadlock (broken tracker → ~20 workflows in \`startup_failure\` → CI couldn't publish the 0.0.20 that would fix it), so #13614 reverted **all of it** — including the devops source.

This PR restores **only the source + publish**, deliberately NOT the workflow:

- Restore \`ci-failure.ts\` (+spec), \`github/index.ts\` barrel, and the \`index.ts\` export of \`client/github/ci-failure\` (reverses #13614 for those files).
- Bump \`devops.mdx\` 0.0.19 → **0.0.20**; regen manifest (\`devops\` 0.0.19 → 0.0.20).
- **Failure-tracker workflow left on the reverted shell/gh impl** — it does NOT import \`@kbve/devops\` here.

## Why split
Publish 0.0.20 to npm **first**, with the \`_\$gha_*\` exports. Only once \`@kbve/devops@latest\` carries them does a follow-up PR re-wire the tracker to import them. This ordering makes re-creating the deadlock impossible.

## Verification
- Built \`devops.es.js\` contains \`_\$gha_failureIssueTitle\` + \`_\$gha_parseFailureLog\`.
- \`nx run devops:test\` → **236 passed**.
- \`version.toml\` untouched — CI post-publish owns it (gate: manifest 0.0.20 > version.toml 0.0.19 → publish).

## Follow-up (PR B, after 0.0.20 is on npm)
- Re-land the tracker rewrite (\`npm install @kbve/devops@latest\` + \`import\`).
- Add \`permissions: actions: read\` to tracker callers (secondary gap from #13615).

Refs #13615, #13606, #13614.