### PR TITLE
feat(mc): stop tamed pets colliding with Immersive Aircraft

### DIFF
--- a/apps/mc/behavior_statetree/java/build.gradle
+++ b/apps/mc/behavior_statetree/java/build.gradle
@@ -16,6 +16,17 @@ base.archivesName = 'behavior_statetree'
 
 repositories {
     mavenCentral()
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'Modrinth'
+                url = 'https://api.modrinth.com/maven'
+            }
+        }
+        filter {
+            includeGroup 'maven.modrinth'
+        }
+    }
 }
 
 dependencies {
@@ -27,6 +38,12 @@ dependencies {
     // mXparser — math expression evaluator for BBModel animation variables
     // (Blockbench keyframes use string expressions like "variable.speed * 0.5")
     include implementation("org.mariuszgromada.math:MathParser.org-mXparser:6.1.0")
+
+    // Immersive Aircraft — compile-only for the pet/vehicle collision
+    // mixin. Runtime presence stays optional: the mixin lies dormant when
+    // the mod is absent because its target class never loads. Version
+    // must track the pin in apps/mc/Dockerfile.mods.
+    modCompileOnly "maven.modrinth:immersive-aircraft:1.4.7+1.21.11"
 }
 
 // Inject version into fabric.mod.json + copy Rust native libraries

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/VehicleEntityPetMixin.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/VehicleEntityPetMixin.java
@@ -1,0 +1,41 @@
+package com.kbve.statetree.mixin;
+
+import immersive_aircraft.entity.VehicleEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.TameableEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Removes hard collision between Immersive Aircraft vehicles and tamed
+ * pets (wolves, parrots, cats) in both directions.
+ *
+ * <p>IA's {@code VehicleEntity.canCollide} treats any pushable entity as
+ * a collision box, so a pet standing near a taxiing aircraft jams its
+ * movement; the hull's {@code isCollidable} in turn blocks the pet and
+ * lets parrots perch and jitter on it. Cancelling both checks for tamed
+ * pets lets aircraft and pets pass through each other cleanly.
+ *
+ * <p>Compile-time dependency on IA is {@code modCompileOnly}; at runtime
+ * the mixin stays dormant when IA is absent because the target class
+ * never loads.
+ */
+@Mixin(value = VehicleEntity.class, remap = false)
+public abstract class VehicleEntityPetMixin {
+
+    @Inject(method = "collidesWith", at = @At("HEAD"), cancellable = true, remap = true)
+    private void kbve$aircraftIgnoresPets(Entity other, CallbackInfoReturnable<Boolean> cir) {
+        if (other instanceof TameableEntity pet && pet.isTamed()) {
+            cir.setReturnValue(false);
+        }
+    }
+
+    @Inject(method = "isCollidable", at = @At("HEAD"), cancellable = true, remap = true)
+    private void kbve$petsIgnoreAircraft(Entity other, CallbackInfoReturnable<Boolean> cir) {
+        if (other instanceof TameableEntity pet && pet.isTamed()) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
@@ -3,12 +3,8 @@
 	"minVersion": "0.8",
 	"package": "com.kbve.statetree.mixin",
 	"compatibilityLevel": "JAVA_21",
-	"mixins": [
-		"BowAttackGoalMixin"
-	],
-	"client": [
-		"client.InventoryScreenMixin"
-	],
+	"mixins": ["BowAttackGoalMixin", "VehicleEntityPetMixin"],
+	"client": ["client.InventoryScreenMixin"],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
## Problem

Tamed pets (parrot, wolf, cat) cause collision issues with Immersive Aircraft vehicles:

- IA `VehicleEntity.canCollide` counts any **pushable** entity as a hard collision box → pet standing near a taxiing/taking-off aircraft jams its movement
- the hull is `isCollidable` → pets get blocked by parked aircraft, climb/perch on it and jitter

Verified against the shipped IA 1.4.7+1.21.11 bytecode: only `VehicleEntity` overrides `collidesWith` (method_30949) and `isCollidable(Entity)` (method_30948) — subclasses inherit, so a vanilla `Entity` mixin would be bypassed and one mixin target covers every aircraft.

## Fix

`VehicleEntityPetMixin` — HEAD-cancels both methods, returning `false` when the other entity is a tamed `TameableEntity`. Aircraft and pets pass through each other in both directions; everything else keeps IA behavior.

- `modCompileOnly maven.modrinth:immersive-aircraft:1.4.7+1.21.11` (exclusiveContent Modrinth maven repo), version pinned to match `Dockerfile.mods`
- runtime-optional: when IA is absent the target class never loads and the mixin stays dormant — standalone `behavior_statetree` installs unaffected

## Verification

- gradle build clean in Loom image
- built jar bytecode inspected: `@Inject` targets remapped to `method_30949`/`method_30948`, matching `javap` of IA's compiled `VehicleEntity` exactly (modern Loom annotation remap, no refmap)
- no `fabric.mod.json` dependency changes — mod graph untouched; e2e boot validates mixin apply