### PR TITLE
fix(arc-runners): scope egress policies to runner pods only

### DIFF
--- a/apps/kube/github/runners/manifests/runner-apiserver-egress.yaml
+++ b/apps/kube/github/runners/manifests/runner-apiserver-egress.yaml
@@ -18,13 +18,22 @@
 # toEntities: kube-apiserver rule — identity-based, survives CP IP changes.
 # Same pattern as kasm/manifest/network-policy.yaml. Additive to the vanilla
 # arc-runner-egress policy; widens egress only to the apiserver on 443/6443.
+#
+# Scoped to ARC ephemeral runner pods only, matching arc-runner-egress. An
+# empty endpointSelector made this CNP select every pod in the shared
+# arc-runners namespace (MC stack included), and any Cilium egress rule on an
+# endpoint flips it to default-deny — silently dropping all non-apiserver MC
+# traffic.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
     name: arc-runner-apiserver-egress
     namespace: arc-runners
 spec:
-    endpointSelector: {}
+    endpointSelector:
+        matchExpressions:
+            - key: actions.github.com/scale-set-name
+              operator: Exists
     egress:
         - toEntities:
               - kube-apiserver

--- a/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
+++ b/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
@@ -10,13 +10,24 @@
 # Internal cluster services (PostgreSQL 5432, RCON 25575, etc.) are
 # unreachable because the public-internet rule excepts all private CIDRs
 # and no other rule selects them.
+#
+# Scoped to ARC ephemeral runner pods ONLY — actions.github.com/scale-set-name
+# is stamped on every gha-runner-scale-set runner pod. arc-runners is a shared
+# namespace: the MC stack (mc-velocity, mc-lobby, mc-fabric gameservers) lives
+# here too, and an empty podSelector put it under runner default-deny —
+# velocity could not reach its backends and the gameserver's IRC connect
+# blackholed on the Server thread, wedging SERVER_STARTED and the Agones
+# Ready call (4-minute recycle loop).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
     name: arc-runner-egress
     namespace: arc-runners
 spec:
-    podSelector: {}
+    podSelector:
+        matchExpressions:
+            - key: actions.github.com/scale-set-name
+              operator: Exists
     policyTypes:
         - Egress
     egress:

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/chat/McChatEvents.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/chat/McChatEvents.java
@@ -49,6 +49,9 @@ public final class McChatEvents {
     /** Opaque native handle. Zero means the bridge is disabled. */
     private static final AtomicLong HANDLE = new AtomicLong(0);
 
+    /** Set on SERVER_STOPPING so a late connect result is torn down, not leaked. */
+    private static volatile boolean closed = false;
+
     private McChatEvents() {}
 
     /**
@@ -56,10 +59,15 @@ public final class McChatEvents {
      * connection on server start. Call once from {@code onInitialize}.
      */
     public static void register() {
-        // Open the IRC connection when the server starts, not at class
-        // load time, so failures don't block mod boot and env vars are
-        // evaluated with the container's final environment.
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> openConnection());
+        // Connect on a background thread: the native connect blocks its
+        // caller, and hanging the Server thread inside SERVER_STARTED
+        // would stall the tick loop and every later lifecycle callback
+        // (Agones Ready, NPC AI runtime).
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            Thread t = new Thread(McChatEvents::openConnection, "kbve-irc-connect");
+            t.setDaemon(true);
+            t.start();
+        });
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> closeConnection());
 
         // Player death — emit on final death tick.
@@ -113,10 +121,19 @@ public final class McChatEvents {
             return;
         }
         HANDLE.set(handle);
+        if (closed) {
+            long h = HANDLE.getAndSet(0L);
+            if (h != 0L) {
+                ChatBridge.disconnect(h);
+            }
+            LOGGER.info("[chat] IRC connect completed after shutdown — discarded");
+            return;
+        }
         LOGGER.info("[chat] Connected to IRC {}:{} as {} ({})", host, port, nick, channels);
     }
 
     private static void closeConnection() {
+        closed = true;
         long h = HANDLE.getAndSet(0L);
         if (h != 0L) {
             ChatBridge.disconnect(h);

--- a/packages/rust/bevy/bevy_chat/src/client_native.rs
+++ b/packages/rust/bevy/bevy_chat/src/client_native.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::sync::{Mutex, broadcast, mpsc};
 
 use crate::config::{IrcConfig, IrcTransport};
 use crate::message::ChatMessage;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Async IRC client that connects to a server, joins channels, and
 /// sends/receives structured game messages.
@@ -65,8 +68,9 @@ impl ChatClient {
         let addr = format!("{}:{}", self.config.host, self.config.port);
         tracing::info!("IRC connecting to {} (tcp)", addr);
 
-        let stream = TcpStream::connect(&addr)
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(&addr))
             .await
+            .map_err(|_| format!("IRC connect timed out after {:?}: {}", CONNECT_TIMEOUT, addr))?
             .map_err(|e| format!("IRC connect failed: {}", e))?;
 
         let (reader, writer) = tokio::io::split(stream);
@@ -133,9 +137,11 @@ impl ChatClient {
         };
         tracing::info!("IRC connecting to {} (websocket)", url);
 
-        let (ws, _resp) = tokio_tungstenite::connect_async(&url)
-            .await
-            .map_err(|e| format!("IRC-WS connect failed: {}", e))?;
+        let (ws, _resp) =
+            tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url))
+                .await
+                .map_err(|_| format!("IRC-WS connect timed out after {:?}: {}", CONNECT_TIMEOUT, url))?
+                .map_err(|e| format!("IRC-WS connect failed: {}", e))?;
         let (mut sink, mut stream) = ws.split();
 
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();


### PR DESCRIPTION
## Problem

mc.kbve.com unjoinable — Velocity returns `Unable to connect you to mc` and the mc-fabric Agones gameserver recycles every ~4 minutes (fleet READY=0).

Root cause: `arc-runner-egress` (NetworkPolicy, 7ff79289b) and `arc-runner-apiserver-egress` (CiliumNetworkPolicy, #13297) both use empty selectors, so the runner default-deny egress applies to **every pod in the shared arc-runners namespace** — mc-velocity, mc-lobby, and mc-fabric gameservers included. All in-cluster MC egress is silently dropped (SYN blackhole):

- velocity → mc-fabric/mc-lobby backends: players can't be forwarded
- gameserver → ergo IRC: `ChatBridge.connect` (native, no timeout) hangs the Server thread inside the **first** SERVER_STARTED callback, so the tick loop never starts and the later callbacks (mc_auth Agones `Ready()` + health pings, NPC AI runtime) never run → Agones health recycles the pod forever
- mc_auth → Supabase kong, wallet → axum-kbve: silently degraded

Masked until the mc:1.0.61 rollout (2026-07-08 03:32Z) replaced long-lived pods that predated the policies. Verified via JVM thread dump (Server thread parked in `ChatBridge.connect`) and TCP probes from the gameserver pod.

## Fix

- Scope both policies to ARC ephemeral runner pods via `actions.github.com/scale-set-name` Exists match — runner lockdown intent unchanged, MC stack freed
- Defense in depth so egress loss can never wedge the server again:
  - bevy_chat: 10s connect timeout (TCP + WebSocket)
  - McChatEvents: IRC connect on a daemon thread instead of the Server thread; late connect after SERVER_STOPPING is torn down, not leaked

## Verification

- `cargo check` + `cargo clippy -D warnings` clean on bevy_chat
- behavior_statetree Java compiles in the mc image CI build
- Post-merge: Argo sync → new mc-fabric gameserver should reach Ready and hold; velocity join path restored

https://kbve.com/application/kubernetes/