### PR TITLE
feat(kbve): vibeshine webrtc signaling relay + player page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVibeshinePlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVibeshinePlayer.astro
@@ -1,0 +1,89 @@
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import ReactVibeshinePlayer from '@/components/dashboard/ReactVibeshinePlayer';
+---
+
+<BentoShell
+	id="vibeshine-player-wrapper"
+	eyebrow="GameOps"
+	heading="Vibeshine remote play.">
+	<div class="svc-dash not-content">
+		<div class="svc-dash__stream not-content">
+			<ReactVibeshinePlayer client:only="react" />
+		</div>
+	</div>
+</BentoShell>
+
+<style>
+	.svc-dash {
+		padding: 1.5rem 1rem 3rem;
+	}
+
+	@media (min-width: 640px) {
+		.svc-dash {
+			padding-inline: 1.5rem;
+		}
+	}
+
+	.svc-dash__stream {
+		min-height: 60vh;
+	}
+
+	:global(.vibeshine-player__stage) {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		background: #000;
+		border-radius: 0.75rem;
+		overflow: hidden;
+	}
+
+	:global(.vibeshine-player__video) {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+
+	:global(.vibeshine-player__overlay) {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		color: #e5e7eb;
+		text-align: center;
+		padding: 1rem;
+	}
+
+	:global(.vibeshine-player__error) {
+		color: #f87171;
+		font-size: 0.875rem;
+	}
+
+	:global(.vibeshine-player__meta) {
+		color: #9ca3af;
+		font-size: 0.8125rem;
+	}
+
+	:global(.vibeshine-player__controls) {
+		display: flex;
+		gap: 0.75rem;
+		margin-top: 1rem;
+	}
+
+	:global(.vibeshine-player__controls button) {
+		padding: 0.5rem 1.25rem;
+		border-radius: 0.5rem;
+		border: 1px solid #3f3f46;
+		background: #18181b;
+		color: #e5e7eb;
+		cursor: pointer;
+	}
+
+	:global(.vibeshine-player__controls button:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVibeshinePlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVibeshinePlayer.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	$playerState,
+	$hostStatus,
+	$lastError,
+	VibeshineSession,
+	fetchHostStatus,
+} from './vibeshineService';
+
+const STATE_LABEL: Record<string, string> = {
+	idle: 'Ready',
+	'auth-required': 'Sign in required',
+	checking: 'Checking host…',
+	'host-offline': 'Host offline',
+	signaling: 'Negotiating session…',
+	connecting: 'Connecting media…',
+	streaming: 'Streaming',
+	error: 'Error',
+};
+
+export default function ReactVibeshinePlayer() {
+	const state = useStore($playerState);
+	const hostStatus = useStore($hostStatus);
+	const lastError = useStore($lastError);
+	const videoRef = useRef<HTMLVideoElement>(null);
+	const [session] = useState(() => new VibeshineSession());
+
+	useEffect(() => {
+		void fetchHostStatus();
+		return () => {
+			void session.stop();
+		};
+	}, [session]);
+
+	const busy =
+		state === 'checking' || state === 'signaling' || state === 'connecting';
+	const streaming = state === 'streaming';
+
+	return (
+		<div className="vibeshine-player">
+			<div className="vibeshine-player__stage">
+				<video
+					ref={videoRef}
+					playsInline
+					autoPlay
+					muted={false}
+					className="vibeshine-player__video"
+				/>
+				{!streaming && (
+					<div className="vibeshine-player__overlay">
+						<p>{STATE_LABEL[state] ?? state}</p>
+						{state === 'error' && lastError && (
+							<p className="vibeshine-player__error">
+								{lastError}
+							</p>
+						)}
+						{hostStatus && (
+							<p className="vibeshine-player__meta">
+								host:{' '}
+								{hostStatus.reachable
+									? `up (${hostStatus.latency_ms ?? '?'} ms via tunnel)`
+									: 'unreachable'}
+							</p>
+						)}
+					</div>
+				)}
+			</div>
+			<div className="vibeshine-player__controls">
+				{!streaming ? (
+					<button
+						type="button"
+						disabled={busy}
+						onClick={() => {
+							if (videoRef.current) {
+								void session.start(videoRef.current);
+							}
+						}}>
+						{busy ? 'Connecting…' : 'Connect'}
+					</button>
+				) : (
+					<button
+						type="button"
+						onClick={() => {
+							void session.stop();
+						}}>
+						Disconnect
+					</button>
+				)}
+				<button
+					type="button"
+					disabled={busy}
+					onClick={() => {
+						void fetchHostStatus();
+					}}>
+					Refresh status
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/vibeshineService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vibeshineService.ts
@@ -1,0 +1,255 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+
+export type PlayerState =
+	| 'idle'
+	| 'auth-required'
+	| 'checking'
+	| 'host-offline'
+	| 'signaling'
+	| 'connecting'
+	| 'streaming'
+	| 'error';
+
+export interface HostStatus {
+	reachable: boolean;
+	upstream_status?: number;
+	latency_ms?: number;
+	error?: string;
+}
+
+export const $playerState = atom<PlayerState>('idle');
+export const $hostStatus = atom<HostStatus | null>(null);
+export const $lastError = atom<string | null>(null);
+
+const STATUS_URL = '/api/v1/vibeshine/status';
+const WEBRTC_BASE = '/api/v1/vibeshine/webrtc';
+
+// Browser-side STUN only; the host advertises host candidates and learns the
+// browser's public address via peer-reflexive discovery. No TURN by design.
+const ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+const ICE_POLL_MS = 500;
+
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+	const supa = getSupa() ?? initSupa();
+	if (!supa) return null;
+	const { session } = await supa.getSession();
+	if (!session?.access_token) return null;
+	return {
+		Authorization: `Bearer ${session.access_token}`,
+		'Content-Type': 'application/json',
+	};
+}
+
+async function api<T>(
+	path: string,
+	init?: { method?: string; body?: unknown },
+): Promise<T> {
+	const headers = await getAuthHeaders();
+	if (!headers) {
+		$playerState.set('auth-required');
+		throw new Error('not authenticated');
+	}
+	const resp = await fetch(`${WEBRTC_BASE}${path}`, {
+		method: init?.method ?? 'GET',
+		headers,
+		body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+	});
+	if (!resp.ok) {
+		throw new Error(
+			`${init?.method ?? 'GET'} ${path} → HTTP ${resp.status}`,
+		);
+	}
+	const text = await resp.text();
+	return (text ? JSON.parse(text) : {}) as T;
+}
+
+export async function fetchHostStatus(): Promise<HostStatus | null> {
+	const headers = await getAuthHeaders();
+	if (!headers) {
+		$playerState.set('auth-required');
+		return null;
+	}
+	const resp = await fetch(STATUS_URL, { headers });
+	if (!resp.ok) {
+		$hostStatus.set({ reachable: false, error: `HTTP ${resp.status}` });
+		return null;
+	}
+	const status = (await resp.json()) as HostStatus;
+	$hostStatus.set(status);
+	return status;
+}
+
+interface CreateSessionResponse {
+	id?: string;
+	session_id?: string;
+	ice_servers?: RTCIceServer[];
+	[key: string]: unknown;
+}
+
+interface SdpResponse {
+	sdp?: string;
+	type?: string;
+	[key: string]: unknown;
+}
+
+interface IceResponse {
+	candidates?: RTCIceCandidateInit[];
+	[key: string]: unknown;
+}
+
+// Lifecycle below assumes browser-sends-offer; the exact body shapes and
+// offer/answer direction get finalized from the host-side signaling recon.
+export class VibeshineSession {
+	private pc: RTCPeerConnection | null = null;
+	private sessionId: string | null = null;
+	private icePollTimer: ReturnType<typeof setInterval> | null = null;
+	private seenCandidates = 0;
+
+	async start(video: HTMLVideoElement): Promise<void> {
+		$lastError.set(null);
+		$playerState.set('checking');
+
+		const status = await fetchHostStatus();
+		if (!status?.reachable) {
+			$playerState.set('host-offline');
+			return;
+		}
+
+		$playerState.set('signaling');
+		try {
+			const created = await api<CreateSessionResponse>('/sessions', {
+				method: 'POST',
+				body: {},
+			});
+			this.sessionId = created.id ?? created.session_id ?? null;
+			if (!this.sessionId) {
+				throw new Error('session create returned no id');
+			}
+
+			const iceServers = created.ice_servers?.length
+				? [...created.ice_servers, ...ICE_SERVERS]
+				: ICE_SERVERS;
+
+			const pc = new RTCPeerConnection({ iceServers });
+			this.pc = pc;
+
+			pc.addTransceiver('video', { direction: 'recvonly' });
+			pc.addTransceiver('audio', { direction: 'recvonly' });
+
+			pc.ontrack = (ev) => {
+				if (video.srcObject !== ev.streams[0]) {
+					video.srcObject = ev.streams[0];
+					void video.play().catch(() => undefined);
+				}
+			};
+
+			pc.onicecandidate = (ev) => {
+				if (!ev.candidate || !this.sessionId) return;
+				void api(`/sessions/${this.sessionId}/ice`, {
+					method: 'POST',
+					body: ev.candidate.toJSON(),
+				}).catch((e) =>
+					console.warn('[vibeshine] ice send failed:', e),
+				);
+			};
+
+			pc.onconnectionstatechange = () => {
+				switch (pc.connectionState) {
+					case 'connected':
+						$playerState.set('streaming');
+						break;
+					case 'failed':
+						this.fail(
+							'peer connection failed (NAT may be symmetric)',
+						);
+						break;
+					case 'disconnected':
+					case 'closed':
+						if ($playerState.get() === 'streaming') {
+							void this.stop();
+						}
+						break;
+				}
+			};
+
+			const offer = await pc.createOffer();
+			await pc.setLocalDescription(offer);
+
+			const answer = await api<SdpResponse>(
+				`/sessions/${this.sessionId}/offer`,
+				{ method: 'POST', body: { type: offer.type, sdp: offer.sdp } },
+			);
+			if (!answer.sdp) {
+				throw new Error('no answer SDP from host');
+			}
+			await pc.setRemoteDescription({
+				type: (answer.type as RTCSdpType) ?? 'answer',
+				sdp: answer.sdp,
+			});
+
+			$playerState.set('connecting');
+			this.startIcePolling();
+		} catch (e) {
+			this.fail(e instanceof Error ? e.message : String(e));
+		}
+	}
+
+	private startIcePolling(): void {
+		this.icePollTimer = setInterval(() => {
+			void (async () => {
+				if (!this.sessionId || !this.pc) return;
+				if (this.pc.connectionState === 'connected') {
+					this.stopIcePolling();
+					return;
+				}
+				try {
+					const remote = await api<IceResponse>(
+						`/sessions/${this.sessionId}/ice`,
+					);
+					const candidates = remote.candidates ?? [];
+					for (const c of candidates.slice(this.seenCandidates)) {
+						await this.pc.addIceCandidate(c);
+					}
+					this.seenCandidates = Math.max(
+						this.seenCandidates,
+						candidates.length,
+					);
+				} catch (e) {
+					console.warn('[vibeshine] ice poll failed:', e);
+				}
+			})();
+		}, ICE_POLL_MS);
+	}
+
+	private stopIcePolling(): void {
+		if (this.icePollTimer !== null) {
+			clearInterval(this.icePollTimer);
+			this.icePollTimer = null;
+		}
+	}
+
+	private fail(message: string): void {
+		$lastError.set(message);
+		$playerState.set('error');
+		void this.stop(false);
+	}
+
+	async stop(resetState = true): Promise<void> {
+		this.stopIcePolling();
+		this.pc?.close();
+		this.pc = null;
+		if (this.sessionId) {
+			const id = this.sessionId;
+			this.sessionId = null;
+			await api(`/sessions/${id}`, { method: 'DELETE' }).catch(
+				() => undefined,
+			);
+		}
+		this.seenCandidates = 0;
+		if (resetState) {
+			$playerState.set('idle');
+		}
+	}
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/vibeshine/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/vibeshine/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Vibeshine Remote Play
+description: Browser WebRTC player for the Vibeshine game-stream host — staff panel.
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+sidebar:
+    label: Vibeshine
+    order: 6
+unsplash: 1552820728-8b83bb6b773f
+img: https://images.unsplash.com/photo-1552820728-8b83bb6b773f?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - vibeshine
+    - gameops
+    - staff
+---
+
+import AstroVibeshinePlayer from '@/components/dashboard/AstroVibeshinePlayer.astro';
+
+<AstroVibeshinePlayer />

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -233,6 +233,16 @@ async fn main() -> anyhow::Result<()> {
         info!("Vibeshine proxy not configured (using default wg tunnel URL)");
     }
 
+    // Initialize Vibeshine WebRTC signaling relay (optional - DASHBOARD_VIEW gated,
+    // separate webrtc-scoped upstream token via VIBESHINE_WEBRTC_TOKEN)
+    if transport::proxy::init_vibeshine_webrtc_proxy() {
+        info!(
+            "Vibeshine WebRTC relay initialized - /api/v1/vibeshine/webrtc/* enabled (DASHBOARD_VIEW required)"
+        );
+    } else {
+        info!("Vibeshine WebRTC relay not configured (using default wg tunnel URL)");
+    }
+
     // Initialize Firecracker-Net proxy (optional - DASHBOARD_MANAGE gated, routes to firecracker-ctl-net with Gluetun/WireGuard sidecar)
     if transport::proxy::init_firecracker_net_proxy() {
         info!(

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -668,6 +668,10 @@ fn router(state: AppState) -> Router {
             axum::routing::get(super::proxy::vibeshine_status_handler),
         )
         .route(
+            "/api/v1/vibeshine/webrtc/{*rest}",
+            any(super::proxy::vibeshine_webrtc_handler),
+        )
+        .route(
             "/dashboard/firecracker-net/proxy/{*path}",
             any(super::proxy::firecracker_net_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -2120,6 +2120,59 @@ pub async fn vibeshine_status_handler(req: Request<Body>) -> Response {
     }
 }
 
+static VIBESHINE_WEBRTC: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_vibeshine_webrtc_proxy() -> bool {
+    let upstream = std::env::var("VIBESHINE_UPSTREAM_URL")
+        .unwrap_or_else(|_| "https://10.10.0.3:47990".into());
+    let token = std::env::var("VIBESHINE_WEBRTC_TOKEN").ok();
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        // No overall timeout — /api/webrtc/.../ice/stream is long-lived SSE.
+        .danger_accept_invalid_certs(true)
+        .http1_only()
+        .build()
+        .expect("failed to build reqwest client for vibeshine webrtc proxy");
+
+    VIBESHINE_WEBRTC
+        .set(ServiceProxy {
+            name: "Vibeshine-WebRTC",
+            client,
+            upstream: upstream.trim_end_matches('/').to_string(),
+            upstream_token: token,
+            upstream_headers: Vec::new(),
+            iframe_safe: false,
+            streaming: true,
+        })
+        .is_ok()
+}
+
+pub async fn vibeshine_webrtc_handler(Path(rest): Path<String>, req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(str::to_owned);
+    if let Err(resp) =
+        require_dashboard_view_with_query(&headers, query.as_deref(), "Vibeshine-WebRTC").await
+    {
+        return resp;
+    }
+
+    match VIBESHINE_WEBRTC.get() {
+        Some(proxy) => {
+            let upstream_path = format!("api/webrtc/{rest}");
+            proxy
+                .handle_preauthorized(Some(Path(upstream_path)), req)
+                .await
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Vibeshine WebRTC proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
 static FIRECRACKER_NET: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_firecracker_net_proxy() -> bool {


### PR DESCRIPTION
Phase 2 of the Vibeshine remote-play lane (control plane on the wg tunnel, media direct to viewers).

**axum-kbve**
- `init_vibeshine_webrtc_proxy()` — dedicated relay to the host's `/api/webrtc/*` signaling API, separate upstream token (`VIBESHINE_WEBRTC_TOKEN`, optional), streaming enabled for the SSE ICE feed, no overall client timeout
- `/api/v1/vibeshine/webrtc/{*rest}` — `DASHBOARD_VIEW`-gated, forwards to `api/webrtc/{rest}` on the laptop over the tunnel

**astro-kbve**
- `vibeshineService.ts` — Supabase-authed signaling client + `VibeshineSession` (RTCPeerConnection, STUN-only iceServers, recvonly transceivers, trickle ICE via poll, teardown)
- `ReactVibeshinePlayer.tsx` / `AstroVibeshinePlayer.astro` — player island with status overlay + connect/disconnect
- `/dashboard/gameops/vibeshine/` page

Media never touches the cluster: browser gets STUN, laptop answers with host candidates, peer-reflexive ICE forms the direct pair.

**Known-unknowns, marked in code**: browser-sends-offer direction, session-create/ICE body shapes, and idle-timeout semantics are assumptions pending the host-side signaling recon; the relay path itself is shape-agnostic. `VIBESHINE_WEBRTC_TOKEN` sealing + deployment env comes in a follow-up PR once the second token is minted.

Verified: `cargo check` clean; `astro check` — no diagnostics in the new files (baseline pre-existing errors unchanged).

https://kbve.com/application/kubernetes/