### PR TITLE
fix(rentearth): enable ServerSideDiff on rentearth app

### DIFF
--- a/apps/kube/rentearth/application.yaml
+++ b/apps/kube/rentearth/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: application
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:


### PR DESCRIPTION
## Review
Manual review of rentearth's single OutOfSync resource, `HTTPRoute/axum-rentearth-route`:
- Live spec matches `apps/kube/rentearth/manifest/axum-rentearth-httproute.yaml` on main exactly.
- Only differences are API-server defaults: `weight: 1` and `group`/`kind` on parentRefs/backendRefs.
- No operator/CRD drift, no manual edits. Route Accepted by Cilium gateway controller, generation 3, healthy.

## Fix
Same pilot annotation as irc (#13851): `argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true` so defaults stop registering as drift.

## Rollout
Second of 18. Remaining apps get reviewed per-namespace before annotating.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)