### PR TITLE
feat(kbve-gate): windmill session bridge — Supabase SSO for Windmill CE

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -12,7 +12,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.7"
+version: "0.1.8"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -25,6 +25,7 @@ deployment_yamls:
     - apps/kube/storage/manifests/longhorn-gate-deployment.yaml
     - apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml
     - apps/kube/studio/manifests/studio-gate-deployment.yaml
+    - apps/kube/windmill/manifest/windmill-gate-deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
+++ b/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
@@ -67,6 +67,17 @@ spec:
                             secretKeyRef:
                                 name: windmill-gate-supabase-jwt
                                 key: anon-key
+                      # Windmill session bridge: enabled by token presence. Until
+                      # seal-superadmin-token.sh writes the SealedSecret the ref is
+                      # absent (optional) and the gate proxies without the bridge.
+                      - name: WINDMILL_SUPERADMIN_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: windmill-superadmin-token
+                                key: token
+                                optional: true
+                      - name: GATE_WINDMILL_WORKSPACE
+                        value: kbve
                       - name: RUST_LOG
                         value: info
                   resources:

--- a/apps/kube/windmill/seal-superadmin-token.sh
+++ b/apps/kube/windmill/seal-superadmin-token.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# seal-superadmin-token.sh — Seal the Windmill superadmin API token for the gate bridge
+#
+# The kbve-gate Windmill bridge (GATE_WINDMILL_BRIDGE) provisions users and
+# mints per-user impersonation tokens with a superadmin API token. Mint one in
+# the Windmill UI as a superadmin (User settings -> Tokens, no expiration),
+# then run this script and paste it when prompted.
+#
+# The plaintext token exists only in memory between pipe stages.
+# It never touches disk, shell history, or git.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#   - kubeseal installed (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#
+# Usage:
+#   ./seal-superadmin-token.sh
+#   # Output: apps/kube/windmill/manifest/windmill-superadmin-sealedsecret.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_FILE="${SCRIPT_DIR}/manifest/windmill-superadmin-sealedsecret.yaml"
+
+for cmd in kubectl kubeseal; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is not installed or not in PATH" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl cluster-info &>/dev/null; then
+    echo "Error: Cannot connect to Kubernetes cluster" >&2
+    exit 1
+fi
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system namespace" >&2
+    exit 1
+fi
+
+read -r -s -p "Windmill superadmin token: " TOKEN
+echo
+
+if [ -z "$TOKEN" ]; then
+    echo "Error: empty token" >&2
+    exit 1
+fi
+
+printf '%s' "$TOKEN" \
+| kubectl create secret generic windmill-superadmin-token \
+    --namespace=windmill \
+    --from-file=token=/dev/stdin \
+    --dry-run=client \
+    -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${OUTPUT_FILE}"
+
+echo "Sealed secret written to: ${OUTPUT_FILE}"
+echo "Plaintext token was never written to disk."

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -9,10 +9,14 @@
 mod auth;
 #[cfg(feature = "gate")]
 mod proxy;
+#[cfg(feature = "gate")]
+mod windmill;
 
 pub use auth::{AuthError, Authz, Claims, StaffGate, extract_token, validate_token};
 #[cfg(feature = "gate")]
 pub use proxy::{GateConfig, GateState};
+#[cfg(feature = "gate")]
+pub use windmill::WindmillBridge;
 
 #[cfg(feature = "gate")]
 use std::net::SocketAddr;
@@ -40,6 +44,12 @@ use std::net::SocketAddr;
 /// - `SUPABASE_ANON_KEY`    optional PostgREST apikey when authz=is_staff
 ///   (falls back to the minted service_role bearer)
 /// - `SUPABASE_JWT_ISSUER`  optional; pins the accepted token issuer when set
+/// - `WINDMILL_SUPERADMIN_TOKEN` when set, enables the Windmill session
+///   bridge: the gate provisions a Windmill user for the authed email and
+///   injects a per-user impersonation token upstream (Windmill CE has no
+///   custom SSO)
+/// - `GATE_WINDMILL_WORKSPACE` workspace new users are auto-added to
+/// - `GATE_WINDMILL_TOKEN_TTL_SECS` impersonation token TTL (default 43200)
 #[cfg(feature = "gate")]
 pub fn config_from_env() -> Result<GateConfig, String> {
     let upstream =
@@ -119,6 +129,20 @@ pub fn config_from_env() -> Result<GateConfig, String> {
             jedi::jwks::JwtVerifier::new(jwks_uri, Some(jwt_secret.as_bytes()), issuer, None)
         });
 
+    let windmill = std::env::var("WINDMILL_SUPERADMIN_TOKEN")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(|admin_token| {
+            let workspace = std::env::var("GATE_WINDMILL_WORKSPACE")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ttl = std::env::var("GATE_WINDMILL_TOKEN_TTL_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(43200);
+            WindmillBridge::new(&upstream, admin_token, workspace, ttl)
+        });
+
     Ok(GateConfig {
         upstream,
         upstream_prefix,
@@ -133,6 +157,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         forward_user_header,
         forward_user_value,
         verifier,
+        windmill,
     })
 }
 

--- a/packages/rust/kbve/src/gate/proxy.rs
+++ b/packages/rust/kbve/src/gate/proxy.rs
@@ -62,6 +62,10 @@ pub struct GateConfig {
     /// from GoTrue's JWKS (the HS256->ES256 transition). When `None` the gate
     /// falls back to HS256-only via `validate_token`.
     pub verifier: Option<jedi::jwks::JwtVerifier>,
+    /// Windmill session bridge: provisions a Windmill user for the authed email
+    /// and injects a per-user impersonation token upstream. Requires the JWT to
+    /// carry an email claim.
+    pub windmill: Option<super::windmill::WindmillBridge>,
 }
 
 pub struct GateState {
@@ -329,7 +333,7 @@ async fn authorize(
     query: Option<&str>,
     ext_url: &str,
     bounced: bool,
-) -> Result<(i64, String), Response> {
+) -> Result<(i64, String, Option<String>), Response> {
     let token = extract_token(
         headers
             .get(header::AUTHORIZATION)
@@ -372,6 +376,7 @@ async fn authorize(
         }
     };
     let exp = claims.exp;
+    let email = claims.email.clone();
     let user = claims
         .kbve_username
         .clone()
@@ -380,7 +385,7 @@ async fn authorize(
     let sub = claims.sub;
 
     match &state.cfg.authz {
-        Authz::JwtOnly => Ok((exp, user)),
+        Authz::JwtOnly => Ok((exp, user, email)),
         Authz::IsStaff => {
             let staff = match &state.cfg.staff {
                 Some(s) => s,
@@ -394,7 +399,7 @@ async fn authorize(
                 }
             };
             match staff.is_staff(&sub).await {
-                Ok(true) => Ok((exp, user)),
+                Ok(true) => Ok((exp, user, email)),
                 Ok(false) => Err(deny(
                     state,
                     headers,
@@ -422,10 +427,11 @@ async fn gate_handler(State(state): State<Arc<GateState>>, req: Request<Body>) -
     let ext_url = external_url(&headers, req.uri());
     let bounced = query.as_deref().and_then(access_token_in_query).is_some();
 
-    let (exp, user) = match authorize(&state, &headers, query.as_deref(), &ext_url, bounced).await {
-        Ok(ok) => ok,
-        Err(resp) => return resp,
-    };
+    let (exp, user, email) =
+        match authorize(&state, &headers, query.as_deref(), &ext_url, bounced).await {
+            Ok(ok) => ok,
+            Err(resp) => return resp,
+        };
     metrics::counter!("gate_auth_total", "result" => "allow").increment(1);
 
     // Token arrived in the URL (post-login bounce): convert it to a session
@@ -437,11 +443,44 @@ async fn gate_handler(State(state): State<Arc<GateState>>, req: Request<Body>) -
         }
     }
 
+    // Windmill bridge: swap the gate identity for a per-user upstream token so
+    // Windmill sees the request as that user (its CE build has no custom SSO).
+    let upstream_token = match &state.cfg.windmill {
+        Some(bridge) => {
+            let email = match email {
+                Some(e) => e,
+                None => {
+                    return deny(
+                        &state,
+                        &headers,
+                        StatusCode::FORBIDDEN,
+                        "email claim required for windmill bridge",
+                        &ext_url,
+                        bounced,
+                    );
+                }
+            };
+            match bridge.ensure_token(&state.client, &email).await {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    warn!(%email, "windmill bridge failed: {e}");
+                    metrics::counter!("gate_auth_total", "result" => "error_backend").increment(1);
+                    return (
+                        StatusCode::BAD_GATEWAY,
+                        axum::Json(serde_json::json!({ "error": "windmill bridge failed" })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        None => None,
+    };
+
     if is_websocket_upgrade(&headers) {
-        return ws_bridge(&state, req, &user).await;
+        return ws_bridge(&state, req, &user, upstream_token).await;
     }
 
-    forward_http(&state, req, &user).await
+    forward_http(&state, req, &user, upstream_token).await
 }
 
 const HOP_BY_HOP: &[&str] = &[
@@ -507,13 +546,23 @@ fn upstream_uri(upstream: &str, prefix: &str, uri: &Uri) -> String {
 /// Inject the gate's upstream credentials: an optional Basic/Bearer
 /// `Authorization` and an optional trusted user header. `insert` overwrites any
 /// client-supplied value, so the user header cannot be spoofed.
-fn inject_upstream_auth(state: &GateState, headers: &mut HeaderMap, user: &str) {
+fn inject_upstream_auth(
+    state: &GateState,
+    headers: &mut HeaderMap,
+    user: &str,
+    bearer_override: Option<&str>,
+) {
     if let Some(basic) = &state.cfg.upstream_basic {
         if let Ok(v) = HeaderValue::from_str(basic) {
             headers.insert(header::AUTHORIZATION, v);
         }
     }
     if let Some(bearer) = &state.cfg.upstream_bearer {
+        if let Ok(v) = HeaderValue::from_str(&format!("Bearer {bearer}")) {
+            headers.insert(header::AUTHORIZATION, v);
+        }
+    }
+    if let Some(bearer) = bearer_override {
         if let Ok(v) = HeaderValue::from_str(&format!("Bearer {bearer}")) {
             headers.insert(header::AUTHORIZATION, v);
         }
@@ -529,7 +578,12 @@ fn inject_upstream_auth(state: &GateState, headers: &mut HeaderMap, user: &str) 
     }
 }
 
-async fn forward_http(state: &GateState, req: Request<Body>, user: &str) -> Response {
+async fn forward_http(
+    state: &GateState,
+    req: Request<Body>,
+    user: &str,
+    upstream_token: Option<String>,
+) -> Response {
     let method = req.method().clone();
     let url = upstream_uri(&state.cfg.upstream, &state.cfg.upstream_prefix, req.uri());
     let mut headers = req.headers().clone();
@@ -542,7 +596,7 @@ async fn forward_http(state: &GateState, req: Request<Body>, user: &str) -> Resp
         headers.remove(*h);
     }
 
-    inject_upstream_auth(state, &mut headers, user);
+    inject_upstream_auth(state, &mut headers, user, upstream_token.as_deref());
 
     let body = reqwest::Body::wrap_stream(req.into_body().into_data_stream());
 
@@ -630,18 +684,27 @@ fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
 
 /// Bridge a browser WebSocket to the upstream. reqwest is HTTP-only, so the
 /// upgrade leg uses tokio-tungstenite directly.
-async fn ws_bridge(state: &GateState, req: Request<Body>, user: &str) -> Response {
+async fn ws_bridge(
+    state: &GateState,
+    req: Request<Body>,
+    user: &str,
+    upstream_token: Option<String>,
+) -> Response {
     let mut ws_url = upstream_uri(&state.cfg.upstream, &state.cfg.upstream_prefix, req.uri());
     if let Some(rest) = ws_url.strip_prefix("http://") {
         ws_url = format!("ws://{rest}");
     } else if let Some(rest) = ws_url.strip_prefix("https://") {
         ws_url = format!("wss://{rest}");
     }
-    let auth = state
-        .cfg
-        .upstream_bearer
-        .as_ref()
-        .map(|b| format!("Bearer {b}"))
+    let auth = upstream_token
+        .map(|t| format!("Bearer {t}"))
+        .or_else(|| {
+            state
+                .cfg
+                .upstream_bearer
+                .as_ref()
+                .map(|b| format!("Bearer {b}"))
+        })
         .or_else(|| state.cfg.upstream_basic.clone());
     let user_header = state.cfg.forward_user_header.clone().map(|h| {
         let v = state

--- a/packages/rust/kbve/src/gate/windmill.rs
+++ b/packages/rust/kbve/src/gate/windmill.rs
@@ -1,0 +1,181 @@
+//! Windmill session bridge — turns a gate-authenticated Supabase identity into
+//! a Windmill session without Windmill EE SSO. The gate ensures an instance
+//! user + workspace membership exist for the staff member's email, mints a
+//! short-lived impersonation token with a superadmin API token, and injects it
+//! as the upstream `Authorization: Bearer` so Windmill sees every request as
+//! that user. The token never reaches the browser.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use reqwest::Client;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+pub struct WindmillBridge {
+    base: String,
+    admin_token: String,
+    workspace: Option<String>,
+    ttl_secs: i64,
+    cache: Mutex<HashMap<String, CachedToken>>,
+}
+
+struct CachedToken {
+    token: String,
+    exp: i64,
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn rfc3339_in(secs: i64) -> String {
+    (chrono::Utc::now() + chrono::Duration::seconds(secs.max(0)))
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+impl WindmillBridge {
+    pub fn new(base: &str, admin_token: String, workspace: Option<String>, ttl_secs: i64) -> Self {
+        Self {
+            base: base.trim_end_matches('/').to_string(),
+            admin_token,
+            workspace,
+            ttl_secs,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return a Windmill token for `email`, minting (and provisioning the user
+    /// on first sight) when the cached one is missing or near expiry.
+    pub async fn ensure_token(&self, client: &Client, email: &str) -> Result<String, String> {
+        let now = unix_now();
+        {
+            let cache = self.cache.lock().await;
+            if let Some(entry) = cache.get(email) {
+                if entry.exp - 60 > now {
+                    return Ok(entry.token.clone());
+                }
+            }
+        }
+
+        if !self.user_exists(client, email).await? {
+            self.create_user(client, email).await?;
+            if let Some(ws) = &self.workspace {
+                self.add_to_workspace(client, email, ws).await;
+            }
+        }
+
+        let token = self.impersonate(client, email).await?;
+        let exp = now + self.ttl_secs;
+        self.cache.lock().await.insert(
+            email.to_string(),
+            CachedToken {
+                token: token.clone(),
+                exp,
+            },
+        );
+        Ok(token)
+    }
+
+    async fn user_exists(&self, client: &Client, email: &str) -> Result<bool, String> {
+        let url = format!("{}/api/users/exists/{}", self.base, email);
+        let resp = client
+            .get(&url)
+            .bearer_auth(&self.admin_token)
+            .send()
+            .await
+            .map_err(|e| format!("windmill user_exists: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("windmill user_exists HTTP {}", resp.status()));
+        }
+        resp.json::<bool>()
+            .await
+            .map_err(|e| format!("windmill user_exists body: {e}"))
+    }
+
+    async fn create_user(&self, client: &Client, email: &str) -> Result<(), String> {
+        // Random throwaway password: the account only ever logs in through the
+        // gate's impersonation tokens.
+        let password = format!("{}{}", ulid::Ulid::new(), ulid::Ulid::new());
+        let url = format!("{}/api/users/create", self.base);
+        let resp = client
+            .post(&url)
+            .bearer_auth(&self.admin_token)
+            .json(&serde_json::json!({
+                "email": email,
+                "password": password,
+                "super_admin": false,
+                "name": email,
+                "skip_email": true,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("windmill create_user: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("windmill create_user HTTP {status}: {body}"));
+        }
+        info!(%email, "windmill bridge: instance user created");
+        Ok(())
+    }
+
+    async fn add_to_workspace(&self, client: &Client, email: &str, workspace: &str) {
+        let url = format!("{}/api/w/{}/workspaces/add_user", self.base, workspace);
+        let result = client
+            .post(&url)
+            .bearer_auth(&self.admin_token)
+            .json(&serde_json::json!({
+                "email": email,
+                "is_admin": false,
+                "operator": false,
+            }))
+            .send()
+            .await;
+        match result {
+            Ok(resp) if resp.status().is_success() => {
+                info!(%email, %workspace, "windmill bridge: user added to workspace");
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                warn!(%email, %workspace, %status, %body, "windmill bridge: workspace add failed");
+            }
+            Err(e) => {
+                warn!(%email, %workspace, "windmill bridge: workspace add error: {e}");
+            }
+        }
+    }
+
+    async fn impersonate(&self, client: &Client, email: &str) -> Result<String, String> {
+        let url = format!("{}/api/users/tokens/impersonate", self.base);
+        let resp = client
+            .post(&url)
+            .bearer_auth(&self.admin_token)
+            .json(&serde_json::json!({
+                "impersonate_email": email,
+                "label": "kbve-gate",
+                "expiration": rfc3339_in(self.ttl_secs),
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("windmill impersonate: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("windmill impersonate HTTP {status}: {body}"));
+        }
+        let token = resp
+            .text()
+            .await
+            .map_err(|e| format!("windmill impersonate body: {e}"))?;
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return Err("windmill impersonate returned empty token".to_string());
+        }
+        Ok(token)
+    }
+}


### PR DESCRIPTION
## Summary
Windmill CE has no custom SSO slot (`Add custom SSO client` is EE-gated in AuthSettings.svelte), so this makes kbve-gate the SSO layer for windmill.kbve.com:

- New `WindmillBridge` in `kbve::gate`: when `WINDMILL_SUPERADMIN_TOKEN` is set, a gate-authenticated Supabase identity (staff-gated as before) is provisioned as a Windmill instance user on first sight (`/api/users/exists` → `/api/users/create` with a throwaway password), auto-added to `GATE_WINDMILL_WORKSPACE` (`/api/w/{ws}/workspaces/add_user`), and a short-lived impersonation token (`/api/users/tokens/impersonate`, default 12h) is injected as the upstream `Authorization: Bearer` on every proxied request — HTTP and WebSocket. Tokens are cached per email and never reach the browser. Works for any staff email domain; no auto-invite-by-domain dependency.
- Bridge enables purely by token presence, so rollout is crash-free: the deployment references the `windmill-superadmin-token` SealedSecret as `optional`, and until `seal-superadmin-token.sh` writes it the gate proxies exactly as today.
- `authorize()` now also returns the JWT email claim; bridge requests without an email claim get 403.
- kbve-gate mdx 0.1.7 → 0.1.8 (CI owns version.toml/Cargo/deployment tags).

## Verification
Local e2e against real Windmill 1.751.0 (kilobase prod-replica postgres, `PG_SCHEMA` + `search_path` wiring from #13919): gate binary with the bridge + a locally-minted HS256 Supabase JWT → `/api/users/whoami` through the gate returned the auto-provisioned user (`username: staffer`), `/api/w/kbve/users/whoami` confirmed workspace membership, repeat requests served from the token cache (single "instance user created" log line). `nx kbve-gate:build` / `lint` / `test` green.

## Post-merge steps
1. Wait for kbve-gate 0.1.8 publish + post-publish sync PR (updates deployment image tags).
2. In Windmill UI as superadmin: create an API token (no expiration), then run `apps/kube/windmill/seal-superadmin-token.sh` and commit the SealedSecret.
3. Reloader restarts the gate; staff then land in Windmill signed in via their Supabase identity.

https://kbve.com/application/kubernetes/