### PR TITLE
fix(mc): chown seeded world dir so server can write session.lock

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -415,7 +415,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.65",
+			"version": "1.0.66",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.65"
+version: "1.0.66"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest

--- a/apps/mc/scripts/opac-airship-claim-access.sh
+++ b/apps/mc/scripts/opac-airship-claim-access.sh
@@ -47,6 +47,11 @@ if [ "$found" -eq 0 ]; then
 	stub="/data/${LEVEL:-world}/serverconfig/openpartiesandclaims-server.toml"
 	echo "[opac-airship] no OPAC serverconfig found — seeding stub at $stub"
 	mkdir -p "$(dirname "$stub")"
+	# This entrypoint runs as root before itzg drops to its runtime user, so
+	# the <level>/ dirs mkdir just created are root-owned. Left that way the
+	# server (uid 1000) can't write <level>/session.lock and dies with
+	# AccessDeniedException. Re-own what we created to match /data's owner.
+	chown -R --reference=/data "/data/${LEVEL:-world}" 2>/dev/null || true
 	cat > "$stub" <<EOF
 [serverConfig]
 


### PR DESCRIPTION
## Problem — fixes #14001

`CI - Docker / mc` fails at the **Nx e2e mc** step:

```
Server did not start in 300s
[main/ERROR]: Failed to start the minecraft server
java.nio.file.AccessDeniedException: ./world/session.lock
```

## Root cause

`apps/mc/scripts/opac-airship-claim-access.sh` (the OPAC-airship entrypoint) runs **as root** before itzg drops to its runtime user (uid 1000). On a **fresh world**, OPAC's `openpartiesandclaims-server.toml` doesn't exist yet, so the script takes the `found=0` branch and:

```sh
mkdir -p "/data/${LEVEL:-world}/serverconfig"   # creates /data/world owned by root
```

The Minecraft server then runs as uid 1000 and can't write `/data/world/session.lock` → `AccessDeniedException` → startup fails → the e2e times out waiting for RCON.

Deterministic on any fresh world, which is every ephemeral e2e container — not a flake. Introduced by #13994; surfaced now because the 1.0.65 e2e ran the fresh-world path.

## Fix

`chown` the seeded `<level>` tree to match `/data`'s owner, right after the `mkdir`:

```sh
chown -R --reference=/data "/data/${LEVEL:-world}" 2>/dev/null || true
```

`--reference=/data` respects itzg's `UID/GID` env instead of hardcoding 1000.

## Verification

Built a Fabric server from the real baked mod set and booted a fresh ephemeral container (the e2e scenario):

- **Before:** `/data/world` owned `root:root` → `AccessDeniedException: ./world/session.lock` → crash.
- **After:** `/data/world` owned `1000:1000` → `Done (11.6s)!`, no session.lock error, stub seeding still runs.

Bumps mc `1.0.65 → 1.0.66`.