### PR TITLE
fix(ci): skip cargo-ndk install when cached, add net retry

### DIFF
--- a/.github/workflows/ci-uniti.yml
+++ b/.github/workflows/ci-uniti.yml
@@ -254,7 +254,9 @@ jobs:
                   add-to-path: true
 
             - name: Install cargo-ndk
-              run: cargo install cargo-ndk --locked
+              env:
+                  CARGO_NET_RETRY: '10'
+              run: command -v cargo-ndk >/dev/null || cargo install cargo-ndk --locked
 
             - name: cargo ndk build
               env:


### PR DESCRIPTION
## Why

Run 28644983684 (`Build Android (4 ABIs)`) failed in `Install cargo-ndk`: transient cluster DNS flake resolving `index.crates.io` exhausted cargo's retries (exit 101). `cargo install` touches the crates.io index on every run even though `$CARGO_HOME/bin` sits on the persistent runner cache, so warm runs pay a needless network dependency.

## What

- Skip `cargo install cargo-ndk` when the binary is already on PATH (persistent cache) — warm runs no longer touch the network at all
- `CARGO_NET_RETRY: 10` for cold-cache runs to ride out short DNS blips

Trade-off: cargo-ndk version stays frozen until the runner cache is wiped; acceptable for a CI-only tool.