### PR TITLE
fix(kube): scope vector alertmanager webhook :9002 to monitoring namespace

### DIFF
--- a/apps/kube/vector/manifests/vector-networkpolicy.yaml
+++ b/apps/kube/vector/manifests/vector-networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: vector-alertmanager-webhook
+    namespace: vector
+    labels:
+        app: supabase-vector
+        component: vector
+        kbve.com/category: observability
+        kbve.com/stack: core
+        kbve.com/managed-by: argocd
+spec:
+    podSelector:
+        matchLabels:
+            app: supabase-vector
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: monitoring
+          ports:
+              - port: 9002
+                protocol: TCP


### PR DESCRIPTION
Closes #13087

The `alertmanager_webhook` http_server source in the vector daemonset listens on `0.0.0.0:9002` with no auth, so any pod in the cluster could POST forged alerts that land in ClickHouse `alerts_distributed`.

Adds a NetworkPolicy in the `vector` namespace selecting the `supabase-vector` pods with a single ingress rule: TCP 9002 from the `monitoring` namespace (Alertmanager). All other pod ingress to vector is denied; kubelet health probes on :9001 come from the host and are unaffected, and no other in-cluster consumer of the vector service exists.