### PR TITLE
fix(mc): resolve modded entities in GrimAC + clamp survival worldborder

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -38,6 +38,11 @@ public class BehaviorStateTreeMod implements ModInitializer {
 
         StarterKit.register();
 
+        // Clamp the survival world to a finite border on first boot so a
+        // vehicle can't reach the vanilla far-lands edge that froze the
+        // server. Idempotent: skips once an admin has set a border.
+        WorldBorderSetup.register();
+
         // Teach GrimAC's bundled PacketEvents about modded item/entity IDs at
         // server start so it stops throwing on every inventory tick and
         // freezing the server. Guarded no-op when PacketEvents is absent.

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/WorldBorderSetup.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/WorldBorderSetup.java
@@ -1,0 +1,55 @@
+package com.kbve.statetree;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.border.WorldBorder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Clamps the survival world to a finite border on first boot.
+ *
+ * <p>An Immersive Aircraft warship flown to the vanilla ±29,999,984 edge hit
+ * the broken far-lands zone, where the vehicle's velocity ran away and the
+ * "moved too quickly" flood plus a GrimAC entity NPE starved the server thread
+ * until Agones recycled the GameServer. A finite border keeps every vehicle
+ * inside loaded, valid space so that edge is never reached.
+ *
+ * <p>Runs at {@code SERVER_STARTED} and only acts while the border is still at
+ * its vanilla default (size &ge; {@code UNSET_THRESHOLD}). Once set, the value
+ * persists in level.dat, so a later {@code /worldborder} change by an admin is
+ * kept and never overridden on the next boot.
+ */
+public final class WorldBorderSetup {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    private static final double DIAMETER = 100_000.0;
+    private static final double UNSET_THRESHOLD = 1_000_000.0;
+    private static final double DAMAGE_PER_BLOCK = 0.2;
+    private static final double SAFE_ZONE = 5.0;
+    private static final int WARNING_BLOCKS = 64;
+
+    private WorldBorderSetup() {}
+
+    public static void register() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            ServerWorld overworld = server.getOverworld();
+            if (overworld == null) {
+                return;
+            }
+            WorldBorder border = overworld.getWorldBorder();
+            if (border.getSize() < UNSET_THRESHOLD) {
+                LOGGER.info("[WorldBorder] Border already {} blocks — leaving admin config untouched",
+                        border.getSize());
+                return;
+            }
+            border.setCenter(0.0, 0.0);
+            border.setSize(DIAMETER);
+            border.setDamagePerBlock(DAMAGE_PER_BLOCK);
+            border.setSafeZone(SAFE_ZONE);
+            border.setWarningBlocks(WARNING_BLOCKS);
+            LOGGER.info("[WorldBorder] Survival border set — {}-block diameter centered on 0,0", DIAMETER);
+        });
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/compat/PacketEventsRegistryBridge.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/compat/PacketEventsRegistryBridge.java
@@ -1,5 +1,7 @@
 package com.kbve.statetree.compat;
 
+import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.item.type.ItemType;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -16,32 +18,38 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 /**
- * Teaches GrimAC's bundled PacketEvents about our modded items so it stops
- * throwing on every inventory tick.
+ * Teaches GrimAC's bundled PacketEvents about our modded items and entities so
+ * it stops throwing on decode.
  *
- * <p>PacketEvents resolves items through a static, per-protocol vanilla
- * registry loaded from bundled mappings. Modded items get server-assigned
- * network IDs beyond the vanilla range, so {@code IRegistry.getByIdOrThrow}
- * throws "Can't resolve #N in 'minecraft:item'" whenever GrimAC decodes a
- * player inventory holding one — a flood that starves the server thread and
+ * <p>PacketEvents resolves items and entities through static, per-protocol
+ * vanilla registries loaded from bundled mappings. Modded types get
+ * server-assigned network IDs beyond the vanilla range, so
+ * {@code IRegistry.getByIdOrThrow} throws "Can't resolve #N" whenever GrimAC
+ * decodes a packet referencing one — a flood that starves the server thread and
  * freezes the JVM (see GrimAnticheat/Grim#2631; upstream will not fix it).
+ *
+ * <p>Items surface the throw on every inventory tick. Entities surface it
+ * differently: a modded vehicle's {@code EntityType} resolves to null, so
+ * GrimAC's {@code MultiActionsG} check NPEs on {@code getRiding().type
+ * .isInstanceOf(...)} the moment a player rides one — an Immersive Aircraft
+ * warship at the world edge froze the survival server this way.
  *
  * <p>PacketEvents-fabric runs inside the server JVM, so the correct source of
  * truth is the live {@link Registries}. At {@code SERVER_STARTED} — registries
- * frozen, before any player joins — we inject each modded item's real
- * {@code getRawId} into PacketEvents' versioned registry so decoding resolves
- * instead of throwing. GrimAC's movement/combat checks are untouched.
+ * frozen, before any player joins — we inject each modded item's and entity's
+ * real {@code getRawId} into PacketEvents' versioned registries so decoding
+ * resolves instead of throwing. GrimAC's movement/combat checks are untouched;
+ * a resolved modded vehicle simply reports {@code isInstanceOf == false}, the
+ * safe path the null previously blew up.
+ *
+ * <p>Both item and entity registries expose a public {@code getRegistry()}
+ * whose {@code TypesBuilder} we reload and inject into with one shared path.
+ * Blocks are out of scope — block-state IDs need the full global palette and
+ * no modded block has flooded GrimAC yet.
  *
  * <p>Everything is guarded: no-op when PacketEvents isn't present (client, or a
  * server without GrimAC), and any {@link LinkageError} from a PacketEvents
  * SNAPSHOT drift degrades to a logged skip rather than a crash.
- *
- * <p>Scope is items only. Modded blocks and entities hit the same wall, but
- * PacketEvents' entity registry exposes only a static {@code define(...)} whose
- * backing builder can't be reloaded from outside the library, and block-state
- * IDs need the full global palette. Both are handled by the upstream
- * packetevents-fabric live-registry reader tracked separately; items are the
- * flood that froze the server, so they are fixed here.
  */
 public final class PacketEventsRegistryBridge {
 
@@ -63,11 +71,14 @@ public final class PacketEventsRegistryBridge {
         }
         try {
             int items = bridgeItems();
-            LOGGER.info("[{}] PacketEvents registry bridge active — +{} modded items", MOD_ID, items);
+            int entities = bridgeEntities();
+            LOGGER.info("[{}] PacketEvents registry bridge active — +{} modded items, +{} modded entities",
+                    MOD_ID, items, entities);
             verifyDecode();
+            verifyEntityDecode();
         } catch (LinkageError | RuntimeException e) {
             LOGGER.warn("[{}] PacketEvents registry bridge skipped — {}. "
-                    + "Modded items may spam GrimAC encode errors.", MOD_ID, e.toString());
+                    + "Modded items/entities may spam GrimAC decode errors.", MOD_ID, e.toString());
         }
     }
 
@@ -90,6 +101,38 @@ public final class PacketEventsRegistryBridge {
                 count++;
             } catch (RuntimeException e) {
                 LOGGER.debug("[{}] Skipped item {} — {}", MOD_ID, name, e.toString());
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Entity twin of {@link #bridgeItems()}. Injects each modded entity's real
+     * {@code getRawId} into PacketEvents' entity registry, then {@code define}s
+     * the type so {@code getByIdOrThrow} resolves it. A null parent is safe —
+     * {@code StaticEntityType} wraps it in {@code Optional.ofNullable} — and the
+     * modded type needs no vanilla parent to stop GrimAC's null-deref: a
+     * resolved type just answers {@code isInstanceOf == false}.
+     */
+    private static int bridgeEntities() {
+        VersionedRegistry<EntityType> registry = EntityTypes.getRegistry();
+        TypesBuilder builder = registry.getTypesBuilder();
+        ensureMappingsLoaded(builder);
+        int count = 0;
+        for (net.minecraft.entity.EntityType<?> type : Registries.ENTITY_TYPE) {
+            Identifier id = Registries.ENTITY_TYPE.getId(type);
+            if (id == null || VANILLA_NAMESPACE.equals(id.getNamespace())) {
+                continue;
+            }
+            String name = id.toString();
+            if (!injectId(builder, name, Registries.ENTITY_TYPE.getRawId(type))) {
+                continue;
+            }
+            try {
+                EntityTypes.define(name, null);
+                count++;
+            } catch (RuntimeException e) {
+                LOGGER.debug("[{}] Skipped entity {} — {}", MOD_ID, name, e.toString());
             }
         }
         return count;
@@ -128,6 +171,37 @@ public final class PacketEventsRegistryBridge {
     }
 
     /**
+     * Entity twin of {@link #verifyDecode()}. Resolves the first modded entity
+     * through the exact call GrimAC decodes with, proving a ridden warship no
+     * longer yields a null {@code EntityType}.
+     */
+    private static void verifyEntityDecode() {
+        ClientVersion version;
+        try {
+            version = com.github.retrooper.packetevents.PacketEvents.getAPI()
+                    .getServerManager().getVersion().toClientVersion();
+        } catch (RuntimeException | LinkageError e) {
+            version = ClientVersion.getLatest();
+        }
+        for (net.minecraft.entity.EntityType<?> type : Registries.ENTITY_TYPE) {
+            Identifier id = Registries.ENTITY_TYPE.getId(type);
+            if (id == null || VANILLA_NAMESPACE.equals(id.getNamespace())) {
+                continue;
+            }
+            int rawId = Registries.ENTITY_TYPE.getRawId(type);
+            try {
+                EntityType resolved = EntityTypes.getRegistry().getByIdOrThrow(version, rawId);
+                LOGGER.info("[{}] entity decode self-check OK — {} (#{}) resolves to {} at {}",
+                        MOD_ID, id, rawId, resolved.getName(), version);
+            } catch (RuntimeException | LinkageError e) {
+                LOGGER.warn("[{}] entity decode self-check FAILED — {} (#{}) at {}: {}",
+                        MOD_ID, id, rawId, version, e.toString());
+            }
+            return;
+        }
+    }
+
+    /**
      * PacketEvents unloads its string→id mapping tables after boot to save
      * memory ({@code VersionedRegistry.unloadMappings} →
      * {@code TypesBuilder.unloadFileMappings}), leaving {@code getEntries()}
@@ -144,7 +218,7 @@ public final class PacketEventsRegistryBridge {
         try {
             builder.load();
         } catch (RuntimeException | LinkageError e) {
-            LOGGER.debug("[{}] Could not reload item mappings — {}", MOD_ID, e.toString());
+            LOGGER.debug("[{}] Could not reload registry mappings — {}", MOD_ID, e.toString());
         }
     }
 


### PR DESCRIPTION
## What crashed

A player flew an **Immersive Aircraft warship** to the vanilla ±29,999,984 world edge on the survival GameServer (`mc-fabric` fleet, `arc-runners` ns). Recovered from vector→ClickHouse (`observability.logs_distributed`, pod `mc-fabric-52b8w-frrgq`, 2026-07-10 20:29:27Z):

```
[Server thread/WARN]: Warship (vehicle of Ziggy9263) moved too quickly! ...,13.61   (z-velocity runaway, climbing each tick)
[Netty Epoll IO/WARN]: PacketEvents caught an unhandled exception...
java.lang.NullPointerException: ...PacketEntitySelf.getRiding().type is null
  at ac.grim.grimac.checks.impl.multiactions.MultiActionsG.isCheckActive(MultiActionsG.java:55)
```

In the far-lands zone the vehicle velocity ran away, and GrimAC's `MultiActionsG` check NPE'd because its bundled PacketEvents resolved the modded warship `EntityType` to **null**. The combined flood starved the server thread → Agones health check failed → GameServer recycled ("whole server crashed").

## Fix

**1. GrimAC resolves modded entities** — `PacketEventsRegistryBridge` bridged modded *items* only; its doc claimed the entity registry couldn't be reloaded from outside the library. That's **stale for PacketEvents 2.12.1** — `EntityTypes.getRegistry()` is public, exactly like `ItemTypes.getRegistry()`. Added `bridgeEntities()` reusing the same `injectId`/`ensureMappingsLoaded` path, `define`s each modded entity (null parent is safe — `StaticEntityType` wraps it in `Optional.ofNullable`), plus an entity decode self-check. A resolved modded vehicle now answers `isInstanceOf == false` — the safe path the null blew up.

**2. Finite worldborder** — `WorldBorderSetup` clamps the overworld to a **100,000-block** border on first boot so no vehicle reaches the broken edge again. This also removes the velocity-runaway trigger. Idempotent — skips once a border is set, so admin `/worldborder` changes persist in `level.dat`.

## Verification

- `./gradlew compileJava` clean
- All PacketEvents APIs verified against the bundled `packetevents-api-2.12.1` bytecode: `EntityTypes.getRegistry()` public, `define` null-parent-safe, `IRegistry.getByIdOrThrow` present, `isInstanceOf` is the exact NPE site
- Runtime self-check logs `entity decode self-check OK/FAILED` on the real server, mirroring the existing item self-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)