### PR TITLE
feat(rows): fleet-restart orchestration Phase 3 (drain fan-out, safe_to_roll barrier, trigger API)

### DIFF
--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -159,7 +159,11 @@ metadata:
         app: rows
         app.kubernetes.io/part-of: ows
 spec:
-    minAvailable: 1
+    # maxUnavailable (not minAvailable): with a single replica, minAvailable:1 blocks every
+    # voluntary eviction and hangs node drains. maxUnavailable:1 always permits the drain; run
+    # replicas >= 2 before enabling the fleet-restart reconcile live so one pod is always serving
+    # (the per-tenant advisory lock makes multi-replica safe).
+    maxUnavailable: 1
     selector:
         matchLabels:
             app: rows

--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -201,7 +201,11 @@ metadata:
         app: rows
         app.kubernetes.io/part-of: ows
 spec:
-    minAvailable: 1
+    # maxUnavailable (not minAvailable): with a single replica, minAvailable:1 blocks every
+    # voluntary eviction and hangs node drains. maxUnavailable:1 always permits the drain; run
+    # replicas >= 2 before enabling the fleet-restart reconcile live so one pod is always serving
+    # (the per-tenant advisory lock makes multi-replica safe).
+    maxUnavailable: 1
     selector:
         matchLabels:
             app: rows

--- a/apps/rows/src/agones/fleet.rs
+++ b/apps/rows/src/agones/fleet.rs
@@ -25,6 +25,33 @@ pub struct FleetStatus {
 }
 
 impl AgonesClient {
+    /// Count of GameServer objects in this tenant's fleet, ALL states included. This is the
+    /// Agones half of the fleet-restart "all old gone" barrier: a DB row can hit `status=0` while
+    /// its pod is still alive (flushing a save, mid-SIGTERM), so the barrier only opens when the
+    /// GameServer list itself is empty. Callers must cache this (see `rest::system`) — it is a
+    /// kube-apiserver LIST per call.
+    pub async fn count_gameservers(&self) -> Result<i64, AgonesError> {
+        let url = format!(
+            "/apis/agones.dev/v1/namespaces/{}/gameservers?labelSelector=agones.dev/fleet={}",
+            self.namespace, self.fleet
+        );
+
+        let req = http::Request::get(&url)
+            .body(Vec::new())
+            .map_err(|e| anyhow::anyhow!("Failed to build gameserver count request: {e}"))?;
+
+        let resp: serde_json::Value =
+            tokio::time::timeout(super::client::api_timeout(), self.client.request(req))
+                .await
+                .map_err(|_| anyhow::anyhow!("K8s gameserver count request timed out (10s)"))??;
+
+        Ok(resp
+            .get("items")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len() as i64)
+            .unwrap_or(0))
+    }
+
     #[tracing::instrument(skip(self))]
     pub async fn fleet_status(&self) -> Result<FleetStatus, AgonesError> {
         let url = format!(

--- a/apps/rows/src/config.rs
+++ b/apps/rows/src/config.rs
@@ -134,6 +134,34 @@ pub struct ReaperConfigOverride {
     pub empty_fresh_secs: Option<i64>,
 }
 
+/// Fleet-restart control row, read from the `ows.fleet_restart` table (operator/dashboard-written,
+/// one row per tenant). Drives the `fleet_restart_reconcile` job: `active=true` fans
+/// `set_drain_state` across active instances and (when `lockout`) holds the admission lockout.
+/// `lockout_applied` tracks lockout ownership so the reconcile only lifts a lockout it itself set
+/// (the `admission_control` table is shared with other writers). Absent row / `active=false` = inert.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FleetRestart {
+    pub active: bool,
+    pub reason: String,
+    pub urgency: i16,
+    #[sqlx(rename = "dropplayers")]
+    pub drop_players: bool,
+    pub stagger: bool,
+    #[sqlx(rename = "batchsize")]
+    pub batch_size: i32,
+    pub lockout: bool,
+    #[sqlx(rename = "lockoutapplied")]
+    pub lockout_applied: bool,
+    #[sqlx(rename = "startedat")]
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    #[sqlx(rename = "draindeadline")]
+    pub drain_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    #[sqlx(rename = "targetversion")]
+    pub target_version: Option<String>,
+    #[sqlx(rename = "requestid")]
+    pub request_id: uuid::Uuid,
+}
+
 /// Per-scope admission override, read from the `ows.admission_control` table. `accept_new_joins`
 /// is `Option`: `None` (or no row) means "fall back to the env baseline" (`ROWS_ACCEPT_NEW_JOINS`).
 /// One of these is read per scope (tenant + global sentinel) and combined by
@@ -224,6 +252,10 @@ pub struct RowsConfig {
     /// Env baseline for the new-join admission gate (`ROWS_ACCEPT_NEW_JOINS`, default `true`). Used
     /// when neither the tenant nor the global `admission_control` row overrides it.
     pub accept_new_joins: bool,
+    /// Non-aggressive stall SLA: seconds a restart may sit `active` with `draining > 0` before it is
+    /// declared stalled (surfaced on /fleet-restart/status and, at 2× this, auto-lifts the lockout).
+    /// Env: ROWS_FLEET_RESTART_STALL_SECS. Default 1800 (30 min).
+    pub fleet_restart_stall_secs: i64,
 }
 
 impl RowsConfig {
@@ -318,6 +350,8 @@ impl RowsConfig {
         // a freeze requires either an env override or an `admission_control` DB row.
         let accept_new_joins = env_bool("ROWS_ACCEPT_NEW_JOINS", true);
 
+        let fleet_restart_stall_secs = env_i64("ROWS_FLEET_RESTART_STALL_SECS", 1800);
+
         Ok(Self {
             tenant: TenantConfig {
                 customer_guid,
@@ -333,6 +367,7 @@ impl RowsConfig {
             docs_port,
             reaper,
             accept_new_joins,
+            fleet_restart_stall_secs,
         })
     }
 }

--- a/apps/rows/src/config.rs
+++ b/apps/rows/src/config.rs
@@ -162,6 +162,18 @@ pub struct FleetRestart {
     pub request_id: uuid::Uuid,
 }
 
+/// The tenant's `ows.deploy_state` row: the authoritative rollout target (`target_version` is a
+/// PVC path version, not an image tag) plus rollout state. `rolled=true` ⇒ this version is the one
+/// being served (the launcher's download target); `rolled=false` ⇒ merged but not yet rolled
+/// (update pending). `health='unhealthy'` ⇒ a soak failed and a human must decide (no auto-rollback).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DeployState {
+    #[sqlx(rename = "targetversion")]
+    pub target_version: String,
+    pub rolled: bool,
+    pub health: String,
+}
+
 /// Per-scope admission override, read from the `ows.admission_control` table. `accept_new_joins`
 /// is `Option`: `None` (or no row) means "fall back to the env baseline" (`ROWS_ACCEPT_NEW_JOINS`).
 /// One of these is read per scope (tenant + global sentinel) and combined by

--- a/apps/rows/src/jobs.rs
+++ b/apps/rows/src/jobs.rs
@@ -34,6 +34,24 @@ pub fn spawn_all(svc: Arc<OWSService>) {
         );
     }
 
+    // One-shot startup check: a failed CREATE INDEX CONCURRENTLY leaves an INVALID
+    // idx_mapinstances_drainable that Postgres silently refuses to use — the fleet-restart
+    // reconcile's per-tick scan would seq-scan the hot mapinstances table with no error. Surface
+    // it loudly instead (recovery: DROP INDEX + re-create CONCURRENTLY; see the index migration).
+    {
+        let svc = svc.clone();
+        tokio::spawn(async move {
+            match InstanceRepo(&svc.state().db).check_drainable_index_valid().await {
+                Ok(Some(false)) => warn!(
+                    "idx_mapinstances_drainable is INVALID (failed CONCURRENTLY build) — \
+                     drainable scans are seq-scanning; DROP INDEX and re-create CONCURRENTLY"
+                ),
+                Ok(_) => {} // valid, or not created yet (migration not applied)
+                Err(e) => warn!(error = %e, "failed to check idx_mapinstances_drainable validity"),
+            }
+        });
+    }
+
     tokio::spawn(zone_health_monitor(svc.clone()));
     tokio::spawn(stale_zone_cleanup(svc.clone()));
     tokio::spawn(empty_server_reaper(svc.clone()));

--- a/apps/rows/src/jobs.rs
+++ b/apps/rows/src/jobs.rs
@@ -55,6 +55,7 @@ pub fn spawn_all(svc: Arc<OWSService>) {
     tokio::spawn(zone_health_monitor(svc.clone()));
     tokio::spawn(stale_zone_cleanup(svc.clone()));
     tokio::spawn(empty_server_reaper(svc.clone()));
+    tokio::spawn(fleet_restart_reconcile(svc.clone()));
     tokio::spawn(spinup_lock_expiry(svc.clone()));
     tokio::spawn(session_cache_sweep(svc));
 }
@@ -572,6 +573,328 @@ async fn reap_one(svc: Arc<OWSService>, guid: uuid::Uuid, target: ReapTarget) {
             // Leave status>0 + tracking intact; next cycle re-evaluates and retries.
             warn!(error = %e, gs = %gs, instance_id, "Reaper: deallocate failed — will retry next cycle");
         }
+    }
+}
+
+/// Whole-fleet (`!stagger`) batch cap for the fleet-restart drain fan-out.
+const FLEET_DRAIN_CAP: i64 = 4096;
+
+/// DB-backed coordinated fleet restart: reconciles the tenant's `fleet_restart` control row every
+/// 30s. While a restart is `active` it fans `set_drain_state` across active instances (whole-fleet
+/// or staggered batches), holds the admission lockout (when `lockout`), and enforces the aggressive
+/// deadline / non-aggressive stall backstop. When the row is absent or `active=false` it lifts the
+/// lockout ONCE iff it owns it (`lockoutapplied`), then no-ops — the feature ships dark.
+///
+/// Lock/unlock pattern mirrors `empty_server_reaper` EXACTLY. The advisory lock is SESSION-level,
+/// so it MUST be taken and released on the same pinned connection — taking it on the pool would
+/// unlock on a different pooled connection (a no-op), leak the lock, and wedge the reconcile for
+/// this tenant until restart. The POOLER CONSTRAINT documented in `empty_server_reaper` applies
+/// verbatim: this must stay on the session-pinned direct RW endpoint, never the transaction-mode
+/// pooler. Single-flight per tenant, so >1 ROWS replica never double-fans `set_drain_state`.
+async fn fleet_restart_reconcile(svc: Arc<OWSService>) {
+    // Convergence coupling, surfaced at job start: an instance only leaves `status>0` when the
+    // reaper tears it down (`set_drain_state` rejects state=0), so a fleet restart CANNOT converge
+    // with the reaper disabled — the stall backstop below turns that into a bounded, loud stall.
+    if !svc.state().config.reaper.enabled {
+        info!(
+            "fleet-restart: empty_server_reaper is DISABLED in the env baseline — a fleet restart \
+             cannot converge unless a per-tenant reaperconfig override enables it (stall backstop \
+             will surface this)"
+        );
+    }
+
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    interval.tick().await;
+    loop {
+        interval.tick().await;
+        let guid = svc.state().config.customer_guid;
+
+        // Pin a dedicated connection for the session-level advisory lock (see doc comment).
+        let mut lock_conn = match svc.state().db.acquire().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "fleet-restart: failed to acquire lock connection — skipping tick");
+                continue;
+            }
+        };
+        let locked = match sqlx::query_scalar::<_, bool>(
+            "SELECT pg_try_advisory_lock(hashtext('rows-fleet-restart'), hashtext($1))",
+        )
+        .bind(guid.to_string())
+        .fetch_one(&mut *lock_conn)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "fleet-restart: advisory-lock query failed — skipping tick");
+                continue; // no lock held; lock_conn returns to the pool normally
+            }
+        };
+        if !locked {
+            continue; // another replica owns this tenant's reconcile this tick
+        }
+
+        // Arm the RAII guard so the session lock is dropped even if the cycle panics.
+        let mut lock_guard = AdvisoryLockGuard::new(lock_conn);
+
+        // Run the cycle as a supervised task so a panic is caught at the JoinError boundary and
+        // the explicit unlock below ALWAYS runs (a leaked session lock would wedge this tenant).
+        if let Err(e) = tokio::spawn(run_fleet_restart_cycle(svc.clone(), guid)).await {
+            error!(error = %e, "fleet-restart: cycle panicked — releasing lock, loop continues");
+        }
+
+        // Release on the SAME pinned connection. On failure, detach+close so Postgres drops the
+        // session lock when the backend session ends, rather than leaking it on a pooled connection.
+        match sqlx::query("SELECT pg_advisory_unlock(hashtext('rows-fleet-restart'), hashtext($1))")
+            .bind(guid.to_string())
+            .execute(lock_guard.conn_mut())
+            .await
+        {
+            Ok(_) => lock_guard.disarm(),
+            Err(e) => {
+                warn!(error = %e, "fleet-restart: failed to release advisory lock — closing connection");
+                if let Err(e) = lock_guard.take().detach().close().await {
+                    warn!(error = %e, "fleet-restart: error closing detached lock connection");
+                }
+            }
+        }
+    }
+}
+
+/// The `deadline` stamped on each `set_drain_state`: aggressive restarts carry the row's
+/// `draindeadline` (UTC-naive per the column contract); non-aggressive ⇒ `None` (never forces).
+fn fr_deadline(fr: &crate::config::FleetRestart) -> Option<chrono::NaiveDateTime> {
+    fr.drain_deadline.map(|d| d.naive_utc())
+}
+
+/// One reconcile pass, run under the advisory lock held by the caller (mirrors `run_reap_cycle`).
+async fn run_fleet_restart_cycle(svc: Arc<OWSService>, guid: uuid::Uuid) {
+    let repo = InstanceRepo(&svc.state().db);
+
+    let fr = match repo.get_fleet_restart(guid).await {
+        Ok(Some(fr)) if fr.active => fr,
+        // No active restart (row present, active=false). Lift the lockout ONLY if THIS restart
+        // applied it (lockoutapplied) — never blindly NULL the shared admission_control row, which
+        // maintenance/abuse flows also write. One-shot + idempotent on cold-start resume.
+        Ok(Some(fr)) => {
+            if fr.lockout_applied {
+                if let Err(e) = repo.set_admission(guid, None).await {
+                    warn!(error = %e, "fleet-restart: failed to lift lockout");
+                    return; // leave lockoutapplied=true; retry next tick
+                }
+                if let Err(e) = repo.set_fleet_lockout_applied(guid, false).await {
+                    warn!(error = %e, "fleet-restart: failed to clear lockout-applied flag");
+                }
+                info!("fleet-restart: restart cleared — admission lockout lifted");
+            }
+            return;
+        }
+        Ok(None) => return, // inert: no row at all, nothing to do (and nothing we ever locked)
+        Err(e) => {
+            warn!(error = %e, "fleet-restart: read failed");
+            return;
+        }
+    };
+
+    // Hold the lockout while the restart runs (travel still allowed — the admission gate only
+    // blocks *new* joins). Record ownership so the inactive branch above lifts only what we set.
+    if fr.lockout {
+        if let Err(e) = repo.set_admission(guid, Some(false)).await {
+            warn!(error = %e, "fleet-restart: failed to set lockout");
+        } else if !fr.lockout_applied {
+            if let Err(e) = repo.set_fleet_lockout_applied(guid, true).await {
+                warn!(error = %e, "fleet-restart: failed to record lockout ownership");
+            }
+        }
+    }
+
+    // Batch source: instances not yet draining. Whole-fleet if !stagger.
+    let limit = if fr.stagger {
+        i64::from(fr.batch_size.max(1))
+    } else {
+        FLEET_DRAIN_CAP
+    };
+    let batch = match repo.list_drainable_instances(guid, limit).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "fleet-restart: list failed");
+            return;
+        }
+    };
+
+    for id in &batch {
+        if let Err(e) = repo
+            .set_drain_state(
+                guid,
+                *id,
+                1, // draining
+                fr.urgency,
+                fr.drop_players,
+                &fr.reason,
+                fr.request_id,
+                fr_deadline(&fr),
+            )
+            .await
+        {
+            warn!(error = %e, instance_id = id, "fleet-restart: set_drain_state failed");
+        }
+    }
+
+    // Deadline + stall backstop: even the non-aggressive path bounds the join outage, so a
+    // stuck/disabled reaper (or a population that never leaves) surfaces as a loud, observable
+    // stall instead of an indefinitely-held lockout.
+    enforce_drain_deadline(&svc, &repo, guid, &fr).await;
+
+    let remaining = repo.count_active_instances(guid).await.unwrap_or(-1);
+    info!(
+        active = remaining,
+        staggered = fr.stagger,
+        batch = batch.len(),
+        "fleet-restart: reconcile tick"
+    );
+    // remaining == 0 is the DB all-drained signal (exposed via /fleet-restart/status). It only
+    // reaches 0 once instances hit status=0, which ONLY empty_server_reaper writes
+    // (set_drain_state rejects state=0) — so convergence depends on the reaper AND the backstop.
+}
+
+/// Two paths, two behaviours (safe-by-default is a hard invariant):
+///
+/// **Aggressive** (`drain_deadline` set and passed): force-deallocate the overdue instances
+/// per-GameServer — never a whole-Fleet scale-to-0, which would also kill instances still draining
+/// cleanly. Aggressive explicitly opts into save-then-disconnect at the deadline.
+///
+/// **Non-aggressive** (no deadline): never disconnect anyone, but bound the join outage in two
+/// escalating stages off `started_at`:
+///   1. past `fleet_restart_stall_secs`: loud warn + `stalled` surfaces on /fleet-restart/status.
+///   2. past 2×: auto-lift the join lockout while leaving the restart active (new players land on
+///      old-version instances — safe within a version line; the roll just takes longer).
+async fn enforce_drain_deadline(
+    svc: &Arc<OWSService>,
+    repo: &InstanceRepo<'_>,
+    guid: uuid::Uuid,
+    fr: &crate::config::FleetRestart,
+) {
+    if let Some(deadline) = fr.drain_deadline {
+        // Aggressive path: per-GameServer force-deallocate of overdue instances.
+        if chrono::Utc::now() < deadline {
+            return;
+        }
+        let overdue = match repo
+            .list_overdue_draining_instances(guid, chrono::Utc::now().naive_utc())
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "fleet-restart: overdue-instance query failed");
+                return;
+            }
+        };
+        if overdue.is_empty() {
+            return;
+        }
+        let Some(ref agones) = svc.state().agones else {
+            warn!(
+                overdue = overdue.len(),
+                "fleet-restart: deadline passed but Agones unavailable — cannot force-deallocate"
+            );
+            return;
+        };
+        info!(
+            overdue = overdue.len(),
+            "fleet-restart: drain deadline passed — force-deallocating overdue instances"
+        );
+        // Resolve GameServer names: in-memory tracking first, one batched DB fallback for misses
+        // (mirrors the reaper's resolution; a resolve failure just retries next tick).
+        let mut named: Vec<(i32, String)> = Vec::new();
+        let mut misses: Vec<i32> = Vec::new();
+        for id in &overdue {
+            match svc.state().zone_servers.get(id) {
+                Some(v) => named.push((*id, v.value().clone())),
+                None => misses.push(*id),
+            }
+        }
+        if !misses.is_empty() {
+            match repo.get_gameserver_names(guid, &misses).await {
+                Ok(rows) => {
+                    for (id, gs) in rows {
+                        match gs {
+                            Some(gs) => named.push((id, gs)),
+                            None => warn!(
+                                instance_id = id,
+                                "fleet-restart: overdue instance has no resolvable GameServer name"
+                            ),
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "fleet-restart: failed to resolve GameServer names — retrying next tick")
+                }
+            }
+        }
+        // Deallocate-first, serially (deadline batches are small; the reaper's concurrency budget
+        // reasoning applies — don't starve the hot path). A failure leaves the row for next tick.
+        for (id, gs) in named {
+            match agones.deallocate(&gs).await {
+                Ok(()) => {
+                    svc.state().zone_servers.remove(&id);
+                    if let Err(e) = repo.shut_down_server_instance(guid, id).await {
+                        warn!(error = %e, instance_id = id, "fleet-restart: deallocated but failed to set status=0");
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, gs = %gs, instance_id = id, "fleet-restart: deallocate failed — will retry next tick");
+                }
+            }
+        }
+        return;
+    }
+
+    // Non-aggressive path: never disconnect; bound the join outage off started_at.
+    let stall_secs = svc.state().config.fleet_restart_stall_secs;
+    let stalled_secs = (chrono::Utc::now() - fr.started_at).num_seconds();
+    if stalled_secs <= stall_secs {
+        return;
+    }
+    let draining = match repo.count_active_instances(guid).await {
+        Ok(n) => n,
+        Err(e) => {
+            warn!(error = %e, "fleet-restart: active-count read failed during stall check");
+            return;
+        }
+    };
+    if draining == 0 {
+        return; // converged — nothing stalled
+    }
+    if stalled_secs > 2 * stall_secs {
+        // Stage 2: hard join-outage cap. Auto-lift the lockout while leaving the restart active,
+        // idempotently and in an order that won't re-apply next tick: lift admission, clear
+        // ownership, then lockout=false (so the active branch's `if fr.lockout` stops re-applying).
+        if fr.lockout || fr.lockout_applied {
+            if let Err(e) = repo.set_admission(guid, None).await {
+                warn!(error = %e, "fleet-restart: stall auto-lift failed to lift admission");
+                return; // retry next tick; flags untouched so we come back here
+            }
+            if let Err(e) = repo.set_fleet_lockout_applied(guid, false).await {
+                warn!(error = %e, "fleet-restart: stall auto-lift failed to clear ownership flag");
+            }
+            if let Err(e) = repo.set_fleet_lockout(guid, false).await {
+                warn!(error = %e, "fleet-restart: stall auto-lift failed to clear lockout flag");
+            }
+            error!(
+                stalled_secs,
+                draining,
+                "fleet-restart: join-outage cap hit — lockout auto-lifted, drain still pending; \
+                 escalate to aggressive (deadline) or clear the restart"
+            );
+        }
+    } else {
+        // Stage 1: stall SLA breached. Drain continues; lockout still held; /fleet-restart/status
+        // reports stalled=true off the same started_at clock.
+        warn!(
+            stalled_secs,
+            draining,
+            "fleet-restart: drain stalled — check empty_server_reaper is enabled and healthy"
+        );
     }
 }
 

--- a/apps/rows/src/main.rs
+++ b/apps/rows/src/main.rs
@@ -130,6 +130,7 @@ async fn main() -> anyhow::Result<()> {
         .agones_config(&cfg.agones_namespace, &cfg.agones_fleet)
         .reaper_config(cfg.reaper.clone())
         .accept_new_joins(cfg.accept_new_joins)
+        .fleet_restart_stall_secs(cfg.fleet_restart_stall_secs)
         .mq(mq_producer)
         .agones(agones_client)
         .build()?;

--- a/apps/rows/src/models.rs
+++ b/apps/rows/src/models.rs
@@ -455,8 +455,21 @@ pub struct HealthResponse {
     pub uptime_seconds: u64,
     pub active_sessions: usize,
     pub active_instances: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// The authoritative served UE build version (`deploy_state.target_version` where
+    /// `rolled=true`, falling back to the in-memory ReportBuild value when the table is dark).
+    /// **This is the launcher's download target.** Explicitly `null` (not omitted) when there is
+    /// no authoritative target — the launcher must surface a maintenance/hold state and NOT
+    /// auto-download an arbitrary build.
     pub unreal_version: Option<String>,
+    /// A merged-but-not-yet-rolled version (`deploy_state.rolled=false`). Informational.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_version: Option<String>,
+    /// `false` = the last rollout soak failed (`deploy_state.health='unhealthy'`). Advisory only —
+    /// never gates `/ready` (a bad game build must not deregister the ROWS API pod).
+    pub deploy_healthy: bool,
+    /// The version whose soak failed, when `deploy_healthy=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failing_version: Option<String>,
 }
 
 #[derive(sqlx::FromRow)]

--- a/apps/rows/src/openapi.rs
+++ b/apps/rows/src/openapi.rs
@@ -33,6 +33,7 @@ use crate::models::*;
         crate::rest::system::restart_game_server,
         crate::rest::system::restart_fleet,
         crate::rest::system::verify_deployment,
+        crate::rest::system::fleet_restart_status,
         crate::rest::auth::login,
         crate::rest::auth::external_login,
         crate::rest::auth::get_user_session,
@@ -104,6 +105,7 @@ use crate::models::*;
         PlayerGroupMembership,
         UserInfo,
         crate::rest::system::InstanceEvent,
+        crate::rest::system::FleetRestartStatus,
     )),
     tags(
         (name = "health", description = "Health and readiness probes"),

--- a/apps/rows/src/openapi.rs
+++ b/apps/rows/src/openapi.rs
@@ -34,6 +34,8 @@ use crate::models::*;
         crate::rest::system::restart_fleet,
         crate::rest::system::verify_deployment,
         crate::rest::system::fleet_restart_status,
+        crate::rest::system::fleet_restart_pending,
+        crate::rest::system::fleet_restart_trigger,
         crate::rest::auth::login,
         crate::rest::auth::external_login,
         crate::rest::auth::get_user_session,
@@ -106,6 +108,7 @@ use crate::models::*;
         UserInfo,
         crate::rest::system::InstanceEvent,
         crate::rest::system::FleetRestartStatus,
+        crate::rest::system::FleetRestartPending,
     )),
     tags(
         (name = "health", description = "Health and readiness probes"),

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -1186,6 +1186,71 @@ impl<'a> InstanceRepo<'a> {
 
         Ok(row.0)
     }
+
+    /// The tenant's `fleet_restart` control row. `None` when no row exists AND when the table
+    /// doesn't exist yet (SQLSTATE 42P01) — the reconcile job treats both as "inert, nothing to
+    /// do", so a rows image shipping ahead of the migration runs dark instead of erroring every
+    /// tick. Other DB errors propagate.
+    pub async fn get_fleet_restart(
+        &self,
+        customer_guid: Uuid,
+    ) -> Result<Option<crate::config::FleetRestart>, RowsError> {
+        let result = sqlx::query_as::<_, crate::config::FleetRestart>(
+            "SELECT active, reason, urgency, dropplayers, stagger, batchsize, lockout,
+                    lockoutapplied, startedat, draindeadline, targetversion, requestid
+             FROM fleet_restart WHERE customerguid = $1",
+        )
+        .bind(customer_guid)
+        .fetch_optional(self.0)
+        .await;
+        match result {
+            Ok(row) => Ok(row),
+            Err(e) if is_undefined_table(&e) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Active (`status > 0`) instances not already draining (`drainstate IS NULL`), oldest first,
+    /// capped — the fleet-restart reconcile's batch source. Excluding already-draining rows means
+    /// the reconcile never re-drains; an instance leaves the "active" count only when the reaper /
+    /// lifecycle moves it to `status = 0`.
+    pub async fn list_drainable_instances(
+        &self,
+        customer_guid: Uuid,
+        limit: i64,
+    ) -> Result<Vec<i32>, RowsError> {
+        let rows: Vec<(i32,)> = sqlx::query_as(
+            "SELECT mapinstanceid FROM mapinstances
+             WHERE customerguid = $1 AND status > 0 AND drainstate IS NULL
+             ORDER BY mapinstanceid
+             LIMIT $2",
+        )
+        .bind(customer_guid)
+        .bind(limit)
+        .fetch_all(self.0)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    /// Detects the silent-failure mode of `CREATE INDEX CONCURRENTLY`: a failed concurrent build
+    /// leaves the index in an `INVALID` state that Postgres refuses to use, degrading the per-tick
+    /// `list_drainable_instances` scan to a seq-scan on the hot `mapinstances` table with no error.
+    /// Called once at startup (see `jobs::spawn_all`); logs a `warn!` for alerting. Returns
+    /// `Ok(None)` when the index doesn't exist yet (migration not applied) — that is not invalid,
+    /// just absent. Recovery: `DROP INDEX idx_mapinstances_drainable;` then re-create CONCURRENTLY.
+    pub async fn check_drainable_index_valid(&self) -> Result<Option<bool>, RowsError> {
+        let result = sqlx::query_scalar::<_, bool>(
+            "SELECT i.indisvalid FROM pg_index i
+             JOIN pg_class c ON c.oid = i.indexrelid
+             WHERE c.relname = 'idx_mapinstances_drainable'",
+        )
+        .fetch_optional(self.0)
+        .await;
+        match result {
+            Ok(v) => Ok(v),
+            Err(e) => Err(e.into()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -1318,6 +1318,95 @@ impl<'a> InstanceRepo<'a> {
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
 
+    /// The tenant's `deploy_state` row (single row: the authoritative rollout target + health).
+    /// `rolled=true` ⇒ `target_version` is the served PVC version (the launcher's download
+    /// target); `rolled=false` ⇒ an update is pending. `None` on row-absent OR 42P01 (feature
+    /// dark) so `/health` and the pending gate degrade instead of erroring.
+    pub async fn get_deploy_state(
+        &self,
+        customer_guid: Uuid,
+    ) -> Result<Option<crate::config::DeployState>, RowsError> {
+        let result = sqlx::query_as::<_, crate::config::DeployState>(
+            "SELECT targetversion, rolled, health FROM deploy_state WHERE customerguid = $1",
+        )
+        .bind(customer_guid)
+        .fetch_optional(self.0)
+        .await;
+        match result {
+            Ok(row) => Ok(row),
+            Err(e) if is_undefined_table(&e) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// One-shot seed of the currently-served version (`rolled=true, health='healthy'`), called
+    /// from the ReportBuild path when a GameServer reports the build it loaded. `ON CONFLICT DO
+    /// NOTHING` so it never overwrites a real roll or a pending update; degrade on 42P01. This is
+    /// what keeps `/health.unreal_version` non-null before the first orchestrated roll.
+    pub async fn seed_deploy_state(
+        &self,
+        customer_guid: Uuid,
+        version: &str,
+    ) -> Result<(), RowsError> {
+        let result = sqlx::query(
+            "INSERT INTO deploy_state (customerguid, targetversion, rolled, health)
+             VALUES ($1, $2, true, 'healthy')
+             ON CONFLICT (customerguid) DO NOTHING",
+        )
+        .bind(customer_guid)
+        .bind(version)
+        .execute(self.0)
+        .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_undefined_table(&e) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Rollout-health upsert (the orchestrator's failed-soak / recovered signal). Marks the row's
+    /// `health`; when `failing_version` is given it also pins `targetversion` so `/health` reports
+    /// which build failed. Degrades on 42P01.
+    pub async fn set_deploy_health(
+        &self,
+        customer_guid: Uuid,
+        healthy: bool,
+        failing_version: Option<&str>,
+    ) -> Result<(), RowsError> {
+        let health = if healthy { "healthy" } else { "unhealthy" };
+        let result = match failing_version {
+            Some(v) => {
+                sqlx::query(
+                    "INSERT INTO deploy_state (customerguid, targetversion, rolled, health)
+                     VALUES ($1, $2, false, $3)
+                     ON CONFLICT (customerguid)
+                     DO UPDATE SET targetversion = EXCLUDED.targetversion,
+                                   health = EXCLUDED.health, updatedat = now()",
+                )
+                .bind(customer_guid)
+                .bind(v)
+                .bind(health)
+                .execute(self.0)
+                .await
+            }
+            None => {
+                sqlx::query(
+                    "UPDATE deploy_state SET health = $2, updatedat = now()
+                     WHERE customerguid = $1",
+                )
+                .bind(customer_guid)
+                .bind(health)
+                .execute(self.0)
+                .await
+            }
+        };
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_undefined_table(&e) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Detects the silent-failure mode of `CREATE INDEX CONCURRENTLY`: a failed concurrent build
     /// leaves the index in an `INVALID` state that Postgres refuses to use, degrading the per-tick
     /// `list_drainable_instances` scan to a seq-scan on the hot `mapinstances` table with no error.

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -1407,6 +1407,42 @@ impl<'a> InstanceRepo<'a> {
         }
     }
 
+    /// (Re)activates the tenant's `fleet_restart` row (the `POST /fleet-restart/trigger` upsert).
+    /// Aggressive ⇒ `urgency=1, dropplayers=true` + the caller-computed `deadline`; non-aggressive
+    /// ⇒ `urgency=0, dropplayers=false, draindeadline=NULL`. Either mode resets `startedat=now()`
+    /// (the stall clock), `lockoutapplied=false` (ownership), AND `lockout=true` — a prior run's
+    /// stage-2 auto-lift may have left `lockout=false`, and without the reset a re-trigger would
+    /// never re-lock new joins. Does NOT degrade on 42P01: triggering a restart with no table is a
+    /// real error the caller must surface, not a silent no-op.
+    pub async fn set_fleet_restart(
+        &self,
+        customer_guid: Uuid,
+        aggressive: bool,
+        deadline: Option<chrono::DateTime<chrono::Utc>>,
+        reason: &str,
+    ) -> Result<(), RowsError> {
+        let (urgency, drop_players): (i16, bool) = if aggressive { (1, true) } else { (0, false) };
+        sqlx::query(
+            "INSERT INTO fleet_restart
+                 (customerguid, active, reason, urgency, dropplayers, stagger, batchsize,
+                  lockout, lockoutapplied, startedat, draindeadline, requestid)
+             VALUES ($1, true, $2, $3, $4, false, 1, true, false, now(), $5, gen_random_uuid())
+             ON CONFLICT (customerguid) DO UPDATE SET
+                 active = true, reason = EXCLUDED.reason, urgency = EXCLUDED.urgency,
+                 dropplayers = EXCLUDED.dropplayers, draindeadline = EXCLUDED.draindeadline,
+                 lockout = true, lockoutapplied = false, startedat = now(),
+                 requestid = gen_random_uuid()",
+        )
+        .bind(customer_guid)
+        .bind(reason)
+        .bind(urgency)
+        .bind(drop_players)
+        .bind(deadline)
+        .execute(self.0)
+        .await?;
+        Ok(())
+    }
+
     /// Detects the silent-failure mode of `CREATE INDEX CONCURRENTLY`: a failed concurrent build
     /// leaves the index in an `INVALID` state that Postgres refuses to use, degrading the per-tick
     /// `list_drainable_instances` scan to a seq-scan on the hot `mapinstances` table with no error.

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -1297,6 +1297,27 @@ impl<'a> InstanceRepo<'a> {
         }
     }
 
+    /// Draining instances whose per-instance `draindeadline` has passed (aggressive fleet-restart
+    /// only stamps one). These are the force-deallocate targets for the deadline backstop.
+    /// `now` is UTC-naive to match the `DrainDeadline TIMESTAMP` column's UTC contract.
+    pub async fn list_overdue_draining_instances(
+        &self,
+        customer_guid: Uuid,
+        now: chrono::NaiveDateTime,
+    ) -> Result<Vec<i32>, RowsError> {
+        let rows: Vec<(i32,)> = sqlx::query_as(
+            "SELECT mapinstanceid FROM mapinstances
+             WHERE customerguid = $1 AND status > 0
+               AND drainstate IS NOT NULL AND draindeadline IS NOT NULL AND draindeadline < $2
+             ORDER BY mapinstanceid",
+        )
+        .bind(customer_guid)
+        .bind(now)
+        .fetch_all(self.0)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
     /// Detects the silent-failure mode of `CREATE INDEX CONCURRENTLY`: a failed concurrent build
     /// leaves the index in an `INVALID` state that Postgres refuses to use, degrading the per-tick
     /// `list_drainable_instances` scan to a seq-scan on the hot `mapinstances` table with no error.

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -1232,6 +1232,71 @@ impl<'a> InstanceRepo<'a> {
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
 
+    /// Writes the tenant's `admission_control` row (Phase 2's shared new-join lockout).
+    /// `Some(false)` sets the lockout; `None` writes SQL `NULL`, which makes admission fall back
+    /// to the env baseline — i.e. `None` lifts the lockout. The table is shared with other writers
+    /// (maintenance/abuse flows), so the fleet-restart reconcile must only lift a lockout it set —
+    /// ownership is tracked on `fleet_restart.lockoutapplied` via [`Self::set_fleet_lockout_applied`].
+    pub async fn set_admission(
+        &self,
+        customer_guid: Uuid,
+        accept_new_joins: Option<bool>,
+    ) -> Result<(), RowsError> {
+        sqlx::query(
+            "INSERT INTO admission_control (customerguid, acceptnewjoins)
+             VALUES ($1, $2)
+             ON CONFLICT (customerguid) DO UPDATE SET acceptnewjoins = EXCLUDED.acceptnewjoins",
+        )
+        .bind(customer_guid)
+        .bind(accept_new_joins)
+        .execute(self.0)
+        .await?;
+        Ok(())
+    }
+
+    /// Lockout-ownership flag: true while THIS restart holds the admission lockout, so the
+    /// reconcile only lifts what it set (never clobbers another writer's `admission_control` row).
+    /// No-op if the row is absent; degrades on 42P01 (feature dark — nothing to track).
+    pub async fn set_fleet_lockout_applied(
+        &self,
+        customer_guid: Uuid,
+        applied: bool,
+    ) -> Result<(), RowsError> {
+        let result = sqlx::query(
+            "UPDATE fleet_restart SET lockoutapplied = $2 WHERE customerguid = $1",
+        )
+        .bind(customer_guid)
+        .bind(applied)
+        .execute(self.0)
+        .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_undefined_table(&e) => Ok(()), // feature dark — nothing to track
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Sets `fleet_restart.lockout` (degrade on 42P01). Used by the non-aggressive stall-SLA
+    /// auto-lift to stop the reconcile re-applying the lockout while the restart stays active.
+    pub async fn set_fleet_lockout(
+        &self,
+        customer_guid: Uuid,
+        lockout: bool,
+    ) -> Result<(), RowsError> {
+        let result = sqlx::query(
+            "UPDATE fleet_restart SET lockout = $2 WHERE customerguid = $1",
+        )
+        .bind(customer_guid)
+        .bind(lockout)
+        .execute(self.0)
+        .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_undefined_table(&e) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Detects the silent-failure mode of `CREATE INDEX CONCURRENTLY`: a failed concurrent build
     /// leaves the index in an `INVALID` state that Postgres refuses to use, degrading the per-tick
     /// `list_drainable_instances` scan to a seq-scan on the hot `mapinstances` table with no error.

--- a/apps/rows/src/rest/mod.rs
+++ b/apps/rows/src/rest/mod.rs
@@ -95,6 +95,35 @@ pub async fn root() -> Json<serde_json::Value> {
     responses((status = 200, description = "Health check", body = HealthResponse))
 )]
 pub async fn health(State(hs): State<HandlerState>) -> Json<HealthResponse> {
+    // Authoritative version from the DB-backed deploy_state (survives ROWS restarts; the launcher
+    // needs the target BEFORE any server connects). Degrades to the in-memory ReportBuild value on
+    // 42P01/absent row, and never fails the probe over a deploy_state read error —
+    // `deploy_healthy:true` is the degrade default.
+    let deploy = crate::repo::InstanceRepo(&hs.app.db)
+        .get_deploy_state(hs.app.config.customer_guid)
+        .await
+        .unwrap_or_default();
+    let (unreal_version, pending_version, deploy_healthy, failing_version) = match deploy {
+        Some(ds) => {
+            let healthy = ds.health != "unhealthy";
+            let failing = (!healthy).then(|| ds.target_version.clone());
+            if ds.rolled {
+                (Some(ds.target_version), None, healthy, failing)
+            } else {
+                // Update pending: the served version isn't in deploy_state (single row), so fall
+                // back to the in-memory GameServer-reported value for the served build.
+                let served = hs.app.server_build_version.read().unwrap().clone();
+                (served, Some(ds.target_version), healthy, failing)
+            }
+        }
+        None => (
+            hs.app.server_build_version.read().unwrap().clone(),
+            None,
+            true,
+            None,
+        ),
+    };
+
     Json(HealthResponse {
         status: "healthy",
         service: "rows",
@@ -102,7 +131,10 @@ pub async fn health(State(hs): State<HandlerState>) -> Json<HealthResponse> {
         uptime_seconds: hs.app.started_at.elapsed().as_secs(),
         active_sessions: hs.app.sessions.len(),
         active_instances: hs.app.zone_servers.len(),
-        unreal_version: hs.app.server_build_version.read().unwrap().clone(),
+        unreal_version,
+        pending_version,
+        deploy_healthy,
+        failing_version,
     })
 }
 

--- a/apps/rows/src/rest/mod.rs
+++ b/apps/rows/src/rest/mod.rs
@@ -64,6 +64,7 @@ pub fn router(app: Arc<AppState>, svc: Arc<OWSService>) -> Router {
     let zones = zones::zones_routes(hs.clone());
     let management = management::management_routes(hs.clone());
     let system = system::system_routes(hs.clone());
+    let fleet_restart = system::fleet_restart_routes(hs.clone());
 
     Router::new()
         .route("/", get(root))
@@ -77,6 +78,7 @@ pub fn router(app: Arc<AppState>, svc: Arc<OWSService>) -> Router {
         .merge(zones)
         .merge(management)
         .merge(system)
+        .merge(fleet_restart)
 }
 
 #[utoipa::path(get, path = "/", tag = "health",

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -432,11 +432,23 @@ pub async fn report_build(
         return Json(serde_json::json!({ "success": false, "error": "version required" }));
     }
 
-    let mut current = hs.app.server_build_version.write().unwrap();
-    if current.as_deref() != Some(version) {
-        tracing::info!(version, "Gameserver reported loaded UE build version");
+    {
+        let mut current = hs.app.server_build_version.write().unwrap();
+        if current.as_deref() != Some(version) {
+            tracing::info!(version, "Gameserver reported loaded UE build version");
+        }
+        *current = Some(version.to_string());
     }
-    *current = Some(version.to_string());
+
+    // One-shot deploy_state seed (ON CONFLICT DO NOTHING): keeps /health.unreal_version non-null
+    // before the first orchestrated roll ever writes rolled=true. Never overwrites a real roll or
+    // a pending update; best-effort (a failure just leaves the in-memory fallback).
+    if let Err(e) = crate::repo::InstanceRepo(&hs.app.db)
+        .seed_deploy_state(hs.app.config.customer_guid, version)
+        .await
+    {
+        tracing::warn!(error = %e, "ReportBuild: deploy_state seed failed (non-fatal)");
+    }
 
     Json(serde_json::json!({ "success": true, "version": version }))
 }

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -42,11 +42,42 @@ pub fn system_routes(hs: HandlerState) -> Router {
 pub fn fleet_restart_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/fleet-restart/status", get(fleet_restart_status))
+        .route("/fleet-restart/pending", get(fleet_restart_pending))
+        .route(
+            "/fleet-restart/trigger",
+            axum::routing::post(fleet_restart_trigger),
+        )
         .layer(middleware::from_fn_with_state(
             hs.clone(),
             require_customer_guid,
         ))
         .with_state(hs)
+}
+
+/// App-level auth for the MUTATING fleet-restart route (HIGH-1). The gateway holds
+/// `ROWS_FLEET_RESTART_TOKEN` (from the ows sealed-secret set); GameServers do NOT — a
+/// NetworkPolicy cannot keep them off this path (same port 4322, and policies can't filter by
+/// HTTP path). Fails closed: unset/empty env ⇒ every caller is rejected 401.
+fn fleet_restart_token_ok(headers: &HeaderMap) -> bool {
+    let Ok(expected) = std::env::var("ROWS_FLEET_RESTART_TOKEN") else {
+        return false;
+    };
+    if expected.is_empty() {
+        return false;
+    }
+    let presented = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+    // Constant-time-ish compare: length check then byte fold, so a prefix match doesn't
+    // short-circuit early.
+    presented.len() == expected.len()
+        && presented
+            .bytes()
+            .zip(expected.bytes())
+            .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+            == 0
 }
 
 /// TTL for the cached Agones GameServer count behind `/fleet-restart/status`. The DB counts are
@@ -128,6 +159,166 @@ pub async fn fleet_restart_status(
         safe_to_roll,
         stalled,
     }))
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct FleetRestartPending {
+    /// A merged-but-not-rolled update exists (`deploy_state.rolled=false`).
+    pub pending: bool,
+    /// The pending version, when `pending=true`.
+    pub target_version: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/fleet-restart/pending",
+    tag = "system",
+    summary = "Is a version update pending?",
+    description = "pending=true when deploy_state has rolled=false. Gates the aggressive trigger (and the dashboard button). Cluster-internal only.",
+    responses((status = 200, description = "Pending-update state", body = FleetRestartPending)),
+)]
+pub async fn fleet_restart_pending(
+    State(hs): State<HandlerState>,
+) -> Result<Json<FleetRestartPending>, crate::error::RowsError> {
+    let ds = crate::repo::InstanceRepo(&hs.app.db)
+        .get_deploy_state(hs.app.config.customer_guid)
+        .await?;
+    let (pending, target_version) = match ds {
+        Some(ds) if !ds.rolled => (true, Some(ds.target_version)),
+        _ => (false, None),
+    };
+    Ok(Json(FleetRestartPending {
+        pending,
+        target_version,
+    }))
+}
+
+/// Default aggressive grace window (seconds) when the trigger body omits `grace_secs`.
+const FLEET_RESTART_DEFAULT_GRACE_SECS: i64 = 300;
+
+#[utoipa::path(
+    post,
+    path = "/fleet-restart/trigger",
+    tag = "system",
+    summary = "Trigger a coordinated fleet restart",
+    description = "Upserts the fleet_restart control row. aggressive: urgency=1, dropplayers=true, deadline=now()+grace_secs (default 300) — save-then-disconnect at the deadline; requires a pending update. non_aggressive: drain-to-natural-empty, never disconnects. Requires the gateway bearer token (ROWS_FLEET_RESTART_TOKEN); NOT public, NOT for GameServers.",
+    request_body(
+        description = "{ mode: \"aggressive\"|\"non_aggressive\", grace_secs?: i64 }",
+        content_type = "application/json"
+    ),
+    responses(
+        (status = 200, description = "Restart activated: { success, mode, drain_deadline? }"),
+        (status = 400, description = "Invalid mode / grace_secs"),
+        (status = 401, description = "Missing/invalid gateway token"),
+        (status = 404, description = "Aggressive mode with no pending update"),
+        (status = 409, description = "A restart is already active"),
+    ),
+)]
+pub async fn fleet_restart_trigger(
+    State(hs): State<HandlerState>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    if !fleet_restart_token_ok(&headers) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "fleet-restart trigger requires the gateway bearer token",
+            })),
+        )
+            .into_response();
+    }
+
+    let mode = body.get("mode").and_then(|v| v.as_str()).unwrap_or("");
+    let aggressive = match mode {
+        "aggressive" => true,
+        "non_aggressive" => false,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": "mode must be \"aggressive\" or \"non_aggressive\"",
+                })),
+            )
+                .into_response();
+        }
+    };
+    let grace_secs = body
+        .get("grace_secs")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(FLEET_RESTART_DEFAULT_GRACE_SECS);
+    if aggressive && grace_secs <= 0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "grace_secs must be > 0",
+            })),
+        )
+            .into_response();
+    }
+
+    let guid = hs.app.config.customer_guid;
+    let repo = crate::repo::InstanceRepo(&hs.app.db);
+
+    // One restart at a time: a re-trigger mid-drain would silently reset the stall clock and
+    // (aggressive) re-arm the deadline; make the operator clear or finish the active one first.
+    match repo.get_fleet_restart(guid).await {
+        Ok(Some(fr)) if fr.active => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": "a fleet restart is already active",
+                })),
+            )
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => return e.into_response(),
+    }
+
+    // The aggressive path exists to *deploy a pending update* — you can't restart-to-deploy with
+    // nothing to deploy (this narrows WHEN it fires; the token above controls WHO).
+    if aggressive {
+        match repo.get_deploy_state(guid).await {
+            Ok(Some(ds)) if !ds.rolled => {}
+            Ok(_) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({
+                        "success": false,
+                        "error": "no pending update — aggressive restart refused",
+                    })),
+                )
+                    .into_response();
+            }
+            Err(e) => return e.into_response(),
+        }
+    }
+
+    let deadline = aggressive.then(|| chrono::Utc::now() + chrono::Duration::seconds(grace_secs));
+    let reason = if aggressive {
+        "fleet-restart:aggressive"
+    } else {
+        "fleet-restart:non_aggressive"
+    };
+    if let Err(e) = repo.set_fleet_restart(guid, aggressive, deadline, reason).await {
+        return e.into_response();
+    }
+
+    tracing::info!(mode, grace_secs = aggressive.then_some(grace_secs), "fleet-restart triggered via API");
+    Json(serde_json::json!({
+        "success": true,
+        "mode": mode,
+        "drain_deadline": deadline.map(|d| d.to_rfc3339()),
+    }))
+    .into_response()
 }
 
 #[utoipa::path(

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -33,6 +33,103 @@ pub fn system_routes(hs: HandlerState) -> Router {
         .with_state(hs)
 }
 
+/// Fleet-restart routes. SECURITY POSTURE (HIGH-1): these are served on the same port (4322) every
+/// GameServer already reaches, and a NetworkPolicy filters by pod-selector + port, never HTTP path
+/// — so "cluster-internal" is NOT an access control here. The read routes (`status`, `pending`)
+/// are tolerable for any in-cluster caller; the mutating `trigger` route additionally requires the
+/// gateway-held bearer token (`ROWS_FLEET_RESTART_TOKEN`, from the ows sealed-secret set) that
+/// GameServers do NOT hold — see `require_fleet_restart_token`. Keep these off any public Ingress.
+pub fn fleet_restart_routes(hs: HandlerState) -> Router {
+    Router::new()
+        .route("/fleet-restart/status", get(fleet_restart_status))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
+        .with_state(hs)
+}
+
+/// TTL for the cached Agones GameServer count behind `/fleet-restart/status`. The DB counts are
+/// cheap; only the Agones LIST needs the cache (this cluster has a documented apiserver/etcd
+/// pressure history). Orchestrators should poll no faster than every 5s.
+const GS_COUNT_TTL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Agones GameServer count, cached for `GS_COUNT_TTL` (shared across callers). `None` = Agones
+/// unavailable or the LIST failed — callers must FAIL CLOSED (report not-safe-to-roll), never
+/// treat unknown as zero.
+async fn cached_gameserver_count(hs: &HandlerState) -> Option<i64> {
+    if let Some((at, n)) = *hs.app.gs_count_cache.lock().unwrap() {
+        if at.elapsed() < GS_COUNT_TTL {
+            return Some(n);
+        }
+    }
+    let agones = hs.app.agones.as_ref()?;
+    match agones.count_gameservers().await {
+        Ok(n) => {
+            *hs.app.gs_count_cache.lock().unwrap() = Some((Instant::now(), n));
+            Some(n)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "fleet-restart: gameserver count failed");
+            None
+        }
+    }
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct FleetRestartStatus {
+    /// A `fleet_restart` row is active for this tenant.
+    pub active: bool,
+    /// DB-level count of instances still `status > 0` (the *necessary* barrier level).
+    pub draining: i64,
+    /// Agones GameServer objects still present, any state (the *sufficient* barrier level).
+    /// `-1` = Agones unavailable/LIST failed — unknown, never treated as zero.
+    pub gameservers: i64,
+    /// `active && draining == 0` — the DB says every instance is gone; begin the cutover.
+    pub all_drained: bool,
+    /// `all_drained && gameservers == 0` — every old pod is actually gone; safe to roll.
+    pub safe_to_roll: bool,
+    /// Non-aggressive stall backstop: `active && draining > 0` past the stall SLA. The alertable
+    /// "drain not converging — check empty_server_reaper" signal.
+    pub stalled: bool,
+}
+
+#[utoipa::path(
+    get,
+    path = "/fleet-restart/status",
+    tag = "system",
+    summary = "Fleet-restart drain status + two-level safe-to-roll barrier",
+    description = "DB draining count (necessary) + Agones GameServer count (sufficient). safe_to_roll only when both hit 0 while a restart is active. Poll cadence >= 5s (the GS count is cached ~5s). Cluster-internal only.",
+    responses((status = 200, description = "Fleet-restart status", body = FleetRestartStatus)),
+)]
+pub async fn fleet_restart_status(
+    State(hs): State<HandlerState>,
+) -> Result<Json<FleetRestartStatus>, crate::error::RowsError> {
+    let guid = hs.app.config.customer_guid;
+    let repo = crate::repo::InstanceRepo(&hs.app.db);
+    let fr = repo.get_fleet_restart(guid).await?;
+    let active = matches!(&fr, Some(fr) if fr.active);
+    let draining = repo.count_active_instances(guid).await?;
+    // Fail closed on an unknown GS count: -1 can never satisfy `== 0`.
+    let gameservers = cached_gameserver_count(&hs).await.unwrap_or(-1);
+    let all_drained = active && draining == 0;
+    let safe_to_roll = all_drained && gameservers == 0;
+    let stalled = fr.as_ref().is_some_and(|fr| {
+        fr.active
+            && draining > 0
+            && (chrono::Utc::now() - fr.started_at).num_seconds()
+                > hs.app.config.fleet_restart_stall_secs
+    });
+    Ok(Json(FleetRestartStatus {
+        active,
+        draining,
+        gameservers,
+        all_drained,
+        safe_to_roll,
+        stalled,
+    }))
+}
+
 #[utoipa::path(
     get,
     path = "/api/System/FleetStatus",

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -550,14 +550,51 @@ pub async fn restart_game_server(
     ),
     responses(
         (status = 200, description = "{ success: bool, message?: string, error?: string }"),
+        (status = 409, description = "A cooperative fleet restart is active — refused (use the fleet-restart flow)"),
+        (status = 503, description = "Could not verify the fleet_restart control row — refused (fail closed)"),
     )
 )]
 pub async fn restart_fleet(
     State(hs): State<HandlerState>,
     Json(body): Json<serde_json::Value>,
-) -> Json<serde_json::Value> {
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
     let customer_guid = hs.app.config.customer_guid;
     let desired_replicas = body.get("replicas").and_then(|v| v.as_i64()).unwrap_or(2) as i32;
+
+    // The cooperative fleet-restart flow supersedes this imperative scale-to-0: firing it during
+    // an in-flight drain would delete instances out from under the reconcile AND force-drop every
+    // player a non-aggressive drain promised not to touch. Refuse while a restart is active; this
+    // stays available as a break-glass once the restart row is cleared (active=false).
+    match crate::repo::InstanceRepo(&hs.app.db)
+        .get_fleet_restart(customer_guid)
+        .await
+    {
+        Ok(Some(fr)) if fr.active => {
+            return (
+                axum::http::StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": "A cooperative fleet restart is active — use the fleet-restart flow \
+                              (or clear it with active=false) instead of the legacy RestartFleet",
+                })),
+            )
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => {
+            // Fail closed: if we can't read the control row we can't prove no drain is in flight.
+            return (
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Cannot verify no cooperative restart is active: {e}"),
+                })),
+            )
+                .into_response();
+        }
+    }
 
     if let Some(ref agones) = hs.app.agones {
         tracing::info!("RestartFleet: scaling to 0");
@@ -565,7 +602,8 @@ pub async fn restart_fleet(
             return Json(serde_json::json!({
                 "success": false,
                 "error": format!("Failed to scale fleet to 0: {e}")
-            }));
+            }))
+            .into_response();
         }
 
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -576,7 +614,8 @@ pub async fn restart_fleet(
         return Json(serde_json::json!({
             "success": false,
             "error": format!("Failed to clean DB: {e}")
-        }));
+        }))
+        .into_response();
     }
     if let Err(e) = repo.deactivate_all_world_servers(customer_guid).await {
         tracing::warn!(error = %e, "Failed to deactivate world servers");
@@ -591,7 +630,8 @@ pub async fn restart_fleet(
             return Json(serde_json::json!({
                 "success": false,
                 "error": format!("DB cleaned but failed to scale fleet back up: {e}. Manual scale needed.")
-            }));
+            }))
+            .into_response();
         }
     }
 
@@ -608,6 +648,7 @@ pub async fn restart_fleet(
         "success": true,
         "message": format!("Fleet restarted. Scaled 0 → {desired_replicas}. DB cleaned.")
     }))
+    .into_response()
 }
 
 #[utoipa::path(

--- a/apps/rows/src/state.rs
+++ b/apps/rows/src/state.rs
@@ -33,6 +33,10 @@ pub struct AppState {
     /// UE5 build version loaded off the `ows-server-build` PVC, reported by each gameserver on
     /// boot via `POST /api/System/ReportBuild`. `None` until a gameserver checks in.
     pub server_build_version: std::sync::RwLock<Option<String>>,
+    /// Short-TTL cache for the Agones GameServer count behind `/fleet-restart/status`
+    /// (`(fetched_at, count)`), shared across callers so an orchestrator polling the endpoint
+    /// doesn't turn into a kube-apiserver LIST per request.
+    pub gs_count_cache: std::sync::Mutex<Option<(Instant, i64)>>,
 }
 
 pub struct AppConfig {
@@ -153,6 +157,7 @@ impl AppStateBuilder {
             instance_log: crate::rest::system::InstanceEventLog::new(),
             started_at: Instant::now(),
             server_build_version: std::sync::RwLock::new(None),
+            gs_count_cache: std::sync::Mutex::new(None),
         }))
     }
 }

--- a/apps/rows/src/state.rs
+++ b/apps/rows/src/state.rs
@@ -46,6 +46,9 @@ pub struct AppConfig {
     /// Env baseline for the new-join admission gate (`ROWS_ACCEPT_NEW_JOINS`, default `true`). The
     /// join path combines this with the per-scope `admission_control` overrides.
     pub accept_new_joins: bool,
+    /// Non-aggressive fleet-restart stall SLA in seconds (`ROWS_FLEET_RESTART_STALL_SECS`, default
+    /// 1800). Past this the restart is `stalled`; past 2× the reconcile auto-lifts the join lockout.
+    pub fleet_restart_stall_secs: i64,
 }
 
 impl AppState {
@@ -66,6 +69,7 @@ pub struct AppStateBuilder {
     agones: Option<AgonesClient>,
     reaper: Option<ReaperKnobs>,
     accept_new_joins: Option<bool>,
+    fleet_restart_stall_secs: Option<i64>,
 }
 
 impl AppStateBuilder {
@@ -115,6 +119,11 @@ impl AppStateBuilder {
         self
     }
 
+    pub fn fleet_restart_stall_secs(mut self, secs: i64) -> Self {
+        self.fleet_restart_stall_secs = Some(secs);
+        self
+    }
+
     pub fn build(self) -> anyhow::Result<Arc<AppState>> {
         let tenant = self
             .tenant
@@ -136,6 +145,7 @@ impl AppStateBuilder {
                 agones_fleet: self.agones_fleet.unwrap_or_else(|| "ows-hubworld".into()),
                 reaper: self.reaper.unwrap_or_default(),
                 accept_new_joins: self.accept_new_joins.unwrap_or(true),
+                fleet_restart_stall_secs: self.fleet_restart_stall_secs.unwrap_or(1800),
             },
             mq: self.mq,
             agones: self.agones,

--- a/docs/superpowers/plans/2026-06-24-rows-config-and-docs-index.md
+++ b/docs/superpowers/plans/2026-06-24-rows-config-and-docs-index.md
@@ -97,7 +97,12 @@ marked 🕳️ are unpinned — see [ue-chuck-drain-contract](./2026-06-24-ue-ch
 |---|---|---|---|---|
 | `ROWS_DRAIN_GRACE_SECS` | u64 | `8` | **live** (`main.rs`, process shutdown grace) | lifecycle-spec |
 | `ROWS_ACCEPT_NEW_JOINS` | bool | — | proposed | [drain-core](./2026-06-24-rows-drain-core.md) |
-| `fleet_restart` control row (`active`/`reason`/`urgency`/`drop_players`/`stagger`/`batchsize`/`lockout`/`targetversion`/`requestid`) | DB table | safe-by-default (`urgency=0 when_able`, `dropplayers=false`) | proposed | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
+| `ROWS_FLEET_RESTART_STALL_SECS` | i64 | `1800` | **shipped (inert)** — non-aggressive stall SLA; `stalled=true` past it, lockout auto-lift past 2× | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
+| `ROWS_FLEET_RESTART_TOKEN` | string | unset (**fail closed**: trigger 401s) | **shipped** — gateway-held bearer token for `POST /fleet-restart/trigger`; GameServers must NOT hold it | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
+| `fleet_restart` control row (`active`/`reason`/`urgency`/`dropplayers`/`stagger`/`batchsize`/`lockout`/`lockoutapplied`/`startedat`/`draindeadline`/`targetversion`/`requestid`) | DB table (migration `20260629120000`) | safe-by-default, DB-enforced (`chk_safe_default`, `chk_deadline_aggr`) | **shipped (inert)** — clear with `active=false`, never DELETE | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
+| `deploy_state` (`targetversion`/`rolled`/`health`) | DB table (migration `20260629130000`) | seeded one-shot by ReportBuild | **shipped (inert)** — backs `/health` version + `/fleet-restart/pending` | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
+| `GET /fleet-restart/status` | REST (4322, cluster-internal) | — | **shipped** — `{active, draining, gameservers, all_drained, safe_to_roll, stalled}`; poll ≥5s (GS count cached ~5s); `gameservers:-1` = unknown, fail closed | lifecycle-spec runbook |
+| `GET /fleet-restart/pending` / `POST /fleet-restart/trigger` | REST (4322; trigger token-authed) | trigger grace default 300s | **shipped** — trigger 404s unless an update is pending; 409 while a restart is active | lifecycle-spec runbook |
 | drain request schema (`reason`/`urgency`/`drop_players`/`deadline`/`request_id`) | annotations | — | 🕳️ unpinned | [drain-fleet-restart](./2026-06-24-rows-drain-fleet-restart.md) |
 
 ### Restart triggers & version-parity gate (Phase 3 — proposed)
@@ -227,3 +232,7 @@ internal constants, design-stage `drain-*` knobs, and the bug ledger in this liv
 - 2026-06-24 — initial index at SHA `fdb3a44`. Catalogs reaper (PR #13200) + core/agones env, the
   `ows.reaper_config` override, Agones wire keys, and the `drain-*` proposed knobs. Recorded the
   pre-existing `ROWS_SPINUP_*` malformed-env-key bug (§5).
+- 2026-07-09 — Phase 3 (fleet-restart) shipped inert: `fleet_restart` + `deploy_state` tables,
+  `ROWS_FLEET_RESTART_STALL_SECS` / `ROWS_FLEET_RESTART_TOKEN`, `/fleet-restart/{status,pending,trigger}`
+  endpoints, `idx_mapinstances_drainable`. Operator runbook lives in the lifecycle spec
+  ("Fleet-restart — operator runbook").

--- a/docs/superpowers/plans/2026-06-24-rows-server-lifecycle-and-shutdown.md
+++ b/docs/superpowers/plans/2026-06-24-rows-server-lifecycle-and-shutdown.md
@@ -491,6 +491,89 @@ Three escalating tiers, build only what's needed:
    **Never buffer authoritative saves in valkey** (volatile; eviction/restart = data loss — it
    reintroduces the exact risk the graceful save exists to prevent).
 
+### Fleet-restart — operator runbook (Phase 3, SHIPPED inert)
+
+Shipped by the Phase 3 implementation (`fleet_restart_reconcile` in `apps/rows/src/jobs.rs`, 30s
+cadence, per-tenant advisory lock). Inert until a `fleet_restart` row goes `active=true`.
+
+**Trigger a restart (SQL):**
+
+```sql
+SET search_path TO ows;
+
+-- Routine version roll (NON-AGGRESSIVE, safe-by-default): drain-to-natural-empty, no forced
+-- disconnects. urgency=0, dropplayers=false, no draindeadline. The default path.
+-- Re-activating MUST reset startedat (the stall clock), lockoutapplied (ownership), AND lockout=true:
+-- a prior run's stage-2 auto-lift may have set lockout=false, and without the reset a re-trigger
+-- inherits lockout=false and never re-locks new joins; a stale startedat misfires the stall backstop.
+INSERT INTO fleet_restart (customerguid, active, reason, urgency, dropplayers, stagger, batchsize, lockout, requestid)
+VALUES ('<tenant-guid>', true, 'fleet-restart', 0, false, false, 1, true, gen_random_uuid())
+ON CONFLICT (customerguid) DO UPDATE SET active = true, urgency = 0, dropplayers = false,
+    draindeadline = NULL, lockout = true, startedat = now(), lockoutapplied = false, requestid = gen_random_uuid();
+
+-- Urgent / security roll (AGGRESSIVE, dashboard opt-in only): save-then-disconnect at the deadline.
+-- Prefer POST /fleet-restart/trigger (computes the deadline, requires the gateway token, and is
+-- gated on a pending update). SQL equivalent:
+-- ... DO UPDATE SET active = true, urgency = 1, dropplayers = true, draindeadline = now() + interval '5 min',
+--                   lockout = true, startedat = now(), lockoutapplied = false, requestid = gen_random_uuid();
+
+-- After safe_to_roll + deploy: clear it. The reconcile lifts the admission lockout itself on the
+-- next tick (writes acceptnewjoins = NULL) — ONLY if it owns it (lockoutapplied). Do NOT manually
+-- DELETE admission_control, and NEVER `DELETE FROM fleet_restart` — a deleted row is unreadable,
+-- so the one-shot lockout lift can't run and players stay locked out.
+UPDATE fleet_restart SET active = false WHERE customerguid = '<tenant-guid>';
+```
+
+**Lockout behaviour:** while `active && lockout`, the reconcile holds `admission_control.acceptnewjoins
+= false` and records ownership on `fleet_restart.lockoutapplied`. On clear (`active=false`) it lifts
+the lockout **once, iff it owns it** — it never clobbers a lockout another writer (maintenance /
+abuse mitigation) set. Travel is unaffected; only *new* joins are blocked.
+
+**Polling contract (`GET /fleet-restart/status`):** `{ active, draining, gameservers, all_drained,
+safe_to_roll, stalled }`. Two-level barrier: `all_drained` (DB `status>0` count == 0) is the
+*necessary* trigger to begin a cutover; `safe_to_roll` additionally requires the Agones GameServer
+count == 0 (a DB row can hit 0 while its pod is still flushing a save). `gameservers: -1` = Agones
+unknown — fail closed, never roll on it. Poll cadence ≥ 5s (the GS count is cached ~5s). Note:
+`all_drained`/`safe_to_roll` flip back to `false` the instant `active` clears — completion is
+"operator/orchestrator sets `active=false` after a confirmed scale-up," recorded durably as
+`deploy_state.rolled=true`, not a post-clear `safe_to_roll` reading. If the orchestrator dies
+between scale-up and `rolled=true`, the update re-reports pending; break-glass: manually
+`UPDATE deploy_state SET rolled = true` for a confirmed-healthy roll.
+
+**Stall behaviour operators must expect (non-aggressive; stall SLA = `ROWS_FLEET_RESTART_STALL_SECS`,
+default 1800s):**
+
+- **Stage 1** (`age(startedat) > SLA`): `/fleet-restart/status` shows `stalled=true`; a `warn!` is
+  logged. Meaning: drain isn't converging → **check `empty_server_reaper` is enabled and healthy
+  first** (only the reaper moves instances to `status=0`; `set_drain_state` rejects `state=0`).
+  Lockout still held.
+- **Stage 2** (`age > 2 × SLA`): ROWS **auto-lifts the join lockout** (an `error!` "join-outage cap
+  hit" is logged). New players can join again — on old-version instances, which is safe within a
+  version line; the roll just takes longer. The restart stays `active` + `stalled=true` (alerting
+  continues). To actually complete the roll, **escalate to aggressive** (a deadline that
+  force-deallocates) or clear the row.
+- **Aggressive:** the `draindeadline` force-deallocates overdue instances **per-GameServer** (never a
+  whole-fleet scale — that would kill instances still draining cleanly). No stage-2 auto-lift is
+  needed; the deadline drives convergence.
+
+**Legacy `POST /api/System/RestartFleet`:** refused with 409 while a restart is `active` (it would
+delete instances out from under the reconcile and force-drop every player). Break-glass only, after
+clearing the row.
+
+**Aggressive trigger API (`POST /fleet-restart/trigger`):** requires the gateway bearer token
+(`ROWS_FLEET_RESTART_TOKEN` — GameServers must NOT hold it; a NetworkPolicy can't keep them off the
+path since they share port 4322), and 404s unless `deploy_state` reports an update pending
+(`GET /fleet-restart/pending`).
+
+**Index health:** the drainable scan is backed by `idx_mapinstances_drainable` (built
+`CONCURRENTLY`). An interrupted build strands an INVALID index Postgres silently ignores; ROWS
+checks `pg_index.indisvalid` at startup and warns. Recovery: `DROP INDEX CONCURRENTLY
+ows.idx_mapinstances_drainable;` then re-run dbmate up.
+
+**Orchestrator handoff:** ROWS only *signals* (`safe_to_roll`); the named deploy orchestrator (R3,
+blocked on the chuck login-crash) sequences drain → barrier → scale-to-0 `maxSurge:0` cutover →
+migration → scale-up → soak → `deploy_state.rolled=true`. Until it exists, that sequence is manual.
+
 ## Drain state representation
 
 Lean toward dedicated columns on `mapinstances` (keeps the existing `status` 0/1/2 semantics intact):

--- a/packages/data/sql/dbmate/migrations/20260629120000_ows_fleet_restart.sql
+++ b/packages/data/sql/dbmate/migrations/20260629120000_ows_fleet_restart.sql
@@ -1,0 +1,46 @@
+-- migrate:up
+SET search_path TO ows;
+
+-- Fleet-restart control row: operator/dashboard-written (like admission_control), consumed by the
+-- ROWS fleet_restart_reconcile job. One row per tenant. Active=true fans set_drain_state across
+-- active instances and (when Lockout) holds the admission lockout until the fleet drains. Inert
+-- when absent or Active=false — the feature ships dark. Clear a restart with Active=false, never
+-- DELETE (a deleted row is unreadable, so the one-shot lockout lift can't run).
+CREATE TABLE IF NOT EXISTS fleet_restart
+(
+    CustomerGUID  UUID    NOT NULL,
+    Active        BOOLEAN NOT NULL DEFAULT false,
+    Reason        TEXT    NOT NULL DEFAULT 'fleet-restart',
+    Urgency       SMALLINT NOT NULL DEFAULT 0,    -- 0 = when_able (non-aggressive); 1 = asap
+    DropPlayers   BOOLEAN NOT NULL DEFAULT false, -- aggressive paths set true explicitly
+    Stagger       BOOLEAN NOT NULL DEFAULT false,
+    BatchSize     INT     NOT NULL DEFAULT 1,
+    Lockout       BOOLEAN NOT NULL DEFAULT true, -- block new joins while active
+    LockoutApplied BOOLEAN NOT NULL DEFAULT false,-- ownership flag: true while THIS restart holds the admission lockout (so the reconcile only lifts what it set)
+    StartedAt     TIMESTAMPTZ NOT NULL DEFAULT now(), -- when this restart went active; backs the stall backstop
+    DrainDeadline TIMESTAMPTZ NULL,              -- aggressive only: force-deallocate overdue instances past this; NULL on the non-aggressive path (never forces)
+    TargetVersion TEXT    NULL,                  -- reserved (version-selective drain; deferred)
+    RequestID     UUID    NOT NULL,
+    CONSTRAINT PK_FleetRestart PRIMARY KEY (CustomerGUID),
+    CONSTRAINT chk_urgency CHECK (Urgency IN (0,1)),
+    -- Safe-by-default is a HARD invariant. Column defaults alone don't stop a hand-written /
+    -- partial-upsert row like (urgency=0, dropplayers=true) from force-disconnecting on the
+    -- "non-aggressive" path. Make it structural: force-disconnect and a deadline require aggressive.
+    CONSTRAINT chk_safe_default   CHECK (Urgency = 1 OR DropPlayers = false),
+    CONSTRAINT chk_deadline_aggr  CHECK (DrainDeadline IS NULL OR Urgency = 1)
+);
+
+-- Security: mirror the ows-table pattern — block anon/authenticated/public, full access for the
+-- ows + service_role roles. NOTE: these USING(true) policies provide no tenant isolation; that is
+-- acceptable only because ROWS is single-tenant-per-deployment (customer_guid comes from config).
+ALTER TABLE fleet_restart ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fleet_restart FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON fleet_restart FROM anon, authenticated, PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON fleet_restart TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON fleet_restart TO ows;
+CREATE POLICY ows_access ON fleet_restart FOR ALL TO ows USING (true) WITH CHECK (true);
+CREATE POLICY service_role_access ON fleet_restart FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- migrate:down
+SET search_path TO ows;
+DROP TABLE IF EXISTS fleet_restart;

--- a/packages/data/sql/dbmate/migrations/20260629120100_ows_mapinstances_drainable_index.sql
+++ b/packages/data/sql/dbmate/migrations/20260629120100_ows_mapinstances_drainable_index.sql
@@ -1,0 +1,24 @@
+-- migrate:up transaction:false
+-- NB: no `SET search_path` here. With transaction:false dbmate sends the body as one batch, and a
+-- multi-statement batch runs as an implicit transaction block — which CREATE INDEX CONCURRENTLY
+-- rejects. The CONCURRENTLY statement must be the only statement, so the schema is qualified inline.
+--
+-- Backs the fleet-restart reconcile's per-tick `list_drainable_instances` scan
+-- (`WHERE customerguid = $1 AND status > 0 AND drainstate IS NULL ORDER BY mapinstanceid`).
+-- `mapinstances` is a hot table (spin-up/teardown write it constantly), so a plain CREATE INDEX
+-- would take a write-blocking SHARE lock for the whole build; CONCURRENTLY avoids that.
+--
+-- RECOVERY NOTE: a CONCURRENTLY build that is interrupted leaves an INVALID index behind that
+-- Postgres silently refuses to use (the scan degrades to a seq-scan with no error). Because of
+-- `IF NOT EXISTS`, a re-run sees the name already present and SKIPS the rebuild. ROWS detects this
+-- at startup via pg_index.indisvalid and logs a warn (repo::check_drainable_index_valid). Recovery:
+--     -- confirm it is invalid:
+--     SELECT c.relname FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+--       JOIN pg_namespace n ON n.oid = c.relnamespace
+--       WHERE NOT i.indisvalid AND c.relname = 'idx_mapinstances_drainable' AND n.nspname = 'ows';
+--     DROP INDEX CONCURRENTLY IF EXISTS ows.idx_mapinstances_drainable;  -- then re-run dbmate up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mapinstances_drainable
+    ON ows.MapInstances (CustomerGUID, Status, DrainState);
+
+-- migrate:down transaction:false
+DROP INDEX CONCURRENTLY IF EXISTS ows.idx_mapinstances_drainable;

--- a/packages/data/sql/dbmate/migrations/20260629130000_ows_deploy_state.sql
+++ b/packages/data/sql/dbmate/migrations/20260629130000_ows_deploy_state.sql
@@ -1,0 +1,35 @@
+-- migrate:up
+SET search_path TO ows;
+
+-- Rollout state, one row per tenant: the authoritative server version target (a PVC path version,
+-- not an image tag) plus rollout health. Written rolled=false by the post-publish gate when a new
+-- version merges; rolled=true by the deploy orchestrator only after a healthy soak;
+-- health='unhealthy' on a failed soak (surfaced on /health as deploy_healthy:false). Read by
+-- /health (unreal_version = the launcher's download target) and /fleet-restart/pending.
+--
+-- SEED NOTE: the tenant guid is not known at migration time (it is per-deployment env), so the
+-- "seed the currently-served version" requirement is met by a one-shot ROWS upsert instead: the
+-- ReportBuild path upserts (guid, reported_version, rolled=true) ON CONFLICT DO NOTHING, so the
+-- row exists as soon as a GameServer checks in and never overwrites a real roll.
+CREATE TABLE IF NOT EXISTS deploy_state
+(
+    CustomerGUID  UUID    NOT NULL,
+    TargetVersion TEXT    NOT NULL,
+    Rolled        BOOLEAN NOT NULL DEFAULT false,
+    Health        TEXT    NOT NULL DEFAULT 'healthy',
+    UpdatedAt     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT PK_DeployState PRIMARY KEY (CustomerGUID),
+    CONSTRAINT chk_health CHECK (Health IN ('healthy','unhealthy'))
+);
+
+ALTER TABLE deploy_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deploy_state FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON deploy_state FROM anon, authenticated, PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON deploy_state TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON deploy_state TO ows;
+CREATE POLICY ows_access ON deploy_state FOR ALL TO ows USING (true) WITH CHECK (true);
+CREATE POLICY service_role_access ON deploy_state FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- migrate:down
+SET search_path TO ows;
+DROP TABLE IF EXISTS deploy_state;

--- a/packages/data/sql/schema/ows/deploy_state.sql
+++ b/packages/data/sql/schema/ows/deploy_state.sql
@@ -1,0 +1,27 @@
+-- OWS Schema: deploy_state
+-- Rollout state, one row per tenant: the authoritative server version target (a PVC path version,
+-- not an image tag) plus rollout health. rolled=false = update pending (post-publish merge);
+-- rolled=true = served (set by the orchestrator after a healthy soak, or by the one-shot
+-- ReportBuild seed); health='unhealthy' = failed soak, surfaced on /health as deploy_healthy:false.
+SET search_path TO ows;
+
+CREATE TABLE deploy_state
+(
+    CustomerGUID  UUID    NOT NULL,
+    TargetVersion TEXT    NOT NULL,
+    Rolled        BOOLEAN NOT NULL DEFAULT false,
+    Health        TEXT    NOT NULL DEFAULT 'healthy',
+    UpdatedAt     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT PK_DeployState
+        PRIMARY KEY (CustomerGUID),
+    CONSTRAINT chk_health CHECK (Health IN ('healthy','unhealthy'))
+);
+
+-- Security: deploy_state
+ALTER TABLE deploy_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deploy_state FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON deploy_state FROM anon, authenticated, PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON deploy_state TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON deploy_state TO ows;
+CREATE POLICY ows_access ON deploy_state FOR ALL TO ows USING (true) WITH CHECK (true);
+CREATE POLICY service_role_access ON deploy_state FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/packages/data/sql/schema/ows/fleet_restart.sql
+++ b/packages/data/sql/schema/ows/fleet_restart.sql
@@ -1,0 +1,39 @@
+-- OWS Schema: fleet_restart
+-- Fleet-restart control row: operator/dashboard-written (like admission_control), consumed by the
+-- ROWS fleet_restart_reconcile job. One row per tenant. Active=true fans set_drain_state across
+-- active instances and (when Lockout) holds the admission lockout until the fleet drains. Inert
+-- when absent or Active=false. Clear with Active=false, never DELETE (the one-shot lockout lift
+-- needs a readable row).
+SET search_path TO ows;
+
+CREATE TABLE fleet_restart
+(
+    CustomerGUID  UUID    NOT NULL,
+    Active        BOOLEAN NOT NULL DEFAULT false,
+    Reason        TEXT    NOT NULL DEFAULT 'fleet-restart',
+    Urgency       SMALLINT NOT NULL DEFAULT 0,    -- 0 = when_able (non-aggressive); 1 = asap
+    DropPlayers   BOOLEAN NOT NULL DEFAULT false, -- aggressive paths set true explicitly
+    Stagger       BOOLEAN NOT NULL DEFAULT false,
+    BatchSize     INT     NOT NULL DEFAULT 1,
+    Lockout       BOOLEAN NOT NULL DEFAULT true, -- block new joins while active
+    LockoutApplied BOOLEAN NOT NULL DEFAULT false,-- ownership: true while THIS restart holds the admission lockout
+    StartedAt     TIMESTAMPTZ NOT NULL DEFAULT now(), -- stall-backstop clock
+    DrainDeadline TIMESTAMPTZ NULL,              -- aggressive only; NULL = never force
+    TargetVersion TEXT    NULL,                  -- reserved (version-selective drain; deferred)
+    RequestID     UUID    NOT NULL,
+    CONSTRAINT PK_FleetRestart
+        PRIMARY KEY (CustomerGUID),
+    CONSTRAINT chk_urgency CHECK (Urgency IN (0,1)),
+    -- Safe-by-default, structurally: force-disconnect and a deadline require aggressive.
+    CONSTRAINT chk_safe_default   CHECK (Urgency = 1 OR DropPlayers = false),
+    CONSTRAINT chk_deadline_aggr  CHECK (DrainDeadline IS NULL OR Urgency = 1)
+);
+
+-- Security: fleet_restart
+ALTER TABLE fleet_restart ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fleet_restart FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON fleet_restart FROM anon, authenticated, PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON fleet_restart TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON fleet_restart TO ows;
+CREATE POLICY ows_access ON fleet_restart FOR ALL TO ows USING (true) WITH CHECK (true);
+CREATE POLICY service_role_access ON fleet_restart FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
Implements Phase 3 of the ROWS drain plan (docs/superpowers/plans/2026-06-24-rows-drain-fleet-restart.md, updated in #13575): DB-backed coordinated fleet restart + the rollout signal surface.

## What shipped (Tasks 1–8 + R4/R5 — all inert until a control row exists)

- **`fleet_restart` control table** (`20260629120000`) — safe-by-default enforced structurally (`chk_safe_default`, `chk_deadline_aggr`); `lockoutapplied` tracks lockout ownership.
- **`deploy_state` table** (`20260629130000`) — rollout target + health; seeded one-shot from the ReportBuild path (tenant GUID isn't known at migration time, per the plan's fallback).
- **`idx_mapinstances_drainable`** (`20260629120100`, CONCURRENTLY, single-statement) + startup `indisvalid` check with loud warn.
- **`fleet_restart_reconcile` job** — 30s cadence, session advisory lock on a pinned connection (mirrors the reaper exactly, F1), owned-lockout lift (F3), aggressive per-GameServer deadline enforcement, two-stage non-aggressive stall backstop (warn at SLA, lockout auto-lift at 2×, F2/HIGH-2).
- **`GET /fleet-restart/status`** — two-level barrier (`all_drained` = DB count 0; `safe_to_roll` also requires Agones GS count 0), GS count cached ~5s (F5), `gameservers:-1` = unknown → fail closed, `stalled` signal.
- **`/health`** now reports the authoritative served version from `deploy_state` (launcher download target; explicit `null` = maintenance-hold), plus `pending_version`, `deploy_healthy`, `failing_version`. `/ready` untouched.
- **Legacy `RestartFleet`** refuses (409) while a cooperative restart is active; 503 fail-closed if the control row is unreadable.
- **`POST /fleet-restart/trigger`** — requires gateway bearer token `ROWS_FLEET_RESTART_TOKEN` (fail-closed when unset; GameServers must not hold it — HIGH-1), 409 while active, aggressive mode 404s unless `GET /fleet-restart/pending` reports an update (R5).
- **K1 partial:** `rows-pdb` switched `minAvailable:1` → `maxUnavailable:1` (both manifests) so a single replica can never hang a node drain. Deliberately did **not** bump `replicas` in git — scaling ROWS up is a live operational decision; the job ships dark regardless.
- **Runbook** added to the lifecycle spec (trigger/clear SQL, stall stages, index recovery, orchestrator handoff) + config index registration.

## Not in this PR (per the plan's own gates)

- **R0** (version-pinned PVC delivery) — needs the PVC cross-namespace reachability check + measured save budget for TGPS.
- **R1/R2** (parity gate, migration lint/N-1 compat CI) — CI workflow changes.
- **R3** (orchestrator) — explicitly BLOCKED on the chuck login-crash (`project_chuckrpg_ready_hang`).
- DB-integration tests from the plan's test list (repo has no Postgres test harness in CI; pure-logic paths covered by the existing 61 tests).

Verified: `cargo build` + `cargo clippy` clean for apps/rows, `cargo test` 61/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)