### PR TITLE
fix(unreal): missing TextLayout.h include breaks KBVEUI strict-include build

### DIFF
--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVELabel.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVELabel.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Framework/Text/TextLayout.h"
 
 class KBVEUI_API SKBVELabel : public SCompoundWidget
 {


### PR DESCRIPTION
## Summary
- `SKBVELabel.h` uses `ETextJustify` without including `Framework/Text/TextLayout.h`, which breaks the plugin verify build (`BuildPlugin -StrictIncludes`) on Mac — every subsequent `SLATE_ARGUMENT`/`SLATE_ATTRIBUTE` line cascades into `TSlateBaseNamedArgs` errors.
- Adds the missing include.

## Verification
Reproduced and verified locally with UE 5.8 using the exact CI command sequence: built dependency plugins KBVEROWS + KBVESupabase into the engine Marketplace, then `RunUAT BuildPlugin -Plugin=KBVEUI.uplugin -TargetPlatforms=Mac -Rocket -StrictIncludes`. Fails before the include, succeeds after.

Fixes #13566