### PR TITLE
fix(arpg-web): anchor ambient dust to world space

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -2,10 +2,10 @@ import Phaser from 'phaser';
 import {
 	GameClient,
 	PROTOCOL_VERSION,
-	createDustMoteLayer,
+	createWorldDustLayer,
 	drawHealthBar,
 	drawHealthBarCached,
-	type GpuSpriteLayerHandle,
+	type WorldDustHandle,
 	type EntityDelta,
 	type KindEntry,
 	type Snapshot,
@@ -244,7 +244,7 @@ const LEAVING_HANDOFF_MS =
 
 export class IsoArpgScene extends Phaser.Scene {
 	private client: GameClient | null = null;
-	private dustLayer: GpuSpriteLayerHandle | null = null;
+	private dustLayer: WorldDustHandle | null = null;
 	private store = new EntityStore<EntityRefs>();
 	private kindRegistry = new Map<number, KindEntry>();
 	private kinds!: KindResolvers;
@@ -475,15 +475,18 @@ export class IsoArpgScene extends Phaser.Scene {
 		registerShipAnims(this);
 
 		this.drawGrid();
-		this.dustLayer = createDustMoteLayer(this, {
-			count: 500,
-			width: this.cameras.main.width,
-			height: this.cameras.main.height,
+		this.dustLayer = createWorldDustLayer(this, {
+			count: 2000,
+			tileWidth: Math.ceil(
+				this.cameras.main.width / IsoArpgScene.ZOOM_MIN,
+			),
+			tileHeight: Math.ceil(
+				this.cameras.main.height / IsoArpgScene.ZOOM_MIN,
+			),
 			depth: DEPTH_ENTITY_BASE - 1,
 			color: 0xbfcad6,
 			radius: 2,
 			alpha: 0.4,
-			scrollFactor: 0,
 		});
 		if (USE_GROUND_SHADER) {
 			this.ground = makeGroundShader(this);
@@ -1912,6 +1915,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		tickPlayerInterpV(this, this.store, this.myEid);
 		tickFacingV(this, this.store);
 		this.tickZoom(delta);
+		this.dustLayer?.update(this.cameras.main);
 		this.ground?.update(this.cameras.main);
 		this.residency.tick((id) => {
 			if (!id.startsWith('creature:')) return;

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -48,8 +48,16 @@ export type {
 	GpuSpriteLayerOptions,
 	GpuSpriteLayerHandle,
 } from './lib/phaser/gpu-sprite-layer';
-export { createDustMoteLayer, dustMemberAt } from './lib/phaser/ambient-dust';
-export type { DustMoteOptions } from './lib/phaser/ambient-dust';
+export {
+	createDustMoteLayer,
+	createWorldDustLayer,
+	dustMemberAt,
+} from './lib/phaser/ambient-dust';
+export type {
+	DustMoteOptions,
+	WorldDustHandle,
+	WorldDustOptions,
+} from './lib/phaser/ambient-dust';
 export { GameObjectPool } from './lib/phaser/object-pool';
 export { setupKeyboardMap } from './lib/phaser/keyboard-map';
 export type { KeyboardMap } from './lib/phaser/keyboard-map';

--- a/packages/npm/laser/src/lib/phaser/ambient-dust.spec.ts
+++ b/packages/npm/laser/src/lib/phaser/ambient-dust.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { dustMemberAt, createDustMoteLayer } from './ambient-dust';
+import {
+	dustMemberAt,
+	createDustMoteLayer,
+	createWorldDustLayer,
+} from './ambient-dust';
 
 vi.mock('phaser', () => ({
 	default: { WEBGL: 2, CANVAS: 1 },
@@ -59,6 +63,7 @@ describe('dustMemberAt', () => {
 function makeScene(rendererType: number) {
 	const layer = {
 		setDepth: vi.fn().mockReturnThis(),
+		editMember: vi.fn().mockReturnThis(),
 		setAlpha: vi.fn().mockReturnThis(),
 		setBlendMode: vi.fn().mockReturnThis(),
 		setVisible: vi.fn().mockReturnThis(),
@@ -110,5 +115,60 @@ describe('createDustMoteLayer', () => {
 		expect(gfx.destroy).toHaveBeenCalledTimes(1);
 		expect(layer.addMember).toHaveBeenCalledTimes(50);
 		expect(layer.setDepth).toHaveBeenCalledWith(-5);
+	});
+});
+
+describe('createWorldDustLayer', () => {
+	it('returns null on Canvas', () => {
+		const { scene } = makeScene(1);
+		const handle = createWorldDustLayer(scene as never, {
+			count: 10,
+			tileWidth: 200,
+			tileHeight: 100,
+		});
+		expect(handle).toBeNull();
+	});
+
+	it('duplicates each mote across a 2x2 tile grid', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createWorldDustLayer(
+			scene as never,
+			{ count: 3, tileWidth: 200, tileHeight: 100 },
+			() => 0.5,
+		);
+		expect(handle).not.toBeNull();
+		expect(layer.addMember).toHaveBeenCalledTimes(12);
+		const xs = layer.addMember.mock.calls.map(
+			(c) => (c[0] as { x: number }).x,
+		);
+		expect(xs).toContain(100);
+		expect(xs).toContain(300);
+		const ys = layer.addMember.mock.calls.map(
+			(c) => (c[0] as { y: { base: number } }).y.base,
+		);
+		expect(ys).toContain(50);
+		expect(ys).toContain(150);
+	});
+
+	it('re-bases members only when the camera crosses a tile boundary', () => {
+		const { scene, layer } = makeScene(2);
+		const handle = createWorldDustLayer(
+			scene as never,
+			{ count: 2, tileWidth: 200, tileHeight: 100 },
+			() => 0.5,
+		);
+		const cam = (x: number, y: number) =>
+			({ worldView: { x, y } }) as never;
+		handle?.update(cam(50, 20));
+		expect(layer.editMember).not.toHaveBeenCalled();
+		handle?.update(cam(250, 20));
+		expect(layer.editMember).toHaveBeenCalledTimes(8);
+		const edited = layer.editMember.mock.calls.map(
+			(c) => (c[1] as { x: number }).x,
+		);
+		expect(Math.min(...edited)).toBe(300);
+		layer.editMember.mockClear();
+		handle?.update(cam(260, 30));
+		expect(layer.editMember).not.toHaveBeenCalled();
 	});
 });

--- a/packages/npm/laser/src/lib/phaser/ambient-dust.ts
+++ b/packages/npm/laser/src/lib/phaser/ambient-dust.ts
@@ -102,3 +102,98 @@ export function createDustMoteLayer(
 
 	return handle;
 }
+
+export interface WorldDustOptions {
+	count: number;
+	tileWidth: number;
+	tileHeight: number;
+	depth?: number;
+	color?: number;
+	radius?: number;
+	alpha?: number;
+	blendMode?: number;
+	textureKey?: string;
+}
+
+export interface WorldDustHandle {
+	readonly layer: Phaser.GameObjects.SpriteGPULayer;
+	update(camera: Phaser.Cameras.Scene2D.Camera): void;
+	dispose(): void;
+}
+
+const TILE_OFFSETS = [
+	[0, 0],
+	[1, 0],
+	[0, 1],
+	[1, 1],
+] as const;
+
+type DustMember = Partial<Phaser.Types.GameObjects.SpriteGPULayer.Member>;
+
+function offsetMember(member: DustMember, ox: number, oy: number): DustMember {
+	const y = member.y as { base: number };
+	return {
+		...member,
+		x: (member.x as number) + ox,
+		y: { ...y, base: y.base + oy },
+	};
+}
+
+export function createWorldDustLayer(
+	scene: Phaser.Scene,
+	opts: WorldDustOptions,
+	rand: Rand = Math.random,
+): WorldDustHandle | null {
+	if (scene.renderer.type !== Phaser.WEBGL) {
+		return null;
+	}
+
+	const key = opts.textureKey ?? 'laser-dust-mote';
+	const radius = opts.radius ?? 2;
+	ensureDotTexture(scene, key, radius, opts.color ?? 0xffffff);
+
+	const handle = createGpuSpriteLayer(scene, key, {
+		size: opts.count * TILE_OFFSETS.length,
+		depth: opts.depth,
+		alpha: opts.alpha,
+		blendMode: opts.blendMode,
+	});
+	if (!handle) return null;
+
+	const { tileWidth, tileHeight, count } = opts;
+	const members: DustMember[] = [];
+	for (let i = 0; i < count; i++) {
+		const base = dustMemberAt(
+			i,
+			{ width: tileWidth, height: tileHeight, count },
+			rand,
+		);
+		for (const [dx, dy] of TILE_OFFSETS) {
+			members.push(offsetMember(base, dx * tileWidth, dy * tileHeight));
+		}
+	}
+	for (const member of members) handle.layer.addMember(member);
+
+	let tileX = 0;
+	let tileY = 0;
+
+	return {
+		layer: handle.layer,
+		update(camera) {
+			const view = camera.worldView;
+			const tx = Math.floor(view.x / tileWidth);
+			const ty = Math.floor(view.y / tileHeight);
+			if (tx === tileX && ty === tileY) return;
+			tileX = tx;
+			tileY = ty;
+			const ox = tx * tileWidth;
+			const oy = ty * tileHeight;
+			for (let i = 0; i < members.length; i++) {
+				handle.layer.editMember(i, offsetMember(members[i], ox, oy));
+			}
+		},
+		dispose() {
+			handle.dispose();
+		},
+	};
+}


### PR DESCRIPTION
## Why

The ambient dust/snow effect on the web ARPG was created with `scrollFactor: 0` in a viewport-sized field, so the entire particle field was glued to the screen and moved with the camera — it looked like the dust was riding the frame instead of existing in the world.

## What

- New `createWorldDustLayer` in `@kbve/laser` (`ambient-dust.ts`): motes are placed in world space inside one random tile, duplicated across a 2x2 tile grid. When the camera crosses a tile boundary, all members are re-based to the new tile origin via `editMember`. Since the pattern is periodic with the tile size, the re-base maps visible motes onto identical copies — no visible pop, and it only touches the buffer on boundary crossings, not per frame.
- `IsoArpgScene` now uses the world layer with tile dimensions sized to the largest visible world area (`viewport / ZOOM_MIN`) and calls `dustLayer.update(camera)` in `update()`. Count raised 500 → 2000 per tile to preserve on-screen density (tile is 4 viewport-areas at zoom 1).
- Old screen-space `createDustMoteLayer` kept unchanged for other consumers.

## Verified

- `nx laser:test` — 172 tests pass, including 3 new specs for the world layer (2x2 duplication, boundary re-base, no-op when tile unchanged)
- `nx laser:lint` — clean
- `vite build` (standalone mode) — passes

Note: `tsc --noEmit` in arpg web reports a pre-existing `postcard-wire.ts` `mp`/`EntityDelta` error on dev, unrelated to this change.