### PR TITLE
fix(kong): enable ServerSideDiff on kong app

### DIFF
--- a/apps/kube/kong/application.yaml
+++ b/apps/kube/kong/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: networking
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:


### PR DESCRIPTION
## Review
kong's single OutOfSync resource `HTTPRoute/kilobase-api-route` (kilobase ns):
- Live spec matches `apps/kube/kong/manifests/httproute.yaml` on main — all 3 rules, timeouts (3600s realtime, 600s storage upload), hostnames identical.
- Only differences: API-server defaults `weight: 1`, `group`/`kind` on refs.
- No drift, no CRD skew.

## Fix
Same annotation as irc (#13851) and rentearth (#13858): `argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`.

## Validation
irc flipped **Synced** after its annotation reached main (hard refresh) — mechanism confirmed.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)