### PR TITLE
fix(ci): publish chisel builder under versioned tags, drop metadata tag hijack

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -125,7 +125,7 @@
 		{
 			"key": "chisel_ubuntu_axum",
 			"app_name": "chisel-ubuntu-axum",
-			"version": "24.04.8",
+			"version": "24.04.9",
 			"version_toml": "packages/docker/chisel-ubuntu-axum/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx",
 			"source_path": "packages/docker/chisel-ubuntu-axum",

--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.8"
+version: "24.04.9"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -47,9 +47,6 @@
 						"ghcr.io/kbve/chisel-ubuntu-axum:latest"
 					],
 					"push": true,
-					"metadata": {
-						"images": ["ghcr.io/kbve/chisel-ubuntu-axum"]
-					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/chisel-ubuntu-axum:buildcache-runtime"
 					],
@@ -81,9 +78,6 @@
 						"ghcr.io/kbve/chisel-ubuntu-axum:builder"
 					],
 					"push": true,
-					"metadata": {
-						"images": ["ghcr.io/kbve/chisel-ubuntu-axum"]
-					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/chisel-ubuntu-axum:buildcache-builder"
 					],


### PR DESCRIPTION
## Problem

Docker e2e jobs still fail with `rustc 1.94.1 is not supported` after #13828 (e.g. run 28655834282 / arpg-server), even though the chisel 24.04.8 publish run succeeded at 09:35 UTC.

Registry forensics:

- `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder` config still shows `RUST_VERSION=1.94.1`, created **2026-04-02** — the tag was never replaced
- `:builder` tag returns 404 — it has never been pushed at all
- the freshly built Rust 1.96 builder image *was* pushed — but only as `:main` / `:ci-<sha>`

Cause: the `metadata.images` block in both `containerx-*` production configurations makes nx-container generate tags from git context (`main`, `ci-<sha>`), and those replace the explicit `tags` list. The publish workflow's daemon push loop re-tags the runtime image to `24.04.8`/`latest`, which masked the problem for the runtime target — but nothing does that for the builder, and the subsequent `imagetools create` just re-aliases the stale registry `24.04-builder` (that's how `24.04.7-builder` got minted from the April image in the same run).

## Fix

- Remove the `metadata` blocks from `containerx-runtime:production` and `containerx-builder:production` so the explicit tags (`24.04`/`latest`, `24.04-builder`/`builder`) are what buildx pushes
- Bump chisel `24.04.8` → `24.04.9` (MDX) + regenerate the dispatch manifest so the version gate re-publishes the builder image

Once 24.04.9 publishes, `24.04-builder` finally points at the Rust 1.96 toolchain and the failing service jobs (#13809–#13815, arpg-server, arpg-web) pass on next dispatch.