### PR TITLE
chore(deps): tikv-jemallocator 0.6 → 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16742,9 +16742,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -16752,9 +16752,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -41,7 +41,7 @@ jedi = { path = "../../../packages/rust/jedi", features = ["postgres", "valkey"]
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -37,7 +37,7 @@ kbve = { path = "../../../packages/rust/kbve", features = ["supabase", "image-ge
 jedi = { path = "../../../packages/rust/jedi", features = ["postgres"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -50,7 +50,7 @@ bevy_pathfinder = { path = "../../../packages/rust/bevy/bevy_pathfinder", defaul
 bevy_db = { path = "../../../packages/rust/bevy/bevy_db", default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/apps/herbmail/axum-herbmail/Cargo.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.toml
@@ -35,7 +35,7 @@ jedi = { path = "../../../packages/rust/jedi" }
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -35,7 +35,7 @@ kbve = { path = "../../../packages/rust/kbve" }
 bevy_chat = { path = "../../../packages/rust/bevy/bevy_chat" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -100,7 +100,7 @@ hmac = "0.12"
 sha2 = "0.10"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [build-dependencies]
 prost-build = "0.14"

--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -38,7 +38,7 @@ jedi = { path = "../../../packages/rust/jedi" }
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/apps/rareicon/axum-rareicon/Cargo.toml
+++ b/apps/rareicon/axum-rareicon/Cargo.toml
@@ -31,7 +31,7 @@ num_cpus = "1.17.0"
 dotenvy = "0.15"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tower = { version = "0.5.3", features = ["util"] }

--- a/apps/rows/Cargo.toml
+++ b/apps/rows/Cargo.toml
@@ -77,7 +77,7 @@ kbve = { path = "../../packages/rust/kbve" }
 tonic-prost-build = "0.14.5"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- `tikv-jemallocator` `0.6` → `0.7` in all 9 consumers (axum-kbve, axum-memes, axum-herbmail, axum-discordsh, discordsh-bot, axum-cryptothrone, axum-rareicon, irc-gateway, rows)
- Resolves `tikv-jemalloc-sys 0.7.1` → vendored jemalloc **5.3.1** (up from 5.3.0 line), MSRV 1.71

## Dockerfiles — checked, no changes needed
- App images build with `cargo build --features jemalloc`, which compiles jemalloc from the crate's vendored source; only build-time requirement is `make`, already installed in the builder stages.
- `chisel-ubuntu-axum` base's `LD_PRELOAD=libjemalloc.so.2` is the Ubuntu system package — independent of the crate version, untouched.

Follow-up to #13912 / #13914 (axum 0.8.9 + tower-http 0.7.0 wave).

## Testing
- `cargo check --features jemalloc` on axum-kbve, irc-gateway, rows — clean (jemalloc 5.3.1 source build succeeds)
- `cargo test -p axum-kbve -p irc-gateway -p rows` — 186 passed