### PR TITLE
fix(KBVELibGit): link Win64 system libs for libgit2 WinHTTP/SSPI

### DIFF
--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
@@ -34,6 +34,16 @@ public class KBVELibGit : ModuleRules
 		{
 			LibDir = Path.Combine(ThirdPartyDir, "lib", "Win64");
 			PublicAdditionalLibraries.Add(Path.Combine(LibDir, "git2.lib"));
+			PublicSystemLibraries.AddRange(new string[]
+			{
+				"Ws2_32.lib",
+				"Secur32.lib",
+				"Winhttp.lib",
+				"Crypt32.lib",
+				"Rpcrt4.lib",
+				"Ole32.lib",
+				"Advapi32.lib"
+			});
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Mac)
 		{


### PR DESCRIPTION
Closes #13494.

## What
Add the Win64 system libraries libgit2 links against to `KBVELibGit.Build.cs` (`Ws2_32`, `Secur32`, `Winhttp`, `Crypt32`, `Rpcrt4`, `Ole32`, `Advapi32`), upstreamed from Chuck.

## Why
Without these the Win64 link fails: libgit2's WinHTTP HTTPS transport, SSPI/Negotiate auth, and certificate handling resolve against these system libs. Chuck's copy of the plugin already carried the fix; this makes the monorepo canonical.

## Notes
- `git2.lib` provenance checked: both trees ship libgit2 1.9.0 (Chuck's is larger only from embedded debug paths). Keeping the monorepo lib.
- `ThirdParty/build-libgit2.sh` already exists monorepo-side (Chuck pulls it in Phase B #13499).
