### PR TITLE
feat(mc): Towns and Towers + stranded 1.0.63 version bump

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.226",
+			"version": "1.0.228",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -83,7 +83,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",
@@ -414,7 +414,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.62",
+			"version": "1.0.63",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.62"
+version: "1.0.63"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest

--- a/apps/mc/Dockerfile.mods
+++ b/apps/mc/Dockerfile.mods
@@ -174,6 +174,15 @@ declare -A MODS=(
   # Repurposed Structures 7.6.2 — adds biome-themed variants of vanilla
   # structures (villages, temples, strongholds, etc). Server-only.
   ["repurposed_structures-7.6.2+1.21.11-fabric.jar"]="dc88e4bea42a5e007eb5c2d0107271a43f1db363 https://cdn.modrinth.com/data/muf0XoRe/versions/LgshXq1u/repurposed_structures-7.6.2%2B1.21.11-fabric.jar"
+  # Cloth Config — config library required by Cristel Lib.
+  ["cloth-config-21.11.153-fabric.jar"]="4c224606a963bce223db5b27edb4959ecf40d4ee https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+  # Cristel Lib — structure/config library required by Towns and Towers.
+  ["cristellib-fabric-1.21.11-3.1.7.jar"]="2a37db56e908edda5436a18e28552c43512a84ab https://cdn.modrinth.com/data/cl223EMc/versions/1NM741mO/cristellib-fabric-1.21.11-3.1.7.jar"
+  # Towns and Towers 1.13.9 — overhauls villages and pillager outposts
+  # with 20+ themed town/tower variants. Server-required, client-optional
+  # (vanilla blocks). Only generates in NEW chunks — existing terrain
+  # untouched until the next map rotation regenerates outer regions.
+  ["t_and_t-fabric-neoforge-1.13.9.jar"]="8e3bfd88661311dcdde93b5bcb03ce919ad4ef1c https://cdn.modrinth.com/data/DjLobEOy/versions/qb0cwwDT/t_and_t-fabric-neoforge-1.13.9.jar"
   # ChoiceTheorem's Overhauled Village 3.6.2a — replaces vanilla village
   # generation with larger, more detailed layouts. Server-only.
   ["[fabric]ctov-1.21.11-3.6.2a.jar"]="6aad41978d561c9e766ae38013b916164473a60a https://cdn.modrinth.com/data/fgmhI8kH/versions/K2dNRnIZ/%5Bfabric%5Dctov-1.21.11-3.6.2a.jar"


### PR DESCRIPTION
## Heads-up: rescues a stranded commit

#13956 merged into `feat/mc-native-observability` — but #13955 (that branch's PR) had already squash-merged to dev moments earlier, so #13956's second commit (the MDX version bump) never reached dev. The ship retirement itself DID land (the #13955 squash picked it up — dev has zero ship files). This PR cherry-picks the stranded bump.

## Changes

- **mc 1.0.62 → 1.0.63** (mc.mdx version lever + `nx astro-kbve:gen:ci-manifest` regen, which also syncs drifted axum-kbve/arpg entries). Publishing 1.0.63 ships: egress-hang hardening, native observability, mod bumps, Immersive Aircraft, npc_plan channel, ship system retirement.
- **Towns and Towers 1.13.9** + deps (Cristel Lib 3.1.7, Cloth Config 21.11.153) added to the server modlist. Server-required / client-optional per Modrinth — no client pack change needed. Structures generate in new chunks only; existing terrain picks them up at the next map rotation.

All three sha1 pins verified against actual CDN downloads.