### PR TITLE
fix|style(kbve): mobile projects filters + footer tooltip viewport overflow

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -3,7 +3,7 @@ import AstroDroidFooter from './AstroDroidFooter.astro';
 import SocialTooltip from '@kbve/astro/components/tooltip/social/SocialTooltip.astro';
 import SocialIcon from '@kbve/astro/components/social/icons/SocialIcon.astro';
 import { SOCIALS, withUtm } from '@kbve/astro/data/socials';
-import AstroYukiDock from '@/components/jay/dock/AstroYukiDock.astro';
+// import AstroYukiDock from '@/components/jay/dock/AstroYukiDock.astro';
 
 const legalLinks = [
 	{ href: '/legal/privacy', label: 'Privacy' },
@@ -213,13 +213,14 @@ const currentYear = new Date().getFullYear();
 	<AstroDroidFooter />
 </footer>
 
-<AstroYukiDock />
+{/* <AstroYukiDock /> */}
 
 <style>
 	.kf-footer {
 		margin-top: 0;
 		background-color: var(--sl-color-black);
 		border-top: 1px solid var(--bento-hairline);
+		overflow-x: clip;
 	}
 
 	.kf-container {

--- a/apps/kbve/astro-kbve/src/components/kbve/CookbookFilters.tsx
+++ b/apps/kbve/astro-kbve/src/components/kbve/CookbookFilters.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	$facetLanguage,
@@ -33,6 +33,13 @@ export default function CookbookFilters({ groups }: Props) {
 	const search = useStore($facetSearch);
 
 	const active = { language, category, status };
+	const [open, setOpen] = useState(false);
+
+	const activeCount =
+		(language !== 'all' ? 1 : 0) +
+		(category !== 'all' ? 1 : 0) +
+		(status !== 'all' ? 1 : 0) +
+		(search.trim() ? 1 : 0);
 
 	useEffect(() => {
 		const cells = document.querySelectorAll<HTMLElement>(
@@ -69,6 +76,31 @@ export default function CookbookFilters({ groups }: Props) {
 					aria-label="Search projects"
 				/>
 			</div>
+			<button
+				type="button"
+				className="facet-toggle"
+				aria-expanded={open}
+				onClick={() => setOpen((o) => !o)}>
+				<span>Filters{activeCount ? ` (${activeCount})` : ''}</span>
+				<svg
+					className={cn(
+						'facet-toggle__chevron',
+						open && 'facet-toggle__chevron--open',
+					)}
+					viewBox="0 0 24 24"
+					width="16"
+					height="16"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true">
+					<path d="M6 9l6 6 6-6" />
+				</svg>
+			</button>
+			<div
+				className={cn('facet-groups', open && 'facet-groups--open')}>
 			{groups.map((group) => {
 				const labelId = `facet-${group.key}-label`;
 				return (
@@ -119,6 +151,7 @@ export default function CookbookFilters({ groups }: Props) {
 					</div>
 				);
 			})}
+			</div>
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/styles/bento.css
+++ b/apps/kbve/astro-kbve/src/styles/bento.css
@@ -75,7 +75,54 @@
 	.facet-panel {
 		display: flex;
 		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.facet-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 0.625rem 0.85rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--sl-color-white);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-white) 4%,
+			transparent
+		);
+		border: 1px solid var(--bento-hairline-strong);
+		border-radius: 8px;
+		cursor: pointer;
+	}
+
+	.facet-toggle__chevron {
+		transition: transform 200ms ease;
+	}
+
+	.facet-toggle__chevron--open {
+		transform: rotate(180deg);
+	}
+
+	.facet-groups {
+		display: none;
+		flex-direction: column;
 		gap: 1.5rem;
+	}
+
+	.facet-groups--open {
+		display: flex;
+	}
+
+	@media (min-width: 1024px) {
+		.facet-toggle {
+			display: none;
+		}
+
+		.facet-groups {
+			display: flex;
+		}
 	}
 
 	.facet-search__input {
@@ -121,8 +168,9 @@
 		justify-content: space-between;
 		gap: 0.5rem;
 		width: 100%;
-		padding: 0.35rem 0.5rem;
-		font-size: 0.8125rem;
+		min-height: 2.5rem;
+		padding: 0.5rem;
+		font-size: 0.875rem;
 		text-align: left;
 		color: var(--sl-color-gray-2);
 		background: transparent;
@@ -156,6 +204,14 @@
 		font-size: 0.6875rem;
 		font-variant-numeric: tabular-nums;
 		color: var(--sl-color-gray-4);
+	}
+
+	@media (min-width: 1024px) {
+		.facet-row {
+			min-height: 0;
+			padding: 0.35rem 0.5rem;
+			font-size: 0.8125rem;
+		}
 	}
 
 	/* Full-width section band: black surface + bottom hairline seam */
@@ -292,11 +348,13 @@
 		);
 	}
 
-	/* Live-event connector: brand red, stands apart from the gold rails */
+	/* Live-event connector: brand red, stands apart from the gold rails.
+	   Raw brand token on purpose — dark theme remaps --sl-color-text-accent
+	   to gold, which would collapse the wire color grammar. */
 	.bento-wire--live {
 		stroke: color-mix(
 			in srgb,
-			var(--sl-color-text-accent) 85%,
+			color-mix(in srgb, var(--color-red, #ad0013) 65%, white) 85%,
 			transparent
 		);
 	}

--- a/packages/npm/astro/src/components/tooltip/social/SocialTooltip.astro
+++ b/packages/npm/astro/src/components/tooltip/social/SocialTooltip.astro
@@ -448,6 +448,7 @@ const {
 		position: absolute;
 		left: 50%;
 		z-index: 50;
+		max-width: calc(100vw - 1rem);
 		opacity: 0;
 		visibility: hidden;
 		pointer-events: none;


### PR DESCRIPTION
## What

- **projects page**: facet sidebar collapses into a `Filters (N)` disclosure under 1024px; search stays visible; tap targets bumped to 40px on mobile (compact again at lg).
- **footer overflow**: `overflow-x: clip` on `.kf-footer`. Off-screen *closed* `SocialTooltip` panels (`position:absolute; left:50%`, only `visibility:hidden` → still in layout) on right-edge social icons were widening the document by **+71px** at 412px → horizontal scroll on mobile. `clip` (not `hidden`) keeps sticky/positioning intact and doesn't affect the upward tooltip animation.
- **SocialTooltip (shared package)**: cap panel to `calc(100vw - 1rem)` so an *open* panel near a screen edge can't itself force scroll — latent bug affecting every consumer.
- **Yuki dock**: mount + import commented out in the footer.

## Verify

Playwright at 412×915 on the built `/projects/`:

| | before | after |
|---|---|---|
| document width | 483px | 412px |
| horizontal overflow | +71px | 0 |

Header (412px) and logo (right edge 141px) were never the cause — measured, not guessed.