### PR TITLE
fix(ci): add KBVENPCDB and KBVEYYJson to KBVENet plugin build deps

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -898,7 +898,7 @@
 			"key": "ue_kbvenet",
 			"plugin_name": "KBVENet",
 			"plugin_path": "packages/unreal/KBVENet",
-			"dependency_plugins": "packages/unreal/KBVESupabase packages/unreal/KBVEWorld packages/unreal/KBVEGameplay",
+			"dependency_plugins": "packages/unreal/KBVESupabase packages/unreal/KBVEWorld packages/unreal/KBVEGameplay packages/unreal/KBVEYYJson packages/unreal/KBVENPCDB",
 			"supported_platforms": [
 				"Win64",
 				"Linux",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvenet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvenet.mdx
@@ -12,7 +12,7 @@ key: ue_kbvenet
 pipeline: unreal
 plugin_name: KBVENet
 plugin_path: packages/unreal/KBVENet
-dependency_plugins: packages/unreal/KBVESupabase packages/unreal/KBVEWorld packages/unreal/KBVEGameplay
+dependency_plugins: packages/unreal/KBVESupabase packages/unreal/KBVEWorld packages/unreal/KBVEGameplay packages/unreal/KBVEYYJson packages/unreal/KBVENPCDB
 version: "0.1.0"
 source_path: packages/unreal/KBVENet
 version_toml: packages/unreal/KBVENet/version.toml

--- a/packages/unreal/KBVENet/KBVENet.uplugin
+++ b/packages/unreal/KBVENet/KBVENet.uplugin
@@ -41,6 +41,10 @@
 		{
 			"Name": "KBVEGameplay",
 			"Enabled": true
+		},
+		{
+			"Name": "KBVENPCDB",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
Fixes #13698

The plugin CI run in #13698 had two failures:

1. **KBVENet — `Could not find definition for module 'KBVENPCSprite'`**: `KBVESimgridRender.Build.cs` now depends on the `KBVENPCSprite` module, which lives in the `KBVENPCDB` plugin. The isolated plugin build only copies the plugins listed in `dependency_plugins`, so UBT could not resolve the module. This PR adds `KBVENPCDB` and its transitive dependency `KBVEYYJson` to the KBVENet dependency list (kbvenet.mdx source + regenerated `.github/ci-dispatch-manifest.json`) and declares the plugin reference in `KBVENet.uplugin`.

2. **KBVEMover — `incomplete type 'ULocalPlayer'`**: already fixed on dev by #13697 (the failing run predated that merge); no change needed here.