### PR TITLE
fix(arpg-web): add fastnoise-lite dep for @kbve/laser heightfield import

### DIFF
--- a/apps/agones/arpg/web/package.json
+++ b/apps/agones/arpg/web/package.json
@@ -24,6 +24,7 @@
 		"@supabase/supabase-js": "^2.95.3",
 		"bitecs": "^0.4.0",
 		"dexie": "^4.4.2",
+		"fastnoise-lite": "1.1.1",
 		"phaser": "^4.1.0",
 		"react": "19.2.3",
 		"react-dom": "19.2.3",

--- a/apps/agones/arpg/web/pnpm-lock.yaml
+++ b/apps/agones/arpg/web/pnpm-lock.yaml
@@ -4,23 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@novnc/novnc': 1.5.0
-  '@xmldom/xmldom@<0.8.13': '>=0.8.13'
-  '@expo/plist>@xmldom/xmldom': ^0.8.13
-  react: 19.2.3
-  react-dom: 19.2.3
-  dompurify@<3.4.0: '>=3.4.0'
-  fast-xml-parser: '>=5.5.8'
-  handlebars@<4.7.9: '>=4.7.9'
-  lodash-es@<4.18.0: '>=4.18.0'
-  minimatch@<3.1.4: 3.1.4
-  minimatch@>=5.0.0 <5.1.8: 5.1.8
-  minimatch@>=7.0.0 <7.4.8: 7.4.8
-  minimatch@>=9.0.0 <9.0.7: 9.0.7
-  minimatch@>=10.0.0 <10.2.3: 10.2.3
-  postcss@<8.5.10: '>=8.5.10'
-
 importers:
 
   .:
@@ -46,6 +29,9 @@ importers:
       dexie:
         specifier: ^4.4.2
         version: 4.4.4
+      fastnoise-lite:
+        specifier: 1.1.1
+        version: 1.1.1
       phaser:
         specifier: ^4.1.0
         version: 4.2.0
@@ -366,8 +352,8 @@ packages:
     resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
     peerDependencies:
       '@react-three/fiber': ^9.0.0
-      react: 19.2.3
-      react-dom: 19.2.3
+      react: ^19
+      react-dom: ^19
       three: '>=0.159'
     peerDependenciesMeta:
       react-dom:
@@ -380,8 +366,8 @@ packages:
       expo-asset: '>=8.4'
       expo-file-system: '>=11.0'
       expo-gl: '>=11.0'
-      react: 19.2.3
-      react-dom: 19.2.3
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
       react-native: '>=0.78'
       three: '>=0.156'
     peerDependenciesMeta:
@@ -614,7 +600,7 @@ packages:
   '@use-gesture/react@10.3.1':
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
-      react: 19.2.3
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -722,6 +708,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  fastnoise-lite@1.1.1:
+    resolution: {integrity: sha512-3XEk16gmVq1HUL0+BdoR+/wD/tfB6VQjpliqQ7rSSE2omh23wrJGidQ5Mfr4mECCUtBGtcEov44BGIyVqs+U4w==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -771,7 +760,7 @@ packages:
   its-fine@2.0.0:
     resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
     peerDependencies:
-      react: 19.2.3
+      react: ^19.0.0
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -848,7 +837,7 @@ packages:
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
-      react: 19.2.3
+      react: ^19.2.3
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -857,8 +846,8 @@ packages:
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
     peerDependencies:
-      react: 19.2.3
-      react-dom: 19.2.3
+      react: '>=16.13'
+      react-dom: '>=16.13'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -914,7 +903,7 @@ packages:
   suspend-react@0.1.3:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
-      react: 19.2.3
+      react: '>=17.0'
 
   terser@5.48.0:
     resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
@@ -971,7 +960,7 @@ packages:
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
-      react: 19.2.3
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
@@ -1044,7 +1033,7 @@ packages:
     peerDependencies:
       '@types/react': '>=16.8'
       immer: '>=9.0.6'
-      react: 19.2.3
+      react: '>=16.8'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1059,7 +1048,7 @@ packages:
     peerDependencies:
       '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
-      react: 19.2.3
+      react: '>=18.0.0'
       use-sync-external-store: '>=1.2.0'
     peerDependenciesMeta:
       '@types/react':
@@ -1656,6 +1645,8 @@ snapshots:
   escalade@3.2.0: {}
 
   eventemitter3@5.0.4: {}
+
+  fastnoise-lite@1.1.1: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/apps/agones/arpg/web/vite.config.ts
+++ b/apps/agones/arpg/web/vite.config.ts
@@ -178,6 +178,7 @@ export default defineConfig(({ mode }) => {
 				'bitecs',
 				'phaser',
 				'@phaserjs/rapier-connector',
+				'fastnoise-lite',
 			],
 			alias: [
 				laserAlias,

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_server
 pipeline: docker
 app_name: arpg-server
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/agones/arpg/server
 version_toml: apps/agones/arpg/server/version.toml
 # Pre-build sync: CI writes this MDX `version` into version_target (Cargo.toml →

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_web
 pipeline: docker
 app_name: arpg-web
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/agones/arpg
 version_toml: apps/agones/arpg/web/version.toml
 version_source: apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx


### PR DESCRIPTION
arpg.kbve.com build broke with `Could not resolve "fastnoise-lite" imported by "@kbve/laser"`.

**Root cause:** #13746 added `import FastNoiseLite from 'fastnoise-lite'` to `@kbve/laser` (`src/lib/determ/heightfield.ts`). arpg-web aliases `@kbve/laser` to source, so laser's bare imports resolve from arpg-web's isolated container install — which never declared `fastnoise-lite`. Local builds masked it via the hoisted root node_modules. Same trap as the earlier phaser/bitecs breakage already documented in `vite.config.ts`.

**Fix:**
- Add `fastnoise-lite@1.1.1` to arpg-web dependencies (matches root pin)
- Add it to the Vite `dedupe` list alongside phaser/bitecs
- Update standalone lockfile
- Bump arpg-web + arpg-server MDX versions to 0.1.25 to ship the rebuild