### PR TITLE
fix(rentearth): resolve UE 5.8 Mass and StateTree deprecation warnings

### DIFF
--- a/apps/rentearth/unreal-rentearth/Source/chuck/Core/chuckCoreCharacter.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Core/chuckCoreCharacter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "MassEntityHandle.h"
+#include "Mass/EntityHandle.h"
 #include "chuckCharacter.h"
 #include "chuckInventory.h"
 #include "chuckStats.h"

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Events/chuckEventPayloads.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Events/chuckEventPayloads.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "MassEntityHandle.h"
+#include "Mass/EntityHandle.h"
 #include "KBVEGameplayEvents.h"
 
 // Generic stat/combat payloads (Health / Mana / Stamina / DamageReceived /

--- a/apps/rentearth/unreal-rentearth/Source/chuck/Variant_Combat/AI/CombatStateTreeUtility.h
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/Variant_Combat/AI/CombatStateTreeUtility.h
@@ -28,7 +28,7 @@ struct FStateTreeCharacterGroundedConditionInstanceData
 	UPROPERTY(EditAnywhere, Category = "Condition")
 	bool bMustBeOnAir = false;
 };
-STATETREE_POD_INSTANCEDATA(FStateTreeCharacterGroundedConditionInstanceData);
+UE_STATETREE_ZEROED_TRIVIALLY_COPIED_NO_DESTRUCTOR_INSTANCEDATA(FStateTreeCharacterGroundedConditionInstanceData);
 
 /**
  *  StateTree condition to check if the character is grounded
@@ -82,7 +82,7 @@ struct FStateTreeIsInDangerConditionInstanceData
 	UPROPERTY(EditAnywhere, Category = "Parameters", meta = (Units = "degrees"))
 	float DangerSightConeAngle = 120.0f;
 };
-STATETREE_POD_INSTANCEDATA(FStateTreeIsInDangerConditionInstanceData);
+UE_STATETREE_ZEROED_TRIVIALLY_COPIED_NO_DESTRUCTOR_INSTANCEDATA(FStateTreeIsInDangerConditionInstanceData);
 
 /**
  *  StateTree condition to check if the character is about to be hit by an attack


### PR DESCRIPTION
## Summary

Both deprecations become hard compile errors on the next engine release.

- `#include "MassEntityHandle.h"` → `#include "Mass/EntityHandle.h"` in `chuckCoreCharacter.h` and `chuckEventPayloads.h` (header moved to MassCore; `MassCore` already in `chuck.Build.cs`).
- `STATETREE_POD_INSTANCEDATA(...)` → `UE_STATETREE_ZEROED_TRIVIALLY_COPIED_NO_DESTRUCTOR_INSTANCEDATA(...)` for both instance-data structs in `CombatStateTreeUtility.h`.

Only 4 sites repo-wide, all in the rentearth chuck module.

## Testing

- Local `chuckEditor Mac Development` build in the worktree: **Succeeded**, deprecation warnings gone.