### PR TITLE
fix(kbve): single-writer TLS certs, drop gateway-shim annotation

### DIFF
--- a/apps/kube/kbve/application.yaml
+++ b/apps/kube/kbve/application.yaml
@@ -11,6 +11,7 @@ metadata:
         kbve.com/schema-version: 'v1'
         kbve.com/category: 'application'
         kbve.com/stack: 'core'
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
     project: default
     source:

--- a/apps/kube/kbve/manifest/direct-git-cert.yaml
+++ b/apps/kube/kbve/manifest/direct-git-cert.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: direct-git-tls
+    namespace: kbve
+spec:
+    secretName: direct-git-tls
+    issuerRef:
+        name: letsencrypt-dns
+        kind: ClusterIssuer
+        group: cert-manager.io
+    commonName: direct.git.kbve.com
+    dnsNames:
+        - direct.git.kbve.com
+    duration: 2160h
+    renewBefore: 720h
+    privateKey:
+        algorithm: ECDSA
+        size: 256

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -3,8 +3,6 @@ kind: Gateway
 metadata:
     name: kbve-gateway
     namespace: kbve
-    annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-dns
 spec:
     gatewayClassName: cilium
     infrastructure:

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
     - vibeshine-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
     - kbve-wt-cert.yaml
+    - direct-git-cert.yaml
     - kubevirt-rbac.yaml
     - kbve-deployment.yaml
     - kbve-gateway.yaml


### PR DESCRIPTION
## Problem
`Certificate/kbve-wt-tls` has two writers: cert-manager's gateway-shim (generated from `cert-manager.io/cluster-issuer: letsencrypt-dns` on kbve-gateway) and the standalone `kbve-wt-cert.yaml` Argo applies. Each stamps its own spec (shim: bare + usages; git: ECDSA/duration/renewBefore/commonName) — 217 generations of flapping, 23 failed issuance attempts, and the LetsEncrypt duplicate-certificate rate limit (5 per 168h) is exhausted.

**No outage**: the served secret is valid until **2026-10-02**; renewal window opens ~09-02 (renewBefore 720h). The 168h rate-limit window clears well before then.

## Fix — git manifests become the sole owner
- Remove `cert-manager.io/cluster-issuer` annotation from kbve-gateway (kills the shim generator)
- Add `direct-git-cert.yaml` — `direct-git-tls` for `direct.git.kbve.com` existed **only** via the shim; without a standalone Certificate the annotation removal would orphan its renewal. Mirrors kbve-wt-cert (ECDSA-256, 2160h/720h)
- ServerSideDiff annotation on the kbve app (consistent with the fleet-wide rollout)

## Post-merge follow-up (live cluster, one-time)
Both live Certificates carry `ownerReferences` to Gateway/kbve-gateway from shim adoption. After sync, strip them — otherwise deleting the Gateway would garbage-collect the Certificates and their secrets:
```
kubectl patch certificate kbve-wt-tls -n kbve --type=json -p='[{"op":"remove","path":"/metadata/ownerReferences"}]'
kubectl patch certificate direct-git-tls -n kbve --type=json -p='[{"op":"remove","path":"/metadata/ownerReferences"}]'
```

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)