### PR TITLE
chore(ci): bump uv pin 0.11.26 → 0.11.28

### DIFF
--- a/uv.toml
+++ b/uv.toml
@@ -1,1 +1,1 @@
-required-version = "==0.11.26"
+required-version = "==0.11.28"


### PR DESCRIPTION
0.11.28 is a security release: ZIP handling hardened against [parser differentials](https://www.brainonfire.net/blog/2022/04/11/what-is-parser-mismatch/) via astral-async-zip v0.0.20. 0.11.27 brings perf improvements (SIMD TOML parsing, reduced allocations).

Single-line change — root `uv.toml` `required-version` is the sole source of truth; all four setup-uv workflow call sites (utils-ci-lint-test, python-test-package, utils-python-publish, ci-actionlint) inherit it automatically. No other references to 0.11.26 in the repo.

Refs #13903