### PR TITLE
feat(herbmail): fps arm viewmodel with skeletal idle/wave

### DIFF
--- a/apps/herbmail/herbmail-game/art/arms/build_anims.py
+++ b/apps/herbmail/herbmail-game/art/arms/build_anims.py
@@ -1,0 +1,128 @@
+import bpy, mathutils, math, sys, json
+
+# args: mode  (render <action> <frame> <out>) | (export <out>)
+argv = sys.argv[sys.argv.index("--") + 1:]
+mode = argv[0]
+
+arm = next(o for o in bpy.data.objects if o.type == 'ARMATURE')
+bpy.context.view_layer.objects.active = arm
+
+for pb in arm.pose.bones:
+    pb.rotation_mode = 'XYZ'
+
+R_IK, L_IK = 'wrist_ik.r', 'wrist_ik.l'
+
+# capture rest matrices of the IK target bones (armature space)
+def rest_mat(name):
+    return arm.pose.bones[name].bone.matrix_local.copy()
+
+def key_target(name, frame, loc, rot):
+    pb = arm.pose.bones[name]
+    r = mathutils.Euler(rot, 'XYZ').to_matrix().to_4x4()
+    pb.matrix = mathutils.Matrix.Translation(mathutils.Vector(loc)) @ r
+    bpy.context.view_layer.update()
+    pb.keyframe_insert('location', frame=frame)
+    pb.keyframe_insert('rotation_euler', frame=frame)
+
+def new_action(name):
+    if arm.animation_data is None:
+        arm.animation_data_create()
+    act = bpy.data.actions.new(name)
+    act.use_fake_user = True
+    arm.animation_data.action = act
+    return act
+
+# hand rotation so palm faces roughly forward/down (tuned via render)
+# --- analytic IK target from bone data (armature space, Z-up) ---
+# chain root = shoulder/bicep joint; chain length = bicep + forearm
+SHOULDER_R = mathutils.Vector((1.924, 0.0, 0.013))
+CHAIN_LEN = 2.685 + 2.519  # 5.204
+REACH = 0.90               # fraction of full length: 1.0=straight, lower=more bend
+# aim direction from shoulder: +Y forward, -Z down, -X inward (for right arm)
+AIM_R = mathutils.Vector((0.20, 0.64, -0.74)).normalized()
+
+def ik_target(shoulder, aim):
+    return tuple(shoulder + aim * (CHAIN_LEN * REACH))
+
+IDLE_RROT = (-0.2, 0.0, 0.0)
+IDLE_LROT = (-0.2, 0.0, 0.0)
+IDLE_R = ik_target(SHOULDER_R, AIM_R)
+IDLE_L = ik_target(
+    mathutils.Vector((-SHOULDER_R.x, SHOULDER_R.y, SHOULDER_R.z)),
+    mathutils.Vector((-AIM_R.x, AIM_R.y, AIM_R.z)),
+)
+
+def build_idle():
+    act = new_action('idle')
+    for f, dz in ((1, 0.0), (24, 0.12), (48, 0.0)):
+        key_target(R_IK, f, (IDLE_R[0], IDLE_R[1], IDLE_R[2] + dz), IDLE_RROT)
+        key_target(L_IK, f, (IDLE_L[0], IDLE_L[1], IDLE_L[2] + dz), IDLE_LROT)
+    return act
+
+# raised hand target: up + forward from shoulder, arm near-straight (no crumple)
+WAVE_AIM = mathutils.Vector((0.22, 0.80, 0.10)).normalized()
+WAVE_R = ik_target(SHOULDER_R, WAVE_AIM)
+# palm-toward-camera base wrist rotation (tuned via render)
+WAVE_WROT = (-0.2, 0.0, 1.0)
+WAVE_ROCK = 0.55  # wrist tilt amplitude
+
+def build_wave():
+    act = new_action('wave')
+    for f in (1, 44):
+        key_target(L_IK, f, IDLE_L, IDLE_LROT)
+    wr = WAVE_WROT
+    tilt = lambda s: (wr[0], wr[1], wr[2] + s * WAVE_ROCK)
+    frames = [
+        (1, IDLE_R, IDLE_RROT),
+        (10, WAVE_R, tilt(+1)),
+        (17, WAVE_R, tilt(-1)),
+        (24, WAVE_R, tilt(+1)),
+        (31, WAVE_R, tilt(-1)),
+        (38, WAVE_R, tilt(+1)),
+        (44, IDLE_R, IDLE_RROT),
+    ]
+    for f, loc, rot in frames:
+        key_target(R_IK, f, loc, rot)
+    return act
+
+idle = build_idle()
+wave = build_wave()
+
+if mode == 'render':
+    action_name, frame, out = argv[1], int(argv[2]), argv[3]
+    arm.animation_data.action = {'idle': idle, 'wave': wave}[action_name]
+    bpy.context.scene.frame_set(frame)
+    bpy.context.view_layer.update()
+    cam_data = bpy.data.cameras.new("C"); cam_data.lens = 18
+    cam = bpy.data.objects.new("C", cam_data)
+    bpy.context.scene.collection.objects.link(cam)
+    loc = mathutils.Vector((0.0, -0.5, 1.3)); tgt = mathutils.Vector((0.0, 2.3, -2.2))
+    cam.location = loc
+    cam.rotation_euler = (tgt - loc).to_track_quat('-Z', 'Y').to_euler()
+    bpy.context.scene.camera = cam
+    ld = bpy.data.lights.new("S", 'SUN'); ld.energy = 4
+    lo = bpy.data.objects.new("S", ld); lo.location = (0, -2, 3)
+    bpy.context.scene.collection.objects.link(lo)
+    bpy.context.scene.world.node_tree.nodes["Background"].inputs[1].default_value = 1.0
+    sc = bpy.context.scene
+    try: sc.render.engine = 'BLENDER_EEVEE_NEXT'
+    except Exception: sc.render.engine = 'BLENDER_EEVEE'
+    sc.render.resolution_x = 640; sc.render.resolution_y = 480
+    sc.render.filepath = out
+    bpy.ops.render.render(write_still=True)
+    print("RENDERED", out)
+
+elif mode == 'export':
+    out = argv[1]
+    bpy.context.scene.frame_set(1)
+    bpy.ops.export_scene.gltf(
+        filepath=out,
+        export_format='GLB',
+        export_animations=True,
+        export_animation_mode='ACTIONS',
+        export_bake_animation=True,
+        export_frame_range=False,
+        export_apply=False,
+        use_selection=False,
+    )
+    print("EXPORTED", out, "actions:", [a.name for a in bpy.data.actions])

--- a/apps/herbmail/herbmail-game/src/app/App.tsx
+++ b/apps/herbmail/herbmail-game/src/app/App.tsx
@@ -32,7 +32,7 @@ export function App() {
 			const el = e.target as HTMLElement;
 			if (el?.tagName === 'INPUT') return;
 
-			if (debugRef.current) {
+			{
 				if (e.code === 'Backspace' || e.code === 'Digit0') {
 					e.preventDefault();
 					setRest({ ...REST });
@@ -41,21 +41,24 @@ export function App() {
 				}
 				const r = { ...restRef.current };
 				const P = 0.02;
-				const A = 0.05;
+				const A = 0.15;
 				const S = 0.005;
 				let hit = true;
 				switch (e.code) {
 					case 'ArrowUp':
-						r.py += P;
-						break;
-					case 'ArrowDown':
-						r.py -= P;
-						break;
-					case 'ArrowLeft':
 						r.pz -= P;
 						break;
-					case 'ArrowRight':
+					case 'ArrowDown':
 						r.pz += P;
+						break;
+					case 'ArrowLeft':
+						r.py -= P;
+						break;
+					case 'ArrowRight':
+						r.py += P;
+						break;
+					case 'KeyF':
+						r.ry += Math.PI;
 						break;
 					case 'KeyN':
 						r.px -= P;

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/Viewmodel.tsx
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/Viewmodel.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
-import { useFrame, useThree } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
+import { useThree } from '@react-three/fiber';
+import { useAnimations, useGLTF } from '@react-three/drei';
 import { ARMS_URL, REST, type ViewmodelRest } from './config';
 import { makePsxViewmodelMaterial } from './psxSkinnedMaterial';
 import { useViewmodelMotion } from './useViewmodelMotion';
-import { createFsm } from './state';
-import { equipmentById } from './equipment';
 
 useGLTF.preload(ARMS_URL);
 
@@ -16,28 +14,14 @@ interface Props {
 	restOverride?: ViewmodelRest;
 }
 
-export function Viewmodel({ equippedId, snap, restOverride }: Props) {
+export function Viewmodel({ snap, restOverride }: Props) {
 	const size = useThree((s) => s.size);
 	const gltf = useGLTF(ARMS_URL);
 
-	const armRef = useRef<THREE.Mesh>(null);
+	const groupRef = useRef<THREE.Group>(null);
 	const restRef = useRef<ViewmodelRest>({ ...REST });
-	const fsm = useMemo(() => createFsm(), []);
-	const motion = useViewmodelMotion(armRef, restRef);
-	const equip = equipmentById(equippedId);
-
-	const armGeo = useMemo(() => {
-		let g: THREE.BufferGeometry | null = null;
-		gltf.scene.traverse((o) => {
-			const m = o as THREE.Mesh;
-			if (m.isMesh && !g) {
-				g = m.geometry.index
-					? m.geometry.toNonIndexed()
-					: m.geometry.clone();
-			}
-		});
-		return g as THREE.BufferGeometry | null;
-	}, [gltf]);
+	useViewmodelMotion(groupRef, restRef);
+	const { actions, mixer } = useAnimations(gltf.animations, groupRef);
 
 	const psx = useMemo(() => {
 		let map: THREE.Texture | null = null;
@@ -52,6 +36,18 @@ export function Viewmodel({ equippedId, snap, restOverride }: Props) {
 	}, [gltf]);
 
 	useEffect(() => {
+		gltf.scene.traverse((o) => {
+			const mesh = o as THREE.Mesh;
+			if (mesh.isMesh) {
+				mesh.material = psx.material;
+				mesh.frustumCulled = false;
+				mesh.renderOrder = 999;
+				mesh.raycast = () => {};
+			}
+		});
+	}, [gltf, psx]);
+
+	useEffect(() => {
 		restRef.current = { ...(restOverride ?? REST) };
 	}, [restOverride]);
 
@@ -64,55 +60,53 @@ export function Viewmodel({ equippedId, snap, restOverride }: Props) {
 	}, [size, psx]);
 
 	useEffect(() => {
-		const act = (ev: 'primary' | 'secondary' | 'reload') => {
-			if (!document.pointerLockElement) return;
-			if (ev === 'reload' && !equip.reload) return;
-			if (!fsm.fire(ev)) return;
-			if (ev === 'primary') motion.trigger(equip.primaryImpulse);
-			else if (ev === 'secondary') motion.trigger(equip.secondaryImpulse);
+		const idle = actions['idle'];
+		if (!idle) return;
+		idle.reset().setLoop(THREE.LoopRepeat, Infinity).fadeIn(0.3).play();
+		return () => {
+			idle.fadeOut(0.2);
+		};
+	}, [actions]);
+
+	useEffect(() => {
+		const idle = actions['idle'];
+		const wave = actions['wave'];
+		if (!wave) return;
+
+		const play = (force = false) => {
+			if (!force && !document.pointerLockElement) return;
+			wave.reset();
+			wave.setLoop(THREE.LoopOnce, 1);
+			wave.clampWhenFinished = false;
+			if (idle) wave.crossFadeFrom(idle, 0.15, false);
+			wave.play();
+		};
+		const forcePlay = () => play(true);
+		window.addEventListener('vmwave', forcePlay);
+		const onFinished = () => {
+			if (idle) idle.reset().fadeIn(0.2).play();
 		};
 		const onDown = (e: MouseEvent) => {
-			if (e.button === 0) act('primary');
-			else if (e.button === 2) act('secondary');
+			if (e.button === 0) play();
 		};
 		const onKey = (e: KeyboardEvent) => {
-			if (e.code === 'KeyR') act('reload');
-			else if (e.code === 'KeyE') act('secondary');
+			if (e.code === 'KeyV') play();
 		};
-		const noMenu = (e: MouseEvent) => e.preventDefault();
+
+		mixer.addEventListener('finished', onFinished);
 		window.addEventListener('mousedown', onDown);
 		window.addEventListener('keydown', onKey);
-		window.addEventListener('contextmenu', noMenu);
 		return () => {
+			mixer.removeEventListener('finished', onFinished);
 			window.removeEventListener('mousedown', onDown);
 			window.removeEventListener('keydown', onKey);
-			window.removeEventListener('contextmenu', noMenu);
+			window.removeEventListener('vmwave', forcePlay);
 		};
-	}, [equip, fsm, motion]);
-
-	useFrame((_, dt) => {
-		fsm.tick(dt);
-	});
-
-	if (!armGeo) return null;
+	}, [actions, mixer]);
 
 	return (
-		<>
-			<mesh
-				geometry={armGeo}
-				material={psx.material}
-				position={[10, 1.4, 10]}
-				scale={0.2}
-				renderOrder={10000}
-				frustumCulled={false}
-			/>
-			<mesh
-				ref={armRef}
-				geometry={armGeo}
-				material={psx.material}
-				renderOrder={999}
-				frustumCulled={false}
-			/>
-		</>
+		<group ref={groupRef}>
+			<primitive object={gltf.scene} />
+		</group>
 	);
 }

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/ViewmodelDebug.tsx
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/ViewmodelDebug.tsx
@@ -52,11 +52,11 @@ export function ViewmodelDebug({ value, onChange }: Props) {
 					fontSize: 11,
 					lineHeight: 1.5,
 				}}>
-				keyboard (no mouse needed):
+				arrow keys (always on):
 				<br />
-				↑↓ y · ←→ z · N/M x · [ ] scale
+				↑ out · ↓ back · ← down · → up
 				<br />
-				I/K pitch · J/L yaw · U/O roll
+				N/M x · [ ] scale · I/K pitch · J/L yaw · U/O roll
 				<br />0 = reset · Enter = log
 			</div>
 			{rows.map((r) => (

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/config.ts
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/config.ts
@@ -12,12 +12,12 @@ export interface ViewmodelRest {
 
 export const REST: ViewmodelRest = {
 	px: 0,
-	py: -0.2,
-	pz: -0.8,
+	py: -0.28,
+	pz: -0.54,
 	rx: 0.1,
 	ry: 0,
 	rz: 0,
-	scale: 0.13,
+	scale: 0.12,
 };
 
 export const MOTION = {
@@ -33,8 +33,8 @@ export const MOTION = {
 	recoilBack: 0.09,
 	recoilKick: 0.16,
 	recoilRoll: 0.05,
-	reachPush: 0.12,
-	springBack: 14,
+	reachPush: 0.5,
+	springBack: 10,
 } as const;
 
 export const SOCKET_BONE = 'socket.r';

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/psxSkinnedMaterial.ts
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/psxSkinnedMaterial.ts
@@ -33,9 +33,9 @@ export function makePsxViewmodelMaterial(
 		color: map ? 0xffffff : 0xff44aa,
 	});
 	material.toneMapped = false;
-	material.depthTest = false;
-	material.depthWrite = false;
-	material.side = THREE.DoubleSide;
+	material.depthTest = true;
+	material.depthWrite = true;
+	material.side = THREE.FrontSide;
 
 	const uSnap = { value: snap };
 	const uRes = { value: new THREE.Vector2(1, 1) };

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/useViewmodelMotion.ts
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/useViewmodelMotion.ts
@@ -60,19 +60,20 @@ export function useViewmodelMotion(
 		const targetWalk = THREE.MathUtils.clamp(speed / 3.2, 0, 1);
 		walk.current = damp(walk.current, targetWalk, MOTION.walkLerp, dt);
 
+		const safeDt = Math.max(dt, 1e-4);
 		const dYaw = euler.y - prevYaw.current;
 		const dPitch = euler.x - prevPitch.current;
 		prevYaw.current = euler.y;
 		prevPitch.current = euler.x;
 		swayX.current = damp(
 			swayX.current,
-			THREE.MathUtils.clamp(-dYaw / dt / 12, -1, 1),
+			THREE.MathUtils.clamp(-dYaw / safeDt / 12, -1, 1),
 			MOTION.swayLerp,
 			dt,
 		);
 		swayY.current = damp(
 			swayY.current,
-			THREE.MathUtils.clamp(-dPitch / dt / 12, -1, 1),
+			THREE.MathUtils.clamp(-dPitch / safeDt / 12, -1, 1),
 			MOTION.swayLerp,
 			dt,
 		);


### PR DESCRIPTION
First-person arm viewmodel for `herbmail-game`.

## What
- Camera-attached rigged arms (follow view + procedural walk-bob / look-sway).
- Baked skeletal animations played via `AnimationMixer`: **idle** loop + **wave** (LMB / `V`, eases back to idle).
- Live in-game position tuning (` panel + arrow keys) for iterating the rest pose.
- Solid depth-correct render (self-occluding), full albedo.

## How the animations were made
- Arms rig has IK (`arms.blend`); glTF can't carry IK, so poses are authored on the IK targets and **baked IK→FK on export**.
- Poses computed analytically from measured bone lengths (no eyeballing) in `art/arms/build_anims.py`; re-export to update `arms.glb`.

## Notes
- `arms.glb` (animated) + `arms.blend` already on origin/dev via Forgejo LFS (`KBVE/herbmail`); this PR is the code + the authoring script.
- Only forearms/hands frame in view (low-poly upper-arm bend kept off-screen).