### PR TITLE
fix(ci): give buildkitd GC real headroom so cache stops wedging builds

### DIFF
--- a/apps/kube/github/runners/manifests/buildkitd.yaml
+++ b/apps/kube/github/runners/manifests/buildkitd.yaml
@@ -43,15 +43,16 @@ data:
           # Self-prune below the PVC size so the cache never wedges a build with
           # ENOSPC. Working set = astro .astro + cargo registry + sccache-local +
           # pnpm store + layer cache across every app.
-          gckeepstorage = "110GB"
+          gckeepstorage = "90GB"
           [[worker.oci.gcpolicy]]
-            keepBytes = "80GB"
-            keepDuration = "336h"
+            keepBytes = "60GB"
+            keepDuration = "168h"
           # Final tier has no keepDuration: a hard ceiling that evicts oldest
-          # regardless of age. Without it, a burst of builds inside the 336h
-          # window protects every entry and the cache fills to the PVC (ENOSPC).
+          # regardless of age. Set well below the 146GiB usable PVC so a burst
+          # of concurrent mode=max exports (each multi-GB) cannot outrun the
+          # async LRU GC and hit ENOSPC on containerdmeta.db before it reclaims.
           [[worker.oci.gcpolicy]]
-            keepBytes = "120GB"
+            keepBytes = "90GB"
 
         [worker.containerd]
           enabled = false
@@ -59,6 +60,8 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+    annotations:
+        reloader.stakater.com/auto: 'true'
     name: buildkitd
     namespace: arc-runners
     labels:


### PR DESCRIPTION
## Problem

buildkitd cache PVC keeps filling to 100% and wedging every CI build with:
```
no space left on device: write /var/lib/buildkit/runc-overlayfs/containerdmeta.db
```
Fixed only by manual `buildctl prune` (done live to unblock current builds).

## Root cause

- Usable PVC = **146.6 GiB**. Hard-ceiling gcpolicy `keepBytes 120GB` (~112 GiB) sat only **~35 GiB** below full.
- buildkit GC is **async LRU**, runs after builds. A burst of concurrent CI builds — each cargo `--release` layer + `mode=max` cache export is multi-GB — writes past that 35 GiB gap faster than GC reclaims → `ENOSPC` on `containerdmeta.db`.
- `keepDuration 336h` (14d) on tier0 protected nearly every entry, so tier0 evicted ~nothing and the cache permanently rode the 120GB ceiling.

## Fix

- Ceiling `120GB → 90GB` (~84 GiB) → **~62 GiB headroom**.
- tier0 `80GB/336h → 60GB/168h` so it actually evicts.
- `gckeepstorage 110GB → 90GB`.
- Add `reloader.stakater.com/auto: 'true'` — buildkitd reads the toml only at boot, so a ConfigMap change alone would not restart the pod.