### PR TITLE
chore(dev): vscode C++ intellisense off + FilterPlugin.ini for KBVEROWS/KBVESupabase/KBVEUI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,6 +60,10 @@
 		"plpgsql"
 	],
 	"godotTools.editorPath.godot4": "/Applications/Godot.app",
+	"C_Cpp.intelliSenseEngine": "disabled",
+	"C_Cpp.autocomplete": "disabled",
+	"C_Cpp.errorSquiggles": "disabled",
+	"C_Cpp.codeAnalysis.runAutomatically": false,
 	"rust-analyzer.initializeStopped": true,
 	"git.autoRepositoryDetection": false,
 	"git.ignoreLimitWarning": true

--- a/packages/unreal/KBVEROWS/Config/FilterPlugin.ini
+++ b/packages/unreal/KBVEROWS/Config/FilterPlugin.ini
@@ -1,0 +1,8 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll

--- a/packages/unreal/KBVESupabase/Config/FilterPlugin.ini
+++ b/packages/unreal/KBVESupabase/Config/FilterPlugin.ini
@@ -1,0 +1,8 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll

--- a/packages/unreal/KBVEUI/Config/FilterPlugin.ini
+++ b/packages/unreal/KBVEUI/Config/FilterPlugin.ini
@@ -1,0 +1,8 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll


### PR DESCRIPTION
## Summary
- Disables the VSCode C_Cpp extension's IntelliSense, autocomplete, error squiggles, and automatic code analysis in workspace settings (UE codebase overwhelms it; clangd/UBT own this).
- Adds the standard UE `Config/FilterPlugin.ini` to KBVEROWS, KBVESupabase, and KBVEUI, matching the nine other KBVE plugins that already ship it.