### PR TITLE
fix(chisel): stop metadata action clobbering builder image tags

### DIFF
--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -47,9 +47,6 @@
 						"ghcr.io/kbve/chisel-ubuntu-axum:latest"
 					],
 					"push": true,
-					"metadata": {
-						"images": ["ghcr.io/kbve/chisel-ubuntu-axum"]
-					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/chisel-ubuntu-axum:buildcache-runtime"
 					],
@@ -81,9 +78,6 @@
 						"ghcr.io/kbve/chisel-ubuntu-axum:builder"
 					],
 					"push": true,
-					"metadata": {
-						"images": ["ghcr.io/kbve/chisel-ubuntu-axum"]
-					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/chisel-ubuntu-axum:buildcache-builder"
 					],


### PR DESCRIPTION
Second half of #13815 / follow-up to #13827.

## Why #13827 didn't stick
The chisel rebuild DID run with rust:1.96-slim and pushed successfully — but only to `ghcr.io/kbve/chisel-ubuntu-axum:main`. The `metadata.images` block in the `production` configurations makes nx-container's metadata action generate tags from the git ref, **overriding** the declared `tags` list. So:

- `24.04-builder` (moving tag every Rust Dockerfile FROMs) still points at the rustc 1.94.1 build
- the post-build `imagetools create` then copied that stale `24.04-builder` onto `24.04.7-builder`
- `24.04.8-builder` never existed; arpg-server run 28655834282 failed again on 1.94.1

Verified via `docker run ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder rustc --version` → 1.94.1, and `24.04.8-builder` → not found.

## Fix
Remove the `metadata` blocks from `containerx-runtime` and `containerx-builder` production configs. Declared tags (`24.04`, `latest`, `24.04-builder`, `builder`) then push directly.

Other app project.json files keep their metadata blocks — their versioned tags come from the workflow retag step; chisel's builder moving tag is uniquely consumed by other images' FROM lines.

## Known wart (out of scope)
The `${VERSION}-builder` copy reads version.toml, which is bumped post-publish, so the versioned builder tag is persistently one release behind. Separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)