### PR TITLE
feat(talos): add Windows laptop peer 10.10.0.3 to wg0

### DIFF
--- a/apps/kube/talos/patches/wireguard-wg0.yaml
+++ b/apps/kube/talos/patches/wireguard-wg0.yaml
@@ -1,29 +1,39 @@
-## Talos machine config patch — wg0 WireGuard tunnel to external runner hosts.
-## PROOF OF CONCEPT — template only. No real keys. Fill placeholders at apply.
+## Talos machine config patch — wg0 WireGuard tunnel to external hosts.
+## Template only. No real keys. Fill placeholders at apply.
 ##
 ## NOT deployed by Argo. Tracked here as the source-of-record; applied
 ## manually with talosctl (same flow as kvm-node-label.yaml).
 ##
-## Adds a wg0 interface so machines OUTSIDE the cluster (e.g. a MacBook CI
-## host running act_runner + GitHub ARC) can reach cluster services over an
-## encrypted tunnel. Separate from Cilium's internal cilium_wg0 — do NOT
-## conflate the two. User-managed tunnel on UDP 51820.
+## Adds a wg0 interface so machines OUTSIDE the cluster (CI hosts, dev
+## laptops) can reach the node over an encrypted tunnel. Separate from
+## Cilium's internal cilium_wg0 — do NOT conflate the two. User-managed
+## tunnel on UDP 51820.
 ##
 ## Tunnel subnet: 10.10.0.0/24
 ##   10.10.0.1  → Talos node (this interface)
-##   10.10.0.2  → external CI host
+##   10.10.0.2  → MacBook Air CI host (act_runner + GitHub ARC)
+##   10.10.0.3  → Windows laptop
 ##
-## SECRETS — nothing committed. Both the node private key and every peer
-## public key are injected at apply time from the ESO backend:
-##   ${TALOS_WG_PRIVATE_KEY}  → secret: talos-wireguard, key: privateKey
-##   ${PEER_MAC_PUBLIC_KEY}   → secret: talos-wireguard, key: peerMacPublicKey
+## SECRETS — nothing committed. There is no talos-wireguard secret in the
+## cluster; the node private key lives only in the applied machine config.
+## Recover it with:
+##   talosctl -n <node> get machineconfig -o yaml | grep -A2 'wireguard:'
+## Peer public keys are not secret but are still injected at apply time to
+## keep this file a pure template.
 ##
 ## Apply:
-##   export TALOS_WG_PRIVATE_KEY=...   # from ESO / kubectl get secret
+##   export TALOS_WG_PRIVATE_KEY=...   # from current machineconfig, see above
 ##   export PEER_MAC_PUBLIC_KEY=...
+##   export PEER_WIN_PUBLIC_KEY=...
 ##   envsubst < wireguard-wg0.yaml > /tmp/wg0-apply.yaml
 ##   talosctl -n <node> patch machineconfig --patch @/tmp/wg0-apply.yaml
 ##   rm /tmp/wg0-apply.yaml
+##
+## MERGE GOTCHA: the strategic merge APPENDS to the peers list — re-applying
+## duplicates existing peers. After apply, verify with
+##   talosctl -n <node> get machineconfig -o yaml | grep -A12 'peers:'
+## and dedupe if needed with an RFC6902 replace patch on
+##   /machine/network/interfaces/<wg0-index>/wireguard/peers
 ##
 ## Peers: one list entry + one allowedIPs /32 per external host.
 
@@ -41,3 +51,7 @@ machine:
                       - publicKey: ${PEER_MAC_PUBLIC_KEY}
                         allowedIPs:
                             - 10.10.0.2/32
+                      ## Windows laptop
+                      - publicKey: ${PEER_WIN_PUBLIC_KEY}
+                        allowedIPs:
+                            - 10.10.0.3/32


### PR DESCRIPTION
Adds the Windows laptop as a second wg0 peer (`10.10.0.3/32`) in the Talos machine config patch template. Already applied to the node and verified: handshake established, bidirectional traffic, tunnel runs as an auto-start Windows service.

Also corrects the header docs:
- The `talos-wireguard` ESO secret referenced by the old header never existed — the node private key lives only in the applied machineconfig; header now documents how to recover it.
- Documents the strategic-merge append gotcha: re-applying the patch duplicates existing peers; dedupe via RFC6902 replace on the peers list.

Topology: hub-and-spoke on `10.10.0.0/24` — node `.1`, MacBook Air CI `.2`, Windows laptop `.3`. Spoke-to-spoke and cluster CIDR access remain out of scope.

https://kbve.com/application/kubernetes/