### PR TITLE
fix(unreal): include Engine/GameInstance.h in SimgridClientSubsystem for strict-include build

### DIFF
--- a/packages/unreal/KBVENet/Source/KBVESimgrid/Private/SimgridClientSubsystem.cpp
+++ b/packages/unreal/KBVENet/Source/KBVESimgrid/Private/SimgridClientSubsystem.cpp
@@ -2,6 +2,7 @@
 #include "SimgridWebSocket.h"
 #include "KBVESimgridModule.h"
 #include "KBVESupabaseSubsystem.h"
+#include "Engine/GameInstance.h"
 
 static const uint32 GSimgridProtocolVersion = 16;
 


### PR DESCRIPTION
## Summary

Rescues commit `933e25433`, pushed to `feat/rentearth-tree-billboards` 28 minutes *after* PR #13730 was merged — it never landed on dev.

The isolated KBVENet plugin build (`-StrictIncludes`) fails with `member access into incomplete type 'UGameInstance'`; the monolithic game build only compiled because another header pulled in the definition transitively.

## Testing

- Cherry-pick of the already-build-tested commit from the tree-billboards branch.