### PR TITLE
fix(unreal): KBVEMover strict-include build break

### DIFF
--- a/packages/unreal/KBVEMover/Source/KBVEMover/Private/KBVEMoverPawn.cpp
+++ b/packages/unreal/KBVEMover/Source/KBVEMover/Private/KBVEMoverPawn.cpp
@@ -9,6 +9,7 @@
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "InputMappingContext.h"
+#include "Engine/LocalPlayer.h"
 #include "Engine/World.h"
 #include "Net/UnrealNetwork.h"
 


### PR DESCRIPTION
Fixes the `ue_kbvemover` Linux/Mac verify failure on dev:

```
KBVEMoverPawn.cpp:65:5: error: incomplete type 'ULocalPlayer' named in nested name specifier
KBVEMoverPawn.cpp:65:32: error: 'UEnhancedInputLocalPlayerSubsystem' does not refer to a value
```

`ULocalPlayer::GetSubsystem<>` needs the complete type; the non-unity/no-PCH dep build exposes the missing `Engine/LocalPlayer.h` include. Same class of break as the KBVEWorld includes already fixed on dev.

Part of closing out #13497 (plugin build green).