### PR TITLE
feat(windmill): bootstrap windmill.kbve.com workflow engine on kilobase

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -53,6 +53,8 @@ resources:
     - jobboard/application.yaml
     - metrics/application.yaml
     - n8n/application.yaml
+    # Windmill — workflow engine (n8n replacement candidate), windmill.kbve.com
+    - windmill/application.yaml
     - rabbitmq/application.yaml
     # rows = shared ROWS infra (ns `rows`): ows-valkey, externalsecrets, servicemonitor,
     # and the `rows-agones-allocator-binding` Kyverno ClusterPolicy that grants every

--- a/apps/kube/windmill/application.yaml
+++ b/apps/kube/windmill/application.yaml
@@ -1,0 +1,101 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: windmill
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    annotations:
+        kbve.com/source-path: kube/windmill
+        kbve.com/manifest-path: apps/kube/windmill/manifest
+        kbve.com/application-file: kube/windmill/application.yaml
+        kbve.com/managed-by: argocd
+        kbve.com/schema-version: v1
+        kbve.com/category: application
+        kbve.com/stack: core
+spec:
+    project: default
+    sources:
+        - chart: windmill
+          repoURL: https://windmill-labs.github.io/windmill-helm-charts
+          targetRevision: 4.0.200
+          helm:
+              valuesObject:
+                  postgresql:
+                      enabled: false
+                  minio:
+                      enabled: false
+                  ingress:
+                      enabled: false
+                  windmill:
+                      baseDomain: windmill.kbve.com
+                      baseProtocol: https
+                      appReplicas: 1
+                      databaseUrlSecretName: windmill-database-url
+                      databaseUrlSecretKey: url
+                      app:
+                          extraEnv:
+                              - name: PG_SCHEMA
+                                value: windmill
+                          resources:
+                              requests:
+                                  memory: 512Mi
+                                  cpu: 250m
+                              limits:
+                                  memory: 2Gi
+                                  cpu: 1000m
+                      workerGroups:
+                          - name: default
+                            controller: Deployment
+                            replicas: 1
+                            terminationGracePeriodSeconds: 600
+                            extraEnv:
+                                - name: PG_SCHEMA
+                                  value: windmill
+                            resources:
+                                requests:
+                                    memory: 512Mi
+                                    cpu: 250m
+                                limits:
+                                    memory: 2Gi
+                                    cpu: 1000m
+                          - name: native
+                            controller: Deployment
+                            replicas: 1
+                            terminationGracePeriodSeconds: 600
+                            extraEnv:
+                                - name: PG_SCHEMA
+                                  value: windmill
+                                - name: NATIVE_MODE
+                                  value: 'true'
+                                - name: SLEEP_QUEUE
+                                  value: '200'
+                            resources:
+                                requests:
+                                    memory: 256Mi
+                                    cpu: 100m
+                                limits:
+                                    memory: 1Gi
+                                    cpu: 500m
+        - repoURL: https://github.com/KBVE/kbve.git
+          targetRevision: main
+          path: apps/kube/windmill/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: windmill
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+            allowEmpty: false
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m
+    revisionHistoryLimit: 3

--- a/apps/kube/windmill/manifest/rbac.yaml
+++ b/apps/kube/windmill/manifest/rbac.yaml
@@ -1,0 +1,26 @@
+# Role: Allow windmill ExternalSecrets SA to read the supabase secrets it syncs
+# (postgres DB password for DATABASE_URL + the gate JWT signing secret).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: windmill-supabase-access
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-postgres', 'supabase-jwt']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: windmill-supabase-access-binding
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: windmill-supabase-access
+subjects:
+    - kind: ServiceAccount
+      name: windmill-external-secrets
+      namespace: windmill

--- a/apps/kube/windmill/manifest/windmill-externalsecret.yaml
+++ b/apps/kube/windmill/manifest/windmill-externalsecret.yaml
@@ -1,0 +1,86 @@
+# ServiceAccount for ExternalSecrets cross-namespace access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: windmill-external-secrets
+    namespace: windmill
+---
+# SecretStore: Kilobase namespace (for supabase-postgres password)
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: windmill-supabase-secret-store
+    namespace: windmill
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: windmill-external-secrets
+                    namespace: windmill
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: Build the full Windmill DATABASE_URL from the shared
+# supabase postgres password. Windmill runs in the shared `supabase`
+# database with PG_SCHEMA=windmill set on server + worker containers.
+# The options=-csearch_path=windmill URL parameter is REQUIRED: sqlx
+# migrations follow the connection search_path, not PG_SCHEMA, and
+# without it Windmill creates its ~145 tables in the public schema
+# (verified empirically against the kilobase image).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: windmill-database-url
+    namespace: windmill
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: windmill-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: windmill-database-url
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                url: 'postgres://postgres:{{ .dbpassword | urlquery }}@kilobase-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=require&options=-csearch_path%3Dwindmill'
+    data:
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: windmill-gate-supabase-jwt
+    namespace: windmill
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: windmill-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: windmill-gate-supabase-jwt
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                SUPABASE_JWT_SECRET: '{{ .jwt_secret }}'
+                anon-key: '{{ .anonkey }}'
+    data:
+        - secretKey: jwt_secret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key

--- a/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
+++ b/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
@@ -1,0 +1,116 @@
+# kbve-gate runs as a standalone deployment (not a sidecar) because the
+# Windmill helm chart owns the app Deployment. HTTPRoute -> gate -> windmill-app.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: windmill-gate
+    namespace: windmill
+    labels:
+        app: windmill-gate
+        kbve.com/category: application
+        kbve.com/stack: core
+        kbve.com/managed-by: argocd
+    annotations:
+        reloader.stakater.com/auto: 'true'
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: windmill-gate
+    template:
+        metadata:
+            labels:
+                app: windmill-gate
+        spec:
+            automountServiceAccountToken: false
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: kbve-gate
+                  image: ghcr.io/kbve/kbve-gate:0.1.7
+                  imagePullPolicy: IfNotPresent
+                  ports:
+                      - name: gateway
+                        containerPort: 5678
+                        protocol: TCP
+                      - name: gate-metrics
+                        containerPort: 9090
+                        protocol: TCP
+                  env:
+                      - name: GATE_LISTEN
+                        value: 0.0.0.0:5678
+                      - name: GATE_METRICS_PORT
+                        value: '9090'
+                      - name: GATE_UPSTREAM
+                        value: http://windmill-app.windmill.svc.cluster.local:8000
+                      - name: GATE_AUTHZ
+                        value: is_staff
+                      - name: GATE_STAFF_SCHEMA
+                        value: forum
+                      - name: GATE_LOGIN_REDIRECT
+                        value: https://kbve.com/login
+                      - name: GATE_COOKIE_DOMAIN
+                        value: .kbve.com
+                      - name: SUPABASE_URL
+                        value: http://kong.kilobase.svc.cluster.local:8000
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: windmill-gate-supabase-jwt
+                                key: SUPABASE_JWT_SECRET
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: windmill-gate-supabase-jwt
+                                key: anon-key
+                      - name: RUST_LOG
+                        value: info
+                  resources:
+                      requests:
+                          memory: 64Mi
+                          cpu: 50m
+                      limits:
+                          memory: 128Mi
+                          cpu: 500m
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  livenessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 3
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: windmill-gate
+    namespace: windmill
+    labels:
+        app: windmill-gate
+spec:
+    type: ClusterIP
+    selector:
+        app: windmill-gate
+    ports:
+        - name: gateway
+          port: 5678
+          targetPort: 5678
+          protocol: TCP

--- a/apps/kube/windmill/manifest/windmill-httproute.yaml
+++ b/apps/kube/windmill/manifest/windmill-httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: windmill-route
+    namespace: windmill
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - windmill.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          timeouts:
+              backendRequest: 3600s
+          backendRefs:
+              - name: windmill-gate
+                port: 5678

--- a/packages/data/sql/dbmate/migration-tests/20260707000000_windmill_schema_init.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260707000000_windmill_schema_init.test.sql
@@ -1,0 +1,59 @@
+-- Companion test fixtures for 20260707000000_windmill_schema_init.
+-- Run via: ./test-migration.sh 20260707000000_windmill_schema_init
+
+-- SEED
+-- No fixtures needed; migration only creates schema, roles, and grants.
+SELECT 1;
+
+-- ASSERT_AFTER_UP
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata WHERE schema_name = 'windmill'
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill schema missing after up';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_user') THEN
+        RAISE EXCEPTION 'fail: windmill_user role missing after up';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_roles WHERE rolname = 'windmill_admin' AND rolbypassrls
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill_admin role missing or lacks BYPASSRLS';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_auth_members m
+        JOIN pg_roles r ON r.oid = m.roleid
+        JOIN pg_roles g ON g.oid = m.member
+        WHERE r.rolname = 'windmill_user' AND g.rolname = 'windmill_admin'
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill_admin not member of windmill_user';
+    END IF;
+
+    IF NOT has_schema_privilege('windmill_user', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: windmill_user lacks USAGE on windmill schema';
+    END IF;
+
+    IF has_schema_privilege('anon', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: anon must not have USAGE on windmill schema';
+    END IF;
+
+    IF has_schema_privilege('authenticated', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: authenticated must not have USAGE on windmill schema';
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.schemata WHERE schema_name = 'windmill'
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill schema still present after down';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260707000000_windmill_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260707000000_windmill_schema_init.sql
@@ -1,0 +1,99 @@
+-- migrate:up
+
+-- ============================================================
+-- WINDMILL SCHEMA INITIALIZATION
+--
+-- Creates a dedicated PostgreSQL schema for the Windmill
+-- workflow engine. Windmill connects to the shared supabase
+-- database with PG_SCHEMA=windmill (server + workers) and its
+-- sqlx migrations manage all tables within this schema.
+--
+-- We ONLY create the schema, the two Windmill roles, and grants
+-- here. Windmill owns its own table lifecycle.
+--
+-- Windmill requires the group roles windmill_user and
+-- windmill_admin (BYPASSRLS) to exist; it connects as postgres
+-- and uses SET ROLE for row-level security enforcement.
+-- ============================================================
+
+CREATE SCHEMA IF NOT EXISTS windmill;
+
+COMMENT ON SCHEMA windmill IS
+    'Windmill workflow engine schema. Tables managed by Windmill sqlx migrations, not dbmate.';
+
+-- ===========================================
+-- ROLES (idempotent; required by Windmill)
+-- ===========================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_user') THEN
+        CREATE ROLE windmill_user NOLOGIN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_admin') THEN
+        CREATE ROLE windmill_admin NOLOGIN BYPASSRLS;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT windmill_user TO windmill_admin;
+
+-- ===========================================
+-- GRANTS
+-- ===========================================
+
+GRANT ALL ON SCHEMA windmill TO postgres;
+GRANT ALL ON SCHEMA windmill TO windmill_user;
+GRANT ALL ON SCHEMA windmill TO windmill_admin;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    GRANT ALL ON TABLES TO windmill_user;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    GRANT ALL ON SEQUENCES TO windmill_user;
+
+-- ===========================================
+-- ISOLATION: Block anon/authenticated from windmill internals
+-- ===========================================
+
+REVOKE ALL ON SCHEMA windmill FROM PUBLIC;
+REVOKE ALL ON SCHEMA windmill FROM anon;
+REVOKE ALL ON SCHEMA windmill FROM authenticated;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata
+        WHERE schema_name = 'windmill'
+    ) THEN
+        RAISE EXCEPTION 'windmill schema creation failed';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_user') THEN
+        RAISE EXCEPTION 'windmill_user role creation failed';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_admin' AND rolbypassrls) THEN
+        RAISE EXCEPTION 'windmill_admin role must exist with BYPASSRLS';
+    END IF;
+
+    IF has_schema_privilege('anon', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'anon must NOT have USAGE on windmill schema';
+    END IF;
+
+    IF has_schema_privilege('authenticated', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have USAGE on windmill schema';
+    END IF;
+
+    RAISE NOTICE 'windmill_schema_init: schema, roles, and grants verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+DROP SCHEMA IF EXISTS windmill CASCADE;


### PR DESCRIPTION
## Summary
- New ArgoCD Application `apps/kube/windmill` (multi-source: windmill helm chart 4.0.200 / app 1.751.0 + git manifest dir), registered in the app-of-apps kustomization.
- Runs against the shared `supabase` database on `kilobase-rw` in a dedicated `windmill` schema — n8n-parity pattern. dbmate migration creates the schema, the required `windmill_user` / `windmill_admin` (BYPASSRLS) roles, grants, and anon/authenticated isolation, plus a companion harness test.
- `DATABASE_URL` is assembled by an ExternalSecret from the kilobase `supabase-postgres` password and carries `options=-csearch_path=windmill`. This is load-bearing: Windmill's sqlx migrations follow the connection search_path, not `PG_SCHEMA` — without it all ~145 tables land in `public`. `PG_SCHEMA=windmill` is additionally set on the app and both worker groups per upstream docs.
- kbve-gate (is_staff) fronts the UI as a standalone Deployment (chart owns the app Deployment, so no sidecar); HTTPRoute `windmill.kbve.com` rides the existing `*.kbve.com` wildcard listener → gate → `windmill-app:8000`.
- Minimal bring-up sizing: 1 app replica, 1 default worker, 1 native worker; bundled postgres/minio/ingress disabled.
- Windmill's job queue is postgres-based — no valkey/redis dependency (unlike n8n's bull queue). Valkey remains available as a workflow resource for integrations.

## Verification
- Helm render with these values: app + default/native worker Deployments all wired with `PG_SCHEMA` and the `windmill-database-url` secret.
- Migration applied + rolled back cleanly on the `ghcr.io/kbve/postgres:17.4.1.069-kilobase` prod-replica image via dbmate.
- Booted `ghcr.io/windmill-labs/windmill:1.751.0` against that database with the final URL shape: 145 tables created in the `windmill` schema, zero in `public`, `n8n` schema untouched, `/api/version` healthy.

Deploy order: dbmate migration first (ci-dbmate-deploy), then the ArgoCD app lands once this reaches `main`.

https://kbve.com/application/kubernetes/