### PR TITLE
fix(kube): explicit Certificate for kbve-wt-tls wildcard

### DIFF
--- a/apps/kube/kbve/manifest/kbve-wt-cert.yaml
+++ b/apps/kube/kbve/manifest/kbve-wt-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: kbve-wt-tls
+    namespace: kbve
+spec:
+    secretName: kbve-wt-tls
+    issuerRef:
+        name: letsencrypt-dns
+        kind: ClusterIssuer
+        group: cert-manager.io
+    commonName: '*.kbve.com'
+    dnsNames:
+        - '*.kbve.com'
+        - kbve.com
+    duration: 2160h
+    renewBefore: 720h
+    privateKey:
+        algorithm: ECDSA
+        size: 256

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
     - arpg-discord-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
+    - kbve-wt-cert.yaml
     - kubevirt-rbac.yaml
     - kbve-deployment.yaml
     - kbve-gateway.yaml


### PR DESCRIPTION
Closes #13110.

## Problem
`kbve-wt-tls` (secret backing every `*.kbve.com` + `kbve.com` HTTPS listener on `kbve-gateway`) was minted implicitly by the cert-manager gateway-shim from the Gateway's `cert-manager.io/cluster-issuer` annotation. The single most-depended-on cert had no GitOps-visible owner — the silent-renewal-failure class #12973 set out to fix.

## Fix
Add explicit `Certificate` `kbve-wt-tls` (`apps/kube/kbve/manifest/kbve-wt-cert.yaml`):
- `*.kbve.com` + `kbve.com`, `letsencrypt-dns` ClusterIssuer (DNS-01)
- secretName `kbve-wt-tls`, ECDSA-256, 90d duration / 30d renewBefore

Wired into `kustomization.yaml`. Gateway annotation kept — other listener certs (`direct-git-tls`, etc.) still rely on the shim; explicit Cert owns the `kbve-wt-tls` secret so the shim skips it (no double-mint).

`kubectl kustomize` builds clean.