### PR TITLE
feat(astro-kbve): SEO hardening pass on landing pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/api/ApiDirectory.astro
+++ b/apps/kbve/astro-kbve/src/components/api/ApiDirectory.astro
@@ -60,6 +60,12 @@ const groups: ApiGroup[] = [
 				docs: [{ label: 'MapDB', href: '/mapdb/' }],
 			},
 			{
+				name: '/api/mapdb.proto.json',
+				href: '/api/mapdb.proto.json',
+				body: 'MapDB serialized against the shared protobuf schema for engine clients.',
+				docs: [{ label: 'MapDB', href: '/mapdb/' }],
+			},
+			{
 				name: '/api/questdb.json',
 				href: '/api/questdb.json',
 				body: 'Quest chains, objectives, and reward tables.',

--- a/apps/kbve/astro-kbve/src/content/docs/api/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/api/index.mdx
@@ -14,6 +14,7 @@ tags:
     - developers
 ogTitle: KBVE API Hub — OpenAPI Specs, JSON Data Endpoints & Feeds
 ogDescription: Explore the KBVE public REST API, staff services, and prebuilt JSON endpoints for the shared game databases — all documented and served from one open monorepo.
+ogImage: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
 jsonld:
     type: WebPage
     breadcrumb:
@@ -21,6 +22,15 @@ jsonld:
           path: /
         - name: API
           path: /api/
+    faq:
+        - question: Where is the interactive API explorer?
+          answer: The dashboard at /dashboard/api/ renders live OpenAPI 3.1 specs for the KBVE public API, the staff-only Firecracker control service, and the ROWS game-services API.
+        - question: How fresh are the JSON data endpoints?
+          answer: They are regenerated from the MDX content collections on every deploy, so they always match the published docs pages.
+        - question: Do I need an API key?
+          answer: The static JSON endpoints and feeds are fully public. The REST API uses Supabase JWT auth for authenticated routes — see the API project docs for details.
+        - question: Can I use this data in my own project?
+          answer: Yes — everything is generated from the public monorepo. Attribution is appreciated but the data endpoints are free to consume.
 ---
 
 import Hero from '@/components/marketing/Hero.astro';
@@ -28,6 +38,8 @@ import StatStrip from '@/components/marketing/StatStrip.astro';
 import FaqAccordion from '@/components/marketing/FaqAccordion.astro';
 import Cta from '@/components/marketing/Cta.astro';
 import ApiDirectory from '@/components/api/ApiDirectory.astro';
+
+<h1 class="sr-only">KBVE API Hub</h1>
 
 <Hero
 	eyebrow="kbve api"

--- a/apps/kbve/astro-kbve/src/content/docs/blog/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/blog/index.mdx
@@ -16,6 +16,7 @@ tags:
     - devlog
 ogTitle: KBVE Blog — Daily Dev Journal from an Open Monorepo
 ogDescription: Daily entries on game development, Rust, Unreal, Unity, and Kubernetes — the full dev log behind kbve.com, written in the open.
+ogImage: https://images.unsplash.com/photo-1456513080510-7bf3a84b82f8?fit=crop&w=1400&h=700&q=75
 jsonld:
     type: WebPage
     breadcrumb:
@@ -29,6 +30,8 @@ import Hero from '@/components/marketing/Hero.astro';
 import StatStrip from '@/components/marketing/StatStrip.astro';
 import Cta from '@/components/marketing/Cta.astro';
 import BlogArchive from '@/components/blog/BlogArchive.astro';
+
+<h1 class="sr-only">KBVE Blog & Dev Journal</h1>
 
 <Hero
 	eyebrow="kbve blog"

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
@@ -24,3 +24,5 @@ import AstroApiDashboard from '@/components/dashboard/AstroApiDashboard.astro';
         { slug: 'rows', title: 'ROWS (ChuckRPG)', url: '/api/rows/openapi.json' },
     ]}
 />
+
+Looking for the static JSON data endpoints and feeds? Browse the full [API hub](/api/).

--- a/apps/kbve/astro-kbve/src/content/docs/docs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/docs/index.mdx
@@ -13,6 +13,7 @@ tags:
     - projects
 ogTitle: KBVE Docs — Application References & Project Index
 ogDescription: Browse every application reference and project in the KBVE monorepo — Docker services, Rust crates, Unreal plugins, Unity systems, and the packages that ship them.
+ogImage: https://images.unsplash.com/photo-1461344552813-5985830be0a3?fit=crop&w=1400&h=700&q=75
 jsonld:
     type: WebPage
     breadcrumb:
@@ -27,6 +28,8 @@ import StatStrip from '@/components/marketing/StatStrip.astro';
 import ProcessSteps from '@/components/marketing/ProcessSteps.astro';
 import Cta from '@/components/marketing/Cta.astro';
 import DocsDirectory from '@/components/docs/DocsDirectory.astro';
+
+<h1 class="sr-only">KBVE Documentation</h1>
 
 <Hero
 	eyebrow="kbve docs"

--- a/apps/kbve/astro-kbve/src/content/docs/journal/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/index.mdx
@@ -25,5 +25,7 @@ The goals are to capture fleeting ideas, spiritual insights, and technical revel
 Think of each entry as a sacred snippet of code or contemplation, sparking inspiration for seekers and coders alike?
 This will be all fed into a machine when I am old and it will merge my future ghost into a robot!
 
+Looking for a specific day? The [blog archive](/blog/) lists every entry grouped by month, or subscribe via [RSS](/rss.xml).
+
 
 <Adsense />


### PR DESCRIPTION
## Summary

Follow-up to #13756 (commit landed on the branch after merge).

- Server-rendered `sr-only` h1 on /blog/, /api/, /docs/ — the Hero sections are `client:only` islands, so all three pages previously shipped without any `<h1>` in the prerendered HTML
- `ogImage` frontmatter on all three pages for proper social cards (previously defaulted to the brand letter logo)
- FAQPage JSON-LD on /api/ mirroring the FaqAccordion island content, which is invisible to crawlers
- Add the missing `/api/mapdb.proto.json` endpoint to the API directory
- Inbound links: journal index → /blog/ archive + RSS, dashboard API page → /api/ hub

## Testing

- `nx astro-kbve:build` passes
- Verified in built HTML: sr-only h1 on all three pages, `FAQPage` node on /api/, unsplash og:image on all three, `mapdb.proto.json` card present, inbound links resolve