### PR TITLE
fix(kube): resolve remaining ArgoCD perpetual OutOfSync apps

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -22,6 +22,7 @@ spec:
                 app.kubernetes.io/part-of: ows
                 app.kubernetes.io/instance: chuckrpg-beta
         spec:
+            container: ue5-server
             ports:
                 - name: game
                   portPolicy: Dynamic

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -22,6 +22,7 @@ spec:
                 app.kubernetes.io/part-of: ows
                 app.kubernetes.io/instance: chuckrpg-dev
         spec:
+            container: ue5-server
             ports:
                 - name: game
                   portPolicy: Dynamic

--- a/apps/kube/agones/rows-tenants/chuckrpg-prod/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-prod/manifests/fleet.yaml
@@ -22,6 +22,7 @@ spec:
                 app.kubernetes.io/part-of: ows
                 app.kubernetes.io/instance: chuckrpg-prod
         spec:
+            container: ue5-server
             ports:
                 - name: game
                   portPolicy: Dynamic

--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -59,7 +59,6 @@ agones:
 gameservers:
     # Namespaces for game servers
     namespaces:
-        - ows
         - arc-runners
         - factorio
         - cryptothrone

--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -15,7 +15,7 @@ spec:
     storageClassName: longhorn
     resources:
         requests:
-            storage: 120Gi
+            storage: 300Gi
 ---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine

--- a/apps/kube/firecracker/application.yaml
+++ b/apps/kube/firecracker/application.yaml
@@ -13,16 +13,21 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: virtualization
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:
         repoURL: https://github.com/kbve/kbve
         targetRevision: HEAD
         path: apps/kube/firecracker/manifests
-        kustomize: {}
     destination:
         server: https://kubernetes.default.svc
         namespace: firecracker
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+              - /spec/replicas
     syncPolicy:
         automated:
             prune: true

--- a/apps/kube/functions/application.yaml
+++ b/apps/kube/functions/application.yaml
@@ -19,7 +19,6 @@ spec:
         repoURL: https://github.com/kbve/kbve
         targetRevision: HEAD
         path: apps/kube/functions/manifests
-        kustomize: {}
     destination:
         server: https://kubernetes.default.svc
         namespace: kilobase

--- a/apps/kube/github/controller/application.yaml
+++ b/apps/kube/github/controller/application.yaml
@@ -12,6 +12,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: ci-cd
         kbve.com/stack: github-actions
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     sources:

--- a/apps/kube/kilobase/application.yaml
+++ b/apps/kube/kilobase/application.yaml
@@ -14,6 +14,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: application
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:
@@ -43,21 +44,17 @@ spec:
           jsonPointers:
               - /status
               - /metadata/generation
-        - group: ''
-          kind: Pod
+        - kind: Pod
           jsonPointers:
               - /spec/containers/*/resources
               - /metadata/labels/role
               - /metadata/annotations
-        - group: ''
-          kind: Secret
+        - kind: Secret
           jsonPointers:
               - /data
-        - group: ''
-          kind: Service
+        - kind: Service
           jsonPointers:
               - /spec/selector
-        - group: ''
-          kind: PersistentVolumeClaim
+        - kind: PersistentVolumeClaim
           jsonPointers:
               - /status

--- a/apps/kube/kubevirt/download-proxy-application.yaml
+++ b/apps/kube/kubevirt/download-proxy-application.yaml
@@ -8,6 +8,7 @@ metadata:
     namespace: argocd
     annotations:
         argocd.argoproj.io/sync-wave: '3'
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     finalizers:
         - resources-finalizer.argocd.argoproj.io
 spec:
@@ -19,6 +20,11 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: angelscript
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+              - /spec/replicas
     syncPolicy:
         automated:
             prune: true
@@ -26,6 +32,7 @@ spec:
         syncOptions:
             - CreateNamespace=true
             - ServerSideApply=true
+            - RespectIgnoreDifferences=true
         retry:
             limit: 3
             backoff:

--- a/apps/kube/kubevirt/guacamole-application.yaml
+++ b/apps/kube/kubevirt/guacamole-application.yaml
@@ -7,6 +7,7 @@ metadata:
     namespace: argocd
     annotations:
         argocd.argoproj.io/sync-wave: '3'
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     finalizers:
         - resources-finalizer.argocd.argoproj.io
 spec:
@@ -18,6 +19,11 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: angelscript
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+              - /spec/replicas
     syncPolicy:
         automated:
             prune: true
@@ -25,6 +31,7 @@ spec:
         syncOptions:
             - CreateNamespace=true
             - ServerSideApply=true
+            - RespectIgnoreDifferences=true
         retry:
             limit: 3
             backoff:

--- a/apps/kube/realtime/application.yaml
+++ b/apps/kube/realtime/application.yaml
@@ -19,7 +19,6 @@ spec:
         repoURL: https://github.com/kbve/kbve
         targetRevision: HEAD
         path: apps/kube/realtime/manifests
-        kustomize: {}
     destination:
         server: https://kubernetes.default.svc
         namespace: kilobase

--- a/apps/kube/valkey/application.yaml
+++ b/apps/kube/valkey/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: v1
         kbve.com/category: database
         kbve.com/stack: core
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     sources:


### PR DESCRIPTION
## Review results (all 12 remaining apps, live vs main)

### Defaulting-only → ServerSideDiff annotation
| App | Resources | Diff |
|-----|-----------|------|
| kilobase | 2 ClusterPolicies | Kyverno webhook defaults (admission, emitWarning, skipBackgroundRequests, allowExistingViolations) |
| valkey | ClusterPolicy/sync-valkey-auth | same + background/validationFailureAction defaults |
| arc-controller | 4 ARC CRDs | `preserveUnknownFields: false` stripped + `conversion.strategy: None` defaulted; chart 0.9.3 == live, **no version skew** |

### KEDA owns replicas → ignoreDifferences /spec/replicas + RespectIgnoreDifferences
kubevirt-guacamole, kubevirt-download-proxy, firecracker-ctl — images/resources/env all match git; only `spec.replicas` differs because KEDA scalers manage it while git pins a literal.

### Real drift fixed
- **chuckrpg fleets (beta/dev/prod)**: added `container: ue5-server` — Agones webhook has rejected every sync since the build-reporter sidecar made pods multi-container; live fleets were stuck on pre-June-25 spec. Fleet `/spec/replicas` already in ignoreDifferences (FleetAutoscaler-owned).
- **agones values.yaml**: removed deleted `ows` ns from `gameservers.namespaces` — sync hard-failed with `namespaces "ows" not found`.
- **windows-builder-rootdisk PVC**: 120Gi → 300Gi to match in-place expansion (shrink impossible).
- **kube-root children**: dropped `kustomize: {}` (functions, realtime, firecracker-ctl) and `group: ''` (kilobase ignoreDifferences) — server pruning strips both on apply, causing permanent parent diff.

## NOT fixed here — needs decisions
1. **kbve / Certificate kbve-wt-tls (URGENT)**: cert-manager gateway-shim (via `cert-manager.io/cluster-issuer` on kbve-gateway) and Argo's standalone Certificate manifest fight over the same object — generation 217, 23 failed issuances, **LetsEncrypt rate limit exhausted (429, 5 certs/168h)**. Must pick one owner: drop the gateway annotation OR delete the standalone manifest.
2. **angelscript orphans**: Deployment/Service/PVC of retired dedicated-server exist live but not in git (prune disabled). Delete or re-add.
3. **download-proxy ImagePullBackOff**: `ghcr.io/kbve/aria2-proxy:0.1.0` anonymous pull → 403; package private/deleted.
4. **kube-root app object** is not in git (bootstrapped manually) — longhorn child's Argo-injected pre-delete finalizers keep kube-root OutOfSync even with ServerSideDiff; needs live ignoreDifferences on Application /metadata/finalizers or moving kube-root into git.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)