### PR TITLE
feat(mc): broadcast NPC plans to modded clients

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/NpcPlanClient.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/NpcPlanClient.java
@@ -1,0 +1,110 @@
+package com.kbve.statetree.client;
+
+import com.kbve.statetree.command.NpcPlanPayload;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.entity.Entity;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.glfw.GLFW;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client half of the NPC plan channel: receives
+ * {@code behavior_statetree:npc_plan} payloads into {@link NpcPlanRegistry}
+ * and offers a keybind-toggled particle overlay showing where each AI mob
+ * intends to go.
+ *
+ * <p>Particles instead of world-space line rendering on purpose — the
+ * 1.21.9+ render pipeline rework made custom debug line drawing fragile
+ * across versions, while {@code world.addParticle} is stable and cheap.
+ */
+public final class NpcPlanClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    /** Overlay refresh cadence in client ticks (10 = twice a second). */
+    private static final int RENDER_INTERVAL = 10;
+
+    /** Ignore plans farther than this from the camera (squared blocks). */
+    private static final double MAX_RENDER_DIST_SQ = 64.0 * 64.0;
+
+    private static KeyBinding toggleKey;
+    private static boolean overlayEnabled = false;
+    private static int tickCounter = 0;
+
+    private NpcPlanClient() {}
+
+    public static void register() {
+        ClientPlayNetworking.registerGlobalReceiver(NpcPlanPayload.ID, (payload, context) ->
+                NpcPlanRegistry.put(payload.entityId(), payload.kind(),
+                        payload.x(), payload.y(), payload.z(), payload.targetEntityId()));
+
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) ->
+                NpcPlanRegistry.clear());
+
+        toggleKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.behavior_statetree.npcplans",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_B,
+                KeyBinding.Category.MISC));
+
+        ClientTickEvents.END_CLIENT_TICK.register(NpcPlanClient::onClientTick);
+
+        LOGGER.info("[NpcPlan Client] Registered — plan receiver + overlay keybind ready");
+    }
+
+    private static void onClientTick(MinecraftClient client) {
+        if (client.player == null || client.world == null) return;
+
+        while (toggleKey != null && toggleKey.wasPressed()) {
+            overlayEnabled = !overlayEnabled;
+            client.player.sendMessage(
+                    Text.of("NPC plan overlay " + (overlayEnabled ? "ON" : "OFF")), true);
+        }
+
+        tickCounter++;
+        if (tickCounter % RENDER_INTERVAL != 0) return;
+
+        NpcPlanRegistry.prune();
+        if (!overlayEnabled) return;
+
+        Vec3d camera = client.player.getEyePos();
+        for (var entry : NpcPlanRegistry.all().entrySet()) {
+            Entity mob = client.world.getEntityById(entry.getKey());
+            if (mob == null || !mob.isAlive()) continue;
+            if (mob.squaredDistanceTo(camera) > MAX_RENDER_DIST_SQ) continue;
+            drawPlan(client, mob, entry.getValue());
+        }
+    }
+
+    private static void drawPlan(MinecraftClient client, Entity mob,
+                                 NpcPlanRegistry.NpcPlan plan) {
+        Vec3d from = mob.getEyePos();
+        Vec3d to = plan.target().add(0, 0.25, 0);
+        boolean attack = "attack".equals(plan.kind());
+
+        Vec3d delta = to.subtract(from);
+        double length = delta.length();
+        int points = (int) Math.min(24, Math.max(2, length / 1.5));
+        for (int i = 0; i <= points; i++) {
+            Vec3d p = from.add(delta.multiply((double) i / points));
+            client.particleManager.addParticle(
+                    attack ? ParticleTypes.CRIT : ParticleTypes.END_ROD,
+                    p.x, p.y, p.z, 0, 0, 0);
+        }
+
+        for (int i = 0; i < 3; i++) {
+            client.particleManager.addParticle(
+                    attack ? ParticleTypes.CRIT : ParticleTypes.END_ROD,
+                    to.x, to.y + i * 0.5, to.z, 0, 0.02, 0);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/NpcPlanRegistry.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/NpcPlanRegistry.java
@@ -1,0 +1,60 @@
+package com.kbve.statetree.client;
+
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side store of the latest known plan per AI mob, fed by
+ * {@code behavior_statetree:npc_plan} payloads. Read-only anticipation
+ * data — where an NPC intends to go, never authoritative position.
+ *
+ * <p>Entries expire after {@link #TTL_MS} so a mob whose AI went quiet
+ * (or that despawned server-side) doesn't leave a stale marker around.
+ */
+public final class NpcPlanRegistry {
+
+    /** Plans older than this are dropped — AI replans well within 10s. */
+    private static final long TTL_MS = 10_000;
+
+    public record NpcPlan(String kind, Vec3d target, int targetEntityId, long receivedAtMs) {
+        public boolean expired(long nowMs) {
+            return nowMs - receivedAtMs > TTL_MS;
+        }
+    }
+
+    private static final Map<Integer, NpcPlan> PLANS = new ConcurrentHashMap<>();
+
+    private NpcPlanRegistry() {}
+
+    public static void put(int entityId, String kind, double x, double y, double z,
+                           int targetEntityId) {
+        PLANS.put(entityId, new NpcPlan(kind, new Vec3d(x, y, z), targetEntityId,
+                System.currentTimeMillis()));
+    }
+
+    public static NpcPlan get(int entityId) {
+        NpcPlan plan = PLANS.get(entityId);
+        if (plan == null) return null;
+        if (plan.expired(System.currentTimeMillis())) {
+            PLANS.remove(entityId);
+            return null;
+        }
+        return plan;
+    }
+
+    /** Live view for iteration; call {@link #prune()} periodically instead of filtering here. */
+    public static Map<Integer, NpcPlan> all() {
+        return PLANS;
+    }
+
+    public static void prune() {
+        long now = System.currentTimeMillis();
+        PLANS.values().removeIf(plan -> plan.expired(now));
+    }
+
+    public static void clear() {
+        PLANS.clear();
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -85,6 +85,8 @@ public class ShipClientMod implements ClientModInitializer {
                 GLFW.GLFW_KEY_K,
                 KeyBinding.Category.MISC));
 
+        NpcPlanClient.register();
+
         HudRenderCallback.EVENT.register(hud);
         ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/MobCommandApplier.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/MobCommandApplier.java
@@ -61,6 +61,7 @@ public final class MobCommandApplier {
 
     private void applyMoveTo(CommandContext ctx, AiCommand.MoveTo cmd) {
         ctx.mob().getNavigation().startMovingTo(cmd.x(), cmd.y(), cmd.z(), cmd.speed());
+        NpcPlanBroadcaster.broadcast(ctx.mob(), "move_to", cmd.x(), cmd.y(), cmd.z(), -1);
     }
 
     private void applyAttack(CommandContext ctx, AiCommand.Attack cmd) {
@@ -68,6 +69,8 @@ public final class MobCommandApplier {
         if (target != null && target.isAlive()) {
             ctx.mob().tryAttack(ctx.world(), target);
             ctx.mob().lookAtEntity(target, 30.0f, 30.0f);
+            NpcPlanBroadcaster.broadcast(ctx.mob(), "attack",
+                    target.getX(), target.getY(), target.getZ(), target.getId());
         }
     }
 
@@ -137,6 +140,8 @@ public final class MobCommandApplier {
         world.spawnParticles(ParticleTypes.PORTAL,
                 cmd.x(), cmd.y() + 1.0, cmd.z(),
                 32, 0.5, 1.0, 0.5, 0.1);
+
+        NpcPlanBroadcaster.broadcast(mob, "teleport", cmd.x(), cmd.y(), cmd.z(), -1);
     }
 
     private void applyShootArrow(CommandContext ctx, AiCommand.ShootArrow cmd) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/NpcPlanBroadcaster.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/NpcPlanBroadcaster.java
@@ -1,0 +1,27 @@
+package com.kbve.statetree.command;
+
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+/**
+ * Fans an {@link NpcPlanPayload} out to every modded client currently
+ * tracking the mob. Vanilla clients are skipped via
+ * {@link ServerPlayNetworking#canSend} so the packet never reaches a
+ * connection that can't decode it.
+ */
+public final class NpcPlanBroadcaster {
+
+    private NpcPlanBroadcaster() {}
+
+    public static void broadcast(MobEntity mob, String kind,
+                                 double x, double y, double z, int targetEntityId) {
+        NpcPlanPayload payload = new NpcPlanPayload(mob.getId(), kind, x, y, z, targetEntityId);
+        for (ServerPlayerEntity player : PlayerLookup.tracking(mob)) {
+            if (ServerPlayNetworking.canSend(player, NpcPlanPayload.ID)) {
+                ServerPlayNetworking.send(player, payload);
+            }
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/NpcPlanPayload.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/NpcPlanPayload.java
@@ -1,0 +1,45 @@
+package com.kbve.statetree.command;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+/**
+ * S2C broadcast of an applied NPC intent so modded clients can anticipate
+ * where an AI mob is headed (map markers, destination hints, debug overlay).
+ *
+ * <p>Sent from {@link MobCommandApplier} at the moment the server applies a
+ * plan-shaped command. The server stays fully authoritative — this is a
+ * read-only hint, never consumed back. Vanilla clients never receive it
+ * (guarded by {@code ServerPlayNetworking.canSend}).
+ *
+ * @param entityId       network entity id of the AI mob
+ * @param kind           plan kind: {@code move_to}, {@code teleport}, {@code attack}
+ * @param x              destination X (attack: target's position)
+ * @param y              destination Y
+ * @param z              destination Z
+ * @param targetEntityId network id of the target entity, or -1 when positional
+ */
+public record NpcPlanPayload(int entityId, String kind, double x, double y, double z,
+                             int targetEntityId) implements CustomPayload {
+
+    public static final Identifier PLAN_ID = Identifier.of("behavior_statetree", "npc_plan");
+    public static final CustomPayload.Id<NpcPlanPayload> ID = new CustomPayload.Id<>(PLAN_ID);
+
+    public static final PacketCodec<PacketByteBuf, NpcPlanPayload> CODEC =
+            PacketCodec.tuple(
+                    PacketCodecs.VAR_INT, NpcPlanPayload::entityId,
+                    PacketCodecs.STRING, NpcPlanPayload::kind,
+                    PacketCodecs.DOUBLE, NpcPlanPayload::x,
+                    PacketCodecs.DOUBLE, NpcPlanPayload::y,
+                    PacketCodecs.DOUBLE, NpcPlanPayload::z,
+                    PacketCodecs.VAR_INT, NpcPlanPayload::targetEntityId,
+                    NpcPlanPayload::new);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -74,6 +74,9 @@ public final class ShipNetworking {
     public static void registerPayloads() {
         PayloadTypeRegistry.playC2S().register(HelmInputPayload.ID, HelmInputPayload.CODEC);
         PayloadTypeRegistry.playC2S().register(WeaponFirePayload.ID, WeaponFirePayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(
+                com.kbve.statetree.command.NpcPlanPayload.ID,
+                com.kbve.statetree.command.NpcPlanPayload.CODEC);
         LOGGER.info("[Ship] Network payloads registered");
     }
 

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/lang/en_us.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/lang/en_us.json
@@ -1,5 +1,6 @@
 {
 	"item.behavior_statetree.airship": "KBVE Airship",
 	"item.behavior_statetree.biplane": "KBVE Biplane",
-	"item.behavior_statetree.gyrodyne": "KBVE Gyrodyne"
+	"item.behavior_statetree.gyrodyne": "KBVE Gyrodyne",
+	"key.behavior_statetree.npcplans": "Toggle NPC Plan Overlay"
 }


### PR DESCRIPTION
## What

Client-side anticipation channel for the Rust behavior-tree AI: when the server applies a plan-shaped intent (MoveTo / Teleport / Attack), it now broadcasts a small `behavior_statetree:npc_plan` payload to every **modded** client tracking that mob. Clients can deterministically know where an NPC intends to go without polling or guessing from position packets.

## Design

- **Server stays authoritative** — the payload is a read-only hint emitted at apply time in `MobCommandApplier`; nothing is consumed back from clients.
- **Vanilla-safe** — `ServerPlayNetworking.canSend` guard means unmodded clients never see the packet.
- **Payload** (6 fields, tuple codec): mob network id, kind, target x/y/z, target entity id (-1 when positional).
- **Client**: `NpcPlanRegistry` holds the latest plan per mob with a 10s TTL (AI replans well inside that); cleared on disconnect. Foundation for map markers / quest hints later.
- **Debug overlay**: keybind (default `B`) toggles a particle visualization — END_ROD trail from mob to destination, CRIT for attack targets, 64-block radius, refresh every 10 ticks. Particles instead of world-space line rendering because the 1.21.9+ render pipeline rework made custom debug line drawing fragile across versions.

## Verification

- `gradle compileJava` clean against yarn 1.21.11 mappings (via the `ghcr.io/kbve/mc:gradle` cached Loom image; caught and fixed two `addParticle` signature changes).
- Rides the next mc image publish — no manual version bump.