### PR TITLE
fix(irc): enable ServerSideDiff on irc app

### DIFF
--- a/apps/kube/irc/application.yaml
+++ b/apps/kube/irc/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: application
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:


### PR DESCRIPTION
## Problem
18 ArgoCD apps sit perpetually OutOfSync while Healthy. Root cause: apps sync with `ServerSideApply=true` but the controller diffs client-side, so API-server-defaulted fields (HTTPRoute `weight: 1`, `group`/`kind` on parentRefs/backendRefs) register as drift forever. Sync succeeds at main tip, diff immediately reappears.

## Fix
Pilot on the smallest case: annotate the `irc` Application with
`argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`
so the diff is computed via server-side dry-run apply and defaults stop counting as drift.

## Verification
After merge to main, kube-root syncs the annotation; irc should flip to Synced without any resource changes. If confirmed, follow-up enables `controller.diff.server.side=true` globally for the remaining 17 apps.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)