### PR TITLE
feat(arpg): hybrid soft-aim + Tab-lock combat

### DIFF
--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -2628,6 +2628,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	private teardown() {
 		this.ground?.shader.destroy();
 		this.ground = undefined;
+		this.lockReticle?.destroy();
 		this.offIntent?.();
 		this.offIntent = undefined;
 		this.offPetBattle?.();

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -137,6 +137,16 @@ import {
 	tickPlayerInterp as tickPlayerInterpV,
 	tickFacing as tickFacingV,
 } from './systems/creatureView';
+import {
+	makeTargetLockState,
+	lockUnderCursor as lockUnderCursorV,
+	cycleLock as cycleLockV,
+	clearLock as clearLockV,
+	tickLockValidity as tickLockValidityV,
+	lockedAimPoint as lockedAimPointV,
+	type TargetLockState,
+	type TargetLockDeps,
+} from './systems/targetLock';
 import { preloadStairs } from './entities/stairs';
 import { preloadItemAtlas, makeItemSprite } from './entities/itemSprite';
 import { itemKey } from './entities/itemMeta';
@@ -310,6 +320,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	private move: MovementState = makeMovementState({ x: 0, y: 0 });
 	// Bow-shot bookkeeping: in-flight arrow, deferred server hits, corpses.
 	private combat: CombatState = makeCombatState();
+	private targetLock: TargetLockState = makeTargetLockState();
 	private fireKey!: Phaser.Input.Keyboard.Key;
 	// Central input: a keyboard device feeds the router (movement, ToggleChat, …);
 	// the context stack gates actions per mode (Gameplay / Chat). Polled + cleared
@@ -1483,6 +1494,9 @@ export class IsoArpgScene extends Phaser.Scene {
 				return screenToWorldF(p.worldX, p.worldY);
 			},
 			isHostile: (e) => this.isHostileServer(e),
+			lockedTarget: () => this.targetLock.lockedEid,
+			lockedAim: () =>
+				lockedAimPointV(this.targetLock, this.targetLockDeps()),
 		};
 	}
 
@@ -1643,12 +1657,50 @@ export class IsoArpgScene extends Phaser.Scene {
 			myEid: () => this.myEid,
 			floatPos: () => this.move.floatState.pos,
 			isHostile: (eid) => this.isHostileServer(eid),
+			lockedTarget: () => this.targetLock.lockedEid,
+			lockedAim: () =>
+				lockedAimPointV(this.targetLock, this.targetLockDeps()),
 			clearMovePath: () => {
 				this.move.movePath = [];
 			},
 			refreshHud: () => this.refreshHud(),
 			destroyRefs: (refs) => this.destroyRefs(refs),
 		};
+	}
+
+	private targetLockDeps(): TargetLockDeps {
+		return {
+			store: this.store,
+			myEid: () => this.myEid,
+			isHostile: (e) => this.isHostileServer(e),
+			isCorpse: (e) => this.kinds.ref(this.store.kind(e)) === CORPSE_REF,
+			playerTile: () => this.move.predicted,
+			maxRange: () => ARROW_MAX_RANGE,
+		};
+	}
+
+	private lockedTargetEid(): number | null {
+		return this.targetLock.lockedEid;
+	}
+
+	private toggleLockTarget(cursorTile: TileXY): void {
+		if (this.targetLock.lockedEid == null) {
+			lockUnderCursorV(
+				this.targetLock,
+				this.targetLockDeps(),
+				cursorTile,
+			);
+		} else {
+			cycleLockV(this.targetLock, this.targetLockDeps());
+		}
+	}
+
+	private cycleLockTarget(): void {
+		cycleLockV(this.targetLock, this.targetLockDeps());
+	}
+
+	private clearLockTarget(): void {
+		clearLockV(this.targetLock);
 	}
 
 	/** Tear down an entity's display objects. */
@@ -1952,6 +2004,8 @@ export class IsoArpgScene extends Phaser.Scene {
 		}
 
 		if (!this.client || !this.predictSeeded) return;
+
+		tickLockValidityV(this.targetLock, this.targetLockDeps());
 
 		// Space fells an adjacent standing tree if there is one, else fires the bow
 		// toward the cursor. Suppressed while the chat input owns the keyboard.

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -147,6 +147,7 @@ import {
 	type TargetLockState,
 	type TargetLockDeps,
 } from './systems/targetLock';
+import { makeLockReticle, type LockReticleHandle } from './systems/lockReticle';
 import { preloadStairs } from './entities/stairs';
 import { preloadItemAtlas, makeItemSprite } from './entities/itemSprite';
 import { itemKey } from './entities/itemMeta';
@@ -321,6 +322,7 @@ export class IsoArpgScene extends Phaser.Scene {
 	// Bow-shot bookkeeping: in-flight arrow, deferred server hits, corpses.
 	private combat: CombatState = makeCombatState();
 	private targetLock: TargetLockState = makeTargetLockState();
+	private lockReticle!: LockReticleHandle;
 	private fireKey!: Phaser.Input.Keyboard.Key;
 	// Central input: a keyboard device feeds the router (movement, ToggleChat, …);
 	// the context stack gates actions per mode (Gameplay / Chat). Polled + cleared
@@ -518,6 +520,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		this.setupInput();
 		this.buildBridge();
 		this.setupZoom();
+		this.lockReticle = makeLockReticle(this, this.store);
 
 		this.prewarmTreePool();
 		this.connectClient();
@@ -984,6 +987,11 @@ export class IsoArpgScene extends Phaser.Scene {
 			updatePlaceGhost: (t) => this.updatePlaceGhost(t),
 			fireBowAt: (a, t) => this.fireBowAt(a, t),
 			startMoveTo: (t) => this.startMoveTo(t),
+			toggleLockTarget: (t) => this.toggleLockTarget(t),
+			cycleLockTarget: () => this.cycleLockTarget(),
+			clearLockTarget: () => this.clearLockTarget(),
+			lockedTarget: () => this.lockedTargetEid(),
+			lockTargetEid: (e) => this.lockTargetEid(e),
 		};
 	}
 
@@ -1703,6 +1711,10 @@ export class IsoArpgScene extends Phaser.Scene {
 		clearLockV(this.targetLock);
 	}
 
+	private lockTargetEid(serverEid: number): void {
+		this.targetLock.lockedEid = serverEid;
+	}
+
 	/** Tear down an entity's display objects. */
 	private destroyRefs(refs: EntityRefs) {
 		destroyRefsV(refs);
@@ -2039,6 +2051,7 @@ export class IsoArpgScene extends Phaser.Scene {
 		// Redraw health bars every frame so they track the smoothly interpolated
 		// sprite instead of lagging behind it at snapshot cadence.
 		this.refreshHud();
+		this.lockReticle.update(this.targetLock.lockedEid);
 		this.tickHud(delta);
 	}
 

--- a/apps/agones/arpg/web/src/game/input/sceneInput.ts
+++ b/apps/agones/arpg/web/src/game/input/sceneInput.ts
@@ -40,6 +40,11 @@ export interface SceneInputDeps {
 	updatePlaceGhost(tile: TileXY): void;
 	fireBowAt(aim: TileXY, target?: number): void;
 	startMoveTo(tile: TileXY): void;
+	toggleLockTarget(cursorTile: TileXY): void;
+	cycleLockTarget(): void;
+	clearLockTarget(): void;
+	lockedTarget(): number | null;
+	lockTargetEid(serverEid: number): void;
 }
 
 export interface SceneInputRefs {
@@ -84,12 +89,22 @@ export function setupInput(
 				deps.rotatePlacement();
 			}
 		} else if (ev.key === 'Escape') {
-			if (deps.inv.placingRef) {
+			if (deps.lockedTarget() != null) {
+				deps.clearLockTarget();
+			} else if (deps.inv.placingRef) {
 				deps.exitPlacement();
 			} else if (deps.inv.open) {
 				deps.inv.open = false;
 				emitInventoryOpen(false);
 			}
+		} else if (ev.key === 'Tab') {
+			ev.preventDefault();
+			const p = scene.input.activePointer;
+			const aim = screenToWorldF(p.worldX, p.worldY);
+			deps.toggleLockTarget({
+				x: Math.round(aim.x),
+				y: Math.round(aim.y),
+			});
 		}
 	});
 
@@ -157,6 +172,7 @@ export function setupInput(
 			// Fire at the clicked enemy. fireBowAt sends the single authoritative
 			// attack (targeting THIS enemy) — no separate action() call, or the
 			// server would see a double-fire.
+			deps.lockTargetEid(hit.serverEid);
 			deps.move.movePath = [];
 			deps.fireBowAt(aim, hit.serverEid);
 			return;

--- a/apps/agones/arpg/web/src/game/systems/combat.ts
+++ b/apps/agones/arpg/web/src/game/systems/combat.ts
@@ -120,6 +120,8 @@ export interface CombatDeps {
 	myEid(): number;
 	floatPos(): { x: number; y: number };
 	isHostile(serverEid: number): boolean;
+	lockedTarget(): number | null;
+	lockedAim(): TileXY | null;
 	clearMovePath(): void;
 	refreshHud(): void;
 	destroyRefs(refs: EntityRefs): void;
@@ -144,12 +146,14 @@ export function fireBowAt(
 	deps.clearMovePath();
 	const fp = deps.floatPos();
 	const from = { x: fp.x, y: fp.y };
-	const shotTarget = target ?? acquireBowTarget(deps, from, aim);
-	// Fly the arrow AT the acquired enemy (not the raw cursor point) so the
-	// visual shot connects with whatever the server resolves — a near-path
-	// target snaps the arrow onto it instead of sailing past.
+	const locked = target == null ? deps.lockedTarget() : null;
+	const shotTarget = target ?? locked ?? acquireBowTarget(deps, from, aim);
+	// A lock supplies both the target and the aim (auto-face); else the arrow
+	// flies at the acquired enemy's tile, else the raw cursor aim.
+	const lockedAim = locked != null ? deps.lockedAim() : null;
 	const shotTile =
-		shotTarget != null ? (deps.store.tile(shotTarget) ?? aim) : aim;
+		lockedAim ??
+		(shotTarget != null ? (deps.store.tile(shotTarget) ?? aim) : aim);
 	// Land the arrow on the target's on-screen SPRITE (hovering flyers are drawn
 	// above their ground tile), so a hit connects with the wyvern the player sees
 	// instead of the empty ground beneath it. Tile drives the hit-test; this only

--- a/apps/agones/arpg/web/src/game/systems/lockReticle.ts
+++ b/apps/agones/arpg/web/src/game/systems/lockReticle.ts
@@ -1,0 +1,42 @@
+import Phaser from 'phaser';
+import { EntityStore } from '@kbve/laser';
+import type { EntityRefs } from '../entities/sprites';
+import { DEPTH_UI } from '../config';
+
+/**
+ * Lock reticle: a ring pinned to the locked target's on-screen sprite (already
+ * hover-adjusted for flyers). Render-only — reads the locked eid each frame and
+ * draws; holds no game state.
+ */
+export interface LockReticleHandle {
+	update(lockedEid: number | null): void;
+	destroy(): void;
+}
+
+const RING_COLOR = 0xf87171;
+const RING_RADIUS = 26;
+
+export function makeLockReticle(
+	scene: Phaser.Scene,
+	store: EntityStore<EntityRefs>,
+): LockReticleHandle {
+	const g = scene.add.graphics();
+	g.setDepth(DEPTH_UI + 1);
+	let phase = 0;
+	return {
+		update(lockedEid: number | null) {
+			g.clear();
+			if (lockedEid == null) return;
+			const refs = store.refs(lockedEid);
+			const sprite = refs?.sprite;
+			if (!sprite) return;
+			phase = (phase + 0.08) % (Math.PI * 2);
+			const pulse = RING_RADIUS + Math.sin(phase) * 3;
+			g.lineStyle(2, RING_COLOR, 0.9);
+			g.strokeCircle(sprite.x, sprite.y, pulse);
+		},
+		destroy() {
+			g.destroy();
+		},
+	};
+}

--- a/apps/agones/arpg/web/src/game/systems/spells.ts
+++ b/apps/agones/arpg/web/src/game/systems/spells.ts
@@ -40,6 +40,8 @@ export interface SpellDeps {
 	predicted(): TileXY;
 	aim(): TileXY;
 	isHostile(serverEid: number): boolean;
+	lockedTarget(): number | null;
+	lockedAim(): TileXY | null;
 }
 
 const AIM_PERP = 0.75;
@@ -74,9 +76,11 @@ export function castSpellSlot(
 	const meta = st.meta.get(ref);
 	const targeted = meta?.effect === 'damage' || meta?.effect === 'status';
 	const from = deps.predicted();
-	const aim = deps.aim();
+	const locked = deps.lockedTarget();
+	const lockedAim = locked != null ? deps.lockedAim() : null;
+	const aim = lockedAim ?? deps.aim();
 	const target = targeted
-		? acquireSpellTarget(deps, from, aim, meta?.range ?? 0)
+		? (locked ?? acquireSpellTarget(deps, from, aim, meta?.range ?? 0))
 		: null;
 	deps.client()?.castSpell(ref, target);
 	playSpellVfxAt(deps, meta, target, aim);

--- a/apps/agones/arpg/web/src/game/systems/targetLock.spec.ts
+++ b/apps/agones/arpg/web/src/game/systems/targetLock.spec.ts
@@ -107,6 +107,17 @@ describe('targetLock', () => {
 		expect(st.lockedEid).toBe(2);
 	});
 
+	it('nearest fallback ignores a hostile beyond range (no lock-then-instant-break)', () => {
+		const deps = fakeDeps(
+			{ 1: { tile: { x: 50, y: 0 }, kind: CAT_NPC } },
+			{ x: 0, y: 0 },
+			5,
+		);
+		const st = makeTargetLockState();
+		expect(lockUnderCursor(st, deps, { x: 9, y: 9 })).toBeNull();
+		expect(st.lockedEid).toBeNull();
+	});
+
 	it('validity: unlocks on death when no other hostile in range', () => {
 		const ents: Record<number, FakeEntity> = {
 			1: { tile: { x: 1, y: 0 }, kind: CAT_NPC },

--- a/apps/agones/arpg/web/src/game/systems/targetLock.spec.ts
+++ b/apps/agones/arpg/web/src/game/systems/targetLock.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import type { EntityStore } from '@kbve/laser';
+import type { EntityRefs } from '../entities/sprites';
+import {
+	makeTargetLockState,
+	lockUnderCursor,
+	cycleLock,
+	clearLock,
+	tickLockValidity,
+	lockedAimPoint,
+	hostilesByDistance,
+	type TargetLockDeps,
+} from './targetLock';
+
+const CAT_NPC = 1;
+
+interface FakeEntity {
+	tile: { x: number; y: number };
+	kind: number;
+	corpse?: boolean;
+}
+
+function fakeDeps(
+	ents: Record<number, FakeEntity>,
+	player = { x: 0, y: 0 },
+	range = 10,
+): TargetLockDeps {
+	const store = {
+		serverIdsWith: (_c: number) =>
+			Object.keys(ents)
+				.map(Number)
+				.filter((id) => ents[id].kind === CAT_NPC),
+		tile: (id: number) => (ents[id] ? { ...ents[id].tile } : null),
+		has: (id: number) => ents[id] !== undefined,
+		refs: (id: number) => (ents[id] ? ({} as EntityRefs) : undefined),
+		at: (x: number, y: number, _except: number) => {
+			const id = Object.keys(ents)
+				.map(Number)
+				.find((k) => ents[k].tile.x === x && ents[k].tile.y === y);
+			return id === undefined
+				? null
+				: { serverEid: id, eid: id, refs: {} as EntityRefs };
+		},
+	} as unknown as EntityStore<EntityRefs>;
+	return {
+		store,
+		myEid: () => 999,
+		isHostile: (id) => ents[id]?.kind === CAT_NPC && !ents[id]?.corpse,
+		isCorpse: (id) => ents[id]?.corpse === true,
+		playerTile: () => ({ ...player }),
+		maxRange: () => range,
+	};
+}
+
+describe('targetLock', () => {
+	it('locks the hostile under the cursor when one is there', () => {
+		const deps = fakeDeps({
+			1: { tile: { x: 5, y: 0 }, kind: CAT_NPC },
+			2: { tile: { x: 2, y: 0 }, kind: CAT_NPC },
+		});
+		const st = makeTargetLockState();
+		const got = lockUnderCursor(st, deps, { x: 5, y: 0 });
+		expect(got).toBe(1);
+		expect(st.lockedEid).toBe(1);
+	});
+
+	it('falls back to nearest hostile when cursor is on empty tile', () => {
+		const deps = fakeDeps({
+			1: { tile: { x: 5, y: 0 }, kind: CAT_NPC },
+			2: { tile: { x: 2, y: 0 }, kind: CAT_NPC },
+		});
+		const st = makeTargetLockState();
+		expect(lockUnderCursor(st, deps, { x: 9, y: 9 })).toBe(2);
+	});
+
+	it('cycles nearest-outward and wraps, skipping the current lock', () => {
+		const deps = fakeDeps({
+			1: { tile: { x: 1, y: 0 }, kind: CAT_NPC },
+			2: { tile: { x: 3, y: 0 }, kind: CAT_NPC },
+			3: { tile: { x: 6, y: 0 }, kind: CAT_NPC },
+		});
+		const st = makeTargetLockState();
+		lockUnderCursor(st, deps, { x: 1, y: 0 }); // lock 1 (nearest)
+		expect(cycleLock(st, deps)).toBe(2);
+		expect(cycleLock(st, deps)).toBe(3);
+		expect(cycleLock(st, deps)).toBe(1); // wrap
+	});
+
+	it('clears the lock', () => {
+		const deps = fakeDeps({ 1: { tile: { x: 1, y: 0 }, kind: CAT_NPC } });
+		const st = makeTargetLockState();
+		lockUnderCursor(st, deps, { x: 1, y: 0 });
+		clearLock(st);
+		expect(st.lockedEid).toBeNull();
+	});
+
+	it('validity: breaks and auto-advances when the target dies', () => {
+		const ents: Record<number, FakeEntity> = {
+			1: { tile: { x: 1, y: 0 }, kind: CAT_NPC },
+			2: { tile: { x: 2, y: 0 }, kind: CAT_NPC },
+		};
+		const deps = fakeDeps(ents);
+		const st = makeTargetLockState();
+		lockUnderCursor(st, deps, { x: 1, y: 0 }); // lock 1
+		ents[1].corpse = true; // 1 dies
+		expect(tickLockValidity(st, deps)).toBe(2); // advanced to next-nearest
+		expect(st.lockedEid).toBe(2);
+	});
+
+	it('validity: unlocks on death when no other hostile in range', () => {
+		const ents: Record<number, FakeEntity> = {
+			1: { tile: { x: 1, y: 0 }, kind: CAT_NPC },
+		};
+		const deps = fakeDeps(ents);
+		const st = makeTargetLockState();
+		lockUnderCursor(st, deps, { x: 1, y: 0 });
+		ents[1].corpse = true;
+		expect(tickLockValidity(st, deps)).toBeNull();
+		expect(st.lockedEid).toBeNull();
+	});
+
+	it('validity: breaks when the target leaves range', () => {
+		const ents: Record<number, FakeEntity> = {
+			1: { tile: { x: 1, y: 0 }, kind: CAT_NPC },
+		};
+		const deps = fakeDeps(ents, { x: 0, y: 0 }, 5);
+		const st = makeTargetLockState();
+		lockUnderCursor(st, deps, { x: 1, y: 0 });
+		ents[1].tile = { x: 50, y: 0 }; // far out of range
+		expect(tickLockValidity(st, deps)).toBeNull();
+	});
+
+	it('lockedAimPoint returns the locked target tile, null when unlocked', () => {
+		const deps = fakeDeps({ 1: { tile: { x: 4, y: 2 }, kind: CAT_NPC } });
+		const st = makeTargetLockState();
+		expect(lockedAimPoint(st, deps)).toBeNull();
+		lockUnderCursor(st, deps, { x: 4, y: 2 });
+		expect(lockedAimPoint(st, deps)).toEqual({ x: 4, y: 2 });
+	});
+
+	it('hostilesByDistance sorts nearest-first, tie-breaks by sid', () => {
+		const deps = fakeDeps({
+			5: { tile: { x: 2, y: 0 }, kind: CAT_NPC },
+			3: { tile: { x: 2, y: 0 }, kind: CAT_NPC },
+			1: { tile: { x: 5, y: 0 }, kind: CAT_NPC },
+		});
+		const order = hostilesByDistance(deps).map((h) => h.sid);
+		expect(order).toEqual([3, 5, 1]);
+	});
+});

--- a/apps/agones/arpg/web/src/game/systems/targetLock.ts
+++ b/apps/agones/arpg/web/src/game/systems/targetLock.ts
@@ -1,0 +1,110 @@
+import { EntityStore, Cat } from '@kbve/laser';
+import type { EntityRefs } from '../entities/sprites';
+import type { TileXY } from '../iso';
+
+/**
+ * Client-side target lock. A locked hostile takes all attacks regardless of the
+ * cursor, so the cursor is freed for kiting. Pure selection/validity logic; the
+ * scene owns the state and ticks validity each frame. LoS break is deferred —
+ * the scene has no tile-to-tile LoS helper — so validity is range + death only.
+ */
+export interface TargetLockState {
+	lockedEid: number | null;
+}
+
+export interface TargetLockDeps {
+	store: EntityStore<EntityRefs>;
+	myEid(): number;
+	isHostile(sid: number): boolean;
+	isCorpse(sid: number): boolean;
+	playerTile(): TileXY;
+	maxRange(): number;
+}
+
+export function makeTargetLockState(): TargetLockState {
+	return { lockedEid: null };
+}
+
+export function clearLock(st: TargetLockState): void {
+	st.lockedEid = null;
+}
+
+function isLiveHostile(deps: TargetLockDeps, sid: number): boolean {
+	return deps.store.has(sid) && deps.isHostile(sid) && !deps.isCorpse(sid);
+}
+
+/** Hostiles sorted nearest→farthest by tile distance from the player, stable
+ * tie-break by ascending serverEid. */
+export function hostilesByDistance(
+	deps: TargetLockDeps,
+): { sid: number; dist: number }[] {
+	const p = deps.playerTile();
+	const out: { sid: number; dist: number }[] = [];
+	for (const sid of deps.store.serverIdsWith(Cat.Npc)) {
+		if (!isLiveHostile(deps, sid)) continue;
+		const t = deps.store.tile(sid);
+		if (!t) continue;
+		out.push({ sid, dist: Math.hypot(t.x - p.x, t.y - p.y) });
+	}
+	out.sort((a, b) => a.dist - b.dist || a.sid - b.sid);
+	return out;
+}
+
+/** First Tab / click: lock the hostile under the cursor, else the nearest. */
+export function lockUnderCursor(
+	st: TargetLockState,
+	deps: TargetLockDeps,
+	cursorTile: TileXY,
+): number | null {
+	const under = deps.store.at(cursorTile.x, cursorTile.y, deps.myEid());
+	if (under && isLiveHostile(deps, under.serverEid)) {
+		st.lockedEid = under.serverEid;
+		return st.lockedEid;
+	}
+	const nearest = hostilesByDistance(deps)[0];
+	st.lockedEid = nearest ? nearest.sid : null;
+	return st.lockedEid;
+}
+
+/** Subsequent Tab: advance to the next hostile nearest-outward, wrapping. */
+export function cycleLock(
+	st: TargetLockState,
+	deps: TargetLockDeps,
+): number | null {
+	const ordered = hostilesByDistance(deps).map((h) => h.sid);
+	if (ordered.length === 0) {
+		st.lockedEid = null;
+		return null;
+	}
+	const idx = st.lockedEid == null ? -1 : ordered.indexOf(st.lockedEid);
+	st.lockedEid = ordered[(idx + 1) % ordered.length];
+	return st.lockedEid;
+}
+
+/** Per-frame validity: break on death (auto-advance to next-nearest in range)
+ * or out-of-range; returns the effective lockedEid after the tick. */
+export function tickLockValidity(
+	st: TargetLockState,
+	deps: TargetLockDeps,
+): number | null {
+	if (st.lockedEid == null) return null;
+	const sid = st.lockedEid;
+	const range = deps.maxRange();
+	const p = deps.playerTile();
+	const t = isLiveHostile(deps, sid) ? deps.store.tile(sid) : null;
+	const inRange = t != null && Math.hypot(t.x - p.x, t.y - p.y) <= range;
+	if (inRange) return sid;
+	// Dead or out of range: auto-advance to the nearest hostile still in range.
+	const next = hostilesByDistance(deps).find((h) => h.dist <= range);
+	st.lockedEid = next ? next.sid : null;
+	return st.lockedEid;
+}
+
+/** The aim point attacks use while locked (the locked target's tile). */
+export function lockedAimPoint(
+	st: TargetLockState,
+	deps: TargetLockDeps,
+): TileXY | null {
+	if (st.lockedEid == null) return null;
+	return deps.store.tile(st.lockedEid);
+}

--- a/apps/agones/arpg/web/src/game/systems/targetLock.ts
+++ b/apps/agones/arpg/web/src/game/systems/targetLock.ts
@@ -61,7 +61,8 @@ export function lockUnderCursor(
 		st.lockedEid = under.serverEid;
 		return st.lockedEid;
 	}
-	const nearest = hostilesByDistance(deps)[0];
+	const range = deps.maxRange();
+	const nearest = hostilesByDistance(deps).find((h) => h.dist <= range);
 	st.lockedEid = nearest ? nearest.sid : null;
 	return st.lockedEid;
 }

--- a/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
+++ b/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
@@ -2,8 +2,10 @@
  * Vitest-only stand-in for the @kbve/laser runtime barrel. The real barrel
  * value-exports Phaser-backed helpers node-env vitest cannot load. This stub
  * re-exports the pure leaves the spec import graphs actually execute
- * (heightfield via iso.ts, game-auth via config.ts); laser type-only imports
- * are erased before resolution and never reach it.
+ * (heightfield via iso.ts, game-auth via config.ts, the Cat enum via
+ * targetLock.ts); laser type-only imports are erased before resolution and
+ * never reach it.
  */
 export * from '../../../../../../packages/npm/laser/src/lib/determ/heightfield';
 export * from '../../../../../../packages/npm/laser/src/lib/auth/game-auth';
+export { Cat } from '../../../../../../packages/npm/laser/src/lib/ecs/store';


### PR DESCRIPTION
## What

Adds a hybrid combat model to the arpg web client (rentearth): cursor soft-aim stays the default, with a **Tab hard-lock** layered on top. A locked hostile takes all bow/spell attacks regardless of cursor — freeing the cursor for kiting — and a reticle ring shows the lock.

Spec: `docs/superpowers/specs/2026-07-02-arpg-tab-lock-combat-design.md`
Plan: `docs/superpowers/plans/2026-07-02-arpg-tab-lock-combat.md`

## Behavior

- **Tab** — lock the hostile under the cursor (else nearest in range); Tab again cycles nearest-outward, wrapping.
- **Click a hostile** — locks it directly.
- **While locked** — bow (Space/RMB) + spells (1-9) route to the lock and auto-face it; cursor/WASD/click-move freed for kiting; reticle ring tracks the target sprite (hover-aware for flyers).
- **Lock auto-breaks** on target death (auto-advancing to next-nearest in range), out-of-range, or manually (Esc / Tab on empty).

## Architecture

- New `systems/targetLock.ts` — pure lock state + selection/validity logic (10 unit tests).
- New `systems/lockReticle.ts` — render-only ring.
- `combat.ts` / `spells.ts` — attack routing consults the lock before the existing cursor-acquire cones (`lockedTarget`/`lockedAim`).
- `IsoArpgScene.ts` / `sceneInput.ts` — scene owns the state, ticks validity each frame, wires Tab/Esc/click + reticle.

**No server / simgrid / parity changes** — the server is already target-authoritative by `serverEid`; the lock only selects the client-side target.

## Also in this branch (earlier same-session fixes)

- `HEIGHT_RENDER_SCALE` tames over-tall terrain lift (one knob feeds projection, raycast, ground shader; no parity churn).
- Biome atlas `REPEAT` wrap kills side texture bleed.
- Sprite-space bow acquisition + arrow flies at the target sprite, so shots at hovering flyers connect visually and logically.
- Spell damage defers to bolt arrival (`inflightSpells`) so the number lands on impact, not at cast.

## Testing

- 35 vitest specs green (10 new `targetLock` + 25 prior), typecheck clean.
- Input / reticle / routing verified live (Phaser render + timing).

Built via 5-task subagent-driven development with per-task + whole-branch review (final verdict: ready to merge, no Critical/Important).

## Deferred (documented, benign)

- Tab-lock is NPC-only; PvP players are cone-attackable but not Tab-lockable (dungeon edge).
- Locked casts use bow range as the validity envelope regardless of per-spell range (server authoritative).
- LoS lock-break deferred (no tile-to-tile LoS helper exists).