### PR TITLE
feat(axum-kbve): vibeshine proxy over wg tunnel

### DIFF
--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -223,6 +223,16 @@ async fn main() -> anyhow::Result<()> {
         info!("Factorio proxy not configured (using default cluster URL)");
     }
 
+    // Initialize Vibeshine proxy (optional - DASHBOARD_MANAGE gated, routes to the
+    // Windows game-stream host over the wg0 tunnel)
+    if transport::proxy::init_vibeshine_proxy() {
+        info!(
+            "Vibeshine proxy initialized - /dashboard/vibeshine/proxy enabled (DASHBOARD_MANAGE required)"
+        );
+    } else {
+        info!("Vibeshine proxy not configured (using default wg tunnel URL)");
+    }
+
     // Initialize Firecracker-Net proxy (optional - DASHBOARD_MANAGE gated, routes to firecracker-ctl-net with Gluetun/WireGuard sidecar)
     if transport::proxy::init_firecracker_net_proxy() {
         info!(

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -656,6 +656,18 @@ fn router(state: AppState) -> Router {
             any(super::proxy::factorio_proxy_handler),
         )
         .route(
+            "/dashboard/vibeshine/proxy/{*path}",
+            any(super::proxy::vibeshine_proxy_handler),
+        )
+        .route(
+            "/dashboard/vibeshine/proxy",
+            any(super::proxy::vibeshine_proxy_handler),
+        )
+        .route(
+            "/api/v1/vibeshine/status",
+            axum::routing::get(super::proxy::vibeshine_status_handler),
+        )
+        .route(
             "/dashboard/firecracker-net/proxy/{*path}",
             any(super::proxy::firecracker_net_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -2033,6 +2033,93 @@ pub async fn factorio_openapi_handler(req: Request<Body>) -> Response {
     }
 }
 
+static VIBESHINE: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_vibeshine_proxy() -> bool {
+    let upstream = std::env::var("VIBESHINE_UPSTREAM_URL")
+        .unwrap_or_else(|_| "https://10.10.0.3:47990".into());
+    let token = std::env::var("VIBESHINE_API_TOKEN").ok();
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(30))
+        // Vibeshine serves a self-signed cert on the wg tunnel; traffic never
+        // leaves the encrypted tunnel so certificate identity adds nothing.
+        .danger_accept_invalid_certs(true)
+        .http1_only()
+        .build()
+        .expect("failed to build reqwest client for vibeshine proxy");
+
+    VIBESHINE
+        .set(ServiceProxy {
+            name: "Vibeshine",
+            client,
+            upstream: upstream.trim_end_matches('/').to_string(),
+            upstream_token: token,
+            upstream_headers: Vec::new(),
+            iframe_safe: false,
+            streaming: false,
+        })
+        .is_ok()
+}
+
+pub async fn vibeshine_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(str::to_owned);
+    if let Err(resp) =
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Vibeshine").await
+    {
+        return resp;
+    }
+
+    match VIBESHINE.get() {
+        Some(proxy) => proxy.handle_preauthorized(path, req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Vibeshine proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn vibeshine_status_handler(req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    if let Err(resp) = require_dashboard_view(&headers, "Vibeshine").await {
+        return resp;
+    }
+
+    let Some(proxy) = VIBESHINE.get() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Vibeshine proxy not configured"})),
+        )
+            .into_response();
+    };
+
+    let started = std::time::Instant::now();
+    let result = proxy
+        .client
+        .get(format!("{}/", proxy.upstream))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await;
+
+    match result {
+        Ok(resp) => axum::Json(json!({
+            "reachable": true,
+            "upstream_status": resp.status().as_u16(),
+            "latency_ms": started.elapsed().as_millis() as u64,
+        }))
+        .into_response(),
+        Err(e) => axum::Json(json!({
+            "reachable": false,
+            "error": e.to_string(),
+        }))
+        .into_response(),
+    }
+}
+
 static FIRECRACKER_NET: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_firecracker_net_proxy() -> bool {


### PR DESCRIPTION
Adds a Vibeshine (Sunshine fork, game-stream host) proxy to axum-kbve, fronting the Windows laptop at wg peer `10.10.0.3` through the Talos wg0 hub.

- `/dashboard/vibeshine/proxy[/{*path}]` — full proxy to `https://10.10.0.3:47990`, gated `DASHBOARD_MANAGE` (mirrors firecracker-net)
- `/api/v1/vibeshine/status` — reachability probe (upstream status + latency), gated `DASHBOARD_VIEW`
- `VIBESHINE_UPSTREAM_URL` / `VIBESHINE_API_TOKEN` env, defaults to the tunnel address; unconfigured token just omits upstream auth
- Self-signed upstream cert accepted (`danger_accept_invalid_certs`) — same posture as the KASM proxy; traffic never leaves the wg tunnel

Verified: `cargo check` + `cargo clippy` clean (0 errors, pre-existing warnings only).

Follow-ups (separate PRs): ESO secret entry for the API token once the Windows host issues one; astro-kbve dashboard panel; WebRTC signaling phase.

https://kbve.com/application/kubernetes/