### PR TITLE
fix(mc): allow Immersive Aircraft mount/dismount inside OPAC claims

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -183,3 +183,10 @@ COPY apps/mc/mods/ /mods/
 
 # Server config overrides
 COPY apps/mc/config/ /config/
+
+# OPAC claim-access seed — wraps itzg's /start so Immersive Aircraft can be
+# mounted/dismounted inside land claims (see script header). exec /start keeps
+# itzg as PID1 for graceful RCON shutdown; the base image's CMD is inherited.
+COPY apps/mc/scripts/opac-airship-claim-access.sh /usr/local/bin/opac-airship-claim-access.sh
+RUN chmod +x /usr/local/bin/opac-airship-claim-access.sh
+ENTRYPOINT ["/usr/local/bin/opac-airship-claim-access.sh"]

--- a/apps/mc/e2e/helpers/docker.ts
+++ b/apps/mc/e2e/helpers/docker.ts
@@ -8,3 +8,10 @@ export function dockerLogs(container = CONTAINER): string {
 		maxBuffer: 32 * 1024 * 1024,
 	});
 }
+
+export function dockerExec(cmd: string, container = CONTAINER): string {
+	return execSync(`docker exec ${container} sh -c ${JSON.stringify(cmd)}`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}

--- a/apps/mc/e2e/opac-airship-claim.spec.ts
+++ b/apps/mc/e2e/opac-airship-claim.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { waitForRcon } from './helpers/rcon';
+import { dockerExec } from './helpers/docker';
+
+describe('OPAC airship claim access', () => {
+	let authoritativeConfig = '';
+
+	beforeAll(async () => {
+		await waitForRcon();
+		const files = dockerExec(
+			"grep -rl hostileChunkProtectedEntityList /data --include=openpartiesandclaims-server.toml 2>/dev/null || true",
+		)
+			.split('\n')
+			.map((l) => l.trim())
+			.filter(Boolean);
+		authoritativeConfig = files
+			.map((f) => dockerExec(`cat ${JSON.stringify(f)}`))
+			.join('\n');
+	});
+
+	it('OPAC generated its authoritative serverconfig', () => {
+		expect(authoritativeConfig).toMatch(/friendlyChunkProtectedEntityList/);
+	});
+
+	it('immersive_aircraft is granted mount access inside claims', () => {
+		expect(authoritativeConfig).toMatch(/immersive_aircraft/);
+	});
+});

--- a/apps/mc/scripts/opac-airship-claim-access.sh
+++ b/apps/mc/scripts/opac-airship-claim-access.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper entrypoint: lets players mount/dismount Immersive Aircraft inside
+# Open Parties and Claims (OPAC) land claims, then hands off to itzg's /start.
+#
+# WHY: OPAC treats mounting an entity as an "interaction" and blocks it for
+# non-owners inside a claim. Vanilla boats are exempt because OPAC ships them
+# in friendlyChunkProtectedEntityList (default type ALL_BUT = "protect all
+# entities EXCEPT those listed"). IA aircraft aren't in that list, so an
+# airship parked on a claim can't be re-mounted — the reported reclaim bug.
+# Fix: add immersive_aircraft:* to the same list, mirroring the boat exemption.
+#
+# WHERE: OPAC writes this per-world at <level>/serverconfig/, but the exact
+# path varies by loader/version (sometimes /data/config). We discover the file
+# wherever OPAC generated it rather than hardcode a path. On an existing world
+# the file is already present, so the entry lands on the next restart. On a
+# brand-new world the file doesn't exist yet — we seed a minimal stub OPAC
+# merges its defaults into; if the guessed path is wrong it self-heals on the
+# second boot once discovery finds OPAC's real file. Edits happen here, before
+# /start, so OPAC never re-reads a stale value mid-session.
+
+ENTRY='immersive_aircraft:*'
+KEY='friendlyChunkProtectedEntityList'
+
+ensure_entry() {
+	local f="$1"
+	if grep -q 'immersive_aircraft' "$f" 2>/dev/null; then
+		echo "[opac-airship] $f already grants IA claim access — skipping"
+		return
+	fi
+	if ! grep -qE "^[[:space:]]*${KEY}[[:space:]]*=" "$f" 2>/dev/null; then
+		echo "[opac-airship] $f has no ${KEY} key yet — OPAC will regenerate it, retry next boot"
+		return
+	fi
+	sed -i -E "s/(^[[:space:]]*${KEY}[[:space:]]*=[[:space:]]*\[)/\1\"${ENTRY}\", /" "$f"
+	echo "[opac-airship] added ${ENTRY} to ${KEY} in $f"
+}
+
+found=0
+while IFS= read -r f; do
+	found=1
+	ensure_entry "$f"
+done < <(find /data -name 'openpartiesandclaims-server.toml' 2>/dev/null)
+
+if [ "$found" -eq 0 ]; then
+	stub="/data/${LEVEL:-world}/serverconfig/openpartiesandclaims-server.toml"
+	echo "[opac-airship] no OPAC serverconfig found — seeding stub at $stub"
+	mkdir -p "$(dirname "$stub")"
+	cat > "$stub" <<EOF
+[serverConfig]
+
+	[serverConfig.claims]
+
+		[serverConfig.claims.protection]
+			${KEY}Type = "ALL_BUT"
+			${KEY} = ["minecraft:boat", "${ENTRY}"]
+EOF
+fi
+
+exec /start "$@"


### PR DESCRIPTION
## Problem
Reported bug: an airship (Immersive Aircraft mod) that dismounts onto a land claim is hard to re-mount. IA aircraft should mount/dismount freely inside claims.

## Root cause
Claims are enforced by **Open Parties and Claims (OPAC) 0.27.5** (third-party jar in `Dockerfile.mods`). OPAC treats mounting an entity as an *interaction* and blocks it for non-owners inside a claim. Vanilla **boats** work because OPAC ships them in `friendlyChunkProtectedEntityList` (default type `ALL_BUT` = "protect all entities EXCEPT those listed"). IA aircraft aren't in that list → protected → can't be re-mounted.

## Fix
Mirror the boat exemption: add `immersive_aircraft:*` to `friendlyChunkProtectedEntityList`. That list is a global OPAC setting, so this applies in **all** claims (admin spawn + player), exactly like boats.

OPAC writes this config per-world at `<level>/serverconfig/openpartiesandclaims-server.toml` (path varies by loader/version), generated at first world-load and meant to be edited server-off. So delivery is a **pre-start wrapper entrypoint** that:
- discovers the OPAC serverconfig wherever it was generated (no hardcoded path),
- idempotently inserts `immersive_aircraft:*` into the list (skips if already present; leaves the `...Type` line and every other key untouched),
- seeds a minimal stub on a brand-new world (self-heals on the 2nd boot if the guessed path is ever wrong),
- `exec /start` so itzg stays PID1 and graceful RCON shutdown is preserved.

On the live (existing) world the config is already present, so the entry lands on the next restart.

## Verification
- sed transform unit-tested across 5 config variants (default/empty/multi-entry/idempotent/`...Type`-line-safe) — the `...Type` line and unrelated keys are never touched.
- `bash -n` syntax check.
- OPAC semantics + config key path confirmed from OPAC `ServerConfig.java` source and docs.
- New e2e (`opac-airship-claim.spec.ts`) locates OPAC's *authoritative* generated serverconfig and asserts `immersive_aircraft` is present — this also empirically confirms the config path in CI.
- Not run locally: the full server e2e (`nx run mc:e2e`) needs the heavy `kbve/mc:latest` image build; CI exercises it.