### PR TITLE
fix(cilium): lock public-ip-pool to kbve-gateway, exempt arpg-game-udp from LB-IPAM

### DIFF
--- a/apps/kube/agones/arpg/manifests/game-udp-service.yaml
+++ b/apps/kube/agones/arpg/manifests/game-udp-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
     name: arpg-game-udp
     namespace: arpg
+    annotations:
+        lbipam.cilium.io/ignore: 'true'
     labels:
         app: arpg-server
         app.kubernetes.io/part-of: arpg

--- a/apps/kube/cilium/manifests/lb-ipam.yaml
+++ b/apps/kube/cilium/manifests/lb-ipam.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
     blocks:
         - cidr: 142.132.206.71/32
+    serviceSelector:
+        matchLabels:
+            io.cilium.gateway/owning-gateway: kbve-gateway
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy


### PR DESCRIPTION
## Outage
All HTTPS ingress (kbve.com, supabase.kbve.com, git.kbve.com) down since ~07:33 UTC — Cloudflare 521/timeouts.

## Root cause
1. etcd request timeouts caused cilium-operator to lose leader election repeatedly (607 restarts).
2. On restart, LB-IPAM re-ran allocation. `arpg/arpg-game-udp` (added in #13767) is `type: LoadBalancer` with no IP request; its stale IP 142.132.206.74 was dropped from the pool in #11811, so "regular allocation logic" handed it 142.132.206.71 — the pool's only IP.
3. `cilium-gateway-kbve-gateway` went `<pending>`, Gateway `Programmed=False` (AddressNotAssigned), envoy listener unprogrammed, origin refused :443.

## Fix
- `public-ip-pool` gets a `serviceSelector` matching only the gateway service (`io.cilium.gateway/owning-gateway: kbve-gateway`) — no other LoadBalancer service can take the ingress IP.
- `arpg-game-udp` annotated `lbipam.cilium.io/ignore: 'true'` — exempt from LB-IPAM until its transport is decided (#13767 UDP DNS rollout still open).

Both changes already applied live to restore service; this PR makes GitOps match so Argo does not revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)