### PR TITLE
refactor(devops): v0.0.22 gha grouped namespace (retire _$gha_ prefix, additive)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -532,7 +532,7 @@
 		{
 			"key": "devops",
 			"package_name": "devops",
-			"version": "0.0.21",
+			"version": "0.0.22",
 			"version_toml": "packages/npm/devops/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/devops.mdx",
 			"version_target": "packages/npm/devops/package.json"

--- a/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
@@ -11,7 +11,7 @@ tags:
 key: devops
 pipeline: npm
 package_name: devops
-version: "0.0.21"
+version: "0.0.22"
 source_path: packages/npm/devops
 version_toml: packages/npm/devops/version.toml
 author: h0lybyte

--- a/docs/superpowers/plans/2026-07-02-devops-0022-gha-namespace.md
+++ b/docs/superpowers/plans/2026-07-02-devops-0022-gha-namespace.md
@@ -1,0 +1,633 @@
+# @kbve/devops v0.0.22 — `gha` grouped namespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat `_$gha_*` GitHub-helper exports with one clean `gha` grouped namespace, additively (all `_$gha_*` aliases and top-level `ci` keep working), and ship as v0.0.22.
+
+**Architecture:** Per module, rename each `_$gha_`-prefixed function to a clean name (updating in-file references), export a module group object, and keep every `_$gha_*` name as a `@deprecated` `export const` alias to the renamed function — the exact pattern `ci-failure.ts` already uses. A new `gha.ts` aggregates the group objects (plus `ci` and `withGitHubRetry`) into one `gha` object exported from the package root.
+
+**Tech Stack:** TypeScript, Vitest (globals, node env), Nx.
+
+## Global Constraints
+
+- Additive, non-breaking: NO function signature or behavior changes. Every `_$gha_*` export name must still resolve after the rename (as a `@deprecated` alias). Top-level `ci` export stays exactly as-is.
+- Member names strip the module prefix (e.g. `gha.issues.createComment`, not `createIssueComment`).
+- Files use TAB indentation (repo prettier `useTabs:true`) — match each file. `sanitization.ts` is 2-space but is untouched here.
+- No comments in code bodies. Terse `@deprecated` JSDoc on each alias only (one line), matching the existing `ci-failure.ts` aliases.
+- Test runner: `pnpm nx test devops` (focused: append `-- <spec path>`). Run from repo root of the worktree.
+- Do NOT hand-edit `version.toml` (CI marker). Version source is the MDX frontmatter.
+- Full suite must stay green after every task (baseline: run `pnpm nx test devops` once at start to capture the number).
+
+## Reference: the established pattern (already in `ci-failure.ts`)
+
+```ts
+function parseFailureLog(...) { ... }              // plain internal name
+export const ci = { parseFailureLog, ... };        // group object
+/** @deprecated Use `ci.parseFailureLog`. */
+export const _$gha_parseFailureLog = parseFailureLog;   // deprecated alias
+```
+
+Each module below follows this shape. "Rename" means: change the `export function _$gha_X` / `export async function _$gha_X` definition to a non-exported `function X` / `async function X`, update any in-file callers of `_$gha_X` to `X`, then re-expose `X` via the group object and the `_$gha_X` alias.
+
+---
+
+### Task 1: `issues.ts` → `gha.issues` group
+
+**Files:**
+
+- Modify: `packages/npm/devops/src/lib/client/github/issues.ts`
+- Test: `packages/npm/devops/src/lib/client/github/issues.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `GitHubClient`, `GitHubContext`, `_$gha_extractIssueContext` (imported from `./types` — leave that import name as-is for this task; Task 4 renames it and keeps the alias, so it stays valid).
+- Produces: `export const issues = { createComment, addReaction, removeLabel, addLabel, verifyMatrixLabel, addAssignees, removeAssignees, closeIssue, reopenIssue, lockIssue, unlockIssue }`, plus all 11 `_$gha_*` names as `@deprecated` aliases.
+
+Rename map (definition + in-file references):
+| current export | new name |
+|---|---|
+| `_$gha_createIssueComment` | `createComment` |
+| `_$gha_addReaction` | `addReaction` |
+| `_$gha_removeLabel` | `removeLabel` |
+| `_$gha_addLabel` | `addLabel` |
+| `_$gha_verifyMatrixLabel` | `verifyMatrixLabel` |
+| `_$gha_addAssignees` | `addAssignees` |
+| `_$gha_removeAssignees` | `removeAssignees` |
+| `_$gha_closeIssue` | `closeIssue` |
+| `_$gha_reopenIssue` | `reopenIssue` |
+| `_$gha_lockIssue` | `lockIssue` |
+| `_$gha_unlockIssue` | `unlockIssue` |
+
+Note: `verifyMatrixLabel` calls `addLabel` and `removeLabel` internally — update those two call sites to the new names.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `issues.spec.ts` (add the imports it needs to the existing import block: `issues` and the `_$gha_*` names referenced):
+
+```ts
+describe('gha.issues group (v0.0.22)', () => {
+	it('group members are the same references as their _$gha_ aliases', () => {
+		expect(issues.createComment).toBe(_$gha_createIssueComment);
+		expect(issues.verifyMatrixLabel).toBe(_$gha_verifyMatrixLabel);
+		expect(issues.unlockIssue).toBe(_$gha_unlockIssue);
+	});
+	it('exposes all 11 members as functions', () => {
+		const names = [
+			'createComment',
+			'addReaction',
+			'removeLabel',
+			'addLabel',
+			'verifyMatrixLabel',
+			'addAssignees',
+			'removeAssignees',
+			'closeIssue',
+			'reopenIssue',
+			'lockIssue',
+			'unlockIssue',
+		];
+		for (const n of names)
+			expect(typeof (issues as Record<string, unknown>)[n]).toBe(
+				'function',
+			);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx test devops -- src/lib/client/github/issues.spec.ts`
+Expected: FAIL — `issues` is not exported.
+
+- [ ] **Step 3: Rename + add group + aliases**
+
+For each row in the rename map: change `export async function _$gha_X(` to `async function newName(` (drop `export`), and update in-file references. Then at the end of the file add the group object and the alias block:
+
+```ts
+export const issues = {
+	createComment,
+	addReaction,
+	removeLabel,
+	addLabel,
+	verifyMatrixLabel,
+	addAssignees,
+	removeAssignees,
+	closeIssue,
+	reopenIssue,
+	lockIssue,
+	unlockIssue,
+};
+
+/** @deprecated Use `gha.issues.createComment`. */
+export const _$gha_createIssueComment = createComment;
+/** @deprecated Use `gha.issues.addReaction`. */
+export const _$gha_addReaction = addReaction;
+/** @deprecated Use `gha.issues.removeLabel`. */
+export const _$gha_removeLabel = removeLabel;
+/** @deprecated Use `gha.issues.addLabel`. */
+export const _$gha_addLabel = addLabel;
+/** @deprecated Use `gha.issues.verifyMatrixLabel`. */
+export const _$gha_verifyMatrixLabel = verifyMatrixLabel;
+/** @deprecated Use `gha.issues.addAssignees`. */
+export const _$gha_addAssignees = addAssignees;
+/** @deprecated Use `gha.issues.removeAssignees`. */
+export const _$gha_removeAssignees = removeAssignees;
+/** @deprecated Use `gha.issues.closeIssue`. */
+export const _$gha_closeIssue = closeIssue;
+/** @deprecated Use `gha.issues.reopenIssue`. */
+export const _$gha_reopenIssue = reopenIssue;
+/** @deprecated Use `gha.issues.lockIssue`. */
+export const _$gha_lockIssue = lockIssue;
+/** @deprecated Use `gha.issues.unlockIssue`. */
+export const _$gha_unlockIssue = unlockIssue;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx test devops -- src/lib/client/github/issues.spec.ts`
+Expected: PASS. Existing issues tests still green (they reference `_$gha_*` names, which still resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/devops/src/lib/client/github/issues.ts packages/npm/devops/src/lib/client/github/issues.spec.ts
+git commit -m "refactor(devops): issues.ts → gha.issues group, keep _\$gha_ aliases"
+```
+
+---
+
+### Task 2: `pulls.ts` → `gha.pulls` group
+
+**Files:**
+
+- Modify: `packages/npm/devops/src/lib/client/github/pulls.ts`
+- Test: `packages/npm/devops/src/lib/client/github/pulls.spec.ts`
+
+**Interfaces:**
+
+- Produces: `export const pulls = { formatCommits, categorizeApiCommits, generatePRTitle, formatDevBody, getPullRequestNumber, updatePullRequestBody, fetchAndCleanCommits, processAndUpdatePR, createOrUpdatePR }` plus all 9 `_$gha_*` aliases.
+
+Rename map:
+| current export | new name |
+|---|---|
+| `_$gha_formatCommits` | `formatCommits` |
+| `_$gha_categorizeApiCommits` | `categorizeApiCommits` |
+| `_$gha_generatePRTitle` | `generatePRTitle` |
+| `_$gha_formatDevBody` | `formatDevBody` |
+| `_$gha_getPullRequestNumber` | `getPullRequestNumber` |
+| `_$gha_updatePullRequestBody` | `updatePullRequestBody` |
+| `_$gha_fetchAndCleanCommits` | `fetchAndCleanCommits` |
+| `_$gha_processAndUpdatePR` | `processAndUpdatePR` |
+| `_$gha_createOrUpdatePR` | `createOrUpdatePR` |
+
+Note: several of these call each other in-file (e.g. `processAndUpdatePR`/`createOrUpdatePR` call the formatting + fetch helpers). After renaming the definitions, update ALL in-file references from `_$gha_X` to `X`. Grep the file for `_$gha_` after editing — the only remaining occurrences should be the `export const _$gha_X = X;` alias lines at the bottom.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pulls.spec.ts` (extend the import block with `pulls` and the `_$gha_*` names referenced):
+
+```ts
+describe('gha.pulls group (v0.0.22)', () => {
+	it('group members match their _$gha_ aliases', () => {
+		expect(pulls.formatCommits).toBe(_$gha_formatCommits);
+		expect(pulls.createOrUpdatePR).toBe(_$gha_createOrUpdatePR);
+		expect(pulls.generatePRTitle).toBe(_$gha_generatePRTitle);
+	});
+	it('exposes all 9 members as functions', () => {
+		const names = [
+			'formatCommits',
+			'categorizeApiCommits',
+			'generatePRTitle',
+			'formatDevBody',
+			'getPullRequestNumber',
+			'updatePullRequestBody',
+			'fetchAndCleanCommits',
+			'processAndUpdatePR',
+			'createOrUpdatePR',
+		];
+		for (const n of names)
+			expect(typeof (pulls as Record<string, unknown>)[n]).toBe(
+				'function',
+			);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx test devops -- src/lib/client/github/pulls.spec.ts`
+Expected: FAIL — `pulls` not exported.
+
+- [ ] **Step 3: Rename + add group + aliases**
+
+Rename each definition per the map, update all in-file cross-references, then append:
+
+```ts
+export const pulls = {
+	formatCommits,
+	categorizeApiCommits,
+	generatePRTitle,
+	formatDevBody,
+	getPullRequestNumber,
+	updatePullRequestBody,
+	fetchAndCleanCommits,
+	processAndUpdatePR,
+	createOrUpdatePR,
+};
+
+/** @deprecated Use `gha.pulls.formatCommits`. */
+export const _$gha_formatCommits = formatCommits;
+/** @deprecated Use `gha.pulls.categorizeApiCommits`. */
+export const _$gha_categorizeApiCommits = categorizeApiCommits;
+/** @deprecated Use `gha.pulls.generatePRTitle`. */
+export const _$gha_generatePRTitle = generatePRTitle;
+/** @deprecated Use `gha.pulls.formatDevBody`. */
+export const _$gha_formatDevBody = formatDevBody;
+/** @deprecated Use `gha.pulls.getPullRequestNumber`. */
+export const _$gha_getPullRequestNumber = getPullRequestNumber;
+/** @deprecated Use `gha.pulls.updatePullRequestBody`. */
+export const _$gha_updatePullRequestBody = updatePullRequestBody;
+/** @deprecated Use `gha.pulls.fetchAndCleanCommits`. */
+export const _$gha_fetchAndCleanCommits = fetchAndCleanCommits;
+/** @deprecated Use `gha.pulls.processAndUpdatePR`. */
+export const _$gha_processAndUpdatePR = processAndUpdatePR;
+/** @deprecated Use `gha.pulls.createOrUpdatePR`. */
+export const _$gha_createOrUpdatePR = createOrUpdatePR;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx test devops -- src/lib/client/github/pulls.spec.ts`
+Expected: PASS. Existing pulls tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/devops/src/lib/client/github/pulls.ts packages/npm/devops/src/lib/client/github/pulls.spec.ts
+git commit -m "refactor(devops): pulls.ts → gha.pulls group, keep _\$gha_ aliases"
+```
+
+---
+
+### Task 3: `actions.ts` → `gha.actions` group
+
+**Files:**
+
+- Modify: `packages/npm/devops/src/lib/client/github/actions.ts`
+- Test: `packages/npm/devops/src/lib/client/github/actions.spec.ts`
+
+**Interfaces:**
+
+- Produces: `export const actions = { findActionInTitle, kbveActionProcess, findActionInTitleSafe }` plus the 2 `_$gha_*` aliases. `findActionInTitleSafe` already exists as a plain export (v0.0.21) — leave it exported and include it in the group.
+
+Rename map:
+| current export | new name |
+|---|---|
+| `_$gha_findActionInTitle` | `findActionInTitle` |
+| `_$gha_kbve_ActionProcess` | `kbveActionProcess` |
+
+Note: `_$gha_kbve_ActionProcess` calls `_$gha_findActionInTitle` in-file — update that call to `findActionInTitle`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `actions.spec.ts` (extend the top import block with `actions`, `_$gha_findActionInTitle`, `_$gha_kbve_ActionProcess`):
+
+```ts
+describe('gha.actions group (v0.0.22)', () => {
+	it('group members match their _$gha_ aliases', () => {
+		expect(actions.findActionInTitle).toBe(_$gha_findActionInTitle);
+		expect(actions.kbveActionProcess).toBe(_$gha_kbve_ActionProcess);
+	});
+	it('includes findActionInTitleSafe', () => {
+		expect(typeof actions.findActionInTitleSafe).toBe('function');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx test devops -- src/lib/client/github/actions.spec.ts`
+Expected: FAIL — `actions` not exported.
+
+- [ ] **Step 3: Rename + add group + aliases**
+
+Rename the 2 definitions (drop `export`, update the in-file call), keep `findActionInTitleSafe` as-is, then append:
+
+```ts
+export const actions = {
+	findActionInTitle,
+	kbveActionProcess,
+	findActionInTitleSafe,
+};
+
+/** @deprecated Use `gha.actions.findActionInTitle`. */
+export const _$gha_findActionInTitle = findActionInTitle;
+/** @deprecated Use `gha.actions.kbveActionProcess`. */
+export const _$gha_kbve_ActionProcess = kbveActionProcess;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx test devops -- src/lib/client/github/actions.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/devops/src/lib/client/github/actions.ts packages/npm/devops/src/lib/client/github/actions.spec.ts
+git commit -m "refactor(devops): actions.ts → gha.actions group, keep _\$gha_ aliases"
+```
+
+---
+
+### Task 4: `docker.ts` → `gha.docker` + `types.ts` → `gha.context`
+
+**Files:**
+
+- Modify: `packages/npm/devops/src/lib/client/github/docker.ts`
+- Modify: `packages/npm/devops/src/lib/client/github/types.ts`
+- Test (create): `packages/npm/devops/src/lib/client/github/docker.spec.ts` (if one exists, append instead)
+- Test (create): `packages/npm/devops/src/lib/client/github/types.spec.ts`
+
+**Interfaces:**
+
+- Produces: `export const docker = { runContainer, stopContainer }` (+ 2 aliases); `export const context = { extractIssue, extractRepo }` (+ 2 aliases).
+- Consumes note: `issues.ts` imports `_$gha_extractIssueContext` from `./types`; that alias is preserved, so no cross-file break.
+
+docker.ts rename map:
+| current export | new name |
+|---|---|
+| `_$gha_runDockerContainer` | `runContainer` |
+| `_$gha_stopDockerContainer` | `stopContainer` |
+
+types.ts rename map:
+| current export | new name |
+|---|---|
+| `_$gha_extractIssueContext` | `extractIssue` |
+| `_$gha_extractRepoContext` | `extractRepo` |
+
+Note: `types.ts` also holds interfaces/types — leave all of those exactly as-is. Only the two functions are touched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `docker.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+	docker,
+	_$gha_runDockerContainer,
+	_$gha_stopDockerContainer,
+} from './docker';
+
+describe('gha.docker group (v0.0.22)', () => {
+	it('members match aliases', () => {
+		expect(docker.runContainer).toBe(_$gha_runDockerContainer);
+		expect(docker.stopContainer).toBe(_$gha_stopDockerContainer);
+	});
+});
+```
+
+Create `types.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+	context,
+	_$gha_extractIssueContext,
+	_$gha_extractRepoContext,
+} from './types';
+
+describe('gha.context group (v0.0.22)', () => {
+	it('members match aliases', () => {
+		expect(context.extractIssue).toBe(_$gha_extractIssueContext);
+		expect(context.extractRepo).toBe(_$gha_extractRepoContext);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm nx test devops -- src/lib/client/github/docker.spec.ts src/lib/client/github/types.spec.ts`
+Expected: FAIL — `docker` / `context` not exported.
+
+- [ ] **Step 3: Rename + add groups + aliases**
+
+In `docker.ts`, rename both functions (drop `export`), then append:
+
+```ts
+export const docker = {
+	runContainer,
+	stopContainer,
+};
+
+/** @deprecated Use `gha.docker.runContainer`. */
+export const _$gha_runDockerContainer = runContainer;
+/** @deprecated Use `gha.docker.stopContainer`. */
+export const _$gha_stopDockerContainer = stopContainer;
+```
+
+In `types.ts`, rename the two functions (drop `export`), then append (leave all type/interface exports untouched):
+
+```ts
+export const context = {
+	extractIssue,
+	extractRepo,
+};
+
+/** @deprecated Use `gha.context.extractIssue`. */
+export const _$gha_extractIssueContext = extractIssue;
+/** @deprecated Use `gha.context.extractRepo`. */
+export const _$gha_extractRepoContext = extractRepo;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm nx test devops -- src/lib/client/github/docker.spec.ts src/lib/client/github/types.spec.ts`
+Expected: PASS. Also run the issues/pulls specs to confirm the preserved `_$gha_extractIssueContext` import still resolves:
+Run: `pnpm nx test devops -- src/lib/client/github/issues.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/devops/src/lib/client/github/docker.ts packages/npm/devops/src/lib/client/github/docker.spec.ts packages/npm/devops/src/lib/client/github/types.ts packages/npm/devops/src/lib/client/github/types.spec.ts
+git commit -m "refactor(devops): docker.ts + types.ts → gha.docker/gha.context, keep _\$gha_ aliases"
+```
+
+---
+
+### Task 5: `gha` aggregator + entrypoint wiring + smoke tests
+
+**Files:**
+
+- Create: `packages/npm/devops/src/lib/client/github/gha.ts`
+- Create: `packages/npm/devops/src/lib/client/github/gha.spec.ts`
+- Modify: `packages/npm/devops/src/index.ts`
+- Modify: `packages/npm/devops/src/index.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `ci` (from `./ci-failure`), `issues` (Task 1), `pulls` (Task 2), `actions` (Task 3), `docker` + `context` (Task 4), `withGitHubRetry` (from `./retry`).
+- Produces: `export const gha = { ci, issues, actions, pulls, docker, context, withRetry }` where `withRetry === withGitHubRetry`; re-exported from the package root as `gha`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gha.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { gha } from './gha';
+import { ci } from './ci-failure';
+
+describe('gha aggregator (v0.0.22)', () => {
+	it('groups every domain', () => {
+		for (const g of [
+			'ci',
+			'issues',
+			'actions',
+			'pulls',
+			'docker',
+			'context',
+		]) {
+			expect(typeof (gha as Record<string, unknown>)[g]).toBe('object');
+		}
+		expect(typeof gha.withRetry).toBe('function');
+	});
+	it('gha.ci is the same object as the top-level ci', () => {
+		expect(gha.ci).toBe(ci);
+	});
+	it('representative members are functions', () => {
+		expect(typeof gha.issues.createComment).toBe('function');
+		expect(typeof gha.pulls.createOrUpdatePR).toBe('function');
+		expect(typeof gha.actions.findActionInTitle).toBe('function');
+		expect(typeof gha.docker.runContainer).toBe('function');
+		expect(typeof gha.context.extractIssue).toBe('function');
+		expect(typeof gha.ci.parseFailureLog).toBe('function');
+	});
+});
+```
+
+Append to `index.spec.ts` (inside a new describe; the file already imports `* as devops from './index'`):
+
+```ts
+describe('gha entrypoint export (v0.0.22)', () => {
+	it('exposes gha with all groups from the package root', () => {
+		expect(typeof devops.gha).toBe('object');
+		expect(typeof devops.gha.issues.createComment).toBe('function');
+		expect(typeof devops.gha.pulls.createOrUpdatePR).toBe('function');
+		expect(typeof devops.gha.docker.runContainer).toBe('function');
+		expect(typeof devops.gha.context.extractIssue).toBe('function');
+		expect(typeof devops.gha.withRetry).toBe('function');
+	});
+	it('keeps top-level ci working and equal to gha.ci', () => {
+		expect(devops.gha.ci).toBe(devops.ci);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm nx test devops -- src/lib/client/github/gha.spec.ts src/index.spec.ts`
+Expected: FAIL — `./gha` does not exist; `devops.gha` undefined.
+
+- [ ] **Step 3: Create the aggregator + wire the entrypoint**
+
+Create `gha.ts`:
+
+```ts
+import { ci } from './ci-failure';
+import { issues } from './issues';
+import { actions } from './actions';
+import { pulls } from './pulls';
+import { docker } from './docker';
+import { context } from './types';
+import { withGitHubRetry } from './retry';
+
+export const gha = {
+	ci,
+	issues,
+	actions,
+	pulls,
+	docker,
+	context,
+	withRetry: withGitHubRetry,
+};
+```
+
+In `src/index.ts`, add after the existing `export * from './lib/client/github/retry';` line:
+
+```ts
+export { gha } from './lib/client/github/gha';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm nx test devops -- src/lib/client/github/gha.spec.ts src/index.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/npm/devops/src/lib/client/github/gha.ts packages/npm/devops/src/lib/client/github/gha.spec.ts packages/npm/devops/src/index.ts packages/npm/devops/src/index.spec.ts
+git commit -m "feat(devops): gha aggregator namespace wired into entrypoint"
+```
+
+---
+
+### Task 6: full suite + build green, version bump, manifest regen
+
+**Files:**
+
+- Modify: `apps/kbve/astro-kbve/src/content/docs/project/devops.mdx:14`
+- Modify: `.github/ci-dispatch-manifest.json` (generated)
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `pnpm nx test devops`
+Expected: PASS — all pre-existing tests plus the new group/aggregator tests green.
+
+- [ ] **Step 2: Verify the build compiles (proves `gha` resolves from the root)**
+
+Run: `pnpm nx build devops`
+Expected: build succeeds; `dist/packages/npm/devops` emitted.
+
+- [ ] **Step 3: Confirm no stray `_$gha_` references remain outside alias lines**
+
+Run: `grep -rn '_\$gha_' packages/npm/devops/src --include='*.ts' | grep -v spec | grep -v 'export const _\$gha_'`
+Expected: NO output (every non-spec `_$gha_` occurrence is now an `export const _$gha_X = X;` alias line). If any in-file call site was missed, it appears here — fix it and re-run the module's tests.
+
+- [ ] **Step 4: Bump the version source**
+
+Edit `apps/kbve/astro-kbve/src/content/docs/project/devops.mdx` line 14:
+
+```
+version: "0.0.22"
+```
+
+(Leave `version.toml` untouched.)
+
+- [ ] **Step 5: Regenerate the dispatch manifest**
+
+Run: `pnpm nx run astro-kbve:gen:ci-manifest --skip-nx-cache`
+Verify: `git diff .github/ci-dispatch-manifest.json` shows only the devops `version` field changing (0.0.21 → 0.0.22).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/content/docs/project/devops.mdx .github/ci-dispatch-manifest.json
+git commit -m "release(devops): bump to 0.0.22 + regen ci-dispatch-manifest"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- `gha.issues` → Task 1 ✓ | `gha.pulls` → Task 2 ✓ | `gha.actions` → Task 3 ✓ | `gha.docker` + `gha.context` → Task 4 ✓ | `gha` aggregator + entrypoint + `ci` reuse → Task 5 ✓ | release (MDX bump, manifest regen, version.toml untouched) → Task 6 ✓
+- All 33 `_$gha_*` names preserved as `@deprecated` aliases across Tasks 1–4 (11+9+2+2+2 renamed here; ci-failure's 7 already aliased in v0.0.21 and reused via `gha.ci`).
+- Non-breaking guard: Task 6 Step 3 grep proves no missed in-file call site; top-level `ci` untouched.
+
+**Placeholder scan:** none — every step carries the exact rename map, group object, alias block, and test code.
+
+**Type consistency:** group object names (`issues`, `pulls`, `actions`, `docker`, `context`) and member names match between each module task, the `gha.ts` aggregator (Task 5), and the tests. `withRetry` maps to `withGitHubRetry`. `gha.ci === ci` asserted in Task 5.

--- a/docs/superpowers/specs/2026-07-02-devops-0022-gha-namespace-design.md
+++ b/docs/superpowers/specs/2026-07-02-devops-0022-gha-namespace-design.md
@@ -1,0 +1,122 @@
+# @kbve/devops v0.0.22 — `gha` grouped namespace (retire `_$gha_*`)
+
+**Date:** 2026-07-02
+**Package:** `packages/npm/devops`
+**Version target:** 0.0.21 → 0.0.22
+**Compat stance:** Additive, non-breaking. Every existing `_$gha_*` export and the top-level `ci` namespace keep working. New: a single `gha` aggregator namespace with clean grouped members.
+
+## Motivation
+
+The GitHub-Actions helper surface is a flat set of 33 `_$gha_*`-prefixed exports across `issues.ts`, `pulls.ts`, `ci-failure.ts`, `actions.ts`, `docker.ts`, `types.ts`. The prefix is noisy at call sites and undiscoverable via autocomplete. v0.0.21 already proved the target pattern for one module (`ci.*` object + `_$gha_*` `@deprecated` aliases). v0.0.22 extends that pattern across the whole surface under one aggregator, `gha`, so a consumer writes `gha.issues.createComment(...)` and finds everything from one import.
+
+A second win: `issues.ts`, `pulls.ts`, `docker.ts`, `types.ts` are **not currently reachable from the package entrypoint** (only `ci-failure`, `actions`, `retry` are wired into `src/index.ts`). Exporting `gha` wires the entire helper surface into the public API for the first time.
+
+## Design
+
+### The `gha` aggregator
+
+One object, exported from the package root, grouping helpers by GitHub domain. Members strip the redundant module prefix (the group conveys context). Each member points at the module's plain-named function; the `_$gha_*` names remain as `@deprecated` aliases to the same functions.
+
+```ts
+import { gha } from '@kbve/devops';
+
+gha.ci        // === the existing `ci` object (unchanged; also still exported top-level)
+gha.issues
+gha.actions
+gha.pulls
+gha.docker
+gha.context
+gha.withRetry // === withGitHubRetry (v0.0.21)
+```
+
+### Member map (clean name ← current `_$gha_*`)
+
+`gha.ci` — reuse the existing `ci` object verbatim (`issueTitle`, `parseFailureLog`, `classifyFailure`, `classifyAll`, `buildIssueBody`, `buildComment`, `buildResolveComment`, `incrementHistory`, `failurePatterns`).
+
+`gha.issues` (from `issues.ts`):
+| member | ← alias |
+|---|---|
+| `createComment` | `_$gha_createIssueComment` |
+| `addReaction` | `_$gha_addReaction` |
+| `removeLabel` | `_$gha_removeLabel` |
+| `addLabel` | `_$gha_addLabel` |
+| `verifyMatrixLabel` | `_$gha_verifyMatrixLabel` |
+| `addAssignees` | `_$gha_addAssignees` |
+| `removeAssignees` | `_$gha_removeAssignees` |
+| `closeIssue` | `_$gha_closeIssue` |
+| `reopenIssue` | `_$gha_reopenIssue` |
+| `lockIssue` | `_$gha_lockIssue` |
+| `unlockIssue` | `_$gha_unlockIssue` |
+
+`gha.actions` (from `actions.ts`):
+| member | ← alias |
+|---|---|
+| `findActionInTitle` | `_$gha_findActionInTitle` |
+| `kbveActionProcess` | `_$gha_kbve_ActionProcess` |
+| `findActionInTitleSafe` | *(v0.0.21, already plain)* |
+
+`gha.pulls` (from `pulls.ts`):
+| member | ← alias |
+|---|---|
+| `formatCommits` | `_$gha_formatCommits` |
+| `categorizeApiCommits` | `_$gha_categorizeApiCommits` |
+| `generatePRTitle` | `_$gha_generatePRTitle` |
+| `formatDevBody` | `_$gha_formatDevBody` |
+| `getPullRequestNumber` | `_$gha_getPullRequestNumber` |
+| `updatePullRequestBody` | `_$gha_updatePullRequestBody` |
+| `fetchAndCleanCommits` | `_$gha_fetchAndCleanCommits` |
+| `processAndUpdatePR` | `_$gha_processAndUpdatePR` |
+| `createOrUpdatePR` | `_$gha_createOrUpdatePR` |
+
+`gha.docker` (from `docker.ts`):
+| member | ← alias |
+|---|---|
+| `runContainer` | `_$gha_runDockerContainer` |
+| `stopContainer` | `_$gha_stopDockerContainer` |
+
+`gha.context` (from `types.ts`):
+| member | ← alias |
+|---|---|
+| `extractIssue` | `_$gha_extractIssueContext` |
+| `extractRepo` | `_$gha_extractRepoContext` |
+
+`gha.withRetry` ← `withGitHubRetry` (v0.0.21).
+
+### Per-module refactor pattern (the v0.0.21 `ci-failure` precedent)
+
+For each module, apply the pattern `ci-failure.ts` already uses:
+
+1. The function is defined with its **plain name** (rename the `_$gha_`-prefixed definition to the clean name).
+2. Export a module-level group object literal (`issues`, `actions`, `pulls`, `docker`, `context`) binding clean member names to those functions.
+3. Keep every `_$gha_*` name as an `@deprecated` `export const _$gha_X = cleanName;` alias, so nothing that imported the old name breaks.
+
+Then a new `src/lib/client/github/gha.ts` imports the per-module group objects (and `ci`, `withGitHubRetry`) and assembles `export const gha = { ci, issues, actions, pulls, docker, context, withRetry }`.
+
+### Entrypoint wiring
+
+`src/index.ts` gains `export { gha } from './lib/client/github/gha';` (and keeps the existing `ci`, `actions`, `retry` exports). Top-level `ci` stays exactly as-is. The package-root smoke test (from v0.0.21) is extended to assert `gha.issues.createComment`, `gha.pulls.createOrUpdatePR`, `gha.docker.runContainer`, `gha.context.extractIssue`, `gha.actions.findActionInTitle`, `gha.ci.parseFailureLog`, and `gha.withRetry` are all functions, and that a representative `_$gha_*` alias still resolves.
+
+## Non-goals
+
+- No removal of any `_$gha_*` alias (that is a later minor, once consumers migrate).
+- No behavior/signature changes to any function.
+- No workflow YAML changes (the tracker re-wire, "PR B", remains separate and still deferred).
+- No new helper functionality — this is a pure naming/grouping release.
+
+## Testing
+
+- Per-module: existing `*.spec.ts` stay green; where a module gains its group object, add a small test asserting the group member is the same reference as its `_$gha_*` alias (e.g. `expect(issues.createComment).toBe(_$gha_createIssueComment)`).
+- New `gha.spec.ts`: asserts the full `gha` shape — every group present, representative members are functions, `gha.ci === ci`.
+- Extend `src/index.spec.ts` for the entrypoint assertions above.
+- Full `nx test devops` green; `nx build devops` green (proves `gha` resolves from the root).
+
+## Release mechanics
+
+- Bump only `apps/kbve/astro-kbve/src/content/docs/project/devops.mdx` `version: "0.0.21"` → `"0.0.22"`. `version.toml` untouched (CI marker).
+- Regenerate `.github/ci-dispatch-manifest.json` via `nx run astro-kbve:gen:ci-manifest` (devops-only change expected).
+- PR into `dev`; dev→main promotion publishes.
+
+## Follow-ups
+
+- Once 0.0.22 is on npm and consumers migrate to `gha.*`, a future minor removes the `_$gha_*` aliases.
+- The deferred tracker workflow re-wire ("PR B") can then import `gha.ci.*` on `@latest`.

--- a/packages/npm/devops/src/index.spec.ts
+++ b/packages/npm/devops/src/index.spec.ts
@@ -23,3 +23,17 @@ describe('index.ts entrypoint exports (v0.0.21 smoke test)', () => {
 		expect(typeof devops.ci.classifyAll).toBe('function');
 	});
 });
+
+describe('gha entrypoint export (v0.0.22)', () => {
+	it('exposes gha with all groups from the package root', () => {
+		expect(typeof devops.gha).toBe('object');
+		expect(typeof devops.gha.issues.createComment).toBe('function');
+		expect(typeof devops.gha.pulls.createOrUpdatePR).toBe('function');
+		expect(typeof devops.gha.docker.runContainer).toBe('function');
+		expect(typeof devops.gha.context.extractIssue).toBe('function');
+		expect(typeof devops.gha.withRetry).toBe('function');
+	});
+	it('keeps top-level ci working and equal to gha.ci', () => {
+		expect(devops.gha.ci).toBe(devops.ci);
+	});
+});

--- a/packages/npm/devops/src/index.ts
+++ b/packages/npm/devops/src/index.ts
@@ -4,6 +4,7 @@ export * from './lib/client/kbve';
 export * from './lib/client/github/ci-failure';
 export * from './lib/client/github/actions';
 export * from './lib/client/github/retry';
+export { gha } from './lib/client/github/gha';
 export * from './lib/ci';
 export * from './lib/forum';
 export * as telemetry from './lib/telemetry';

--- a/packages/npm/devops/src/lib/client/github/actions.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/actions.spec.ts
@@ -2,6 +2,7 @@ import {
 	_$gha_findActionInTitle,
 	_$gha_kbve_ActionProcess,
 	findActionInTitleSafe,
+	actions,
 } from './actions';
 import { GithubActionReferenceMap } from './types';
 
@@ -69,5 +70,15 @@ describe('findActionInTitleSafe (v0.0.21)', () => {
 	});
 	it('returns null on no match instead of throwing', () => {
 		expect(findActionInTitleSafe('nothing here', map)).toBeNull();
+	});
+});
+
+describe('gha.actions group (v0.0.22)', () => {
+	it('group members match their _$gha_ aliases', () => {
+		expect(actions.findActionInTitle).toBe(_$gha_findActionInTitle);
+		expect(actions.kbveActionProcess).toBe(_$gha_kbve_ActionProcess);
+	});
+	it('includes findActionInTitleSafe', () => {
+		expect(typeof actions.findActionInTitleSafe).toBe('function');
 	});
 });

--- a/packages/npm/devops/src/lib/client/github/actions.ts
+++ b/packages/npm/devops/src/lib/client/github/actions.ts
@@ -1,7 +1,7 @@
 import { _title } from '../../sanitization';
 import { GithubActionReferenceMap } from './types';
 
-export function _$gha_findActionInTitle(
+function findActionInTitle(
 	title: string,
 	referenceMap: GithubActionReferenceMap[],
 ): string {
@@ -20,8 +20,8 @@ const defaultReferenceMap: GithubActionReferenceMap[] = [
 	{ keyword: 'music', action: 'music_action' },
 ];
 
-export function _$gha_kbve_ActionProcess(title: string): string {
-	return _$gha_findActionInTitle(title.toLowerCase(), defaultReferenceMap);
+function kbveActionProcess(title: string): string {
+	return findActionInTitle(title.toLowerCase(), defaultReferenceMap);
 }
 
 export function findActionInTitleSafe(
@@ -36,3 +36,14 @@ export function findActionInTitleSafe(
 	}
 	return null;
 }
+
+export const actions = {
+	findActionInTitle,
+	kbveActionProcess,
+	findActionInTitleSafe,
+};
+
+/** @deprecated Use `gha.actions.findActionInTitle`. */
+export const _$gha_findActionInTitle = findActionInTitle;
+/** @deprecated Use `gha.actions.kbveActionProcess`. */
+export const _$gha_kbve_ActionProcess = kbveActionProcess;

--- a/packages/npm/devops/src/lib/client/github/docker.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.spec.ts
@@ -3,168 +3,200 @@ import { GitHubClient, GitHubContext } from './types';
 const mockExecAsync = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
-  exec: vi.fn(),
+	exec: vi.fn(),
 }));
 
 vi.mock('util', () => ({
-  promisify: () => mockExecAsync,
+	promisify: () => mockExecAsync,
 }));
 
 // Import after mocks are set up
-const { _$gha_runDockerContainer, _$gha_stopDockerContainer } = await import('./docker');
+const { _$gha_runDockerContainer, _$gha_stopDockerContainer, docker } =
+	await import('./docker');
 
 function mockGitHubContext(): GitHubContext {
-  return {
-    repo: { owner: 'KBVE', repo: 'kbve' },
-    issue: { number: 42 },
-    ref: 'refs/heads/main',
-    payload: {},
-    job: 'test-job',
-  };
+	return {
+		repo: { owner: 'KBVE', repo: 'kbve' },
+		issue: { number: 42 },
+		ref: 'refs/heads/main',
+		payload: {},
+		job: 'test-job',
+	};
 }
 
 function mockGitHubClient(): GitHubClient {
-  return {
-    rest: {
-      issues: {
-        createComment: vi.fn().mockResolvedValue({}),
-        addLabels: vi.fn().mockResolvedValue({}),
-        removeLabel: vi.fn().mockResolvedValue({}),
-        listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
-        addAssignees: vi.fn().mockResolvedValue({}),
-        removeAssignees: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-        lock: vi.fn().mockResolvedValue({}),
-        unlock: vi.fn().mockResolvedValue({}),
-      },
-      pulls: {
-        list: vi.fn().mockResolvedValue({ data: [] }),
-        create: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-      },
-      reactions: {
-        createForIssueComment: vi.fn().mockResolvedValue({}),
-      },
-    },
-  };
+	return {
+		rest: {
+			issues: {
+				createComment: vi.fn().mockResolvedValue({}),
+				addLabels: vi.fn().mockResolvedValue({}),
+				removeLabel: vi.fn().mockResolvedValue({}),
+				listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
+				addAssignees: vi.fn().mockResolvedValue({}),
+				removeAssignees: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+				lock: vi.fn().mockResolvedValue({}),
+				unlock: vi.fn().mockResolvedValue({}),
+			},
+			pulls: {
+				list: vi.fn().mockResolvedValue({ data: [] }),
+				create: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+			},
+			reactions: {
+				createForIssueComment: vi.fn().mockResolvedValue({}),
+			},
+		},
+	};
 }
 
 describe('_$gha_runDockerContainer', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-  it('should throw on invalid port', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw on invalid port', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_runDockerContainer(github, context, 0, 'mycontainer', 'nginx:latest'),
-    ).rejects.toThrow('Invalid port number');
-  });
+		await expect(
+			_$gha_runDockerContainer(
+				github,
+				context,
+				0,
+				'mycontainer',
+				'nginx:latest',
+			),
+		).rejects.toThrow('Invalid port number');
+	});
 
-  it('should throw on restricted port', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw on restricted port', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_runDockerContainer(github, context, 443, 'mycontainer', 'nginx:latest'),
-    ).rejects.toThrow('Port 443 is restricted');
-  });
+		await expect(
+			_$gha_runDockerContainer(
+				github,
+				context,
+				443,
+				'mycontainer',
+				'nginx:latest',
+			),
+		).rejects.toThrow('Port 443 is restricted');
+	});
 
-  it('should throw on empty container name', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw on empty container name', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_runDockerContainer(github, context, 8080, '', 'nginx:latest'),
-    ).rejects.toThrow('Invalid container name');
-  });
+		await expect(
+			_$gha_runDockerContainer(github, context, 8080, '', 'nginx:latest'),
+		).rejects.toThrow('Invalid container name');
+	});
 
-  it('should throw on empty image name', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw on empty image name', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_runDockerContainer(github, context, 8080, 'mycontainer', ''),
-    ).rejects.toThrow('Invalid container image name');
-  });
+		await expect(
+			_$gha_runDockerContainer(github, context, 8080, 'mycontainer', ''),
+		).rejects.toThrow('Invalid container image name');
+	});
 
-  it('should succeed with valid inputs when exec succeeds', async () => {
-    mockExecAsync.mockResolvedValue({ stdout: 'container-id-123' });
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should succeed with valid inputs when exec succeeds', async () => {
+		mockExecAsync.mockResolvedValue({ stdout: 'container-id-123' });
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_runDockerContainer(github, context, 8080, 'mycontainer', 'nginx:latest');
+		await _$gha_runDockerContainer(
+			github,
+			context,
+			8080,
+			'mycontainer',
+			'nginx:latest',
+		);
 
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('started successfully'),
-      }),
-    );
-  });
+		expect(github.rest.issues.createComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.stringContaining('started successfully'),
+			}),
+		);
+	});
 
-  it('should report error and throw when exec fails', async () => {
-    mockExecAsync.mockRejectedValue(new Error('Docker not found'));
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should report error and throw when exec fails', async () => {
+		mockExecAsync.mockRejectedValue(new Error('Docker not found'));
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_runDockerContainer(github, context, 8080, 'mycontainer', 'nginx:latest'),
-    ).rejects.toThrow('Docker not found');
+		await expect(
+			_$gha_runDockerContainer(
+				github,
+				context,
+				8080,
+				'mycontainer',
+				'nginx:latest',
+			),
+		).rejects.toThrow('Docker not found');
 
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('Error running Docker container'),
-      }),
-    );
-  });
+		expect(github.rest.issues.createComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.stringContaining('Error running Docker container'),
+			}),
+		);
+	});
 });
 
 describe('_$gha_stopDockerContainer', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-  it('should throw on invalid container name', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw on invalid container name', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_stopDockerContainer(github, context, ''),
-    ).rejects.toThrow('Invalid container name');
-  });
+		await expect(
+			_$gha_stopDockerContainer(github, context, ''),
+		).rejects.toThrow('Invalid container name');
+	});
 
-  it('should succeed when both stop and remove succeed', async () => {
-    mockExecAsync.mockResolvedValue({ stdout: 'ok' });
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should succeed when both stop and remove succeed', async () => {
+		mockExecAsync.mockResolvedValue({ stdout: 'ok' });
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_stopDockerContainer(github, context, 'mycontainer');
+		await _$gha_stopDockerContainer(github, context, 'mycontainer');
 
-    // Should have been called for both stop and remove success comments
-    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(2);
-  });
+		// Should have been called for both stop and remove success comments
+		expect(github.rest.issues.createComment).toHaveBeenCalledTimes(2);
+	});
 
-  it('should throw when stop command fails', async () => {
-    mockExecAsync.mockRejectedValue(new Error('Container not running'));
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw when stop command fails', async () => {
+		mockExecAsync.mockRejectedValue(new Error('Container not running'));
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_stopDockerContainer(github, context, 'mycontainer'),
-    ).rejects.toThrow('Container not running');
-  });
+		await expect(
+			_$gha_stopDockerContainer(github, context, 'mycontainer'),
+		).rejects.toThrow('Container not running');
+	});
 
-  it('should throw when stop succeeds but remove fails', async () => {
-    mockExecAsync
-      .mockResolvedValueOnce({ stdout: 'stopped' })
-      .mockRejectedValueOnce(new Error('Remove failed'));
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should throw when stop succeeds but remove fails', async () => {
+		mockExecAsync
+			.mockResolvedValueOnce({ stdout: 'stopped' })
+			.mockRejectedValueOnce(new Error('Remove failed'));
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_stopDockerContainer(github, context, 'mycontainer'),
-    ).rejects.toThrow('Remove failed');
-  });
+		await expect(
+			_$gha_stopDockerContainer(github, context, 'mycontainer'),
+		).rejects.toThrow('Remove failed');
+	});
+});
+
+describe('gha.docker group (v0.0.22)', () => {
+	it('members match aliases', () => {
+		expect(docker.runContainer).toBe(_$gha_runDockerContainer);
+		expect(docker.stopContainer).toBe(_$gha_stopDockerContainer);
+	});
 });

--- a/packages/npm/devops/src/lib/client/github/docker.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.ts
@@ -1,113 +1,123 @@
 import { promisify } from 'util';
 import { exec } from 'child_process';
 import {
-  sanitizePort,
-  sanitizeContainerName,
-  sanitizeContainerImage,
+	sanitizePort,
+	sanitizeContainerName,
+	sanitizeContainerImage,
 } from '../../sanitization';
 import { GitHubClient, GitHubContext } from './types';
 import { _$gha_createIssueComment } from './issues';
 
 const execAsync = promisify(exec);
 
-export async function _$gha_runDockerContainer(
-  github: GitHubClient,
-  context: GitHubContext,
-  port: number,
-  name: string,
-  image: string,
+async function runContainer(
+	github: GitHubClient,
+	context: GitHubContext,
+	port: number,
+	name: string,
+	image: string,
 ): Promise<void> {
-  let sanitizedPort: number;
-  let sanitizedName: string;
-  let sanitizedImage: string;
+	let sanitizedPort: number;
+	let sanitizedName: string;
+	let sanitizedImage: string;
 
-  try {
-    sanitizedPort = sanitizePort(port);
-    sanitizedName = sanitizeContainerName(name);
-    sanitizedImage = sanitizeContainerImage(image);
-  } catch (error) {
-    console.error('Error sanitizing input:', error);
-    throw error;
-  }
+	try {
+		sanitizedPort = sanitizePort(port);
+		sanitizedName = sanitizeContainerName(name);
+		sanitizedImage = sanitizeContainerImage(image);
+	} catch (error) {
+		console.error('Error sanitizing input:', error);
+		throw error;
+	}
 
-  const command = `docker run -d -p ${sanitizedPort}:${sanitizedPort} --name ${sanitizedName} ${sanitizedImage}`;
+	const command = `docker run -d -p ${sanitizedPort}:${sanitizedPort} --name ${sanitizedName} ${sanitizedImage}`;
 
-  try {
-    const { stdout } = await execAsync(command);
-    console.log('Docker container started successfully:', stdout);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Docker container started successfully: ${stdout}`,
-    );
-  } catch (error) {
-    const errMessage =
-      error instanceof Error ? error.message : String(error);
-    console.error('Error running Docker container:', error);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Error running Docker container: ${errMessage}`,
-    );
-    throw error;
-  }
+	try {
+		const { stdout } = await execAsync(command);
+		console.log('Docker container started successfully:', stdout);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Docker container started successfully: ${stdout}`,
+		);
+	} catch (error) {
+		const errMessage =
+			error instanceof Error ? error.message : String(error);
+		console.error('Error running Docker container:', error);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Error running Docker container: ${errMessage}`,
+		);
+		throw error;
+	}
 }
 
-export async function _$gha_stopDockerContainer(
-  github: GitHubClient,
-  context: GitHubContext,
-  name: string,
+async function stopContainer(
+	github: GitHubClient,
+	context: GitHubContext,
+	name: string,
 ): Promise<void> {
-  let sanitizedName: string;
+	let sanitizedName: string;
 
-  try {
-    sanitizedName = sanitizeContainerName(name);
-  } catch (error) {
-    console.error('Error sanitizing container name:', error);
-    throw error;
-  }
+	try {
+		sanitizedName = sanitizeContainerName(name);
+	} catch (error) {
+		console.error('Error sanitizing container name:', error);
+		throw error;
+	}
 
-  try {
-    const { stdout: stopStdout } = await execAsync(
-      `docker stop ${sanitizedName}`,
-    );
-    console.log('Docker container stopped successfully:', stopStdout);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Docker container stopped successfully: ${stopStdout}`,
-    );
-  } catch (error) {
-    const errMessage =
-      error instanceof Error ? error.message : String(error);
-    console.error('Error stopping Docker container:', error);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Error stopping Docker container: ${errMessage}`,
-    );
-    throw error;
-  }
+	try {
+		const { stdout: stopStdout } = await execAsync(
+			`docker stop ${sanitizedName}`,
+		);
+		console.log('Docker container stopped successfully:', stopStdout);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Docker container stopped successfully: ${stopStdout}`,
+		);
+	} catch (error) {
+		const errMessage =
+			error instanceof Error ? error.message : String(error);
+		console.error('Error stopping Docker container:', error);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Error stopping Docker container: ${errMessage}`,
+		);
+		throw error;
+	}
 
-  try {
-    const { stdout: removeStdout } = await execAsync(
-      `docker rm ${sanitizedName}`,
-    );
-    console.log('Docker container removed successfully:', removeStdout);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Docker container removed successfully: ${removeStdout}`,
-    );
-  } catch (error) {
-    const errMessage =
-      error instanceof Error ? error.message : String(error);
-    console.error('Error removing Docker container:', error);
-    await _$gha_createIssueComment(
-      github,
-      context,
-      `Error removing Docker container: ${errMessage}`,
-    );
-    throw error;
-  }
+	try {
+		const { stdout: removeStdout } = await execAsync(
+			`docker rm ${sanitizedName}`,
+		);
+		console.log('Docker container removed successfully:', removeStdout);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Docker container removed successfully: ${removeStdout}`,
+		);
+	} catch (error) {
+		const errMessage =
+			error instanceof Error ? error.message : String(error);
+		console.error('Error removing Docker container:', error);
+		await _$gha_createIssueComment(
+			github,
+			context,
+			`Error removing Docker container: ${errMessage}`,
+		);
+		throw error;
+	}
 }
+
+export const docker = {
+	runContainer,
+	stopContainer,
+};
+
+/** @deprecated Use `gha.docker.runContainer`. */
+export const _$gha_runDockerContainer = runContainer;
+/** @deprecated Use `gha.docker.stopContainer`. */
+export const _$gha_stopDockerContainer = stopContainer;

--- a/packages/npm/devops/src/lib/client/github/docker.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.ts
@@ -6,7 +6,7 @@ import {
 	sanitizeContainerImage,
 } from '../../sanitization';
 import { GitHubClient, GitHubContext } from './types';
-import { _$gha_createIssueComment } from './issues';
+import { issues } from './issues';
 
 const execAsync = promisify(exec);
 
@@ -35,7 +35,7 @@ async function runContainer(
 	try {
 		const { stdout } = await execAsync(command);
 		console.log('Docker container started successfully:', stdout);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Docker container started successfully: ${stdout}`,
@@ -44,7 +44,7 @@ async function runContainer(
 		const errMessage =
 			error instanceof Error ? error.message : String(error);
 		console.error('Error running Docker container:', error);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Error running Docker container: ${errMessage}`,
@@ -72,7 +72,7 @@ async function stopContainer(
 			`docker stop ${sanitizedName}`,
 		);
 		console.log('Docker container stopped successfully:', stopStdout);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Docker container stopped successfully: ${stopStdout}`,
@@ -81,7 +81,7 @@ async function stopContainer(
 		const errMessage =
 			error instanceof Error ? error.message : String(error);
 		console.error('Error stopping Docker container:', error);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Error stopping Docker container: ${errMessage}`,
@@ -94,7 +94,7 @@ async function stopContainer(
 			`docker rm ${sanitizedName}`,
 		);
 		console.log('Docker container removed successfully:', removeStdout);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Docker container removed successfully: ${removeStdout}`,
@@ -103,7 +103,7 @@ async function stopContainer(
 		const errMessage =
 			error instanceof Error ? error.message : String(error);
 		console.error('Error removing Docker container:', error);
-		await _$gha_createIssueComment(
+		await issues.createComment(
 			github,
 			context,
 			`Error removing Docker container: ${errMessage}`,

--- a/packages/npm/devops/src/lib/client/github/gha.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/gha.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { gha } from './gha';
+import { ci } from './ci-failure';
+
+describe('gha aggregator (v0.0.22)', () => {
+	it('groups every domain', () => {
+		for (const g of [
+			'ci',
+			'issues',
+			'actions',
+			'pulls',
+			'docker',
+			'context',
+		]) {
+			expect(typeof (gha as Record<string, unknown>)[g]).toBe('object');
+		}
+		expect(typeof gha.withRetry).toBe('function');
+	});
+	it('gha.ci is the same object as the top-level ci', () => {
+		expect(gha.ci).toBe(ci);
+	});
+	it('representative members are functions', () => {
+		expect(typeof gha.issues.createComment).toBe('function');
+		expect(typeof gha.pulls.createOrUpdatePR).toBe('function');
+		expect(typeof gha.actions.findActionInTitle).toBe('function');
+		expect(typeof gha.docker.runContainer).toBe('function');
+		expect(typeof gha.context.extractIssue).toBe('function');
+		expect(typeof gha.ci.parseFailureLog).toBe('function');
+	});
+});

--- a/packages/npm/devops/src/lib/client/github/gha.ts
+++ b/packages/npm/devops/src/lib/client/github/gha.ts
@@ -1,0 +1,17 @@
+import { ci } from './ci-failure';
+import { issues } from './issues';
+import { actions } from './actions';
+import { pulls } from './pulls';
+import { docker } from './docker';
+import { context } from './types';
+import { withGitHubRetry } from './retry';
+
+export const gha = {
+	ci,
+	issues,
+	actions,
+	pulls,
+	docker,
+	context,
+	withRetry: withGitHubRetry,
+};

--- a/packages/npm/devops/src/lib/client/github/issues.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/issues.spec.ts
@@ -1,309 +1,353 @@
 import {
-  _$gha_createIssueComment,
-  _$gha_addReaction,
-  _$gha_removeLabel,
-  _$gha_addLabel,
-  _$gha_verifyMatrixLabel,
-  _$gha_addAssignees,
-  _$gha_removeAssignees,
-  _$gha_closeIssue,
-  _$gha_reopenIssue,
-  _$gha_lockIssue,
-  _$gha_unlockIssue,
+	_$gha_createIssueComment,
+	_$gha_addReaction,
+	_$gha_removeLabel,
+	_$gha_addLabel,
+	_$gha_verifyMatrixLabel,
+	_$gha_addAssignees,
+	_$gha_removeAssignees,
+	_$gha_closeIssue,
+	_$gha_reopenIssue,
+	_$gha_lockIssue,
+	_$gha_unlockIssue,
+	issues,
 } from './issues';
 import { GitHubClient, GitHubContext } from './types';
 
 function mockGitHubContext(overrides?: Partial<GitHubContext>): GitHubContext {
-  return {
-    repo: { owner: 'KBVE', repo: 'kbve' },
-    issue: { number: 42 },
-    ref: 'refs/heads/main',
-    payload: {},
-    job: 'test-job',
-    ...overrides,
-  };
+	return {
+		repo: { owner: 'KBVE', repo: 'kbve' },
+		issue: { number: 42 },
+		ref: 'refs/heads/main',
+		payload: {},
+		job: 'test-job',
+		...overrides,
+	};
 }
 
 function mockGitHubClient(overrides?: Partial<GitHubClient>): GitHubClient {
-  return {
-    rest: {
-      issues: {
-        createComment: vi.fn().mockResolvedValue({}),
-        addLabels: vi.fn().mockResolvedValue({}),
-        removeLabel: vi.fn().mockResolvedValue({}),
-        listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
-        addAssignees: vi.fn().mockResolvedValue({}),
-        removeAssignees: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-        lock: vi.fn().mockResolvedValue({}),
-        unlock: vi.fn().mockResolvedValue({}),
-      },
-      pulls: {
-        list: vi.fn().mockResolvedValue({ data: [] }),
-        create: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-      },
-      reactions: {
-        createForIssueComment: vi.fn().mockResolvedValue({}),
-      },
-    },
-    ...overrides,
-  };
+	return {
+		rest: {
+			issues: {
+				createComment: vi.fn().mockResolvedValue({}),
+				addLabels: vi.fn().mockResolvedValue({}),
+				removeLabel: vi.fn().mockResolvedValue({}),
+				listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
+				addAssignees: vi.fn().mockResolvedValue({}),
+				removeAssignees: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+				lock: vi.fn().mockResolvedValue({}),
+				unlock: vi.fn().mockResolvedValue({}),
+			},
+			pulls: {
+				list: vi.fn().mockResolvedValue({ data: [] }),
+				create: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+			},
+			reactions: {
+				createForIssueComment: vi.fn().mockResolvedValue({}),
+			},
+		},
+		...overrides,
+	};
 }
 
 describe('_$gha_createIssueComment', () => {
-  it('should call createComment with correct params', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should call createComment with correct params', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_createIssueComment(github, context, 'Hello World');
+		await _$gha_createIssueComment(github, context, 'Hello World');
 
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      body: 'Hello World',
-    });
-  });
+		expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			body: 'Hello World',
+		});
+	});
 
-  it('should throw when API call fails', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.createComment as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error('API Error'),
-    );
-    const context = mockGitHubContext();
+	it('should throw when API call fails', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.createComment as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error('API Error'));
+		const context = mockGitHubContext();
 
-    await expect(
-      _$gha_createIssueComment(github, context, 'test'),
-    ).rejects.toThrow('API Error');
-  });
+		await expect(
+			_$gha_createIssueComment(github, context, 'test'),
+		).rejects.toThrow('API Error');
+	});
 });
 
 describe('_$gha_addReaction', () => {
-  it('should call createForIssueComment with correct params', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should call createForIssueComment with correct params', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_addReaction(github, context, 123, '+1');
+		await _$gha_addReaction(github, context, 123, '+1');
 
-    expect(github.rest.reactions.createForIssueComment).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      comment_id: 123,
-      content: '+1',
-    });
-  });
+		expect(
+			github.rest.reactions.createForIssueComment,
+		).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			comment_id: 123,
+			content: '+1',
+		});
+	});
 });
 
 describe('_$gha_removeLabel', () => {
-  it('should remove label when it exists on the issue', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: 'bug' }, { name: 'feature' }],
-    });
-    const context = mockGitHubContext();
+	it('should remove label when it exists on the issue', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: 'bug' }, { name: 'feature' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_removeLabel(github, context, 'bug');
+		await _$gha_removeLabel(github, context, 'bug');
 
-    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      name: 'bug',
-    });
-  });
+		expect(github.rest.issues.removeLabel).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			name: 'bug',
+		});
+	});
 
-  it('should not call removeLabel when label does not exist', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: 'feature' }],
-    });
-    const context = mockGitHubContext();
+	it('should not call removeLabel when label does not exist', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: 'feature' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_removeLabel(github, context, 'bug');
+		await _$gha_removeLabel(github, context, 'bug');
 
-    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
-  });
+		expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+	});
 });
 
 describe('_$gha_addLabel', () => {
-  it('should add label when it does not exist on the issue', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: 'feature' }],
-    });
-    const context = mockGitHubContext();
+	it('should add label when it does not exist on the issue', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: 'feature' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_addLabel(github, context, 'bug');
+		await _$gha_addLabel(github, context, 'bug');
 
-    expect(github.rest.issues.addLabels).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      labels: ['bug'],
-    });
-  });
+		expect(github.rest.issues.addLabels).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			labels: ['bug'],
+		});
+	});
 
-  it('should not call addLabels when label already exists', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: 'bug' }],
-    });
-    const context = mockGitHubContext();
+	it('should not call addLabels when label already exists', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: 'bug' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_addLabel(github, context, 'bug');
+		await _$gha_addLabel(github, context, 'bug');
 
-    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
-  });
+		expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+	});
 });
 
 describe('_$gha_verifyMatrixLabel', () => {
-  it('should add label 0 when no matrix labels are present', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: 'feature' }],
-    });
-    const context = mockGitHubContext();
+	it('should add label 0 when no matrix labels are present', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: 'feature' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_verifyMatrixLabel(github, context);
+		await _$gha_verifyMatrixLabel(github, context);
 
-    // It calls _$gha_addLabel which calls listLabelsOnIssue again then addLabels
-    expect(github.rest.issues.addLabels).toHaveBeenCalled();
-  });
+		// It calls _$gha_addLabel which calls listLabelsOnIssue again then addLabels
+		expect(github.rest.issues.addLabels).toHaveBeenCalled();
+	});
 
-  it('should keep single matrix label unchanged', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: '3' }],
-    });
-    const context = mockGitHubContext();
+	it('should keep single matrix label unchanged', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: '3' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_verifyMatrixLabel(github, context);
+		await _$gha_verifyMatrixLabel(github, context);
 
-    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
-    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
-  });
+		expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+		expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+	});
 
-  it('should keep highest label and remove lower ones when multiple matrix labels exist', async () => {
-    const github = mockGitHubClient();
-    (github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ name: '1' }, { name: '3' }, { name: '5' }],
-    });
-    const context = mockGitHubContext();
+	it('should keep highest label and remove lower ones when multiple matrix labels exist', async () => {
+		const github = mockGitHubClient();
+		(
+			github.rest.issues.listLabelsOnIssue as ReturnType<typeof vi.fn>
+		).mockResolvedValue({
+			data: [{ name: '1' }, { name: '3' }, { name: '5' }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_verifyMatrixLabel(github, context);
+		await _$gha_verifyMatrixLabel(github, context);
 
-    // Should remove labels '1' and '3', keeping '5'
-    // removeLabel is called via _$gha_removeLabel which lists labels again
-    expect(github.rest.issues.listLabelsOnIssue).toHaveBeenCalled();
-  });
+		// Should remove labels '1' and '3', keeping '5'
+		// removeLabel is called via _$gha_removeLabel which lists labels again
+		expect(github.rest.issues.listLabelsOnIssue).toHaveBeenCalled();
+	});
 });
 
 describe('_$gha_addAssignees', () => {
-  it('should call addAssignees with correct params', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should call addAssignees with correct params', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_addAssignees(github, context, ['user1', 'user2']);
+		await _$gha_addAssignees(github, context, ['user1', 'user2']);
 
-    expect(github.rest.issues.addAssignees).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      assignees: ['user1', 'user2'],
-    });
-  });
+		expect(github.rest.issues.addAssignees).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			assignees: ['user1', 'user2'],
+		});
+	});
 });
 
 describe('_$gha_removeAssignees', () => {
-  it('should call removeAssignees with correct params', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should call removeAssignees with correct params', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_removeAssignees(github, context, ['user1']);
+		await _$gha_removeAssignees(github, context, ['user1']);
 
-    expect(github.rest.issues.removeAssignees).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      assignees: ['user1'],
-    });
-  });
+		expect(github.rest.issues.removeAssignees).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			assignees: ['user1'],
+		});
+	});
 });
 
 describe('_$gha_closeIssue', () => {
-  it('should update issue state to closed', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should update issue state to closed', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_closeIssue(github, context);
+		await _$gha_closeIssue(github, context);
 
-    expect(github.rest.issues.update).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      state: 'closed',
-    });
-  });
+		expect(github.rest.issues.update).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			state: 'closed',
+		});
+	});
 });
 
 describe('_$gha_reopenIssue', () => {
-  it('should update issue state to open', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should update issue state to open', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_reopenIssue(github, context);
+		await _$gha_reopenIssue(github, context);
 
-    expect(github.rest.issues.update).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      state: 'open',
-    });
-  });
+		expect(github.rest.issues.update).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			state: 'open',
+		});
+	});
 });
 
 describe('_$gha_lockIssue', () => {
-  it('should lock issue without reason', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should lock issue without reason', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_lockIssue(github, context);
+		await _$gha_lockIssue(github, context);
 
-    expect(github.rest.issues.lock).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      lock_reason: undefined,
-    });
-  });
+		expect(github.rest.issues.lock).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			lock_reason: undefined,
+		});
+	});
 
-  it('should lock issue with reason', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should lock issue with reason', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_lockIssue(github, context, 'spam');
+		await _$gha_lockIssue(github, context, 'spam');
 
-    expect(github.rest.issues.lock).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-      lock_reason: 'spam',
-    });
-  });
+		expect(github.rest.issues.lock).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+			lock_reason: 'spam',
+		});
+	});
 });
 
 describe('_$gha_unlockIssue', () => {
-  it('should unlock issue', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext();
+	it('should unlock issue', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext();
 
-    await _$gha_unlockIssue(github, context);
+		await _$gha_unlockIssue(github, context);
 
-    expect(github.rest.issues.unlock).toHaveBeenCalledWith({
-      owner: 'KBVE',
-      repo: 'kbve',
-      issue_number: 42,
-    });
-  });
+		expect(github.rest.issues.unlock).toHaveBeenCalledWith({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+		});
+	});
+});
+
+describe('gha.issues group (v0.0.22)', () => {
+	it('group members are the same references as their _$gha_ aliases', () => {
+		expect(issues.createComment).toBe(_$gha_createIssueComment);
+		expect(issues.verifyMatrixLabel).toBe(_$gha_verifyMatrixLabel);
+		expect(issues.unlockIssue).toBe(_$gha_unlockIssue);
+	});
+	it('exposes all 11 members as functions', () => {
+		const names = [
+			'createComment',
+			'addReaction',
+			'removeLabel',
+			'addLabel',
+			'verifyMatrixLabel',
+			'addAssignees',
+			'removeAssignees',
+			'closeIssue',
+			'reopenIssue',
+			'lockIssue',
+			'unlockIssue',
+		];
+		for (const n of names)
+			expect(typeof (issues as Record<string, unknown>)[n]).toBe(
+				'function',
+			);
+	});
 });

--- a/packages/npm/devops/src/lib/client/github/issues.ts
+++ b/packages/npm/devops/src/lib/client/github/issues.ts
@@ -1,257 +1,306 @@
 import {
-  GitHubClient,
-  GitHubContext,
-  _$gha_extractIssueContext,
+	GitHubClient,
+	GitHubContext,
+	_$gha_extractIssueContext,
 } from './types';
 
-export async function _$gha_createIssueComment(
-  github: GitHubClient,
-  context: GitHubContext,
-  body: string,
+async function createComment(
+	github: GitHubClient,
+	context: GitHubContext,
+	body: string,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number,
-      body,
-    });
-  } catch (error) {
-    console.error('Error creating issue comment:', error);
-    throw error;
-  }
+		await github.rest.issues.createComment({
+			owner,
+			repo,
+			issue_number,
+			body,
+		});
+	} catch (error) {
+		console.error('Error creating issue comment:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_addReaction(
-  github: GitHubClient,
-  context: GitHubContext,
-  comment_id: number,
-  reaction: string,
+async function addReaction(
+	github: GitHubClient,
+	context: GitHubContext,
+	comment_id: number,
+	reaction: string,
 ): Promise<void> {
-  try {
-    const { owner, repo } = context.repo;
+	try {
+		const { owner, repo } = context.repo;
 
-    await github.rest.reactions.createForIssueComment({
-      owner,
-      repo,
-      comment_id,
-      content: reaction,
-    });
-  } catch (error) {
-    console.error('Error adding reaction:', error);
-    throw error;
-  }
+		await github.rest.reactions.createForIssueComment({
+			owner,
+			repo,
+			comment_id,
+			content: reaction,
+		});
+	} catch (error) {
+		console.error('Error adding reaction:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_removeLabel(
-  github: GitHubClient,
-  context: GitHubContext,
-  labelName: string,
+async function removeLabel(
+	github: GitHubClient,
+	context: GitHubContext,
+	labelName: string,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-      owner,
-      repo,
-      issue_number,
-    });
+		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+			owner,
+			repo,
+			issue_number,
+		});
 
-    if (labels.some((label) => label.name === labelName)) {
-      await github.rest.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name: labelName,
-      });
-    }
-  } catch (error) {
-    console.error(`Error removing label ${labelName} from issue:`, error);
-    throw error;
-  }
+		if (labels.some((label) => label.name === labelName)) {
+			await github.rest.issues.removeLabel({
+				owner,
+				repo,
+				issue_number,
+				name: labelName,
+			});
+		}
+	} catch (error) {
+		console.error(`Error removing label ${labelName} from issue:`, error);
+		throw error;
+	}
 }
 
-export async function _$gha_addLabel(
-  github: GitHubClient,
-  context: GitHubContext,
-  labelName: string,
+async function addLabel(
+	github: GitHubClient,
+	context: GitHubContext,
+	labelName: string,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-      owner,
-      repo,
-      issue_number,
-    });
+		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+			owner,
+			repo,
+			issue_number,
+		});
 
-    if (!labels.some((label) => label.name === labelName)) {
-      await github.rest.issues.addLabels({
-        owner,
-        repo,
-        issue_number,
-        labels: [labelName],
-      });
-    }
-  } catch (error) {
-    console.error(`Error adding label ${labelName} to issue:`, error);
-    throw error;
-  }
+		if (!labels.some((label) => label.name === labelName)) {
+			await github.rest.issues.addLabels({
+				owner,
+				repo,
+				issue_number,
+				labels: [labelName],
+			});
+		}
+	} catch (error) {
+		console.error(`Error adding label ${labelName} to issue:`, error);
+		throw error;
+	}
 }
 
-export async function _$gha_verifyMatrixLabel(
-  github: GitHubClient,
-  context: GitHubContext,
+async function verifyMatrixLabel(
+	github: GitHubClient,
+	context: GitHubContext,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-      owner,
-      repo,
-      issue_number,
-    });
+		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+			owner,
+			repo,
+			issue_number,
+		});
 
-    const matrixLabels = ['0', '1', '2', '3', '4', '5', '6'];
-    const presentLabels = labels
-      .filter((label) => matrixLabels.includes(label.name))
-      .map((label) => label.name)
-      .sort((a, b) => parseInt(a) - parseInt(b));
+		const matrixLabels = ['0', '1', '2', '3', '4', '5', '6'];
+		const presentLabels = labels
+			.filter((label) => matrixLabels.includes(label.name))
+			.map((label) => label.name)
+			.sort((a, b) => parseInt(a) - parseInt(b));
 
-    if (presentLabels.length === 0) {
-      await _$gha_addLabel(github, context, '0');
-      console.log('No matrix labels present. Added label: 0');
-    } else if (presentLabels.length > 1) {
-      const highestLabel = presentLabels.pop();
-      for (const label of presentLabels) {
-        await _$gha_removeLabel(github, context, label);
-      }
-      console.log(`Removed lower labels, kept highest label: ${highestLabel}`);
-    }
-  } catch (error) {
-    console.error('Error verifying matrix labels:', error);
-    throw error;
-  }
+		if (presentLabels.length === 0) {
+			await addLabel(github, context, '0');
+			console.log('No matrix labels present. Added label: 0');
+		} else if (presentLabels.length > 1) {
+			const highestLabel = presentLabels.pop();
+			for (const label of presentLabels) {
+				await removeLabel(github, context, label);
+			}
+			console.log(
+				`Removed lower labels, kept highest label: ${highestLabel}`,
+			);
+		}
+	} catch (error) {
+		console.error('Error verifying matrix labels:', error);
+		throw error;
+	}
 }
 
 // Assignee Management
 
-export async function _$gha_addAssignees(
-  github: GitHubClient,
-  context: GitHubContext,
-  assignees: string[],
+async function addAssignees(
+	github: GitHubClient,
+	context: GitHubContext,
+	assignees: string[],
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.addAssignees({
-      owner,
-      repo,
-      issue_number,
-      assignees,
-    });
-  } catch (error) {
-    console.error('Error adding assignees to issue:', error);
-    throw error;
-  }
+		await github.rest.issues.addAssignees({
+			owner,
+			repo,
+			issue_number,
+			assignees,
+		});
+	} catch (error) {
+		console.error('Error adding assignees to issue:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_removeAssignees(
-  github: GitHubClient,
-  context: GitHubContext,
-  assignees: string[],
+async function removeAssignees(
+	github: GitHubClient,
+	context: GitHubContext,
+	assignees: string[],
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.removeAssignees({
-      owner,
-      repo,
-      issue_number,
-      assignees,
-    });
-  } catch (error) {
-    console.error('Error removing assignees from issue:', error);
-    throw error;
-  }
+		await github.rest.issues.removeAssignees({
+			owner,
+			repo,
+			issue_number,
+			assignees,
+		});
+	} catch (error) {
+		console.error('Error removing assignees from issue:', error);
+		throw error;
+	}
 }
 
 // Issue State Management
 
-export async function _$gha_closeIssue(
-  github: GitHubClient,
-  context: GitHubContext,
+async function closeIssue(
+	github: GitHubClient,
+	context: GitHubContext,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.update({
-      owner,
-      repo,
-      issue_number,
-      state: 'closed',
-    });
-  } catch (error) {
-    console.error('Error closing issue:', error);
-    throw error;
-  }
+		await github.rest.issues.update({
+			owner,
+			repo,
+			issue_number,
+			state: 'closed',
+		});
+	} catch (error) {
+		console.error('Error closing issue:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_reopenIssue(
-  github: GitHubClient,
-  context: GitHubContext,
+async function reopenIssue(
+	github: GitHubClient,
+	context: GitHubContext,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.update({
-      owner,
-      repo,
-      issue_number,
-      state: 'open',
-    });
-  } catch (error) {
-    console.error('Error reopening issue:', error);
-    throw error;
-  }
+		await github.rest.issues.update({
+			owner,
+			repo,
+			issue_number,
+			state: 'open',
+		});
+	} catch (error) {
+		console.error('Error reopening issue:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_lockIssue(
-  github: GitHubClient,
-  context: GitHubContext,
-  lockReason?: string,
+async function lockIssue(
+	github: GitHubClient,
+	context: GitHubContext,
+	lockReason?: string,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.lock({
-      owner,
-      repo,
-      issue_number,
-      lock_reason: lockReason,
-    });
-  } catch (error) {
-    console.error('Error locking issue:', error);
-    throw error;
-  }
+		await github.rest.issues.lock({
+			owner,
+			repo,
+			issue_number,
+			lock_reason: lockReason,
+		});
+	} catch (error) {
+		console.error('Error locking issue:', error);
+		throw error;
+	}
 }
 
-export async function _$gha_unlockIssue(
-  github: GitHubClient,
-  context: GitHubContext,
+async function unlockIssue(
+	github: GitHubClient,
+	context: GitHubContext,
 ): Promise<void> {
-  try {
-    const { owner, repo, issue_number } = _$gha_extractIssueContext(context);
+	try {
+		const { owner, repo, issue_number } =
+			_$gha_extractIssueContext(context);
 
-    await github.rest.issues.unlock({
-      owner,
-      repo,
-      issue_number,
-    });
-  } catch (error) {
-    console.error('Error unlocking issue:', error);
-    throw error;
-  }
+		await github.rest.issues.unlock({
+			owner,
+			repo,
+			issue_number,
+		});
+	} catch (error) {
+		console.error('Error unlocking issue:', error);
+		throw error;
+	}
 }
+
+export const issues = {
+	createComment,
+	addReaction,
+	removeLabel,
+	addLabel,
+	verifyMatrixLabel,
+	addAssignees,
+	removeAssignees,
+	closeIssue,
+	reopenIssue,
+	lockIssue,
+	unlockIssue,
+};
+
+/** @deprecated Use `gha.issues.createComment`. */
+export const _$gha_createIssueComment = createComment;
+/** @deprecated Use `gha.issues.addReaction`. */
+export const _$gha_addReaction = addReaction;
+/** @deprecated Use `gha.issues.removeLabel`. */
+export const _$gha_removeLabel = removeLabel;
+/** @deprecated Use `gha.issues.addLabel`. */
+export const _$gha_addLabel = addLabel;
+/** @deprecated Use `gha.issues.verifyMatrixLabel`. */
+export const _$gha_verifyMatrixLabel = verifyMatrixLabel;
+/** @deprecated Use `gha.issues.addAssignees`. */
+export const _$gha_addAssignees = addAssignees;
+/** @deprecated Use `gha.issues.removeAssignees`. */
+export const _$gha_removeAssignees = removeAssignees;
+/** @deprecated Use `gha.issues.closeIssue`. */
+export const _$gha_closeIssue = closeIssue;
+/** @deprecated Use `gha.issues.reopenIssue`. */
+export const _$gha_reopenIssue = reopenIssue;
+/** @deprecated Use `gha.issues.lockIssue`. */
+export const _$gha_lockIssue = lockIssue;
+/** @deprecated Use `gha.issues.unlockIssue`. */
+export const _$gha_unlockIssue = unlockIssue;

--- a/packages/npm/devops/src/lib/client/github/issues.ts
+++ b/packages/npm/devops/src/lib/client/github/issues.ts
@@ -1,8 +1,4 @@
-import {
-	GitHubClient,
-	GitHubContext,
-	_$gha_extractIssueContext,
-} from './types';
+import { GitHubClient, GitHubContext, context as ghaContext } from './types';
 
 async function createComment(
 	github: GitHubClient,
@@ -10,8 +6,7 @@ async function createComment(
 	body: string,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.createComment({
 			owner,
@@ -52,8 +47,7 @@ async function removeLabel(
 	labelName: string,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
 			owner,
@@ -81,8 +75,7 @@ async function addLabel(
 	labelName: string,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
 			owner,
@@ -109,8 +102,7 @@ async function verifyMatrixLabel(
 	context: GitHubContext,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		const { data: labels } = await github.rest.issues.listLabelsOnIssue({
 			owner,
@@ -150,8 +142,7 @@ async function addAssignees(
 	assignees: string[],
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.addAssignees({
 			owner,
@@ -171,8 +162,7 @@ async function removeAssignees(
 	assignees: string[],
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.removeAssignees({
 			owner,
@@ -193,8 +183,7 @@ async function closeIssue(
 	context: GitHubContext,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.update({
 			owner,
@@ -213,8 +202,7 @@ async function reopenIssue(
 	context: GitHubContext,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.update({
 			owner,
@@ -234,8 +222,7 @@ async function lockIssue(
 	lockReason?: string,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.lock({
 			owner,
@@ -254,8 +241,7 @@ async function unlockIssue(
 	context: GitHubContext,
 ): Promise<void> {
 	try {
-		const { owner, repo, issue_number } =
-			_$gha_extractIssueContext(context);
+		const { owner, repo, issue_number } = ghaContext.extractIssue(context);
 
 		await github.rest.issues.unlock({
 			owner,

--- a/packages/npm/devops/src/lib/client/github/pulls.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.spec.ts
@@ -1,211 +1,258 @@
-import { _$gha_formatCommits, _$gha_createOrUpdatePR } from './pulls';
-import { GitHubClient, GitHubContext, CleanedCommit, CommitCategory } from './types';
+import {
+	_$gha_formatCommits,
+	_$gha_createOrUpdatePR,
+	pulls,
+	_$gha_categorizeApiCommits,
+	_$gha_generatePRTitle,
+	_$gha_formatDevBody,
+	_$gha_getPullRequestNumber,
+	_$gha_updatePullRequestBody,
+	_$gha_fetchAndCleanCommits,
+	_$gha_processAndUpdatePR,
+} from './pulls';
+import {
+	GitHubClient,
+	GitHubContext,
+	CleanedCommit,
+	CommitCategory,
+} from './types';
 
 function mockGitHubContext(overrides?: Partial<GitHubContext>): GitHubContext {
-  return {
-    repo: { owner: 'KBVE', repo: 'kbve' },
-    issue: { number: 42 },
-    ref: 'refs/heads/feature-branch',
-    payload: {},
-    job: 'test-job',
-    ...overrides,
-  };
+	return {
+		repo: { owner: 'KBVE', repo: 'kbve' },
+		issue: { number: 42 },
+		ref: 'refs/heads/feature-branch',
+		payload: {},
+		job: 'test-job',
+		...overrides,
+	};
 }
 
 function mockGitHubClient(overrides?: Partial<GitHubClient>): GitHubClient {
-  return {
-    rest: {
-      issues: {
-        createComment: vi.fn().mockResolvedValue({}),
-        addLabels: vi.fn().mockResolvedValue({}),
-        removeLabel: vi.fn().mockResolvedValue({}),
-        listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
-        addAssignees: vi.fn().mockResolvedValue({}),
-        removeAssignees: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-        lock: vi.fn().mockResolvedValue({}),
-        unlock: vi.fn().mockResolvedValue({}),
-      },
-      pulls: {
-        list: vi.fn().mockResolvedValue({ data: [] }),
-        create: vi.fn().mockResolvedValue({}),
-        update: vi.fn().mockResolvedValue({}),
-      },
-      reactions: {
-        createForIssueComment: vi.fn().mockResolvedValue({}),
-      },
-    },
-    ...overrides,
-  };
+	return {
+		rest: {
+			issues: {
+				createComment: vi.fn().mockResolvedValue({}),
+				addLabels: vi.fn().mockResolvedValue({}),
+				removeLabel: vi.fn().mockResolvedValue({}),
+				listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
+				addAssignees: vi.fn().mockResolvedValue({}),
+				removeAssignees: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+				lock: vi.fn().mockResolvedValue({}),
+				unlock: vi.fn().mockResolvedValue({}),
+			},
+			pulls: {
+				list: vi.fn().mockResolvedValue({ data: [] }),
+				create: vi.fn().mockResolvedValue({}),
+				update: vi.fn().mockResolvedValue({}),
+			},
+			reactions: {
+				createForIssueComment: vi.fn().mockResolvedValue({}),
+			},
+		},
+		...overrides,
+	};
 }
 
 function emptyCommitCategory(): CommitCategory {
-  return {
-    ci: [],
-    fix: [],
-    docs: [],
-    feat: [],
-    merge: [],
-    perf: [],
-    build: [],
-    refactor: [],
-    revert: [],
-    style: [],
-    test: [],
-    sync: [],
-    other: [],
-  };
+	return {
+		ci: [],
+		fix: [],
+		docs: [],
+		feat: [],
+		merge: [],
+		perf: [],
+		build: [],
+		refactor: [],
+		revert: [],
+		style: [],
+		test: [],
+		sync: [],
+		other: [],
+	};
 }
 
 describe('_$gha_formatCommits', () => {
-  it('should format commits with all categories empty', () => {
-    const cleanedCommit: CleanedCommit = {
-      branch: 'main',
-      categorizedCommits: emptyCommitCategory(),
-    };
+	it('should format commits with all categories empty', () => {
+		const cleanedCommit: CleanedCommit = {
+			branch: 'main',
+			categorizedCommits: emptyCommitCategory(),
+		};
 
-    const result = _$gha_formatCommits(cleanedCommit);
+		const result = _$gha_formatCommits(cleanedCommit);
 
-    expect(result).toContain('PR Report for main');
-    expect(result).toContain('KBVE Logo');
-    expect(result).not.toContain('### CI Changes');
-    expect(result).not.toContain('### Fixes');
-  });
+		expect(result).toContain('PR Report for main');
+		expect(result).toContain('KBVE Logo');
+		expect(result).not.toContain('### CI Changes');
+		expect(result).not.toContain('### Fixes');
+	});
 
-  it('should format commits with single category populated', () => {
-    const commits = emptyCommitCategory();
-    commits.feat = ['feat(core): add new feature'];
+	it('should format commits with single category populated', () => {
+		const commits = emptyCommitCategory();
+		commits.feat = ['feat(core): add new feature'];
 
-    const cleanedCommit: CleanedCommit = {
-      branch: 'dev',
-      categorizedCommits: commits,
-    };
+		const cleanedCommit: CleanedCommit = {
+			branch: 'dev',
+			categorizedCommits: commits,
+		};
 
-    const result = _$gha_formatCommits(cleanedCommit);
+		const result = _$gha_formatCommits(cleanedCommit);
 
-    expect(result).toContain('PR Report for dev');
-    expect(result).toContain('### Features:');
-    expect(result).toContain('feat(core): add new feature');
-  });
+		expect(result).toContain('PR Report for dev');
+		expect(result).toContain('### Features:');
+		expect(result).toContain('feat(core): add new feature');
+	});
 
-  it('should format commits with multiple categories', () => {
-    const commits = emptyCommitCategory();
-    commits.feat = ['feat(core): add feature'];
-    commits.fix = ['fix(ui): fix button', 'fix(api): fix endpoint'];
-    commits.ci = ['ci(actions): update workflow'];
+	it('should format commits with multiple categories', () => {
+		const commits = emptyCommitCategory();
+		commits.feat = ['feat(core): add feature'];
+		commits.fix = ['fix(ui): fix button', 'fix(api): fix endpoint'];
+		commits.ci = ['ci(actions): update workflow'];
 
-    const cleanedCommit: CleanedCommit = {
-      branch: 'release',
-      categorizedCommits: commits,
-    };
+		const cleanedCommit: CleanedCommit = {
+			branch: 'release',
+			categorizedCommits: commits,
+		};
 
-    const result = _$gha_formatCommits(cleanedCommit);
+		const result = _$gha_formatCommits(cleanedCommit);
 
-    expect(result).toContain('### Features:');
-    expect(result).toContain('### Fixes:');
-    expect(result).toContain('### CI Changes:');
-    expect(result).toContain('fix(ui): fix button');
-    expect(result).toContain('fix(api): fix endpoint');
-  });
+		expect(result).toContain('### Features:');
+		expect(result).toContain('### Fixes:');
+		expect(result).toContain('### CI Changes:');
+		expect(result).toContain('fix(ui): fix button');
+		expect(result).toContain('fix(api): fix endpoint');
+	});
 
-  it('should include footer with docs link', () => {
-    const cleanedCommit: CleanedCommit = {
-      branch: 'main',
-      categorizedCommits: emptyCommitCategory(),
-    };
+	it('should include footer with docs link', () => {
+		const cleanedCommit: CleanedCommit = {
+			branch: 'main',
+			categorizedCommits: emptyCommitCategory(),
+		};
 
-    const result = _$gha_formatCommits(cleanedCommit);
+		const result = _$gha_formatCommits(cleanedCommit);
 
-    expect(result).toContain('welcome-to-docs');
-  });
+		expect(result).toContain('welcome-to-docs');
+	});
 });
 
 describe('_$gha_createOrUpdatePR', () => {
-  it('should create a new PR when none exists', async () => {
-    const github = mockGitHubClient({
-      ref: 'refs/heads/feature-branch',
-    });
-    (github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [] });
-    const context = mockGitHubContext();
+	it('should create a new PR when none exists', async () => {
+		const github = mockGitHubClient({
+			ref: 'refs/heads/feature-branch',
+		});
+		(github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+			data: [],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_createOrUpdatePR(github, context, 'main');
+		await _$gha_createOrUpdatePR(github, context, 'main');
 
-    expect(github.rest.pulls.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        head: 'feature-branch',
-        base: 'main',
-        owner: 'KBVE',
-        repo: 'kbve',
-      }),
-    );
-  });
+		expect(github.rest.pulls.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				head: 'feature-branch',
+				base: 'main',
+				owner: 'KBVE',
+				repo: 'kbve',
+			}),
+		);
+	});
 
-  it('should add comment when PR already exists', async () => {
-    const github = mockGitHubClient({
-      ref: 'refs/heads/feature-branch',
-    });
-    (github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ number: 99 }],
-    });
-    const context = mockGitHubContext();
+	it('should add comment when PR already exists', async () => {
+		const github = mockGitHubClient({
+			ref: 'refs/heads/feature-branch',
+		});
+		(github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+			data: [{ number: 99 }],
+		});
+		const context = mockGitHubContext();
 
-    await _$gha_createOrUpdatePR(github, context, 'main');
+		await _$gha_createOrUpdatePR(github, context, 'main');
 
-    expect(github.rest.pulls.create).not.toHaveBeenCalled();
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        issue_number: 99,
-        body: expect.stringContaining('Updated by Job'),
-      }),
-    );
-  });
+		expect(github.rest.pulls.create).not.toHaveBeenCalled();
+		expect(github.rest.issues.createComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				issue_number: 99,
+				body: expect.stringContaining('Updated by Job'),
+			}),
+		);
+	});
 
-  it('should use context.payload.pull_request.head.ref when github.ref is not available', async () => {
-    const github = mockGitHubClient();
-    // No github.ref
-    (github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [] });
-    const context = mockGitHubContext({
-      payload: {
-        pull_request: {
-          head: { ref: 'pr-branch' },
-        },
-      },
-    });
+	it('should use context.payload.pull_request.head.ref when github.ref is not available', async () => {
+		const github = mockGitHubClient();
+		// No github.ref
+		(github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+			data: [],
+		});
+		const context = mockGitHubContext({
+			payload: {
+				pull_request: {
+					head: { ref: 'pr-branch' },
+				},
+			},
+		});
 
-    await _$gha_createOrUpdatePR(github, context, 'main');
+		await _$gha_createOrUpdatePR(github, context, 'main');
 
-    expect(github.rest.pulls.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        head: 'pr-branch',
-      }),
-    );
-  });
+		expect(github.rest.pulls.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				head: 'pr-branch',
+			}),
+		);
+	});
 
-  it('should fall back to context.ref when github.ref and payload are unavailable', async () => {
-    const github = mockGitHubClient();
-    (github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [] });
-    const context = mockGitHubContext({
-      ref: 'refs/heads/fallback-branch',
-    });
+	it('should fall back to context.ref when github.ref and payload are unavailable', async () => {
+		const github = mockGitHubClient();
+		(github.rest.pulls.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+			data: [],
+		});
+		const context = mockGitHubContext({
+			ref: 'refs/heads/fallback-branch',
+		});
 
-    await _$gha_createOrUpdatePR(github, context, 'main');
+		await _$gha_createOrUpdatePR(github, context, 'main');
 
-    expect(github.rest.pulls.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        head: 'fallback-branch',
-      }),
-    );
-  });
+		expect(github.rest.pulls.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				head: 'fallback-branch',
+			}),
+		);
+	});
 
-  it('should throw when no branch can be determined', async () => {
-    const github = mockGitHubClient();
-    const context = mockGitHubContext({
-      ref: '',
-    });
+	it('should throw when no branch can be determined', async () => {
+		const github = mockGitHubClient();
+		const context = mockGitHubContext({
+			ref: '',
+		});
 
-    // context.ref is empty string, github.ref is undefined, no payload
-    await expect(
-      _$gha_createOrUpdatePR(github, context, 'main'),
-    ).rejects.toThrow();
-  });
+		// context.ref is empty string, github.ref is undefined, no payload
+		await expect(
+			_$gha_createOrUpdatePR(github, context, 'main'),
+		).rejects.toThrow();
+	});
+});
+
+describe('gha.pulls group (v0.0.22)', () => {
+	it('group members match their _$gha_ aliases', () => {
+		expect(pulls.formatCommits).toBe(_$gha_formatCommits);
+		expect(pulls.createOrUpdatePR).toBe(_$gha_createOrUpdatePR);
+		expect(pulls.generatePRTitle).toBe(_$gha_generatePRTitle);
+	});
+	it('exposes all 9 members as functions', () => {
+		const names = [
+			'formatCommits',
+			'categorizeApiCommits',
+			'generatePRTitle',
+			'formatDevBody',
+			'getPullRequestNumber',
+			'updatePullRequestBody',
+			'fetchAndCleanCommits',
+			'processAndUpdatePR',
+			'createOrUpdatePR',
+		];
+		for (const n of names)
+			expect(typeof (pulls as Record<string, unknown>)[n]).toBe(
+				'function',
+			);
+	});
 });

--- a/packages/npm/devops/src/lib/client/github/pulls.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.ts
@@ -12,7 +12,7 @@ import { context as ghaContext, COMMIT_CATEGORY_LABELS } from './types';
 
 const execAsync = promisify(exec);
 
-export async function getPullRequestNumber(
+async function getPullRequestNumber(
 	github: GitHubClient,
 	context: GitHubContext,
 ): Promise<number> {
@@ -44,7 +44,7 @@ export async function getPullRequestNumber(
 	}
 }
 
-export async function updatePullRequestBody(
+async function updatePullRequestBody(
 	github: GitHubClient,
 	context: GitHubContext,
 	prBody: string,
@@ -65,7 +65,7 @@ export async function updatePullRequestBody(
 	}
 }
 
-export async function fetchAndCleanCommits(
+async function fetchAndCleanCommits(
 	branchToCompare: string,
 ): Promise<CleanedCommit> {
 	await execAsync(`git fetch origin ${branchToCompare}`);
@@ -125,7 +125,7 @@ export async function fetchAndCleanCommits(
 	};
 }
 
-export function formatCommits(cleanedCommit: CleanedCommit): string {
+function formatCommits(cleanedCommit: CleanedCommit): string {
 	const { branch, categorizedCommits } = cleanedCommit;
 
 	const logo_markdown = `[![KBVE Logo](https://kbve.com/assets/img/letter_logo.png)](https://kbve.com)\
@@ -177,7 +177,7 @@ export function formatCommits(cleanedCommit: CleanedCommit): string {
 	return commitSummary;
 }
 
-export async function processAndUpdatePR(
+async function processAndUpdatePR(
 	branchToCompare: string,
 	github: GitHubClient,
 	context: GitHubContext,
@@ -192,7 +192,7 @@ export async function processAndUpdatePR(
 	}
 }
 
-export async function createOrUpdatePR(
+async function createOrUpdatePR(
 	github: GitHubClient,
 	context: GitHubContext,
 	targetBranch: string,
@@ -280,7 +280,7 @@ export async function createOrUpdatePR(
  * Categorize an array of commits from the GitHub API by conventional
  * commit type. Scope is optional — matches both `fix(scope):` and `fix:`.
  */
-export function categorizeApiCommits(commits: ApiCommit[]): CategorizedResult {
+function categorizeApiCommits(commits: ApiCommit[]): CategorizedResult {
 	const keys = Object.keys(
 		COMMIT_CATEGORY_LABELS,
 	) as (keyof CommitCategory)[];
@@ -318,10 +318,7 @@ export function categorizeApiCommits(commits: ApiCommit[]): CategorizedResult {
  * Generate a descriptive PR title summarizing what changed.
  * e.g. "Release: 3 features, 1 fix, 2 CI → Staging"
  */
-export function generatePRTitle(
-	categories: CommitCategory,
-	target: string,
-): string {
+function generatePRTitle(categories: CommitCategory, target: string): string {
 	const titleLabels: Partial<Record<keyof CommitCategory, string>> = {
 		feat: 'feature',
 		fix: 'fix',
@@ -361,7 +358,7 @@ export function generatePRTitle(
 /**
  * Format a PR body for dev→main promotions.
  */
-export function formatDevBody(
+function formatDevBody(
 	categories: CommitCategory,
 	totalCommits: number,
 ): string {

--- a/packages/npm/devops/src/lib/client/github/pulls.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.ts
@@ -8,16 +8,19 @@ import type {
 	ApiCommit,
 	CategorizedResult,
 } from './types';
-import { _$gha_extractRepoContext, COMMIT_CATEGORY_LABELS } from './types';
+import {
+	_$gha_extractRepoContext as extractRepoContext,
+	COMMIT_CATEGORY_LABELS,
+} from './types';
 
 const execAsync = promisify(exec);
 
-export async function _$gha_getPullRequestNumber(
+export async function getPullRequestNumber(
 	github: GitHubClient,
 	context: GitHubContext,
 ): Promise<number> {
 	try {
-		const { owner, repo } = _$gha_extractRepoContext(context);
+		const { owner, repo } = extractRepoContext(context);
 		let branch: string;
 
 		if (context.ref.startsWith('refs/pull/')) {
@@ -44,14 +47,14 @@ export async function _$gha_getPullRequestNumber(
 	}
 }
 
-export async function _$gha_updatePullRequestBody(
+export async function updatePullRequestBody(
 	github: GitHubClient,
 	context: GitHubContext,
 	prBody: string,
 ): Promise<void> {
 	try {
-		const { owner, repo } = _$gha_extractRepoContext(context);
-		const prNumber = await _$gha_getPullRequestNumber(github, context);
+		const { owner, repo } = extractRepoContext(context);
+		const prNumber = await getPullRequestNumber(github, context);
 		await github.rest.pulls.update({
 			owner,
 			repo,
@@ -65,7 +68,7 @@ export async function _$gha_updatePullRequestBody(
 	}
 }
 
-export async function _$gha_fetchAndCleanCommits(
+export async function fetchAndCleanCommits(
 	branchToCompare: string,
 ): Promise<CleanedCommit> {
 	await execAsync(`git fetch origin ${branchToCompare}`);
@@ -125,7 +128,7 @@ export async function _$gha_fetchAndCleanCommits(
 	};
 }
 
-export function _$gha_formatCommits(cleanedCommit: CleanedCommit): string {
+export function formatCommits(cleanedCommit: CleanedCommit): string {
 	const { branch, categorizedCommits } = cleanedCommit;
 
 	const logo_markdown = `[![KBVE Logo](https://kbve.com/assets/img/letter_logo.png)](https://kbve.com)\
@@ -177,28 +180,28 @@ export function _$gha_formatCommits(cleanedCommit: CleanedCommit): string {
 	return commitSummary;
 }
 
-export async function _$gha_processAndUpdatePR(
+export async function processAndUpdatePR(
 	branchToCompare: string,
 	github: GitHubClient,
 	context: GitHubContext,
 ): Promise<void> {
 	try {
-		const cleanedCommit = await _$gha_fetchAndCleanCommits(branchToCompare);
-		const commitSummary = _$gha_formatCommits(cleanedCommit);
-		await _$gha_updatePullRequestBody(github, context, commitSummary);
+		const cleanedCommit = await fetchAndCleanCommits(branchToCompare);
+		const commitSummary = formatCommits(cleanedCommit);
+		await updatePullRequestBody(github, context, commitSummary);
 	} catch (error) {
 		console.error('Error processing and updating PR:', error);
 		throw error;
 	}
 }
 
-export async function _$gha_createOrUpdatePR(
+export async function createOrUpdatePR(
 	github: GitHubClient,
 	context: GitHubContext,
 	targetBranch: string,
 ): Promise<void> {
 	try {
-		const { owner, repo } = _$gha_extractRepoContext(context);
+		const { owner, repo } = extractRepoContext(context);
 
 		let referenceBranch: string | null = null;
 
@@ -280,9 +283,7 @@ export async function _$gha_createOrUpdatePR(
  * Categorize an array of commits from the GitHub API by conventional
  * commit type. Scope is optional — matches both `fix(scope):` and `fix:`.
  */
-export function _$gha_categorizeApiCommits(
-	commits: ApiCommit[],
-): CategorizedResult {
+export function categorizeApiCommits(commits: ApiCommit[]): CategorizedResult {
 	const keys = Object.keys(
 		COMMIT_CATEGORY_LABELS,
 	) as (keyof CommitCategory)[];
@@ -320,7 +321,7 @@ export function _$gha_categorizeApiCommits(
  * Generate a descriptive PR title summarizing what changed.
  * e.g. "Release: 3 features, 1 fix, 2 CI → Staging"
  */
-export function _$gha_generatePRTitle(
+export function generatePRTitle(
 	categories: CommitCategory,
 	target: string,
 ): string {
@@ -363,7 +364,7 @@ export function _$gha_generatePRTitle(
 /**
  * Format a PR body for dev→main promotions.
  */
-export function _$gha_formatDevBody(
+export function formatDevBody(
 	categories: CommitCategory,
 	totalCommits: number,
 ): string {
@@ -381,3 +382,34 @@ export function _$gha_formatDevBody(
 	body += `---\n*This PR is automatically maintained by CI — [KBVE Studio](https://kbve.com)*`;
 	return body;
 }
+
+export const pulls = {
+	formatCommits,
+	categorizeApiCommits,
+	generatePRTitle,
+	formatDevBody,
+	getPullRequestNumber,
+	updatePullRequestBody,
+	fetchAndCleanCommits,
+	processAndUpdatePR,
+	createOrUpdatePR,
+};
+
+/** @deprecated Use `gha.pulls.formatCommits`. */
+export const _$gha_formatCommits = formatCommits;
+/** @deprecated Use `gha.pulls.categorizeApiCommits`. */
+export const _$gha_categorizeApiCommits = categorizeApiCommits;
+/** @deprecated Use `gha.pulls.generatePRTitle`. */
+export const _$gha_generatePRTitle = generatePRTitle;
+/** @deprecated Use `gha.pulls.formatDevBody`. */
+export const _$gha_formatDevBody = formatDevBody;
+/** @deprecated Use `gha.pulls.getPullRequestNumber`. */
+export const _$gha_getPullRequestNumber = getPullRequestNumber;
+/** @deprecated Use `gha.pulls.updatePullRequestBody`. */
+export const _$gha_updatePullRequestBody = updatePullRequestBody;
+/** @deprecated Use `gha.pulls.fetchAndCleanCommits`. */
+export const _$gha_fetchAndCleanCommits = fetchAndCleanCommits;
+/** @deprecated Use `gha.pulls.processAndUpdatePR`. */
+export const _$gha_processAndUpdatePR = processAndUpdatePR;
+/** @deprecated Use `gha.pulls.createOrUpdatePR`. */
+export const _$gha_createOrUpdatePR = createOrUpdatePR;

--- a/packages/npm/devops/src/lib/client/github/pulls.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.ts
@@ -8,10 +8,7 @@ import type {
 	ApiCommit,
 	CategorizedResult,
 } from './types';
-import {
-	_$gha_extractRepoContext as extractRepoContext,
-	COMMIT_CATEGORY_LABELS,
-} from './types';
+import { context as ghaContext, COMMIT_CATEGORY_LABELS } from './types';
 
 const execAsync = promisify(exec);
 
@@ -20,7 +17,7 @@ export async function getPullRequestNumber(
 	context: GitHubContext,
 ): Promise<number> {
 	try {
-		const { owner, repo } = extractRepoContext(context);
+		const { owner, repo } = ghaContext.extractRepo(context);
 		let branch: string;
 
 		if (context.ref.startsWith('refs/pull/')) {
@@ -53,7 +50,7 @@ export async function updatePullRequestBody(
 	prBody: string,
 ): Promise<void> {
 	try {
-		const { owner, repo } = extractRepoContext(context);
+		const { owner, repo } = ghaContext.extractRepo(context);
 		const prNumber = await getPullRequestNumber(github, context);
 		await github.rest.pulls.update({
 			owner,
@@ -201,7 +198,7 @@ export async function createOrUpdatePR(
 	targetBranch: string,
 ): Promise<void> {
 	try {
-		const { owner, repo } = extractRepoContext(context);
+		const { owner, repo } = ghaContext.extractRepo(context);
 
 		let referenceBranch: string | null = null;
 

--- a/packages/npm/devops/src/lib/client/github/types.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/types.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import {
+	context,
+	_$gha_extractIssueContext,
+	_$gha_extractRepoContext,
+} from './types';
+
+describe('gha.context group (v0.0.22)', () => {
+	it('members match aliases', () => {
+		expect(context.extractIssue).toBe(_$gha_extractIssueContext);
+		expect(context.extractRepo).toBe(_$gha_extractRepoContext);
+	});
+});

--- a/packages/npm/devops/src/lib/client/github/types.ts
+++ b/packages/npm/devops/src/lib/client/github/types.ts
@@ -1,150 +1,165 @@
-import type { CommitCategory, CleanedCommit, ApiCommit, CategorizedResult } from '../../../types';
+import type {
+	CommitCategory,
+	CleanedCommit,
+	ApiCommit,
+	CategorizedResult,
+} from '../../../types';
 
 // --- Minimal GitHub REST API Client Interface ---
 // Typed to match actual usage (Octokit from actions/github-script@v7)
 // without pulling in @octokit/rest as a dependency.
 
 export interface GitHubIssuesApi {
-  createComment(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    body: string;
-  }): Promise<unknown>;
-  addLabels(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    labels: string[];
-  }): Promise<unknown>;
-  removeLabel(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    name: string;
-  }): Promise<unknown>;
-  listLabelsOnIssue(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-  }): Promise<{ data: { name: string }[] }>;
-  addAssignees(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    assignees: string[];
-  }): Promise<unknown>;
-  removeAssignees(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    assignees: string[];
-  }): Promise<unknown>;
-  update(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    state?: string;
-  }): Promise<unknown>;
-  lock(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-    lock_reason?: string;
-  }): Promise<unknown>;
-  unlock(params: {
-    owner: string;
-    repo: string;
-    issue_number: number;
-  }): Promise<unknown>;
+	createComment(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		body: string;
+	}): Promise<unknown>;
+	addLabels(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		labels: string[];
+	}): Promise<unknown>;
+	removeLabel(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		name: string;
+	}): Promise<unknown>;
+	listLabelsOnIssue(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+	}): Promise<{ data: { name: string }[] }>;
+	addAssignees(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		assignees: string[];
+	}): Promise<unknown>;
+	removeAssignees(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		assignees: string[];
+	}): Promise<unknown>;
+	update(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		state?: string;
+	}): Promise<unknown>;
+	lock(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+		lock_reason?: string;
+	}): Promise<unknown>;
+	unlock(params: {
+		owner: string;
+		repo: string;
+		issue_number: number;
+	}): Promise<unknown>;
 }
 
 export interface GitHubPullsApi {
-  list(params: {
-    owner: string;
-    repo: string;
-    head: string;
-    base?: string;
-    state?: string;
-  }): Promise<{ data: { number: number; head: { ref: string } }[] }>;
-  create(params: {
-    title: string;
-    owner: string;
-    repo: string;
-    head: string;
-    base: string;
-    body: string;
-  }): Promise<unknown>;
-  update(params: {
-    owner: string;
-    repo: string;
-    pull_number: number;
-    body: string;
-  }): Promise<unknown>;
+	list(params: {
+		owner: string;
+		repo: string;
+		head: string;
+		base?: string;
+		state?: string;
+	}): Promise<{ data: { number: number; head: { ref: string } }[] }>;
+	create(params: {
+		title: string;
+		owner: string;
+		repo: string;
+		head: string;
+		base: string;
+		body: string;
+	}): Promise<unknown>;
+	update(params: {
+		owner: string;
+		repo: string;
+		pull_number: number;
+		body: string;
+	}): Promise<unknown>;
 }
 
 export interface GitHubReactionsApi {
-  createForIssueComment(params: {
-    owner: string;
-    repo: string;
-    comment_id: number;
-    content: string;
-  }): Promise<unknown>;
+	createForIssueComment(params: {
+		owner: string;
+		repo: string;
+		comment_id: number;
+		content: string;
+	}): Promise<unknown>;
 }
 
 export interface GitHubClient {
-  rest: {
-    issues: GitHubIssuesApi;
-    pulls: GitHubPullsApi;
-    reactions: GitHubReactionsApi;
-  };
-  ref?: string;
-  event_name?: string;
+	rest: {
+		issues: GitHubIssuesApi;
+		pulls: GitHubPullsApi;
+		reactions: GitHubReactionsApi;
+	};
+	ref?: string;
+	event_name?: string;
 }
 
 export interface GitHubContext {
-  repo: {
-    owner: string;
-    repo: string;
-  };
-  issue: {
-    number: number;
-  };
-  ref: string;
-  payload: {
-    pull_request?: {
-      head: {
-        ref: string;
-      };
-    };
-  };
-  job: string;
+	repo: {
+		owner: string;
+		repo: string;
+	};
+	issue: {
+		number: number;
+	};
+	ref: string;
+	payload: {
+		pull_request?: {
+			head: {
+				ref: string;
+			};
+		};
+	};
+	job: string;
 }
 
 export interface GitHubRepoInfo {
-  owner: string;
-  repo: string;
+	owner: string;
+	repo: string;
 }
 
 export interface GitHubIssueInfo extends GitHubRepoInfo {
-  issue_number: number;
+	issue_number: number;
 }
 
 export interface GithubActionReferenceMap {
-  keyword: string;
-  action: string;
+	keyword: string;
+	action: string;
 }
 
-export function _$gha_extractIssueContext(context: GitHubContext): GitHubIssueInfo {
-  const { repo, owner } = context.repo;
-  const issue_number = context.issue.number;
-  return { owner, repo, issue_number };
+function extractIssue(context: GitHubContext): GitHubIssueInfo {
+	const { repo, owner } = context.repo;
+	const issue_number = context.issue.number;
+	return { owner, repo, issue_number };
 }
 
-export function _$gha_extractRepoContext(context: GitHubContext): GitHubRepoInfo {
-  const { repo, owner } = context.repo;
-  return { owner, repo };
+function extractRepo(context: GitHubContext): GitHubRepoInfo {
+	const { repo, owner } = context.repo;
+	return { owner, repo };
 }
+
+export const context = {
+	extractIssue,
+	extractRepo,
+};
+
+/** @deprecated Use `gha.context.extractIssue`. */
+export const _$gha_extractIssueContext = extractIssue;
+/** @deprecated Use `gha.context.extractRepo`. */
+export const _$gha_extractRepoContext = extractRepo;
 
 export type { CommitCategory, CleanedCommit, ApiCommit, CategorizedResult };
 export { COMMIT_CATEGORY_LABELS } from '../../../types';


### PR DESCRIPTION
## @kbve/devops v0.0.22 — `gha` grouped namespace (additive, retire `_$gha_*` prefix)

Replaces the flat `_$gha_*` GitHub-helper surface (33 exports) with one clean `gha` grouped namespace. Fully additive/non-breaking: every `_$gha_*` name stays as a `@deprecated` alias; top-level `ci` unchanged. Built via subagent-driven TDD, each task individually reviewed + a whole-branch opus review.

### New API
```ts
import { gha } from '@kbve/devops';
gha.ci.*        // === existing `ci` (parseFailureLog, classifyAll, …), also still top-level
gha.issues.*    // createComment, addReaction, addLabel, removeLabel, verifyMatrixLabel,
                //   addAssignees, removeAssignees, closeIssue, reopenIssue, lockIssue, unlockIssue
gha.actions.*   // findActionInTitle, kbveActionProcess, findActionInTitleSafe
gha.pulls.*     // formatCommits, categorizeApiCommits, generatePRTitle, formatDevBody,
                //   getPullRequestNumber, updatePullRequestBody, fetchAndCleanCommits,
                //   processAndUpdatePR, createOrUpdatePR
gha.docker.*    // runContainer, stopContainer
gha.context.*   // extractIssue, extractRepo
gha.withRetry   // === withGitHubRetry
```

### Changes
- Each of `issues`/`pulls`/`actions`/`docker`/`types` renamed its `_$gha_*` functions to clean names, exposed via a module group object, kept every `_$gha_*` as a `@deprecated` alias (the ci-failure precedent).
- New `gha.ts` aggregator wired into the package entrypoint; `gha.ci === ci` (identity, not copy). This also makes `issues`/`pulls`/`docker`/`context` reachable from the package root for the first time.
- Internal cross-module callers migrated off the deprecated aliases onto group members (so the future alias-removal won't break internal code). Only the `export const _$gha_X = X;` alias definition lines reference the prefix now.

### Release
- `devops.mdx` 0.0.21 → 0.0.22; manifest regenerated (devops-only). `version.toml` untouched.

### Verification
- 280/280 tests green (reference-identity assertions, not truthiness); `nx build devops` passes (exports resolve, no circular imports).

### Follow-ups
- A future minor removes the `_$gha_*` aliases once consumers migrate to `gha.*`.
- **Deferred PR B**: wire the CI failure-tracker workflow to import `gha.ci.*` on `@latest` — held until 0.0.21 + 0.0.22 are confirmed on npm.

Spec: `docs/superpowers/specs/2026-07-02-devops-0022-gha-namespace-design.md`
Plan: `docs/superpowers/plans/2026-07-02-devops-0022-gha-namespace.md`
