### PR TITLE
fix(lint): clippy is_multiple_of + laser fastnoise-lite peer dep

### DIFF
--- a/packages/npm/laser/package.json
+++ b/packages/npm/laser/package.json
@@ -44,7 +44,8 @@
 		"@react-three/fiber": ">=9.0.0",
 		"@react-three/drei": ">=10.0.0",
 		"bitecs": ">=0.4.0",
-		"@phaserjs/rapier-connector": ">=1.0.0"
+		"@phaserjs/rapier-connector": ">=1.0.0",
+		"fastnoise-lite": ">=1.1.0"
 	},
 	"peerDependenciesMeta": {
 		"phaser": {
@@ -63,6 +64,9 @@
 			"optional": true
 		},
 		"@phaserjs/rapier-connector": {
+			"optional": true
+		},
+		"fastnoise-lite": {
 			"optional": true
 		}
 	},

--- a/packages/rust/simgrid/src/net_udp.rs
+++ b/packages/rust/simgrid/src/net_udp.rs
@@ -80,7 +80,7 @@ impl UdpLane {
         };
         if bytes.len() > proto::UDP_MAX_DATAGRAM {
             let count = self.oversize_count.fetch_add(1, Ordering::Relaxed) + 1;
-            if count == 1 || count % 100 == 0 {
+            if count == 1 || count.is_multiple_of(100) {
                 tracing::warn!(
                     len = bytes.len(),
                     count,


### PR DESCRIPTION
Fixes 4 failing lint targets on dev CI (laser, simgrid, arpg-server, cryptothrone-server).

- **simgrid**: `count % 100 == 0` in `net_udp.rs` trips `clippy::manual_is_multiple_of` under Rust 1.94 with `-D warnings`; replaced with `count.is_multiple_of(100)`. arpg-server and cryptothrone-server lint failures were cascades from this since both check simgrid.
- **laser**: `@nx/dependency-checks` flags `fastnoise-lite` (used by `determ/heightfield.ts`) missing from `peerDependencies`; added as optional peer matching the existing pattern.

All four lint targets verified locally.