### PR TITLE
fix(argocd): enable ServerSideDiff on longhorn, monitoring, argocd apps

### DIFF
--- a/apps/kube/argocd/application.yaml
+++ b/apps/kube/argocd/application.yaml
@@ -13,6 +13,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: infrastructure
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:

--- a/apps/kube/monitoring/application.yaml
+++ b/apps/kube/monitoring/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: observability
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     sources:

--- a/apps/kube/storage/application.yaml
+++ b/apps/kube/storage/application.yaml
@@ -13,6 +13,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: infrastructure
         kbve.com/stack: supabase
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     sources:


### PR DESCRIPTION
## Review
Batch of 3 HTTPRoute-only apps, each manually reviewed live vs main:

| App | OutOfSync resource | Verdict |
|-----|-------------------|---------|
| longhorn | `HTTPRoute/longhorn-gate` (longhorn-system) | defaults only; timeout 1800s intact |
| monitoring | `HTTPRoute/grafana-gate` (monitoring) | defaults only; timeout 3600s intact |
| argocd | `HTTPRoute/argocd-route` (argocd) | defaults only; timeout 3600s intact |

Differences in every case: API-server-added `weight: 1`, `group`/`kind` on parentRefs/backendRefs. Helm sources pinned (longhorn 1.9.1, kube-prometheus-stack 75.15.1) — no chart/operator drift involved.

## Fix
Same annotation as irc (#13851), rentearth (#13858), kong (#13859): `argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`.

## Validation
irc already flipped Synced after annotation reached main.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)