### PR TITLE
fix(rows): unbreak Docker build — rust-version inheritance in synthetic planner root

### DIFF
--- a/apps/rows/Dockerfile
+++ b/apps/rows/Dockerfile
@@ -12,7 +12,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS pla
 ENV CARGO_INCREMENTAL=0
 
 # Create workspace
-RUN printf '[workspace]\nmembers = ["apps/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+RUN printf '[workspace]\nmembers = ["apps/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n[workspace.package]\nrust-version = "1.96"\n' > Cargo.toml
 
 # Copy all manifests + source for recipe generation
 COPY apps/rows/Cargo.toml apps/rows/Cargo.toml
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS coo
 ENV CARGO_INCREMENTAL=0
 
 # Create workspace
-RUN printf '[workspace]\nmembers = ["apps/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+RUN printf '[workspace]\nmembers = ["apps/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n[workspace.package]\nrust-version = "1.96"\n' > Cargo.toml
 
 # Copy manifests + build.rs (needed for proc macros / build scripts)
 COPY apps/rows/Cargo.toml apps/rows/Cargo.toml


### PR DESCRIPTION
## Problem

Issue #14011 — `CI - Docker / rows` fails at the cargo-chef planner stage:

\`\`\`
error inheriting \`rust-version\` from workspace root manifest's \`workspace.package.rust-version\`
\`workspace.package.rust-version\` was not defined
\`\`\`

## Root cause

- #13803 added \`rust-version.workspace = true\` to all 4 rows workspace members (rows, jedi, holy, kbve).
- The real root \`Cargo.toml\` defines \`[workspace.package] rust-version = "1.96"\`, so local builds are fine.
- But \`apps/rows/Dockerfile\` \`printf\`s a **synthetic** minimal workspace root (both planner + cook stages) containing only \`[workspace]\` members + resolver — no \`[workspace.package]\`. \`cargo chef prepare\` → \`cargo metadata\` then can't resolve the inherited \`rust-version\` and fails.
- First Docker build since #13803 → break.

## Fix

Append \`[workspace.package]\` \`rust-version = "1.96"\` to the printf'd root in both the planner and cook stages, mirroring the real workspace root. \`rust-version\` is the only key members inherit.