### PR TITLE
feat(unreal): kbve.unreal clangd db + agent syntax check

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: apps/rentearth/unreal-rentearth

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,20 @@ Different rule for content collections under `apps/kbve/astro-kbve/src/content/d
 - Commit the MDX **and** any artifacts the sync target wrote (JSON / binpb under `astro-kbve/public/data/`, Generated C# under `apps/rareicon/.../Generated/`).
 - ❌ Never hand-edit those generated artifacts. The MDX is the source of truth; the sync target is the only writer.
 
+# Unreal C++ — validate edits with kbve-unreal-check
+
+After editing any C++ file under `packages/unreal/` or `apps/rentearth/unreal-rentearth/Source/`, validate it in seconds instead of running a full UBT build:
+
+```
+cd packages/python/kbve
+uv run kbve-unreal-check <absolute-or-relative-file-path>
+```
+
+- Works on `.cpp` and `.h` (headers are checked through a sibling source file from the same module).
+- Exit 0 = clean, 1 = compile errors (printed as `file:line:col: error: ...`), 2 = file not in the compile database.
+- On exit 2 (new file, or flags drifted), regenerate the database first: `uv run kbve-unreal-clangd` (or `pnpm nx run unreal-rentearth:clangd-db`). Takes ~10 s.
+- The database lives at `apps/rentearth/unreal-rentearth/compile_commands.json` (gitignored) and is pointed to by the committed root `.clangd`, which also powers clangd IDE support.
+
 ---
 
 <!-- nx configuration start-->

--- a/apps/rentearth/unreal-rentearth/.gitignore
+++ b/apps/rentearth/unreal-rentearth/.gitignore
@@ -40,3 +40,6 @@ Content/Developers/*
 
 # macOS junk
 .DS_Store
+
+# clangd compile database (kbve-unreal-clangd)
+compile_commands.json

--- a/apps/rentearth/unreal-rentearth/project.json
+++ b/apps/rentearth/unreal-rentearth/project.json
@@ -3,7 +3,10 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"projectType": "application",
 	"sourceRoot": "apps/rentearth/unreal-rentearth/Source",
-	"tags": ["scope:rentearth", "type:unreal-app"],
+	"tags": [
+		"scope:rentearth",
+		"type:unreal-app"
+	],
 	"targets": {
 		"lfs-push": {
 			"executor": "nx:run-commands",
@@ -116,6 +119,14 @@
 				],
 				"parallel": false
 			}
+		},
+		"clangd-db": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "packages/python/kbve",
+				"command": "uv run kbve-unreal-clangd"
+			},
+			"forwardAllArgs": true
 		}
 	}
 }

--- a/docs/superpowers/specs/2026-07-02-kbve-unreal-clangd-design.md
+++ b/docs/superpowers/specs/2026-07-02-kbve-unreal-clangd-design.md
@@ -1,0 +1,83 @@
+# kbve.unreal — clangd database + agent-facing C++ checks
+
+Date: 2026-07-02
+Status: Approved
+
+## Problem
+
+C++ IntelliSense for the Unreal plugins in `packages/unreal/` has never been accurate: no `compile_commands.json` or `c_cpp_properties.json` exists, so cpptools fell back to tag-parser guessing (and burned 8+ hours of CPU indexing, freezing VS Code). AI tooling (`ms-vscode.cpp-devtools`) queries that same broken backend, so agents and Copilot get wrong or empty symbol information. Coding agents validating a UE C++ edit must run a full UBT build (2–10 minutes) per iteration.
+
+## Goal
+
+One generated artifact — a clang compilation database from UBT — serving two consumers:
+
+1. Humans in VS Code via clangd: accurate go-to-definition, references, diagnostics with real UBT defines and engine include paths.
+2. Coding agents via CLI: per-file syntax/semantic validation in seconds instead of a full UBT build.
+
+## Non-goals
+
+- Runtime debugging (lldb attach, breakpoints, crash capture) — future work that can live in the same package.
+- Build/cook orchestration wrappers.
+- Windows/Linux support in v1 (Mac only; flags exist to extend).
+
+## Approach
+
+Pure-stdlib subprocess wrapper (approach A). No new dependencies, no optional extra needed. A clangd-based check engine (`clangd --check`) can be added later behind a flag if editor-identical semantics are wanted.
+
+## Package layout
+
+`packages/python/kbve/kbve/unreal/`, following the existing `sprite`/`osrs`/`seo` module pattern:
+
+```
+kbve/unreal/
+  __init__.py
+  ubt.py        # locate UE install + Build.sh, run UBT commands
+  clangd.py     # GenerateClangDatabase wrapper + .clangd writer  → kbve-unreal-clangd
+  check.py      # per-file syntax check from compile DB           → kbve-unreal-check
+```
+
+## Component: ubt.py
+
+- Parse a `.uproject` for `EngineAssociation` (e.g. `5.8`) and resolve the engine root, defaulting to `/Users/Shared/Epic Games/UE_<ver>`; overridable via `--engine-root` / `KBVE_UE_ROOT`.
+- Build and run `Engine/Build/BatchFiles/Mac/Build.sh` command lines.
+- `--dry-run` support: print the exact command without executing (also the unit-test seam for UBT invocation).
+
+## Component: clangd.py → `kbve-unreal-clangd`
+
+Defaults: `--project apps/rentearth/unreal-rentearth/rentearth.uproject --target chuckEditor --config Development --platform Mac`.
+
+1. Run UBT `-mode=GenerateClangDatabase` for the target.
+2. Ensure the resulting `compile_commands.json` lands at `apps/rentearth/unreal-rentearth/compile_commands.json` (UBT output location varies by UE version; relocate if needed). File is gitignored (often 50–200 MB).
+3. Write/update a committed `.clangd` at the monorepo root with a `CompilationDatabase:` pointer to that directory. One DB serves the whole monorepo — `rentearth.uproject` mounts `packages/unreal` via `AdditionalPluginDirectories`, so all KBVE* plugin sources appear in the DB. Pointer swaps if another uproject becomes primary.
+
+`chuckEditor Development Mac` is the default target because the editor target has the broadest compile surface (`WITH_EDITOR` paths included).
+
+## Component: check.py → `kbve-unreal-check <file...>`
+
+Agent-facing validation, called after every UE C++ edit:
+
+1. Load the compile DB once (resolved via the root `.clangd` pointer or `--db` flag).
+2. For each file argument, find its DB entry, rewrite the command to `-fsyntax-only` (strip `-o`/output args), and run it.
+3. Header files (`.h`): not in the DB directly — check via a source file that includes it, falling back to the nearest sibling `.cpp` in the same module.
+4. Output: terse `file:line:col: error: msg` lines only; exit non-zero when any file has errors. No decoration — agent-parseable.
+5. File not found in DB → clear message: regenerate with `kbve-unreal-clangd`.
+
+Expected latency ~2–5 s per file (clang frontend on UE headers), versus minutes for a UBT round-trip.
+
+## Wiring
+
+- Two `[project.scripts]` entries in `packages/python/kbve/pyproject.toml`: `kbve-unreal-clangd`, `kbve-unreal-check`.
+- nx target `clangd-db` on `apps/rentearth/unreal-rentearth/project.json` invoking the generator.
+- CLAUDE.md note instructing agents to run `kbve-unreal-check` on edited UE C++ files before attempting a full build.
+- VS Code: cpptools IntelliSense already disabled in `.vscode/settings.json`; recommend `llvm-vs-code-extensions.vscode-clangd` which picks up the root `.clangd` automatically.
+
+## Error handling
+
+- Missing engine install → actionable error naming the expected path and the override flag.
+- UBT failure → surface UBT exit code and last lines of output.
+- Stale DB (file missing from DB) → regenerate hint, exit code distinct from compile errors.
+
+## Testing
+
+- Unit tests (pytest, existing harness): DB lookup, flag rewrite (`-fsyntax-only` substitution, `-o` stripping), header→source fallback, not-in-DB error path — all against a small fixture `compile_commands.json`.
+- UBT invocation covered via `--dry-run` command-line assertion; no engine required in CI.

--- a/packages/python/kbve/kbve/unreal/check.py
+++ b/packages/python/kbve/kbve/unreal/check.py
@@ -1,0 +1,141 @@
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+HEADER_SUFFIXES = {".h", ".hpp", ".inl"}
+
+
+class EntryNotFound(Exception):
+    pass
+
+
+def load_db(path: Path) -> list[dict]:
+    return json.loads(Path(path).read_text())
+
+
+def find_entry(entries: list[dict], file: str) -> dict | None:
+    target = str(Path(file).resolve())
+    for entry in entries:
+        if str(Path(entry["file"]).resolve()) == target:
+            return entry
+    return None
+
+
+def rewrite_command(command: str) -> list[str]:
+    args = shlex.split(command)
+    out: list[str] = []
+    skip = False
+    for arg in args:
+        if skip:
+            skip = False
+            continue
+        if arg == "-o":
+            skip = True
+            continue
+        if arg == "-c":
+            continue
+        out.append(arg)
+    out.append("-fsyntax-only")
+    out.append("-Wno-unused-command-line-argument")
+    return out
+
+
+def filter_diagnostics(text: str) -> str:
+    kept = [
+        line
+        for line in text.splitlines()
+        if "error:" in line or "warning:" in line or ": note:" in line
+    ]
+    return "\n".join(kept)
+
+
+def resolve_check_entry(entries: list[dict], file: str) -> tuple[dict, str | None]:
+    path = Path(file).resolve()
+    if path.suffix not in HEADER_SUFFIXES:
+        entry = find_entry(entries, str(path))
+        if entry is None:
+            raise EntryNotFound(str(path))
+        return entry, None
+    candidates = [path.parent]
+    if path.parent.name == "Public":
+        candidates.append(path.parent.parent / "Private")
+    for directory in candidates:
+        sibling = find_entry(entries, str(directory / path.with_suffix(".cpp").name))
+        if sibling is not None:
+            return sibling, str(path)
+    module_root = _module_root(path)
+    for entry in entries:
+        entry_path = Path(entry["file"]).resolve()
+        if entry_path.parent in candidates:
+            return entry, str(path)
+        if module_root is not None and entry_path.is_relative_to(module_root):
+            return entry, str(path)
+    raise EntryNotFound(str(path))
+
+
+def _module_root(path: Path) -> Path | None:
+    for parent in path.parents:
+        if parent.name == "Source":
+            relative = path.relative_to(parent)
+            if len(relative.parts) > 1:
+                return parent / relative.parts[0]
+    return None
+
+
+def build_check_invocation(entries: list[dict], file: str) -> list[str]:
+    entry, include = resolve_check_entry(entries, file)
+    cmd = rewrite_command(entry["command"])
+    if include is not None:
+        cmd += ["-include", include]
+    return cmd
+
+
+def default_db_path() -> Path | None:
+    cwd = Path.cwd().resolve()
+    for root in [cwd, *cwd.parents]:
+        clangd = root / ".clangd"
+        if clangd.exists():
+            for line in clangd.read_text().splitlines():
+                key, _, value = line.partition(":")
+                if key.strip() == "CompilationDatabase":
+                    return root / value.strip() / "compile_commands.json"
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="kbve-unreal-check")
+    parser.add_argument("files", nargs="+")
+    parser.add_argument("--db")
+    args = parser.parse_args(argv)
+
+    db = Path(args.db) if args.db else default_db_path()
+    if db is None or not db.exists():
+        print(
+            "compile_commands.json not found; generate it with kbve-unreal-clangd",
+            file=sys.stderr,
+        )
+        return 2
+
+    entries = load_db(db)
+    failed = False
+    for file in args.files:
+        try:
+            entry, _ = resolve_check_entry(entries, file)
+            cmd = build_check_invocation(entries, file)
+        except EntryNotFound:
+            print(
+                file + " not in compile database; regenerate with kbve-unreal-clangd",
+                file=sys.stderr,
+            )
+            return 2
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=entry["directory"]
+        )
+        if result.returncode != 0:
+            failed = True
+            output = filter_diagnostics(result.stderr or result.stdout)
+            print(output or (result.stderr or result.stdout).strip())
+    return 1 if failed else 0

--- a/packages/python/kbve/kbve/unreal/clangd.py
+++ b/packages/python/kbve/kbve/unreal/clangd.py
@@ -1,0 +1,90 @@
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from .ubt import generate_clang_db_command, resolve_engine_root
+
+DEFAULT_PROJECT = "apps/rentearth/unreal-rentearth/rentearth.uproject"
+
+
+def write_clangd_pointer(repo_root: Path, db_dir: Path) -> Path:
+    rel = Path(db_dir).resolve().relative_to(Path(repo_root).resolve())
+    out = Path(repo_root) / ".clangd"
+    out.write_text("CompileFlags:\n  CompilationDatabase: " + str(rel) + "\n")
+    return out
+
+
+def locate_generated_db(engine_root: Path, project_dir: Path) -> Path | None:
+    for candidate in [
+        Path(project_dir) / "compile_commands.json",
+        Path(engine_root) / "compile_commands.json",
+    ]:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def find_repo_root(start: Path) -> Path:
+    for root in [start, *start.parents]:
+        if (root / ".git").exists():
+            return root
+    return start
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="kbve-unreal-clangd")
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument("--target", default="chuckEditor")
+    parser.add_argument("--config", default="Development")
+    parser.add_argument("--platform", default="Mac")
+    parser.add_argument("--engine-root")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo_root = find_repo_root(Path.cwd().resolve())
+    uproject = (repo_root / args.project).resolve()
+    if not uproject.exists():
+        print(f"uproject not found: {uproject}", file=sys.stderr)
+        return 2
+
+    engine_root = resolve_engine_root(
+        uproject, override=Path(args.engine_root) if args.engine_root else None
+    )
+    if not args.dry_run and not engine_root.exists():
+        print(
+            f"engine not found: {engine_root} (override with --engine-root or KBVE_UE_ROOT)",
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd = generate_clang_db_command(
+        engine_root=engine_root,
+        uproject=uproject,
+        target=args.target,
+        config=args.config,
+        platform=args.platform,
+    )
+    if args.dry_run:
+        print(" ".join(cmd))
+        return 0
+
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"UBT failed with exit code {result.returncode}", file=sys.stderr)
+        return result.returncode
+
+    project_dir = uproject.parent
+    db = locate_generated_db(engine_root, project_dir)
+    if db is None:
+        print("UBT succeeded but compile_commands.json not found", file=sys.stderr)
+        return 2
+    target_db = project_dir / "compile_commands.json"
+    if db != target_db:
+        shutil.move(str(db), str(target_db))
+
+    pointer = write_clangd_pointer(repo_root, project_dir)
+    print(f"database: {target_db}")
+    print(f"pointer:  {pointer}")
+    return 0

--- a/packages/python/kbve/kbve/unreal/ubt.py
+++ b/packages/python/kbve/kbve/unreal/ubt.py
@@ -1,0 +1,37 @@
+import json
+import os
+from pathlib import Path
+
+DEFAULT_ENGINE_BASE = Path("/Users/Shared/Epic Games")
+
+
+def parse_engine_association(uproject: Path) -> str:
+    data = json.loads(Path(uproject).read_text())
+    return data["EngineAssociation"]
+
+
+def resolve_engine_root(uproject: Path, override: Path | None = None) -> Path:
+    if override is not None:
+        return Path(override)
+    env = os.environ.get("KBVE_UE_ROOT")
+    if env:
+        return Path(env)
+    version = parse_engine_association(uproject)
+    return DEFAULT_ENGINE_BASE / f"UE_{version}"
+
+
+def generate_clang_db_command(
+    engine_root: Path,
+    uproject: Path,
+    target: str,
+    config: str,
+    platform: str,
+) -> list[str]:
+    return [
+        str(Path(engine_root) / "Engine/Build/BatchFiles/Mac/Build.sh"),
+        target,
+        platform,
+        config,
+        f"-project={uproject}",
+        "-mode=GenerateClangDatabase",
+    ]

--- a/packages/python/kbve/pyproject.toml
+++ b/packages/python/kbve/pyproject.toml
@@ -44,6 +44,8 @@ kbve-osrs-audit = "kbve.osrs.audit:main"
 kbve-osrs-families = "kbve.osrs.families:main"
 kbve-seo-audit = "kbve.seo.audit:main"
 kbve-seo-report = "kbve.seo.report:main"
+kbve-unreal-clangd = "kbve.unreal.clangd:main"
+kbve-unreal-check = "kbve.unreal.check:main"
 
 [dependency-groups]
 dev = [

--- a/packages/python/kbve/tests/test_unreal.py
+++ b/packages/python/kbve/tests/test_unreal.py
@@ -1,0 +1,52 @@
+import json
+
+import pytest
+
+from kbve.unreal.ubt import (
+    parse_engine_association,
+    resolve_engine_root,
+    generate_clang_db_command,
+)
+
+
+@pytest.fixture
+def uproject(tmp_path):
+    path = tmp_path / "rentearth.uproject"
+    path.write_text(json.dumps({"FileVersion": 3, "EngineAssociation": "5.8"}))
+    return path
+
+
+def test_parse_engine_association_reads_version(uproject):
+    assert parse_engine_association(uproject) == "5.8"
+
+
+def test_resolve_engine_root_defaults_to_shared_epic(uproject, monkeypatch):
+    monkeypatch.delenv("KBVE_UE_ROOT", raising=False)
+    assert str(resolve_engine_root(uproject)) == "/Users/Shared/Epic Games/UE_5.8"
+
+
+def test_resolve_engine_root_env_override(uproject, monkeypatch, tmp_path):
+    monkeypatch.setenv("KBVE_UE_ROOT", str(tmp_path / "UE"))
+    assert resolve_engine_root(uproject) == tmp_path / "UE"
+
+
+def test_resolve_engine_root_arg_beats_env(uproject, monkeypatch, tmp_path):
+    monkeypatch.setenv("KBVE_UE_ROOT", str(tmp_path / "env"))
+    assert resolve_engine_root(uproject, override=tmp_path / "arg") == tmp_path / "arg"
+
+
+def test_generate_clang_db_command_shape(uproject, tmp_path):
+    engine = tmp_path / "UE_5.8"
+    cmd = generate_clang_db_command(
+        engine_root=engine,
+        uproject=uproject,
+        target="chuckEditor",
+        config="Development",
+        platform="Mac",
+    )
+    assert cmd[0] == str(engine / "Engine/Build/BatchFiles/Mac/Build.sh")
+    assert "-mode=GenerateClangDatabase" in cmd
+    assert f"-project={uproject}" in cmd
+    assert "chuckEditor" in cmd
+    assert "Development" in cmd
+    assert "Mac" in cmd

--- a/packages/python/kbve/tests/test_unreal_check.py
+++ b/packages/python/kbve/tests/test_unreal_check.py
@@ -1,0 +1,160 @@
+import json
+
+import pytest
+
+from kbve.unreal.check import (
+    load_db,
+    find_entry,
+    rewrite_command,
+    resolve_check_entry,
+    EntryNotFound,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    src = tmp_path / "Plugins/KBVEUI/Source/KBVEUI/Private"
+    src.mkdir(parents=True)
+    widget = src / "KBVEWidget.cpp"
+    widget.write_text("")
+    other = src / "KBVETheme.cpp"
+    other.write_text("")
+    header = src / "KBVEWidget.h"
+    header.write_text("")
+    lonely_header = src / "KBVEStyle.h"
+    lonely_header.write_text("")
+    entries = [
+        {
+            "file": str(widget),
+            "directory": str(tmp_path),
+            "command": f'clang++ -DWITH_EDITOR=1 -I/ue/inc -c {widget} -o /out/KBVEWidget.o',
+        },
+        {
+            "file": str(other),
+            "directory": str(tmp_path),
+            "command": f'clang++ -DWITH_EDITOR=1 -I/ue/inc -c {other} -o /out/KBVETheme.o',
+        },
+    ]
+    path = tmp_path / "compile_commands.json"
+    path.write_text(json.dumps(entries))
+    return path
+
+
+def test_load_db_parses_entries(db_path):
+    entries = load_db(db_path)
+    assert len(entries) == 2
+    assert entries[0]["file"].endswith("KBVEWidget.cpp")
+
+
+def test_find_entry_matches_absolute_path(db_path):
+    entries = load_db(db_path)
+    target = entries[1]["file"]
+    assert find_entry(entries, target)["file"] == target
+
+
+def test_find_entry_returns_none_for_unknown(db_path):
+    entries = load_db(db_path)
+    assert find_entry(entries, "/nope/missing.cpp") is None
+
+
+def test_rewrite_command_adds_syntax_only_strips_output():
+    cmd = rewrite_command('clang++ -DX=1 -I/inc -c /src/a.cpp -o /out/a.o')
+    assert "-fsyntax-only" in cmd
+    assert "-o" not in cmd
+    assert "/out/a.o" not in cmd
+    assert "-c" not in cmd
+    assert "/src/a.cpp" in cmd
+
+
+def test_resolve_check_entry_source_direct(db_path):
+    entries = load_db(db_path)
+    target = entries[0]["file"]
+    entry, include = resolve_check_entry(entries, target)
+    assert entry["file"] == target
+    assert include is None
+
+
+def test_resolve_check_entry_header_uses_sibling_source(db_path):
+    entries = load_db(db_path)
+    header = entries[0]["file"].replace(".cpp", ".h")
+    entry, include = resolve_check_entry(entries, header)
+    assert entry["file"].endswith("KBVEWidget.cpp")
+    assert include == header
+
+
+def test_resolve_check_entry_header_falls_back_to_module_source(db_path):
+    entries = load_db(db_path)
+    header = entries[0]["file"].replace("KBVEWidget.cpp", "KBVEStyle.h")
+    entry, include = resolve_check_entry(entries, header)
+    assert entry["file"].endswith(".cpp")
+    assert include == header
+
+
+def test_resolve_check_entry_unknown_raises(db_path):
+    entries = load_db(db_path)
+    with pytest.raises(EntryNotFound):
+        resolve_check_entry(entries, "/elsewhere/Foo.cpp")
+
+
+def test_rewrite_command_suppresses_unused_arg_error():
+    cmd = rewrite_command('clang++ @/rsp/file.rsp')
+    assert "-fsyntax-only" in cmd
+    assert "-Wno-unused-command-line-argument" in cmd
+    assert cmd[1] == "@/rsp/file.rsp"
+
+
+def test_filter_diagnostics_keeps_driver_errors():
+    from kbve.unreal.check import filter_diagnostics
+    text = (
+        "note noise\n"
+        "clang++: error: something broke\n"
+        "/src/a.cpp:10:5: error: no member\n"
+        "/src/a.cpp:10:5: note: candidate\n"
+        "random line\n"
+    )
+    kept = filter_diagnostics(text)
+    assert "clang++: error: something broke" in kept
+    assert "/src/a.cpp:10:5: error: no member" in kept
+    assert "random line" not in kept
+
+
+def test_resolve_check_entry_public_header_finds_private_source(tmp_path):
+    priv = tmp_path / "Source/KBVECombat/Private"
+    pub = tmp_path / "Source/KBVECombat/Public"
+    priv.mkdir(parents=True)
+    pub.mkdir(parents=True)
+    cpp = priv / "KBVECombatComponent.cpp"
+    cpp.write_text("")
+    header = pub / "KBVECombatComponent.h"
+    header.write_text("")
+    entries = [
+        {
+            "file": str(cpp),
+            "directory": str(tmp_path),
+            "command": f"clang++ -c {cpp} -o /out/x.o",
+        }
+    ]
+    entry, include = resolve_check_entry(entries, str(header))
+    assert entry["file"] == str(cpp)
+    assert include == str(header)
+
+
+def test_resolve_check_entry_public_header_falls_back_to_module_any_source(tmp_path):
+    priv = tmp_path / "Source/KBVECombat/Private"
+    pub = tmp_path / "Source/KBVECombat/Public"
+    priv.mkdir(parents=True)
+    pub.mkdir(parents=True)
+    cpp = priv / "Other.cpp"
+    cpp.write_text("")
+    header = pub / "KBVELonely.h"
+    header.write_text("")
+    entries = [
+        {
+            "file": str(cpp),
+            "directory": str(tmp_path),
+            "command": f"clang++ -c {cpp} -o /out/x.o",
+        }
+    ]
+    entry, include = resolve_check_entry(entries, str(header))
+    assert entry["file"] == str(cpp)
+    assert include == str(header)

--- a/packages/python/kbve/tests/test_unreal_clangd.py
+++ b/packages/python/kbve/tests/test_unreal_clangd.py
@@ -1,0 +1,83 @@
+import json
+
+import pytest
+
+from kbve.unreal.check import build_check_invocation, main as check_main
+from kbve.unreal.clangd import write_clangd_pointer, locate_generated_db
+
+
+@pytest.fixture
+def db_env(tmp_path):
+    src = tmp_path / "proj/Source/mod"
+    src.mkdir(parents=True)
+    cpp = src / "A.cpp"
+    cpp.write_text("")
+    header = src / "A.h"
+    header.write_text("")
+    entries = [
+        {
+            "file": str(cpp),
+            "directory": str(tmp_path),
+            "command": f"clang++ -DX=1 -c {cpp} -o /out/A.o",
+        }
+    ]
+    db = tmp_path / "proj/compile_commands.json"
+    db.write_text(json.dumps(entries))
+    return tmp_path, db, cpp, header
+
+
+def test_build_check_invocation_header_injects_include(db_env):
+    _, db, cpp, header = db_env
+    entries = json.loads(db.read_text())
+    cmd = build_check_invocation(entries, str(header))
+    assert "-fsyntax-only" in cmd
+    assert "-include" in cmd
+    assert cmd[cmd.index("-include") + 1] == str(header.resolve())
+    assert cmd.index("-include") > cmd.index("-DX=1")
+
+
+def test_check_main_missing_entry_exit_code_2(db_env, capsys):
+    tmp_path, db, _, _ = db_env
+    missing = tmp_path / "proj/Source/mod/Nope.cpp"
+    missing.write_text("")
+    rc = check_main(["--db", str(db), str(missing)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "kbve-unreal-clangd" in err
+
+
+def test_write_clangd_pointer_creates_committed_config(tmp_path):
+    db_dir = tmp_path / "apps/rentearth/unreal-rentearth"
+    db_dir.mkdir(parents=True)
+    out = write_clangd_pointer(tmp_path, db_dir)
+    assert out == tmp_path / ".clangd"
+    text = out.read_text()
+    assert "CompilationDatabase: apps/rentearth/unreal-rentearth" in text
+
+
+def test_locate_generated_db_prefers_project_dir(tmp_path):
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "compile_commands.json").write_text("[]")
+    engine = tmp_path / "UE_5.8"
+    engine.mkdir()
+    found = locate_generated_db(engine, project_dir)
+    assert found == project_dir / "compile_commands.json"
+
+
+def test_locate_generated_db_finds_engine_output(tmp_path):
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    engine = tmp_path / "UE_5.8"
+    engine.mkdir()
+    (engine / "compile_commands.json").write_text("[]")
+    found = locate_generated_db(engine, project_dir)
+    assert found == engine / "compile_commands.json"
+
+
+def test_locate_generated_db_none_when_absent(tmp_path):
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    engine = tmp_path / "UE_5.8"
+    engine.mkdir()
+    assert locate_generated_db(engine, project_dir) is None


### PR DESCRIPTION
## Summary
- Adds `kbve.unreal` module to the kbve python package with two CLIs:
  - `kbve-unreal-clangd` — wraps UBT `GenerateClangDatabase` for rentearth (chuckEditor Development Mac by default), places the DB at `apps/rentearth/unreal-rentearth/compile_commands.json` (gitignored) and writes the committed root `.clangd` pointer.
  - `kbve-unreal-check <file...>` — per-file `-fsyntax-only` validation from the compile DB (~2s vs a full UBT build). Headers check via sibling source (`Public/X.h` → `Private/X.cpp` → any module source) with `-include` appended after the UBT rsp file. Exit codes: 0 clean, 1 errors, 2 not in DB.
- nx target `unreal-rentearth:clangd-db`, AGENTS.md guidance for coding agents, design spec under `docs/superpowers/specs/`.

## Why
cpptools had no compile database for `packages/unreal` — 8h blind indexing froze VS Code and fed wrong symbol info to AI tooling. One UBT-generated DB now powers clangd IDE support and seconds-fast agent-side validation.

## Testing
- 283 pytest pass, flake8 clean
- Real runs: DB generation 6.5s (364 entries, 211 KBVE plugin files); clean cpp check 2s; injected error caught with terse diagnostics; Public/ header check 1.5s