### PR TITLE
feat(unreal): player nameplates + locomotion anims for rentearth

### DIFF
--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckArpgPawn.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckArpgPawn.cpp
@@ -1,6 +1,11 @@
 #include "chuckArpgPawn.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "Components/TextRenderComponent.h"
 #include "Engine/SkeletalMesh.h"
+#include "Animation/AnimationAsset.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "Camera/PlayerCameraManager.h"
 #include "UObject/ConstructorHelpers.h"
 
 AchuckArpgPawn::AchuckArpgPawn()
@@ -18,6 +23,65 @@ AchuckArpgPawn::AchuckArpgPawn()
 	{
 		Body->SetSkeletalMesh(MannyFinder.Object);
 	}
+
+	NameText = CreateDefaultSubobject<UTextRenderComponent>(TEXT("NameText"));
+	NameText->SetupAttachment(Body);
+	NameText->SetRelativeLocation(FVector(0.0f, 0.0f, 220.0f));
+	NameText->SetUsingAbsoluteRotation(true);
+	NameText->SetHorizontalAlignment(EHTA_Center);
+	NameText->SetWorldSize(32.0f);
+	NameText->SetTextRenderColor(FColor::White);
+	NameText->SetVisibility(false);
+
+	static ConstructorHelpers::FObjectFinder<UAnimationAsset> IdleFinder(TEXT("/Game/Characters/Mannequins/Anims/Unarmed/MM_Idle.MM_Idle"));
+	static ConstructorHelpers::FObjectFinder<UAnimationAsset> WalkFinder(TEXT("/Game/Characters/Mannequins/Anims/Unarmed/Walk/MF_Unarmed_Walk_Fwd.MF_Unarmed_Walk_Fwd"));
+	static ConstructorHelpers::FObjectFinder<UAnimationAsset> JogFinder(TEXT("/Game/Characters/Mannequins/Anims/Unarmed/Jog/MF_Unarmed_Jog_Fwd.MF_Unarmed_Jog_Fwd"));
+	if (IdleFinder.Succeeded())
+	{
+		IdleAnim = IdleFinder.Object;
+	}
+	if (WalkFinder.Succeeded())
+	{
+		WalkAnim = WalkFinder.Object;
+	}
+	if (JogFinder.Succeeded())
+	{
+		JogAnim = JogFinder.Object;
+	}
+}
+
+void AchuckArpgPawn::UpdateLocomotion()
+{
+	if (!Body)
+	{
+		return;
+	}
+	const float Speed = (float)FVector2D(Velocity.X, Velocity.Y).Size();
+	UAnimationAsset* Anim = IdleAnim;
+	if (Speed >= 500.0f)
+	{
+		Anim = JogAnim ? JogAnim : WalkAnim;
+	}
+	else if (Speed >= 40.0f)
+	{
+		Anim = WalkAnim ? WalkAnim : JogAnim;
+	}
+	if (Anim && Anim != CurrentAnim)
+	{
+		CurrentAnim = Anim;
+		Body->PlayAnimation(Anim, true);
+	}
+}
+
+void AchuckArpgPawn::SetDisplayName(const FString& Name)
+{
+	if (!NameText || DisplayName == Name)
+	{
+		return;
+	}
+	DisplayName = Name;
+	NameText->SetText(FText::FromString(Name));
+	NameText->SetVisibility(!Name.IsEmpty());
 }
 
 void AchuckArpgPawn::SetVisualMesh(UStaticMesh* Mesh)
@@ -70,6 +134,8 @@ void AchuckArpgPawn::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
 
+	UpdateLocomotion();
+
 	if (!bHasServerPos)
 	{
 		return;
@@ -84,6 +150,24 @@ void AchuckArpgPawn::Tick(float DeltaSeconds)
 	RenderPos.Z = PredictedPos.Z;
 
 	SetActorLocation(RenderPos);
+
+	const FVector2D Vel2(Velocity.X, Velocity.Y);
+	if (Vel2.Size() >= 40.0f)
+	{
+		const float MoveYaw = FMath::RadiansToDegrees(FMath::Atan2(Vel2.Y, Vel2.X));
+		SetActorRotation(FRotator(0.0f, MoveYaw - 90.0f, 0.0f));
+	}
+
+	if (NameText && NameText->IsVisible())
+	{
+		if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+		{
+			if (PC->PlayerCameraManager)
+			{
+				NameText->SetWorldRotation(FRotator(0.0f, PC->PlayerCameraManager->GetCameraRotation().Yaw + 180.0f, 0.0f));
+			}
+		}
+	}
 }
 
 void AchuckArpgPawn::ApplyServerCorrection(const FVector& Position, const FVector& Velocity_)

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckArpgPawn.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckArpgPawn.h
@@ -7,6 +7,8 @@
 
 class USkeletalMeshComponent;
 class UStaticMesh;
+class UTextRenderComponent;
+class UAnimationAsset;
 
 struct FchuckPredIntent
 {
@@ -24,6 +26,7 @@ public:
 	AchuckArpgPawn();
 
 	void SetVisualMesh(UStaticMesh* Mesh);
+	void SetDisplayName(const FString& Name);
 
 	virtual void Tick(float DeltaSeconds) override;
 
@@ -36,10 +39,27 @@ public:
 
 private:
 	static void StepBody(FVector& Pos, FVector& Vel, const FVector2D& Dir, bool bInRun, float Dt);
+	void UpdateLocomotion();
 
 	UPROPERTY()
 	TObjectPtr<USkeletalMeshComponent> Body;
 
+	UPROPERTY()
+	TObjectPtr<UTextRenderComponent> NameText;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> IdleAnim;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> WalkAnim;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> JogAnim;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> CurrentAnim;
+
+	FString DisplayName;
 	FVector PredictedPos = FVector::ZeroVector;
 	FVector RenderPos = FVector::ZeroVector;
 	FVector Velocity = FVector::ZeroVector;

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Net/chuckSimgridController.cpp
@@ -143,6 +143,10 @@ void AchuckSimgridController::Tick(float DeltaSeconds)
 	{
 		CameraPawn->SetFollowTarget(ArpgPawn->GetActorLocation());
 	}
+	if (ArpgPawn && LocalSlot >= 0)
+	{
+		ArpgPawn->SetDisplayName(Manager->NameForSlot((uint16)LocalSlot));
+	}
 
 	FVector LocalPos;
 	const bool bHasLocal = Manager->IsLocalWorldPos(LocalPos);

--- a/packages/unreal/KBVENet/Source/KBVESimgrid/Private/SimgridProto.cpp
+++ b/packages/unreal/KBVENet/Source/KBVESimgrid/Private/SimgridProto.cpp
@@ -132,9 +132,11 @@ FServerDecoded FProtoCodec::DecodeServerEventRaw(const TArray<uint8>& Body)
 		const int32 PlayerCount = R.SeqLen();
 		for (int32 i = 0; i < PlayerCount; ++i)
 		{
-			R.U16();
-			R.String();
-			R.Bool();
+			FSimgridPlayerView P;
+			P.Slot = R.U16();
+			P.Username = R.String();
+			P.bConnected = R.Bool();
+			D.Snapshot.Players.Add(P);
 		}
 		const int32 EntityCount = R.SeqLen();
 		for (int32 i = 0; i < EntityCount; ++i)

--- a/packages/unreal/KBVENet/Source/KBVESimgrid/Public/SimgridProto.h
+++ b/packages/unreal/KBVENet/Source/KBVESimgrid/Public/SimgridProto.h
@@ -61,11 +61,19 @@ struct FSimgridWelcome
 	TArray<FSimgridKindEntry> Registry;
 };
 
+struct FSimgridPlayerView
+{
+	uint16 Slot = 0;
+	FString Username;
+	bool bConnected = false;
+};
+
 struct FSimgridSnapshot
 {
 	uint32 Tick = 0;
 	uint32 ServerTimeMs = 0;
 	uint32 InputAck = 0;
+	TArray<FSimgridPlayerView> Players;
 	TArray<FSimgridEntityDelta> Entities;
 	bool bKeyframe = false;
 };

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityActor.cpp
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityActor.cpp
@@ -1,8 +1,10 @@
 #include "SimgridEntityActor.h"
 #include "Components/StaticMeshComponent.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "Components/TextRenderComponent.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/SkeletalMesh.h"
+#include "Animation/AnimationAsset.h"
 
 ASimgridEntityActor::ASimgridEntityActor()
 {
@@ -15,9 +17,55 @@ ASimgridEntityActor::ASimgridEntityActor()
 
 	SkelComp = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("SkelComp"));
 	SkelComp->SetupAttachment(MeshComp);
+	SkelComp->SetRelativeRotation(FRotator(0.0f, -90.0f, 0.0f));
 	SkelComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 	SkelComp->SetMobility(EComponentMobility::Movable);
 	SkelComp->SetVisibility(false);
+
+	NameText = CreateDefaultSubobject<UTextRenderComponent>(TEXT("NameText"));
+	NameText->SetupAttachment(MeshComp);
+	NameText->SetRelativeLocation(FVector(0.0f, 0.0f, 220.0f));
+	NameText->SetUsingAbsoluteRotation(true);
+	NameText->SetHorizontalAlignment(EHTA_Center);
+	NameText->SetWorldSize(32.0f);
+	NameText->SetTextRenderColor(FColor::White);
+	NameText->SetVisibility(false);
+}
+
+void ASimgridEntityActor::SetDisplayName(const FString& Name)
+{
+	if (!NameText || DisplayName == Name)
+	{
+		return;
+	}
+	DisplayName = Name;
+	NameText->SetText(FText::FromString(Name));
+	NameText->SetVisibility(!Name.IsEmpty());
+}
+
+void ASimgridEntityActor::SetNameplateFacing(const FRotator& Rot)
+{
+	if (NameText && NameText->IsVisible())
+	{
+		NameText->SetWorldRotation(Rot);
+	}
+}
+
+void ASimgridEntityActor::SetLocomotionAnim(UAnimationAsset* Anim)
+{
+	if (!SkelComp || CurrentAnim == Anim)
+	{
+		return;
+	}
+	CurrentAnim = Anim;
+	if (Anim)
+	{
+		SkelComp->PlayAnimation(Anim, true);
+	}
+	else
+	{
+		SkelComp->Stop();
+	}
 }
 
 void ASimgridEntityActor::SetMesh(UStaticMesh* Mesh)

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityManager.cpp
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityManager.cpp
@@ -11,6 +11,9 @@
 #include "Engine/World.h"
 #include "Engine/Texture2D.h"
 #include "Engine/SkeletalMesh.h"
+#include "Animation/AnimationAsset.h"
+#include "GameFramework/PlayerController.h"
+#include "Camera/PlayerCameraManager.h"
 
 static constexpr uint8 KBVE_CAT_PLAYER = 0;
 static constexpr uint8 KBVE_CAT_ENV = 3;
@@ -56,8 +59,22 @@ void USimgridEntityManager::OnSnapshotReceived()
 {
 	if (Sub)
 	{
-		Interp.Push(Sub->GetLastSnapshot());
+		const FSimgridSnapshot& Snap = Sub->GetLastSnapshot();
+		for (const FSimgridPlayerView& P : Snap.Players)
+		{
+			if (P.bConnected && !P.Username.IsEmpty())
+			{
+				SlotNames.Add(P.Slot, P.Username);
+			}
+		}
+		Interp.Push(Snap);
 	}
+}
+
+FString USimgridEntityManager::NameForSlot(uint16 Slot) const
+{
+	const FString* Found = SlotNames.Find(Slot);
+	return Found ? *Found : FString();
 }
 
 FVector USimgridEntityManager::ResolveWorldPos(const FSimgridInterpState& S) const
@@ -122,6 +139,32 @@ USkeletalMesh* USimgridEntityManager::EnsureMannyMesh()
 	return MannyMesh;
 }
 
+void USimgridEntityManager::EnsureLocomotionAnims()
+{
+	if (bAnimsLoaded)
+	{
+		return;
+	}
+	bAnimsLoaded = true;
+	IdleAnim = LoadObject<UAnimationAsset>(nullptr, TEXT("/Game/Characters/Mannequins/Anims/Unarmed/MM_Idle.MM_Idle"));
+	WalkAnim = LoadObject<UAnimationAsset>(nullptr, TEXT("/Game/Characters/Mannequins/Anims/Unarmed/Walk/MF_Unarmed_Walk_Fwd.MF_Unarmed_Walk_Fwd"));
+	JogAnim = LoadObject<UAnimationAsset>(nullptr, TEXT("/Game/Characters/Mannequins/Anims/Unarmed/Jog/MF_Unarmed_Jog_Fwd.MF_Unarmed_Jog_Fwd"));
+}
+
+UAnimationAsset* USimgridEntityManager::PickLocomotionAnim(float Speed)
+{
+	EnsureLocomotionAnims();
+	if (Speed < 40.0f)
+	{
+		return IdleAnim;
+	}
+	if (Speed < 500.0f)
+	{
+		return WalkAnim ? WalkAnim : JogAnim;
+	}
+	return JogAnim ? JogAnim : WalkAnim;
+}
+
 void USimgridEntityManager::Tick(double NowMs)
 {
 	if (!Interp.HasData())
@@ -131,6 +174,18 @@ void USimgridEntityManager::Tick(double NowMs)
 
 	const double RenderTime = NowMs - FSimgridInterpolator::INTERP_DELAY_MS;
 	const TArray<FSimgridEntityDelta>& Keyframe = Interp.LatestEntities();
+
+	FRotator PlateRot = FRotator::ZeroRotator;
+	if (UWorld* World = WorldPtr.Get())
+	{
+		if (APlayerController* PC = World->GetFirstPlayerController())
+		{
+			if (PC->PlayerCameraManager)
+			{
+				PlateRot = FRotator(0.0f, PC->PlayerCameraManager->GetCameraRotation().Yaw + 180.0f, 0.0f);
+			}
+		}
+	}
 
 	bHasLocalPos = false;
 
@@ -215,6 +270,12 @@ void USimgridEntityManager::Tick(double NowMs)
 			}
 		}
 		Actor->ApplyState(WorldPos, Yaw, S.Kind);
+		if (bResolved && Cat == KBVE_CAT_PLAYER)
+		{
+			Actor->SetDisplayName(NameForSlot(S.Owner));
+			Actor->SetNameplateFacing(PlateRot);
+			Actor->SetLocomotionAnim(PickLocomotionAnim((float)S.VelXY.Size()));
+		}
 	}
 
 	TSet<uint32> Live;
@@ -295,6 +356,7 @@ void USimgridEntityManager::Clear()
 		}
 	}
 	SpriteHandleIds.Empty();
+	SlotNames.Empty();
 
 	bHasLocalPos = false;
 }

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityActor.h
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityActor.h
@@ -8,6 +8,8 @@ class UStaticMeshComponent;
 class UStaticMesh;
 class USkeletalMeshComponent;
 class USkeletalMesh;
+class UTextRenderComponent;
+class UAnimationAsset;
 
 UCLASS()
 class KBVESIMGRIDRENDER_API ASimgridEntityActor : public AActor
@@ -20,6 +22,9 @@ public:
 	void ApplyState(const FVector& WorldPos, float Yaw, uint16 Kind);
 	void SetMesh(UStaticMesh* Mesh);
 	void SetSkeletalMesh(USkeletalMesh* Mesh);
+	void SetDisplayName(const FString& Name);
+	void SetNameplateFacing(const FRotator& Rot);
+	void SetLocomotionAnim(UAnimationAsset* Anim);
 	uint16 GetKind() const { return CurrentKind; }
 
 private:
@@ -29,5 +34,12 @@ private:
 	UPROPERTY()
 	TObjectPtr<USkeletalMeshComponent> SkelComp;
 
+	UPROPERTY()
+	TObjectPtr<UTextRenderComponent> NameText;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> CurrentAnim;
+
+	FString DisplayName;
 	uint16 CurrentKind = 0;
 };

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityManager.h
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityManager.h
@@ -12,6 +12,7 @@ class UStaticMesh;
 class USkeletalMesh;
 class UKBVENpcSpriteRenderSubsystem;
 class UKBVENpcSpriteDef;
+class UAnimationAsset;
 
 UCLASS()
 class KBVESIMGRIDRENDER_API USimgridEntityManager : public UObject
@@ -32,6 +33,7 @@ public:
 
 	bool IsLocalWorldPos(FVector& OutPos) const;
 	bool WorldPosOf(uint32 Eid, FVector& OutPos) const;
+	FString NameForSlot(uint16 Slot) const;
 
 private:
 	FVector ResolveWorldPos(const FSimgridInterpState& S) const;
@@ -39,6 +41,8 @@ private:
 	UKBVENpcSpriteRenderSubsystem* GetSpriteRenderer() const;
 	void EnsureEnvDef();
 	USkeletalMesh* EnsureMannyMesh();
+	void EnsureLocomotionAnims();
+	UAnimationAsset* PickLocomotionAnim(float Speed);
 
 	FSimgridInterpolator Interp;
 
@@ -63,7 +67,19 @@ private:
 	UPROPERTY()
 	TObjectPtr<USkeletalMesh> MannyMesh;
 
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> IdleAnim;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> WalkAnim;
+
+	UPROPERTY()
+	TObjectPtr<UAnimationAsset> JogAnim;
+
+	bool bAnimsLoaded = false;
+
 	TMap<uint32, int32> SpriteHandleIds;
+	TMap<uint16, FString> SlotNames;
 
 	UPROPERTY()
 	TWeakObjectPtr<AActor> LocalPawn;

--- a/packages/unreal/KBVEWorld/Source/KBVEHexWorld/Private/HexEnvironmentSubsystem.cpp
+++ b/packages/unreal/KBVEWorld/Source/KBVEHexWorld/Private/HexEnvironmentSubsystem.cpp
@@ -1,7 +1,7 @@
 #include "HexEnvironmentSubsystem.h"
 #include "Engine/World.h"
 #include "Engine/DirectionalLight.h"
-#include "Engine/SkyAtmosphere.h"
+#include "Components/SkyAtmosphereComponent.h"
 #include "Engine/SkyLight.h"
 #include "Components/DirectionalLightComponent.h"
 #include "Components/SkyLightComponent.h"


### PR DESCRIPTION
## Summary
- Fix UE 5.8 baseline build break: `Engine/SkyAtmosphere.h` include moved to `Components/SkyAtmosphereComponent.h` (KBVEHexWorld)
- Decode the slot→username roster the simgrid server already sends in every Snapshot — the Unreal codec was reading the fields and discarding them (`SimgridProto.cpp`)
- Track slot→username in `SimgridEntityManager` and expose `NameForSlot`
- Camera-facing TextRender nameplates above remote player mannequins (`ASimgridEntityActor`) and the local pawn (`AchuckArpgPawn`), billboarded to the iso camera yaw
- Locomotion: mannequins no longer T-pose — idle/walk/jog anims (`MM_Idle`, `MF_Unarmed_Walk_Fwd`, `MF_Unarmed_Jog_Fwd`) picked from entity velocity; remote via server `VelXY`, local via predicted velocity
- Local pawn now faces its movement direction; skeletal meshes get the standard -90° mannequin yaw offset

## Testing
- `chuckEditor Mac Development` builds clean (`Result: Succeeded`)
- Runtime verify pending: needs live simgrid session with LFS assets pulled