### PR TITLE
feat(arpg): error/warning telemetry into metrics.kbve.com (web, discord, server)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8784,6 +8784,7 @@ dependencies = [
  "tonic-reflection",
  "tower 0.5.3",
  "tracing",
+ "tracing-subscriber",
  "twitch-irc",
  "ulid",
  "url",

--- a/apps/agones/arpg/server/Cargo.toml
+++ b/apps/agones/arpg/server/Cargo.toml
@@ -15,7 +15,7 @@ simgrid = { path = "../../../../packages/rust/simgrid" }
 bevy_items = { path = "../../../../packages/rust/bevy/bevy_items" }
 bevy_spells = { path = "../../../../packages/rust/bevy/bevy_spells" }
 bevy_mapdb = { path = "../../../../packages/rust/bevy/bevy_mapdb" }
-jedi = { path = "../../../../packages/rust/jedi", features = ["postgres", "valkey"] }
+jedi = { path = "../../../../packages/rust/jedi", features = ["postgres", "valkey", "observ"] }
 bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
 axum = { version = "0.7", default-features = false, features = ["ws", "json", "http1", "tokio"] }
 tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }

--- a/apps/agones/arpg/server/src/main.rs
+++ b/apps/agones/arpg/server/src/main.rs
@@ -15,14 +15,17 @@ use simgrid::{build_app, run_sim_loop};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,arpg_server=debug,simgrid=debug".into()),
-        )
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "info,arpg_server=debug,simgrid=debug".into());
+    let observ = jedi::observ::init(jedi::observ::ObservConfig::from_env());
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(observ)
         .init();
 
     if db::init_pg_cluster().await {

--- a/apps/agones/arpg/web/src/embed/discord.tsx
+++ b/apps/agones/arpg/web/src/embed/discord.tsx
@@ -10,6 +10,7 @@ import {
 	installDiscordExternal,
 	encourageHardwareAcceleration,
 } from '@kbve/laser';
+import { initObserv } from '@kbve/observ';
 
 const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 	| string
@@ -26,15 +27,24 @@ const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 //                                         on kbve.com, now a cross-origin host)
 //   /arpg-chat     -> chat.kbve.com     (realm chat WS, irc-gateway /gamechat)
 //   /arpg-supabase -> supabase.kbve.com (Supabase auth/REST, if the client runs)
+//   /arpg-metrics  -> metrics.kbve.com  (error telemetry ingest)
 const URL_MAPPINGS: { prefix: string; target: string }[] = [
 	{ prefix: '/arpg-game', target: 'arpg.kbve.com' },
 	{ prefix: '/arpg-assets', target: 'arpg.kbve.com' },
 	{ prefix: '/arpg-session', target: 'kbve.com' },
 	{ prefix: '/arpg-chat', target: 'chat.kbve.com' },
 	{ prefix: '/arpg-supabase', target: 'supabase.kbve.com' },
+	{ prefix: '/arpg-metrics', target: 'metrics.kbve.com' },
 ];
 const PROXY_WS = `wss://${location.host}`;
 const PROXY_HTTP = `https://${location.host}`;
+
+initObserv({
+	endpoint: `${PROXY_HTTP}/.proxy/arpg-metrics/api/v1/ingest/errors`,
+	project: 'arpg',
+	platform: 'web',
+	environment: import.meta.env.MODE,
+});
 const SESSION_ENDPOINT = '/.proxy/arpg-session/api/v1/discord/session';
 const GAME_WS = `${PROXY_WS}/.proxy/arpg-game/ws`;
 const CHAT_WS = `${PROXY_WS}/.proxy/arpg-chat/gamechat`;

--- a/apps/kube/agones/arpg/manifests/fleet.yaml
+++ b/apps/kube/agones/arpg/manifests/fleet.yaml
@@ -58,6 +58,12 @@ spec:
                                 value: '0'
                               - name: RUST_LOG
                                 value: 'info,arpg_server=debug,simgrid=info'
+                              - name: OBSERV_ENDPOINT
+                                value: 'http://metrics-service.kbve.svc.cluster.local:5500/api/v1/ingest/errors'
+                              - name: OBSERV_PROJECT
+                                value: 'arpg'
+                              - name: OBSERV_ENVIRONMENT
+                                value: 'production'
                               - name: SUPABASE_JWT_SECRET
                                 valueFrom:
                                     secretKeyRef:

--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -63,7 +63,7 @@ spec:
                       - name: METRICS_ERRORS_TABLE
                         value: errors_distributed
                       - name: METRICS_ALLOWED_ORIGINS
-                        value: https://kbve.com,https://www.kbve.com,https://jobs.kbve.com
+                        value: https://kbve.com,https://www.kbve.com,https://jobs.kbve.com,https://arpg.kbve.com,https://*.discordsays.com
                       - name: METRICS_RATE_LIMIT_PER_MIN
                         value: '120'
                       - name: CLICKHOUSE_ENDPOINT

--- a/apps/metrics/src/main.rs
+++ b/apps/metrics/src/main.rs
@@ -18,24 +18,71 @@ use crate::auth::StaffAuth;
 use crate::config::Config;
 use crate::state::{AppState, spawn_flusher};
 
+fn origin_allowed(allowed: &[String], origin: &str) -> bool {
+    allowed.iter().any(|entry| {
+        if let Some((scheme, host_pat)) = entry.split_once("://") {
+            if let Some(suffix) = host_pat.strip_prefix("*.") {
+                return origin
+                    .strip_prefix(scheme)
+                    .and_then(|rest| rest.strip_prefix("://"))
+                    .is_some_and(|host| {
+                        host.strip_suffix(suffix)
+                            .is_some_and(|lead| lead.ends_with('.') && lead.len() > 1)
+                    });
+            }
+        }
+        entry == origin
+    })
+}
+
 fn cors_layer(cfg: &Config) -> CorsLayer {
-    let origins: Vec<HeaderValue> = cfg
-        .allowed_origins
-        .iter()
-        .filter_map(|o| o.parse().ok())
-        .collect();
-    let allow = if origins.is_empty() {
+    let allow = if cfg.allowed_origins.is_empty() {
         tracing::warn!(
             "METRICS_ALLOWED_ORIGINS unset — CORS allows any origin; set it in production"
         );
         AllowOrigin::any()
     } else {
-        AllowOrigin::list(origins)
+        let allowed = cfg.allowed_origins.clone();
+        AllowOrigin::predicate(move |origin: &HeaderValue, _| {
+            origin.to_str().is_ok_and(|o| origin_allowed(&allowed, o))
+        })
     };
     CorsLayer::new()
         .allow_origin(allow)
         .allow_methods([Method::GET, Method::POST])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::origin_allowed;
+
+    #[test]
+    fn exact_match() {
+        let allowed = vec!["https://arpg.kbve.com".to_string()];
+        assert!(origin_allowed(&allowed, "https://arpg.kbve.com"));
+        assert!(!origin_allowed(&allowed, "https://evil.kbve.com"));
+    }
+
+    #[test]
+    fn wildcard_subdomain() {
+        let allowed = vec!["https://*.discordsays.com".to_string()];
+        assert!(origin_allowed(&allowed, "https://12345.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://evildiscordsays.com"));
+        assert!(!origin_allowed(&allowed, "http://12345.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://discordsays.com"));
+    }
+
+    #[test]
+    fn mixed_list() {
+        let allowed = vec![
+            "https://kbve.com".to_string(),
+            "https://*.discordsays.com".to_string(),
+        ];
+        assert!(origin_allowed(&allowed, "https://kbve.com"));
+        assert!(origin_allowed(&allowed, "https://x.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://jobs.kbve.com"));
+    }
 }
 
 #[tokio::main]

--- a/docs/superpowers/plans/2026-07-02-arpg-telemetry.md
+++ b/docs/superpowers/plans/2026-07-02-arpg-telemetry.md
@@ -1,0 +1,387 @@
+# ARPG Telemetry Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire arpg (web, Discord Activity, Rust game server) into metrics.kbve.com error/warning tracking.
+
+**Architecture:** Three independent pieces: (1) metrics service CORS gains wildcard-origin support + arpg origins in the deploy env; (2) Discord Activity entry adds a metrics proxy mapping + `initObserv`; (3) new `jedi::observ` feature provides a `tracing_subscriber` Layer (WARN+ERROR, per-callsite throttle), panic hook, and batched POST to the in-cluster ingest, wired into arpg-server.
+
+**Tech Stack:** Rust (axum/tower-http, tracing-subscriber, reqwest, tokio, dashmap), TypeScript (@kbve/observ, Vite/React), k8s manifests.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-02-arpg-telemetry-design.md`
+- NO code comments except constraints code can't show (user rule).
+- Build via `./kbve.sh -nx <project>:<target>` where an nx target exists; `cargo check -p <crate>` acceptable for validation (run from worktree root).
+- metrics crate/nx project is named `met`, NOT `metrics`.
+- jedi is a published crate — new deps MUST be optional behind feature `observ`.
+- Capture path must never panic; transport failures log at `debug` only.
+- Do not push dev/main directly; PR from `worktree-arpg-metrics` → `dev`.
+
+---
+
+### Task 1: metrics CORS wildcard origins
+
+**Files:**
+- Modify: `apps/metrics/src/main.rs` (cors_layer, ~line 21)
+- Test: same file, `#[cfg(test)]` module
+
+**Interfaces:**
+- Produces: `cors_layer(cfg)` behavior change only; new pure fn `origin_allowed(allowed: &[String], origin: &str) -> bool`.
+
+- [ ] **Step 1: Write failing tests** in `apps/metrics/src/main.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::origin_allowed;
+
+    #[test]
+    fn exact_match() {
+        let allowed = vec!["https://arpg.kbve.com".to_string()];
+        assert!(origin_allowed(&allowed, "https://arpg.kbve.com"));
+        assert!(!origin_allowed(&allowed, "https://evil.kbve.com"));
+    }
+
+    #[test]
+    fn wildcard_subdomain() {
+        let allowed = vec!["https://*.discordsays.com".to_string()];
+        assert!(origin_allowed(&allowed, "https://12345.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://evildiscordsays.com"));
+        assert!(!origin_allowed(&allowed, "http://12345.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://discordsays.com"));
+    }
+
+    #[test]
+    fn mixed_list() {
+        let allowed = vec![
+            "https://kbve.com".to_string(),
+            "https://*.discordsays.com".to_string(),
+        ];
+        assert!(origin_allowed(&allowed, "https://kbve.com"));
+        assert!(origin_allowed(&allowed, "https://x.discordsays.com"));
+        assert!(!origin_allowed(&allowed, "https://jobs.kbve.com"));
+    }
+}
+```
+
+- [ ] **Step 2: Run** `cargo test -p met origin_allowed` → FAIL (fn not defined)
+
+- [ ] **Step 3: Implement.** Replace the `AllowOrigin::list` branch in `cors_layer` with a predicate when any entry contains `*.`, else keep list. Add:
+
+```rust
+fn origin_allowed(allowed: &[String], origin: &str) -> bool {
+    allowed.iter().any(|entry| {
+        if let Some((scheme, host_pat)) = entry.split_once("://") {
+            if let Some(suffix) = host_pat.strip_prefix("*.") {
+                return origin
+                    .strip_prefix(scheme)
+                    .and_then(|rest| rest.strip_prefix("://"))
+                    .is_some_and(|host| {
+                        host.strip_suffix(suffix)
+                            .is_some_and(|lead| lead.ends_with('.') && lead.len() > 1)
+                    });
+            }
+        }
+        entry == origin
+    })
+}
+```
+
+In `cors_layer`, when `cfg.allowed_origins` is non-empty:
+
+```rust
+let allowed = cfg.allowed_origins.clone();
+AllowOrigin::predicate(move |origin, _| {
+    origin
+        .to_str()
+        .is_ok_and(|o| origin_allowed(&allowed, o))
+})
+```
+
+(Keep the empty-list `AllowOrigin::any()` + warn branch.)
+
+- [ ] **Step 4: Run** `cargo test -p met` → PASS; `cargo check -p met` clean
+- [ ] **Step 5: Commit** `feat(met): wildcard origin support in CORS allowlist`
+
+### Task 2: metrics deploy env — arpg origins
+
+**Files:**
+- Modify: `apps/kube/metrics/manifest/metrics-deployment.yaml:66`
+
+- [ ] **Step 1:** Change `METRICS_ALLOWED_ORIGINS` value to `https://kbve.com,https://www.kbve.com,https://jobs.kbve.com,https://arpg.kbve.com,https://*.discordsays.com`
+- [ ] **Step 2:** Commit `feat(kube): allow arpg + discordsays origins on metrics ingest`
+
+### Task 3: jedi observ — config + event model + throttle
+
+**Files:**
+- Create: `packages/rust/jedi/src/observ/mod.rs`
+- Modify: `packages/rust/jedi/Cargo.toml` (optional dep + feature), `packages/rust/jedi/src/lib.rs` (module export)
+
+**Interfaces:**
+- Produces: `ObservConfig { endpoint, project, environment, release }`, `ObservConfig::from_env() -> Option<ObservConfig>` (None when `OBSERV_ENDPOINT` unset/empty); `ObservEvent` serde struct matching met `ErrorEvent` wire shape; `Throttle::allow(callsite_id) -> Allow { allowed: bool, suppressed: u64 }` (10/min per callsite, monotonic clock).
+
+- [ ] **Step 1:** Cargo.toml: add `tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["registry", "std"] }`; feature `observ = ["dep:tracing-subscriber"]`.
+- [ ] **Step 2: Failing tests** in `observ/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn config_none_without_endpoint() {
+        assert!(ObservConfig::from_parts(None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn config_defaults() {
+        let c = ObservConfig::from_parts(
+            Some("http://m:5500/api/v1/ingest/errors".into()),
+            Some("arpg".into()),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(c.project, "arpg");
+        assert_eq!(c.environment, "production");
+    }
+
+    #[test]
+    fn throttle_allows_then_suppresses() {
+        let t = Throttle::new(3, Duration::from_secs(60));
+        for _ in 0..3 {
+            assert!(t.allow(1).allowed);
+        }
+        let v = t.allow(1);
+        assert!(!v.allowed);
+        assert!(t.allow(2).allowed);
+    }
+
+    #[test]
+    fn throttle_reports_suppressed_after_window() {
+        let t = Throttle::new(1, Duration::from_millis(1));
+        assert!(t.allow(1).allowed);
+        assert!(!t.allow(1).allowed);
+        std::thread::sleep(Duration::from_millis(5));
+        let v = t.allow(1);
+        assert!(v.allowed);
+        assert_eq!(v.suppressed, 1);
+    }
+}
+```
+
+- [ ] **Step 3:** `cargo test -p jedi --features observ observ` → FAIL
+- [ ] **Step 4: Implement:**
+
+```rust
+use dashmap::DashMap;
+use serde::Serialize;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub struct ObservConfig {
+    pub endpoint: String,
+    pub project: String,
+    pub environment: String,
+    pub release: Option<String>,
+}
+
+impl ObservConfig {
+    pub fn from_env() -> Option<Self> {
+        Self::from_parts(
+            std::env::var("OBSERV_ENDPOINT").ok(),
+            std::env::var("OBSERV_PROJECT").ok(),
+            std::env::var("OBSERV_ENVIRONMENT").ok(),
+            std::env::var("OBSERV_RELEASE").ok(),
+        )
+    }
+
+    pub fn from_parts(
+        endpoint: Option<String>,
+        project: Option<String>,
+        environment: Option<String>,
+        release: Option<String>,
+    ) -> Option<Self> {
+        let endpoint = endpoint.filter(|e| !e.is_empty())?;
+        Some(Self {
+            endpoint,
+            project: project.filter(|p| !p.is_empty()).unwrap_or_else(|| "unknown".into()),
+            environment: environment
+                .filter(|e| !e.is_empty())
+                .unwrap_or_else(|| "production".into()),
+            release,
+        })
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct ObservEvent {
+    pub project: String,
+    pub platform: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+    pub environment: String,
+    pub error_type: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub handled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Value>,
+}
+
+pub struct Allow {
+    pub allowed: bool,
+    pub suppressed: u64,
+}
+
+pub struct Throttle {
+    max: u64,
+    window: Duration,
+    slots: DashMap<u64, (Instant, u64, u64)>,
+}
+
+impl Throttle {
+    pub fn new(max: u64, window: Duration) -> Self {
+        Self { max, window, slots: DashMap::new() }
+    }
+
+    pub fn allow(&self, callsite: u64) -> Allow {
+        let now = Instant::now();
+        let mut entry = self.slots.entry(callsite).or_insert((now, 0, 0));
+        let (start, count, suppressed) = *entry;
+        if now.duration_since(start) >= self.window {
+            *entry = (now, 1, 0);
+            return Allow { allowed: true, suppressed };
+        }
+        if count < self.max {
+            entry.1 = count + 1;
+            Allow { allowed: true, suppressed: 0 }
+        } else {
+            entry.2 = suppressed + 1;
+            Allow { allowed: false, suppressed: 0 }
+        }
+    }
+}
+```
+
+lib.rs: `#[cfg(feature = "observ")] pub mod observ;`
+
+- [ ] **Step 5:** `cargo test -p jedi --features observ observ` → PASS
+- [ ] **Step 6: Commit** `feat(jedi): observ config, event model, per-callsite throttle`
+
+### Task 4: jedi observ — batcher + panic hook + tracing Layer
+
+**Files:**
+- Modify: `packages/rust/jedi/src/observ/mod.rs` (or split `layer.rs`/`sender.rs` submodules if mod.rs passes ~300 lines)
+
+**Interfaces:**
+- Consumes: Task 3 types.
+- Produces: `pub fn init(cfg: Option<ObservConfig>) -> Option<ObservLayer>` — spawns flusher (needs tokio runtime), installs chained panic hook, returns Layer for `.with()`. `ObservLayer` implements `tracing_subscriber::Layer<S>`.
+
+- [ ] **Step 1: Implement sender:** `Sender { tx: tokio::sync::mpsc::Sender<ObservEvent> }` bounded 1024, `try_send` drop-on-full. Flusher task: loop `tokio::select!` on `rx.recv()` + 5s tick; buffer flush at 32 or on tick when non-empty; POST `{"events":[...]}` JSON via shared `reqwest::Client` (5s timeout); on error `tracing::debug!`.
+- [ ] **Step 2: Implement layer:**
+
+```rust
+impl<S> tracing_subscriber::Layer<S> for ObservLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let meta = event.metadata();
+        if *meta.level() > tracing::Level::WARN || meta.target().starts_with("jedi::observ") {
+            return;
+        }
+        let verdict = self.throttle.allow(callsite_hash(meta.callsite()));
+        if !verdict.allowed {
+            return;
+        }
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.sender.enqueue(self.build_event(meta, visitor.render(), verdict.suppressed));
+    }
+}
+```
+
+`MessageVisitor` implements `tracing::field::Visit`, captures `message` + other fields into one string. `build_event`: `error_type` = `meta.target()`, `url` = `format!("{}::{}:{}", meta.target(), meta.file().unwrap_or("?"), meta.line().unwrap_or(0))`, `handled` = true, `extra` = `{"suppressed": n}` when n > 0, plus `{"level": "warn"|"error"}`. The `meta.target()` self-skip guard prevents the debug-log feedback loop.
+- [ ] **Step 3: Panic hook** in `init`: `std::panic::set_hook` chaining `prev`; capture `payload.downcast_ref::<&str>/<String>` + `location()`, `error_type = "panic"`, `handled: false`, enqueue via same sender.
+- [ ] **Step 4: Compile-level test** (flusher needs runtime):
+
+```rust
+#[tokio::test]
+async fn init_none_when_unconfigured() {
+    assert!(init(None).is_none());
+}
+
+#[tokio::test]
+async fn layer_composes_with_registry() {
+    use tracing_subscriber::prelude::*;
+    let cfg = ObservConfig::from_parts(Some("http://127.0.0.1:1/x".into()), Some("t".into()), None, None);
+    let layer = init(cfg).unwrap();
+    let _sub = tracing_subscriber::registry().with(layer);
+}
+```
+
+- [ ] **Step 5:** `cargo test -p jedi --features observ` → PASS; also `cargo check -p jedi` (feature OFF still clean)
+- [ ] **Step 6: Commit** `feat(jedi): observ tracing layer, batcher, panic hook`
+
+### Task 5: arpg-server wiring + fleet env
+
+**Files:**
+- Modify: `apps/agones/arpg/server/Cargo.toml:18` (add `"observ"` to jedi features)
+- Modify: `apps/agones/arpg/server/src/main.rs:21-26`
+- Modify: `apps/kube/agones/arpg/manifests/` fleet/gameserver yaml (locate container env block)
+
+**Interfaces:**
+- Consumes: `jedi::observ::{init, ObservConfig}`.
+
+- [ ] **Step 1:** Replace `tracing_subscriber::fmt()...init()` with registry composition:
+
+```rust
+use tracing_subscriber::prelude::*;
+
+let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| "info,arpg_server=debug,simgrid=debug".into());
+let observ = jedi::observ::init(jedi::observ::ObservConfig::from_env());
+tracing_subscriber::registry()
+    .with(filter)
+    .with(tracing_subscriber::fmt::layer())
+    .with(observ)
+    .init();
+```
+
+(`Option<Layer>` implements `Layer`, so `.with(observ)` is a no-op when unconfigured. EnvFilter as registry layer filters all layers — same behavior as today.)
+- [ ] **Step 2:** `cargo check -p arpg-server` clean.
+- [ ] **Step 3:** Fleet manifest env: add `OBSERV_ENDPOINT=http://metrics.kbve.svc.cluster.local:5500/api/v1/ingest/errors`, `OBSERV_PROJECT=arpg`, `OBSERV_ENVIRONMENT=production`. Verify metrics svc name first: `rtk proxy grep -n "name:" apps/kube/metrics/manifest/*service*`.
+- [ ] **Step 4: Commit** `feat(arpg): server error/warning telemetry via jedi observ`
+
+### Task 6: Discord Activity initObserv
+
+**Files:**
+- Modify: `apps/agones/arpg/web/src/embed/discord.tsx` (URL_MAPPINGS ~line 30, boot init near top-level constants)
+
+- [ ] **Step 1:** Add `{ prefix: '/arpg-metrics', target: 'metrics.kbve.com' }` to `URL_MAPPINGS`. Add import `import { initObserv } from '@kbve/observ';` and after `PROXY_HTTP` const:
+
+```ts
+initObserv({
+	endpoint: `${PROXY_HTTP}/.proxy/arpg-metrics/api/v1/ingest/errors`,
+	project: 'arpg',
+	platform: 'web',
+	environment: import.meta.env.MODE,
+});
+```
+
+- [ ] **Step 2:** Build web: `./kbve.sh -nx arpg-web:build` (confirm project name via `rtk proxy grep -n '"name"' apps/agones/arpg/web/project.json`). Expected: build succeeds.
+- [ ] **Step 3: Commit** `feat(arpg): discord activity error telemetry via metrics proxy mapping`
+
+### Task 7: Final validation + PR
+
+- [ ] **Step 1:** `cargo test -p jedi --features observ && cargo test -p met && cargo check -p arpg-server`
+- [ ] **Step 2:** `git log --oneline origin/dev..HEAD` sanity; push `worktree-arpg-metrics`; PR → `dev`. PR body: summary + manual step (Discord dev portal `/arpg-metrics → metrics.kbve.com` mapping) + note cryptothrone follow-up.
+
+## Self-review notes
+
+- Spec coverage: Part 1 → Tasks 1-2; Part 2 → Task 6; Part 3 → Tasks 3-5; testing section → Tasks 1,3,4,7. Portal manual step → Task 7 PR body.
+- Type consistency: `ObservConfig::from_parts` used by both tests and `from_env`; `init(Option<ObservConfig>) -> Option<ObservLayer>` consumed in Task 5.

--- a/docs/superpowers/specs/2026-07-02-arpg-telemetry-design.md
+++ b/docs/superpowers/specs/2026-07-02-arpg-telemetry-design.md
@@ -1,0 +1,82 @@
+# ARPG Telemetry Integration — Design
+
+Date: 2026-07-02
+Status: approved (brainstorm w/ Al)
+
+## Goal
+
+Wire apps/agones/arpg (web client, Discord Activity, Rust game server) into the
+in-house metrics platform (metrics.kbve.com → ClickHouse telemetry DB) for
+error/warning tracking. Web client already calls `initObserv` (PR #13631) but is
+dead on arrival: the deployed CORS allowlist has no arpg origin.
+
+## Part 1 — Metrics service: CORS wildcard + allowlist
+
+- `apps/metrics/src/main.rs` `cors_layer`: allowlist entries beginning `*.`
+  switch the layer to `AllowOrigin::predicate`; predicate suffix-matches
+  (`https://` scheme + `.domain` suffix) wildcard entries and exact-matches the
+  rest. Mixed exact/wildcard list supported. Empty list keeps existing
+  any-origin + warn behavior.
+- `apps/kube/metrics/manifest/metrics-deployment.yaml`:
+  `METRICS_ALLOWED_ORIGINS` gains `https://arpg.kbve.com` and
+  `https://*.discordsays.com`.
+
+## Part 2 — Discord Activity surface
+
+- `apps/agones/arpg/web/src/embed/discord.tsx`: add
+  `{ prefix: '/arpg-metrics', target: 'metrics.kbve.com' }` to `URL_MAPPINGS`;
+  call `initObserv` at boot with endpoint
+  `${PROXY_HTTP}/.proxy/arpg-metrics/api/v1/ingest/errors`, `project: 'arpg'`,
+  `platform: 'web'`, `environment` from build mode. The auto-captured
+  `location.href` (discordsays origin) distinguishes the Discord surface from
+  arpg.kbve.com in the dashboard.
+- Manual step (Al): add the `/arpg-metrics → metrics.kbve.com` URL mapping in
+  the Discord developer portal. Until then the Activity POSTs 404 through the
+  proxy; observ transport swallows failures, so inert not broken.
+
+## Part 3 — jedi `observ` feature: server-side bridge
+
+New module `jedi::observ` behind feature `observ` (deps: reqwest, tracing,
+tracing-subscriber registry traits, tokio, serde_json — reuse jedi's existing
+versions).
+
+- `ObservConfig::from_env()` — `OBSERV_ENDPOINT`, `OBSERV_PROJECT`,
+  `OBSERV_ENVIRONMENT`, `OBSERV_RELEASE`. Missing endpoint ⇒ bridge inert
+  (init returns no-op; local dev stays clean).
+- `ObservLayer: tracing_subscriber::Layer` — captures WARN + ERROR events.
+  Mapping: `error_type` = event target, `message` = formatted message+fields,
+  `platform` = `server`, `url` = `target::file:line` logical locator,
+  `handled` = true. Per-callsite throttle: max 10 events/min per callsite;
+  suppressed counter emitted in `extra.suppressed` on the next allowed event.
+- Panic hook — `std::panic::set_hook` chaining the previous hook; captures
+  payload + location as `handled: false`; best-effort synchronous-ish flush.
+- Batcher — bounded tokio mpsc, `try_send` (drop on full; never blocks the
+  game tick), background task flushes at 32 events or 5s. One POST per batch
+  keeps the per-IP 120/min ingest limit irrelevant.
+- Transport failures log at `debug` only — no ERROR→capture→fail feedback
+  loop. Capture path must never panic.
+
+### Wiring
+
+- `apps/agones/arpg/server`: enable jedi `observ`; register layer on the
+  existing `tracing_subscriber` registry in `main.rs`; install panic hook.
+- `apps/kube/agones/arpg` fleet manifest: `OBSERV_ENDPOINT`
+  (`http://metrics.kbve.svc.cluster.local:5500/api/v1/ingest/errors`),
+  `OBSERV_PROJECT=arpg`, `OBSERV_ENVIRONMENT=production`.
+- Cryptothrone server: NOT wired in this PR; follow-up one-liner.
+
+## Testing
+
+- jedi unit tests: throttle window, event→ErrorEvent mapping, config parsing,
+  inert-when-unset.
+- metrics unit test: wildcard predicate (accept subdomain, reject lookalike
+  `evildiscordsays.com`, exact entries still match).
+- `cargo check` (kbve.sh nx pipeline) for jedi, arpg-server, met.
+- Web: vite build of arpg web.
+- Live verify post-deploy via /dashboard/telemetry.
+
+## Out of scope
+
+- Perf/product lenses, source-map symbolication.
+- Cryptothrone server + Unreal (rentearth) clients.
+- Ingest token enforcement (`METRICS_INGEST_TOKEN` stays unset).

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -89,6 +89,13 @@ postgres = [
     "dep:uuid",
 ]
 valkey = ["dep:lru", "dep:fred"]
+observ = ["dep:tracing-subscriber"]
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+optional = true
+default-features = false
+features = ["registry", "std"]
 
 [dev-dependencies]
 serial_test = "3"

--- a/packages/rust/jedi/src/lib.rs
+++ b/packages/rust/jedi/src/lib.rs
@@ -11,6 +11,8 @@ mod tests {
 
 pub mod builder;
 pub mod entity;
+#[cfg(feature = "observ")]
+pub mod observ;
 pub mod jwks;
 pub mod jwt_cache;
 pub mod proto;

--- a/packages/rust/jedi/src/observ/mod.rs
+++ b/packages/rust/jedi/src/observ/mod.rs
@@ -1,0 +1,398 @@
+use dashmap::DashMap;
+use serde::Serialize;
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::Context;
+
+const BATCH_SIZE: usize = 32;
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const CHANNEL_CAPACITY: usize = 1024;
+const THROTTLE_MAX_PER_WINDOW: u64 = 10;
+const THROTTLE_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Debug)]
+pub struct ObservConfig {
+    pub endpoint: String,
+    pub project: String,
+    pub environment: String,
+    pub release: Option<String>,
+}
+
+impl ObservConfig {
+    pub fn from_env() -> Option<Self> {
+        Self::from_parts(
+            std::env::var("OBSERV_ENDPOINT").ok(),
+            std::env::var("OBSERV_PROJECT").ok(),
+            std::env::var("OBSERV_ENVIRONMENT").ok(),
+            std::env::var("OBSERV_RELEASE").ok(),
+        )
+    }
+
+    pub fn from_parts(
+        endpoint: Option<String>,
+        project: Option<String>,
+        environment: Option<String>,
+        release: Option<String>,
+    ) -> Option<Self> {
+        let endpoint = endpoint.filter(|e| !e.is_empty())?;
+        Some(Self {
+            endpoint,
+            project: project
+                .filter(|p| !p.is_empty())
+                .unwrap_or_else(|| "unknown".into()),
+            environment: environment
+                .filter(|e| !e.is_empty())
+                .unwrap_or_else(|| "production".into()),
+            release: release.filter(|r| !r.is_empty()),
+        })
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct ObservEvent {
+    pub project: String,
+    pub platform: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+    pub environment: String,
+    pub error_type: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub handled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Value>,
+}
+
+pub struct Allow {
+    pub allowed: bool,
+    pub suppressed: u64,
+}
+
+pub struct Throttle {
+    max: u64,
+    window: Duration,
+    slots: DashMap<u64, (Instant, u64, u64)>,
+}
+
+impl Throttle {
+    pub fn new(max: u64, window: Duration) -> Self {
+        Self {
+            max,
+            window,
+            slots: DashMap::new(),
+        }
+    }
+
+    pub fn allow(&self, callsite: u64) -> Allow {
+        let now = Instant::now();
+        let mut entry = self.slots.entry(callsite).or_insert((now, 0, 0));
+        let (start, count, suppressed) = *entry;
+        if count > 0 && now.duration_since(start) >= self.window {
+            *entry = (now, 1, 0);
+            return Allow {
+                allowed: true,
+                suppressed,
+            };
+        }
+        if count < self.max {
+            *entry = (start, count + 1, suppressed);
+            Allow {
+                allowed: true,
+                suppressed: 0,
+            }
+        } else {
+            *entry = (start, count, suppressed + 1);
+            Allow {
+                allowed: false,
+                suppressed: 0,
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Sender {
+    tx: tokio::sync::mpsc::Sender<ObservEvent>,
+}
+
+impl Sender {
+    fn enqueue(&self, event: ObservEvent) {
+        let _ = self.tx.try_send(event);
+    }
+}
+
+async fn run_flusher(endpoint: String, mut rx: tokio::sync::mpsc::Receiver<ObservEvent>) {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(target: "jedi::observ", error = %e, "reqwest client build failed");
+            return;
+        }
+    };
+    let mut buffer: Vec<ObservEvent> = Vec::with_capacity(BATCH_SIZE);
+    let mut tick = tokio::time::interval(FLUSH_INTERVAL);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            received = rx.recv() => {
+                match received {
+                    Some(event) => {
+                        buffer.push(event);
+                        if buffer.len() >= BATCH_SIZE {
+                            flush(&client, &endpoint, &mut buffer).await;
+                        }
+                    }
+                    None => {
+                        flush(&client, &endpoint, &mut buffer).await;
+                        return;
+                    }
+                }
+            }
+            _ = tick.tick() => {
+                flush(&client, &endpoint, &mut buffer).await;
+            }
+        }
+    }
+}
+
+async fn flush(client: &reqwest::Client, endpoint: &str, buffer: &mut Vec<ObservEvent>) {
+    if buffer.is_empty() {
+        return;
+    }
+    let events: Vec<ObservEvent> = buffer.drain(..).collect();
+    let body = serde_json::json!({ "events": events });
+    if let Err(e) = client.post(endpoint).json(&body).send().await {
+        tracing::debug!(target: "jedi::observ", error = %e, "telemetry flush failed");
+    }
+}
+
+pub struct ObservLayer {
+    cfg: ObservConfig,
+    sender: Sender,
+    throttle: Throttle,
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+    fields: Vec<(String, String)>,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+        } else {
+            self.fields.push((field.name().into(), format!("{value:?}")));
+        }
+    }
+}
+
+impl MessageVisitor {
+    fn render(self) -> String {
+        if self.fields.is_empty() {
+            return self.message;
+        }
+        let rest: Vec<String> = self
+            .fields
+            .into_iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        if self.message.is_empty() {
+            rest.join(" ")
+        } else {
+            format!("{} {}", self.message, rest.join(" "))
+        }
+    }
+}
+
+fn callsite_hash(id: tracing::callsite::Identifier) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    id.hash(&mut hasher);
+    hasher.finish()
+}
+
+impl ObservLayer {
+    fn build_event(
+        &self,
+        meta: &tracing::Metadata<'_>,
+        message: String,
+        suppressed: u64,
+        level: &tracing::Level,
+    ) -> ObservEvent {
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "level".into(),
+            serde_json::Value::String(level.as_str().to_lowercase()),
+        );
+        if suppressed > 0 {
+            extra.insert("suppressed".into(), serde_json::Value::from(suppressed));
+        }
+        ObservEvent {
+            project: self.cfg.project.clone(),
+            platform: "server".into(),
+            release: self.cfg.release.clone(),
+            environment: self.cfg.environment.clone(),
+            error_type: meta.target().to_string(),
+            message,
+            url: Some(format!(
+                "{}::{}:{}",
+                meta.target(),
+                meta.file().unwrap_or("?"),
+                meta.line().unwrap_or(0)
+            )),
+            handled: true,
+            extra: Some(serde_json::Value::Object(extra)),
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for ObservLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        if *meta.level() > tracing::Level::WARN || meta.target().starts_with("jedi::observ") {
+            return;
+        }
+        let verdict = self.throttle.allow(callsite_hash(meta.callsite()));
+        if !verdict.allowed {
+            return;
+        }
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.sender.enqueue(self.build_event(
+            meta,
+            visitor.render(),
+            verdict.suppressed,
+            meta.level(),
+        ));
+    }
+}
+
+pub fn init(cfg: Option<ObservConfig>) -> Option<ObservLayer> {
+    let cfg = cfg?;
+    let (tx, rx) = tokio::sync::mpsc::channel(CHANNEL_CAPACITY);
+    tokio::spawn(run_flusher(cfg.endpoint.clone(), rx));
+    let sender = Sender { tx };
+    install_panic_hook(cfg.clone(), sender.clone());
+    Some(ObservLayer {
+        cfg,
+        sender,
+        throttle: Throttle::new(THROTTLE_MAX_PER_WINDOW, THROTTLE_WINDOW),
+    })
+}
+
+fn install_panic_hook(cfg: ObservConfig, sender: Sender) {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let message = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "panic".into());
+        let url = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()));
+        sender.enqueue(ObservEvent {
+            project: cfg.project.clone(),
+            platform: "server".into(),
+            release: cfg.release.clone(),
+            environment: cfg.environment.clone(),
+            error_type: "panic".into(),
+            message,
+            url,
+            handled: false,
+            extra: None,
+        });
+        prev(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_none_without_endpoint() {
+        assert!(ObservConfig::from_parts(None, None, None, None).is_none());
+        assert!(ObservConfig::from_parts(Some(String::new()), None, None, None).is_none());
+    }
+
+    #[test]
+    fn config_defaults() {
+        let c = ObservConfig::from_parts(
+            Some("http://m:5500/api/v1/ingest/errors".into()),
+            Some("arpg".into()),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(c.project, "arpg");
+        assert_eq!(c.environment, "production");
+        assert!(c.release.is_none());
+    }
+
+    #[test]
+    fn throttle_allows_then_suppresses() {
+        let t = Throttle::new(3, Duration::from_secs(60));
+        for _ in 0..3 {
+            assert!(t.allow(1).allowed);
+        }
+        let v = t.allow(1);
+        assert!(!v.allowed);
+        assert!(t.allow(2).allowed);
+    }
+
+    #[test]
+    fn throttle_reports_suppressed_after_window() {
+        let t = Throttle::new(1, Duration::from_millis(1));
+        assert!(t.allow(1).allowed);
+        assert!(!t.allow(1).allowed);
+        std::thread::sleep(Duration::from_millis(5));
+        let v = t.allow(1);
+        assert!(v.allowed);
+        assert_eq!(v.suppressed, 1);
+    }
+
+    #[test]
+    fn event_serializes_wire_shape() {
+        let e = ObservEvent {
+            project: "arpg".into(),
+            platform: "server".into(),
+            release: None,
+            environment: "production".into(),
+            error_type: "arpg_server::game".into(),
+            message: "boom".into(),
+            url: Some("arpg_server::game::src/game.rs:42".into()),
+            handled: true,
+            extra: None,
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["project"], "arpg");
+        assert_eq!(v["platform"], "server");
+        assert!(v.get("release").is_none());
+    }
+
+    #[tokio::test]
+    async fn init_none_when_unconfigured() {
+        assert!(init(None).is_none());
+    }
+
+    #[tokio::test]
+    async fn layer_composes_with_registry() {
+        use tracing_subscriber::prelude::*;
+        let cfg = ObservConfig::from_parts(
+            Some("http://127.0.0.1:1/x".into()),
+            Some("t".into()),
+            None,
+            None,
+        );
+        let layer = init(cfg).unwrap();
+        let _sub = tracing_subscriber::registry().with(layer);
+    }
+}


### PR DESCRIPTION
Wires apps/agones/arpg into the in-house metrics platform across all three surfaces.

## Changes

- **met**: CORS allowlist now supports wildcard entries (`https://*.discordsays.com`) via `AllowOrigin::predicate`; exact entries unchanged. Unit-tested (suffix match, lookalike-domain rejection, scheme check).
- **kube/metrics**: `METRICS_ALLOWED_ORIGINS` += `https://arpg.kbve.com`, `https://*.discordsays.com` — makes the existing arpg web `initObserv` (PR #13631) actually deliver instead of being CORS-blocked.
- **jedi**: new `observ` feature — `tracing_subscriber` Layer capturing WARN+ERROR (per-callsite throttle 10/min, suppressed counter in `extra`), chained panic hook (`handled: false`), bounded-channel batcher (drop-on-full, flush at 32 events or 5s, one POST per batch). Inert when `OBSERV_ENDPOINT` unset; transport failures log at `debug` only (no feedback loop); capture path never blocks the game tick.
- **arpg-server**: registry-composed subscriber (`EnvFilter` + fmt + observ layer), jedi `observ` feature enabled. Fleet env: `OBSERV_ENDPOINT=http://metrics-service.kbve.svc.cluster.local:5500/api/v1/ingest/errors`, `OBSERV_PROJECT=arpg`, `OBSERV_ENVIRONMENT=production`.
- **arpg web (Discord Activity)**: `/arpg-metrics → metrics.kbve.com` URL mapping + `initObserv` against the proxied endpoint.

## Manual step (post-merge)

Add the `/arpg-metrics → metrics.kbve.com` URL mapping in the Discord developer portal. Until then Activity telemetry 404s through the proxy (observ swallows failures — inert, not broken).

## Follow-up

Cryptothrone server can adopt with a one-line jedi feature flip + fleet env.

## Validation

- `cargo test -p jedi --features observ` — 64 passed
- `cargo test -p met` — 17 passed
- `cargo check -p arpg-server` clean; `nx arpg-web:build` clean

Design spec + plan in `docs/superpowers/`.