### PR TITLE
ci: retry transient egress failures in container:ci builds

### DIFF
--- a/apps/discordsh/discordsh-bot/project.json
+++ b/apps/discordsh/discordsh-bot/project.json
@@ -25,7 +25,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/discordsh-bot:latest --file apps/discordsh/discordsh-bot/Dockerfile .",
+						"bash scripts/ci/retry-transient.sh 'BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/discordsh-bot:latest --file apps/discordsh/discordsh-bot/Dockerfile .'",
 						"VERSION=$(grep '^version' apps/discordsh/discordsh-bot/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh-bot:latest kbve/discordsh-bot:$VERSION && echo \"Tagged kbve/discordsh-bot:$VERSION\""
 					]
 				}

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -99,7 +99,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
+						"bash scripts/ci/retry-transient.sh 'BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .'",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}

--- a/apps/kbve/edge/project.json
+++ b/apps/kbve/edge/project.json
@@ -25,7 +25,7 @@
 				},
 				"ci": {
 					"commands": [
-						"./kbve.sh -nx edge:containerx --configuration=ci"
+						"bash scripts/ci/retry-transient.sh './kbve.sh -nx edge:containerx --configuration=ci'"
 					]
 				}
 			}

--- a/scripts/ci/retry-transient.sh
+++ b/scripts/ci/retry-transient.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+RETRY_MAX="${RETRY_MAX:-10}"
+RETRY_DELAY="${RETRY_DELAY:-30}"
+
+TRANSIENT_PATTERN='server misbehaving|dial tcp|lookup .* on .*:53|no such host|failed to do request|failed to resolve source metadata|failed to fetch|TLS handshake|handshake timeout|i/o timeout|connection reset|connection refused|unexpected EOF|net/http: request canceled|429 Too Many Requests|error pulling image|pull access denied.*(temporary|timeout)|context deadline exceeded|blob upload unknown|received unexpected HTTP status: 5'
+
+cmd="$*"
+if [ -z "$cmd" ]; then
+  echo "::error::retry-transient.sh: no command given" >&2
+  exit 2
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+attempt=1
+while true; do
+  bash -c "$cmd" 2>&1 | tee "$tmp"
+  ec="${PIPESTATUS[0]}"
+  if [ "$ec" -eq 0 ]; then
+    exit 0
+  fi
+
+  if ! grep -qiE "$TRANSIENT_PATTERN" "$tmp"; then
+    echo "::error::non-transient failure (exit $ec); not retrying" >&2
+    exit "$ec"
+  fi
+
+  if [ "$attempt" -ge "$RETRY_MAX" ]; then
+    echo "::error::still failing after $attempt transient attempts (exit $ec)" >&2
+    exit "$ec"
+  fi
+
+  echo "::warning::transient failure (attempt $attempt/$RETRY_MAX, exit $ec); retrying in ${RETRY_DELAY}s" >&2
+  attempt=$((attempt + 1))
+  sleep "$RETRY_DELAY"
+done


### PR DESCRIPTION
## Problem

CI - Docker / axum-kbve e2e failed (#13987) not on a code bug but a transient network flake. The `docker buildx build` `FROM` metadata pull against ghcr.io hit cluster-DNS trouble:

```
#3 ERROR: failed to do request: Head "https://ghcr.io/v2/kbve/chisel-ubuntu-axum/manifests/24.04.3": dial tcp: lookup ghcr.io on 10.96.0.10:53: server misbehaving
```

The whole build canceled → exit 130 → `axum-kbve:container:ci` failed → e2e failed. Same egress-flake class the repo already guards for pnpm/uv installs, but the container build step had no retry.

## Change

**New** `scripts/ci/retry-transient.sh` — belt-and-suspenders wrapper around any build command:
- Streams output live (`tee`), captures for inspection.
- Retries **only** on transient egress signatures (DNS `server misbehaving`/`dial tcp`/`no such host`, `failed to resolve source metadata`, TLS handshake, i/o timeout, connection reset/refused, 5xx / `429`, `context deadline exceeded`).
- **Non-transient** failures (real compile/build errors) fail fast — no wasted retries.
- Tunable: `RETRY_MAX` (default 10), `RETRY_DELAY` (default 30s) → ~5 min cap before giving up and throwing the error.

**Wired** into the three `container:ci` targets that pull from the registry:
- `apps/kbve/axum-kbve` (raw buildx; `${VALKEY_PASSWORD:+…}` conditional secret preserved)
- `apps/discordsh/discordsh-bot` (raw buildx)
- `apps/kbve/edge` (wraps the `kbve.sh -nx edge:containerx` call)

Only the build command is wrapped; the follow-up `docker tag` (no network) stays bare.

## Verification

- Helper unit-smoked: non-transient → fail fast; transient → retry to max → give up; transient → recover → exit 0.
- End-to-end quoting simulated with a `docker` stub: `--secret` flag appears only when `VALKEY_PASSWORD` is set, omitted otherwise; `BUILDKIT_PROGRESS=plain` applied.
- All three `project.json` files validate as JSON.

Closes #13987