### PR TITLE
fix(clickhouse): bump altinity operator 0.25.4 -> 0.27.1

### DIFF
--- a/apps/kube/clickhouse-crds/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse-crds/manifests/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
     - namespace.yaml
     # Remote CRDs from clickhouse-operator repository
-    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
-    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
-    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
-    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.27.1/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.27.1/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.27.1/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.27.1/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml

--- a/apps/kube/clickhouse-operator/application.yaml
+++ b/apps/kube/clickhouse-operator/application.yaml
@@ -16,7 +16,7 @@ spec:
     project: default
     sources:
         - repoURL: https://docs.altinity.com/clickhouse-operator/
-          targetRevision: 0.25.4
+          targetRevision: 0.27.1
           chart: altinity-clickhouse-operator
           helm:
               releaseName: clickhouse-operator

--- a/apps/kube/clickhouse-operator/manifests/values.yaml
+++ b/apps/kube/clickhouse-operator/manifests/values.yaml
@@ -4,7 +4,7 @@
 operator:
   image:
     repository: altinity/clickhouse-operator
-    tag: 0.25.4
+    tag: 0.27.1
     pullPolicy: IfNotPresent
 
   # Resource limits for the operator


### PR DESCRIPTION
## Why
ArgoCD `clickhouse` app stalled 7 days: sync op waiting on `ClickHouseKeeperInstallation/clickhouse-keeper` health. Root cause: operator 0.25.4 panics (nil pointer dereference in `ChkShard.WalkHostsAbortOnError`) mid-CHK reconcile, leaving status stuck `InProgress` and crashlooping (7 restarts). Upstream: Altinity/clickhouse-operator#1881 (dup of #1863), fixed in 0.26+.

## What
- `clickhouse-operator` Argo app helm chart `targetRevision` 0.25.4 -> 0.27.1
- operator image tag in `values.yaml` 0.25.4 -> 0.27.1
- `clickhouse-crds` kustomization CRD sources release-0.25.4 -> release-0.27.1 (all four URLs verified 200)

Server/keeper images stay on `25.8.4` LTS — panic is operator-side, no server change needed.

## Rollout note
Apps track `main`; takes effect after dev -> main merge. Watch keeper CR flip `InProgress` -> `Completed` after operator upgrade.