### PR TITLE
ci: drop unused setup-uv from docker-test-app, retry-wrap remaining call sites

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -58,9 +58,13 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: Wandalen/wretry.action@v3.8.0
               with:
-                  github-token: ${{ github.token }}
+                  action: astral-sh/setup-uv@v7
+                  attempt_limit: 3
+                  attempt_delay: 15000
+                  with: |
+                      github-token: ${{ github.token }}
 
             - name: Run zizmor (offline audits only, informational)
               # GitHub's default bash invocation is `bash --noprofile --norc -eo

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -236,11 +236,6 @@ jobs:
                   UV_THREADPOOL_SIZE: '16'
               run: pnpm install --frozen-lockfile --prefer-offline
 
-            - name: Setup Python + uv
-              uses: astral-sh/setup-uv@v7
-              with:
-                  enable-cache: false
-
             - name: Detect Playwright usage
               id: detect-playwright
               run: |

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -52,7 +52,11 @@ jobs:
                   python-version: '3.12'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: Wandalen/wretry.action@v3.8.0
+              with:
+                  action: astral-sh/setup-uv@v7
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Nx e2e ${{ inputs.project }}
               run: pnpm nx e2e ${{ inputs.project }} --no-cloud

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -96,9 +96,13 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: Wandalen/wretry.action@v3.8.0
               with:
-                  github-token: ${{ github.token }}
+                  action: astral-sh/setup-uv@v7
+                  attempt_limit: 3
+                  attempt_delay: 15000
+                  with: |
+                      github-token: ${{ github.token }}
 
             - name: Setup Rust 1.96
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -74,7 +74,11 @@ jobs:
                   python-version: '3.12'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: Wandalen/wretry.action@v3.8.0
+              with:
+                  action: astral-sh/setup-uv@v7
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Sync version from source to pyproject.toml
               if: ${{ inputs.version_source != '' && inputs.version_target != '' }}


### PR DESCRIPTION
## Problem

`CI - Docker / axum-kbve` failed at **Setup Python + uv** with `fetch failed` ([run 28839288528](https://github.com/KBVE/kbve/actions/runs/28839288528)). setup-uv v7 always fetches the `uv.ndjson` manifest from raw.githubusercontent.com at job time to resolve the artifact URL — even with the version pinned in `uv.toml` (the PR #13860 pin fixed `latest` resolution, not the manifest fetch itself). A transient network blip on the ARC runner killed the job.

## Fix

- **docker-test-app**: remove the `Setup Python + uv` step entirely. Audited all consumers via `.github/ci-dispatch-manifest.json`: no docker app with tests is a python project, and no e2e target invokes uv. Python projects (fudster, kbve, pydesk, notification-bot) flow through the `python` manifest section instead. The step was added speculatively in f13b8673f and never gained a consumer.
- **utils-ci-lint-test, python-test-package, utils-python-publish, ci-actionlint**: wrap setup-uv in `Wandalen/wretry.action` (3 attempts, 15s delay) — same pattern already used for buildx setup. These four genuinely need uv (`nx affected` can hit @nxlv/python projects; zizmor runs via `uvx`).

Closes #13903