### PR TITLE
perf(kbve): replace once_cell with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9099,7 +9099,6 @@ dependencies = [
  "lru 0.16.3",
  "metrics",
  "num-bigint",
- "once_cell",
  "pulldown-cmark 0.13.3",
  "r2d2",
  "rand_core 0.6.4",

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -58,7 +58,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 r2d2 = { version = "0.8.9", optional = true }
 regex = "1.10.2"
-once_cell = "1"
 ulid = "1.2.1"
 num-bigint = "0.4"
 lru = { version = "0.16", optional = true }

--- a/packages/rust/kbve/src/runes.rs
+++ b/packages/rust/kbve/src/runes.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use dashmap::DashMap;
 
-//	use once_cell::sync::Lazy;
-
 use std::sync::{Arc, OnceLock};
 
 use crate::spellbook_sanitize_fields;

--- a/packages/rust/kbve/src/utility.rs
+++ b/packages/rust/kbve/src/utility.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use tower_http::cors::CorsLayer;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 
 use dashmap::DashMap;
@@ -40,21 +40,21 @@ use crate::schema::globals;
 
 //*         [REGEX]
 
-pub static EMAIL_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
+pub static EMAIL_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
 
-pub static GITHUB_USERNAME_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
+pub static GITHUB_USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
 
-pub static INSTAGRAM_USERNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static INSTAGRAM_USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?:@|(?:www\.)?instagram\.com/)?(?:@)?([a-zA-Z0-9_](?:[a-zA-Z0-9_.]*[a-zA-Z0-9_])?)",
     )
     .unwrap()
 });
 
-pub static UNSPLASH_PHOTO_ID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
+pub static UNSPLASH_PHOTO_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
 
 //*         [VALIDATION]
 

--- a/packages/rust/kbve/src/utils/sanitization/regex_extractor.rs
+++ b/packages/rust/kbve/src/utils/sanitization/regex_extractor.rs
@@ -1,36 +1,36 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 
-pub static SANITIZATION_EMAIL_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
+pub static SANITIZATION_EMAIL_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$").unwrap());
 
-pub static SANITIZATION_GITHUB_USERNAME_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
+pub static SANITIZATION_GITHUB_USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"github\.com/([a-zA-Z0-9_-]+)").unwrap());
 
-pub static SANITIZATION_INSTAGRAM_USERNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static SANITIZATION_INSTAGRAM_USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?:@|(?:www\.)?instagram\.com/)?(?:@)?([a-zA-Z0-9_](?:[a-zA-Z0-9_.]*[a-zA-Z0-9_])?)",
     )
     .unwrap()
 });
 
-pub static SANITIZATION_UNSPLASH_PHOTO_ID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
+pub static SANITIZATION_UNSPLASH_PHOTO_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"photo-([a-zA-Z0-9]+-[a-zA-Z0-9]+)").unwrap());
 
-pub static SANITIZATION_DISCORD_SERVER_EMBED_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"discord\.com/widget\?id=(\d+)").unwrap());
+pub static SANITIZATION_DISCORD_SERVER_EMBED_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"discord\.com/widget\?id=(\d+)").unwrap());
 
-pub static SANITIZATION_ULID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$").unwrap());
+pub static SANITIZATION_ULID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$").unwrap());
 
-pub static SANITIZATION_USERNAME_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9]{8,255}$").unwrap());
+pub static SANITIZATION_USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{8,255}$").unwrap());
 
-pub static SANITIZATION_SERVICE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9]{3,32}$").unwrap());
+pub static SANITIZATION_SERVICE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{3,32}$").unwrap());
 
-pub static SANITIZATION_CAPTCHA_TOKEN_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$").unwrap());
+pub static SANITIZATION_CAPTCHA_TOKEN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$").unwrap());
 
 pub fn extract_email_from_regex(email: &str) -> Result<String, &'static str> {
     if SANITIZATION_EMAIL_REGEX.is_match(email) {


### PR DESCRIPTION
Swaps `once_cell::sync::Lazy` for `std::sync::LazyLock` in `regex_extractor.rs` and `utility.rs`, drops the `once_cell` dependency from the kbve crate, and removes a dead commented import in `runes.rs`.

`cargo check -p kbve` clean.

Closes #13602