### PR TITLE
fix(docker): bump rust 1.94 → 1.96 in chisel builder + kubectl images

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -83,7 +83,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.23",
+			"version": "0.1.24",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.23",
+			"version": "0.1.24",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",
@@ -125,7 +125,7 @@
 		{
 			"key": "chisel_ubuntu_axum",
 			"app_name": "chisel-ubuntu-axum",
-			"version": "24.04.7",
+			"version": "24.04.8",
 			"version_toml": "packages/docker/chisel-ubuntu-axum/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx",
 			"source_path": "packages/docker/chisel-ubuntu-axum",

--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.7"
+version: "24.04.8"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -22,7 +22,7 @@
 # ============================================================================
 # [STAGE A] - Cargo Chef Planner
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS planner
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS planner
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ============================================================================
 # [STAGE B] - Cargo Chef Cook (cache deps)
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder-deps
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS builder-deps
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 # [STAGE C] - Build static musl binary
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -22,10 +22,10 @@
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  BUILDER TARGET                                                    ║
-# ║  Rust 1.94 + cargo-chef + sccache + mold + brotli/gzip + Node 24 ║
+# ║  Rust 1.96 + cargo-chef + sccache + mold + brotli/gzip + Node 24 ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
-FROM --platform=linux/amd64 rust:1.94-slim AS builder
+FROM --platform=linux/amd64 rust:1.96-slim AS builder
 
 # ── System build dependencies ────────────────────────────────────────
 RUN apt-get update && \

--- a/packages/docker/chisel-ubuntu-axum/README.md
+++ b/packages/docker/chisel-ubuntu-axum/README.md
@@ -23,7 +23,7 @@ Full build environment for Rust + Astro services:
 
 | Component             | Version | Purpose                             |
 | --------------------- | ------- | ----------------------------------- |
-| **Rust**              | 1.94    | Axum service compilation            |
+| **Rust**              | 1.96    | Axum service compilation            |
 | **cargo-chef**        | latest  | Dependency layer caching for Docker |
 | **Node.js**           | 24      | Astro frontend builds               |
 | **pnpm**              | latest  | Package management (via corepack)   |

--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -116,7 +116,7 @@
 					"RUNTIME_BYTES=$(docker image inspect ghcr.io/kbve/chisel-ubuntu-axum:24.04 --format '{{.Size}}') && echo \"Runtime size: $((RUNTIME_BYTES / 1024 / 1024)) MiB\" && [ $RUNTIME_BYTES -lt 41943040 ] && echo 'PASS: runtime under 40 MiB'",
 					"rm -f /tmp/chisel-runtime.tar",
 					"echo '=== Builder image — toolchain tests ==='",
-					"docker run --rm --platform linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder bash -c 'rustc --version | grep -q \"rustc 1.94\"' && echo 'PASS: rustc 1.94 pinned'",
+					"docker run --rm --platform linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder bash -c 'rustc --version | grep -q \"rustc 1.96\"' && echo 'PASS: rustc 1.96 pinned'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder bash -c 'cargo --version' && echo 'PASS: cargo present'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder bash -c 'cargo chef --version' && echo 'PASS: cargo-chef present'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder bash -c 'sccache --version' && echo 'PASS: sccache present'",
@@ -135,7 +135,7 @@
 					"docker inspect ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1$' && echo 'PASS: Playwright browser download disabled'",
 					"echo '=== All chisel base image tests passed ==='",
 					"echo 'Runtime: user, workdir, jemalloc, libpq, CA bundle, no-shell, size<40MiB'",
-					"echo 'Builder: rustc 1.94, cargo-chef, sccache, mold, protoc, brotli, gzip, libpq-dev, libssl-dev, node 24, pnpm, real-TLS, env hygiene'"
+					"echo 'Builder: rustc 1.96, cargo-chef, sccache, mold, protoc, brotli, gzip, libpq-dev, libssl-dev, node 24, pnpm, real-TLS, env hygiene'"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
Fixes #13815.

## Root cause
Workspace MSRV moved to 1.96 (`[workspace.package] rust-version`, inherited via `rust-version.workspace = true`). The shared builder image `chisel-ubuntu-axum:24.04-builder` still ships rustc **1.94.1**, so every `cargo chef cook` against a workspace crate now aborts:

```
error: rustc 1.94.1 is not supported by the following packages:
  arpg-server@0.0.1 requires rustc 1.96
  jedi@0.0.1 requires rustc 1.96
  ...
```

Failing jobs: **irc-gateway** (#13815), **arpg-server**, **memes** — all chisel consumers. (The original irc-gateway failure at 04:58Z was the missing `workspace.package.rust-version` in `Cargo.workspace.toml`, already fixed by #13819; this is the follow-on toolchain gap.)

## Changes
- `chisel-ubuntu-axum` Dockerfile: `rust:1.94-slim` → `rust:1.96-slim` (+ e2e check `rustc 1.96`, README)
- `apps/vm/kubectl` Dockerfile: `rust:1.94-alpine3.21` → `rust:1.96-alpine3.21` (kubectl is a workspace member, same failure pending)

Both upstream tags verified on Docker Hub. version.toml untouched — CI handles bump.

## Ordering note
Downstream Docker jobs only pass after the new `24.04-builder` tag publishes. If a same-run race hits stale image, rerun after chisel publish completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)