### PR TITLE
fix(devops): execFile for docker commands — close CodeQL shell-injection

### DIFF
--- a/packages/npm/devops/src/lib/client/github/docker.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.spec.ts
@@ -3,7 +3,7 @@ import { GitHubClient, GitHubContext } from './types';
 const mockExecAsync = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
-	exec: vi.fn(),
+	execFile: vi.fn(),
 }));
 
 vi.mock('util', () => ({
@@ -121,6 +121,15 @@ describe('_$gha_runDockerContainer', () => {
 				body: expect.stringContaining('started successfully'),
 			}),
 		);
+		expect(mockExecAsync).toHaveBeenCalledWith('docker', [
+			'run',
+			'-d',
+			'-p',
+			'8080:8080',
+			'--name',
+			'mycontainer',
+			'nginx:latest',
+		]);
 	});
 
 	it('should report error and throw when exec fails', async () => {
@@ -167,8 +176,15 @@ describe('_$gha_stopDockerContainer', () => {
 
 		await _$gha_stopDockerContainer(github, context, 'mycontainer');
 
-		// Should have been called for both stop and remove success comments
 		expect(github.rest.issues.createComment).toHaveBeenCalledTimes(2);
+		expect(mockExecAsync).toHaveBeenCalledWith('docker', [
+			'stop',
+			'mycontainer',
+		]);
+		expect(mockExecAsync).toHaveBeenCalledWith('docker', [
+			'rm',
+			'mycontainer',
+		]);
 	});
 
 	it('should throw when stop command fails', async () => {

--- a/packages/npm/devops/src/lib/client/github/docker.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.ts
@@ -1,5 +1,5 @@
 import { promisify } from 'util';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import {
 	sanitizePort,
 	sanitizeContainerName,
@@ -8,7 +8,7 @@ import {
 import { GitHubClient, GitHubContext } from './types';
 import { issues } from './issues';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 async function runContainer(
 	github: GitHubClient,
@@ -30,10 +30,16 @@ async function runContainer(
 		throw error;
 	}
 
-	const command = `docker run -d -p ${sanitizedPort}:${sanitizedPort} --name ${sanitizedName} ${sanitizedImage}`;
-
 	try {
-		const { stdout } = await execAsync(command);
+		const { stdout } = await execFileAsync('docker', [
+			'run',
+			'-d',
+			'-p',
+			`${sanitizedPort}:${sanitizedPort}`,
+			'--name',
+			sanitizedName,
+			sanitizedImage,
+		]);
 		console.log('Docker container started successfully:', stdout);
 		await issues.createComment(
 			github,
@@ -68,9 +74,10 @@ async function stopContainer(
 	}
 
 	try {
-		const { stdout: stopStdout } = await execAsync(
-			`docker stop ${sanitizedName}`,
-		);
+		const { stdout: stopStdout } = await execFileAsync('docker', [
+			'stop',
+			sanitizedName,
+		]);
 		console.log('Docker container stopped successfully:', stopStdout);
 		await issues.createComment(
 			github,
@@ -90,9 +97,10 @@ async function stopContainer(
 	}
 
 	try {
-		const { stdout: removeStdout } = await execAsync(
-			`docker rm ${sanitizedName}`,
-		);
+		const { stdout: removeStdout } = await execFileAsync('docker', [
+			'rm',
+			sanitizedName,
+		]);
 		console.log('Docker container removed successfully:', removeStdout);
 		await issues.createComment(
 			github,


### PR DESCRIPTION
## Security fix — CodeQL code-scanning 513/514/515

Addresses the `github-advanced-security` review on #13719.

CodeQL flagged `packages/npm/devops/src/lib/client/github/docker.ts` (lines 33/72/94) — *"Unsafe shell command constructed from library input"*: `runContainer`/`stopContainer` built `docker …` command strings by concatenating library inputs, then passed them to `exec` (which spawns a shell).

### Fix
- Switch `exec` → `execFile('docker', [argv…])`. No shell is spawned, so the string-concatenation-into-shell sink is eliminated at the source (not merely mitigated).
- Existing `sanitizePort` / `sanitizeContainerName` / `sanitizeContainerImage` retained as defense-in-depth.
- Specs updated to mock `execFile` and assert the exact argv arrays (proves no shell string is constructed).

Additive/non-breaking; rides the pending **v0.0.22** publish (no new version bump). Public `docker.runContainer` / `docker.stopContainer` signatures unchanged.

### Verify
- `nx test devops` — 280 pass (docker: 11)
- `nx lint devops` — 0 errors
- `nx build devops` — pass