### PR TITLE
build(pnpm): pin pnpm 10.33.0, move overrides to pnpm-workspace.yaml

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.220",
+			"version": "1.0.221",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -125,7 +125,7 @@
 		{
 			"key": "chisel_ubuntu_axum",
 			"app_name": "chisel-ubuntu-axum",
-			"version": "24.04.9",
+			"version": "24.04.10",
 			"version_toml": "packages/docker/chisel-ubuntu-axum/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx",
 			"source_path": "packages/docker/chisel-ubuntu-axum",
@@ -316,7 +316,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.27",
+			"version": "0.1.28",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",

--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -10,7 +10,7 @@ FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
     pnpm install --frozen-lockfile

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
     pnpm install --frozen-lockfile

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -14,7 +14,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
     pnpm install --frozen-lockfile

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
     pnpm install --frozen-lockfile

--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.9"
+version: "24.04.10"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -14,7 +14,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
 # Cache pnpm content-addressable store across builds to skip re-downloading

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -14,7 +14,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS ast
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -10,7 +10,7 @@ FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
     pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.0",
 	"license": "MIT",
 	"private": true,
+	"packageManager": "pnpm@10.33.0",
 	"devDependencies": {
 		"@astrojs/check": "^0.9.9",
 		"@astrojs/markdown-remark": "^7.2.0",
@@ -248,36 +249,5 @@
 	"scripts": {
 		"prepare": "husky",
 		"setup:e2e": "pnpm exec playwright install chromium"
-	},
-	"pnpm": {
-		"minimumReleaseAge": 720,
-		"overrides": {
-			"@novnc/novnc": "1.5.0",
-			"@xmldom/xmldom@<0.8.13": ">=0.8.13",
-			"@expo/plist>@xmldom/xmldom": "^0.8.13",
-			"react": "19.2.3",
-			"react-dom": "19.2.3",
-			"dompurify@<3.4.0": ">=3.4.0",
-			"fast-xml-parser": ">=5.5.8",
-			"handlebars@<4.7.9": ">=4.7.9",
-			"lodash-es@<4.18.0": ">=4.18.0",
-			"minimatch@<3.1.4": "3.1.4",
-			"minimatch@>=5.0.0 <5.1.8": "5.1.8",
-			"minimatch@>=7.0.0 <7.4.8": "7.4.8",
-			"minimatch@>=9.0.0 <9.0.7": "9.0.7",
-			"minimatch@>=10.0.0 <10.2.3": "10.2.3",
-			"postcss@<8.5.10": ">=8.5.10"
-		},
-		"onlyBuiltDependencies": [
-			"@parcel/watcher",
-			"@swc/core",
-			"core-js",
-			"core-js-pure",
-			"esbuild",
-			"grpc-tools",
-			"nx",
-			"sharp",
-			"styled-components"
-		]
 	}
 }

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -64,11 +64,12 @@ ENV CARGO_INCREMENTAL=0
 
 # ── Node.js + pnpm (for Astro frontend builds) ──────────────────────
 ARG NODE_VERSION=24
+ARG PNPM_VERSION=10.33.0
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable && \
-    corepack prepare pnpm@latest --activate
+    corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Prevent Playwright from downloading browsers during pnpm install
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,27 @@
+minimumReleaseAge: 720
+overrides:
+  '@novnc/novnc': 1.5.0
+  '@xmldom/xmldom@<0.8.13': '>=0.8.13'
+  '@expo/plist>@xmldom/xmldom': ^0.8.13
+  react: 19.2.3
+  react-dom: 19.2.3
+  'dompurify@<3.4.0': '>=3.4.0'
+  fast-xml-parser: '>=5.5.8'
+  'handlebars@<4.7.9': '>=4.7.9'
+  'lodash-es@<4.18.0': '>=4.18.0'
+  'minimatch@<3.1.4': 3.1.4
+  'minimatch@>=5.0.0 <5.1.8': 5.1.8
+  'minimatch@>=7.0.0 <7.4.8': 7.4.8
+  'minimatch@>=9.0.0 <9.0.7': 9.0.7
+  'minimatch@>=10.0.0 <10.2.3': 10.2.3
+  'postcss@<8.5.10': '>=8.5.10'
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - core-js
+  - core-js-pure
+  - esbuild
+  - grpc-tools
+  - nx
+  - sharp
+  - styled-components


### PR DESCRIPTION
## Problem

[Run 28699486318](https://github.com/KBVE/kbve/actions/runs/28699486318/job/85115020597) failed: `irc-gateway:container` died at `pnpm install --frozen-lockfile` inside the `astro-builder` stage with:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides", "pnpm.onlyBuiltDependencies".
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

Root cause: `chisel-ubuntu-axum` builder installs `corepack prepare pnpm@latest`, which now resolves to pnpm 11. pnpm 11 dropped reading the `pnpm` field from package.json, so effective overrides = empty ≠ lockfile overrides → frozen install refuses. Host runners (pinned 10.33.0 via action-setup) were unaffected, which is why only the in-image install broke. This hits **every** app built on that builder image, not just irc-gateway.

## Fix

- Move `overrides` / `onlyBuiltDependencies` / `minimumReleaseAge` from package.json `pnpm` block to `pnpm-workspace.yaml` — the config home read by both pnpm 10 and 11.
- Add `"packageManager": "pnpm@10.33.0"` (matches CI action-setup pin). pnpm ≥10 self-switches to the pinned version, so even a stale image with `pnpm@latest` runs 10.33.0.
- Pin corepack in `packages/docker/chisel-ubuntu-axum/Dockerfile` via `PNPM_VERSION=10.33.0` arg instead of `@latest`.
- Add `pnpm-workspace.yaml` to the root COPY line in all 8 axum app Dockerfiles so the overrides are present in-image.

## Verification

- `pnpm-lock.yaml` unchanged after regen — override values identical, only relocated.
- `pnpm install --frozen-lockfile --lockfile-only` passes under pnpm 10.33.0 **and** 11.9.0 locally (the 11.9.0 invocation self-switched to 10.33.0 via the packageManager pin, confirming the guard).
- Reproduced the failing path inside the actual `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder` image: frozen check now passes (`FROZEN_OK`).