### PR TITLE
chore(vscode): exclude worktrees and build dirs from watcher/search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,5 +66,23 @@
 	"C_Cpp.codeAnalysis.runAutomatically": false,
 	"rust-analyzer.initializeStopped": true,
 	"git.autoRepositoryDetection": false,
-	"git.ignoreLimitWarning": true
+	"git.ignoreLimitWarning": true,
+	"files.watcherExclude": {
+		"**/.claude/worktrees/**": true,
+		"**/node_modules/**": true,
+		"**/target/**": true,
+		"**/dist/**": true,
+		"**/.nx/**": true,
+		"**/.astro/**": true
+	},
+	"search.exclude": {
+		"**/.claude/worktrees": true,
+		"**/node_modules": true,
+		"**/target": true,
+		"**/dist": true,
+		"**/.nx": true
+	},
+	"files.exclude": {
+		"**/.claude/worktrees": true
+	}
 }


### PR DESCRIPTION
## Problem

VS Code stalls on this repo. `.claude/worktrees/` holds ~58 worktrees (~87 GB), many with full `node_modules` and `target` trees. `.vscode/settings.json` had no watcher or search excludes, so the file watcher, TS server, and search indexer crawl all of it.

## Change

Add `files.watcherExclude`, `search.exclude`, and `files.exclude` for `.claude/worktrees`, `node_modules`, `target`, `dist`, `.nx`, `.astro`. Complements the existing mitigations already in the file (`rust-analyzer.initializeStopped`, `git.autoRepositoryDetection: false`).

Reload the VS Code window after merge to apply.