### PR TITLE
perf(simgrid,arpg): zero-copy snapshot fan-out + kill per-tick allocs

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/agones/arpg/server/src/creatures.rs
+++ b/apps/agones/arpg/server/src/creatures.rs
@@ -387,7 +387,7 @@ pub fn stream_trees(
         .map(|(p, _)| p.tile)
         .collect();
 
-    let mut alive: Vec<Tile> = Vec::new();
+    let mut alive: std::collections::HashSet<Tile> = std::collections::HashSet::new();
     for (entity, pos, pfloor) in trees.iter() {
         if pfloor.map(|f| f.0).unwrap_or(0) != SPAWN_FLOOR {
             continue;
@@ -396,7 +396,7 @@ pub fn stream_trees(
             .iter()
             .any(|pt| chebyshev(*pt, pos.tile) <= TREE_DESPAWN_RADIUS);
         if near {
-            alive.push(pos.tile);
+            alive.insert(pos.tile);
         } else {
             commands.entity(entity).despawn();
             map.unblock_tile_z(SPAWN_FLOOR, pos.tile);
@@ -437,7 +437,7 @@ pub fn stream_trees(
                     if !felled {
                         map.block_tile_z(SPAWN_FLOOR, tile);
                     }
-                    alive.push(tile);
+                    alive.insert(tile);
                 }
             }
         }
@@ -483,7 +483,7 @@ pub fn stream_bushes(
         .map(|(p, _)| p.tile)
         .collect();
 
-    let mut alive: Vec<Tile> = Vec::new();
+    let mut alive: std::collections::HashSet<Tile> = std::collections::HashSet::new();
     for (entity, pos, pfloor) in bushes.iter() {
         if pfloor.map(|f| f.0).unwrap_or(0) != SPAWN_FLOOR {
             continue;
@@ -492,7 +492,7 @@ pub fn stream_bushes(
             .iter()
             .any(|pt| chebyshev(*pt, pos.tile) <= BUSH_DESPAWN_RADIUS);
         if near {
-            alive.push(pos.tile);
+            alive.insert(pos.tile);
         } else {
             commands.entity(entity).despawn();
         }
@@ -522,7 +522,7 @@ pub fn stream_bushes(
                 let harvested = harvested_tiles.contains(&(tile.x, tile.y));
                 let state = BushState { variant, harvested };
                 if spawn_bush(&mut commands, &registry, tile, SPAWN_FLOOR, state).is_some() {
-                    alive.push(tile);
+                    alive.insert(tile);
                 }
             }
         }

--- a/apps/agones/arpg/server/src/game.rs
+++ b/apps/agones/arpg/server/src/game.rs
@@ -88,12 +88,11 @@ pub const SHIP_PARKED_FACING: u8 = 0;
 /// (`float_move::step_float`) resolves smoothly against whichever tiles are blocked,
 /// so this set IS the collision shape. Reused for driving: unblock the old footprint,
 /// move, block the new one (recompute with the new facing).
-pub fn ship_footprint(base: Tile, facing: u8) -> Vec<Tile> {
+pub fn ship_footprint(base: Tile, facing: u8) -> impl Iterator<Item = Tile> {
     let f = (facing as usize) % 16;
     crate::ship_footprint_gen::SHIP_FOOTPRINTS[f]
         .iter()
-        .map(|&(dx, dy)| Tile::new(base.x + dx, base.y + dy))
-        .collect()
+        .map(move |&(dx, dy)| Tile::new(base.x + dx, base.y + dy))
 }
 
 /// The ship's starter parked tile — where it spawns, and where the orphan-recovery
@@ -111,9 +110,7 @@ pub fn ship_home_tile() -> Tile {
 /// resolves, so it never collides with itself.
 #[allow(dead_code)] // wired in when driving lands; foundation only for now
 pub fn ship_blocked(map: &WalkableMap, z: i32, base: Tile, facing: u8) -> bool {
-    ship_footprint(base, facing)
-        .into_iter()
-        .any(|t| !map.is_walkable_z(z, t))
+    ship_footprint(base, facing).any(|t| !map.is_walkable_z(z, t))
 }
 
 /// Player collision radius, in tiles. Mirrors the web `BODY_RADIUS` (config.ts) so
@@ -194,32 +191,33 @@ pub fn resolve_ship_collision(
         (With<PlayerSlotTag>, Without<simgrid::Piloting>),
     >,
 ) {
-    // (z, base tile, world-space hull verts) per ship.
-    let hulls: Vec<(i32, Vec<(f32, f32)>)> = ships
-        .iter()
-        .filter(|(_, _, _, env)| env.def_ref == SHIP_REF)
-        .map(|(pos, floor, rot, _)| {
-            let z = floor.map(|f| f.0).unwrap_or(0);
-            let facing = (rot.map(|r| r.0).unwrap_or(0) as usize) % 16;
-            let (bx, by) = (pos.tile.x as f32, pos.tile.y as f32);
-            let verts = crate::ship_footprint_gen::SHIP_HULLS[facing]
-                .iter()
-                .map(|&(x, y)| (bx + x, by + y))
-                .collect();
-            (z, verts)
-        })
-        .collect();
-    if hulls.is_empty() {
+    if players.is_empty() {
         return;
     }
+    // World-space hull verts translated per (player, ship) into a reused scratch
+    // buffer — `SHIP_HULLS[facing]` is `&'static`, so translation is the only work
+    // and no per-tick Vec-of-Vecs is allocated.
+    let mut verts: Vec<(f32, f32)> = Vec::new();
     for (mut fm, mut pos, floor) in players.iter_mut() {
         let pz = floor.map(|f| f.0).unwrap_or(0);
-        for (z, verts) in &hulls {
-            if *z != pz {
+        for (spos, sfloor, rot, env) in ships.iter() {
+            if env.def_ref != SHIP_REF {
                 continue;
             }
+            let z = sfloor.map(|f| f.0).unwrap_or(0);
+            if z != pz {
+                continue;
+            }
+            let facing = (rot.map(|r| r.0).unwrap_or(0) as usize) % 16;
+            let (bx, by) = (spos.tile.x as f32, spos.tile.y as f32);
+            verts.clear();
+            verts.extend(
+                crate::ship_footprint_gen::SHIP_HULLS[facing]
+                    .iter()
+                    .map(|&(x, y)| (bx + x, by + y)),
+            );
             if let Some((nx, ny, wnx, wny)) =
-                resolve_circle_poly(fm.body.x, fm.body.y, PLAYER_BODY_RADIUS, verts)
+                resolve_circle_poly(fm.body.x, fm.body.y, PLAYER_BODY_RADIUS, &verts)
             {
                 fm.body.x = nx;
                 fm.body.y = ny;
@@ -1298,7 +1296,7 @@ mod tests {
         use super::Tile;
         let base = Tile::new(10, 20);
         for facing in 0u8..16 {
-            let tiles = super::ship_footprint(base, facing);
+            let tiles: Vec<Tile> = super::ship_footprint(base, facing).collect();
             let baked = &crate::ship_footprint_gen::SHIP_FOOTPRINTS[facing as usize];
             assert!(
                 !tiles.is_empty(),
@@ -1322,8 +1320,8 @@ mod tests {
         let base = Tile::new(0, 0);
         // The sub byte can carry phase in its high bits; ship_footprint masks to 16.
         assert_eq!(
-            super::ship_footprint(base, 3),
-            super::ship_footprint(base, 3 + 16)
+            super::ship_footprint(base, 3).collect::<Vec<_>>(),
+            super::ship_footprint(base, 3 + 16).collect::<Vec<_>>()
         );
     }
 }

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -275,20 +275,19 @@ fn route_snapshot_aoi(
             .entities
             .iter()
             .find(|e| e.owner == h.slot && e.max_hp > 0);
-        let entities: Vec<proto::EntityDelta> = match me {
+        let entities: Vec<&proto::EntityDelta> = match me {
             Some(me) => snap
                 .entities
                 .iter()
                 .filter(|e| e.z == me.z && aoi_chebyshev(e.tile, me.tile) <= AOI_RADIUS)
-                .cloned()
                 .collect(),
-            None => snap.entities.clone(),
+            None => snap.entities.iter().collect(),
         };
-        let view = proto::Snapshot {
+        let view = proto::SnapshotRef {
             tick: snap.tick,
             server_time_ms: snap.server_time_ms,
             input_ack: snap.input_ack,
-            players: players.clone(),
+            players: &players,
             entities,
             keyframe: snap.keyframe,
         };
@@ -298,12 +297,12 @@ fn route_snapshot_aoi(
         {
             continue;
         }
-        let frame = Arc::new(encode_frame(&ServerEvent::Snapshot(view)));
+        let frame = Arc::new(encode_frame(&proto::ServerEventRef::Snapshot(view)));
         deliver(h.value(), frame);
     }
 }
 
-fn encode_frame(evt: &ServerEvent) -> EncodedFrame {
+fn encode_frame<T: serde::Serialize>(evt: &T) -> EncodedFrame {
     EncodedFrame {
         postcard: proto::encode(evt).unwrap_or_default(),
     }

--- a/packages/rust/simgrid/src/net_udp.rs
+++ b/packages/rust/simgrid/src/net_udp.rs
@@ -8,9 +8,14 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
 use crate::net::SlotInput;
-use crate::proto::{self, UdpPacket};
+use crate::proto::{self, UdpPacket, UdpPacketRef};
 
 const UDP_STALE_SECS: u64 = 10;
+
+thread_local! {
+    static SEND_SCRATCH: std::cell::RefCell<[u8; proto::UDP_MAX_DATAGRAM]> =
+        const { std::cell::RefCell::new([0u8; proto::UDP_MAX_DATAGRAM]) };
+}
 
 struct Binding {
     addr: SocketAddr,
@@ -74,28 +79,23 @@ impl UdpLane {
         Some(b.addr)
     }
 
-    pub fn try_send_snapshot(&self, addr: SocketAddr, snap: &proto::Snapshot) -> bool {
-        let Ok(bytes) = proto::encode_inner(&UdpPacket::Snapshot(snap.clone())) else {
-            return false;
-        };
-        if bytes.len() > proto::UDP_MAX_DATAGRAM {
-            let count = self.oversize_count.fetch_add(1, Ordering::Relaxed) + 1;
-            if count == 1 || count.is_multiple_of(100) {
-                tracing::warn!(
-                    len = bytes.len(),
-                    count,
-                    "udp snapshot oversize; falling back to ws"
-                );
-            } else {
-                tracing::debug!(
-                    len = bytes.len(),
-                    count,
-                    "udp snapshot oversize; falling back to ws"
-                );
+    pub fn try_send_snapshot(&self, addr: SocketAddr, snap: &proto::SnapshotRef<'_>) -> bool {
+        SEND_SCRATCH.with(|scratch| {
+            let mut scratch = scratch.borrow_mut();
+            let pkt = UdpPacketRef::Snapshot(snap);
+            match postcard::to_slice(&pkt, scratch.as_mut_slice()) {
+                Ok(bytes) => self.socket.try_send_to(bytes, addr).is_ok(),
+                Err(_) => {
+                    let count = self.oversize_count.fetch_add(1, Ordering::Relaxed) + 1;
+                    if count == 1 || count.is_multiple_of(100) {
+                        tracing::warn!(count, "udp snapshot oversize; falling back to ws");
+                    } else {
+                        tracing::debug!(count, "udp snapshot oversize; falling back to ws");
+                    }
+                    false
+                }
             }
-            return false;
-        }
-        self.socket.try_send_to(&bytes, addr).is_ok()
+        })
     }
 
     pub fn spawn_recv_loop(self: &Arc<Self>, input_tx: mpsc::UnboundedSender<SlotInput>) {
@@ -363,7 +363,7 @@ mod tests {
                 .collect(),
             keyframe: true,
         };
-        assert!(!lane.try_send_snapshot(peer_addr, &big));
+        assert!(!lane.try_send_snapshot(peer_addr, &snapshot_ref(&big)));
 
         let small = proto::Snapshot {
             tick: 1,
@@ -373,7 +373,7 @@ mod tests {
             entities: Vec::new(),
             keyframe: false,
         };
-        assert!(lane.try_send_snapshot(peer_addr, &small));
+        assert!(lane.try_send_snapshot(peer_addr, &snapshot_ref(&small)));
 
         let mut buf = [0u8; 2048];
         let n = tokio::time::timeout(std::time::Duration::from_secs(1), peer.recv(&mut buf))
@@ -384,6 +384,17 @@ mod tests {
             proto::decode_inner::<proto::UdpPacket>(&buf[..n]).unwrap(),
             proto::UdpPacket::Snapshot(s) if s.tick == 1 && s.entities.is_empty()
         ));
+    }
+
+    fn snapshot_ref(snap: &proto::Snapshot) -> proto::SnapshotRef<'_> {
+        proto::SnapshotRef {
+            tick: snap.tick,
+            server_time_ms: snap.server_time_ms,
+            input_ack: snap.input_ack,
+            players: &snap.players,
+            entities: snap.entities.iter().collect(),
+            keyframe: snap.keyframe,
+        }
     }
 
     fn tx_sender(

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -723,6 +723,43 @@ pub enum UdpPacket {
     Snapshot(Snapshot),
 }
 
+#[derive(Serialize)]
+pub struct SnapshotRef<'a> {
+    pub tick: u32,
+    pub server_time_ms: u32,
+    pub input_ack: u32,
+    pub players: &'a [PlayerView],
+    pub entities: Vec<&'a EntityDelta>,
+    pub keyframe: bool,
+}
+
+#[derive(Serialize)]
+pub enum ServerEventRef<'a> {
+    Welcome {
+        protocol: u32,
+        your_slot: PlayerSlot,
+        seed: u64,
+        registry: Vec<KindEntry>,
+    },
+    Snapshot(SnapshotRef<'a>),
+    Ephemeral {
+        kind: u16,
+        to: PlayerSlot,
+        payload: Vec<u8>,
+    },
+    Reject {
+        reason: String,
+    },
+}
+
+#[derive(Serialize)]
+pub enum UdpPacketRef<'a> {
+    Hello { protocol: u32, token: [u8; 16] },
+    HelloAck,
+    Frame(ClientFrame),
+    Snapshot(&'a SnapshotRef<'a>),
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct UdpOffer {
     pub token: [u8; 16],
@@ -773,6 +810,67 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn snapshot_ref_matches_owned_wire() {
+        let snap = Snapshot {
+            tick: 42,
+            server_time_ms: 1000,
+            input_ack: 7,
+            players: vec![PlayerView {
+                slot: PlayerSlot(1),
+                kbve_username: "hero".into(),
+                connected: true,
+            }],
+            entities: vec![EntityDelta {
+                eid: EntityId(9),
+                kind: 3,
+                owner: PlayerSlot(1),
+                tile: Tile::new(5, 6),
+                facing: Facing::Up,
+                sub: 0,
+                qx: 1,
+                qy: 2,
+                qvx: 0,
+                qvy: 0,
+                input_ack: 7,
+                hp: 80,
+                max_hp: 100,
+                destroyed: false,
+                z: -2,
+                effects: vec![StatusView {
+                    kind: StatusKind::Burn,
+                    remaining: 30,
+                }],
+                piloting: 0,
+                mp: 0,
+                max_mp: 0,
+                energy: 0,
+                max_energy: 0,
+                stamina: 0,
+                max_stamina: 0,
+            }],
+            keyframe: true,
+        };
+        let view = SnapshotRef {
+            tick: snap.tick,
+            server_time_ms: snap.server_time_ms,
+            input_ack: snap.input_ack,
+            players: &snap.players,
+            entities: snap.entities.iter().collect(),
+            keyframe: snap.keyframe,
+        };
+        assert_eq!(
+            encode_inner(&UdpPacket::Snapshot(snap.clone())).unwrap(),
+            encode_inner(&UdpPacketRef::Snapshot(&view)).unwrap(),
+            "UdpPacketRef must be byte-identical to owned UdpPacket"
+        );
+        assert_eq!(
+            encode(&ServerEvent::Snapshot(snap.clone())).unwrap(),
+            encode(&ServerEventRef::Snapshot(view)).unwrap(),
+            "ServerEventRef must be byte-identical to owned ServerEvent"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Zero-copy pass over the ARPG game-server hot path and the shared `simgrid` transport. Removes deep clones and per-tick/per-packet heap allocations. Addresses #12932.

### simgrid (shared transport — biggest, per-client-per-tick)
- **New serialize-only borrowing mirrors** `SnapshotRef<'a>`, `ServerEventRef<'a>`, `UdpPacketRef<'a>`. Postcard is positional, so `&T`/`Vec<&T>`/`&[T]` emit byte-identical wire to the owned types — proven by a new `snapshot_ref_matches_owned_wire` byte-equality test.
- `route_snapshot_aoi` collects `Vec<&EntityDelta>` (pointer copies) and borrows `&players` instead of deep-cloning every `EntityDelta` (incl. its heap `effects` Vec) plus the roster, **once per connection per tick**.
- `try_send_snapshot` drops `snap.clone()` + `to_allocvec`; serializes `UdpPacketRef` into a thread-local `[u8; UDP_MAX_DATAGRAM]` scratch via `postcard::to_slice`. Zero heap on the UDP fast path.

### arpg-server
- `creatures::stream_trees` / `stream_bushes`: `alive` set `Vec<Tile>` → `HashSet<Tile>`, removing the **O(tiles × alive) quadratic** `.contains` scan over the ~11k-tile realize square per surface player per stream tick.
- `game::resolve_ship_collision`: `players.is_empty()` early-out + translate the `&'static SHIP_HULLS` into one reused scratch `Vec` instead of allocating a per-tick `Vec` of hull-vert `Vec`s.
- `game::ship_footprint` returns `impl Iterator<Item = Tile>` instead of a fresh `Vec` per call (7+ call sites, all iterate).

## Wire compatibility
Byte-identical postcard output for the new borrowing types (test-enforced). No protocol version bump needed.

## Verification
- `simgrid`: 173 passed, 1 ignored
- `arpg-server`: all tests pass, clippy clean on changed files
- `cryptothrone-server`: builds (shared `simgrid` API changes are internal to `net`/`net_udp`)

## Deferred / follow-ups
Tracked separately — see linked issues for smaller skipped items (proxy.rs `extract_auth_token` Cow, WS decode clone, creatures `Local` scratch buffers, felled/harvested log-set caching).