### PR TITLE
feat(astro-kbve): add AI Tooling, Game DevOps, BizOps service cards

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/service.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/service.mdx
@@ -19,15 +19,36 @@ import ScrollRing from '@kbve/astro/components/hero/observer/ScrollRing.astro';
 
 # Services
 
-KBVE delivers software, automation, and managed game-server hosting. Pick a lane:
+KBVE delivers software engineering, AI tooling, game development, and business operations. Pick a lane:
 
-<RingShipGrid tagline="Four lanes — fixed-price scoping, demos every two weeks, no lock-in.">
+<RingShipGrid tagline="Seven lanes — fixed-price scoping, demos every two weeks, no lock-in.">
     <RingShipCard
-        title="Custom Software"
+        title="Software Engineering"
         description="Bespoke web, mobile, and backend builds — TypeScript, Rust, Python, Astro, React, Bevy."
-        href="mailto:hello@kbve.com?subject=Custom%20software%20enquiry"
+        href="mailto:hello@kbve.com?subject=Software%20engineering%20enquiry"
         icon="rocket"
         accent="#06b6d4"
+    />
+    <RingShipCard
+        title="AI Tooling"
+        description="ML/LLM integration — agents, RAG pipelines, model evals, and AI-powered features in your product."
+        href="mailto:hello@kbve.com?subject=AI%20tooling%20enquiry"
+        icon="spark"
+        accent="#a855f7"
+    />
+    <RingShipCard
+        title="Game DevOps"
+        description="Game development with full CI/CD — Unreal, Unity, and Bevy build farms, packaging, and release automation."
+        href="mailto:hello@kbve.com?subject=Game%20DevOps%20enquiry"
+        icon="controller"
+        accent="#ec4899"
+    />
+    <RingShipCard
+        title="BizOps"
+        description="Business operations tooling — internal dashboards, workflow automation, and data-driven process design."
+        href="mailto:hello@kbve.com?subject=BizOps%20enquiry"
+        icon="compass"
+        accent="#eab308"
     />
     <RingShipCard
         title="Automation Pipelines"


### PR DESCRIPTION
Closes #2208.

Issue lists four core services: AI Tooling, Game DevOps, BizOps, Software Engineering. The service page only covered Software Engineering (as Custom Software), automation pipelines, game-server hosting, and OSS sponsorship.

Changes to `apps/kbve/astro-kbve/src/content/docs/service.mdx`:
- Add **AI Tooling** card (ML/LLM integration, agents, RAG, evals)
- Add **Game DevOps** card (Unreal/Unity/Bevy build farms, packaging, release automation)
- Add **BizOps** card (dashboards, workflow automation, process design)
- Rename Custom Software to Software Engineering to match issue wording
- Update intro line and grid tagline (four → seven lanes)

The old boilerplate `services.astro` referenced in the issue is already gone; the page is MDX with RingShipGrid, which covers the redesign ask.

Verified: `nx astro-kbve:build` passes and the built `service/index.html` contains the new cards.