### PR TITLE
feat(arpg-web): iso height rendering — displaced terrain for 1:1 parity with Unreal

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -45,8 +45,14 @@ import {
 	screenToWorld,
 	screenToWorldF,
 	tileDepth,
+	setIsoHeightSeed,
+	setIsoHeightEnabled,
 	type TileXY,
 } from './iso';
+import {
+	makeHeightTexture,
+	type HeightTextureHandle,
+} from './systems/heightTexture';
 import {
 	setupInput as setupInputV,
 	type SceneInputDeps,
@@ -272,6 +278,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	};
 	private dungeonView!: DungeonView;
 	private ground?: GroundShaderHandle;
+	private heightTex?: HeightTextureHandle;
 	// Eased zoom: wheel/keys nudge zoomTarget, update() smooth-damps the camera
 	// toward it (critically-damped spring) so zoom accelerates then settles instead
 	// of snapping. SMOOTH_TIME ~ time to converge; MAX_SPEED caps the glide rate.
@@ -490,6 +497,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		});
 		if (USE_GROUND_SHADER) {
 			this.ground = makeGroundShader(this);
+			this.heightTex = makeHeightTexture(this);
 			this.ground.update(this.cameras.main);
 			this.ground.shader.setVisible(this.isSurface());
 		}
@@ -1262,6 +1270,9 @@ export class IsoArpgScene extends Phaser.Scene {
 				/* private mode */
 			}
 			this.mySlot = w.your_slot;
+			setIsoHeightSeed(w.seed);
+			setIsoHeightEnabled(this.isSurface());
+			this.heightTex?.reset();
 			this.kindRegistry.clear();
 			for (const entry of w.registry ?? []) {
 				this.kindRegistry.set(entry.kind, entry);
@@ -1748,6 +1759,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	 */
 	private onFloorChange(f: FloorChangeEvent) {
 		this.currentFloor = f.z;
+		setIsoHeightEnabled(this.isSurface());
 		this.ground?.shader.setVisible(this.isSurface());
 		if (!this.isSurface()) {
 			this.clearPredictedTrees();
@@ -1916,7 +1928,8 @@ export class IsoArpgScene extends Phaser.Scene {
 		tickFacingV(this, this.store);
 		this.tickZoom(delta);
 		this.dustLayer?.update(this.cameras.main);
-		this.ground?.update(this.cameras.main);
+		this.heightTex?.update(this.cameras.main);
+		this.ground?.update(this.cameras.main, this.heightTex);
 		this.residency.tick((id) => {
 			if (!id.startsWith('creature:')) return;
 			for (const r of this.creaturePool.drain(id.slice(9)))

--- a/apps/agones/arpg/web/src/game/iso.spec.ts
+++ b/apps/agones/arpg/web/src/game/iso.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	worldToScreen,
+	worldToScreenFlat,
+	screenToWorldF,
+	setIsoHeightSeed,
+	setIsoHeightEnabled,
+	isoHeightActive,
+	terrainLiftPx,
+	HEIGHT_PX_PER_UU,
+} from './iso';
+import { heightAt, seedFromWorld, HEIGHT_AMPLITUDE } from '@kbve/laser';
+
+const SEED = 0xc1a55e5a;
+
+afterEach(() => {
+	setIsoHeightEnabled(false);
+});
+
+describe('iso height projection', () => {
+	it('is flat until a seed is installed and enabled', () => {
+		setIsoHeightEnabled(false);
+		const p = worldToScreen(12, 34);
+		expect(p).toEqual(worldToScreenFlat(12, 34));
+		expect(terrainLiftPx(12, 34)).toBe(0);
+	});
+
+	it('lifts by the shared heightfield when enabled', () => {
+		setIsoHeightSeed(SEED);
+		setIsoHeightEnabled(true);
+		expect(isoHeightActive()).toBe(true);
+		const tx = 64.25;
+		const ty = -18.5;
+		const expectedLift =
+			heightAt(seedFromWorld(SEED), tx, ty) * HEIGHT_PX_PER_UU;
+		const flat = worldToScreenFlat(tx, ty);
+		const lifted = worldToScreen(tx, ty);
+		expect(lifted.x).toBe(flat.x);
+		expect(flat.y - lifted.y).toBeCloseTo(expectedLift, 6);
+		expect(Math.abs(expectedLift)).toBeLessThanOrEqual(
+			HEIGHT_AMPLITUDE * HEIGHT_PX_PER_UU,
+		);
+	});
+
+	it('screenToWorldF inverts the displaced projection', () => {
+		setIsoHeightSeed(SEED);
+		setIsoHeightEnabled(true);
+		const samples: Array<[number, number]> = [
+			[0, 0],
+			[10.5, 3.25],
+			[-40, 87],
+			[123.75, -55.5],
+			[300, 300],
+		];
+		for (const [tx, ty] of samples) {
+			const p = worldToScreen(tx, ty);
+			const back = screenToWorldF(p.x, p.y);
+			// The raycast returns the VISIBLE surface under the pixel — when the
+			// input tile is occluded by nearer terrain that is a different (deeper)
+			// tile, so assert re-projection consistency, not tile identity.
+			const rp = worldToScreen(back.x, back.y);
+			expect(rp.x).toBeCloseTo(p.x, 1);
+			expect(rp.y).toBeCloseTo(p.y, 1);
+			expect(back.x + back.y).toBeGreaterThanOrEqual(tx + ty - 1e-3);
+		}
+	});
+
+	it('stays flat on dungeon floors even with a seed installed', () => {
+		setIsoHeightSeed(SEED);
+		setIsoHeightEnabled(false);
+		expect(isoHeightActive()).toBe(false);
+		const p = worldToScreen(64.25, -18.5);
+		expect(p).toEqual(worldToScreenFlat(64.25, -18.5));
+	});
+});

--- a/apps/agones/arpg/web/src/game/iso.ts
+++ b/apps/agones/arpg/web/src/game/iso.ts
@@ -1,3 +1,9 @@
+import {
+	makeHeightSampler,
+	seedFromWorld,
+	HEIGHT_AMPLITUDE,
+	type HeightSampler,
+} from '@kbve/laser';
 import { TILE_W, TILE_H } from './config';
 
 export interface TileXY {
@@ -10,7 +16,55 @@ export interface PixelXY {
 	y: number;
 }
 
+/**
+ * Height rendering: the shared deterministic heightmap (simgrid heightfield /
+ * FKBVEWorldHeightfield / laser heightAt) lifts every projected point so a
+ * hill displaces on screen exactly as the Unreal client renders it. Height is
+ * in Unreal uu (100 uu per tile); one tile of height = one tile of screen
+ * lift, so uu -> px is TILE_H / 100. Surface floors only — dungeons stay flat.
+ */
+export const HEIGHT_PX_PER_UU = TILE_H / 100;
+const HEIGHT_AMPLITUDE_PX = HEIGHT_AMPLITUDE * HEIGHT_PX_PER_UU;
+
+let heightSampler: HeightSampler | null = null;
+let heightEnabled = false;
+
+/** Install the world seed at Welcome — mirrors the Unreal streamer re-seed. */
+export function setIsoHeightSeed(worldSeed: number): void {
+	heightSampler = makeHeightSampler(seedFromWorld(worldSeed));
+}
+
+/** Toggle the height term (surface floors on, dungeon floors off). */
+export function setIsoHeightEnabled(enabled: boolean): void {
+	heightEnabled = enabled;
+}
+
+export function isoHeightActive(): boolean {
+	return heightEnabled && heightSampler !== null;
+}
+
+/** Terrain lift in screen px at a tile-space position (0 when disabled). */
+export function terrainLiftPx(tx: number, ty: number): number {
+	if (!heightEnabled || !heightSampler) return 0;
+	return heightSampler(tx, ty) * HEIGHT_PX_PER_UU;
+}
+
+/** Terrain height in uu at a tile-space position (0 when disabled). */
+export function terrainHeightUu(tx: number, ty: number): number {
+	if (!heightEnabled || !heightSampler) return 0;
+	return heightSampler(tx, ty);
+}
+
 export function worldToScreen(tx: number, ty: number): PixelXY {
+	return {
+		x: (tx - ty) * (TILE_W / 2),
+		y: (tx + ty) * (TILE_H / 2) - terrainLiftPx(tx, ty),
+	};
+}
+
+/** Flat projection — ignores terrain height. For ground-texture anchoring and
+ * other math that must match the un-displaced iso plane. */
+export function worldToScreenFlat(tx: number, ty: number): PixelXY {
 	return {
 		x: (tx - ty) * (TILE_W / 2),
 		y: (tx + ty) * (TILE_H / 2),
@@ -22,15 +76,54 @@ export function screenToWorld(px: number, py: number): TileXY {
 	return { x: Math.round(f.x), y: Math.round(f.y) };
 }
 
-/** Fractional world position for a screen point — no tile rounding. Use for aim
- * direction and projectile origins where sub-tile precision matters. */
-export function screenToWorldF(px: number, py: number): TileXY {
+function flatSolve(px: number, py: number): TileXY {
 	const a = px / (TILE_W / 2);
 	const b = py / (TILE_H / 2);
 	return {
 		x: (a + b) / 2,
 		y: (b - a) / 2,
 	};
+}
+
+/** Fractional world position for a screen point — no tile rounding. Use for aim
+ * direction and projectile origins where sub-tile precision matters. With
+ * height active this is a heightfield raycast on F(s) = lift(tile(py+s)) - s:
+ * the screen ray can cross the displaced terrain more than once, and the
+ * visible surface is the topmost crossing (largest s = greatest tx+ty depth),
+ * so march down from +amplitude to bracket the first sign change, then bisect.
+ * The march step is far below the noise wavelength in s-space, so no crossing
+ * region is skipped. Naive fixed-point iteration diverges here — the
+ * detail-noise slope exceeds the tile step. */
+const RAY_MARCH_STEP_PX = 16;
+
+export function screenToWorldF(px: number, py: number): TileXY {
+	if (!heightEnabled || !heightSampler) return flatSolve(px, py);
+	const amp = HEIGHT_AMPLITUDE_PX;
+	const liftAt = (s: number): number => {
+		const t = flatSolve(px, py + s);
+		return terrainLiftPx(t.x, t.y);
+	};
+	let hi = amp;
+	let lo = hi;
+	let found = false;
+	while (hi > -amp - RAY_MARCH_STEP_PX) {
+		lo = hi - RAY_MARCH_STEP_PX;
+		if (liftAt(lo) - lo >= 0) {
+			found = true;
+			break;
+		}
+		hi = lo;
+	}
+	if (!found) return flatSolve(px, py);
+	for (let i = 0; i < 12; i++) {
+		const mid = (lo + hi) / 2;
+		if (liftAt(mid) - mid > 0) {
+			lo = mid;
+		} else {
+			hi = mid;
+		}
+	}
+	return flatSolve(px, py + (lo + hi) / 2);
 }
 
 export function tileDepth(tx: number, ty: number): number {

--- a/apps/agones/arpg/web/src/game/systems/dungeonView.ts
+++ b/apps/agones/arpg/web/src/game/systems/dungeonView.ts
@@ -9,7 +9,12 @@ import {
 	DUNGEON_RADIUS,
 	USE_GROUND_SHADER,
 } from '../config';
-import { worldToScreen, tileDepth, type TileXY } from '../iso';
+import {
+	worldToScreen,
+	worldToScreenFlat,
+	tileDepth,
+	type TileXY,
+} from '../iso';
 import { DungeonField, chunkOf, CHUNK_SIZE, StairKind } from './dungeon';
 import { biomeKeyAt } from './biome';
 import {
@@ -230,7 +235,7 @@ function buildChunkGround(
 
 	const midX = cx * CHUNK_SIZE + CHUNK_SIZE / 2;
 	const midY = cy * CHUNK_SIZE + CHUNK_SIZE / 2;
-	const c = worldToScreen(midX, midY);
+	const c = worldToScreenFlat(midX, midY);
 
 	const ux = c.x;
 	const uy = c.y / 0.5;

--- a/apps/agones/arpg/web/src/game/systems/groundShader.ts
+++ b/apps/agones/arpg/web/src/game/systems/groundShader.ts
@@ -1,5 +1,7 @@
 import Phaser from 'phaser';
 import { BIOMES, biomeTextureKey } from '../config';
+import { isoHeightActive } from '../iso';
+import type { HeightTextureHandle } from './heightTexture';
 
 const ATLAS_W = 1024;
 const ATLAS_H = 512;
@@ -21,12 +23,16 @@ uniform sampler2D uBiome0;
 uniform sampler2D uBiome1;
 uniform sampler2D uBiome2;
 uniform sampler2D uBiome3;
+uniform sampler2D uHeight;
 uniform vec4 uWorldView;
 uniform vec2 uAtlas;
 uniform float uRegionFreq;
 uniform float uEdgeFreq;
 uniform float uEdgeJitter;
 uniform float uBlendWidth;
+uniform vec4 uHeightRect;
+uniform float uHeightAmpPx;
+uniform float uHeightOn;
 
 float hash(vec2 p) {
 	return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
@@ -43,18 +49,51 @@ float vnoise(vec2 p) {
 	return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
 }
 
+vec2 flatTile(vec2 ws) {
+	float a = ws.x / 32.0;
+	float b = ws.y / 16.0;
+	return vec2((a + b) * 0.5, (b - a) * 0.5);
+}
+
+float liftPx(vec2 tile) {
+	vec2 huv = (tile - uHeightRect.xy) * uHeightRect.zw;
+	if (huv.x < 0.0 || huv.x > 1.0 || huv.y < 0.0 || huv.y > 1.0) return 0.0;
+	vec4 s = texture2D(uHeight, huv);
+	float hn = (s.r * 65280.0 + s.g * 255.0) / 65535.0;
+	return (hn * 2.0 - 1.0) * uHeightAmpPx;
+}
+
 void main() {
 	vec2 ws = vec2(
 		uWorldView.x + outTexCoord.x * uWorldView.z,
 		uWorldView.y + (1.0 - outTexCoord.y) * uWorldView.w
 	);
 
-	float a = ws.x / 32.0;
-	float b = ws.y / 16.0;
-	vec2 tile = vec2((a + b) * 0.5, (b - a) * 0.5);
+	vec2 tile = flatTile(ws);
+	if (uHeightOn > 0.5) {
+		float hi = uHeightAmpPx;
+		float lo = hi;
+		bool found = false;
+		for (int i = 0; i < 40; i++) {
+			lo = hi - 16.0;
+			if (lo < -uHeightAmpPx - 16.0) { break; }
+			vec2 t = flatTile(vec2(ws.x, ws.y + lo));
+			if (liftPx(t) - lo >= 0.0) { found = true; break; }
+			hi = lo;
+		}
+		if (found) {
+			for (int i = 0; i < 10; i++) {
+				float mid = (lo + hi) * 0.5;
+				vec2 t = flatTile(vec2(ws.x, ws.y + mid));
+				if (liftPx(t) - mid > 0.0) { lo = mid; } else { hi = mid; }
+			}
+			tile = flatTile(vec2(ws.x, ws.y + (lo + hi) * 0.5));
+		}
+	}
 
-	float ux = ws.x;
-	float uy = ws.y * 2.0;
+	vec2 wsFlat = vec2((tile.x - tile.y) * 32.0, (tile.x + tile.y) * 16.0);
+	float ux = wsFlat.x;
+	float uy = wsFlat.y * 2.0;
 	vec2 uv = vec2(ux + uy, uy - ux) * 0.70710678 / uAtlas;
 
 	vec4 t0 = texture2D(uBiome0, uv);
@@ -77,12 +116,21 @@ void main() {
 
 export interface GroundShaderHandle {
 	shader: Phaser.GameObjects.Shader;
-	update(cam: Phaser.Cameras.Scene2D.Camera): void;
+	update(
+		cam: Phaser.Cameras.Scene2D.Camera,
+		heightTex?: HeightTextureHandle,
+	): void;
 }
 
 export function makeGroundShader(scene: Phaser.Scene): GroundShaderHandle {
 	const cam = scene.cameras.main;
 	const textures = BIOMES.map((b) => biomeTextureKey(b));
+	const heightState = {
+		rect: [0, 0, 1, 1] as [number, number, number, number],
+		ampPx: 0,
+		on: 0,
+	};
+	let boundHeightKey = '';
 	const shader = scene.add.shader(
 		{
 			name: 'arpg-ground',
@@ -95,12 +143,16 @@ export function makeGroundShader(scene: Phaser.Scene): GroundShaderHandle {
 				setUniform('uBiome1', 1);
 				setUniform('uBiome2', 2);
 				setUniform('uBiome3', 3);
+				setUniform('uHeight', 4);
 				setUniform('uWorldView', [wv.x, wv.y, wv.width, wv.height]);
 				setUniform('uAtlas', [ATLAS_W, ATLAS_H]);
 				setUniform('uRegionFreq', REGION_FREQ);
 				setUniform('uEdgeFreq', EDGE_FREQ);
 				setUniform('uEdgeJitter', EDGE_JITTER);
 				setUniform('uBlendWidth', BLEND_WIDTH);
+				setUniform('uHeightRect', heightState.rect);
+				setUniform('uHeightAmpPx', heightState.ampPx);
+				setUniform('uHeightOn', heightState.on);
 			},
 		},
 		cam.width / 2,
@@ -118,10 +170,25 @@ export function makeGroundShader(scene: Phaser.Scene): GroundShaderHandle {
 	// uWorldView (which already encodes zoom) maps outTexCoord 0..1 to the viewport.
 	return {
 		shader,
-		update(cam: Phaser.Cameras.Scene2D.Camera) {
+		update(
+			cam: Phaser.Cameras.Scene2D.Camera,
+			heightTex?: HeightTextureHandle,
+		) {
 			shader.setSize(cam.width, cam.height);
 			shader.setPosition(cam.width / 2, cam.height / 2);
 			shader.setScale(1 / cam.zoom);
+
+			if (heightTex && heightTex.key && isoHeightActive()) {
+				heightState.rect = heightTex.rect;
+				heightState.ampPx = heightTex.ampPx;
+				heightState.on = 1;
+				if (boundHeightKey !== heightTex.key) {
+					boundHeightKey = heightTex.key;
+					shader.setSampler2D('uHeight', heightTex.key, 4);
+				}
+			} else {
+				heightState.on = 0;
+			}
 		},
 	};
 }

--- a/apps/agones/arpg/web/src/game/systems/heightTexture.ts
+++ b/apps/agones/arpg/web/src/game/systems/heightTexture.ts
@@ -1,0 +1,101 @@
+import Phaser from 'phaser';
+import { HEIGHT_AMPLITUDE } from '@kbve/laser';
+import {
+	isoHeightActive,
+	terrainHeightUu,
+	screenToWorldF,
+	HEIGHT_PX_PER_UU,
+} from '../iso';
+
+/**
+ * Height texture for the ground shader: a camera-following window of the
+ * shared heightfield, one sample per tile, 16-bit packed into RG. The fragment
+ * shader bilinearly interpolates between tile samples — the same smoothing the
+ * Unreal terrain mesh gets from vertex interpolation.
+ */
+export const HEIGHT_TEX_SIZE = 160;
+export const HEIGHT_TEX_KEYS = ['arpg-height-0', 'arpg-height-1'] as const;
+const REBUILD_MARGIN_TILES = 24;
+
+export interface HeightTextureHandle {
+	/** Current texture key ('' until first build). */
+	key: string;
+	/** Tile-space rect: origin x, origin y, 1/size, 1/size. */
+	rect: [number, number, number, number];
+	ampPx: number;
+	update(cam: Phaser.Cameras.Scene2D.Camera): boolean;
+	reset(): void;
+}
+
+export function makeHeightTexture(scene: Phaser.Scene): HeightTextureHandle {
+	let flip = 0;
+	let originX = Number.NaN;
+	let originY = Number.NaN;
+	const data = new Uint8Array(HEIGHT_TEX_SIZE * HEIGHT_TEX_SIZE * 4);
+
+	const handle: HeightTextureHandle = {
+		key: '',
+		rect: [0, 0, 1 / HEIGHT_TEX_SIZE, 1 / HEIGHT_TEX_SIZE],
+		ampPx: HEIGHT_AMPLITUDE * HEIGHT_PX_PER_UU,
+		update(cam) {
+			if (!isoHeightActive()) return false;
+			const center = screenToWorldF(cam.midPoint.x, cam.midPoint.y);
+			const half = HEIGHT_TEX_SIZE / 2;
+			if (
+				!Number.isNaN(originX) &&
+				Math.abs(center.x - (originX + half)) <
+					half - REBUILD_MARGIN_TILES &&
+				Math.abs(center.y - (originY + half)) <
+					half - REBUILD_MARGIN_TILES
+			) {
+				return false;
+			}
+			originX = Math.floor(center.x) - half;
+			originY = Math.floor(center.y) - half;
+			build(data, originX, originY);
+			flip ^= 1;
+			const key = HEIGHT_TEX_KEYS[flip];
+			if (scene.textures.exists(key)) scene.textures.remove(key);
+			scene.textures.addUint8Array(
+				key,
+				data,
+				HEIGHT_TEX_SIZE,
+				HEIGHT_TEX_SIZE,
+			);
+			handle.key = key;
+			handle.rect = [
+				originX,
+				originY,
+				1 / HEIGHT_TEX_SIZE,
+				1 / HEIGHT_TEX_SIZE,
+			];
+			return true;
+		},
+		reset() {
+			originX = Number.NaN;
+			originY = Number.NaN;
+		},
+	};
+	return handle;
+}
+
+function build(data: Uint8Array, originX: number, originY: number): void {
+	let i = 0;
+	for (let y = 0; y < HEIGHT_TEX_SIZE; y++) {
+		for (let x = 0; x < HEIGHT_TEX_SIZE; x++) {
+			const h = terrainHeightUu(originX + x, originY + y);
+			const hn = Math.min(
+				65535,
+				Math.max(
+					0,
+					Math.round(((h / HEIGHT_AMPLITUDE + 1) / 2) * 65535),
+				),
+			);
+			data[i] = hn >> 8;
+			data[i + 1] = hn & 0xff;
+			data[i + 2] = 0;
+			data[i + 3] = 255;
+			i += 4;
+		}
+	}
+}

--- a/apps/agones/arpg/web/src/game/systems/spells.ts
+++ b/apps/agones/arpg/web/src/game/systems/spells.ts
@@ -8,7 +8,12 @@ import {
 	castStormVfx,
 } from '../entities/projectiles/spells/spellVfx';
 import type { EntityRefs } from '../entities/sprites';
-import { worldToScreen, screenToWorldF, type TileXY } from '../iso';
+import {
+	worldToScreen,
+	worldToScreenFlat,
+	screenToWorldF,
+	type TileXY,
+} from '../iso';
 import type { InterpBuffer } from './interp';
 
 /**
@@ -138,9 +143,10 @@ function leadTarget(
 		Math.hypot(sprite.x - aPx.x, sprite.y - aPx.y) / BOLT_SPEED_PX_MS,
 	);
 	const vel = velTilesPerMs(interp);
-	// worldToScreen is linear (no translation), so it maps the tile-space velocity straight
-	// to a screen-space velocity vector.
-	const sv = worldToScreen(vel.vx, vel.vy);
+	// The FLAT projection is linear (no translation), so it maps the tile-space
+	// velocity straight to a screen-space velocity vector. The height-aware
+	// projection would sample terrain at (vx, vy) as if it were a position.
+	const sv = worldToScreenFlat(vel.vx, vel.vy);
 	let leadX = sv.x * flightMs;
 	let leadY = sv.y * flightMs;
 	const leadMag = Math.hypot(leadX, leadY);

--- a/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
+++ b/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
@@ -1,0 +1,9 @@
+/**
+ * Vitest-only stand-in for the @kbve/laser runtime barrel. The real barrel
+ * value-exports Phaser-backed helpers node-env vitest cannot load. This stub
+ * re-exports the pure leaves the spec import graphs actually execute
+ * (heightfield via iso.ts, game-auth via config.ts); laser type-only imports
+ * are erased before resolution and never reach it.
+ */
+export * from '../../../../../../packages/npm/laser/src/lib/determ/heightfield';
+export * from '../../../../../../packages/npm/laser/src/lib/auth/game-auth';

--- a/apps/agones/arpg/web/vitest.config.ts
+++ b/apps/agones/arpg/web/vitest.config.ts
@@ -1,10 +1,27 @@
+import * as path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 // Unit tests for the game's pure logic (dungeon parity, etc). Kept separate from
 // the build config (vite.config.ts) — these specs need no DOM, no Phaser, and no
 // laser source alias; they exercise plain TS. The dungeon parity spec pins the
 // frozen FNV-1a fingerprint shared with simgrid's Rust arpg_dungeon.
+//
+// @kbve/laser resolves to a pure-leaf stub, not the runtime barrel: the barrel
+// value-exports Phaser-backed helpers that node-env vitest cannot load, while
+// the values these spec graphs execute live in pure leaves (heightfield,
+// game-auth). Type-only laser imports are erased before resolution.
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^@kbve\/laser$/,
+				replacement: path.resolve(
+					__dirname,
+					'src/test/laser-vitest-stub.ts',
+				),
+			},
+		],
+	},
 	test: {
 		globals: true,
 		watch: false,

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -128,8 +128,10 @@ export { RAPIER, createRapierPhysics } from './lib/physics/rapier';
 export { Domain, mix32, mulberry32, stream, rollPct } from './lib/determ';
 export {
 	heightAt,
+	makeHeightSampler,
 	seedFromWorld,
 	HEIGHT_AMPLITUDE,
+	type HeightSampler,
 } from './lib/determ/heightfield';
 
 // Combat — attack geometry mirrored byte-for-byte by simgrid combat.rs

--- a/packages/npm/laser/src/lib/determ/heightfield.ts
+++ b/packages/npm/laser/src/lib/determ/heightfield.ts
@@ -49,8 +49,13 @@ function buildFbm(
 	return noise;
 }
 
-/** Height in Unreal uu for a tile-space position. */
-export function heightAt(seed: number, tileX: number, tileY: number): number {
+export type HeightSampler = (tileX: number, tileY: number) => number;
+
+/**
+ * Cached sampler for hot paths (per-frame projection, ground textures) — one
+ * FastNoiseLite pair per seed instead of two allocations per sample.
+ */
+export function makeHeightSampler(seed: number): HeightSampler {
 	const continent = buildFbm(
 		seed,
 		CONTINENT_FREQ,
@@ -65,8 +70,15 @@ export function heightAt(seed: number, tileX: number, tileY: number): number {
 		DETAIL_GAIN,
 		DETAIL_LACUNARITY,
 	);
-	const mix =
-		CONTINENT_WEIGHT * continent.GetNoise(tileX, tileY) +
-		DETAIL_WEIGHT * detail.GetNoise(tileX, tileY);
-	return Math.min(1, Math.max(-1, mix)) * HEIGHT_AMPLITUDE;
+	return (tileX, tileY) => {
+		const mix =
+			CONTINENT_WEIGHT * continent.GetNoise(tileX, tileY) +
+			DETAIL_WEIGHT * detail.GetNoise(tileX, tileY);
+		return Math.min(1, Math.max(-1, mix)) * HEIGHT_AMPLITUDE;
+	};
+}
+
+/** Height in Unreal uu for a tile-space position. */
+export function heightAt(seed: number, tileX: number, tileY: number): number {
+	return makeHeightSampler(seed)(tileX, tileY);
 }


### PR DESCRIPTION
Closes #13747

Renders the shared heightfield (#13746) on the web client so a hill displaces on screen exactly where and how the Unreal client shows it — same function, same seed, same 2:1 projection of the same geometry.

## How

- **Projection** ([iso.ts](apps/agones/arpg/web/src/game/iso.ts)): `worldToScreen` subtracts the terrain lift (`TILE_H/100` px per uu → ±288 px over the ±900 uu field). Seed installed at Welcome (mirrors the Unreal streamer re-seed), surface floors only — dungeons stay flat. `worldToScreenFlat` keeps the un-displaced plane for linear-map math.
- **Picking**: `screenToWorldF` is now a proper heightfield raycast — march down from +amplitude to the topmost crossing, then bisect. Two subtle failure modes ruled out along the way: naive fixed-point iteration diverges where the detail-noise slope exceeds the tile step, and plain bisection over the full range can land on an occluded crossing when the screen ray intersects terrain more than once.
- **Ground** ([groundShader.ts](apps/agones/arpg/web/src/game/systems/groundShader.ts)): the fullscreen biome shader runs the same raycast per pixel against a height texture and samples biome regions + ground UVs at the displaced tile.
- **Height texture** ([heightTexture.ts](apps/agones/arpg/web/src/game/systems/heightTexture.ts)): camera-following 160×160-tile window, one sample per tile, 16-bit packed RG, rebuilt only when the camera nears the window edge; GPU bilinear filtering interpolates between tile samples (the web analog of Unreal's vertex interpolation).
- **Everything else inherits**: entities, trees, players, projectiles, hole diamonds all place through `worldToScreen`. Two flat-assumption fixes: spell target-leading maps *velocity* through the flat projection, and the dungeon TileSprite anchor stays on the flat plane.
- **laser**: `makeHeightSampler(seed)` — cached FastNoiseLite pair for hot paths.
- **vitest**: `@kbve/laser` resolves to a pure-leaf stub (heightfield + game-auth) because the runtime barrel value-exports Phaser-backed helpers node-env vitest cannot load.

## Verification

- arpg-web: 25 tests pass (new iso.spec: lift correctness, raycast inversion re-projection consistency, floor gating) + build clean
- laser: 175 tests + build clean
- Runtime visual check vs Unreal side-by-side still pending a live session

## Notes

- Depth stays `tx + ty` — height cannot reorder draw order in this projection.
- Shader raycast is ~40 height-texture lookups/pixel worst case; height texture rebuild (~25k samples) fires only on window-edge crossings. Watch perf on low-end Discord Activity clients — knobs exist (window size, march step).