### PR TITLE
feat(kube): seal VIBESHINE_API_TOKEN into kbve deployment

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -219,6 +219,14 @@ spec:
                                 name: referral-config
                                 key: hash-secret
                                 optional: true
+                      - name: VIBESHINE_UPSTREAM_URL
+                        value: https://10.10.0.3:47990
+                      - name: VIBESHINE_API_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: vibeshine-config
+                                key: api-token
+                                optional: true
                       - name: DISCORD_CLIENT_ID
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
     - forgejo-externalsecret.yaml
     - arpg-discord-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
+    - vibeshine-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
     - kbve-wt-cert.yaml
     - kubevirt-rbac.yaml

--- a/apps/kube/kbve/manifest/vibeshine-sealedsecret.yaml
+++ b/apps/kube/kbve/manifest/vibeshine-sealedsecret.yaml
@@ -1,0 +1,24 @@
+# Scoped Vibeshine API token for the /dashboard/vibeshine proxy. axum-kbve
+# reads VIBESHINE_API_TOKEN from this secret's `api-token` key (see
+# kbve-deployment.yaml, marked `optional: true`). The token is minted on the
+# Windows game-stream host (wg peer 10.10.0.3) via its Client Management UI
+# or POST /api/token; it only grants curated read + app launch/close routes.
+#
+# Reseal after rotating the token on the host:
+#
+#   kubectl create secret generic vibeshine-config -n kbve \
+#       --from-literal=api-token='<token>' --dry-run=client -o yaml \
+#   | kubeseal --controller-name=sealed-secrets-controller \
+#       --controller-namespace=kube-system -o yaml
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: vibeshine-config
+    namespace: kbve
+spec:
+    encryptedData:
+        api-token: AgC8Glb6Jrrr2FW/EfverngT2aYb3adJT8tmZf6+F3j80UZwAbDAmMk/49piVZRup/yG4c4ySO4T460k6OB6pi9vDskxKs/CFI6T6cn2wvZdLdBbkHv3IUJel6h8vb4aSsVdp+Q97gXSor2YNnSPWj253ffx3rNpM0xnZtEnqTp4gjTKcdkay/OwTqaB9ymTU75wpudEEIv9g688UTLOr/v70BCwO/o4wxlE4BmpLEKVodRUjBRXn7swN+OkHXMkI5Dnijn0JxmvqWlTOBlFNHXsRf0548z2QYledA1HJhNaaKwMaSg40RcOGpyOojPrAzuAI+GlGJ3aL32h21LxfNR3blcxIKTdkP+pC40aYUknC9O9jV+akhOVN3yrluakYf5J1Qv6MxVA5KinkDnccrK/sXJt7s3wFSJpIDaNnFUDaij6/gHaKt8PVnjcBnBMNObSWHHRSIGQashqetVkGifh/rhFG5VAgHIH+7hTESnno51iEfX53k+jNY5FXxWZ046PdPFt0TXESfzBurcmmIZCQdQL3F1/aNEq+0YMQadm16kmAbIBhLxVW7DOLU5TYnEHKWlWVp07EYbkDYe52DRP3ueDoYTuSsW+F+FsoIXerqVXNfx8xD6PDmoo3nJNTZGYhGX0ysIPNJyuZmtOR9bciQmbg5XavLRgpgexuT6AASVyePTiS6LOtL15tbRlSsB0J+FkCDc11lDjrUMBB+hfPF4jFFPkfnj1M4xD2hHIig==
+    template:
+        metadata:
+            name: vibeshine-config
+            namespace: kbve


### PR DESCRIPTION
Companion to #13854 (axum-kbve vibeshine proxy). Wires the scoped Vibeshine API token into the kbve deployment via sealed-secrets:

- `vibeshine-sealedsecret.yaml`: new SealedSecret `vibeshine-config` (kbve ns) carrying `api-token`, sealed against the kube-system controller; reseal procedure documented in the file header
- `kustomization.yaml`: registers the new manifest
- `kbve-deployment.yaml`: `VIBESHINE_UPSTREAM_URL` (tunnel address `https://10.10.0.3:47990`) + `VIBESHINE_API_TOKEN` from `vibeshine-config/api-token`, `optional: true`

Token was minted on the Windows host with 10 least-privilege scopes (curated GETs + apps/close + playnite/launch; token/user/settings/webrtc routes verified 403). Validated with `kubectl kustomize`.

https://kbve.com/application/kubernetes/