### PR TITLE
fix(ci): bump Rust builder images 1.94 -> 1.96 to match workspace MSRV

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -83,7 +83,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.23",
+			"version": "0.1.24",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.23",
+			"version": "0.1.24",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",
@@ -125,7 +125,7 @@
 		{
 			"key": "chisel_ubuntu_axum",
 			"app_name": "chisel-ubuntu-axum",
-			"version": "24.04.7",
+			"version": "24.04.8",
 			"version_toml": "packages/docker/chisel-ubuntu-axum/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx",
 			"source_path": "packages/docker/chisel-ubuntu-axum",

--- a/apps/agones/factorio/relay/Dockerfile
+++ b/apps/agones/factorio/relay/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.94
+ARG RUST_VERSION=1.96
 
 FROM --platform=linux/amd64 rust:${RUST_VERSION}-bookworm AS builder
 ENV CARGO_INCREMENTAL=0

--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.7"
+version: "24.04.8"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -22,7 +22,7 @@
 # ============================================================================
 # [STAGE A] - Cargo Chef Planner
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS planner
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS planner
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ============================================================================
 # [STAGE B] - Cargo Chef Cook (cache deps)
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder-deps
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS builder-deps
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 # [STAGE C] - Build static musl binary
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder
+FROM --platform=linux/amd64 rust:1.96-alpine3.21 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -22,10 +22,10 @@
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  BUILDER TARGET                                                    ║
-# ║  Rust 1.94 + cargo-chef + sccache + mold + brotli/gzip + Node 24 ║
+# ║  Rust 1.96 + cargo-chef + sccache + mold + brotli/gzip + Node 24 ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
-FROM --platform=linux/amd64 rust:1.94-slim AS builder
+FROM --platform=linux/amd64 rust:1.96-slim AS builder
 
 # ── System build dependencies ────────────────────────────────────────
 RUN apt-get update && \


### PR DESCRIPTION
## Problem

All CI - Docker e2e jobs still fail after #13819 (issues #13809–#13815):

```
error: rustc 1.94.1 is not supported by the following packages:
  axum-kbve@0.0.1 requires rustc 1.96
  ...
```

#13819 added `rust-version = "1.96"` to the synthetic `Cargo.workspace.toml` files, which fixed `cargo chef prepare` — but the shared builder image `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder` is still built from `rust:1.94-slim`, so `cargo chef cook` now refuses to build. Confirmed on the 07:51 UTC retry batch (e.g. run 28646548786), which ran on a main SHA that already includes #13819.

## Fix

- `packages/docker/chisel-ubuntu-axum/Dockerfile`: `rust:1.94-slim` → `rust:1.96-slim`
- `chisel.mdx` version `24.04.7` → `24.04.8` so the manifest dispatches a rebuild/publish of the builder image
- `apps/agones/factorio/relay/Dockerfile`: `ARG RUST_VERSION=1.94` → `1.96` (its Cargo.workspace.toml also requires 1.96 now)
- `apps/vm/kubectl/Dockerfile`: `rust:1.94-alpine3.21` → `rust:1.96-alpine3.21` (same)
- Regenerated `.github/ci-dispatch-manifest.json` via `astro-kbve:sync:ci-manifest` (picks up arpg 0.1.24 drift as well)

Services consume the mutable `24.04-builder` tag, so once the new chisel image publishes, the failing Docker jobs pass on their next dispatch with no further changes.

Refs #13809 #13810 #13811 #13812 #13813 #13814 #13815