### PR TITLE
feat(astro-kbve): widen dash frame to 95rem

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -66,10 +66,15 @@ const crumbs = isDashboard ? buildBreadcrumb(pathname) : [];
 }
 
 <style>
-	/* One grid: full-width section band + centered 80rem frame with side
-	   rails (matches every Bento* section on the homepage). Rail + main are
-	   internal cells; breadcrumbs are flush top/bottom bands. No nested
-	   shells, no floating cards. */
+	/* One grid: full-width section band + centered frame widened to 95rem so
+	   the 15rem rail sits in what is gutter on the homepage — main content
+	   keeps the same 80rem as every Bento* section. Rail + main are internal
+	   cells; breadcrumbs are flush top/bottom bands. No nested shells, no
+	   floating cards. */
+	.dash-shell .dash-frame {
+		max-width: 95rem;
+	}
+
 	.dash-grid {
 		display: grid;
 		grid-template-columns: minmax(0, 1fr);
@@ -96,7 +101,7 @@ const crumbs = isDashboard ? buildBreadcrumb(pathname) : [];
 
 	@media (min-width: 1024px) {
 		.dash-grid {
-			grid-template-columns: 15rem minmax(0, 1fr);
+			grid-template-columns: 15rem minmax(0, 80rem);
 			grid-template-areas:
 				'crumbTop crumbTop'
 				'rail     main'


### PR DESCRIPTION
Dashboard pages squeezed main content to ~65rem because the 15rem nav rail lived inside the 80rem bento frame.

- `.dash-frame` on dashboard pages now caps at 95rem: the rail occupies what is gutter space on the homepage, and main content gets the same 80rem as every Bento section.
- Grid main column capped at `minmax(0, 80rem)` so rail + main fill the frame exactly at wide viewports.
- Below 1024px the stacked rail/toggle behavior is unchanged.

Primary beneficiary: /dashboard/api/ where the Scalar reference (own sidebar + three-pane layout) was cramped.

`nx run astro-kbve:check` passes (0 errors).