### PR TITLE
fix(KBVEYYJson): verify packaged yyjson.h include resolution across platforms

### DIFF
--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
@@ -4,6 +4,7 @@
 #include "Components/InstancedStaticMeshComponent.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/Texture.h"
+#include "Engine/Texture2D.h"
 #include "Engine/World.h"
 #include "Materials/Material.h"
 #include "Materials/MaterialInstanceDynamic.h"

--- a/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
+++ b/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
@@ -12,7 +12,7 @@ public class KBVEYYJson : ModuleRules
 			"Core"
 		});
 
-		string ThirdPartyDir = Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yyjson");
+		string ThirdPartyDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yyjson"));
 
 		PublicIncludePaths.Add(ThirdPartyDir);
 
@@ -21,7 +21,6 @@ public class KBVEYYJson : ModuleRules
 			PrivateDefinitions.Add("YYJSON_EXPORTS=1");
 		}
 
-		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 	}
 }


### PR DESCRIPTION
Closes #13493.

## What
Normalize the `ThirdParty/yyjson` public include path in `KBVEYYJson.Build.cs` with `Path.GetFullPath`, and drop a stray comment.

## Why
Issue #13493 tracked `fatal error: 'yyjson.h' file not found` when consumers (KBVEItemDB) compiled against the packaged KBVEYYJson plugin under `BuildPlugin -StrictIncludes`. The root packaging bug — `ThirdParty/` missing from the packaged plugin — was fixed by adding `Config/FilterPlugin.ini` (79c04e49e, shipped with #13471). KBVEQuestDB's Mac verify (run 28496953459, PR #13634) already compiles green against packaged KBVEYYJson, including its `Generated/` proto-parse header that includes `KBVEYYJson.h`.

Remaining checklist from the issue:
- `yyjson.h` resolvable from public include path — already done (`PublicIncludePaths` + FilterPlugin.ini); this PR normalizes the path.
- `THIRD_PARTY_INCLUDES_START/END` — already wrapped in `KBVEYYJson.h` and `KBVEYYJsonThirdParty.cpp`.
- Verify all three platforms — this PR carries the `ci-full-plugins` label so `ci-unreal-plugins.yml` runs Mac + Linux + Win64 for KBVEYYJson and its reverse-deps (KBVEItemDB, KBVENPCDB, KBVEQuestDB, UEDevOps).

## Note
KBVESpellDB declares a KBVEYYJson plugin dependency but is absent from `.github/ci-dispatch-manifest.json`, so it gets no plugin verify. Needs a manifest regen (`sync:ci-manifest`) in a follow-up.