### PR TITLE
fix(ci): retry pnpm install in docker-test-app to ride egress brownouts

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -234,7 +234,27 @@ jobs:
               timeout-minutes: 10
               env:
                   UV_THREADPOOL_SIZE: '16'
-              run: pnpm install --frozen-lockfile --prefer-offline
+              run: |
+                  set -uo pipefail
+                  # Belt-and-suspenders for the pnpm install: registry tarballs and
+                  # postinstall binary fetches (grpc-tools node-pre-gyp pulling from
+                  # node-precompiled-binaries.grpc.io) ride the shared arc-runner
+                  # egress, which browns out under DNS/timeout blips. --prefer-offline
+                  # reuses the warm store; retry rides transient egress before failing.
+                  attempt() {
+                    echo "::group::pnpm install ($1)"
+                    pnpm install --frozen-lockfile --prefer-offline
+                    local rc=$?
+                    echo "::endgroup::"
+                    return $rc
+                  }
+                  attempt "try 1" && exit 0
+                  echo "::warning::pnpm install try 1 failed; retrying"
+                  sleep 10
+                  attempt "try 2" && exit 0
+                  echo "::warning::pnpm install try 2 failed; retrying"
+                  sleep 20
+                  attempt "try 3"
 
             - name: Detect Playwright usage
               id: detect-playwright


### PR DESCRIPTION
## Problem

axum-kbve-e2e docker test failed at `pnpm install` ([run 28935574543](https://github.com/KBVE/kbve/actions/runs/28935574543/job/85845020805)):

```
node_modules/grpc-tools install: [error] ... getaddrinfo EAI_AGAIN node-precompiled-binaries.grpc.io
 ELIFECYCLE  Command failed with exit code 1.
```

Not a code bug. A transient egress brownout on the shared arc-runner: npmjs tarballs timed out (`ETIMEDOUT`, pnpm's own retries recovered) and `grpc-tools`' `node-pre-gyp` postinstall — which fetches its `protoc` binary from `node-precompiled-binaries.grpc.io` — hit a DNS failure (`EAI_AGAIN`) with **no retry**, making the single-shot install fatal.

## Why not just drop grpc-tools

`grpc-tools`' `protoc` binary is fetched *by* that postinstall (the npm tarball ships only the `.js` wrappers). It is used by the manual Unity C# proto codegen scripts (`packages/data/codegen/gen-*-data.mjs`), so removing it from `onlyBuiltDependencies` would silently break proto regen. Kept as-is.

## Fix

Wrap the install step in the same house retry-loop pattern the workflow already uses for the Playwright steps (3 attempts, `--prefer-offline` reuses the warm store on retry). Belt-and-suspenders: cache + prefer-offline is the belt, retry is the suspenders — rides transient egress blips before failing.

## Verification

- `pnpm install --frozen-lockfile --prefer-offline` succeeds locally (2.8s, warm store); edit does not touch the lockfile (`onlyBuiltDependencies` is not lockfile state).
- `actionlint` clean on the changed step; YAML parses.

https://kbve.com/application/kubernetes