### PR TITLE
fix(ci): restore Docker + bevy wasm builds after MSRV inheritance

### DIFF
--- a/apps/agones/arpg/server/Cargo.workspace.toml
+++ b/apps/agones/arpg/server/Cargo.workspace.toml
@@ -5,6 +5,9 @@ members = [
     "packages/rust/simgrid",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/agones/cryptothrone/server/Cargo.workspace.toml
+++ b/apps/agones/cryptothrone/server/Cargo.workspace.toml
@@ -5,6 +5,9 @@ members = [
     "packages/rust/simgrid",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/agones/factorio/relay/Cargo.workspace.toml
+++ b/apps/agones/factorio/relay/Cargo.workspace.toml
@@ -5,6 +5,9 @@ members = [
     "packages/rust/jedi",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
+++ b/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
@@ -8,6 +8,9 @@ members = [
     "packages/rust/bevy/bevy_npc",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/holy",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/discordsh/axum-discordsh/Cargo.workspace.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/holy",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/discordsh/discordsh-bot/Cargo.workspace.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.workspace.toml
@@ -13,6 +13,9 @@ members = [
     "packages/rust/bevy/bevy_skills",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/herbmail/axum-herbmail/Cargo.workspace.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/holy",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/irc/irc-gateway/Cargo.workspace.toml
+++ b/apps/irc/irc-gateway/Cargo.workspace.toml
@@ -8,6 +8,9 @@ members = [
     "packages/rust/kbve",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/kbve/axum-kbve/Cargo.workspace.toml
+++ b/apps/kbve/axum-kbve/Cargo.workspace.toml
@@ -12,6 +12,9 @@ members = [
     "packages/rust/bevy/bevy_skills",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -818,6 +818,7 @@ fn poll_go_online_request(
 
     #[cfg(target_arch = "wasm32")]
     {
+        let mut pending_token = pending_token;
         pending_token.in_flight = true;
 
         let jwt_for_fetch = jwt.unwrap_or_default();

--- a/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
@@ -13,6 +13,9 @@ use super::tilemap::TileCoord;
 #[cfg(not(target_arch = "wasm32"))]
 use super::input_bridge::BridgedCursorPosition;
 
+#[cfg(target_arch = "wasm32")]
+use super::virtual_joystick::VirtualJoystickState;
+
 // Re-export EntityEvent so event_target() is available
 use bevy::ecs::event::EntityEvent;
 

--- a/apps/kbve/kbve-gate/Cargo.workspace.toml
+++ b/apps/kbve/kbve-gate/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/kbve",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/memes/axum-memes/Cargo.workspace.toml
+++ b/apps/memes/axum-memes/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/holy",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/rareicon/axum-rareicon/Cargo.workspace.toml
+++ b/apps/rareicon/axum-rareicon/Cargo.workspace.toml
@@ -9,6 +9,9 @@ members = [
     "packages/rust/bevy/bevy_npc",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/rentearth/axum-rentearth/Cargo.workspace.toml
+++ b/apps/rentearth/axum-rentearth/Cargo.workspace.toml
@@ -8,6 +8,9 @@ members = [
     "packages/rust/bevy/bevy_npc",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/factorio-ctl/Cargo.workspace.toml
+++ b/apps/vm/factorio-ctl/Cargo.workspace.toml
@@ -5,6 +5,9 @@ members = [
     "packages/rust/jedi",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/firecracker-ctl/Cargo.workspace.toml
+++ b/apps/vm/firecracker-ctl/Cargo.workspace.toml
@@ -7,6 +7,9 @@ members = [
     "packages/rust/holy",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/kubectl/Cargo.workspace.toml
+++ b/apps/vm/kubectl/Cargo.workspace.toml
@@ -4,6 +4,9 @@ members = [
     "apps/vm/kubectl",
 ]
 
+[workspace.package]
+rust-version = "1.96"
+
 [profile.release]
 opt-level = 3
 lto = true


### PR DESCRIPTION
## Root causes

**All Docker e2e builds (#13809–#13815):** crate manifests now use `rust-version.workspace = true` (MSRV 1.96 change), but the synthetic `Cargo.workspace.toml` files that Docker builds copy in as workspace root never defined `workspace.package.rust-version`, so `cargo chef prepare` failed:

```
error inheriting rust-version from workspace root manifest's workspace.package.rust-version
Caused by: workspace.package.rust-version was not defined
```

Fix: add `[workspace.package] rust-version = "1.96"` to all 17 `apps/**/Cargo.workspace.toml`.

**Bevy build_wasm (#13816):** two real compile errors in `isometric-game`:
- `scene_objects.rs:342` — `VirtualJoystickState` not imported (wasm-only system); added cfg'd import
- `net.rs:821` — `pending_token.in_flight = true` on immutable binding; rebound mutable inside the wasm-only block (mutation is wasm-only, keeps desktop free of unused_mut)

Verified: `cargo check --target wasm32-unknown-unknown` on isometric-game — 0 errors.

Closes #13809 #13810 #13811 #13812 #13813 #13814 #13815 #13816