### PR TITLE
chore(herbmail): bump herbmail-game vite build to 0.1.2

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1325,7 +1325,7 @@
 				]
 			},
 			"source_path": "apps/herbmail/herbmail-game",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"version_toml": "apps/herbmail/herbmail-game/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/herbmail-game.mdx",
 			"runner": "ubuntu-latest",

--- a/apps/kbve/astro-kbve/src/content/docs/project/herbmail-game.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/herbmail-game.mdx
@@ -15,7 +15,7 @@ pipeline: vite_game
 app_name: herbmail-game
 source_path: apps/herbmail/herbmail-game
 version_toml: apps/herbmail/herbmail-game/version.toml
-version: "0.1.1"
+version: "0.1.2"
 runner: ubuntu-latest
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
Bumps herbmail-game MDX version 0.1.1 → 0.1.2 to trigger the CI Vite Game dispatch (`ci-vite-game.yml` → Nx build → butler push `kbve/herbmail:html5`).

- `herbmail-game.mdx` version 0.1.1 → 0.1.2
- `.github/ci-dispatch-manifest.json` regenerated (`astro-kbve:gen:ci-manifest`)

version.toml left at sentinel `0.0.0` — CI overwrites on publish.