### PR TITLE
fix(mc): ES256 JWT verify in edge + bento redesign of /mc/

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
@@ -2,76 +2,179 @@
 title: Minecraft
 template: splash
 description: The KBVE Minecraft server — how to join, what to expect, and where to find the technical notes.
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
 sidebar:
     label: Overview
     order: 1
 tags:
     - minecraft
     - mc
+ogTitle: KBVE Minecraft — Public Fabric Server
+ogDescription: Join the KBVE Minecraft server — a public Fabric 1.21.11 world with performance mods, old-combat PvP, and a Rust-powered AI layer for NPCs and mobs.
+ogImage: https://images.unsplash.com/photo-1607513746994-51f730a44832?fit=crop&w=1400&h=700&q=75
+jsonld:
+    type: WebPage
+    breadcrumb:
+        - name: Home
+          path: /
+        - name: Minecraft
+          path: /mc/
 ---
 
-import { Card, CardGrid, Aside, LinkCard } from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
 import AstroMcAuthLink from '@/components/mc/mc-auth/AstroMcAuthLink.astro';
 import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 
-The KBVE Minecraft server is a public, community-run Fabric 1.21.11 world
-with performance mods, old-combat mechanics, and a custom Rust-powered AI
-layer for NPCs and mobs.
+export const backdrop = 'https://images.unsplash.com/photo-1607513746994-51f730a44832?q=80&w=2400&auto=format&fit=crop';
 
-## Link your account
+export const stats = [
+	{ label: 'Server version', value: '1.21.11', icon: 'M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96 12 12.01l8.73-5.05M12 22.08V12' },
+	{ label: 'Mod loader', value: 'Fabric', icon: 'M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5' },
+	{ label: 'Combat', value: '1.8 PvP', icon: 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z' },
+	{ label: 'Fleet', value: 'Agones', icon: 'M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.7-.84.7-2.13-.1-2.91a2.18 2.18 0 0 0-2.9-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z' },
+];
 
-<AstroMcAuthLink />
+export const features = [
+	{ n: '01', title: 'Fabric 1.21.11', desc: 'Modded Fabric server with performance mods (C2ME, Lithium, FerriteCore, ServerCore, VMP) so large player counts and busy chunks stay smooth.', icon: 'M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5' },
+	{ n: '02', title: 'Old-style combat', desc: 'The Old Combat Mod restores 1.8-era PvP mechanics — no attack cooldown, classic hit registration.', icon: 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z' },
+	{ n: '03', title: 'Smarter NPCs', desc: 'NPCs and select mobs run on a Rust behavior-tree mod loaded through JNI. See the technical notes for how the mod ships.', icon: 'M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2M6 6h12v12H6zM9 9h6v6H9z' },
+	{ n: '04', title: 'Run on Agones', desc: 'Fleet-managed by Agones on Kubernetes. Every player session lands on a fresh, clean game server.', icon: 'M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.7-.84.7-2.13-.1-2.91a2.18 2.18 0 0 0-2.9-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z' },
+];
 
-Join **mc.kbve.com** with your Minecraft client. If your Supabase account
-isn't linked yet, you'll see a chat prompt in-game — generate a code
-above and run `/link <code>`. The bridge auto-verifies and flips the
-badge to **Linked**.
+export const related = [
+	{ href: '/project/mc/', title: 'Technical notes', copy: 'Infra, CI/CD, Docker build, Agones fleet config, behavior_statetree mod source.', icon: 'M4 19.5A2.5 2.5 0 0 1 6.5 17H20M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z' },
+	{ href: '/mc/players/', title: 'Online players', copy: 'Live player list with an interactive 3D skin viewer.', icon: 'M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75' },
+	{ href: '/mc/agents/', title: 'Agents & operators', copy: 'Reference for AI agents and human operators working on the server.', icon: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zM2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z' },
+];
 
-## Your wallet
+<div class="mc-hub" style={`--bento-hero-bg: url('${backdrop}')`} data-mc-hub>
 
-<AstroWalletCard />
+<section class="bento-hero bento-section not-content" aria-label="KBVE Minecraft server">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /></svg>
+					<span>kbve minecraft · public server</span>
+				</span>
+				<h1 class="bento-title">
+					Play on the
+					<span class="bento-title__accent">KBVE Minecraft server.</span>
+				</h1>
+				<p class="bento-lede">
+					A public, community-run Fabric 1.21.11 world with performance
+					mods, old-combat mechanics, and a custom Rust-powered AI layer
+					for NPCs and mobs.
+				</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#link">
+						Link your account
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="/mc/players/">Online players</a>
+					<a class="bento-btn bento-btn--ghost" href="/project/mc/">Technical notes</a>
+				</div>
+			</div>
 
-Credits + KHash for the linked account. Claim any pending coupons — the
-welcome 1,000 KHash drops here on first sign-in. Card hides itself when
-you're signed out.
+			{stats.map((s) => (
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d={s.icon} /></svg>
+					</span>
+					<span class="bento-stat__value">{s.value}</span>
+					<span class="bento-stat__label">{s.label}</span>
+				</div>
+			))}
+		</div>
 
-## What to expect
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#link">Link account</a>
+			<a class="bento-chip" href="#wallet">Wallet</a>
+			<a class="bento-chip" href="#features">The server</a>
+			<a class="bento-chip" href="#related">Dig deeper</a>
+		</nav>
+	</div>
+</section>
 
-<CardGrid>
-  <Card title="Fabric 1.21.11" icon="puzzle">
-    Modded Fabric server with performance mods (C2ME, Lithium, FerriteCore,
-    ServerCore, VMP) so large player counts and busy chunks stay smooth.
-  </Card>
-  <Card title="Old-style combat" icon="seti:shield">
-    The Old Combat Mod restores 1.8-era PvP mechanics — no attack cooldown,
-    classic hit registration.
-  </Card>
-  <Card title="Smarter NPCs" icon="seti:rust">
-    NPCs and select mobs run on a Rust behavior-tree mod loaded through
-    JNI. See the [technical notes](/project/mc/) for how the mod ships.
-  </Card>
-  <Card title="Run on Agones" icon="rocket">
-    Fleet-managed by Agones on Kubernetes. Every player session lands on
-    a fresh, clean game server.
-  </Card>
-</CardGrid>
+<BentoShell id="link" eyebrow="Connect your Minecraft profile" heading="Link your account">
+	<div class="bento-board bento-board--cols-2">
+		<AstroMcAuthLink />
+		<div class="bento-cell bento-card bento-card--glass mc-howto">
+			<h3 class="bento-rulecard__title">How linking works</h3>
+			<p class="bento-rulecard__desc">
+				Join <strong>mc.kbve.com</strong> with your Minecraft client. If
+				your Supabase account isn't linked yet, you'll see a chat prompt
+				in-game — generate a code and run <code>/link &lt;code&gt;</code>.
+				The bridge auto-verifies and flips the badge to <strong>Linked</strong>.
+			</p>
+		</div>
+	</div>
+</BentoShell>
 
-## Dig deeper
+<BentoShell id="wallet" eyebrow="Credits &amp; KHash" heading="Your wallet">
+	<div class="bento-board bento-board--cols-2">
+		<AstroWalletCard />
+		<div class="bento-cell bento-card bento-card--glass mc-howto">
+			<h3 class="bento-rulecard__title">Welcome balance</h3>
+			<p class="bento-rulecard__desc">
+				Credits and KHash for the linked account. Claim any pending
+				coupons — the welcome 1,000 KHash drops here on first sign-in.
+				The card hides itself when you're signed out.
+			</p>
+		</div>
+	</div>
+</BentoShell>
 
-<LinkCard
-  title="Technical notes"
-  description="Infra, CI/CD, Docker build, Agones fleet config, behavior_statetree mod source."
-  href="/project/mc/"
-/>
+<BentoShell id="features" eyebrow="What to expect" heading="Built for smooth, old-school play">
+	<div class="bento-board bento-board--cols-2">
+		{features.map((f) => (
+			<div class="bento-cell bento-rulecard bento-card bento-card--glass bento-card--interactive">
+				<div class="bento-rulecard__top">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d={f.icon} /></svg>
+					</span>
+					<span class="bento-rulecard__num">{f.n}</span>
+				</div>
+				<h3 class="bento-rulecard__title">{f.title}</h3>
+				<p class="bento-rulecard__desc">{f.desc}</p>
+			</div>
+		))}
+	</div>
+</BentoShell>
 
-<LinkCard
-  title="Online players"
-  description="Live player list with interactive 3D skin viewer."
-  href="/mc/players/"
-/>
+<BentoShell id="related" eyebrow="Keep going" heading="Dig deeper">
+	<div class="bento-board bento-board--cols-3">
+		{related.map((r) => (
+			<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href={r.href}>
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d={r.icon} /></svg>
+				</span>
+				<span class="bento-linkcard__title">{r.title}</span>
+				<span class="bento-linkcard__copy">{r.copy}</span>
+				<span class="bento-linkcard__go" aria-hidden="true">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+				</span>
+			</a>
+		))}
+	</div>
+</BentoShell>
 
-<LinkCard
-  title="Agents & operators"
-  description="Reference for AI agents and human operators working on the Minecraft server."
-  href="/mc/agents/"
-/>
+</div>
+
+<style is:global>{`
+	.mc-hub {
+		--bento-accent: #5fa83c;
+		--bento-accent-2: #86d15a;
+	}
+	.mc-hub .mc-howto {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		justify-content: center;
+	}
+`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.46"
+version: "0.1.47"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/_shared/supabase.ts
+++ b/apps/kbve/edge/functions/_shared/supabase.ts
@@ -1,5 +1,9 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { jwtVerify } from "https://deno.land/x/jose@v4.14.4/index.ts";
+import {
+  createRemoteJWKSet,
+  decodeProtectedHeader,
+  jwtVerify,
+} from "https://deno.land/x/jose@v4.14.4/index.ts";
 import { corsHeaders } from "./cors.ts";
 
 // ---------------------------------------------------------------------------
@@ -17,11 +21,60 @@ export interface JwtClaims {
   [key: string]: unknown;
 }
 
+export class AuthError extends Error {
+  status: number;
+  constructor(message: string, status = 401) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}
+
+const JWKS = SUPABASE_URL
+  ? createRemoteJWKSet(
+    new URL(`${SUPABASE_URL}/auth/v1/.well-known/jwks.json`),
+  )
+  : null;
+
 export async function parseJwt(token: string): Promise<JwtClaims> {
-  if (!JWT_SECRET) throw new Error("JWT_SECRET not configured");
-  const key = new TextEncoder().encode(JWT_SECRET);
-  const { payload } = await jwtVerify(token, key, { algorithms: ["HS256"] });
-  return payload as JwtClaims;
+  let alg: string | undefined;
+  try {
+    alg = decodeProtectedHeader(token).alg;
+  } catch {
+    throw new AuthError("Malformed session token");
+  }
+
+  try {
+    if (alg && alg !== "HS256") {
+      if (!JWKS) {
+        throw new AuthError("Auth not configured (missing SUPABASE_URL)", 500);
+      }
+      const { payload } = await jwtVerify(token, JWKS, {
+        algorithms: ["ES256"],
+      });
+      return payload as JwtClaims;
+    }
+
+    if (!JWT_SECRET) {
+      throw new AuthError("Auth not configured (missing JWT_SECRET)", 500);
+    }
+    const key = new TextEncoder().encode(JWT_SECRET);
+    const { payload } = await jwtVerify(token, key, { algorithms: ["HS256"] });
+    return payload as JwtClaims;
+  } catch (err) {
+    if (err instanceof AuthError) throw err;
+    const code = (err as { code?: string })?.code ?? "";
+    if (code === "ERR_JWT_EXPIRED") {
+      throw new AuthError("Session expired — please sign in again");
+    }
+    if (code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED") {
+      throw new AuthError("Session token signature invalid");
+    }
+    if (code === "ERR_JOSE_ALG_NOT_ALLOWED") {
+      throw new AuthError(`Unsupported token algorithm: ${alg ?? "unknown"}`);
+    }
+    throw new AuthError("Invalid session token");
+  }
 }
 
 export const SB_ACCESS_TOKEN_COOKIE = "sb-access-token";
@@ -49,7 +102,7 @@ export function extractToken(req: Request): string {
   }
   const cookieToken = readCookie(req, SB_ACCESS_TOKEN_COOKIE);
   if (cookieToken) return cookieToken;
-  throw new Error("Missing or invalid authorization header");
+  throw new AuthError("Missing or invalid authorization header");
 }
 
 export function jsonResponse(data: unknown, status = 200) {

--- a/apps/kbve/edge/functions/mc/_shared.ts
+++ b/apps/kbve/edge/functions/mc/_shared.ts
@@ -1,5 +1,6 @@
 // Re-export all shared utilities from the centralized module
 export {
+  AuthError,
   checkStaffPermissions,
   createServiceClient,
   createUserClient,

--- a/apps/kbve/edge/functions/mc/index.ts
+++ b/apps/kbve/edge/functions/mc/index.ts
@@ -3,7 +3,7 @@ import { preflight, withCors } from "../_shared/cors.ts";
 import { buildHelpText, parseCommand } from "../_shared/routing.ts";
 import { logError } from "../_shared/logging.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
-import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
+import { AuthError, extractToken, jsonResponse, parseJwt } from "./_shared.ts";
 import { AUTH_ACTIONS, handleAuth } from "./auth.ts";
 import { handlePlayer, PLAYER_ACTIONS } from "./player.ts";
 import { CONTAINER_ACTIONS, handleContainer } from "./container.ts";
@@ -92,13 +92,11 @@ serve(async (req) => {
     return withCors(res, req);
   } catch (err) {
     logError("mc", err);
-    const rawMessage = err instanceof Error
-      ? err.message
-      : "Internal server error";
-    const isAuthError =
-      rawMessage.includes("authorization") || rawMessage.includes("JWT");
-    if (isAuthError) {
-      return withCors(jsonResponse({ error: "Unauthorized" }, 401), req);
+    if (err instanceof AuthError) {
+      return withCors(jsonResponse({ error: err.message }, err.status), req);
+    }
+    if (err instanceof SyntaxError) {
+      return withCors(jsonResponse({ error: "Invalid JSON body" }, 400), req);
     }
     return withCors(jsonResponse({ error: "Internal server error" }, 500), req);
   }


### PR DESCRIPTION
## Why

The Minecraft account-link on **/mc/** returned **"Internal server error"** on username lookup.

**Root cause:** Supabase now issues **ES256** asymmetric tokens (Phase-2 of the JWT migration is live — prod JWKS publishes only ES256), but the `mc` edge function's shared `parseJwt` still verified **HS256-only** with `JWT_SECRET`. `jwtVerify` threw `ERR_JOSE_ALG_NOT_ALLOWED`; the message lacked `JWT`/`authorization`, so the router's string-match fell through to the generic **500**. The earlier migration PR only fixed the baked `main/index.ts` verifier, not the per-module one.

## Changes

**Edge (fix)**
- `_shared/supabase.ts` — `parseJwt` routes by token `alg`: **ES256 → remote JWKS**, HS256 → `JWT_SECRET` (legacy service/anon keys). Fixes **all** per-module edge functions (auth/player/character/…), not just mc.
- Typed `AuthError{message,status}` so the mc router returns real messages + correct status (401 expired/invalid, 400 bad JSON) instead of a blanket 500. Frontend `postMc` already surfaces `json.error`, so the UI improves for free.

**Page (bento)**
- `/mc/` overview rebuilt on the **bento.css** system: glass hero + server stats, a Link-account + Wallet board, feature rulecards, and link cards — replacing Starlight `Card`/`CardGrid`/`LinkCard`. Keeps the `AstroMcAuthLink` + `AstroWalletCard` islands, MC-green accent.

## Verification

- Local jose test: old HS256-only path fails ES256 (reproduces the 500); new routing parses both HS256 + ES256.
- `deno check` clean on edited files (pre-existing admin.ts type errors untouched).
- Full `astro build` clean — `/mc/index.html` renders bento markup + both islands.

## Deploy

Edge version bumped **0.1.46 → 0.1.47** (`project/edge.mdx`) in this PR — merging triggers the CI image rebuild + redeploy so the ES256 fix ships. CI syncs `deno.json`/`version.toml`/deploy tag from the MDX; no hand-edits there.
