### PR TITLE
fix(herbmail-game): add eslint config so lint target passes

### DIFF
--- a/apps/herbmail/herbmail-game/.eslintrc.json
+++ b/apps/herbmail/herbmail-game/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+	"extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
+	"ignorePatterns": [
+		"!**/*",
+		"**/vite.config.*.timestamp*",
+		"**/vitest.config.*.timestamp*"
+	],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {
+				"react-hooks/immutability": "off"
+			}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}


### PR DESCRIPTION
## Problem

`Validate Dev→Main PR` lint step failed (#13988) on `herbmail-game:lint`:

```
NX   All files matching the following patterns are ignored:
- 'apps/herbmail/herbmail-game'
Please check your '.eslintignore' file.
```

The root `.eslintrc.json` sets `"ignorePatterns": ["**/*"]` — every file is ignored by default, and each project is expected to ship its own `.eslintrc.json` that un-ignores itself (`!**/*`). `herbmail-game` (new PSX game, added in b5ee5e5a7) had only a `project.json` with a bare `@nx/eslint:lint` target and **no eslint config**, so eslint matched zero files and exited non-zero.

## Fix

Add `apps/herbmail/herbmail-game/.eslintrc.json`, matching sibling vite+react apps (`apps/kbve/isometric`, `desktop-kbve`):
- Extends `plugin:@nx/react` + the repo base config.
- `"ignorePatterns": ["!**/*", …]` un-ignores the project.
- Disables `react-hooks/immutability`: the game imperatively mutates the three.js `camera` and scene objects inside `useEffect`/`useFrame` (`camera.position.set`, `camera.lookAt`, `getWorldDirection`) — the standard react-three-fiber pattern, not a React state-mutation bug. Per-line disable comments were avoided in favor of project-level config.

## Verification

Linted the clean `origin/dev` state with the new config:

```
Linting "herbmail-game"...
✔ All files pass linting
 NX   Successfully ran target lint for project herbmail-game
```

Closes #13988