### PR TITLE
ci(mc): bundle mac/win/linux natives into Modrinth mod jar

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -46,8 +46,90 @@ on:
                 required: false
 
 jobs:
+    # Cross-platform Rust natives for the behavior_statetree client mod.
+    # The Docker image build only produces a Linux .so (server-side); the
+    # Modrinth-published JAR is what clients download, so it must bundle
+    # natives for every desktop platform. Gradle's processResources picks
+    # them up from <source_path>/target/release/ (../../target/release
+    # relative to java/). macOS ships a universal binary (arm64 + x86_64)
+    # because NativeRuntime resolves one dylib per OS, not per arch.
+    natives:
+        name: Native (${{ matrix.platform }})
+        if: |
+            fromJson(inputs.external_publish).modrinth_mod_id != '' ||
+            fromJson(inputs.external_publish).modrinth_pack_id != ''
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - platform: linux
+                      os: ubuntu-latest
+                    - platform: macos
+                      os: macos-latest
+                    - platform: windows
+                      os: windows-latest
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 45
+        permissions:
+            contents: read
+        defaults:
+            run:
+                shell: bash
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  targets: ${{ matrix.platform == 'macos' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+            # aws-lc-rs (rustls default crypto provider, via bevy_chat's
+            # tokio-tungstenite) assembles with NASM on Windows MSVC.
+            - name: Setup NASM (Windows)
+              if: matrix.platform == 'windows'
+              uses: ilammy/setup-nasm@v1
+
+            - name: Rust cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  workspaces: '.'
+                  key: mc-natives-${{ matrix.platform }}
+                  cache-on-failure: true
+
+            - name: Build native (linux/windows)
+              if: matrix.platform != 'macos'
+              run: cargo build -p behavior_statetree --release
+
+            # Repo .cargo/config.toml pins target-dir to dist/target, so
+            # all cargo outputs below live under dist/target/, not target/.
+            - name: Build native (macOS universal)
+              if: matrix.platform == 'macos'
+              run: |
+                  set -euo pipefail
+                  cargo build -p behavior_statetree --release --target aarch64-apple-darwin
+                  cargo build -p behavior_statetree --release --target x86_64-apple-darwin
+                  mkdir -p dist/target/release
+                  lipo -create \
+                    dist/target/aarch64-apple-darwin/release/libbehavior_statetree.dylib \
+                    dist/target/x86_64-apple-darwin/release/libbehavior_statetree.dylib \
+                    -output dist/target/release/libbehavior_statetree.dylib
+                  lipo -info dist/target/release/libbehavior_statetree.dylib
+
+            - name: Upload native artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: native-${{ matrix.platform }}
+                  path: |
+                      dist/target/release/libbehavior_statetree.so
+                      dist/target/release/libbehavior_statetree.dylib
+                      dist/target/release/behavior_statetree.dll
+                  if-no-files-found: error
+                  retention-days: 3
+
     modrinth:
         name: Modrinth (${{ inputs.app_name }} v${{ inputs.version }})
+        needs: natives
         if: |
             fromJson(inputs.external_publish).modrinth_mod_id != '' ||
             fromJson(inputs.external_publish).modrinth_pack_id != ''
@@ -105,6 +187,26 @@ jobs:
                     echo "Pinning $VTOML: $CURRENT → $VERSION (post_publish bump not yet applied)"
                     sed -i "s/^version = .*/version = \"${VERSION}\"/" "$VTOML"
                   fi
+
+            # Land all three platform natives where gradle's processResources
+            # expects them (from("../../target/release") relative to java/),
+            # so the published JAR carries /natives/ for linux, macOS and
+            # Windows clients — not just the server-side Linux .so.
+            - name: Download platform natives
+              uses: actions/download-artifact@v8
+              with:
+                  pattern: native-*
+                  merge-multiple: true
+                  path: ${{ inputs.source_path }}/target/release
+
+            - name: Verify natives present
+              run: |
+                  set -euo pipefail
+                  cd "${{ inputs.source_path }}/target/release"
+                  for f in libbehavior_statetree.so libbehavior_statetree.dylib behavior_statetree.dll; do
+                    [ -f "$f" ] || { echo "::error::missing native $f"; exit 1; }
+                  done
+                  ls -la
 
             - name: Build Fabric mod JAR
               run: |


### PR DESCRIPTION
## Problem

Client log on macOS:

```
[behavior_statetree] Native library not available: Native library not found in JAR: /natives/libbehavior_statetree.dylib
```

The Modrinth publish job (`utils-external-publish.yml`) builds the Fabric jar with plain `gradle build` and no Rust step — `target/release` never exists, so the client-facing jar ships with **no natives at all** (the Linux `.so` only lands in the server Docker image via `Dockerfile`). The Java loader (`NativeRuntime`) and gradle `processResources` already handle `.so`/`.dylib`/`.dll`; only the build pipeline was missing.

## Fix

New `natives` matrix job (ubuntu / macos / windows) ahead of the `modrinth` job:

- `cargo build -p behavior_statetree --release` per platform (repo `.cargo/config.toml` pins `target-dir=dist/target`, paths account for that)
- macOS builds aarch64 + x86_64 and merges with `lipo` into one universal dylib, since `NativeRuntime` resolves one dylib per OS
- Windows installs NASM for aws-lc-rs (rustls default provider via bevy_chat tokio-tungstenite)
- artifacts download into `<source_path>/target/release` where gradle `processResources` already includes them at `/natives/`, with a hard verify step before the jar build
- mrpack bundles the same jar from `build/libs` in `overrides/mods`, so the client modpack inherits the natives automatically

## Verification

- local macOS: `cargo build -p behavior_statetree --release` → arm64 dylib; gradle build with it staged → `unzip -l` shows `natives/libbehavior_statetree.dylib` (2.9 MB) in jar
- `cargo check -p behavior_statetree` clean; workflow YAML parses

Unlocks the client-side determinism lane — bundled natives on mac/win flip the load-failure log back to a real ERROR per the bundled-aware gating.

Fixes the "No native bundled for this platform" client gap.