### PR TITLE
feat(rentearth): tree billboards — replace slime env placeholder with shared tree sheet

### DIFF
--- a/apps/rentearth/unreal-rentearth/Content/Art/Foliage/T_Trees01.uasset
+++ b/apps/rentearth/unreal-rentearth/Content/Art/Foliage/T_Trees01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb0b15df2f1d0266cf36a62db7f7b29748b8364e90c5ceadb8b0efc76acb024e
+size 5882209

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
@@ -4,6 +4,7 @@
 #include "Components/InstancedStaticMeshComponent.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/Texture.h"
+#include "Engine/Texture2D.h"
 #include "Engine/World.h"
 #include "Materials/Material.h"
 #include "Materials/MaterialInstanceDynamic.h"
@@ -32,6 +33,7 @@
 namespace
 {
 	static TStrongObjectPtr<UMaterialInterface> CachedBillboard;
+	static TStrongObjectPtr<UMaterialInterface> CachedStaticCellBillboard;
 
 #if WITH_EDITOR
 	template <typename T>
@@ -55,6 +57,53 @@ namespace
 		S->ParameterName = FName(Name);
 		S->DefaultValue = Default;
 		return S;
+	}
+
+	UMaterialExpressionCustom* BuildBillboardWPO(UMaterial* M, UMaterialExpressionCameraPositionWS* CamP, UMaterialExpressionObjectPositionWS* ObjP)
+	{
+		UMaterialExpressionWorldPosition* WorldP = MakeExpr<UMaterialExpressionWorldPosition>(M);
+		UMaterialExpressionSubtract* LocalOffset = MakeExpr<UMaterialExpressionSubtract>(M);
+		LocalOffset->A.Expression = WorldP;
+		LocalOffset->B.Expression = ObjP;
+
+		UMaterialExpressionScalarParameter* WorldSizeX = MakeScalar(M, TEXT("WorldSizeX"), 150.0f);
+		UMaterialExpressionScalarParameter* WorldSizeY = MakeScalar(M, TEXT("WorldSizeY"), 150.0f);
+		UMaterialExpressionScalarParameter* PivotZ = MakeScalar(M, TEXT("PivotZ"), 0.0f);
+
+		UMaterialExpressionCustom* WPO = MakeExpr<UMaterialExpressionCustom>(M);
+		WPO->OutputType = CMOT_Float3;
+		WPO->Inputs.Empty();
+		AddInput(WPO, TEXT("L"), LocalOffset);
+		AddInput(WPO, TEXT("CamPos"), CamP);
+		AddInput(WPO, TEXT("ObjPos"), ObjP);
+		AddInput(WPO, TEXT("WorldSizeX"), WorldSizeX);
+		AddInput(WPO, TEXT("WorldSizeY"), WorldSizeY);
+		AddInput(WPO, TEXT("PivotZ"), PivotZ);
+		WPO->Code = TEXT(
+			"float3 toCam = CamPos - ObjPos;\n"
+			"toCam.z = 0.0;\n"
+			"float3 fwd = normalize(toCam + float3(0.0, 0.0001, 0.0));\n"
+			"float3 up = float3(0.0, 0.0, 1.0);\n"
+			"float3 right = normalize(cross(up, fwd));\n"
+			"float sx = WorldSizeX / 100.0;\n"
+			"float sy = WorldSizeY / 100.0;\n"
+			"float3 desired = right * (L.x * sx) + up * (L.y * sy);\n"
+			"desired += up * (50.0 * sy * (1.0 - 2.0 * PivotZ));\n"
+			"return desired - L;");
+		return WPO;
+	}
+
+	void FinalizeGeneratedMaterial(UPackage* Pkg, UMaterial* M)
+	{
+		M->PreEditChange(nullptr);
+		M->PostEditChange();
+		M->ForceRecompileForRendering();
+		FAssetRegistryModule::AssetCreated(M);
+		Pkg->MarkPackageDirty();
+		const FString File = FPackageName::LongPackageNameToFilename(Pkg->GetName(), FPackageName::GetAssetPackageExtension());
+		FSavePackageArgs Args;
+		Args.TopLevelFlags = RF_Public | RF_Standalone;
+		UPackage::SavePackage(Pkg, M, *File, Args);
 	}
 #endif
 }
@@ -145,38 +194,9 @@ UMaterialInterface* UKBVENpcSpriteRenderSubsystem::GetOrCreateBillboardMaterial(
 	M->SetUsageByFlag(MATUSAGE_InstancedStaticMeshes, true);
 	M->OpacityMaskClipValue = 0.5f;
 
-	UMaterialExpressionWorldPosition* WorldP = MakeExpr<UMaterialExpressionWorldPosition>(M);
 	UMaterialExpressionObjectPositionWS* ObjP = MakeExpr<UMaterialExpressionObjectPositionWS>(M);
 	UMaterialExpressionCameraPositionWS* CamP = MakeExpr<UMaterialExpressionCameraPositionWS>(M);
-
-	UMaterialExpressionSubtract* LocalOffset = MakeExpr<UMaterialExpressionSubtract>(M);
-	LocalOffset->A.Expression = WorldP;
-	LocalOffset->B.Expression = ObjP;
-
-	UMaterialExpressionScalarParameter* WorldSizeX = MakeScalar(M, TEXT("WorldSizeX"), 150.0f);
-	UMaterialExpressionScalarParameter* WorldSizeY = MakeScalar(M, TEXT("WorldSizeY"), 150.0f);
-	UMaterialExpressionScalarParameter* PivotZ = MakeScalar(M, TEXT("PivotZ"), 0.0f);
-
-	UMaterialExpressionCustom* WPO = MakeExpr<UMaterialExpressionCustom>(M);
-	WPO->OutputType = CMOT_Float3;
-	WPO->Inputs.Empty();
-	AddInput(WPO, TEXT("L"), LocalOffset);
-	AddInput(WPO, TEXT("CamPos"), CamP);
-	AddInput(WPO, TEXT("ObjPos"), ObjP);
-	AddInput(WPO, TEXT("WorldSizeX"), WorldSizeX);
-	AddInput(WPO, TEXT("WorldSizeY"), WorldSizeY);
-	AddInput(WPO, TEXT("PivotZ"), PivotZ);
-	WPO->Code = TEXT(
-		"float3 toCam = CamPos - ObjPos;\n"
-		"toCam.z = 0.0;\n"
-		"float3 fwd = normalize(toCam + float3(0.0, 0.0001, 0.0));\n"
-		"float3 up = float3(0.0, 0.0, 1.0);\n"
-		"float3 right = normalize(cross(up, fwd));\n"
-		"float sx = WorldSizeX / 100.0;\n"
-		"float sy = WorldSizeY / 100.0;\n"
-		"float3 desired = right * (L.x * sx) + up * (L.y * sy);\n"
-		"desired += up * (50.0 * sy * (1.0 - 2.0 * PivotZ));\n"
-		"return desired - L;");
+	UMaterialExpressionCustom* WPO = BuildBillboardWPO(M, CamP, ObjP);
 
 	UMaterialExpressionTextureCoordinate* UV = MakeExpr<UMaterialExpressionTextureCoordinate>(M);
 	UV->CoordinateIndex = 0;
@@ -245,16 +265,78 @@ UMaterialInterface* UKBVENpcSpriteRenderSubsystem::GetOrCreateBillboardMaterial(
 	ED->EmissiveColor.Connect(0, Atlas);
 	ED->OpacityMask.Connect(4, Atlas);
 
-	M->PreEditChange(nullptr);
-	M->PostEditChange();
-	M->ForceRecompileForRendering();
-	FAssetRegistryModule::AssetCreated(M);
-	Pkg->MarkPackageDirty();
-	const FString File = FPackageName::LongPackageNameToFilename(Pkg->GetName(), FPackageName::GetAssetPackageExtension());
-	FSavePackageArgs Args;
-	Args.TopLevelFlags = RF_Public | RF_Standalone;
-	UPackage::SavePackage(Pkg, M, *File, Args);
+	FinalizeGeneratedMaterial(Pkg, M);
 	CachedBillboard.Reset(M);
+	return M;
+#else
+	return nullptr;
+#endif
+}
+
+UMaterialInterface* UKBVENpcSpriteRenderSubsystem::GetOrCreateStaticCellMaterial()
+{
+	if (CachedStaticCellBillboard.IsValid())
+	{
+		return CachedStaticCellBillboard.Get();
+	}
+
+	static const TCHAR* PkgPath = TEXT("/Game/KBVE/Generated/M_KBVENpcBillboardStatic");
+	if (UMaterialInterface* Existing = LoadObject<UMaterialInterface>(nullptr, PkgPath))
+	{
+		CachedStaticCellBillboard.Reset(Existing);
+		return Existing;
+	}
+
+#if WITH_EDITOR
+	UPackage* Pkg = CreatePackage(PkgPath);
+	UMaterial* M = NewObject<UMaterial>(Pkg, TEXT("M_KBVENpcBillboardStatic"), RF_Public | RF_Standalone);
+	M->MaterialDomain = MD_Surface;
+	M->SetShadingModel(MSM_Unlit);
+	M->BlendMode = BLEND_Masked;
+	M->TwoSided = true;
+	M->SetUsageByFlag(MATUSAGE_InstancedStaticMeshes, true);
+	M->OpacityMaskClipValue = 0.5f;
+
+	UMaterialExpressionObjectPositionWS* ObjP = MakeExpr<UMaterialExpressionObjectPositionWS>(M);
+	UMaterialExpressionCameraPositionWS* CamP = MakeExpr<UMaterialExpressionCameraPositionWS>(M);
+	UMaterialExpressionCustom* WPO = BuildBillboardWPO(M, CamP, ObjP);
+
+	UMaterialExpressionTextureCoordinate* UV = MakeExpr<UMaterialExpressionTextureCoordinate>(M);
+	UV->CoordinateIndex = 0;
+
+	UMaterialExpressionPerInstanceCustomData* CellIdx = MakeExpr<UMaterialExpressionPerInstanceCustomData>(M);
+	CellIdx->DataIndex = 0;
+
+	UMaterialExpressionScalarParameter* Cols = MakeScalar(M, TEXT("Cols"), 1.0f);
+	UMaterialExpressionScalarParameter* Rows = MakeScalar(M, TEXT("Rows"), 1.0f);
+
+	UMaterialExpressionCustom* Cell = MakeExpr<UMaterialExpressionCustom>(M);
+	Cell->OutputType = CMOT_Float2;
+	Cell->Inputs.Empty();
+	AddInput(Cell, TEXT("UV"), UV);
+	AddInput(Cell, TEXT("CellIdx"), CellIdx);
+	AddInput(Cell, TEXT("Cols"), Cols);
+	AddInput(Cell, TEXT("Rows"), Rows);
+	Cell->Code = TEXT(
+		"float cell = floor(CellIdx + 0.5);\n"
+		"float col = fmod(cell, Cols);\n"
+		"float row = floor(cell / Cols);\n"
+		"float v = 1.0 - UV.y;\n"
+		"return float2((col + UV.x) / Cols, (row + v) / Rows);");
+
+	UMaterialExpressionTextureSampleParameter2D* Atlas = MakeExpr<UMaterialExpressionTextureSampleParameter2D>(M);
+	Atlas->ParameterName = FName(TEXT("Atlas"));
+	Atlas->Texture = LoadObject<UTexture>(nullptr, TEXT("/Engine/EngineResources/DefaultTexture.DefaultTexture"));
+	Atlas->SamplerType = SAMPLERTYPE_Color;
+	Atlas->Coordinates.Expression = Cell;
+
+	UMaterialEditorOnlyData* ED = M->GetEditorOnlyData();
+	ED->WorldPositionOffset.Connect(0, WPO);
+	ED->EmissiveColor.Connect(0, Atlas);
+	ED->OpacityMask.Connect(4, Atlas);
+
+	FinalizeGeneratedMaterial(Pkg, M);
+	CachedStaticCellBillboard.Reset(M);
 	return M;
 #else
 	return nullptr;
@@ -295,7 +377,9 @@ UInstancedStaticMeshComponent* UKBVENpcSpriteRenderSubsystem::GetOrCreateHISM(UK
 		HISM->SetCullDistances(static_cast<int32>(Def->CullDistance * 0.85f), static_cast<int32>(Def->CullDistance));
 	}
 
-	UMaterialInterface* Base = Def->SpriteMaterial ? Def->SpriteMaterial.Get() : GetOrCreateBillboardMaterial();
+	UMaterialInterface* Base = Def->SpriteMaterial
+		? Def->SpriteMaterial.Get()
+		: (Def->bStaticCell ? GetOrCreateStaticCellMaterial() : GetOrCreateBillboardMaterial());
 	if (Base)
 	{
 		UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(Base, this);
@@ -310,12 +394,15 @@ UInstancedStaticMeshComponent* UKBVENpcSpriteRenderSubsystem::GetOrCreateHISM(UK
 			MID->SetScalarParameterValue(TEXT("PivotZ"), Def->PivotZ);
 			MID->SetScalarParameterValue(TEXT("Cols"), Def->Columns);
 			MID->SetScalarParameterValue(TEXT("Rows"), Def->Rows);
-			MID->SetScalarParameterValue(TEXT("Fps"), Def->Fps);
-			MID->SetScalarParameterValue(TEXT("Frames"), Def->FramesPerAnim);
-			MID->SetScalarParameterValue(TEXT("SwapSide"), Def->bSwapSide ? 1.0f : 0.0f);
-			MID->SetScalarParameterValue(TEXT("RowFront"), Def->RowFront);
-			MID->SetScalarParameterValue(TEXT("RowSide"), Def->RowSide);
-			MID->SetScalarParameterValue(TEXT("RowBack"), Def->RowBack);
+			if (!Def->bStaticCell)
+			{
+				MID->SetScalarParameterValue(TEXT("Fps"), Def->Fps);
+				MID->SetScalarParameterValue(TEXT("Frames"), Def->FramesPerAnim);
+				MID->SetScalarParameterValue(TEXT("SwapSide"), Def->bSwapSide ? 1.0f : 0.0f);
+				MID->SetScalarParameterValue(TEXT("RowFront"), Def->RowFront);
+				MID->SetScalarParameterValue(TEXT("RowSide"), Def->RowSide);
+				MID->SetScalarParameterValue(TEXT("RowBack"), Def->RowBack);
+			}
 			HISM->SetMaterial(0, MID);
 			DefMIDs.Add(Def, MID);
 		}
@@ -327,7 +414,7 @@ UInstancedStaticMeshComponent* UKBVENpcSpriteRenderSubsystem::GetOrCreateHISM(UK
 	return HISM;
 }
 
-FKBVENpcSpriteHandle UKBVENpcSpriteRenderSubsystem::SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg)
+FKBVENpcSpriteHandle UKBVENpcSpriteRenderSubsystem::SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg, int32 StaticCell)
 {
 	FKBVENpcSpriteHandle Handle;
 	UInstancedStaticMeshComponent* HISM = GetOrCreateHISM(Def);
@@ -338,8 +425,16 @@ FKBVENpcSpriteHandle UKBVENpcSpriteRenderSubsystem::SpawnSprite(UKBVENpcSpriteDe
 
 	FTransform Xform(FQuat::Identity, Location, FVector::OneVector);
 	const int32 Index = HISM->AddInstance(Xform, true);
-	HISM->SetCustomDataValue(Index, 0, FMath::DegreesToRadians(FacingYawDeg), false);
-	HISM->SetCustomDataValue(Index, 1, FMath::FRand() * FMath::Max(1, Def->FramesPerAnim), false);
+	if (Def->bStaticCell)
+	{
+		HISM->SetCustomDataValue(Index, 0, static_cast<float>(StaticCell), false);
+		HISM->SetCustomDataValue(Index, 1, 0.0f, false);
+	}
+	else
+	{
+		HISM->SetCustomDataValue(Index, 0, FMath::DegreesToRadians(FacingYawDeg), false);
+		HISM->SetCustomDataValue(Index, 1, FMath::FRand() * FMath::Max(1, Def->FramesPerAnim), false);
+	}
 
 	FInstanceRec Rec;
 	Rec.Def = Def;
@@ -363,6 +458,17 @@ void UKBVENpcSpriteRenderSubsystem::UpdateSprite(FKBVENpcSpriteHandle Handle, FV
 		Rec->Location = Location;
 		Rec->FacingYaw = FacingYawDeg;
 	}
+}
+
+void UKBVENpcSpriteRenderSubsystem::SetSpriteCell(FKBVENpcSpriteHandle Handle, int32 Cell)
+{
+	FInstanceRec* Rec = Instances.Find(Handle.Id);
+	if (!Rec || !Rec->HISM || !Rec->Def || !Rec->Def->bStaticCell)
+	{
+		return;
+	}
+	Rec->HISM->SetCustomDataValue(Rec->Index, 0, static_cast<float>(Cell), false);
+	Rec->HISM->MarkRenderStateDirty();
 }
 
 void UKBVENpcSpriteRenderSubsystem::DespawnSprite(FKBVENpcSpriteHandle Handle)
@@ -463,8 +569,9 @@ void UKBVENpcSpriteRenderSubsystem::Tick(float DeltaTime)
 			continue;
 		}
 
+		const bool bStatic = Rec.Def && Rec.Def->bStaticCell;
 		const bool bMoved = !Rec.Location.Equals(Rec.AppliedLocation, 0.5);
-		const bool bTurned = !FMath::IsNearlyEqual(Rec.FacingYaw, Rec.AppliedYaw, 0.5f);
+		const bool bTurned = !bStatic && !FMath::IsNearlyEqual(Rec.FacingYaw, Rec.AppliedYaw, 0.5f);
 		if (!bMoved && !bTurned)
 		{
 			continue;

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDef.h
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDef.h
@@ -45,6 +45,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
 	bool bSwapSide = false;
 
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
+	bool bStaticCell = false;
+
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Animation", meta = (ClampMin = "1"))
 	int32 FramesPerAnim = 5;
 

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteRenderSubsystem.h
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteRenderSubsystem.h
@@ -34,10 +34,13 @@ public:
 	virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(UKBVENpcSpriteRenderSubsystem, STATGROUP_Tickables); }
 
 	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
-	FKBVENpcSpriteHandle SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg = 0.0f);
+	FKBVENpcSpriteHandle SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg = 0.0f, int32 StaticCell = 0);
 
 	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
 	void UpdateSprite(FKBVENpcSpriteHandle Handle, FVector Location, float FacingYawDeg);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
+	void SetSpriteCell(FKBVENpcSpriteHandle Handle, int32 Cell);
 
 	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
 	void DespawnSprite(FKBVENpcSpriteHandle Handle);
@@ -61,6 +64,7 @@ private:
 	void EnsureHost();
 	UStaticMesh* GetPlaneMesh();
 	UMaterialInterface* GetOrCreateBillboardMaterial();
+	UMaterialInterface* GetOrCreateStaticCellMaterial();
 	UInstancedStaticMeshComponent* GetOrCreateHISM(UKBVENpcSpriteDef* Def);
 
 	UPROPERTY(Transient)

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityManager.cpp
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Private/SimgridEntityManager.cpp
@@ -128,6 +128,40 @@ void USimgridEntityManager::EnsureEnvDef()
 	EnvDef->CullDistance = 12000.0f;
 }
 
+UKBVENpcSpriteDef* USimgridEntityManager::EnsureTreeDef()
+{
+	if (TreeDef)
+	{
+		return TreeDef;
+	}
+	UTexture2D* Atlas = LoadObject<UTexture2D>(nullptr, TEXT("/Game/Art/Foliage/T_Trees01.T_Trees01"));
+	if (!Atlas)
+	{
+		if (!bTreeAtlasWarned)
+		{
+			bTreeAtlasWarned = true;
+			UE_LOG(LogKBVESimgridRender, Warning, TEXT("Tree atlas /Game/Art/Foliage/T_Trees01 missing — trees fall back to env placeholder sprite."));
+		}
+		return nullptr;
+	}
+	TreeDef = NewObject<UKBVENpcSpriteDef>(this);
+	TreeDef->Ref = FName(TEXT("tree"));
+	TreeDef->Atlas = Atlas;
+	TreeDef->bStaticCell = true;
+	TreeDef->Columns = 10;
+	TreeDef->Rows = 14;
+	TreeDef->WorldSize = FVector2f(300.0f, 600.0f);
+	TreeDef->PivotZ = 0.08f;
+	TreeDef->CullDistance = 12000.0f;
+	return TreeDef;
+}
+
+static int32 TreeCellFromSub(uint8 SubByte)
+{
+	const int32 Variant = (SubByte & 0x7F) % 70;
+	return (SubByte & 0x80) ? Variant + 70 : Variant;
+}
+
 USkeletalMesh* USimgridEntityManager::EnsureMannyMesh()
 {
 	if (!MannyMesh)
@@ -232,17 +266,41 @@ void USimgridEntityManager::Tick(double NowMs)
 		{
 			if (UKBVENpcSpriteRenderSubsystem* R = GetSpriteRenderer())
 			{
-				EnsureEnvDef();
+				UKBVENpcSpriteDef* Def = nullptr;
+				int32 Cell = 0;
+				if (Ref == TEXT("tree"))
+				{
+					Def = EnsureTreeDef();
+					Cell = TreeCellFromSub(E.Sub);
+				}
+				if (!Def)
+				{
+					EnsureEnvDef();
+					Def = EnvDef;
+				}
 				if (int32* Id = SpriteHandleIds.Find(E.Eid))
 				{
 					FKBVENpcSpriteHandle H;
 					H.Id = *Id;
 					R->UpdateSprite(H, WorldPos, Yaw);
+					if (Def->bStaticCell)
+					{
+						uint8* Applied = EnvSubApplied.Find(E.Eid);
+						if (!Applied || *Applied != E.Sub)
+						{
+							R->SetSpriteCell(H, Cell);
+							EnvSubApplied.Add(E.Eid, E.Sub);
+						}
+					}
 				}
 				else
 				{
-					const FKBVENpcSpriteHandle H = R->SpawnSprite(EnvDef, WorldPos, Yaw);
+					const FKBVENpcSpriteHandle H = R->SpawnSprite(Def, WorldPos, Yaw, Cell);
 					SpriteHandleIds.Add(E.Eid, H.Id);
+					if (Def->bStaticCell)
+					{
+						EnvSubApplied.Add(E.Eid, E.Sub);
+					}
 				}
 				continue;
 			}
@@ -309,6 +367,7 @@ void USimgridEntityManager::Tick(double NowMs)
 				Renderer->DespawnSprite(H);
 			}
 			SpriteHandleIds.Remove(Eid);
+			EnvSubApplied.Remove(Eid);
 		}
 	}
 }
@@ -353,6 +412,7 @@ void USimgridEntityManager::Clear()
 		}
 	}
 	SpriteHandleIds.Empty();
+	EnvSubApplied.Empty();
 	SlotNames.Empty();
 
 	bHasLocalPos = false;

--- a/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityManager.h
+++ b/packages/unreal/KBVENet/Source/KBVESimgridRender/Public/SimgridEntityManager.h
@@ -57,6 +57,7 @@ private:
 	ASimgridEntityActor* SpawnActor(uint16 Kind);
 	UKBVENpcSpriteRenderSubsystem* GetSpriteRenderer() const;
 	void EnsureEnvDef();
+	UKBVENpcSpriteDef* EnsureTreeDef();
 	USkeletalMesh* EnsureMannyMesh();
 	void EnsureLocomotionAnims();
 	UAnimationAsset* PickLocomotionAnim(float Speed);
@@ -82,6 +83,11 @@ private:
 	TObjectPtr<UKBVENpcSpriteDef> EnvDef;
 
 	UPROPERTY()
+	TObjectPtr<UKBVENpcSpriteDef> TreeDef;
+
+	bool bTreeAtlasWarned = false;
+
+	UPROPERTY()
 	TObjectPtr<USkeletalMesh> MannyMesh;
 
 	UPROPERTY()
@@ -96,6 +102,7 @@ private:
 	bool bAnimsLoaded = false;
 
 	TMap<uint32, int32> SpriteHandleIds;
+	TMap<uint32, uint8> EnvSubApplied;
 	TMap<uint16, FString> SlotNames;
 
 	UPROPERTY()


### PR DESCRIPTION
Closes #13718

Implements the design in #13718:

- **KBVENPCSprite — static-cell billboard mode**: `bStaticCell` on `UKBVENpcSpriteDef` renders a fixed atlas cell per instance via per-instance custom data slot 0 and a new generated material (`M_KBVENpcBillboardStatic`) with the same camera-facing WPO as the animated billboard but no Time/MoveYaw/AnimSeed. `SpawnSprite` takes the initial cell; new `SetSpriteCell` retargets a live instance. Tick skips the yaw custom-data write for static defs so it cannot clobber the cell. Shared WPO/save logic extracted into helpers.
- **KBVESimgridRender**: env ref `tree` resolves to a static-cell def over `/Game/Art/Foliage/T_Trees01` (10x14 grid of 192x384 cells, same sheet the web client ships). Cell = low 7 bits of `EntityDelta.sub` (variant 0..69) + 70 when bit 7 (felled) is set, so a felled tree swaps to its bare twin in place. Per-eid sub tracking, cleaned up on despawn/clear. Unknown env refs keep the slime placeholder; missing atlas falls back with a one-shot warning.
- **Asset**: `trees_01.webp` converted and imported as `T_Trees01.uasset` (nearest filter, no mips), LFS blob registered on the rentearth Forgejo endpoint.
- **CI fix ride-along**: adds `Engine/Texture2D.h` include to `KBVENpcSpriteRenderSubsystem.cpp` — the isolated KBVENPCDB plugin build (newly exercised as a KBVENet dependency after #13705) fails on the `UTexture2D*` → `UTexture*` conversion with only the forward declaration (run [28581845088](https://github.com/KBVE/kbve/actions/runs/28581845088)).

Verified: `unreal-rentearth:build-editor` → Result: Succeeded (twice, incl. post-include fix). Runtime forest verify pending a live simgrid session from the main tree — texture is already imported there too.