### PR TITLE
fix(ci): serialize rustup bootstrap in ci-uniti to prevent ETXTBSY race

### DIFF
--- a/.github/workflows/ci-uniti.yml
+++ b/.github/workflows/ci-uniti.yml
@@ -40,6 +40,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
             - name: Setup Rust stable
               uses: dtolnay/rust-toolchain@stable
@@ -70,6 +79,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
             - name: Setup Rust nightly (asan)
               uses: dtolnay/rust-toolchain@nightly
               with:
@@ -101,6 +119,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
             - name: Setup Rust nightly + miri
               uses: dtolnay/rust-toolchain@nightly
               with:
@@ -128,6 +155,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
             - name: Setup Rust nightly (fuzz)
               uses: dtolnay/rust-toolchain@nightly
             - name: Install cargo-fuzz
@@ -154,6 +190,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
             - name: Setup Rust stable
               uses: dtolnay/rust-toolchain@stable
@@ -186,6 +231,15 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
+            - name: Bootstrap rustup (serialized)
+              run: |
+                  mkdir -p "$CARGO_HOME/bin"
+                  exec 9>/home/runner/_cache/cargo/.rustup-bootstrap.lock
+                  flock 9
+                  if [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+                  fi
+                  echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
             - name: Setup Rust stable
               uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

Run https://github.com/KBVE/kbve/actions/runs/28639105361/job/84931664047 failed in the Miri job:

```
/home/runner/_cache/cargo/home/miri/bin/rustup: Text file busy
```

The `dtolnay/rust-toolchain` action re-runs the rustup installer on every job. Cache paths are namespaced per job name but shared across concurrent workflow runs (PR ref vs main push), so one run can copy over the `rustup` binary (`RUSTUP_PERMIT_COPY_RENAME=1` copies instead of atomic rename) while another run is executing it, producing ETXTBSY.

## Fix

Add a "Bootstrap rustup (serialized)" step to all six arc-runner jobs, before the toolchain action:

- installs rustup only if the binary is missing, under a shared `flock`, so the binary is never rewritten once present
- appends `$CARGO_HOME/bin` to `GITHUB_PATH` so `dtolnay/rust-toolchain` finds rustup and skips its own installer

`build_ios` (macos-latest, no shared cache) is untouched.