### PR TITLE
feat(astro-kbve): add /blog/, /api/, /docs/ SEO landing pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/api/ApiDirectory.astro
+++ b/apps/kbve/astro-kbve/src/components/api/ApiDirectory.astro
@@ -1,0 +1,307 @@
+---
+interface ApiLink {
+	name: string;
+	href: string;
+	body: string;
+	docs?: { label: string; href: string }[];
+	external?: boolean;
+}
+
+interface ApiGroup {
+	label: string;
+	blurb: string;
+	links: ApiLink[];
+}
+
+const groups: ApiGroup[] = [
+	{
+		label: 'Live OpenAPI specifications',
+		blurb: 'Interactive OpenAPI 3.1 explorers rendered inside the dashboard.',
+		links: [
+			{
+				name: 'KBVE Public API',
+				href: '/dashboard/api/#kbve',
+				body: 'The primary public REST API served by axum-kbve — auth, profiles, chat, and platform services.',
+				docs: [{ label: 'API project docs', href: '/project/api/' }],
+			},
+			{
+				name: 'Firecracker Control',
+				href: '/dashboard/api/#firecracker',
+				body: 'Staff-only firecracker-ctl service for managing microVM build and runtime workloads.',
+			},
+			{
+				name: 'ROWS (ChuckRPG)',
+				href: '/dashboard/api/#rows',
+				body: 'Game-services API behind the ChuckRPG launcher — sessions, characters, and instance orchestration.',
+				docs: [{ label: 'ROWS project docs', href: '/project/rows/' }],
+			},
+		],
+	},
+	{
+		label: 'Static data endpoints',
+		blurb: 'Prebuilt JSON generated from the MDX content collections at every deploy.',
+		links: [
+			{
+				name: '/api/itemdb.json',
+				href: '/api/itemdb.json',
+				body: 'Every item in the shared ItemDB with stats, sprites, and cross-game references.',
+				docs: [{ label: 'ItemDB', href: '/itemdb/' }],
+			},
+			{
+				name: '/api/npcdb.json',
+				href: '/api/npcdb.json',
+				body: 'NPC definitions — stats, behaviors, and dialogue hooks.',
+				docs: [{ label: 'NpcDB', href: '/npcdb/' }],
+			},
+			{
+				name: '/api/mapdb.json',
+				href: '/api/mapdb.json',
+				body: 'Map and tilemap metadata for every registered world.',
+				docs: [{ label: 'MapDB', href: '/mapdb/' }],
+			},
+			{
+				name: '/api/questdb.json',
+				href: '/api/questdb.json',
+				body: 'Quest chains, objectives, and reward tables.',
+				docs: [{ label: 'QuestDB', href: '/questdb/' }],
+			},
+			{
+				name: '/api/osrs.json',
+				href: '/api/osrs.json',
+				body: 'Old School RuneScape item metadata powering the OSRS wiki pages.',
+				docs: [{ label: 'OSRS', href: '/osrs/' }],
+			},
+			{
+				name: '/api/projects.json',
+				href: '/api/projects.json',
+				body: 'Every project page — pipelines, versions, and source paths.',
+				docs: [{ label: 'Projects', href: '/docs/' }],
+			},
+			{
+				name: '/api/applications.json',
+				href: '/api/applications.json',
+				body: 'The application reference index — tools, services, and integrations.',
+				docs: [{ label: 'Applications', href: '/docs/' }],
+			},
+			{
+				name: '/api/mc-items.json',
+				href: '/api/mc-items.json',
+				body: 'Minecraft item registry from the MC content collection.',
+				docs: [{ label: 'MC', href: '/mc/' }],
+			},
+			{
+				name: '/api/mc-blocks.json',
+				href: '/api/mc-blocks.json',
+				body: 'Minecraft block registry with states and drops.',
+				docs: [{ label: 'MC', href: '/mc/' }],
+			},
+			{
+				name: '/api/mc-enchants.json',
+				href: '/api/mc-enchants.json',
+				body: 'Minecraft enchantment registry with levels and exclusions.',
+				docs: [{ label: 'MC', href: '/mc/' }],
+			},
+			{
+				name: '/api/ci-registry.json',
+				href: '/api/ci-registry.json',
+				body: 'The CI dispatch registry — every buildable target in the monorepo.',
+			},
+			{
+				name: '/api/sitegraph.json',
+				href: '/api/sitegraph.json',
+				body: 'The full site link graph used by the graph explorer.',
+				docs: [{ label: 'Graph', href: '/dashboard/graph/' }],
+			},
+			{
+				name: '/api/resources.json',
+				href: '/api/resources.json',
+				body: 'Curated resource index across the docs.',
+			},
+			{
+				name: '/api/structures.json',
+				href: '/api/structures.json',
+				body: 'Structure definitions for the building and simulation systems.',
+			},
+			{
+				name: '/api/docs-meta.json',
+				href: '/api/docs-meta.json',
+				body: 'Metadata for every docs page — titles, descriptions, and tags.',
+			},
+		],
+	},
+	{
+		label: 'Feeds & machine-readable',
+		blurb: 'Syndication and LLM-friendly exports of the site.',
+		links: [
+			{
+				name: '/rss.xml',
+				href: '/rss.xml',
+				body: 'RSS feed of the KBVE journal.',
+				docs: [{ label: 'Blog', href: '/blog/' }],
+			},
+			{
+				name: '/llms.txt',
+				href: '/llms.txt',
+				body: 'Condensed site index for language models.',
+			},
+			{
+				name: '/llms-full.txt',
+				href: '/llms-full.txt',
+				body: 'Full-content export for language models.',
+			},
+		],
+	},
+];
+---
+
+<section class="apidir not-content">
+	{
+		groups.map((group) => (
+			<div class="apidir__group">
+				<div class="apidir__head">
+					<h2 class="apidir__heading">{group.label}</h2>
+					<span class="apidir__count">
+						{group.links.length} endpoints
+					</span>
+				</div>
+				<p class="apidir__blurb">{group.blurb}</p>
+				<div class="apidir__grid">
+					{group.links.map((link) => (
+						<div class="apidir__card">
+							<a
+								href={link.href}
+								class="apidir__name"
+								data-astro-prefetch={
+									link.href.endsWith('.json') ||
+									link.href.endsWith('.xml') ||
+									link.href.endsWith('.txt')
+										? 'false'
+										: undefined
+								}>
+								{link.name}
+							</a>
+							<p class="apidir__body">{link.body}</p>
+							{link.docs && (
+								<div class="apidir__links">
+									{link.docs.map((doc) => (
+										<a
+											href={doc.href}
+											class="apidir__doc"
+											data-astro-prefetch>
+											{doc.label} →
+										</a>
+									))}
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			</div>
+		))
+	}
+</section>
+
+<style>
+	.apidir {
+		display: flex;
+		flex-direction: column;
+		gap: 2.5rem;
+		margin: 2.5rem 0;
+	}
+
+	.apidir__head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-bottom: 0.6rem;
+		border-bottom: 1px solid
+			color-mix(
+				in oklab,
+				var(--sl-color-text-accent, #c9a56a) 30%,
+				transparent
+			);
+	}
+
+	.apidir__heading {
+		margin: 0;
+		font-size: 1.15rem;
+		font-weight: 700;
+		color: var(--sl-color-text-accent, #c9a56a);
+	}
+
+	.apidir__count {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.apidir__blurb {
+		margin: 0.6rem 0 1rem;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.apidir__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+		gap: 0.6rem;
+	}
+
+	.apidir__card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		padding: 0.85rem 1rem;
+		border-radius: 10px;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		background: var(--sl-color-bg-nav, #111);
+		transition:
+			border-color 180ms ease,
+			transform 180ms ease;
+	}
+
+	.apidir__card:hover {
+		border-color: color-mix(
+			in oklab,
+			var(--sl-color-text-accent, #c9a56a) 55%,
+			transparent
+		);
+		transform: translateY(-2px);
+	}
+
+	.apidir__name {
+		font-size: 0.9rem;
+		font-weight: 700;
+		color: var(--sl-color-white, #fff);
+		text-decoration: none;
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+		letter-spacing: -0.01em;
+	}
+
+	.apidir__body {
+		margin: 0;
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.apidir__links {
+		display: flex;
+		gap: 0.8rem;
+		flex-wrap: wrap;
+	}
+
+	.apidir__doc {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--sl-color-text-accent, #c9a56a);
+		text-decoration: none;
+	}
+
+	.apidir__doc:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/blog/BlogArchive.astro
+++ b/apps/kbve/astro-kbve/src/components/blog/BlogArchive.astro
@@ -1,0 +1,213 @@
+---
+import { getCollection } from 'astro:content';
+
+const MONTHS = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+];
+
+const posts = await getCollection(
+	'docs',
+	(entry) =>
+		entry.id.startsWith('journal/') &&
+		!entry.id.endsWith('index') &&
+		/^journal\/\d{2}-\d{2}$/.test(entry.id),
+);
+
+interface ArchiveRow {
+	href: string;
+	title: string;
+	description: string;
+	day: number;
+}
+
+const byMonth = new Map<number, ArchiveRow[]>();
+
+for (const entry of posts) {
+	const [mm, dd] = entry.id.replace('journal/', '').split('-');
+	const month = Number(mm);
+	const day = Number(dd);
+	if (!month || !day) continue;
+	const rows = byMonth.get(month) ?? [];
+	rows.push({
+		href: `/${entry.id}/`,
+		title: entry.data.title,
+		description: (entry.data.description ?? '').trim(),
+		day,
+	});
+	byMonth.set(month, rows);
+}
+
+const currentMonth = new Date().getMonth() + 1;
+const monthOrder = Array.from(byMonth.keys()).sort((a, b) => {
+	const ra = (currentMonth - a + 12) % 12;
+	const rb = (currentMonth - b + 12) % 12;
+	return ra - rb;
+});
+
+for (const rows of byMonth.values()) {
+	rows.sort((a, b) => b.day - a.day);
+}
+
+const total = posts.length;
+---
+
+<section class="blogarc not-content">
+	<div class="blogarc__intro">
+		<h2 class="blogarc__title">Journal archive</h2>
+		<span class="blogarc__count">{total} entries</span>
+	</div>
+	{
+		monthOrder.map((month) => (
+			<div class="blogarc__group">
+				<div class="blogarc__head">
+					<h3 class="blogarc__heading">{MONTHS[month - 1]}</h3>
+					<span class="blogarc__meta">
+						{byMonth.get(month)!.length} days
+					</span>
+				</div>
+				<div class="blogarc__grid">
+					{byMonth.get(month)!.map((row) => (
+						<a
+							href={row.href}
+							class="blogarc__card"
+							data-astro-prefetch>
+							<span class="blogarc__day">
+								{MONTHS[month - 1].slice(0, 3)} {row.day}
+							</span>
+							<span class="blogarc__name">{row.title}</span>
+							{row.description && (
+								<span class="blogarc__desc">
+									{row.description}
+								</span>
+							)}
+						</a>
+					))}
+				</div>
+			</div>
+		))
+	}
+</section>
+
+<style>
+	.blogarc {
+		display: flex;
+		flex-direction: column;
+		gap: 2.5rem;
+		margin: 2.5rem 0;
+	}
+
+	.blogarc__intro {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.blogarc__title {
+		margin: 0;
+		font-size: 1.4rem;
+		font-weight: 700;
+		color: var(--sl-color-white, #fff);
+	}
+
+	.blogarc__count {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.blogarc__head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-bottom: 0.6rem;
+		margin-bottom: 1rem;
+		border-bottom: 1px solid
+			color-mix(
+				in oklab,
+				var(--sl-color-text-accent, #c9a56a) 30%,
+				transparent
+			);
+	}
+
+	.blogarc__heading {
+		margin: 0;
+		font-size: 1.15rem;
+		font-weight: 700;
+		color: var(--sl-color-text-accent, #c9a56a);
+	}
+
+	.blogarc__meta {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.blogarc__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+		gap: 0.6rem;
+	}
+
+	.blogarc__card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		padding: 0.85rem 1rem;
+		border-radius: 10px;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		background: var(--sl-color-bg-nav, #111);
+		text-decoration: none;
+		transition:
+			border-color 180ms ease,
+			transform 180ms ease;
+	}
+
+	.blogarc__card:hover {
+		border-color: color-mix(
+			in oklab,
+			var(--sl-color-text-accent, #c9a56a) 55%,
+			transparent
+		);
+		transform: translateY(-2px);
+	}
+
+	.blogarc__day {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--sl-color-text-accent, #c9a56a);
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	}
+
+	.blogarc__name {
+		font-size: 0.9rem;
+		font-weight: 700;
+		color: var(--sl-color-white, #fff);
+	}
+
+	.blogarc__desc {
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--sl-color-gray-3, #8b949e);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/docs/DocsDirectory.astro
+++ b/apps/kbve/astro-kbve/src/components/docs/DocsDirectory.astro
@@ -1,0 +1,248 @@
+---
+import { getCollection } from 'astro:content';
+
+interface DirRow {
+	href: string;
+	title: string;
+	description: string;
+	meta?: string;
+}
+
+const pipelineMeta: Record<string, { label: string; accent: string }> = {
+	docker: { label: 'Services & Containers', accent: '#4f8fdd' },
+	crates: { label: 'Rust Crates', accent: '#e57448' },
+	unreal: { label: 'Unreal Plugins', accent: '#8a63d2' },
+	unreal_game: { label: 'Unreal Games', accent: '#8a63d2' },
+	ue5_server: { label: 'Unreal Servers', accent: '#8a63d2' },
+	unity: { label: 'Unity', accent: '#4fc08d' },
+	npm: { label: 'NPM Packages', accent: '#cb3837' },
+	python: { label: 'Python Packages', accent: '#3776ab' },
+	other: { label: 'Other Projects', accent: '#c9a56a' },
+};
+
+const pipelineOrder = [
+	'docker',
+	'crates',
+	'unreal',
+	'unreal_game',
+	'ue5_server',
+	'unity',
+	'npm',
+	'python',
+	'other',
+];
+
+function firstSentence(text: string): string {
+	const clean = text.replace(/\s+/g, ' ').trim();
+	const match = clean.match(/^.*?[.!?](\s|$)/);
+	return (match ? match[0] : clean).trim();
+}
+
+const applicationEntries = (await getCollection('application'))
+	.filter((entry) => !entry.id.endsWith('index') && entry.data.title)
+	.map((entry): DirRow => {
+		const data = entry.data as Record<string, unknown>;
+		return {
+			href: `/application/${entry.id.replace(/\.mdx?$/, '')}/`,
+			title: String(data.title ?? entry.id),
+			description: firstSentence(String(data.description ?? '')),
+		};
+	})
+	.sort((a, b) => a.title.localeCompare(b.title));
+
+const projectEntries = (await getCollection('project')).filter(
+	(entry) => !entry.id.endsWith('index') && entry.data.title,
+);
+
+const projectBuckets = new Map<string, DirRow[]>();
+
+for (const entry of projectEntries) {
+	const data = entry.data as Record<string, unknown>;
+	const pipeline = String(data.pipeline ?? 'other');
+	const key = pipeline in pipelineMeta ? pipeline : 'other';
+	const rows = projectBuckets.get(key) ?? [];
+	rows.push({
+		href: `/project/${entry.id.replace(/\.mdx?$/, '')}/`,
+		title: String(data.title ?? entry.id),
+		description: firstSentence(String(data.description ?? '')),
+		meta: data.version ? `v${data.version}` : undefined,
+	});
+	projectBuckets.set(key, rows);
+}
+
+for (const rows of projectBuckets.values()) {
+	rows.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+const orderedPipelines = pipelineOrder.filter((k) => projectBuckets.has(k));
+---
+
+<section class="docsdir not-content">
+	<div
+		id="applications"
+		class="docsdir__section"
+		style="--dir-accent: #c9a56a;">
+		<div class="docsdir__head">
+			<h2 class="docsdir__heading">Applications</h2>
+			<span class="docsdir__count">
+				{applicationEntries.length} references
+			</span>
+		</div>
+		<p class="docsdir__blurb">
+			Reference guides for the tools, services, and platforms used across
+			the monorepo — from Docker and Kubernetes to Blender and Unreal.
+		</p>
+		<div class="docsdir__grid">
+			{
+				applicationEntries.map((row) => (
+					<a
+						href={row.href}
+						class="docsdir__card"
+						data-astro-prefetch>
+						<span class="docsdir__name">{row.title}</span>
+						{row.description && (
+							<span class="docsdir__desc">{row.description}</span>
+						)}
+					</a>
+				))
+			}
+		</div>
+	</div>
+	{
+		orderedPipelines.map((pipeline) => (
+			<div
+				class="docsdir__section"
+				style={`--dir-accent: ${pipelineMeta[pipeline].accent};`}>
+				<div class="docsdir__head">
+					<h2 class="docsdir__heading">
+						{pipelineMeta[pipeline].label}
+					</h2>
+					<span class="docsdir__count">
+						{projectBuckets.get(pipeline)!.length} projects
+					</span>
+				</div>
+				<div class="docsdir__grid">
+					{projectBuckets.get(pipeline)!.map((row) => (
+						<a
+							href={row.href}
+							class="docsdir__card"
+							data-astro-prefetch>
+							<span class="docsdir__main">
+								<span class="docsdir__name">{row.title}</span>
+								{row.meta && (
+									<span class="docsdir__version">
+										{row.meta}
+									</span>
+								)}
+							</span>
+							{row.description && (
+								<span class="docsdir__desc">
+									{row.description}
+								</span>
+							)}
+						</a>
+					))}
+				</div>
+			</div>
+		))
+	}
+</section>
+
+<style>
+	.docsdir {
+		display: flex;
+		flex-direction: column;
+		gap: 2.5rem;
+		margin: 2.5rem 0;
+	}
+
+	.docsdir__section {
+		--dir-accent: var(--sl-color-text-accent, #c9a56a);
+	}
+
+	.docsdir__head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-bottom: 0.6rem;
+		margin-bottom: 1rem;
+		border-bottom: 1px solid
+			color-mix(in oklab, var(--dir-accent) 30%, transparent);
+	}
+
+	.docsdir__heading {
+		margin: 0;
+		font-size: 1.15rem;
+		font-weight: 700;
+		color: var(--dir-accent);
+	}
+
+	.docsdir__count {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.docsdir__blurb {
+		margin: 0 0 1rem;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	.docsdir__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+		gap: 0.6rem;
+	}
+
+	.docsdir__card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		padding: 0.85rem 1rem;
+		border-radius: 10px;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		background: var(--sl-color-bg-nav, #111);
+		text-decoration: none;
+		transition:
+			border-color 180ms ease,
+			transform 180ms ease;
+	}
+
+	.docsdir__card:hover {
+		border-color: color-mix(in oklab, var(--dir-accent) 55%, transparent);
+		transform: translateY(-2px);
+	}
+
+	.docsdir__main {
+		display: flex;
+		align-items: baseline;
+		gap: 0.6rem;
+		justify-content: space-between;
+	}
+
+	.docsdir__name {
+		font-size: 0.9rem;
+		font-weight: 700;
+		color: var(--sl-color-white, #fff);
+	}
+
+	.docsdir__version {
+		font-size: 0.72rem;
+		color: var(--sl-color-gray-3, #8b949e);
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	}
+
+	.docsdir__desc {
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--sl-color-gray-3, #8b949e);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/api/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/api/index.mdx
@@ -1,0 +1,73 @@
+---
+title: KBVE API Hub
+description: Every KBVE API in one place — live OpenAPI 3.1 specs for the public REST API, static JSON data endpoints for the item, NPC, map, and quest databases, plus RSS and LLM feeds.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+tags:
+    - api
+    - openapi
+    - json
+    - developers
+ogTitle: KBVE API Hub — OpenAPI Specs, JSON Data Endpoints & Feeds
+ogDescription: Explore the KBVE public REST API, staff services, and prebuilt JSON endpoints for the shared game databases — all documented and served from one open monorepo.
+jsonld:
+    type: WebPage
+    breadcrumb:
+        - name: Home
+          path: /
+        - name: API
+          path: /api/
+---
+
+import Hero from '@/components/marketing/Hero.astro';
+import StatStrip from '@/components/marketing/StatStrip.astro';
+import FaqAccordion from '@/components/marketing/FaqAccordion.astro';
+import Cta from '@/components/marketing/Cta.astro';
+import ApiDirectory from '@/components/api/ApiDirectory.astro';
+
+<Hero
+	eyebrow="kbve api"
+	lead="One hub, "
+	accent="every endpoint. "
+	tail="Specs, data, feeds."
+	subtitle="Live OpenAPI 3.1 explorers for the REST services, prebuilt JSON snapshots of the shared game databases, and machine-readable feeds — all generated from the open monorepo."
+	actions={[
+		{ label: 'Open the API Dashboard', href: '/dashboard/api/#kbve' },
+		{ label: 'API Project Docs', href: '/project/api/', variant: 'outline' },
+	]}
+/>
+
+<StatStrip
+	stats={[
+		{ value: '3', label: 'Live OpenAPI specs' },
+		{ value: '15+', label: 'JSON data endpoints' },
+		{ value: '3.1', label: 'OpenAPI version' },
+		{ value: '100%', label: 'Open source' },
+	]}
+/>
+
+<ApiDirectory />
+
+<FaqAccordion
+	title="API questions"
+	subtitle="Tap a question to expand."
+	items={[
+		{ q: 'Where is the interactive API explorer?', a: 'The dashboard at /dashboard/api/ renders live OpenAPI 3.1 specs for the KBVE public API, the staff-only Firecracker control service, and the ROWS game-services API.' },
+		{ q: 'How fresh are the JSON data endpoints?', a: 'They are regenerated from the MDX content collections on every deploy, so they always match the published docs pages.' },
+		{ q: 'Do I need an API key?', a: 'The static JSON endpoints and feeds are fully public. The REST API uses Supabase JWT auth for authenticated routes — see the API project docs for details.' },
+		{ q: 'Can I use this data in my own project?', a: 'Yes — everything is generated from the public monorepo. Attribution is appreciated but the data endpoints are free to consume.' },
+	]}
+/>
+
+<Cta
+	title="Build against the API."
+	subtitle="Read the service docs or explore the live specs in the dashboard."
+	actions={[
+		{ label: 'API Dashboard', href: '/dashboard/api/' },
+		{ label: 'Browse the Docs', href: '/docs/', variant: 'outline' },
+	]}
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/blog/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/blog/index.mdx
@@ -1,0 +1,63 @@
+---
+title: KBVE Blog & Dev Journal
+description: The KBVE blog — a daily dev journal covering game development, Rust services, Kubernetes infrastructure, and everything shipped in the open monorepo.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+sidebar:
+    label: Blog Home
+    order: 0
+tags:
+    - blog
+    - journal
+    - devlog
+ogTitle: KBVE Blog — Daily Dev Journal from an Open Monorepo
+ogDescription: Daily entries on game development, Rust, Unreal, Unity, and Kubernetes — the full dev log behind kbve.com, written in the open.
+jsonld:
+    type: WebPage
+    breadcrumb:
+        - name: Home
+          path: /
+        - name: Blog
+          path: /blog/
+---
+
+import Hero from '@/components/marketing/Hero.astro';
+import StatStrip from '@/components/marketing/StatStrip.astro';
+import Cta from '@/components/marketing/Cta.astro';
+import BlogArchive from '@/components/blog/BlogArchive.astro';
+
+<Hero
+	eyebrow="kbve blog"
+	lead="Shipped daily, "
+	accent="written in the open. "
+	tail="The dev journal."
+	subtitle="Every day of building games, Rust services, and Kubernetes infrastructure gets an entry — raw notes, fixes, and design decisions straight from the monorepo."
+	actions={[
+		{ label: 'Journal Navigator', href: '/journal/' },
+		{ label: 'Subscribe via RSS', href: '/rss.xml', variant: 'outline' },
+	]}
+/>
+
+<StatStrip
+	stats={[
+		{ value: '365+', label: 'Journal entries' },
+		{ value: '1', label: 'Open monorepo' },
+		{ value: 'Daily', label: 'Publishing cadence' },
+		{ value: '0', label: 'Paywalls' },
+	]}
+/>
+
+<BlogArchive />
+
+<Cta
+	title="Want the code behind the posts?"
+	subtitle="Every entry references real commits in the public monorepo — browse the docs or the source."
+	actions={[
+		{ label: 'Browse the Docs', href: '/docs/' },
+		{ label: 'View on GitHub', href: 'https://github.com/kbve/kbve', variant: 'outline' },
+	]}
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/docs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/docs/index.mdx
@@ -1,0 +1,71 @@
+---
+title: KBVE Documentation
+description: The full KBVE documentation index — application reference guides and every project in the monorepo, from Rust crates and Docker services to Unreal and Unity plugins.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+tags:
+    - docs
+    - applications
+    - projects
+ogTitle: KBVE Docs — Application References & Project Index
+ogDescription: Browse every application reference and project in the KBVE monorepo — Docker services, Rust crates, Unreal plugins, Unity systems, and the packages that ship them.
+jsonld:
+    type: WebPage
+    breadcrumb:
+        - name: Home
+          path: /
+        - name: Docs
+          path: /docs/
+---
+
+import Hero from '@/components/marketing/Hero.astro';
+import StatStrip from '@/components/marketing/StatStrip.astro';
+import ProcessSteps from '@/components/marketing/ProcessSteps.astro';
+import Cta from '@/components/marketing/Cta.astro';
+import DocsDirectory from '@/components/docs/DocsDirectory.astro';
+
+<Hero
+	eyebrow="kbve docs"
+	lead="Every app, "
+	accent="every project. "
+	tail="One index."
+	subtitle="Application reference guides sit next to the projects that use them — Docker services, Rust crates, Unreal and Unity plugins, all documented from the same open monorepo."
+	actions={[
+		{ label: 'Jump to Applications', href: '#applications' },
+		{ label: 'API Hub', href: '/api/', variant: 'outline' },
+	]}
+/>
+
+<StatStrip
+	stats={[
+		{ value: '40+', label: 'Application guides' },
+		{ value: '110+', label: 'Documented projects' },
+		{ value: '5', label: 'Language ecosystems' },
+		{ value: '1', label: 'Monorepo' },
+	]}
+/>
+
+<ProcessSteps
+	title="How the docs are organized"
+	subtitle="Three layers, one source of truth."
+	steps={[
+		{ title: 'Applications', body: 'Deep reference guides for the tools and platforms the stack is built on — Docker, ArgoCD, Blender, and more.' },
+		{ title: 'Projects', body: 'Every buildable target in the monorepo gets a page — pipeline, version, source path, and usage docs.' },
+		{ title: 'Data & APIs', body: 'The game databases and REST services those projects expose, browsable at the API hub.' },
+	]}
+/>
+
+<DocsDirectory />
+
+<Cta
+	title="Can't find what you need?"
+	subtitle="Try the journal for day-by-day context, or ask in the community."
+	actions={[
+		{ label: 'Read the Blog', href: '/blog/' },
+		{ label: 'Join the Discord', href: '/discord/', variant: 'outline' },
+	]}
+/>


### PR DESCRIPTION
## Summary

Three fully static, SEO-ready landing pages for internal linking, built from the rn-astro marketing sections (Hero, StatStrip, ProcessSteps, FaqAccordion, Cta) plus new server-rendered directory components so every internal link exists in the prerendered HTML — no JS required for crawlers.

- **/blog/** — journal archive grouped by month; 366 static links into `/journal/*` plus RSS and Journal Navigator entry points (`BlogArchive.astro`)
- **/api/** — directory of the three live OpenAPI dashboard specs (`/dashboard/api/#kbve`, `#firecracker`, `#rows`), all 15 static `/api/*.json` data endpoints with links to their backing docs, and the RSS/LLM feeds (`ApiDirectory.astro`)
- **/docs/** — full documentation index: 42 application references A–Z plus 112 projects grouped by pipeline (docker, crates, unreal, unity, npm, python) with versions from frontmatter (`DocsDirectory.astro`)

All three pages carry `ogTitle`/`ogDescription` and BreadcrumbList JSON-LD via the existing `Head.astro` frontmatter support. Directory components query the content collections at build time, so they stay in sync with the MDX source of truth on every deploy.

The sidebar config already referenced an autogenerated `blog` directory and showcase.mdx already linked to `/docs/` — both now resolve.

## Testing

- `nx astro-kbve:build` passes (7335 pages)
- Verified in built HTML: 366 `/journal/` links on /blog/, 112 `/project/` + 42 `/application/` links on /docs/, 15 JSON endpoint links on /api/, BreadcrumbList JSON-LD present