### PR TITLE
fix(unreal): link engine OpenSSL for KBVELibGit Linux build

### DIFF
--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
@@ -58,8 +58,8 @@ public class KBVELibGit : ModuleRules
 		{
 			LibDir = Path.Combine(ThirdPartyDir, "lib", "Linux");
 			PublicAdditionalLibraries.Add(Path.Combine(LibDir, "libgit2.a"));
-			// HTTPS via OpenSSL — link system ssl/crypto
-			PublicSystemLibraries.AddRange(new string[] { "ssl", "crypto" });
+			// HTTPS via OpenSSL — link the engine's bundled OpenSSL built against the UE toolchain sysroot
+			AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenSSL");
 		}
 
 		// Suppress warnings in third-party code

--- a/packages/unreal/KBVELibGit/ThirdParty/build-libgit2.sh
+++ b/packages/unreal/KBVELibGit/ThirdParty/build-libgit2.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Builds libgit2 static libs with native TLS per platform:
 #   Mac    -> SecureTransport (Security.framework, no OpenSSL)
-#   Linux  -> OpenSSL (system)
+#   Linux  -> OpenSSL (linked via engine ThirdParty at plugin build time)
 #   Win64  -> WinHTTP / SChannel (build on Windows, see notes)
 # Output: lib/<Platform>/(libgit2.a|git2.lib)
 # Usage:  ./build-libgit2.sh [mac|linux]


### PR DESCRIPTION
## Problem

`Verify (Linux)` for KBVELibGit fails at link:

```
ld.lld: error: unable to find library -lssl
ld.lld: error: unable to find library -lcrypto
clang++: error: linker command failed with exit code 1
```

`KBVELibGit.Build.cs` linked `PublicSystemLibraries { "ssl", "crypto" }` for Linux, but the UE Linux cross-toolchain sysroot has no system `libssl.so`/`libcrypto.so`.

## Fix

Replace the system libs with the engine's bundled OpenSSL third-party module:

```csharp
AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenSSL");
```

Built against the same UE toolchain sysroot, and it also pulls in zlib that libgit2 needs. Mac (SecureTransport) and Win64 (SChannel) paths untouched.

Run: https://github.com/KBVE/kbve/actions/runs/28591128455/job/84775739861