### PR TITLE
chore(kbve-gate): sync windmill gate to v0.1.8 + regenerate ci-dispatch-manifest

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.228",
+			"version": "1.0.229",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -83,7 +83,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.25",
+			"version": "0.1.26",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.25",
+			"version": "0.1.26",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",
@@ -356,7 +356,7 @@
 		{
 			"key": "kbve_gate",
 			"app_name": "kbve-gate",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"version_toml": "apps/kbve/kbve-gate/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
 			"version_target": "apps/kbve/kbve-gate/Cargo.toml",
@@ -369,7 +369,8 @@
 				"apps/kube/argocd/manifests/argocd-gate-deployment.yaml",
 				"apps/kube/storage/manifests/longhorn-gate-deployment.yaml",
 				"apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml",
-				"apps/kube/studio/manifests/studio-gate-deployment.yaml"
+				"apps/kube/studio/manifests/studio-gate-deployment.yaml",
+				"apps/kube/windmill/manifest/windmill-gate-deployment.yaml"
 			],
 			"has_test": false
 		},
@@ -414,7 +415,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.63",
+			"version": "1.0.64",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
+++ b/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
@@ -31,7 +31,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: kbve-gate
-                  image: ghcr.io/kbve/kbve-gate:0.1.7
+                  image: ghcr.io/kbve/kbve-gate:0.1.8
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: gateway


### PR DESCRIPTION
Post-publish sync #13959 updated the six pre-existing gate deployments but skipped windmill: `ci-docker.yml` reads `deployment_yamls` from `.github/ci-dispatch-manifest.json`, and the manifest was never regenerated after the kbve-gate MDX gained the windmill entry (#13957 changed only the MDX).

- Full manifest regeneration via `astro-kbve:build` + `astro-kbve:sync:ci-manifest` — adds the windmill deployment to kbve-gate's `deployment_yamls` and picks up accumulated MDX version drift (api 1.0.229, arpg-server/web 0.1.26, kbve-gate 0.1.8, mc 1.0.64).
- Bumps `windmill-gate-deployment.yaml` to `kbve-gate:0.1.8` — the edit #13959 would have made had the manifest been current. Future publishes handle it automatically.

https://kbve.com/application/kubernetes/