### PR TITLE
perf(rentearth): scope world streaming to isometric view region

### DIFF
--- a/apps/rentearth/unreal-rentearth/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -1214,12 +1214,12 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 			bDidAutoSpawnSlimes = true;
 			if (UNavigationSystemV1* Nav = FNavigationSystem::GetCurrent<UNavigationSystemV1>(GetWorld()))
 			{
-				Nav->RegisterInvoker(*ControlledPawn, 6000.f, 8000.f, FNavAgentSelector(), ENavigationInvokerPriority::Default);
+				Nav->RegisterInvoker(*ControlledPawn, 3000.f, 4500.f, FNavAgentSelector(), ENavigationInvokerPriority::Default);
 				UE_LOG(LogTemp, Warning, TEXT("[SlimeNav] registered invoker on pawn %s"), *ControlledPawn->GetName());
 			}
 			if (UchuckNpcSpawner* NpcSpawner = GetWorld()->GetSubsystem<UchuckNpcSpawner>())
 			{
-				NpcSpawner->SpawnCreature(FName(TEXT("glass-slime")), ControlledPawn->GetActorLocation(), 100, 5500.f);
+				NpcSpawner->SpawnCreature(FName(TEXT("glass-slime")), ControlledPawn->GetActorLocation(), 30, 3000.f);
 			}
 		}
 

--- a/apps/rentearth/unreal-rentearth/Source/chuck/World/chuckTerrainStreamer.cpp
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/World/chuckTerrainStreamer.cpp
@@ -87,9 +87,9 @@ void UchuckTerrainStreamer::OnWorldBeginPlay(UWorld& InWorld)
 
 	const FIntPoint AnchorChunk = WorldToChunk(SpawnLoc);
 	int32 BuiltCount = 0;
-	for (int32 Dy = -ChunkRadius; Dy <= ChunkRadius; ++Dy)
+	for (int32 Dy = -PrewarmRadius; Dy <= PrewarmRadius; ++Dy)
 	{
-		for (int32 Dx = -ChunkRadius; Dx <= ChunkRadius; ++Dx)
+		for (int32 Dx = -PrewarmRadius; Dx <= PrewarmRadius; ++Dx)
 		{
 			EnsureChunk(FIntPoint(AnchorChunk.X + Dx, AnchorChunk.Y + Dy));
 			++BuiltCount;
@@ -231,9 +231,9 @@ void UchuckTerrainStreamer::EnsureBuiltAround(const FVector2D& WorldXY)
 	const FVector AnchorWorld(WorldXY.X, WorldXY.Y, 0.f);
 	const FIntPoint AnchorChunk = WorldToChunk(AnchorWorld);
 	int32 Built = 0;
-	for (int32 Dy = -ChunkRadius; Dy <= ChunkRadius; ++Dy)
+	for (int32 Dy = -PrewarmRadius; Dy <= PrewarmRadius; ++Dy)
 	{
-		for (int32 Dx = -ChunkRadius; Dx <= ChunkRadius; ++Dx)
+		for (int32 Dx = -PrewarmRadius; Dx <= PrewarmRadius; ++Dx)
 		{
 			EnsureChunk(FIntPoint(AnchorChunk.X + Dx, AnchorChunk.Y + Dy));
 			++Built;

--- a/apps/rentearth/unreal-rentearth/Source/chuck/World/chuckTerrainStreamer.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/World/chuckTerrainStreamer.h
@@ -48,9 +48,10 @@ protected:
 	uint32 Seed         = 0xC1A55E5Au;
 	int32  CellsPerEdge = 32;
 	float  CellSize     = 200.f;
-	int32  ChunkRadius  = 6;
-	int32  PoolSize     = 280;
-	int32  MaxBuildsPerTick   = 1;
+	int32  ChunkRadius  = 3;
+	int32  PrewarmRadius = 1;
+	int32  PoolSize     = 120;
+	int32  MaxBuildsPerTick   = 2;
 	int32  MaxReleasesPerTick = 3;
 	float  WaterZ       = -120.f;
 	float  StreamInterval = 0.03f;

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldTerrainRenderSubsystem.cpp
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldTerrainRenderSubsystem.cpp
@@ -5,7 +5,6 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "ProceduralMeshComponent.h"
-#include "NavigationSystem.h"
 
 namespace KBVETerrainCfg
 {
@@ -118,7 +117,8 @@ UProceduralMeshComponent* UKBVEWorldTerrainRenderSubsystem::EnsureRegionSection(
 	UProceduralMeshComponent* PMC = NewObject<UProceduralMeshComponent>(HostActor, NAME_None, RF_Transient);
 	PMC->SetMobility(EComponentMobility::Movable);
 	PMC->SetupAttachment(HostActor->GetRootComponent());
-	PMC->SetCanEverAffectNavigation(true);
+	PMC->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	PMC->SetCanEverAffectNavigation(false);
 	PMC->RegisterComponent();
 	R.Section = PMC;
 	return PMC;
@@ -196,8 +196,6 @@ void UKBVEWorldTerrainRenderSubsystem::RebuildRegion(FIntPoint RegionKey)
 	Colors.Init(FColor::White, Verts.Num());
 
 	PMC->ClearAllMeshSections();
-	PMC->CreateMeshSection(0, Verts, Tris, Normals, UVs, Colors, Tangents, true);
+	PMC->CreateMeshSection(0, Verts, Tris, Normals, UVs, Colors, Tangents, false);
 	if (GroundMaterial) PMC->SetMaterial(0, GroundMaterial);
-
-	FNavigationSystem::UpdateComponentData(*PMC);
 }


### PR DESCRIPTION
## Summary

Gameworld lag: terrain streamer built a 13×13 = 169-chunk (~832 m) grid around the pawn while the isometric camera only ever sees a small region, and the merged region render mesh duplicated collision + navmesh work that chunk actors already do.

- **ChunkRadius 6 → 3** (169 → 49 streamed chunks), pool 280 → 120. Grass render subsystem was already radius 2/3, so nothing visible changes.
- **Pre-warm hitch removed**: only radius 1 builds synchronously at world begin / login (`EnsureBuiltAround`); the rest streams at 2 builds per 0.03 s interval (~66 chunks/s, radius 3 fills in under a second).
- **Region render mesh is render-only**: `AKBVEWorldChunkActor` already provides QueryOnly collision + nav geometry per chunk. The merged 4×4-region ProceduralMesh was *also* cooking collision synchronously (`CreateMeshSection(..., true)`) and calling `FNavigationSystem::UpdateComponentData` on every rebuild — duplicate physics cook + navmesh churn per chunk change, now gone.
- **NavInvoker 6000/8000 → 3000/4500** — runtime navmesh generation over a much smaller area.
- **Debug glass-slime auto-spawn 100 @ 5500 → 30 @ 3000** — fewer per-frame slime ticks/line traces.

## Testing

- Config/flag-level changes; KBVEWorld plugin verify covers the plugin side in CI.
- Needs an in-editor lap to confirm slimes still path (chunk-actor nav geometry is now the sole nav source, same as before this subsystem existed).