### PR TITLE
feat(windmill): seal superadmin token — activate kbve-gate session bridge

### DIFF
--- a/apps/kube/windmill/manifest/windmill-superadmin-sealedsecret.yaml
+++ b/apps/kube/windmill/manifest/windmill-superadmin-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: windmill-superadmin-token
+    namespace: windmill
+spec:
+    encryptedData:
+        token: AgCgEWP2zM3vLovaNxjRq1/IKO0AcDSNGtlv0m2DZZoGw7zGUEF8wJkTSWxtTqPy8ZjX16KnEQuInUTdTCdtqmoUGR5PBoEv3pQ92WKOP/+ExYmjEOAN4sMxpV7Qz8xE1tatiX6cMnrlmSRgddJG1GR0HkB6vS5otGCK6ZVjmnJGloq97lU//mnMH5Mn6c7Yc69DwFZ//rx2hGCwSBa1g123Sl9Q3LVhr6sKQIUcbEZCwibhPGV/dw2vaTsPPie6RDMZ+1wJilY0EGPoq2oF2SijEluPr2ilSgGI+jsgOEtjEhO57ncE3prExB8FVsQaVoikKek3Jvx3eKVIW5M6vIp9XDAulfi35GPTg/2/ehidErS63tBrjl5kwX452UM1MWYa7nbQfFPKCyQhVCqSUpu/BSRxp6RqDaYos90ObeX0uLCL2JUgF5h8EyPRfrhonAxqX3VAOhI/KGP13oVnAj2hIYbPg3pgI4QlgdkUcPJepLcySKojFjS0OCkd+SkvSM8fm1cIZwQmF51S1dKyU3hLthUWYvjeWZcCf/2dEOqa4atYPwsoJTFBAYEFrUePN6ATc8TEPkI6yQhG8v5HjmLtLBnwslrquRN4SHNGEfCDW48GNY4L+deew/2BQlICWmjcJOr2saJ8ZXEkgtrI0tCVnxJ5Q7/16aTBoNd1UAfvOeQnoC2CH2dh3By8cH8R+HgnmOOU5Sz0Rd5wlthLGXEVtp3XQc2TKGwD9cxle/M1bg==
+    template:
+        metadata:
+            name: windmill-superadmin-token
+            namespace: windmill


### PR DESCRIPTION
Adds the `windmill/windmill-superadmin-token` SealedSecret. The kbve-gate deployment already references it as an optional `WINDMILL_SUPERADMIN_TOKEN` secretKeyRef, so once this syncs the session bridge switches on: staff authenticated through the gate are auto-provisioned as Windmill users (+ `kbve` workspace membership) and land signed in via a per-user impersonation token — no Windmill login screen.

Sealed against the cluster's sealed-secrets-controller; plaintext never touched disk. No kustomization in the manifest dir (ArgoCD directory-recurse), so the file is picked up automatically. Reloader restarts the gate when the unsealed Secret lands.

https://kbve.com/application/kubernetes/