### PR TITLE
feat(cilium): share gateway VIP with arpg-game-udp (UDP 7977)

### DIFF
--- a/apps/kube/agones/arpg/manifests/game-udp-service.yaml
+++ b/apps/kube/agones/arpg/manifests/game-udp-service.yaml
@@ -4,9 +4,12 @@ metadata:
     name: arpg-game-udp
     namespace: arpg
     annotations:
-        lbipam.cilium.io/ignore: 'true'
+        lbipam.cilium.io/ips: '142.132.206.71'
+        lbipam.cilium.io/sharing-key: public-71
+        lbipam.cilium.io/sharing-cross-namespace: kbve
     labels:
         app: arpg-server
+        kbve.com/lb-pool: public
         app.kubernetes.io/part-of: arpg
         kbve.com/category: game-server
         kbve.com/stack: agones

--- a/apps/kube/cilium/manifests/lb-ipam.yaml
+++ b/apps/kube/cilium/manifests/lb-ipam.yaml
@@ -7,7 +7,7 @@ spec:
         - cidr: 142.132.206.71/32
     serviceSelector:
         matchLabels:
-            io.cilium.gateway/owning-gateway: kbve-gateway
+            kbve.com/lb-pool: public
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -10,8 +10,11 @@ spec:
     infrastructure:
         labels:
             node.kbve.com/type: dedicated-server
+            kbve.com/lb-pool: public
         annotations:
             io.cilium/lb-ipam-ips: '142.132.206.71'
+            lbipam.cilium.io/sharing-key: public-71
+            lbipam.cilium.io/sharing-cross-namespace: arpg
     listeners:
         - name: http
           protocol: HTTP


### PR DESCRIPTION
Follow-up to #13821. Instead of exempting `arpg-game-udp` from LB-IPAM, share the single public VIP 142.132.206.71 between the gateway (80/443 TCP) and the UDP service (7977) — no port overlap, so Cilium LB-IPAM sharing applies.

- Both services carry `kbve.com/lb-pool: public`; pool `serviceSelector` matches that label.
- Both pin `142.132.206.71` and share `lbipam.cilium.io/sharing-key: public-71`, with `sharing-cross-namespace` grants both directions (kbve ↔ arpg).
- Deterministic across cilium-operator restarts — no reallocation roulette.

Unblocks #13767: point `udp.kbve.com` (DNS-only, no CF proxy) at 142.132.206.71.

Note: Argo selfHeal currently re-adds the #13821 `ignore` annotation, so the live sharing state can only converge after this merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)