### PR TITLE
fix(jedi): satisfy clippy drain_collect lint in observ flush

### DIFF
--- a/packages/rust/jedi/src/observ/mod.rs
+++ b/packages/rust/jedi/src/observ/mod.rs
@@ -164,7 +164,7 @@ async fn flush(client: &reqwest::Client, endpoint: &str, buffer: &mut Vec<Observ
     if buffer.is_empty() {
         return;
     }
-    let events: Vec<ObservEvent> = buffer.drain(..).collect();
+    let events: Vec<ObservEvent> = std::mem::take(buffer);
     let body = serde_json::json!({ "events": events });
     if let Err(e) = client.post(endpoint).json(&body).send().await {
         tracing::debug!(target: "jedi::observ", error = %e, "telemetry flush failed");


### PR DESCRIPTION
`nx run arpg-server:lint` (`cargo clippy -p arpg-server --all-targets -- -D warnings`) failed on the `drain_collect` lint in jedi's telemetry flush path.

## Change
- `packages/rust/jedi/src/observ/mod.rs`: `buffer.drain(..).collect()` → `std::mem::take(buffer)`

## Verify
```
cargo clippy -p arpg-server --all-targets -- -D warnings   # exit 0
```
Fix lands in shared `jedi` crate, not arpg-server itself. Remaining clippy output is benign build-script prints (`BUILD_PROTO not set`).