### PR TITLE
fix(mc): resolve 1.0.63 mod-graph conflicts

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.226",
+			"version": "1.0.228",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -83,7 +83,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",
@@ -414,7 +414,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.62",
+			"version": "1.0.63",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.62"
+version: "1.0.63"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest

--- a/apps/mc/Dockerfile.mods
+++ b/apps/mc/Dockerfile.mods
@@ -30,7 +30,7 @@ set -euo pipefail
 mkdir -p /mods
 
 declare -A MODS=(
-  ["fabric-api-0.141.3+1.21.11.jar"]="50de67eb221f0b38216da8668b09ca311327040e https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
+  ["fabric-api-0.141.4+1.21.11.jar"]="13d3885dfec40313e2b3bf9ee639353272b9b48a https://cdn.modrinth.com/data/P7dR8mSH/versions/5zJNhXV2/fabric-api-0.141.4%2B1.21.11.jar"
   # fabric-language-kotlin: required by Ledger (Kotlin mod) and others.
   ["fabric-language-kotlin-1.13.10+kotlin.2.3.20.jar"]="9873294abf498f509453d37b0a5ba019f4570ffb https://cdn.modrinth.com/data/Ha28R6CL/versions/21TRTKmh/fabric-language-kotlin-1.13.10%2Bkotlin.2.3.20.jar"
   # ViaFabric — Fabric loader shim for ViaVersion + ViaBackwards. The
@@ -205,11 +205,11 @@ declare -A MODS=(
   # Macaw's Paintings 1.1.0 — adds 40+ new painting variants in
   # multiple sizes. Client + server.
   ["mcw-paintings-1.1.0-mc1.21.11fabric.jar"]="580ba60f2811796b7906ebc7edea053849a0d1fd https://cdn.modrinth.com/data/okE6QVAY/versions/VPvufXfe/mcw-paintings-1.1.0-mc1.21.11fabric.jar"
-  # Xaero's Minimap 26.1.4 — client HUD minimap. Server install enables
+  # Xaero's Minimap 26.2.0 — client HUD minimap. Server install enables
   # server-side sync support (bundles XaeroLib via jar-in-jar); without
   # it clients log "Server side doesn't have XaeroLib installed" and
   # reset their map sync state on every join.
-  ["xaerominimap-fabric-1.21.11-26.1.4.jar"]="e6e88fa30efbf2c86b54becd7f96f84e01440a42 https://cdn.modrinth.com/data/1bokaNcj/versions/rLF2AwoN/xaerominimap-fabric-1.21.11-26.1.4.jar"
+  ["xaerominimap-fabric-1.21.11-26.2.0.jar"]="7a3d174fd12c0406db8a8106b3d76c655e86b207 https://cdn.modrinth.com/data/1bokaNcj/versions/z6442Xnl/xaerominimap-fabric-1.21.11-26.2.0.jar"
   # Xaero's World Map 1.42.0 — full-screen world map, pairs with the
   # minimap. Server install provides the world identity + sync endpoint
   # so client map data stays keyed to this server across restarts.
@@ -219,11 +219,11 @@ declare -A MODS=(
   # Complements the KBVE ship system; only dep is Fabric API.
   ["immersive_aircraft-1.4.7+1.21.11-fabric.jar"]="a3c652a1cbf6bcb8f2216de83f8fe9cc20f470f7 https://cdn.modrinth.com/data/x3HZvrj6/versions/NshGBorp/immersive_aircraft-1.4.7%2B1.21.11-fabric.jar"
   # ── Land claims + parties ──────────────────────────────────────────
-  # Open Parties and Claims 0.26.2 — chunk-based claim system with
+  # Open Parties and Claims 0.27.5 — chunk-based claim system with
   # built-in party (guild) support and an admin claim type used to
   # lock the spawn city. Configured in-game via /opac admin-mode +
   # /opac claim on first deploy.
-  ["open-parties-and-claims-fabric-1.21.11-0.26.2.jar"]="af76f66591622b945ef37fbf20bee7ae36d82329 https://cdn.modrinth.com/data/gF3BGWvG/versions/JkiXvTq4/open-parties-and-claims-fabric-1.21.11-0.26.2.jar"
+  ["open-parties-and-claims-fabric-1.21.11-0.27.5.jar"]="52156f795ce0751dfc89553f3e928bd4e635a4a0 https://cdn.modrinth.com/data/gF3BGWvG/versions/DEb4IjSQ/open-parties-and-claims-fabric-1.21.11-0.27.5.jar"
 )
 
 for name in "${!MODS[@]}"; do

--- a/apps/mc/Dockerfile.mods
+++ b/apps/mc/Dockerfile.mods
@@ -174,6 +174,15 @@ declare -A MODS=(
   # Repurposed Structures 7.6.2 — adds biome-themed variants of vanilla
   # structures (villages, temples, strongholds, etc). Server-only.
   ["repurposed_structures-7.6.2+1.21.11-fabric.jar"]="dc88e4bea42a5e007eb5c2d0107271a43f1db363 https://cdn.modrinth.com/data/muf0XoRe/versions/LgshXq1u/repurposed_structures-7.6.2%2B1.21.11-fabric.jar"
+  # Cloth Config — config library required by Cristel Lib.
+  ["cloth-config-21.11.153-fabric.jar"]="4c224606a963bce223db5b27edb4959ecf40d4ee https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+  # Cristel Lib — structure/config library required by Towns and Towers.
+  ["cristellib-fabric-1.21.11-3.1.7.jar"]="2a37db56e908edda5436a18e28552c43512a84ab https://cdn.modrinth.com/data/cl223EMc/versions/1NM741mO/cristellib-fabric-1.21.11-3.1.7.jar"
+  # Towns and Towers 1.13.9 — overhauls villages and pillager outposts
+  # with 20+ themed town/tower variants. Server-required, client-optional
+  # (vanilla blocks). Only generates in NEW chunks — existing terrain
+  # untouched until the next map rotation regenerates outer regions.
+  ["t_and_t-fabric-neoforge-1.13.9.jar"]="8e3bfd88661311dcdde93b5bcb03ce919ad4ef1c https://cdn.modrinth.com/data/DjLobEOy/versions/qb0cwwDT/t_and_t-fabric-neoforge-1.13.9.jar"
   # ChoiceTheorem's Overhauled Village 3.6.2a — replaces vanilla village
   # generation with larger, more detailed layouts. Server-only.
   ["[fabric]ctov-1.21.11-3.6.2a.jar"]="6aad41978d561c9e766ae38013b916164473a60a https://cdn.modrinth.com/data/fgmhI8kH/versions/K2dNRnIZ/%5Bfabric%5Dctov-1.21.11-3.6.2a.jar"

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -62,15 +62,15 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
   },
   "files": [
     {
-      "path": "mods/fabric-api-0.141.3+1.21.11.jar",
+      "path": "mods/fabric-api-0.141.4+1.21.11.jar",
       "hashes": {
-        "sha1": "50de67eb221f0b38216da8668b09ca311327040e",
-        "sha512": "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471"
+        "sha1": "13d3885dfec40313e2b3bf9ee639353272b9b48a",
+        "sha512": "c092d48c6453bec3264f80f6a35bb334aba3112b5cd6c0e0b2676ce4d81e702cb1e522337f3a732348e757cc2226da3c601a314ae8766334f16af71a13bcc98d"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/5zJNhXV2/fabric-api-0.141.4%2B1.21.11.jar"
       ],
-      "fileSize": 2412693,
+      "fileSize": 2413332,
       "env": { "client": "required", "server": "unsupported" }
     },
     {
@@ -398,15 +398,15 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       "env": { "client": "required", "server": "unsupported" }
     },
     {
-      "path": "mods/open-parties-and-claims-fabric-1.21.11-0.26.2.jar",
+      "path": "mods/open-parties-and-claims-fabric-1.21.11-0.27.5.jar",
       "hashes": {
-        "sha1": "af76f66591622b945ef37fbf20bee7ae36d82329",
-        "sha512": "56552c8d772ff5a01baeb897b646bd3c3ec715e46d16457aed8d1208e5662abe831eeae1b45fa0837f93a9775b28c3af14fad9d5acf3da474a1e9bd975bde1a2"
+        "sha1": "52156f795ce0751dfc89553f3e928bd4e635a4a0",
+        "sha512": "758f15e4a4f538dfe0a8b33f2e06352f0511b80e5da08d2cddd65f0ae1bf1e943897daac3c80c2c1014bc3e9ac5d461971c13dc74b5fd6c750ce9f630146693d"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gF3BGWvG/versions/JkiXvTq4/open-parties-and-claims-fabric-1.21.11-0.26.2.jar"
+        "https://cdn.modrinth.com/data/gF3BGWvG/versions/DEb4IjSQ/open-parties-and-claims-fabric-1.21.11-0.27.5.jar"
       ],
-      "fileSize": 1649817,
+      "fileSize": 1733277,
       "env": { "client": "required", "server": "required" }
     },
     {
@@ -434,15 +434,15 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       "env": { "client": "required", "server": "required" }
     },
     {
-      "path": "mods/xaerominimap-fabric-1.21.11-26.1.4.jar",
+      "path": "mods/xaerominimap-fabric-1.21.11-26.2.0.jar",
       "hashes": {
-        "sha1": "e6e88fa30efbf2c86b54becd7f96f84e01440a42",
-        "sha512": "d782ed65dadcd1e7b99a4779cac303e377cda2f0287e1054c0bcafd6bf2765fc15638736c737448bff913ebb4819e78ea88df05e78fcf529922fc776bcb665f6"
+        "sha1": "7a3d174fd12c0406db8a8106b3d76c655e86b207",
+        "sha512": "6b9e28081f300ede43c8cb3cbd410277a704ecdeb7a2b77fa7f1a746dbc4a09652a1a91a328e4e1d523a9edc94ae9817f29c9e0f0fefe6f78d2d8dd23ce8e3d7"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/1bokaNcj/versions/rLF2AwoN/xaerominimap-fabric-1.21.11-26.1.4.jar"
+        "https://cdn.modrinth.com/data/1bokaNcj/versions/z6442Xnl/xaerominimap-fabric-1.21.11-26.2.0.jar"
       ],
-      "fileSize": 2152173,
+      "fileSize": 2190380,
       "env": { "client": "required", "server": "optional" }
     }
   ]


### PR DESCRIPTION
Fixes #13961 — the 1.0.63 publish fails at `Nx e2e mc`: Fabric loader refuses the mod set.

- **Cristel Lib 3.1.7** (Towns and Towers dep, added in #13958) requires `fabric-api >=0.141.4` → bump 0.141.3 → **0.141.4**
- **Xaero minimap / worldmap** (server-side install from #13955) declare `breaks` on OPAC <0.27.0 → bump Open Parties and Claims 0.26.2 → **0.27.5** (SpawnAutoClaim's OPAC integration is reflection-based — no compile coupling)
- **worldmap 1.42.0** requires minimap >=26.2.0 → bump 26.1.4 → **26.2.0**

Same pins mirrored in the client mrpack; all sha1s verified against CDN downloads. ViaFabric lines in the loader dump are unsatisfiable-set noise, unchanged from 1.0.62.

No version bump needed — 1.0.63 publish already pending; the retried dispatch picks these up.