### PR TITLE
feat(kbve): vibeshine host control panel + webrtc token pre-wiring

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVibeshinePlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVibeshinePlayer.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactVibeshinePlayer from '@/components/dashboard/ReactVibeshinePlayer';
+import ReactVibeshineHostPanel from '@/components/dashboard/ReactVibeshineHostPanel';
 ---
 
 <BentoShell
@@ -10,6 +11,9 @@ import ReactVibeshinePlayer from '@/components/dashboard/ReactVibeshinePlayer';
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
 			<ReactVibeshinePlayer client:only="react" />
+		</div>
+		<div class="svc-dash__panel not-content">
+			<ReactVibeshineHostPanel client:only="react" />
 		</div>
 	</div>
 </BentoShell>
@@ -27,6 +31,90 @@ import ReactVibeshinePlayer from '@/components/dashboard/ReactVibeshinePlayer';
 
 	.svc-dash__stream {
 		min-height: 60vh;
+	}
+
+	.svc-dash__panel {
+		margin-top: 1.5rem;
+	}
+
+	:global(.vibeshine-host) {
+		border: 1px solid #27272a;
+		border-radius: 0.75rem;
+		padding: 1rem 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	:global(.vibeshine-host__header) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	:global(.vibeshine-host__header h3) {
+		margin: 0;
+		font-size: 1rem;
+	}
+
+	:global(.vibeshine-host__badge) {
+		font-size: 0.75rem;
+		padding: 0.2rem 0.6rem;
+		border-radius: 999px;
+		border: 1px solid #3f3f46;
+	}
+
+	:global(.vibeshine-host__badge--up) {
+		color: #4ade80;
+		border-color: #14532d;
+	}
+
+	:global(.vibeshine-host__badge--down) {
+		color: #f87171;
+		border-color: #7f1d1d;
+	}
+
+	:global(.vibeshine-host__error) {
+		color: #f87171;
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	:global(.vibeshine-host__apps) {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	:global(.vibeshine-host__app) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid #27272a;
+		border-radius: 0.5rem;
+	}
+
+	:global(.vibeshine-host__actions) {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	:global(.vibeshine-host button) {
+		padding: 0.35rem 0.9rem;
+		border-radius: 0.5rem;
+		border: 1px solid #3f3f46;
+		background: #18181b;
+		color: #e5e7eb;
+		cursor: pointer;
+	}
+
+	:global(.vibeshine-host button:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	:global(.vibeshine-player__stage) {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVibeshineHostPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVibeshineHostPanel.tsx
@@ -1,0 +1,97 @@
+import { useEffect } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	$apps,
+	$appsStatus,
+	$sessionStatus,
+	$controlError,
+	$hostStatus,
+	fetchApps,
+	fetchSessionStatus,
+	fetchHostStatus,
+	closeApp,
+	launchApp,
+} from './vibeshineService';
+
+export default function ReactVibeshineHostPanel() {
+	const apps = useStore($apps);
+	const appsStatus = useStore($appsStatus);
+	const sessionStatus = useStore($sessionStatus);
+	const controlError = useStore($controlError);
+	const hostStatus = useStore($hostStatus);
+
+	useEffect(() => {
+		void fetchHostStatus().then((status) => {
+			if (status?.reachable) {
+				void fetchApps();
+				void fetchSessionStatus();
+			}
+		});
+	}, []);
+
+	const sessionActive =
+		sessionStatus !== null &&
+		Object.values(sessionStatus).some((v) => v === true || v === 'active');
+
+	return (
+		<div className="vibeshine-host">
+			<div className="vibeshine-host__header">
+				<h3>Host control</h3>
+				<span
+					className={
+						hostStatus?.reachable
+							? 'vibeshine-host__badge vibeshine-host__badge--up'
+							: 'vibeshine-host__badge vibeshine-host__badge--down'
+					}>
+					{hostStatus?.reachable
+						? `tunnel up · ${hostStatus.latency_ms ?? '?'} ms`
+						: 'host unreachable'}
+				</span>
+			</div>
+			{controlError && (
+				<p className="vibeshine-host__error">{controlError}</p>
+			)}
+			<div className="vibeshine-host__apps">
+				{appsStatus === 'loading' && <p>Loading apps…</p>}
+				{appsStatus === 'error' && <p>Failed to load apps.</p>}
+				{appsStatus === 'ok' && !apps?.length && (
+					<p>No apps registered on the host.</p>
+				)}
+				{apps?.map((app, i) => (
+					<div
+						className="vibeshine-host__app"
+						key={String(app.uuid ?? app.index ?? i)}>
+						<span>{String(app.name ?? `app ${i}`)}</span>
+						<button
+							type="button"
+							disabled={!hostStatus?.reachable}
+							onClick={() => void launchApp(app)}>
+							Launch
+						</button>
+					</div>
+				))}
+			</div>
+			<div className="vibeshine-host__actions">
+				<button
+					type="button"
+					disabled={!hostStatus?.reachable}
+					onClick={() => void closeApp()}>
+					Stop running app
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						void fetchApps();
+						void fetchSessionStatus();
+					}}>
+					Refresh
+				</button>
+				{sessionActive && (
+					<span className="vibeshine-host__badge vibeshine-host__badge--up">
+						session active
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/vibeshineService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vibeshineService.ts
@@ -253,3 +253,91 @@ export class VibeshineSession {
 		}
 	}
 }
+
+const PROXY_BASE = '/dashboard/vibeshine/proxy';
+
+export interface VibeshineApp {
+	name?: string;
+	uuid?: string;
+	index?: number;
+	[key: string]: unknown;
+}
+
+export interface SessionStatus {
+	[key: string]: unknown;
+}
+
+export const $apps = atom<VibeshineApp[] | null>(null);
+export const $appsStatus = atom<'idle' | 'loading' | 'ok' | 'error'>('idle');
+export const $sessionStatus = atom<SessionStatus | null>(null);
+export const $controlError = atom<string | null>(null);
+
+async function hostApi<T>(
+	path: string,
+	init?: { method?: string; body?: unknown },
+): Promise<T> {
+	const headers = await getAuthHeaders();
+	if (!headers) {
+		$playerState.set('auth-required');
+		throw new Error('not authenticated');
+	}
+	const resp = await fetch(`${PROXY_BASE}${path}`, {
+		method: init?.method ?? 'GET',
+		headers,
+		body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+	});
+	if (!resp.ok) {
+		throw new Error(
+			`${init?.method ?? 'GET'} ${path} → HTTP ${resp.status}`,
+		);
+	}
+	const text = await resp.text();
+	return (text ? JSON.parse(text) : {}) as T;
+}
+
+export async function fetchApps(): Promise<void> {
+	$appsStatus.set('loading');
+	try {
+		const data = await hostApi<{ apps?: VibeshineApp[] } | VibeshineApp[]>(
+			'/api/apps',
+		);
+		const apps = Array.isArray(data) ? data : (data.apps ?? []);
+		$apps.set(apps);
+		$appsStatus.set('ok');
+	} catch (e) {
+		$controlError.set(e instanceof Error ? e.message : String(e));
+		$appsStatus.set('error');
+	}
+}
+
+export async function fetchSessionStatus(): Promise<void> {
+	try {
+		const data = await hostApi<SessionStatus>('/api/session/status');
+		$sessionStatus.set(data);
+	} catch {
+		$sessionStatus.set(null);
+	}
+}
+
+export async function closeApp(): Promise<void> {
+	$controlError.set(null);
+	try {
+		await hostApi('/api/apps/close', { method: 'POST', body: {} });
+		await fetchSessionStatus();
+	} catch (e) {
+		$controlError.set(e instanceof Error ? e.message : String(e));
+	}
+}
+
+export async function launchApp(app: VibeshineApp): Promise<void> {
+	$controlError.set(null);
+	try {
+		await hostApi('/api/playnite/launch', {
+			method: 'POST',
+			body: { id: app.uuid ?? app.index ?? app.name },
+		});
+		await fetchSessionStatus();
+	} catch (e) {
+		$controlError.set(e instanceof Error ? e.message : String(e));
+	}
+}

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
         kbve.com/managed-by: argocd
     annotations:
         configmap.reloader.stakater.com/reload: kube-root-ca.crt
-        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials
+        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials,vibeshine-config
 spec:
     replicas: 1
     strategy:
@@ -226,6 +226,12 @@ spec:
                             secretKeyRef:
                                 name: vibeshine-config
                                 key: api-token
+                                optional: true
+                      - name: VIBESHINE_WEBRTC_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: vibeshine-config
+                                key: webrtc-token
                                 optional: true
                       - name: DISCORD_CLIENT_ID
                         valueFrom:


### PR DESCRIPTION
Continues the Vibeshine lane while the host-side signaling recon is in flight — everything here runs against already-deployed surface.

**astro-kbve** — `/dashboard/gameops/vibeshine/` gains a host control panel (staff):
- app list from `GET /api/apps` via the MANAGE-gated `/dashboard/vibeshine/proxy`
- launch (Playnite route) / stop-running-app buttons, session-active badge, tunnel status chip
- service additions in `vibeshineService.ts` (`hostApi` against the dashboard proxy, tolerant response parsing until the exact shapes are confirmed)

**kube**
- Reloader annotation now includes `vibeshine-config` — closes the token-rotation gap noted at deploy time
- `VIBESHINE_WEBRTC_TOKEN` env pre-wired from `vibeshine-config/webrtc-token`, `optional: true` — the sealed key gets added via `kubeseal --merge-into` once the second token is minted, no further deployment change needed

Verified: `astro check` — no diagnostics in vibeshine files (baseline unchanged); `kubectl apply --dry-run=client` clean.

https://kbve.com/application/kubernetes/