### PR TITLE
fix(windmill): worker groups must set privileged false explicitly

### DIFF
--- a/apps/kube/windmill/application.yaml
+++ b/apps/kube/windmill/application.yaml
@@ -48,6 +48,7 @@ spec:
                           - name: default
                             controller: Deployment
                             replicas: 1
+                            privileged: false
                             terminationGracePeriodSeconds: 600
                             extraEnv:
                                 - name: PG_SCHEMA
@@ -62,6 +63,7 @@ spec:
                           - name: native
                             controller: Deployment
                             replicas: 1
+                            privileged: false
                             terminationGracePeriodSeconds: 600
                             extraEnv:
                                 - name: PG_SCHEMA


### PR DESCRIPTION
Worker ReplicaSets were stuck at 0 pods: the chart's worker-groups template renders `privileged: true` whenever the `privileged` key is **absent** from a custom `workerGroups` entry (`ternary $v.privileged true (hasKey $v "privileged")`), and PodSecurity `baseline:latest` rejects privileged pods:

```
Error creating: pods "windmill-workers-default-..." is forbidden: violates PodSecurity "baseline:latest": privileged (container "windmill-worker" must not set securityContext.privileged=true)
```

Sets `privileged: false` explicitly on both worker groups. Re-rendered chart 4.0.200 with these values: zero `privileged: true` occurrences.

The app pod's separate CrashLoop (`no schema has been selected to create in`) is the unapplied `20260707000000_windmill_schema_init` dbmate migration, not a manifest issue — resolves when ci-dbmate-deploy runs.

https://kbve.com/application/kubernetes/