### PR TITLE
chore(isometric): migrate Bevy 0.18→0.19 (wgpu 29, avian 0.7, lightyear 0.28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,10 +345,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d50ca460ea143f90a3c1ecf36709b9cbb49752d5ddfbf2d67623b465fbfb81"
 dependencies = [
  "anyhow",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bytes",
+ "derive_more 2.1.1",
+ "log",
+]
+
+[[package]]
+name = "aeronet_io"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04965191fb40bbe69e1a81111849242614eb256aee64220b3b06a8ff8bc8a5b"
+dependencies = [
+ "anyhow",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
  "bytes",
  "derive_more 2.1.1",
  "log",
@@ -360,11 +376,31 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c9fea14c3de9d1f8c4cb7bdd8be3e304ae4a45be9f3a8c02008b033165df976"
 dependencies = [
- "aeronet_io",
+ "aeronet_io 0.19.1",
  "anyhow",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "blocking",
+ "bytes",
+ "derive_more 2.1.1",
+ "oneshot",
+ "steamworks",
+ "sync_wrapper 1.0.2",
+ "tracing",
+]
+
+[[package]]
+name = "aeronet_steam"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07302d8c623fce3c40db4bd761e4c93d7e0405879975a04d57b334f23c2bee7"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "anyhow",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
  "blocking",
  "bytes",
  "derive_more 2.1.1",
@@ -380,10 +416,10 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab40ded6412a153f6e189620251f44cb74dc43a218eddea9f4fe4ba55a72e763"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
+ "aeronet_io 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
  "bytes",
  "cfg-if",
  "derive_more 2.1.1",
@@ -402,17 +438,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "aeronet_websocket"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a928ea484a1fda0e9bf24a84eaef93328b0f1176bee37e99a3cdec78b3c58b3"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bytes",
+ "cfg-if",
+ "derive_more 2.1.1",
+ "futures",
+ "js-sys",
+ "rcgen",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "aeronet_webtransport"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4243f8320cca7bf4ce0e1e41aea4553007279685e181e3d566325260a49822"
 dependencies = [
- "aeronet_io",
+ "aeronet_io 0.19.1",
  "base64 0.22.1",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bytes",
+ "cfg-if",
+ "derive_more 2.1.1",
+ "futures",
+ "gloo-timers",
+ "js-sys",
+ "spki",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wtransport",
+ "x509-cert",
+ "xwt-core",
+ "xwt-web",
+ "xwt-wtransport",
+]
+
+[[package]]
+name = "aeronet_webtransport"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c2be31f4a24a05b93538dd4cbaaa7f0c71c29481968756eae5536177eb4fb4"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "base64 0.22.1",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
  "bytes",
  "cfg-if",
  "derive_more 2.1.1",
@@ -525,9 +617,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -537,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -620,11 +712,10 @@ dependencies = [
  "jni 0.22.4",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum 0.7.6",
- "simd_cesu8",
  "thiserror 2.0.18",
 ]
 
@@ -751,6 +842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary-chunks"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad8689a486416c401ea15715a4694de30054248ec627edbf31f49cb64ee4086"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,7 +895,7 @@ dependencies = [
  "agones",
  "async-trait",
  "axum 0.8.9",
- "bevy",
+ "bevy 0.18.1",
  "bevy_items",
  "bevy_mapdb",
  "bevy_spells",
@@ -1347,18 +1444,42 @@ dependencies = [
  "approx",
  "arrayvec",
  "avian_derive",
- "bevy",
- "bevy_heavy",
- "bevy_math",
- "bevy_transform_interpolation",
+ "bevy 0.18.1",
+ "bevy_heavy 0.4.0",
+ "bevy_math 0.18.1",
+ "bevy_transform_interpolation 0.4.0",
  "bitflags 2.11.0",
  "derive_more 2.1.1",
  "disqualified",
- "glam_matrix_extras",
+ "glam_matrix_extras 0.2.0",
  "itertools 0.13.0",
  "slab",
  "smallvec",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "avian2d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375fa2f2b6d042bda24d6b2ecea01ef1d7c8b7b3eed5c730d3409df4778588c9"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "avian_derive",
+ "bevy 0.19.0",
+ "bevy_heavy 0.5.0",
+ "bevy_math 0.19.0",
+ "bevy_transform_interpolation 0.5.0",
+ "bitflags 2.11.0",
+ "derive_more 2.1.1",
+ "disqualified",
+ "glam_matrix_extras 0.3.0",
+ "itertools 0.15.0",
+ "obvhs",
+ "smallvec",
+ "thiserror 2.0.18",
+ "thread_local",
 ]
 
 [[package]]
@@ -1369,22 +1490,48 @@ checksum = "b82608b43397affac139547dfa9beb3208034c53e1a3cfe5d4079db1af362104"
 dependencies = [
  "approx",
  "avian_derive",
- "bevy",
- "bevy_heavy",
- "bevy_math",
- "bevy_transform_interpolation",
+ "bevy 0.18.1",
+ "bevy_heavy 0.4.0",
+ "bevy_math 0.18.1",
+ "bevy_transform_interpolation 0.4.0",
  "bitflags 2.11.0",
  "derive_more 2.1.1",
  "disqualified",
- "glam_matrix_extras",
+ "glam_matrix_extras 0.2.0",
  "itertools 0.13.0",
  "nalgebra 0.34.2",
- "parry3d",
- "parry3d-f64",
+ "parry3d 0.25.3",
+ "parry3d-f64 0.25.3",
  "serde",
  "slab",
  "smallvec",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "avian3d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a30cb730c72527ffaca7f8806881c7e4acc70a4a74c54eb1ffb56c27f64235"
+dependencies = [
+ "approx",
+ "avian_derive",
+ "bevy 0.19.0",
+ "bevy_heavy 0.5.0",
+ "bevy_math 0.19.0",
+ "bevy_transform_interpolation 0.5.0",
+ "bitflags 2.11.0",
+ "derive_more 2.1.1",
+ "disqualified",
+ "glam_matrix_extras 0.3.0",
+ "itertools 0.15.0",
+ "obvhs",
+ "parry3d 0.27.0",
+ "parry3d-f64 0.27.0",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "thread_local",
 ]
 
 [[package]]
@@ -1662,12 +1809,12 @@ version = "1.0.230"
 dependencies = [
  "anyhow",
  "askama 0.16.0",
- "avian3d",
+ "avian3d 0.5.0",
  "axum 0.8.9",
  "axum-extra",
  "axum-server",
  "base64 0.22.1",
- "bevy",
+ "bevy 0.18.1",
  "bevy_inventory",
  "bevy_items",
  "bevy_kbve_net",
@@ -1682,8 +1829,8 @@ dependencies = [
  "jedi",
  "jsonwebtoken 10.3.0",
  "kbve",
- "lightyear",
- "lightyear_avian3d",
+ "lightyear 0.26.4",
+ "lightyear_avian3d 0.26.4",
  "lru 0.18.0",
  "num_cpus",
  "prost 0.14.3",
@@ -1915,7 +2062,7 @@ dependencies = [
 name = "behavior_statetree"
 version = "1.0.16"
 dependencies = [
- "bevy",
+ "bevy 0.18.1",
  "bevy_behavior",
  "bevy_chat",
  "bevy_npc",
@@ -1935,7 +2082,16 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
 dependencies = [
- "bevy_internal",
+ "bevy_internal 0.18.1",
+]
+
+[[package]]
+name = "bevy"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950238d3049d81006a6fd6b898a34cfc01bb5462a7668795a54d640aed19fd0a"
+dependencies = [
+ "bevy_internal 0.19.0",
 ]
 
 [[package]]
@@ -1945,10 +2101,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
 dependencies = [
  "accesskit 0.21.1",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "serde",
+]
+
+[[package]]
+name = "bevy_a11y"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86f2cb45b000a9d121a5a7606f9af4a49e72b8b6a3885dc2acac2f0897a04f1"
+dependencies = [
+ "accesskit 0.24.0",
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
  "serde",
 ]
 
@@ -1962,24 +2132,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_animation"
-version = "0.18.1"
+name = "bevy_android"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bf5b285f0d3fab983b4505e62e195e06930a29007ffc95bdabde834e163a2"
+checksum = "e6e5e2a949be318bf7184eb084622892afcc1e8b2af44973ac53ab53201756e0"
+dependencies = [
+ "android-activity",
+]
+
+[[package]]
+name = "bevy_animation"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da2fcd94cc32ba1c875c62e88506c0ba4775555a413e34cd172ea95fa26098e"
 dependencies = [
  "bevy_animation_macros",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
  "blake3",
  "derive_more 2.1.1",
  "downcast-rs 2.0.2",
@@ -1996,34 +2175,34 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
+checksum = "4fa3d816d7788e27da936b9c7ec27f9828906d53cb1d06e26c58cac5c5ee799f"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.19.0",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_anti_alias"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726cc494eb7d6a84ce6291c23636fd451fa4846604dc059fa93febca4e60a928"
+checksum = "815414ea2e11afe1f2396d89279cfa0986907ef3ec673ec936d9fa695b2bfbf9"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_utils",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_utils 0.19.0",
  "tracing",
 ]
 
@@ -2033,19 +2212,41 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
- "bevy_derive",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_utils 0.18.1",
  "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
  "downcast-rs 2.0.2",
  "log",
  "thiserror 2.0.18",
- "variadics_please",
+ "variadics_please 1.1.0",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "bevy_app"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671ae6f3a8d84f9ed696c531a138558596e041231a8414b6efeafa8469e841f9"
+dependencies = [
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_utils 0.19.0",
+ "console_error_panic_hook",
+ "ctrlc",
+ "downcast-rs 2.0.2",
+ "log",
+ "thiserror 2.0.18",
+ "variadics_please 1.1.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2062,15 +2263,58 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomicow",
- "bevy_android",
- "bevy_app",
- "bevy_asset_macros",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_android 0.18.1",
+ "bevy_app 0.18.1",
+ "bevy_asset_macros 0.18.1",
+ "bevy_diagnostic 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_utils 0.18.1",
+ "bitflags 2.11.0",
+ "blake3",
+ "crossbeam-channel",
+ "derive_more 2.1.1",
+ "disqualified",
+ "downcast-rs 2.0.2",
+ "either",
+ "futures-io",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "ron",
+ "serde",
+ "stackfuture",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "bevy_asset"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a05907de6a362d2c609a7a1d1b4dca3b58b768f746b719ca1a3c7dfa87d391"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "atomicow",
+ "bevy_android 0.19.0",
+ "bevy_app 0.19.0",
+ "bevy_asset_macros 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_utils 0.19.0",
  "bitflags 2.11.0",
  "blake3",
  "crossbeam-channel",
@@ -2099,7 +2343,19 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_asset_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9444998cc37b51dfd1572c23a501865733ea65619a7d88b47aa654ae2290a4f"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2107,18 +2363,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d68da32468ce7f4bb2863b71326acfaaa88e9aef8da8306257cd487d40cede4"
+checksum = "06af3bd91de885f2a5c024569779a7fb43349df611d92f7b795c66c8797378db"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_transform",
- "coreaudio-sys",
- "cpal",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_transform 0.19.0",
  "rodio",
  "tracing",
 ]
@@ -2127,7 +2381,7 @@ dependencies = [
 name = "bevy_battle"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "bevy_behavior",
  "getrandom 0.4.2",
  "rand 0.10.0",
@@ -2138,7 +2392,7 @@ dependencies = [
 name = "bevy_behavior"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "serde",
 ]
 
@@ -2146,7 +2400,7 @@ dependencies = [
 name = "bevy_cam"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "criterion",
 ]
 
@@ -2156,18 +2410,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_reflect",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_mesh 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "bevy_window 0.18.1",
  "derive_more 2.1.1",
  "downcast-rs 2.0.2",
  "serde",
@@ -2177,10 +2431,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_camera"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20105c3e77c2fb391bf3ded3a473d60e4058b837c9bf4e3412225833e524c75a"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
+ "derive_more 2.1.1",
+ "downcast-rs 2.0.2",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
 name = "bevy_chat"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "crossbeam-channel",
  "futures-util",
  "js-sys",
@@ -2197,13 +2477,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_clipboard"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc5fb913f25c5a16a2a1aa2942ba3f1365a6d0f2db3c0ea5bc0be01f85dca5d"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_platform 0.19.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "bevy_color"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
 dependencies = [
- "bevy_math",
- "bevy_reflect",
+ "bevy_math 0.18.1",
+ "bevy_reflect 0.18.1",
  "bytemuck",
  "derive_more 2.1.1",
  "encase",
@@ -2213,40 +2508,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_core_pipeline"
-version = "0.18.1"
+name = "bevy_color"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
+checksum = "7e2dfc0091be6eb62fec9158b2d3e6f21b002be7bdb42dd3b8322e949c8426b0"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
- "bitflags 2.11.0",
- "nonmax",
- "radsort",
- "smallvec",
+ "bevy_math 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bytemuck",
+ "derive_more 2.1.1",
+ "encase",
+ "serde",
  "thiserror 2.0.18",
- "tracing",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
+name = "bevy_core_pipeline"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885d640bbff6c4fa3beadbb043d0d1ae53b2fda864da18a2bf2670fb90428865"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_light",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
+ "bitflags 2.11.0",
+ "indexmap 2.13.1",
+ "nonmax",
 ]
 
 [[package]]
 name = "bevy_db"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "bevy_tasker",
  "bincode",
  "crossbeam-channel",
@@ -2267,37 +2577,51 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293df2b2f7ed65ef2ce02b2e7359faac1a9a92a8cc96c182c9de77eb06049ae0"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_dev_tools"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f1464a3f5ef5c23d917987714ee89881f9f791e9ff97ecf6600ee846b9569e"
+checksum = "db815000affd21545a6d6986f180a66393aee8c84330843e854d376c8537b10f"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_image",
- "bevy_input",
- "bevy_math",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_core_pipeline",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_pbr",
  "bevy_picking",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_state",
- "bevy_text",
- "bevy_time",
- "bevy_transform",
- "bevy_ui",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_state 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_ui 0.19.0",
  "bevy_ui_render",
- "bevy_window",
+ "bevy_window 0.19.0",
  "tracing",
 ]
 
@@ -2308,15 +2632,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
 dependencies = [
  "atomic-waker",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_tasks",
- "bevy_time",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_time 0.18.1",
  "const-fnv1a-hash",
  "log",
  "serde",
- "sysinfo 0.37.2",
+]
+
+[[package]]
+name = "bevy_diagnostic"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a73e11555051f37c3e0e9ef7775e77108f2482310242996fb5bb6ef8b685b78e"
+dependencies = [
+ "atomic-waker",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_time 0.19.0",
+ "const-fnv1a-hash",
+ "log",
+ "serde",
+ "sysinfo 0.38.4",
 ]
 
 [[package]]
@@ -2326,12 +2667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "arrayvec",
- "bevy_ecs_macros",
- "bevy_platform",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_ecs_macros 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_ptr 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_utils 0.18.1",
  "bitflags 2.11.0",
  "bumpalo",
  "concurrent-queue",
@@ -2344,7 +2685,47 @@ dependencies = [
  "slotmap",
  "smallvec",
  "thiserror 2.0.18",
- "variadics_please",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_ecs"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4654b9b3535fa7813d2878a50e1b5ad80a361dc1c913b96ded57667f65d70a01"
+dependencies = [
+ "arrayvec",
+ "bevy_ecs_macros 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_ptr 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_utils 0.19.0",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "concurrent-queue",
+ "derive_more 2.1.1",
+ "fixedbitset",
+ "indexmap 2.13.1",
+ "log",
+ "nonmax",
+ "serde",
+ "slotmap",
+ "smallvec",
+ "thiserror 2.0.18",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_ecs_macro_logic"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b98a74141ce8dce4654c60020ebbaefab32646f42af6bbae55f282ae65ff7"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2353,7 +2734,20 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_ecs_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc958a194d226d618404e0fea99a3c8b4146207a00a3ba07fa712bf71607240"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils 0.19.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2365,7 +2759,17 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "encase_derive_impl",
+]
+
+[[package]]
+name = "bevy_encase_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dc5bf9e6cb46c4401a66625b5f7eb9654a7f3c8586423c428b79586a1c55cd"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
  "encase_derive_impl",
 ]
 
@@ -2375,13 +2779,28 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e4981e85546349e7ccce7e68aaf9c36e6eed556f7f29087dee184ee7941fb9"
 dependencies = [
- "bevy",
- "bevy_enhanced_input_macros",
+ "bevy 0.18.1",
+ "bevy_enhanced_input_macros 0.22.0",
  "bitflags 2.11.0",
  "log",
  "serde",
  "smallvec",
- "variadics_please",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_enhanced_input"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9446023d5c2cea9983f6c6b27a77b19a626028b00e387c68686858765988e68f"
+dependencies = [
+ "bevy 0.19.0",
+ "bevy_enhanced_input_macros 0.26.0",
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "smallvec",
+ "variadics_please 2.0.0",
 ]
 
 [[package]]
@@ -2396,46 +2815,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_feathers"
-version = "0.18.1"
+name = "bevy_enhanced_input_macros"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb29be8f8443c5cc44e1c4710bbe02877e73703c60228ca043f20529a5496c6"
+checksum = "8066e3699f8f982fc141352a18e7812d8ae44746f9627e603bacfe4173be3ca7"
 dependencies = [
- "accesskit 0.21.1",
- "bevy_a11y",
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_input_focus",
- "bevy_log",
- "bevy_math",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_feathers"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e744e047f9328a9c072982569fabbbc837db0474fd902473b5f438f8688c30b6"
+dependencies = [
+ "accesskit 0.24.0",
+ "bevy_a11y 0.19.0",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_input_focus 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
  "bevy_picking",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_text",
- "bevy_ui",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_scene 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_ui 0.19.0",
  "bevy_ui_render",
  "bevy_ui_widgets",
- "bevy_window",
+ "bevy_window 0.19.0",
  "smol_str",
 ]
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611827ab0ce43b88c0a695e6603901b5f34687efecaf526c861456c9d8e6fedb"
+checksum = "7998fe83c89d527efa83c85c574a17f7bb6e34881d638ecb7f706d9d79e82f3c"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_input",
- "bevy_platform",
- "bevy_time",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_time 0.19.0",
  "gilrs",
  "thiserror 2.0.18",
  "tracing",
@@ -2443,85 +2875,91 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
+checksum = "9c0cbd55cc33b6412777d60d8c24a96bee148c82a5731f35ac85b2df4a7cf957"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_ecs",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
  "bevy_gizmos_macros",
- "bevy_light",
- "bevy_math",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
+ "bevy_input 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
+checksum = "9903f2614f53bacacb92bef1e407afe3a27a4abddb500bfd479909c5d7b254df"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.19.0",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_gizmos_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
+checksum = "dd569456c4b19bafa6d37c1bd9cc743fdadda3a2f23d79d2ceb0a088ea8d475f"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_ecs",
+ "bevy_ecs 0.19.0",
  "bevy_gizmos",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
+ "bevy_image 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_material",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
  "bevy_pbr",
- "bevy_render",
- "bevy_shader",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
  "bevy_sprite_render",
- "bevy_transform",
- "bevy_utils",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
  "bytemuck",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_gltf"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
+checksum = "84e21ad83b7dc8d456491ea3d50057685d8c4cca8bc52a1b4a7161c86c369842"
 dependencies = [
  "async-lock",
  "base64 0.22.1",
  "bevy_animation",
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_ecs",
- "bevy_image",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
  "bevy_light",
- "bevy_math",
- "bevy_mesh",
- "bevy_pbr",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_scene",
- "bevy_tasks",
- "bevy_transform",
+ "bevy_material",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_world_serialization",
  "fixedbitset",
  "gltf",
  "itertools 0.14.0",
@@ -2531,6 +2969,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -2539,9 +2978,21 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc496d1d43b890896cf561d8ce3dcf7b7b8e4c03c4e837a49a83a530abccbc5e"
 dependencies = [
- "bevy_math",
- "bevy_reflect",
- "glam_matrix_extras",
+ "bevy_math 0.18.1",
+ "bevy_reflect 0.18.1",
+ "glam_matrix_extras 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "bevy_heavy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afbd898e2c06dfba5854db187a3daece1eaf655c8fc385604bbe5b9304ed3f9b"
+dependencies = [
+ "bevy_math 0.19.0",
+ "bevy_reflect 0.19.0",
+ "glam_matrix_extras 0.3.0",
  "serde",
 ]
 
@@ -2551,14 +3002,41 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_ecs",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "futures-lite",
+ "guillotiere",
+ "half 2.7.1",
+ "image",
+ "rectangle-pack",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "bevy_image"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37bc41f69a0c6ade2e7961602517545b39ab8e42bc8c4a729bd24ffee3bcd904"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
  "bitflags 2.11.0",
  "bytemuck",
  "futures-lite",
@@ -2571,7 +3049,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
- "wgpu-types 27.0.1",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -2580,11 +3058,29 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "derive_more 2.1.1",
+ "log",
+ "serde",
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_input"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd221cf0732f5bf06caf594bdb233361ac735d4d416cf5849757b64bf4e8472a"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
  "derive_more 2.1.1",
  "log",
  "serde",
@@ -2598,13 +3094,29 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_input",
- "bevy_math",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_window 0.18.1",
+ "log",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_input_focus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1a14f56c6e722048ec9dc20dbbc6f46b8037f61e319ea776829199278da166"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_math 0.19.0",
  "bevy_picking",
- "bevy_reflect",
- "bevy_window",
+ "bevy_reflect 0.19.0",
+ "bevy_window 0.19.0",
  "log",
  "thiserror 2.0.18",
 ]
@@ -2615,60 +3127,101 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
 dependencies = [
- "bevy_a11y",
- "bevy_android",
+ "bevy_a11y 0.18.1",
+ "bevy_android 0.18.1",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_camera 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_diagnostic 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_input_focus 0.18.1",
+ "bevy_log 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_mesh 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_ptr 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_render 0.18.1",
+ "bevy_scene 0.18.1",
+ "bevy_shader 0.18.1",
+ "bevy_state 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_ui 0.18.1",
+ "bevy_utils 0.18.1",
+ "bevy_window 0.18.1",
+ "bevy_winit 0.18.1",
+]
+
+[[package]]
+name = "bevy_internal"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a85632a749f956f92b7b391c31ce1f229e57b06de879d1b60a3bb91e4e240"
+dependencies = [
+ "bevy_a11y 0.19.0",
+ "bevy_android 0.19.0",
  "bevy_animation",
  "bevy_anti_alias",
- "bevy_app",
- "bevy_asset",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
  "bevy_audio",
- "bevy_camera",
- "bevy_color",
+ "bevy_camera 0.19.0",
+ "bevy_clipboard",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
+ "bevy_derive 0.19.0",
  "bevy_dev_tools",
- "bevy_diagnostic",
- "bevy_ecs",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
  "bevy_feathers",
  "bevy_gilrs",
  "bevy_gizmos",
  "bevy_gizmos_render",
  "bevy_gltf",
- "bevy_image",
- "bevy_input",
- "bevy_input_focus",
+ "bevy_image 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_input_focus 0.19.0",
  "bevy_light",
- "bevy_log",
- "bevy_math",
- "bevy_mesh",
+ "bevy_log 0.19.0",
+ "bevy_material",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
  "bevy_pbr",
  "bevy_picking",
- "bevy_platform",
+ "bevy_platform 0.19.0",
  "bevy_post_process",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_render",
- "bevy_scene",
- "bevy_shader",
- "bevy_sprite",
+ "bevy_ptr 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_scene 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_sprite 0.19.0",
  "bevy_sprite_render",
- "bevy_state",
- "bevy_tasks",
- "bevy_text",
- "bevy_time",
- "bevy_transform",
- "bevy_ui",
+ "bevy_state 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_ui 0.19.0",
  "bevy_ui_render",
- "bevy_utils",
- "bevy_window",
- "bevy_winit",
+ "bevy_ui_widgets",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
+ "bevy_winit 0.19.0",
+ "bevy_world_serialization",
 ]
 
 [[package]]
 name = "bevy_inventory"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "serde",
  "serde_json",
 ]
@@ -2677,7 +3230,7 @@ dependencies = [
 name = "bevy_items"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "bevy_inventory",
  "prost 0.14.3",
  "prost-build 0.14.3",
@@ -2689,10 +3242,10 @@ dependencies = [
 name = "bevy_kbve_net"
 version = "0.1.0"
 dependencies = [
- "aeronet_webtransport",
- "avian3d",
+ "aeronet_webtransport 0.21.0",
+ "avian3d 0.7.0",
  "base64 0.22.1",
- "bevy",
+ "bevy 0.19.0",
  "bevy_npc",
  "bevy_tasker",
  "bytes",
@@ -2703,8 +3256,8 @@ dependencies = [
  "getrandom 0.4.2",
  "hex",
  "js-sys",
- "lightyear",
- "lightyear_aeronet",
+ "lightyear 0.28.0",
+ "lightyear_aeronet 0.28.0",
  "serde",
  "ulid",
  "wasm-bindgen",
@@ -2713,23 +3266,28 @@ dependencies = [
 
 [[package]]
 name = "bevy_light"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9d2ac64390a9baacb3c0fa0f5456ac1553959d5a387874c102a09aab8b92cc"
+checksum = "bd7b5009e9cc765c30b21daf2277ea4423cbd347b05280ea0943b50c5a80cd42"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_gizmos",
+ "bevy_image 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "half 2.7.1",
+ "smallvec",
  "tracing",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -2739,10 +3297,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
 dependencies = [
  "android_log-sys",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_utils 0.18.1",
+ "tracing",
+ "tracing-log",
+ "tracing-oslog",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2017a5fe12ea230d00cfdca00c65c262924be26e0324f7e0033c64f8cc265888"
+dependencies = [
+ "android_log-sys",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_utils 0.19.0",
  "tracing",
  "tracing-log",
  "tracing-oslog",
@@ -2763,14 +3339,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_macro_utils"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746a19912c6dc1bbe79188778573e8a253d5832c696b2fcb95578c17b29ff7ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "toml_edit 0.25.11+spec-1.1.0",
+]
+
+[[package]]
 name = "bevy_mapdb"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bevy_material"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423710403b4a4d8e9ee872c6ac8108787f2396422b582d15a660a40731ddfbf0"
+dependencies = [
+ "bevy_asset 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_material_macros",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_utils 0.19.0",
+ "encase",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please 1.1.0",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
+name = "bevy_material_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6928e167592472f6ee900f80de199cc2dafd31d4f082a86e8d594b81b973e3d"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2781,16 +3403,36 @@ checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
 dependencies = [
  "approx",
  "arrayvec",
- "bevy_reflect",
+ "bevy_reflect 0.18.1",
  "derive_more 2.1.1",
  "glam 0.30.10",
  "itertools 0.14.0",
  "libm",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "serde",
  "thiserror 2.0.18",
- "variadics_please",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_math"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c280440d2a5bc07ea393b5346b5712eec73ea30f0133097b8b13dade385beb"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bevy_reflect 0.19.0",
+ "derive_more 2.1.1",
+ "glam 0.32.1",
+ "itertools 0.14.0",
+ "libm",
+ "rand 0.10.0",
+ "rand_distr 0.6.0",
+ "serde",
+ "thiserror 2.0.18",
+ "variadics_please 1.1.0",
 ]
 
 [[package]]
@@ -2799,20 +3441,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mikktspace",
- "bevy_platform",
- "bevy_reflect",
- "bevy_transform",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_transform 0.18.1",
  "bitflags 2.11.0",
  "bytemuck",
  "derive_more 2.1.1",
- "hexasphere",
+ "hexasphere 16.0.0",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -2820,16 +3460,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_mikktspace"
-version = "0.17.0-dev"
+name = "bevy_mesh"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
+checksum = "c59863e6f37ef0ba1f37021bce9dd940f9dc31d15e03f548cda5fd3e674f409e"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_encase_derive 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mikktspace",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_transform 0.19.0",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "derive_more 2.1.1",
+ "encase",
+ "glam 0.32.1",
+ "half 2.7.1",
+ "hexasphere 18.0.0",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
+name = "bevy_mikktspace"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_npc"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "serde",
@@ -2840,66 +3509,72 @@ dependencies = [
 name = "bevy_pathfinder"
 version = "0.1.1"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "serde",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab6944ffc6fd71604c0fbca68cc3e2a3654edfcdbfd232f9d8b88e3d20fdc0"
+checksum = "38ebc777de2d7f45888c68e8e04949bfb8a40aee62f700283fc340f525e67f52"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
+ "arrayvec",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_image",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_gltf",
+ "bevy_image 0.19.0",
  "bevy_light",
- "bevy_log",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_transform",
- "bevy_utils",
+ "bevy_log 0.19.0",
+ "bevy_material",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
  "bitflags 2.11.0",
  "bytemuck",
  "derive_more 2.1.1",
  "fixedbitset",
+ "indexmap 2.13.1",
  "nonmax",
  "offset-allocator",
  "smallvec",
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
 name = "bevy_picking"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d524dbc8f2c9e73f7ab70c148c8f7886f3c24b8aa8c252a38ba68ed06cbf10"
+checksum = "93468ac5937f76be3af763d496f01e899edf6d9c1a1d39a87ae4ce8eba36f78b"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_derive",
- "bevy_ecs",
- "bevy_input",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_window",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_window 0.19.0",
  "crossbeam-channel",
  "tracing",
  "uuid",
@@ -2926,40 +3601,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_platform"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3120670bb2308980f723477c9d82476fcda31f08be9b256c3f0acdee82a65094"
+dependencies = [
+ "critical-section",
+ "foldhash 0.2.0",
+ "futures-channel",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "spin 0.10.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "bevy_player"
 version = "0.1.0"
 dependencies = [
- "avian3d",
- "bevy",
+ "avian3d 0.7.0",
+ "bevy 0.19.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "bevy_post_process"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f77a4e894aea992e3d6938f1d5898a1cdbb87dba6eebfb95cb4038d0a2600e9"
+checksum = "57379b51aa0f1b2066c956263e1f12686d22cf8939cf9644eebf2ee42d3dd460"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
- "bitflags 2.11.0",
- "nonmax",
- "radsort",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_utils 0.19.0",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -2972,10 +3664,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
 
 [[package]]
+name = "bevy_ptr"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511e89f7078fd21fdea77061a0ca3e737297c7011bb10c073e0aecb17c9fea6"
+
+[[package]]
 name = "bevy_quests"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "serde",
@@ -2989,10 +3687,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
 dependencies = [
  "assert_type_match",
- "bevy_platform",
- "bevy_ptr",
- "bevy_reflect_derive",
- "bevy_utils",
+ "bevy_platform 0.18.1",
+ "bevy_ptr 0.18.1",
+ "bevy_reflect_derive 0.18.1",
+ "bevy_utils 0.18.1",
  "derive_more 2.1.1",
  "disqualified",
  "downcast-rs 2.0.2",
@@ -3001,14 +3699,42 @@ dependencies = [
  "glam 0.30.10",
  "indexmap 2.13.1",
  "inventory",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "thiserror 2.0.18",
+ "uuid",
+ "variadics_please 1.1.0",
+ "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "bevy_reflect"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92abd59cbba1524c1847e9a50f74d94e6b7836c80a8edfa9c47e59f7fd81021d"
+dependencies = [
+ "assert_type_match",
+ "bevy_platform 0.19.0",
+ "bevy_ptr 0.19.0",
+ "bevy_reflect_derive 0.19.0",
+ "bevy_utils 0.19.0",
+ "derive_more 2.1.1",
+ "disqualified",
+ "downcast-rs 2.0.2",
+ "erased-serde",
+ "foldhash 0.2.0",
+ "glam 0.32.1",
+ "indexmap 2.13.1",
+ "inventory",
  "petgraph 0.8.3",
  "serde",
  "smallvec",
  "smol_str",
  "thiserror 2.0.18",
  "uuid",
- "variadics_please",
- "wgpu-types 27.0.1",
+ "variadics_please 1.1.0",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -3017,7 +3743,21 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "indexmap 2.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_reflect_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fa4e6b97fd2d582dd5ed96762a70d04505a477c833cf4f69d016dcd03d2d04"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
  "indexmap 2.13.1",
  "proc-macro2",
  "quote",
@@ -3032,26 +3772,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
 dependencies = [
  "async-channel",
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_encase_derive",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render_macros",
- "bevy_shader",
- "bevy_tasks",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_camera 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_diagnostic 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_encase_derive 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_mesh 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_render_macros 0.18.1",
+ "bevy_shader 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "bevy_window 0.18.1",
  "bitflags 2.11.0",
  "bytemuck",
  "derive_more 2.1.1",
@@ -3069,10 +3809,64 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
- "variadics_please",
+ "variadics_please 1.1.0",
  "wasm-bindgen",
  "web-sys",
  "wgpu 27.0.1",
+]
+
+[[package]]
+name = "bevy_render"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89b2cc850a4c3fd12a6a088a4fc3e80118b2e1b569da8936f6d4d99ca1b6ee7"
+dependencies = [
+ "async-channel",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_encase_derive 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_material",
+ "bevy_material_macros",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render_macros 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "derive_more 2.1.1",
+ "downcast-rs 2.0.2",
+ "encase",
+ "glam 0.32.1",
+ "image",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "js-sys",
+ "naga 29.0.4",
+ "nonmax",
+ "offset-allocator",
+ "send_wrapper",
+ "smallvec",
+ "thiserror 2.0.18",
+ "variadics_please 1.1.0",
+ "wasm-bindgen",
+ "weak-table",
+ "web-sys",
+ "wgpu 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -3081,10 +3875,43 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_render_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0eb5cffe5253a6ab4e4b84b2e40a6a2f4673deb16fd63ab9dfc4a015449873a"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_replicon"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25105650eb1b27c6ada888e06bb38ff7e326a94c7c5b4d75fb5aee50c5ae45e"
+dependencies = [
+ "bevy 0.19.0",
+ "bitflags 2.11.0",
+ "bytes",
+ "deterministic-hash",
+ "log",
+ "petgraph 0.8.3",
+ "postcard",
+ "serde",
+ "smallbitvec",
+ "smallvec",
+ "typeid",
+ "variadics_please 2.0.0",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3093,15 +3920,15 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cc1047d85ec8048261b63ef675c12f1e6b5782dc0b422fbcee0c140d026bd4"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_derive",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_camera 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
  "derive_more 2.1.1",
  "ron",
  "serde",
@@ -3110,16 +3937,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_scene"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a3c891148c40e1352fc41001c0e1894ba63fc4e2d3aca33447343c4122b782"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_scene_macros",
+ "bevy_utils 0.19.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_scene_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bc33a36a4e9e344985a96cd8b4abc816cf2c5d2fa002d72fd7bcd11396589c"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils 0.19.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bevy_shader"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
 dependencies = [
- "bevy_asset",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_asset 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
  "naga 27.0.3",
- "naga_oil",
+ "naga_oil 0.20.0",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -3127,10 +3988,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_shader"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0ac51378bb6a021165ee334f846b515cd06082e24ce962adce58ad7df1c39a"
+dependencies = [
+ "bevy_asset 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "naga 29.0.4",
+ "naga_oil 0.22.0",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
 name = "bevy_skills"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "serde",
  "serde_json",
 ]
@@ -3139,7 +4019,7 @@ dependencies = [
 name = "bevy_spells"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "serde",
@@ -3152,49 +4032,75 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_picking",
- "bevy_reflect",
- "bevy_text",
- "bevy_transform",
- "bevy_window",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_camera 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_mesh 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_text 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_window 0.18.1",
  "radsort",
  "tracing",
  "wgpu-types 27.0.1",
 ]
 
 [[package]]
-name = "bevy_sprite_render"
-version = "0.18.1"
+name = "bevy_sprite"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
+checksum = "c679b88cc655881d403929bcdf02d30f688fd8916eb1635e6e7f8585d8ae6894"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_picking",
+ "bevy_reflect 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_window 0.19.0",
+ "radsort",
+ "tracing",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
+name = "bevy_sprite_render"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a65ca9a286dd5815ca4d2d41d4f83bdbb22c8a639d10b4c33eac114b369c36"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_sprite",
- "bevy_text",
- "bevy_transform",
- "bevy_utils",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_material",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_sprite 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
  "bitflags 2.11.0",
  "bytemuck",
  "derive_more 2.1.1",
@@ -3209,14 +4115,30 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_state_macros",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_state_macros 0.18.1",
+ "bevy_utils 0.18.1",
  "log",
- "variadics_please",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "bevy_state"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c22e694ea52e42994aea6ed2d0b378fa1e9d5a9b615db88626e33508bc03f35"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_state_macros 0.19.0",
+ "bevy_utils 0.19.0",
+ "log",
+ "variadics_please 1.1.0",
 ]
 
 [[package]]
@@ -3225,7 +4147,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.18.1",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_state_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835f45091fa0df1ff3cb10f4ca5a397d4e9249b550f1be6893b08a2a06d6eed7"
+dependencies = [
+ "bevy_macro_utils 0.19.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3234,7 +4167,7 @@ dependencies = [
 name = "bevy_statemachine"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "bincode",
  "serde",
  "serde_json",
@@ -3244,7 +4177,7 @@ dependencies = [
 name = "bevy_supa"
 version = "0.1.0"
 dependencies = [
- "bevy",
+ "bevy 0.19.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3272,7 +4205,7 @@ dependencies = [
  "async-executor",
  "async-task",
  "atomic-waker",
- "bevy_platform",
+ "bevy_platform 0.18.1",
  "concurrent-queue",
  "crossbeam-queue",
  "derive_more 2.1.1",
@@ -3282,22 +4215,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_tasks"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa34e6b9b804851ec08a41c0346c859d82e2fa98c906d74b965ee61bbbb688e4"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform 0.19.0",
+ "concurrent-queue",
+ "crossbeam-queue",
+ "derive_more 2.1.1",
+ "futures-lite",
+ "heapless 0.9.2",
+ "web-task",
+]
+
+[[package]]
 name = "bevy_text"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc5233291dfc22e584de2535f2e37ae9766d37cb5a01652de2133ba202dcb9b"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_log",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_log 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
  "cosmic-text",
  "serde",
  "smallvec",
@@ -3308,15 +4260,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_text"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e1d7eb8b10229f424b4fc56c864a26c32ac02b8cd184e2cc25eceea7b5e892"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_clipboard",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "parley",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-types 29.0.4",
+]
+
+[[package]]
 name = "bevy_time"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "crossbeam-channel",
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "bevy_time"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21e3be2aa4426ea1e0a7036d3d1dbbded84c319459d9f3e2a616b33563372f2"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
  "crossbeam-channel",
  "log",
  "serde",
@@ -3328,13 +4324,30 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_log",
- "bevy_math",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_log 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_utils 0.18.1",
+ "derive_more 2.1.1",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_transform"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95fefe69c9223d10e6b52a0fdf12811bab9d0c7dcb27570cb86824b451f180d"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_utils 0.19.0",
  "derive_more 2.1.1",
  "serde",
  "thiserror 2.0.18",
@@ -3346,7 +4359,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88545c8b0fa8f3502b9a439c71fa6b596ee9e808bfb16f27a51c8c6f7405a657"
 dependencies = [
- "bevy",
+ "bevy 0.18.1",
+ "serde",
+]
+
+[[package]]
+name = "bevy_transform_interpolation"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea40784f1c6a3f61333064ea1d1c7663ef677c1ce46b5ca148c46c4a62c27e62"
+dependencies = [
+ "bevy 0.19.0",
  "serde",
 ]
 
@@ -3357,29 +4380,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1691a411014085e0d35f8bb8208e5f973edd7ace061a4b1c41c83de21579dc70"
 dependencies = [
  "accesskit 0.21.1",
- "bevy_a11y",
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_input",
- "bevy_input_focus",
- "bevy_math",
- "bevy_picking",
- "bevy_platform",
- "bevy_reflect",
- "bevy_sprite",
- "bevy_text",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_a11y 0.18.1",
+ "bevy_app 0.18.1",
+ "bevy_asset 0.18.1",
+ "bevy_camera 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_image 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_input_focus 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_sprite 0.18.1",
+ "bevy_text 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "bevy_window 0.18.1",
  "derive_more 2.1.1",
  "serde",
  "smallvec",
- "taffy",
+ "taffy 0.9.2",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_ui"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5519c799ecf14e2eeece8b9b823250a00c9df14523e2638b647fccfe4ff0d20"
+dependencies = [
+ "accesskit 0.24.0",
+ "bevy_a11y 0.19.0",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_input_focus 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_picking",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_sprite 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bevy_window 0.19.0",
+ "derive_more 2.1.1",
+ "parley",
+ "serde",
+ "smallvec",
+ "swash",
+ "taffy 0.10.1",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -3387,53 +4447,59 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c35402d8a052f512e3fec1f36b26e83eee713fcca57f965c244ee795e1fcb0"
+checksum = "4f1d3921936d88bd2638dd4d87bff8fc3b9908a046a50658548045102249f93e"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_color 0.19.0",
  "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_sprite",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_input_focus 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_mesh 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_render 0.19.0",
+ "bevy_shader 0.19.0",
+ "bevy_sprite 0.19.0",
  "bevy_sprite_render",
- "bevy_text",
- "bevy_transform",
- "bevy_ui",
- "bevy_utils",
+ "bevy_text 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_ui 0.19.0",
+ "bevy_utils 0.19.0",
  "bytemuck",
  "derive_more 2.1.1",
+ "indexmap 2.13.1",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_ui_widgets"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a63cb818b0de41bdb14990e0ce1aaaa347f871750ab280f80c427e83d72712"
+checksum = "d5fc616ccc51b36dea5cb1de91ed82569b41649923388e5ba82cb7d2f1ef18d8"
 dependencies = [
- "accesskit 0.21.1",
- "bevy_a11y",
- "bevy_app",
- "bevy_camera",
- "bevy_ecs",
- "bevy_input",
- "bevy_input_focus",
- "bevy_log",
- "bevy_math",
+ "accesskit 0.24.0",
+ "bevy_a11y 0.19.0",
+ "bevy_app 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_input_focus 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
  "bevy_picking",
- "bevy_reflect",
- "bevy_ui",
+ "bevy_reflect 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_ui 0.19.0",
+ "bevy_window 0.19.0",
+ "parley",
+ "smol_str",
 ]
 
 [[package]]
@@ -3442,8 +4508,21 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
 dependencies = [
- "bevy_platform",
+ "bevy_platform 0.18.1",
  "disqualified",
+ "thread_local",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aceea6c7ffdd568f866d5ca4dfe50c33440c54f7bc230c13a9ba7ab0c91aed1"
+dependencies = [
+ "async-channel",
+ "bevy_platform 0.19.0",
+ "disqualified",
+ "indexmap 2.13.1",
  "thread_local",
 ]
 
@@ -3453,14 +4532,31 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_ecs",
- "bevy_image",
- "bevy_input",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "log",
+ "raw-window-handle",
+ "serde",
+]
+
+[[package]]
+name = "bevy_window"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcc255b43db156fba393b2ff8fa552aac5e7e02ae4c6298eacdbab655ddf988"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
  "log",
  "raw-window-handle",
  "serde",
@@ -3475,29 +4571,80 @@ dependencies = [
  "accesskit 0.21.1",
  "accesskit_winit 0.29.2",
  "approx",
- "bevy_a11y",
- "bevy_android",
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_input",
- "bevy_input_focus",
- "bevy_log",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_window",
- "bytemuck",
+ "bevy_a11y 0.18.1",
+ "bevy_android 0.18.1",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_input_focus 0.18.1",
+ "bevy_log 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_tasks 0.18.1",
+ "bevy_window 0.18.1",
  "cfg-if",
  "js-sys",
  "tracing",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 27.0.1",
  "winit",
+]
+
+[[package]]
+name = "bevy_winit"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308c9eb04f74f340593b3def6a7c1778fd42581d779c6db836d690c7d471f94c"
+dependencies = [
+ "accesskit 0.24.0",
+ "accesskit_winit 0.32.2",
+ "approx",
+ "bevy_a11y 0.19.0",
+ "bevy_android 0.19.0",
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_image 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_input_focus 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_tasks 0.19.0",
+ "bevy_window 0.19.0",
+ "bytemuck",
+ "js-sys",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 29.0.4",
+ "winit",
+]
+
+[[package]]
+name = "bevy_world_serialization"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de58ae74410d4f940e3f00484f58603b4f1a53a7d84ebe3fca258d2a3aa96620"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_asset 0.19.0",
+ "bevy_camera 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "derive_more 2.1.1",
+ "ron",
+ "serde",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -3527,24 +4674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
@@ -4367,6 +5496,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
+ "serde",
+ "termcolor",
  "unicode-width",
 ]
 
@@ -4664,22 +5795,16 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
-dependencies = [
- "bindgen 0.72.1",
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4690,7 +5815,7 @@ checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
- "harfrust",
+ "harfrust 0.4.1",
  "linebender_resource_handle",
  "log",
  "rangemap",
@@ -4708,25 +5833,32 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.4",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4919,7 +6051,7 @@ dependencies = [
  "agones",
  "async-trait",
  "axum 0.8.9",
- "bevy",
+ "bevy 0.18.1",
  "jedi",
  "simgrid",
  "tokio",
@@ -5337,6 +6469,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "deterministic-hash"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11277822c27bde750de02c5dc5159b91e88bf2661a2c1d98106f2fb1c5c6f590"
 
 [[package]]
 name = "diesel"
@@ -5799,7 +6937,7 @@ dependencies = [
  "thiserror 2.0.18",
  "type-map",
  "web-time",
- "wgpu 29.0.1",
+ "wgpu 29.0.4",
  "winit",
 ]
 
@@ -6116,7 +7254,7 @@ dependencies = [
  "ecolor",
  "emath",
  "epaint_default_fonts",
- "font-types 0.11.2",
+ "font-types 0.11.3",
  "log",
  "nohash-hasher",
  "parking_lot",
@@ -6539,9 +7677,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
  "serde",
@@ -6568,6 +7706,20 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser",
+]
+
+[[package]]
+name = "fontique"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
+dependencies = [
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "memmap2",
+ "parlance",
+ "read-fonts 0.39.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -7258,7 +8410,12 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 dependencies = [
+ "approx",
+ "bytemuck",
+ "encase",
  "libm",
+ "rand 0.10.0",
+ "serde_core",
 ]
 
 [[package]]
@@ -7267,9 +8424,33 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4664468a60479272b880a8bfc00ad2915229b93d2b2d585556fb33f9ba80e72"
 dependencies = [
- "bevy_reflect",
+ "bevy_reflect 0.18.1",
  "glam 0.30.10",
  "serde",
+]
+
+[[package]]
+name = "glam_matrix_extras"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db060a7f23a5666ccbe9c770cd0e0e419b2eb94c86a7c8bfd091bacf8b4926cd"
+dependencies = [
+ "bevy_reflect 0.19.0",
+ "glam 0.32.1",
+ "serde",
+]
+
+[[package]]
+name = "glamx"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59157a5886a9c68eb694df59254f7c9419c5648fc6ca1b728601a8baecc0dfcd"
+dependencies = [
+ "approx",
+ "glam 0.32.1",
+ "num-traits",
+ "serde",
+ "simba",
 ]
 
 [[package]]
@@ -7616,6 +8797,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "gpu-descriptor"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7764,9 +8959,11 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "serde",
  "zerocopy",
 ]
 
@@ -7780,6 +8977,19 @@ dependencies = [
  "bytemuck",
  "core_maths",
  "read-fonts 0.36.0",
+ "smallvec",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551ed25397e4b444e89686602877d5cf3a7f6e3d548dcac37a8357d1e195f4df"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.39.2",
  "smallvec",
 ]
 
@@ -7905,6 +9115,17 @@ checksum = "29a164ceff4500f2a72b1d21beaa8aa8ad83aec2b641844c659b190cb3ea2e0b"
 dependencies = [
  "constgebra",
  "glam 0.30.10",
+ "tinyvec",
+]
+
+[[package]]
+name = "hexasphere"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177ea6330876de4ef08e184f827b98acc037614a4ce409902c5b0d53a9c2e951"
+dependencies = [
+ "constgebra",
+ "glam 0.32.1",
  "tinyvec",
 ]
 
@@ -8316,6 +9537,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8323,10 +9559,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -8376,12 +9619,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -8659,9 +9925,9 @@ name = "isometric-game"
 version = "0.1.0"
 dependencies = [
  "android-activity",
- "avian3d",
+ "avian3d 0.7.0",
  "base64 0.22.1",
- "bevy",
+ "bevy 0.19.0",
  "bevy_behavior",
  "bevy_cam",
  "bevy_chat",
@@ -8680,7 +9946,7 @@ dependencies = [
  "getrandom 0.2.17",
  "js-sys",
  "libm",
- "lightyear",
+ "lightyear 0.28.0",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -8703,7 +9969,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu 27.0.1",
+ "wgpu 29.0.4",
 ]
 
 [[package]]
@@ -8729,6 +9995,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -9197,8 +10472,8 @@ dependencies = [
  "isometric-game",
  "jni 0.21.1",
  "log",
- "ndk 0.9.0",
- "ndk-sys 0.6.0+11769913",
+ "ndk",
+ "ndk-sys",
  "objc2 0.6.4",
  "pollster",
  "raw-window-handle",
@@ -9245,9 +10520,9 @@ dependencies = [
 
 [[package]]
 name = "ktx2"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
+checksum = "1d50be8a24c37debdf3170be6ca396d5b5b165f37f94837891adac735ca416b8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -9421,7 +10696,23 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed83d1d7334e742aab3409782cdbb2bc96cc017df9ff342dd5aeb80eed1b784"
 dependencies = [
- "bevy",
+ "bevy 0.18.1",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
+ "itertools 0.14.0",
+ "leafwing_input_manager_macros",
+ "serde",
+ "serde_flexitos",
+]
+
+[[package]]
+name = "leafwing-input-manager"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2052ba82a881309ab7a01d14136f861fde5e8ad43c041659f0f9a9a6ceace0"
+dependencies = [
+ "bevy 0.19.0",
  "dyn-clone",
  "dyn-eq",
  "dyn-hash",
@@ -9555,39 +10846,84 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be51d4b8fe01a81efe7b0e53f1d5577719a507ca3bbd40cadcbf3ccaea82030d"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
+ "aeronet_io 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
  "console_error_panic_hook",
  "document-features",
- "lightyear_aeronet",
- "lightyear_avian2d",
- "lightyear_avian3d",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_frame_interpolation",
- "lightyear_inputs",
- "lightyear_inputs_bei",
- "lightyear_inputs_leafwing",
- "lightyear_inputs_native",
- "lightyear_interpolation",
- "lightyear_link",
- "lightyear_messages",
- "lightyear_metrics",
- "lightyear_netcode",
- "lightyear_prediction",
- "lightyear_raw_connection",
- "lightyear_replication",
- "lightyear_serde",
- "lightyear_steam",
- "lightyear_sync",
- "lightyear_transport",
- "lightyear_udp",
+ "lightyear_aeronet 0.26.4",
+ "lightyear_avian2d 0.26.4",
+ "lightyear_avian3d 0.26.4",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_frame_interpolation 0.26.4",
+ "lightyear_inputs 0.26.4",
+ "lightyear_inputs_bei 0.26.4",
+ "lightyear_inputs_leafwing 0.26.4",
+ "lightyear_inputs_native 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_metrics 0.26.4",
+ "lightyear_netcode 0.26.4",
+ "lightyear_prediction 0.26.4",
+ "lightyear_raw_connection 0.26.4",
+ "lightyear_replication 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_steam 0.26.4",
+ "lightyear_sync 0.26.4",
+ "lightyear_transport 0.26.4",
+ "lightyear_udp 0.26.4",
  "lightyear_ui",
- "lightyear_utils",
- "lightyear_web",
- "lightyear_websocket",
- "lightyear_webtransport",
+ "lightyear_utils 0.26.4",
+ "lightyear_web 0.26.4",
+ "lightyear_websocket 0.26.4",
+ "lightyear_webtransport 0.26.4",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccf8a5a84d29c0bdf7db4b7a709a8699f3a8359927c8310ffb5b6dd0056d883"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "console_error_panic_hook",
+ "document-features",
+ "lightyear_aeronet 0.28.0",
+ "lightyear_avian2d 0.28.0",
+ "lightyear_avian3d 0.28.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_deterministic_replication",
+ "lightyear_frame_interpolation 0.28.0",
+ "lightyear_inputs 0.28.0",
+ "lightyear_inputs_bei 0.28.0",
+ "lightyear_inputs_leafwing 0.28.0",
+ "lightyear_inputs_native 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_metrics 0.28.0",
+ "lightyear_netcode 0.28.0",
+ "lightyear_prediction 0.28.0",
+ "lightyear_raw_connection 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_steam 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_tools",
+ "lightyear_transport 0.28.0",
+ "lightyear_udp 0.28.0",
+ "lightyear_utils 0.28.0",
+ "lightyear_web 0.28.0",
+ "lightyear_websocket 0.28.0",
+ "lightyear_webtransport 0.28.0",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -9599,12 +10935,27 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a8e7f2b66a63bba410403708bf9c98a7c8e0834a0a069db010e63e669e6735b"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "lightyear_core",
- "lightyear_link",
+ "aeronet_io 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_aeronet"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fb1f65e664b5456ff5029bf242f554ddacf8a8b45c8f233e43802077900592"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
  "tracing",
 ]
 
@@ -9614,19 +10965,41 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3229fb076a2750bcf41037c6af553a8cb1dc59e3cdd1f7c8e0d6ae7cd855dc03"
 dependencies = [
- "avian2d",
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "lightyear_core",
- "lightyear_frame_interpolation",
- "lightyear_interpolation",
- "lightyear_link",
- "lightyear_prediction",
- "lightyear_replication",
+ "avian2d 0.5.0",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_core 0.26.4",
+ "lightyear_frame_interpolation 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_prediction 0.26.4",
+ "lightyear_replication 0.26.4",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_avian2d"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226205837bacb1723b383e29dab8d903901aaf5be00037941769f5be13c78896"
+dependencies = [
+ "avian2d 0.7.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_core 0.28.0",
+ "lightyear_frame_interpolation 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_prediction 0.28.0",
+ "lightyear_replication 0.28.0",
  "tracing",
 ]
 
@@ -9636,19 +11009,41 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca582724703dccafe64991bbe0d480e616de7e1056b07cd9c6862a48196b9ce0"
 dependencies = [
- "avian3d",
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "lightyear_core",
- "lightyear_frame_interpolation",
- "lightyear_interpolation",
- "lightyear_link",
- "lightyear_prediction",
- "lightyear_replication",
+ "avian3d 0.5.0",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_core 0.26.4",
+ "lightyear_frame_interpolation 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_prediction 0.26.4",
+ "lightyear_replication 0.26.4",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_avian3d"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb481e8ccfaf3f35586da46092f1fe232619ee34422786427ab35c1471b3a81"
+dependencies = [
+ "avian3d 0.7.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_core 0.28.0",
+ "lightyear_frame_interpolation 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_prediction 0.28.0",
+ "lightyear_replication 0.28.0",
  "tracing",
 ]
 
@@ -9658,14 +11053,34 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad7fa5c7b928074895a56e96d0154e78cbc4e751f37e1a9b0b5fda469eb28c74"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
  "bytes",
- "lightyear_core",
- "lightyear_link",
- "lightyear_serde",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_serde 0.26.4",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_connection"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d66880a2e656ff9ed43898e7593e0c5ee013687d52ad43ddef04de4b00a8f2d"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bytes",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_serde 0.28.0",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -9678,16 +11093,60 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a310d13cb0059fd20f59ec60b24056403ffc2388daabbc663c8eb1d4a08ddf4"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
  "chrono",
  "fixed",
- "lightyear_serde",
- "lightyear_utils",
+ "lightyear_serde 0.26.4",
+ "lightyear_utils 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_core"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5882cda02c297336b79c0fc7caeaad656fe05d0a12cdbbdde38359369b2ed1"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "chrono",
+ "fixed",
+ "lightyear_serde 0.28.0",
+ "lightyear_utils 0.28.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_deterministic_replication"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0989fe60f91f5d4f9a9281aaa00bc2a6868e6d0a3819ccdd5ef65ae9d8108"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_replicon",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_inputs 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_prediction 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_transport 0.28.0",
+ "lightyear_utils 0.28.0",
+ "seahash",
  "serde",
  "tracing",
 ]
@@ -9698,16 +11157,36 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ce32814bfcd07d1b694443dd988d3e842976e87223ec48fc18283e8e0046ab"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_interpolation",
- "lightyear_replication",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_replication 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_frame_interpolation"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ae3a2ec5e9492b48efe0ebbbea39962d20a7b899e4403d94f1a3f49948ac16"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_replication 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9718,20 +11197,44 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4bbfad8e59fbd0d569a2e359be47a7a1b28fc8e494ae124eb2b5efbec54b8e2"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_interpolation",
- "lightyear_link",
- "lightyear_messages",
- "lightyear_prediction",
- "lightyear_replication",
- "lightyear_sync",
- "lightyear_transport",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_prediction 0.26.4",
+ "lightyear_replication 0.26.4",
+ "lightyear_sync 0.26.4",
+ "lightyear_transport 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_inputs"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03fac5216402f484b0018318b1174c7d3530e8886745bc954c6883f7e882edd"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_prediction 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_transport 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9742,18 +11245,41 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2266633e2eeebfe5fcd5d3cea8984bc26b24b13942fd9c1aa9123da4de6c1a02"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_enhanced_input",
- "bevy_reflect",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_inputs",
- "lightyear_link",
- "lightyear_messages",
- "lightyear_replication",
- "lightyear_serde",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_enhanced_input 0.22.2",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_inputs 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_replication 0.26.4",
+ "lightyear_serde 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_inputs_bei"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336d6f7c302924c1093fd1959c5ebdf59f8bdea74af5d0e58585b9883bda8c0a"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_enhanced_input 0.26.0",
+ "bevy_reflect 0.19.0",
+ "bevy_replicon",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_inputs 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_serde 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9764,17 +11290,39 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2cfbd794d8a42f06796acc6b8d4274d3fb53cd58f480881d2dd59176f076e49"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_input",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_utils",
- "leafwing-input-manager",
- "lightyear_core",
- "lightyear_inputs",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_input 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
+ "leafwing-input-manager 0.20.0",
+ "lightyear_core 0.26.4",
+ "lightyear_inputs 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_inputs_leafwing"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0f00b5535d0b867d01f185ac49330167218cc60433402c86f920eacc2eda68"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_input 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "leafwing-input-manager 0.21.0",
+ "lightyear_core 0.28.0",
+ "lightyear_inputs 0.28.0",
+ "lightyear_sync 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9785,12 +11333,28 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c992924e07b463528f34987fbd6b2248f37a66cfd41757dd9b9f8b5085765cdc"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_reflect",
- "lightyear_core",
- "lightyear_inputs",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "lightyear_core 0.26.4",
+ "lightyear_inputs 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_inputs_native"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765cb40b1a38396e4f311e0bb4da99a96b36d40bcf6cf64a80585433a88fcc7a"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "lightyear_core 0.28.0",
+ "lightyear_inputs 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9801,21 +11365,47 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4545cb52f0232da161dd93836e5b4f23816850330ef322ba6bd3abba2a20f21"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_messages",
- "lightyear_replication",
- "lightyear_serde",
- "lightyear_sync",
- "lightyear_utils",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_replication 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_sync 0.26.4",
+ "lightyear_utils 0.26.4",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_interpolation"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb312a07c83674e7f581aa19b30576edc6561617e8e06bd2100a50ff74d8975e"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_replicon",
+ "bevy_time 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_utils 0.28.0",
  "serde",
  "tracing",
 ]
@@ -9826,14 +11416,31 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ede74a86374f21606be56aaf1c1bf9dd333f473866bd780ab449653f0caca24"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
  "bytes",
- "lightyear_core",
- "lightyear_utils",
+ "lightyear_core 0.26.4",
+ "lightyear_utils 0.26.4",
  "rand 0.9.2",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_link"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f78fdd1e0722b9c488896a21b20c11e6cb435d93f1f0bd472a7c7c4abbbd45"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "bytes",
+ "lightyear_core 0.28.0",
+ "lightyear_utils 0.28.0",
+ "rand 0.10.0",
  "tracing",
 ]
 
@@ -9843,17 +11450,38 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1141fb3d9895f5c9e8aa5d723d9b9bf9db800fd044ba8c8b542ac660beeab47"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
  "bytes",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_serde",
- "lightyear_transport",
- "lightyear_utils",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_transport 0.26.4",
+ "lightyear_utils 0.26.4",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_messages"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183859015aef9270415787c456fcd3d6b1ab7fee1134fde1ddd49befc043e50"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "bytes",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_transport 0.28.0",
+ "lightyear_utils 0.28.0",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -9865,15 +11493,35 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3264ac1729043c949bf2c9526bfa712a1c7e683e4e0034ce7cac0f233c19db"
 dependencies = [
- "bevy_app",
- "bevy_color",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_text",
- "bevy_time",
- "bevy_ui",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_text 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_ui 0.18.1",
+ "bevy_utils 0.18.1",
+ "metrics",
+ "metrics-util",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_metrics"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e00d80e123c73cf1dc121875852e1c7447cee26a0c1f37f7bb322a32ba6839"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_ui 0.19.0",
+ "bevy_utils 0.19.0",
  "metrics",
  "metrics-util",
  "tracing",
@@ -9885,21 +11533,44 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db834d08f6826a2c25c9a355a33bb0db036da2da98b5f43b3982e6b5c41a0f4e"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_time",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_time 0.18.1",
  "bytes",
  "chacha20poly1305",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_serde",
- "lightyear_transport",
- "lightyear_utils",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_transport 0.26.4",
+ "lightyear_utils 0.26.4",
  "no_std_io2",
  "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "lightyear_netcode"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f009241f6954e89fc2417f10488deee00cca08028e4eb20b7ad8c4954fc8832"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bytes",
+ "chacha20poly1305",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_transport 0.28.0",
+ "lightyear_utils 0.28.0",
+ "no_std_io2",
  "thiserror 2.0.18",
  "tracing",
  "web-time",
@@ -9911,23 +11582,52 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ddda7d875590a2f91c082dd339507b79eb3221661f50fca18e6c2fdafbcc6c"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_frame_interpolation",
- "lightyear_interpolation",
- "lightyear_messages",
- "lightyear_replication",
- "lightyear_sync",
- "lightyear_utils",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_diagnostic 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_frame_interpolation 0.26.4",
+ "lightyear_interpolation 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_replication 0.26.4",
+ "lightyear_sync 0.26.4",
+ "lightyear_utils 0.26.4",
+ "parking_lot",
+ "seahash",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_prediction"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2054a4758b5a8a57532dbf48501a4a9bedb5121cc6a28fd6d3b5e089b1dee4c"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_replicon",
+ "bevy_time 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_frame_interpolation 0.28.0",
+ "lightyear_interpolation 0.28.0",
+ "lightyear_replication 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_utils 0.28.0",
  "parking_lot",
  "seahash",
  "serde",
@@ -9940,13 +11640,29 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631b5527b4f11d1e199f823ecdcd02585136fc55dd3261d5280e03bbcc29cdd3"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_transport",
+ "aeronet_io 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_transport 0.26.4",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_raw_connection"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c3dd25d5168ece94862f36fc4f9531caff7c92bca604754ac5fb86886a41c4e"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_transport 0.28.0",
  "tracing",
 ]
 
@@ -9956,29 +11672,68 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a451536b73e618035472548e8d7f1af51e193649f556318f7836ddc70e6f73d2"
 dependencies = [
- "avian2d",
- "avian3d",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_platform",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
+ "avian2d 0.5.0",
+ "avian3d 0.5.0",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_math 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_ptr 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_transform 0.18.1",
+ "bevy_utils 0.18.1",
  "bytes",
  "dashmap 6.1.0",
  "indexmap 2.13.1",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_messages",
- "lightyear_serde",
- "lightyear_sync",
- "lightyear_transport",
- "lightyear_utils",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_sync 0.26.4",
+ "lightyear_transport 0.26.4",
+ "lightyear_utils 0.26.4",
+ "seahash",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_replication"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bd33e61d5fe7925e36cd1e9844b872d99dcf8bea1653a8049261bccadb7cb5"
+dependencies = [
+ "avian2d 0.7.0",
+ "avian3d 0.7.0",
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_math 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_ptr 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_replicon",
+ "bevy_state 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_transform 0.19.0",
+ "bevy_utils 0.19.0",
+ "bytes",
+ "dashmap 6.1.0",
+ "fixedbitset",
+ "indexmap 2.13.1",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_sync 0.28.0",
+ "lightyear_transport 0.28.0",
+ "lightyear_utils 0.28.0",
  "seahash",
  "serde",
  "smallvec",
@@ -9992,19 +11747,40 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c00dfe55ea4ba8413424616564b36c64d404fe9f5c68e4d71c4a97193da3d6e"
 dependencies = [
- "bevy_derive",
- "bevy_ecs",
- "bevy_platform",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_derive 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_ptr 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
  "bincode",
  "bytes",
  "no_std_io2",
  "serde",
  "thiserror 2.0.18",
  "tracing",
- "variadics_please",
+ "variadics_please 1.1.0",
+]
+
+[[package]]
+name = "lightyear_serde"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e7f9c535d3b2e73b6f9eca4a180972d41d11ae6f4c0310caf1fb59379730a6"
+dependencies = [
+ "bevy_derive 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_ptr 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "bincode",
+ "bytes",
+ "no_std_io2",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please 2.0.0",
 ]
 
 [[package]]
@@ -10013,14 +11789,32 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b513c7aaeeaee3fbfe82e4ab7698cc3360d42526d167054af357920a166566"
 dependencies = [
- "aeronet_io",
- "aeronet_steam",
- "bevy_app",
- "bevy_ecs",
- "lightyear_aeronet",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
+ "aeronet_io 0.19.1",
+ "aeronet_steam 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "lightyear_aeronet 0.26.4",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_steam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7886d0ea99ab0b9e021d5627ea1a9810f8c2bcd0189c2402ff29541d52fb01"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "aeronet_steam 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "lightyear_aeronet 0.28.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -10031,22 +11825,74 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834af4e025c9d7954c9684d82255e5ed639e0ce4482e3c674582687ce1f2dbfd"
 dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_time",
- "bevy_utils",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_messages",
- "lightyear_serde",
- "lightyear_transport",
- "lightyear_utils",
+ "bevy_app 0.18.1",
+ "bevy_derive 0.18.1",
+ "bevy_diagnostic 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_messages 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_transport 0.26.4",
+ "lightyear_utils 0.26.4",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "lightyear_sync"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c8790e915819a587a0b63b3a1826fea85583ac4878b0c52f0e21f0765ea399"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_derive 0.19.0",
+ "bevy_diagnostic 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_messages 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_transport 0.28.0",
+ "lightyear_utils 0.28.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_tools"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e6425d9b85396c2920f764af46452ceb1fd44b7e099f8792b08702cea0c2b0"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_color 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_log 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_text 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_ui 0.19.0",
+ "bevy_utils 0.19.0",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_metrics 0.28.0",
+ "metrics",
+ "metrics-util",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10055,22 +11901,51 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "272b66fae233f66887cbef40c30d2a7673d299d327a9fdd2becbd3b2ae59336b"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_utils",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_utils 0.18.1",
  "bytes",
  "crossbeam-channel",
  "enum_dispatch",
  "governor",
  "indexmap 2.13.1",
- "lightyear_connection",
- "lightyear_core",
- "lightyear_link",
- "lightyear_serde",
- "lightyear_utils",
+ "lightyear_connection 0.26.4",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "lightyear_serde 0.26.4",
+ "lightyear_utils 0.26.4",
+ "nonzero_ext",
+ "ringbuffer",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_transport"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a2263fb8894355217420cb49a0a25fc74aaa5638dbf58e519bb2660c91ae83"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_time 0.19.0",
+ "bevy_utils 0.19.0",
+ "bytes",
+ "crossbeam-channel",
+ "enum_dispatch",
+ "governor",
+ "indexmap 2.13.1",
+ "lightyear_connection 0.28.0",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
+ "lightyear_serde 0.28.0",
+ "lightyear_utils 0.28.0",
  "nonzero_ext",
  "ringbuffer",
  "serde",
@@ -10084,13 +11959,29 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367cdb2e11ac6448bec036a26ce1aa7a97a695e1a50a28e2d3d4e3f8ae34c670"
 dependencies = [
- "aeronet_io",
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
+ "aeronet_io 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
  "bytes",
- "lightyear_core",
- "lightyear_link",
+ "lightyear_core 0.26.4",
+ "lightyear_link 0.26.4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_udp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5de693f3e82a67aeed2bdec3f29dad9394aaa5b8a63c6268131824e4d312a71"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bytes",
+ "lightyear_core 0.28.0",
+ "lightyear_link 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -10101,16 +11992,16 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd20cb05463553dd19006a2e318b86b2afb6db8e9e8e46931fc6592d8069e3c2"
 dependencies = [
- "bevy_app",
- "bevy_color",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_text",
- "bevy_time",
- "bevy_ui",
- "bevy_utils",
- "lightyear_metrics",
+ "bevy_app 0.18.1",
+ "bevy_color 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_text 0.18.1",
+ "bevy_time 0.18.1",
+ "bevy_ui 0.18.1",
+ "bevy_utils 0.18.1",
+ "lightyear_metrics 0.26.4",
  "metrics",
  "metrics-util",
  "tracing",
@@ -10122,11 +12013,27 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a54a63441f9001dc834fc8e6b4bb23eeb8f6b2ef28db8c65b4bfbf9496b139"
 dependencies = [
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_ecs 0.18.1",
+ "bevy_platform 0.18.1",
+ "bevy_reflect 0.18.1",
+ "bevy_utils 0.18.1",
  "hashbrown 0.16.1",
+ "paste",
+ "seahash",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_utils"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400b72926af5383e43619035d8d3becc0fc5d271ff330374ccedbf0b6cd31404"
+dependencies = [
+ "bevy_ecs 0.19.0",
+ "bevy_platform 0.19.0",
+ "bevy_reflect 0.19.0",
+ "bevy_utils 0.19.0",
+ "hashbrown 0.17.1",
  "paste",
  "seahash",
  "tracing",
@@ -10138,9 +12045,22 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72450d46e6c5052c174e3723e14fd78726ffca7e00e64b6f9342cdd642621eb6"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_winit",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_winit 0.18.1",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "lightyear_web"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8036a839a28aa82b43820b86e6587405f39f74fde9c13b15ba88e9d81723b5a"
+dependencies = [
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "bevy_winit 0.19.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -10151,13 +12071,29 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e5ee75b46e0be8f9e746f1b53464376715d400fbddb4a3faf8fb348eec2919"
 dependencies = [
- "aeronet_io",
- "aeronet_websocket",
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "lightyear_aeronet",
- "lightyear_link",
+ "aeronet_io 0.19.1",
+ "aeronet_websocket 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "lightyear_aeronet 0.26.4",
+ "lightyear_link 0.26.4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_websocket"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754048029ad9ceb2a108d0546bd20dfceb78aa1d85d9d6900e5b357a466cbafc"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "aeronet_websocket 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "lightyear_aeronet 0.28.0",
+ "lightyear_link 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -10168,13 +12104,29 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c100a3f88ced77327f04ab3e583ecca627e53d93031c5aaf7c2260d6c9faf25"
 dependencies = [
- "aeronet_io",
- "aeronet_webtransport",
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "lightyear_aeronet",
- "lightyear_link",
+ "aeronet_io 0.19.1",
+ "aeronet_webtransport 0.19.1",
+ "bevy_app 0.18.1",
+ "bevy_ecs 0.18.1",
+ "bevy_reflect 0.18.1",
+ "lightyear_aeronet 0.26.4",
+ "lightyear_link 0.26.4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "lightyear_webtransport"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d9b8cc1471cdf897c4d1810606eac9011b75dd18a23acc0dd6e82af35f62ec"
+dependencies = [
+ "aeronet_io 0.21.0",
+ "aeronet_webtransport 0.21.0",
+ "bevy_app 0.19.0",
+ "bevy_ecs 0.19.0",
+ "lightyear_aeronet 0.28.0",
+ "lightyear_link 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -10277,9 +12229,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -10678,6 +12630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "naga"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10699,16 +12657,16 @@ dependencies = [
  "once_cell",
  "pp-rs",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
 
 [[package]]
 name = "naga"
-version = "29.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -10724,7 +12682,9 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
+ "pp-rs",
  "rustc-hash 1.1.0",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -10739,6 +12699,23 @@ dependencies = [
  "data-encoding",
  "indexmap 2.13.1",
  "naga 27.0.3",
+ "regex",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga_oil"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "319f03062940ed85c03da020042618356bb8ca5263020322930883b05e30208e"
+dependencies = [
+ "codespan-reporting 0.12.0",
+ "data-encoding",
+ "indexmap 2.13.1",
+ "naga 29.0.4",
  "regex",
  "rustc-hash 1.1.0",
  "thiserror 2.0.18",
@@ -10836,20 +12813,6 @@ checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.11.0",
- "jni-sys 0.3.1",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum 0.7.6",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -10857,7 +12820,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum 0.7.6",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -10868,15 +12831,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys 0.3.1",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -11271,6 +13225,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11306,6 +13285,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11335,7 +13337,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -11505,6 +13509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -11630,26 +13635,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
+name = "obvhs"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+checksum = "3194269f7697a676e6b6d93b3a8c9558727ce8f2425c6fdd01b6e364fdbbdb2e"
 dependencies = [
- "jni 0.21.1",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
+ "bytemuck",
+ "glam 0.32.1",
+ "half 2.7.1",
+ "log",
+ "rdst",
+ "static_assertions",
 ]
 
 [[package]]
@@ -11937,6 +13933,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+dependencies = [
+ "fontique",
+ "harfrust 0.6.2",
+ "hashbrown 0.17.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_data",
+ "skrifa 0.42.1",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+dependencies = [
+ "icu_properties",
+]
+
+[[package]]
 name = "parry2d"
 version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11992,6 +14021,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "parry3d"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99613136af5c3ae1e26907eb8ef90183636f54d02341c0a1121caa813a242cb5"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "glamx",
+ "hashbrown 0.16.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rstar",
+ "serde",
+ "serde_arrays",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parry3d-f64"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12019,6 +14078,41 @@ dependencies = [
  "spade",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "parry3d-f64"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f331c2ecfa5c34dfe379eff7efb824e5e8cfcc933d9624d74e7f867ea696dd"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "glamx",
+ "hashbrown 0.16.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rstar",
+ "serde",
+ "serde_arrays",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "partition"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947f833aaa585cf12b8ec7c0476c98784c49f33b861376ffc84ed92adebf2aba"
 
 [[package]]
 name = "password-hash"
@@ -12206,7 +14300,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cc",
  "clang-sys",
  "eyre",
@@ -12783,7 +14877,19 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "postcard-derive",
  "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12839,6 +14945,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -13241,7 +15349,7 @@ name = "q"
 version = "0.1.1"
 dependencies = [
  "axum 0.7.9",
- "bevy",
+ "bevy 0.18.1",
  "bevy_mapdb",
  "bevy_npc",
  "bincode",
@@ -13551,6 +15659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13637,6 +15755,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13685,6 +15815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdst"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf18dd479f856ca75267591c062e22b50e2db791157495bc2d533558de7061d"
+dependencies = [
+ "arbitrary-chunks",
+ "partition",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13702,7 +15842,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
- "font-types 0.11.2",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -14152,12 +16302,16 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
  "cpal",
+ "dasp_sample",
  "lewton",
+ "num-rational",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -15353,7 +17507,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
- "bevy",
+ "bevy 0.18.1",
  "bevy_spells",
  "dashmap 6.1.0",
  "fastnoise-lite",
@@ -15446,6 +17600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15459,6 +17623,12 @@ checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "smallbitvec"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b0e903ee191d8f7a8fbf0d712c3a1699d19e04ceba5ad1eb673053c7d938a09"
 
 [[package]]
 name = "smallvec"
@@ -15569,7 +17739,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -15654,6 +17824,15 @@ name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -16136,20 +18315,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
@@ -16230,6 +18395,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16255,9 +18432,9 @@ dependencies = [
  "jni 0.21.1",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -16860,6 +19037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -18054,6 +20232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "unsynn"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18277,6 +20466,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "variadics_please"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b53d0f7f2d0182759a549f1f313ce16b07d8f9ba93098157b5fa10ee3e61117f"
+dependencies = [
+ "quote",
+ "unsynn",
 ]
 
 [[package]]
@@ -18708,6 +20907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18740,6 +20945,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "web-task"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
+dependencies = [
+ "async-task",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -18955,9 +21172,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -18968,6 +21185,8 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
+ "naga 29.0.4",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -18978,7 +21197,7 @@ dependencies = [
  "web-sys",
  "wgpu-core 29.0.1",
  "wgpu-hal 29.0.1",
- "wgpu-types 29.0.1",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -19006,9 +21225,8 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-wasm",
+ "wgpu-core-deps-apple 27.0.0",
+ "wgpu-core-deps-emscripten 27.0.0",
  "wgpu-core-deps-windows-linux-android 27.0.0",
  "wgpu-hal 27.0.4",
  "wgpu-types 27.0.1",
@@ -19030,7 +21248,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.13.1",
  "log",
- "naga 29.0.1",
+ "naga 29.0.4",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -19039,10 +21257,13 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
+ "wgpu-core-deps-apple 29.0.4",
+ "wgpu-core-deps-emscripten 29.0.4",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android 29.0.0",
  "wgpu-hal 29.0.1",
  "wgpu-naga-bridge",
- "wgpu-types 29.0.1",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -19055,6 +21276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal 29.0.1",
+]
+
+[[package]]
 name = "wgpu-core-deps-emscripten"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19064,12 +21294,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wgpu-core-deps-wasm"
-version = "27.0.0"
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
 dependencies = [
- "wgpu-hal 27.0.4",
+ "wgpu-hal 29.0.1",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
+dependencies = [
+ "wgpu-hal 29.0.1",
 ]
 
 [[package]]
@@ -19109,7 +21348,7 @@ dependencies = [
  "glow 0.16.0",
  "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator",
+ "gpu-allocator 0.27.0",
  "gpu-descriptor",
  "hashbrown 0.16.1",
  "js-sys",
@@ -19119,7 +21358,7 @@ dependencies = [
  "log",
  "metal",
  "naga 27.0.3",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "objc",
  "once_cell",
  "ordered-float 5.3.0",
@@ -19145,29 +21384,61 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
 dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
+ "glow 0.17.0",
+ "glutin_wgl_sys",
+ "gpu-allocator 0.28.0",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
  "libloading 0.8.9",
  "log",
- "naga 29.0.1",
+ "naga 29.0.4",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
+ "profiling",
+ "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
+ "smallvec",
  "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
  "wgpu-naga-bridge",
- "wgpu-types 29.0.1",
+ "wgpu-types 29.0.4",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
 dependencies = [
- "naga 29.0.1",
- "wgpu-types 29.0.1",
+ "naga 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -19187,15 +21458,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
  "raw-window-handle",
+ "serde",
  "web-sys",
 ]
 
@@ -19286,16 +21558,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -19355,16 +21617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -19970,7 +22222,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -20193,7 +22445,7 @@ dependencies = [
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -20424,6 +22676,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20634,6 +22892,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -20642,6 +22901,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -50,7 +50,7 @@ tauri-build = { version = "2", features = [] }
 
 # --- Shared dependencies ---
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
     "bevy_core_pipeline",
@@ -74,7 +74,7 @@ bevy = { version = "0.18", default-features = false, features = [
 libm = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-avian3d = { version = "0.5", default-features = false, features = ["3d", "f32", "parry-f32", "debug-plugin"] }
+avian3d = { version = "0.7", default-features = false, features = ["3d", "f32", "parry-f32", "debug-plugin"] }
 bevy_inventory = { path = "../../../../packages/rust/bevy/bevy_inventory" }
 bevy_items = { path = "../../../../packages/rust/bevy/bevy_items", features = ["inventory"] }
 bevy_cam = { path = "../../../../packages/rust/bevy/bevy_cam" }
@@ -84,7 +84,7 @@ bevy_pathfinder = { path = "../../../../packages/rust/bevy/bevy_pathfinder" }
 bevy_skills = { path = "../../../../packages/rust/bevy/bevy_skills" }
 bevy_db = { path = "../../../../packages/rust/bevy/bevy_db" }
 bevy_chat = { path = "../../../../packages/rust/bevy/bevy_chat", features = ["plugin"] }
-lightyear = { version = "0.26", default-features = false, features = [
+lightyear = { version = "0.28", default-features = false, features = [
     "client",
     "replication",
     "prediction",
@@ -105,7 +105,7 @@ log = "0.4"
 
 # --- Native (desktop + mobile) render deps ---
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wgpu = "27"
+wgpu = "29"
 pollster = "0.4"
 raw-window-handle = "0.6"
 ureq = { version = "3", features = ["json"] }
@@ -134,12 +134,12 @@ android-activity = { version = "0.6", features = ["native-activity"] }
 
 # --- Linux-only Bevy features (x11/wayland) ---
 [target.'cfg(target_os = "linux")'.dependencies.bevy]
-version = "0.18"
+version = "0.19"
 features = ["x11", "wayland"]
 
 # --- WASM-only Bevy features (WebGPU backend) ---
 [target.'cfg(target_arch = "wasm32")'.dependencies.bevy]
-version = "0.18"
+version = "0.19"
 features = ["webgpu"]
 
 # --- WASM-only dependencies ---

--- a/apps/kbve/isometric/src-tauri/src/game/actions.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/actions.rs
@@ -493,7 +493,7 @@ fn animate_smoke_particles(
         };
         transform.scale = Vec3::splat(scale_curve);
 
-        if let Some(mat) = smoke_materials.get_mut(&particle.material_handle) {
+        if let Some(mut mat) = smoke_materials.get_mut(&particle.material_handle) {
             mat.uniforms.progress = t;
         }
 

--- a/apps/kbve/isometric/src-tauri/src/game/camera.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/camera.rs
@@ -34,7 +34,7 @@ impl Plugin for IsometricCameraPlugin {
             Update,
             attach_pixelate_settings.run_if(
                 any_with_component::<DisplayCamera>
-                    .and(not(any_with_component::<PixelateSettings>)),
+                    .and_then(not(any_with_component::<PixelateSettings>)),
             ),
         );
 

--- a/apps/kbve/isometric/src-tauri/src/game/campfire.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/campfire.rs
@@ -133,7 +133,7 @@ fn setup_campfires(
                     intensity: 120000.0,
                     radius: 1.0,
                     range: 40.0,
-                    shadows_enabled: false,
+                    shadow_maps_enabled: false,
                     ..default()
                 },
                 Transform::from_xyz(wx, ground_y + 1.4, wz),
@@ -169,7 +169,7 @@ fn animate_campfires(
         tf.translation = campfire.base_pos + push_back;
         tf.look_to(cam_tf.forward().as_vec3(), Vec3::Y);
 
-        if let Some(mat) = fire_materials.get_mut(&mat_handle.0) {
+        if let Some(mut mat) = fire_materials.get_mut(&mat_handle.0) {
             mat.uniforms.time = t + campfire.phase;
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/candle.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/candle.rs
@@ -86,7 +86,7 @@ fn setup_candles(
                     intensity: 4000.0,
                     radius: 0.1,
                     range: 6.0,
-                    shadows_enabled: false,
+                    shadow_maps_enabled: false,
                     ..default()
                 },
                 Transform::from_xyz(wx, candle_top + 0.3, wz),
@@ -114,7 +114,7 @@ fn animate_candles(
     }
 
     for mat_handle in &flame_q {
-        if let Some(mat) = fire_materials.get_mut(&mat_handle.0) {
+        if let Some(mut mat) = fire_materials.get_mut(&mat_handle.0) {
             mat.uniforms.time = t;
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/chat_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/chat_ui.rs
@@ -151,7 +151,7 @@ fn render_log(
                     line.spawn((
                         Text::new(format!("{}:", entry.sender)),
                         TextFont {
-                            font_size: 11.0,
+                            font_size: bevy::text::FontSize::Px(11.0),
                             ..default()
                         },
                         TextColor(entry.color),
@@ -161,7 +161,7 @@ fn render_log(
                     line.spawn((
                         Text::new(entry.content.clone()),
                         TextFont {
-                            font_size: 11.0,
+                            font_size: bevy::text::FontSize::Px(11.0),
                             ..default()
                         },
                         TextColor(ui_color::TEXT_PRIMARY),

--- a/apps/kbve/isometric/src-tauri/src/game/crafting_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/crafting_ui.rs
@@ -77,7 +77,7 @@ fn spawn_crafting_panel(mut commands: Commands) {
             panel.spawn((
                 Text::new("Crafting (C to toggle)"),
                 TextFont {
-                    font_size: 11.0,
+                    font_size: bevy::text::FontSize::Px(11.0),
                     ..default()
                 },
                 TextColor(GOLD_TEXT),
@@ -191,7 +191,7 @@ fn populate_recipes(
                 row.spawn((
                     Text::new(emoji),
                     TextFont {
-                        font_size: 18.0,
+                        font_size: bevy::text::FontSize::Px(18.0),
                         ..default()
                     },
                 ));
@@ -204,7 +204,7 @@ fn populate_recipes(
                         col.spawn((
                             Text::new(item.name.clone()),
                             TextFont {
-                                font_size: 11.0,
+                                font_size: bevy::text::FontSize::Px(11.0),
                                 ..default()
                             },
                             TextColor(ui_color::TEXT_PRIMARY),
@@ -212,7 +212,7 @@ fn populate_recipes(
                         col.spawn((
                             Text::new(format!("{ingredients_text}{skill_label}{facility_label}")),
                             TextFont {
-                                font_size: 9.0,
+                                font_size: bevy::text::FontSize::Px(9.0),
                                 ..default()
                             },
                             TextColor(ui_color::TEXT_SECONDARY),
@@ -235,7 +235,7 @@ fn populate_recipes(
                 .with_child((
                     Text::new("Craft"),
                     TextFont {
-                        font_size: 10.0,
+                        font_size: bevy::text::FontSize::Px(10.0),
                         ..default()
                     },
                     TextColor(GOLD_TEXT),

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
@@ -397,7 +397,7 @@ pub(super) fn render_butterflies(
                     cr.phase,
                     bs.size_scale,
                 );
-                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+                if let Some(mut mat) = materials.get_mut(&rd.mat_handle) {
                     let mut c = mat.base_color.to_srgba();
                     c.alpha = df * 0.9 * progress;
                     mat.base_color = c.into();
@@ -416,7 +416,7 @@ pub(super) fn render_butterflies(
                     cr.phase,
                     bs.size_scale,
                 );
-                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+                if let Some(mut mat) = materials.get_mut(&rd.mat_handle) {
                     let mut c = mat.base_color.to_srgba();
                     c.alpha = df * 0.9;
                     mat.base_color = c.into();
@@ -435,7 +435,7 @@ pub(super) fn render_butterflies(
                     cr.phase,
                     bs.size_scale,
                 );
-                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+                if let Some(mut mat) = materials.get_mut(&rd.mat_handle) {
                     let mut c = mat.base_color.to_srgba();
                     c.alpha = df * 0.9 * (1.0 - progress);
                     mat.base_color = c.into();

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
@@ -58,7 +58,7 @@ pub(super) fn spawn_fireflies(
                     intensity: 0.0,
                     radius: 0.08,
                     range: 10.0,
-                    shadows_enabled: false,
+                    shadow_maps_enabled: false,
                     ..default()
                 },
                 Transform::from_xyz(0.0, -100.0, 0.0),
@@ -335,7 +335,7 @@ pub(super) fn render_fireflies(
         let glow = 0.35 + pulse * 0.65;
         let intensity = glow * nf;
 
-        if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+        if let Some(mut mat) = materials.get_mut(&rd.mat_handle) {
             let emit = intensity * 55.0;
             mat.emissive = LinearRgba::new(0.3 * emit, 0.85 * emit, 0.15 * emit, 1.0);
             mat.base_color = Color::srgba(0.5, 0.9, 0.3, intensity * 0.95 + 0.3 * nf);

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/render.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/render.rs
@@ -5,7 +5,7 @@
 //! Visibility component management, and the SimulationCenter update from camera.
 
 use bevy::prelude::*;
-use bevy::render::storage::ShaderStorageBuffer;
+use bevy::render::storage::ShaderBuffer;
 
 use super::super::common::{GameTime, day_factor};
 use super::super::creature::{Creature, CreaturePoolIndex, SpriteData, SpriteHopState};
@@ -22,7 +22,7 @@ pub fn render_sprite_creatures(
     time: Res<Time>,
     game_time: Res<GameTime>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
-    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    mut buffers: ResMut<Assets<ShaderBuffer>>,
     mut atlas_pool: ResMut<SpriteAtlasPool>,
     types: Res<SpriteCreatureTypes>,
     mut creature_q: Query<
@@ -133,7 +133,7 @@ pub fn render_sprite_creatures(
     }
 
     for entry in &atlas_pool.entries {
-        if let Some(buffer) = buffers.get_mut(&entry.anim_buffer) {
+        if let Some(mut buffer) = buffers.get_mut(&entry.anim_buffer) {
             buffer.set_data(entry.anim_data.as_slice());
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
@@ -4,7 +4,7 @@ use bevy::camera::visibility::NoFrustumCulling;
 use bevy::light::NotShadowCaster;
 use bevy::mesh::MeshTag;
 use bevy::prelude::*;
-use bevy::render::storage::ShaderStorageBuffer;
+use bevy::render::storage::ShaderBuffer;
 
 use super::super::common::{CreaturePool, build_billboard_quad, hash_f32};
 use super::super::creature::{
@@ -23,7 +23,7 @@ pub fn spawn_sprite_creatures(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut atlas_materials: ResMut<Assets<SpriteAtlasMaterial>>,
-    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    mut buffers: ResMut<Assets<ShaderBuffer>>,
     asset_server: Res<AssetServer>,
     _pool: Res<CreaturePool>,
     registry: Res<CreatureRegistry>,
@@ -61,7 +61,7 @@ pub fn spawn_sprite_creatures(
 
         let anim_data: Vec<SpriteAnimData> =
             (0..count).map(|_| SpriteAnimData::default()).collect();
-        let anim_buffer = buffers.add(ShaderStorageBuffer::from(anim_data.clone()));
+        let anim_buffer = buffers.add(ShaderBuffer::from(anim_data.clone()));
 
         let material = atlas_materials.add(SpriteAtlasMaterial {
             atlas: texture,

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/tint.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/tint.rs
@@ -40,7 +40,7 @@ pub fn tint_sprite_creatures(
             }
         };
 
-        if let Some(mat) = atlas_materials.get_mut(&entry.material) {
+        if let Some(mut mat) = atlas_materials.get_mut(&entry.material) {
             mat.tint = LinearRgba::new(r, g, b, alpha);
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/types.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/types.rs
@@ -2,7 +2,7 @@
 //! per-creature hardcoded modules.
 
 use bevy::prelude::*;
-use bevy::render::storage::ShaderStorageBuffer;
+use bevy::render::storage::ShaderBuffer;
 
 use super::super::sprite_material::{SpriteAnimData, SpriteAtlasMaterial};
 
@@ -293,7 +293,7 @@ pub struct SpriteAtlasPool {
 pub struct SpriteAtlasEntry {
     pub type_key: &'static str,
     pub material: Handle<SpriteAtlasMaterial>,
-    pub anim_buffer: Handle<ShaderStorageBuffer>,
+    pub anim_buffer: Handle<ShaderBuffer>,
     pub anim_data: Vec<SpriteAnimData>,
     pub spawned: bool,
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use bevy::render::render_resource::{AsBindGroup, ShaderType};
-use bevy::render::storage::ShaderStorageBuffer;
+use bevy::render::storage::ShaderBuffer;
 use bevy::shader::ShaderRef;
 
 const SHADER_PATH: &str = "shaders/sprite_sheet.wgsl";
@@ -22,7 +22,7 @@ pub struct SpriteAtlasMaterial {
     pub atlas: Handle<Image>,
 
     #[storage(2, read_only)]
-    pub anim_data: Handle<ShaderStorageBuffer>,
+    pub anim_data: Handle<ShaderBuffer>,
 
     #[uniform(3)]
     pub atlas_grid: UVec2,

--- a/apps/kbve/isometric/src-tauri/src/game/equipment_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/equipment_ui.rs
@@ -101,7 +101,7 @@ fn spawn_equipment_panel(mut commands: Commands) {
             panel.spawn((
                 Text::new("Equipment (V to toggle)"),
                 TextFont {
-                    font_size: 11.0,
+                    font_size: bevy::text::FontSize::Px(11.0),
                     ..default()
                 },
                 TextColor(GOLD_TEXT),
@@ -139,7 +139,7 @@ fn spawn_equipment_panel(mut commands: Commands) {
                             slot_node.spawn((
                                 Text::new(""),
                                 TextFont {
-                                    font_size: 16.0,
+                                    font_size: bevy::text::FontSize::Px(16.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::TEXT_PRIMARY),
@@ -150,7 +150,7 @@ fn spawn_equipment_panel(mut commands: Commands) {
                             slot_node.spawn((
                                 Text::new(*label),
                                 TextFont {
-                                    font_size: 8.0,
+                                    font_size: bevy::text::FontSize::Px(8.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::TEXT_SECONDARY),

--- a/apps/kbve/isometric/src-tauri/src/game/hotbar_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/hotbar_ui.rs
@@ -81,7 +81,7 @@ fn spawn_hotbar(mut commands: Commands) {
                     slot.spawn((
                         Text::new(""),
                         TextFont {
-                            font_size: 18.0,
+                            font_size: bevy::text::FontSize::Px(18.0),
                             ..default()
                         },
                         HotbarSlotIcon { slot: i },
@@ -89,7 +89,7 @@ fn spawn_hotbar(mut commands: Commands) {
                     slot.spawn((
                         Text::new(format!("{}", i + 1)),
                         TextFont {
-                            font_size: 8.0,
+                            font_size: bevy::text::FontSize::Px(8.0),
                             ..default()
                         },
                         TextColor(GOLD_TEXT),
@@ -104,7 +104,7 @@ fn spawn_hotbar(mut commands: Commands) {
                     slot.spawn((
                         Text::new(""),
                         TextFont {
-                            font_size: 9.0,
+                            font_size: bevy::text::FontSize::Px(9.0),
                             ..default()
                         },
                         TextColor(GOLD_TEXT),

--- a/apps/kbve/isometric/src-tauri/src/game/input_bridge.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/input_bridge.rs
@@ -155,6 +155,7 @@ fn inject_input_from_ipc(
             x: 0.0,
             y: frame.scroll_delta_y,
             window: window_entity,
+            phase: bevy::input::touch::TouchPhase::Moved,
         });
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/interaction_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/interaction_ui.rs
@@ -212,7 +212,7 @@ fn spawn_interaction_panel(mut commands: Commands) {
             panel.spawn((
                 Text::new("Object"),
                 TextFont {
-                    font_size: 16.0,
+                    font_size: bevy::text::FontSize::Px(16.0),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_PRIMARY),
@@ -223,7 +223,7 @@ fn spawn_interaction_panel(mut commands: Commands) {
             panel.spawn((
                 Text::new("Description"),
                 TextFont {
-                    font_size: 12.0,
+                    font_size: bevy::text::FontSize::Px(12.0),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_SECONDARY),
@@ -240,7 +240,7 @@ fn spawn_interaction_panel(mut commands: Commands) {
                 UiButtonConfig {
                     width: Val::Percent(100.0),
                     height: Val::Px(36.0),
-                    font_size: 14.0,
+                    font_size: bevy::text::FontSize::Px(14.0),
                     border_radius: 4.0,
                     kind: ButtonKind::Primary,
                 },

--- a/apps/kbve/isometric/src-tauri/src/game/inventory_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/inventory_ui.rs
@@ -148,7 +148,7 @@ fn spawn_inventory_ui(mut commands: Commands) {
             .with_child((
                 Text::new("Bag"),
                 TextFont {
-                    font_size: 11.0,
+                    font_size: bevy::text::FontSize::Px(11.0),
                     ..default()
                 },
                 TextColor(GOLD_TEXT),
@@ -173,7 +173,7 @@ fn spawn_inventory_ui(mut commands: Commands) {
                 grid_container.spawn((
                     Text::new("Inventory"),
                     TextFont {
-                        font_size: 11.0,
+                        font_size: bevy::text::FontSize::Px(11.0),
                         ..default()
                     },
                     TextColor(GOLD_TEXT),
@@ -214,7 +214,7 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                 slot.spawn((
                                     Text::new(""),
                                     TextFont {
-                                        font_size: 16.0,
+                                        font_size: bevy::text::FontSize::Px(16.0),
                                         ..default()
                                     },
                                     TextColor(ui_color::TEXT_PRIMARY),
@@ -225,7 +225,7 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                 slot.spawn((
                                     Text::new(""),
                                     TextFont {
-                                        font_size: 8.0,
+                                        font_size: bevy::text::FontSize::Px(8.0),
                                         ..default()
                                     },
                                     TextColor(ui_color::TEXT_SECONDARY),
@@ -236,7 +236,7 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                 slot.spawn((
                                     Text::new(""),
                                     TextFont {
-                                        font_size: 8.0,
+                                        font_size: bevy::text::FontSize::Px(8.0),
                                         ..default()
                                     },
                                     TextColor(GOLD_TEXT),
@@ -370,7 +370,7 @@ fn spawn_slot_context_menu(
             menu.spawn((
                 Text::new(item_name),
                 TextFont {
-                    font_size: 12.0,
+                    font_size: bevy::text::FontSize::Px(12.0),
                     ..default()
                 },
                 TextColor(GOLD_TEXT),
@@ -408,7 +408,7 @@ fn spawn_action_button(parent: &mut ChildSpawnerCommands, label: &str, action: S
         .with_child((
             Text::new(label.to_string()),
             TextFont {
-                font_size: 11.0,
+                font_size: bevy::text::FontSize::Px(11.0),
                 ..default()
             },
             TextColor(ui_color::TEXT_PRIMARY),
@@ -531,7 +531,7 @@ fn spawn_inspect_modal(
                             header.spawn((
                                 Text::new(emoji),
                                 TextFont {
-                                    font_size: 22.0,
+                                    font_size: bevy::text::FontSize::Px(22.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::TEXT_PRIMARY),
@@ -542,7 +542,7 @@ fn spawn_inspect_modal(
                         header.spawn((
                             Text::new(name),
                             TextFont {
-                                font_size: 16.0,
+                                font_size: bevy::text::FontSize::Px(16.0),
                                 ..default()
                             },
                             TextColor(GOLD_TEXT),
@@ -554,7 +554,7 @@ fn spawn_inspect_modal(
                     panel.spawn((
                         Text::new(description),
                         TextFont {
-                            font_size: 12.0,
+                            font_size: bevy::text::FontSize::Px(12.0),
                             ..default()
                         },
                         TextColor(ui_color::TEXT_PRIMARY),
@@ -566,7 +566,7 @@ fn spawn_inspect_modal(
                     panel.spawn((
                         Text::new(lore),
                         TextFont {
-                            font_size: 11.0,
+                            font_size: bevy::text::FontSize::Px(11.0),
                             ..default()
                         },
                         TextColor(ui_color::TEXT_SECONDARY),

--- a/apps/kbve/isometric/src-tauri/src/game/minimap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/minimap.rs
@@ -156,9 +156,10 @@ fn redraw_minimap(
     let Ok(player_tf) = player_q.single() else {
         return;
     };
-    let Some(img) = images.get_mut(&handle.0) else {
+    let Some(mut img) = images.get_mut(&handle.0) else {
         return;
     };
+    let img = &mut *img;
 
     paint_background(img);
 

--- a/apps/kbve/isometric/src-tauri/src/game/native_input.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/native_input.rs
@@ -167,6 +167,7 @@ fn drain_native_input(
                     x: dx as f32,
                     y: dy as f32,
                     window: window_entity,
+                    phase: bevy::input::touch::TouchPhase::Moved,
                 };
                 wheel_writer.write(mw);
                 window_event_writer.write(WindowEvent::MouseWheel(mw));

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -1172,7 +1172,7 @@ fn spawn_remote_player_visuals(
             .with_child((
                 Text2d::new(""),
                 TextFont {
-                    font_size: 24.0,
+                    font_size: bevy::text::FontSize::Px(24.0),
                     ..default()
                 },
                 TextColor(Color::WHITE),

--- a/apps/kbve/isometric/src-tauri/src/game/object_registry.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/object_registry.rs
@@ -430,7 +430,7 @@ fn spawn_object_entity(
                     range: 30.0,
                     outer_angle: PI / 8.0,
                     inner_angle: PI / 16.0,
-                    shadows_enabled: true,
+                    shadow_maps_enabled: true,
                     ..default()
                 },
                 Transform::from_translation(position).looking_at(Vec3::ZERO, Vec3::Y),
@@ -444,7 +444,7 @@ fn spawn_object_entity(
                     color: Color::srgb(0.5, 0.6, 0.9),
                     intensity: 40000.0,
                     range: 20.0,
-                    shadows_enabled: true,
+                    shadow_maps_enabled: true,
                     ..default()
                 },
                 Transform::from_translation(position),

--- a/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
@@ -203,7 +203,7 @@ fn update_orbs(
 
     // Update health orb
     for handle in &hp_query {
-        if let Some(mat) = orb_materials.get_mut(handle) {
+        if let Some(mut mat) = orb_materials.get_mut(handle) {
             mat.uniforms.fill = hp_fill;
             // Pulse glow when low health
             mat.uniforms.glow = if hp_fill < 0.2 { 0.8 } else { 0.45 };
@@ -213,14 +213,14 @@ fn update_orbs(
 
     // Update mana orb
     for handle in &mp_query {
-        if let Some(mat) = orb_materials.get_mut(handle) {
+        if let Some(mut mat) = orb_materials.get_mut(handle) {
             mat.uniforms.fill = mp_fill;
         }
     }
 
     // Update energy orb
     for handle in &ep_query {
-        if let Some(mat) = orb_materials.get_mut(handle) {
+        if let Some(mut mat) = orb_materials.get_mut(handle) {
             mat.uniforms.fill = ep_fill;
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
@@ -67,7 +67,7 @@ impl Plugin for OrbHudPlugin {
         app.add_systems(
             Update,
             update_orbs.run_if(
-                in_state(GamePhase::Playing).and(resource_changed::<super::state::PlayerState>),
+                in_state(GamePhase::Playing).and_then(resource_changed::<super::state::PlayerState>),
             ),
         );
     }

--- a/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
@@ -189,7 +189,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                         header.spawn((
                             Text::new("Settings"),
                             TextFont {
-                                font_size: 16.0,
+                                font_size: bevy::text::FontSize::Px(16.0),
                                 ..default()
                             },
                             TextColor(ui_color::TEXT_PRIMARY),
@@ -237,7 +237,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                                     .with_child((
                                         Text::new(label),
                                         TextFont {
-                                            font_size: 12.0,
+                                            font_size: bevy::text::FontSize::Px(12.0),
                                             ..default()
                                         },
                                         TextColor(if is_active {
@@ -265,7 +265,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                             content.spawn((
                                 Text::new(category_title(SettingsCategory::General)),
                                 TextFont {
-                                    font_size: 14.0,
+                                    font_size: bevy::text::FontSize::Px(14.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::TEXT_PRIMARY),
@@ -277,7 +277,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                                     &settings_snapshot,
                                 )),
                                 TextFont {
-                                    font_size: 11.0,
+                                    font_size: bevy::text::FontSize::Px(11.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::TEXT_SECONDARY),
@@ -313,7 +313,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                             .with_child((
                                 Text::new("Exit"),
                                 TextFont {
-                                    font_size: 12.0,
+                                    font_size: bevy::text::FontSize::Px(12.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::BTN_TEXT),
@@ -338,7 +338,7 @@ fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameS
                             .with_child((
                                 Text::new("Resume"),
                                 TextFont {
-                                    font_size: 12.0,
+                                    font_size: bevy::text::FontSize::Px(12.0),
                                     ..default()
                                 },
                                 TextColor(ui_color::BTN_TEXT),

--- a/apps/kbve/isometric/src-tauri/src/game/phase.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/phase.rs
@@ -94,7 +94,7 @@ impl Plugin for PhasePlugin {
             Update,
             probe_transport.run_if(
                 in_state(GamePhase::Title)
-                    .and(|pf: Res<PreFlight>| pf.transport == TransportKind::Unknown),
+                    .and_then(|pf: Res<PreFlight>| pf.transport == TransportKind::Unknown),
             ),
         );
 

--- a/apps/kbve/isometric/src-tauri/src/game/phase.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/phase.rs
@@ -141,7 +141,7 @@ fn spawn_connecting_overlay(mut commands: Commands) {
             root.spawn((
                 Text::new("Connecting..."),
                 TextFont {
-                    font_size: 32.0,
+                    font_size: bevy::text::FontSize::Px(32.0),
                     ..default()
                 },
                 TextColor(Color::srgba(0.9, 0.9, 0.95, 1.0)),
@@ -149,7 +149,7 @@ fn spawn_connecting_overlay(mut commands: Commands) {
             root.spawn((
                 Text::new("Establishing secure connection to server"),
                 TextFont {
-                    font_size: 14.0,
+                    font_size: bevy::text::FontSize::Px(14.0),
                     ..default()
                 },
                 TextColor(Color::srgba(0.6, 0.6, 0.65, 1.0)),

--- a/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
@@ -1,8 +1,6 @@
-use bevy::core_pipeline::core_3d::graph::Node3d;
 use bevy::core_pipeline::fullscreen_material::{FullscreenMaterial, FullscreenMaterialPlugin};
 use bevy::prelude::*;
 use bevy::render::extract_component::ExtractComponent;
-use bevy::render::render_graph::{InternedRenderLabel, RenderLabel, RenderSubGraph};
 use bevy::render::render_resource::ShaderType;
 use bevy::shader::ShaderRef;
 
@@ -64,19 +62,6 @@ impl Default for PixelateSettings {
 impl FullscreenMaterial for PixelateSettings {
     fn fragment_shader() -> ShaderRef {
         "shaders/pixelate.wgsl".into()
-    }
-
-    fn node_edges() -> Vec<InternedRenderLabel> {
-        vec![
-            Node3d::Tonemapping.intern(),
-            Self::node_label().intern(),
-            Node3d::EndMainPassPostProcessing.intern(),
-        ]
-    }
-
-    fn sub_graph() -> Option<bevy::render::render_graph::InternedRenderSubGraph> {
-        use bevy::core_pipeline::core_3d::graph::Core3d;
-        Some(Core3d.intern())
     }
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
@@ -481,7 +481,7 @@ fn update_hover_highlight(
         );
         if let Some(mat) = materials.get(&mat_handle.0) {
             if mat.emissive != target {
-                if let Some(mat) = materials.get_mut(&mat_handle.0) {
+                if let Some(mut mat) = materials.get_mut(&mat_handle.0) {
                     mat.emissive = target;
                 }
             }
@@ -490,7 +490,7 @@ fn update_hover_highlight(
     for (mat_handle, original) in &unhovered {
         if let Some(mat) = materials.get(&mat_handle.0) {
             if mat.emissive != original.0 {
-                if let Some(mat) = materials.get_mut(&mat_handle.0) {
+                if let Some(mut mat) = materials.get_mut(&mat_handle.0) {
                     mat.emissive = original.0;
                 }
             }
@@ -638,7 +638,7 @@ fn update_occlusion(
 
         let occludes = obj_depth < player_depth && lateral_dist_sq < 4.0;
 
-        if let Some(mat) = materials.get_mut(&mat_handle.0) {
+        if let Some(mut mat) = materials.get_mut(&mat_handle.0) {
             if occludes && mat.alpha_mode != AlphaMode::Blend {
                 mat.base_color = mat.base_color.with_alpha(0.3);
                 mat.alpha_mode = AlphaMode::Blend;

--- a/apps/kbve/isometric/src-tauri/src/game/settings.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/settings.rs
@@ -235,7 +235,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                         header.spawn((
                             Text::new("Settings"),
                             TextFont {
-                                font_size: 18.0,
+                                font_size: bevy::text::FontSize::Px(18.0),
                                 ..default()
                             },
                             TextColor(ui_color::TEXT_PRIMARY),
@@ -248,7 +248,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                             UiButtonConfig {
                                 width: Val::Px(70.0),
                                 height: Val::Px(28.0),
-                                font_size: 12.0,
+                                font_size: bevy::text::FontSize::Px(12.0),
                                 border_radius: 4.0,
                                 kind: ButtonKind::Secondary,
                             },
@@ -285,7 +285,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                 panel.spawn((
                     Text::new("Transport"),
                     TextFont {
-                        font_size: 13.0,
+                        font_size: bevy::text::FontSize::Px(13.0),
                         ..default()
                     },
                     TextColor(ui_color::TEXT_SECONDARY),
@@ -306,7 +306,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                             UiButtonConfig {
                                 width: Val::Px(80.0),
                                 height: Val::Px(28.0),
-                                font_size: 11.0,
+                                font_size: bevy::text::FontSize::Px(11.0),
                                 border_radius: 4.0,
                                 kind: kind_for(settings.transport_override.is_none()),
                             },
@@ -318,7 +318,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                             UiButtonConfig {
                                 width: Val::Px(100.0),
                                 height: Val::Px(28.0),
-                                font_size: 11.0,
+                                font_size: bevy::text::FontSize::Px(11.0),
                                 border_radius: 4.0,
                                 kind: kind_for(
                                     settings.transport_override == Some(TransportKind::WebSocket),
@@ -332,7 +332,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                             UiButtonConfig {
                                 width: Val::Px(120.0),
                                 height: Val::Px(28.0),
-                                font_size: 11.0,
+                                font_size: bevy::text::FontSize::Px(11.0),
                                 border_radius: 4.0,
                                 kind: kind_for(
                                     settings.transport_override
@@ -345,7 +345,7 @@ fn spawn_settings_modal(commands: &mut Commands, settings: &GameSettings) {
                 panel.spawn((
                     Text::new(transport_label(&settings.transport_override)),
                     TextFont {
-                        font_size: 11.0,
+                        font_size: bevy::text::FontSize::Px(11.0),
                         ..default()
                     },
                     TextColor(ui_color::TEXT_SECONDARY),
@@ -385,7 +385,7 @@ fn volume_row(
             row.spawn((
                 Text::new(label.to_string()),
                 TextFont {
-                    font_size: 13.0,
+                    font_size: bevy::text::FontSize::Px(13.0),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_SECONDARY),
@@ -405,7 +405,7 @@ fn volume_row(
                     UiButtonConfig {
                         width: Val::Px(28.0),
                         height: Val::Px(24.0),
-                        font_size: 14.0,
+                        font_size: bevy::text::FontSize::Px(14.0),
                         border_radius: 4.0,
                         kind: ButtonKind::Secondary,
                     },
@@ -414,7 +414,7 @@ fn volume_row(
                 controls.spawn((
                     Text::new(format!("{value:>3}%")),
                     TextFont {
-                        font_size: 12.0,
+                        font_size: bevy::text::FontSize::Px(12.0),
                         ..default()
                     },
                     TextColor(ui_color::TEXT_PRIMARY),
@@ -428,7 +428,7 @@ fn volume_row(
                     UiButtonConfig {
                         width: Val::Px(28.0),
                         height: Val::Px(24.0),
-                        font_size: 14.0,
+                        font_size: bevy::text::FontSize::Px(14.0),
                         border_radius: 4.0,
                         kind: ButtonKind::Secondary,
                     },

--- a/apps/kbve/isometric/src-tauri/src/game/title_screen.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/title_screen.rs
@@ -106,7 +106,7 @@ fn spawn_title_screen(mut commands: Commands) {
             root.spawn((
                 Text::new("KBVE ISOMETRIC"),
                 TextFont {
-                    font_size: TITLE_FONT_SIZE,
+                    font_size: bevy::text::FontSize::Px(TITLE_FONT_SIZE),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_PRIMARY),
@@ -119,7 +119,7 @@ fn spawn_title_screen(mut commands: Commands) {
             root.spawn((
                 Text::new("a multiplayer sandbox"),
                 TextFont {
-                    font_size: SUBTITLE_FONT_SIZE,
+                    font_size: bevy::text::FontSize::Px(SUBTITLE_FONT_SIZE),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_SECONDARY),
@@ -141,7 +141,7 @@ fn spawn_title_screen(mut commands: Commands) {
                 badges.spawn((
                     Text::new("Transport: detecting..."),
                     TextFont {
-                        font_size: BADGE_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BADGE_FONT_SIZE),
                         ..default()
                     },
                     TextColor(ui_color::BADGE_LOADING),
@@ -152,7 +152,7 @@ fn spawn_title_screen(mut commands: Commands) {
                 badges.spawn((
                     Text::new("Auth: checking..."),
                     TextFont {
-                        font_size: BADGE_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BADGE_FONT_SIZE),
                         ..default()
                     },
                     TextColor(ui_color::BADGE_LOADING),
@@ -182,7 +182,7 @@ fn spawn_title_screen(mut commands: Commands) {
                         UiButtonConfig {
                             width: Val::Px(95.0),
                             height: Val::Px(BTN_HEIGHT),
-                            font_size: BTN_FONT_SIZE,
+                            font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                             kind: ButtonKind::Secondary,
                             ..default()
                         },
@@ -194,7 +194,7 @@ fn spawn_title_screen(mut commands: Commands) {
                         UiButtonConfig {
                             width: Val::Px(95.0),
                             height: Val::Px(BTN_HEIGHT),
-                            font_size: BTN_FONT_SIZE,
+                            font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                             kind: ButtonKind::Secondary,
                             ..default()
                         },
@@ -206,7 +206,7 @@ fn spawn_title_screen(mut commands: Commands) {
                         UiButtonConfig {
                             width: Val::Px(95.0),
                             height: Val::Px(BTN_HEIGHT),
-                            font_size: BTN_FONT_SIZE,
+                            font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                             kind: ButtonKind::Secondary,
                             ..default()
                         },
@@ -218,7 +218,7 @@ fn spawn_title_screen(mut commands: Commands) {
                         UiButtonConfig {
                             width: Val::Px(95.0),
                             height: Val::Px(BTN_HEIGHT),
-                            font_size: BTN_FONT_SIZE,
+                            font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                             kind: ButtonKind::Secondary,
                             ..default()
                         },
@@ -232,7 +232,7 @@ fn spawn_title_screen(mut commands: Commands) {
                     UiButtonConfig {
                         width: Val::Px(BTN_WIDTH),
                         height: Val::Px(BTN_HEIGHT),
-                        font_size: BTN_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                         kind: ButtonKind::Primary,
                         ..default()
                     },
@@ -244,7 +244,7 @@ fn spawn_title_screen(mut commands: Commands) {
                     UiButtonConfig {
                         width: Val::Px(BTN_WIDTH),
                         height: Val::Px(BTN_HEIGHT),
-                        font_size: BTN_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                         kind: ButtonKind::Secondary,
                         ..default()
                     },
@@ -256,7 +256,7 @@ fn spawn_title_screen(mut commands: Commands) {
                     UiButtonConfig {
                         width: Val::Px(BTN_WIDTH),
                         height: Val::Px(BTN_HEIGHT),
-                        font_size: BTN_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                         kind: ButtonKind::Secondary,
                         ..default()
                     },
@@ -268,7 +268,7 @@ fn spawn_title_screen(mut commands: Commands) {
                     UiButtonConfig {
                         width: Val::Px(BTN_WIDTH),
                         height: Val::Px(BTN_HEIGHT),
-                        font_size: BTN_FONT_SIZE,
+                        font_size: bevy::text::FontSize::Px(BTN_FONT_SIZE),
                         kind: ButtonKind::Danger,
                         ..default()
                     },
@@ -279,7 +279,7 @@ fn spawn_title_screen(mut commands: Commands) {
             root.spawn((
                 Text::new("v0.1 — dev build"),
                 TextFont {
-                    font_size: 12.0,
+                    font_size: bevy::text::FontSize::Px(12.0),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_SECONDARY),

--- a/apps/kbve/isometric/src-tauri/src/game/toast.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/toast.rs
@@ -232,7 +232,7 @@ fn spawn_toast_pool(mut commands: Commands) {
                         panel.spawn((
                             Text::new(""),
                             TextFont {
-                                font_size: 13.0,
+                                font_size: bevy::text::FontSize::Px(13.0),
                                 ..default()
                             },
                             TextColor(ui_color::TEXT_PRIMARY),

--- a/apps/kbve/isometric/src-tauri/src/game/ui/badge.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/ui/badge.rs
@@ -40,7 +40,7 @@ pub fn spawn_badge(
         .spawn((
             Text::new(text.to_string()),
             TextFont {
-                font_size,
+                font_size: bevy::text::FontSize::Px(font_size),
                 ..default()
             },
             TextColor(kind.color()),

--- a/apps/kbve/isometric/src-tauri/src/game/ui/button.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/ui/button.rs
@@ -44,7 +44,7 @@ impl ButtonKind {
 pub struct UiButtonConfig {
     pub width: Val,
     pub height: Val,
-    pub font_size: f32,
+    pub font_size: bevy::text::FontSize,
     pub border_radius: f32,
     pub kind: ButtonKind,
 }
@@ -54,7 +54,7 @@ impl Default for UiButtonConfig {
         Self {
             width: Val::Px(220.0),
             height: Val::Px(40.0),
-            font_size: 16.0,
+            font_size: bevy::text::FontSize::Px(16.0),
             border_radius: 6.0,
             kind: ButtonKind::Primary,
         }

--- a/apps/kbve/isometric/src-tauri/src/game/ui/modal.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/ui/modal.rs
@@ -102,7 +102,7 @@ pub fn spawn_modal(commands: &mut Commands, cfg: ModalConfig, marker: impl Compo
             .spawn((
                 Text::new(title),
                 TextFont {
-                    font_size: 14.0,
+                    font_size: bevy::text::FontSize::Px(14.0),
                     ..default()
                 },
                 TextColor(ui_color::TEXT_PRIMARY),
@@ -136,7 +136,7 @@ pub fn spawn_modal(commands: &mut Commands, cfg: ModalConfig, marker: impl Compo
         .with_child((
             Text::new("✕"),
             TextFont {
-                font_size: 12.0,
+                font_size: bevy::text::FontSize::Px(12.0),
                 ..default()
             },
             TextColor(ui_color::TEXT_SECONDARY),

--- a/apps/kbve/isometric/src-tauri/src/game/ui/text_label.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/ui/text_label.rs
@@ -38,7 +38,7 @@ pub fn spawn_label(
         .spawn((
             Text::new(text.to_string()),
             TextFont {
-                font_size,
+                font_size: bevy::text::FontSize::Px(font_size),
                 ..default()
             },
             TextColor(kind.color()),

--- a/apps/kbve/isometric/src-tauri/src/game/virtual_joystick.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/virtual_joystick.rs
@@ -155,7 +155,7 @@ fn spawn_joystick_ui(mut commands: Commands) {
                 .with_child((
                     Text::new("ACT".to_string()),
                     TextFont {
-                        font_size: 14.0,
+                        font_size: bevy::text::FontSize::Px(14.0),
                         ..default()
                     },
                     TextColor(Color::srgba(1.0, 1.0, 1.0, 0.7)),
@@ -179,7 +179,7 @@ fn spawn_joystick_ui(mut commands: Commands) {
                 .with_child((
                     Text::new("JMP".to_string()),
                     TextFont {
-                        font_size: 14.0,
+                        font_size: bevy::text::FontSize::Px(14.0),
                         ..default()
                     },
                     TextColor(Color::srgba(1.0, 1.0, 1.0, 0.7)),

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -268,7 +268,7 @@ fn spawn_lighting(mut commands: Commands, day: Res<DayCycle>) {
         DirectionalLight {
             illuminance: params.illuminance,
             color: params.color,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_translation(sun_pos).looking_at(Vec3::ZERO, Vec3::Y),
@@ -475,7 +475,7 @@ fn tint_trees_for_daynight(
     let r = 0.18 + h * 0.92;
     let g = 0.20 + h * 0.90;
     let b = 0.28 + h * 0.75;
-    if let Some(mat) = materials.get_mut(&tile_mats.tree_body_mat) {
+    if let Some(mut mat) = materials.get_mut(&tile_mats.tree_body_mat) {
         mat.base_color = Color::srgb(r, g, b);
     }
 }
@@ -681,7 +681,7 @@ fn animate_wind_streaks(
 
         if alpha < 0.003 {
             *vis = Visibility::Hidden;
-            if let Some(mat) = materials.get_mut(&streak.mat_handle) {
+            if let Some(mut mat) = materials.get_mut(&streak.mat_handle) {
                 mat.base_color = Color::srgba(1.0, 1.0, 1.0, 0.0);
             }
             continue;
@@ -689,7 +689,7 @@ fn animate_wind_streaks(
         *vis = Visibility::Visible;
 
         // Set per-streak alpha
-        if let Some(mat) = materials.get_mut(&streak.mat_handle) {
+        if let Some(mut mat) = materials.get_mut(&streak.mat_handle) {
             mat.base_color = Color::srgba(1.0, 1.0, 1.0, alpha);
         }
 

--- a/apps/kbve/isometric/src-tauri/src/mobile.rs
+++ b/apps/kbve/isometric/src-tauri/src/mobile.rs
@@ -191,9 +191,9 @@ fn create_render_resources<W>(window: &W) -> ManualRenderResources
 where
     W: HasWindowHandle + HasDisplayHandle + Send + Sync,
 {
-    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::all(),
-        ..Default::default()
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
     });
 
     let surface = instance

--- a/apps/kbve/isometric/src-tauri/src/renderer.rs
+++ b/apps/kbve/isometric/src-tauri/src/renderer.rs
@@ -14,9 +14,9 @@ pub struct CustomRendererPlugin {
 
 impl Plugin for CustomRendererPlugin {
     fn build(&self, app: &mut bevy::app::App) {
-        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
 
         let surface = instance

--- a/apps/kbve/isometric/src-tauri/src/tauri_plugin.rs
+++ b/apps/kbve/isometric/src-tauri/src/tauri_plugin.rs
@@ -60,10 +60,10 @@ mod desktop {
                 .build(tauri::generate_context!())
                 .expect("error while building tauri application");
 
-            app.insert_non_send_resource(tauri_app.handle().clone());
-            app.insert_non_send_resource(TauriAppResource(Some(tauri_app)));
+            app.insert_non_send(tauri_app.handle().clone());
+            app.insert_non_send(TauriAppResource(Some(tauri_app)));
             if let Some(post_render) = self.post_render_fn.lock().unwrap().take() {
-                app.insert_non_send_resource(PostRenderSetup(Some(post_render)));
+                app.insert_non_send(PostRenderSetup(Some(post_render)));
             }
             app.add_systems(Startup, create_window_handle);
             app.set_runner(run_tauri_app);
@@ -142,7 +142,7 @@ mod desktop {
             let mut app_ref = app.borrow_mut();
             app_ref
                 .world_mut()
-                .remove_non_send_resource::<TauriAppResource>()
+                .remove_non_send::<TauriAppResource>()
                 .expect("TauriAppResource missing")
                 .0
                 .expect("Tauri app already consumed")
@@ -244,7 +244,7 @@ mod desktop {
 
         let post_render = app
             .world_mut()
-            .remove_non_send_resource::<PostRenderSetup>()
+            .remove_non_send::<PostRenderSetup>()
             .and_then(|mut h| h.0.take());
         if let Some(setup) = post_render {
             setup(app);

--- a/packages/rust/bevy/bevy_battle/Cargo.toml
+++ b/packages/rust/bevy/bevy_battle/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["derive"] }
 rand = "0.10"
 
 # Bevy — only pulled in under the `bevy` feature.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }
 

--- a/packages/rust/bevy/bevy_behavior/Cargo.toml
+++ b/packages/rust/bevy/bevy_behavior/Cargo.toml
@@ -21,6 +21,6 @@ bevy = ["dep:bevy"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }

--- a/packages/rust/bevy/bevy_cam/Cargo.toml
+++ b/packages/rust/bevy/bevy_cam/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 zoom = []
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
     "bevy_core_pipeline",

--- a/packages/rust/bevy/bevy_cam/src/lib.rs
+++ b/packages/rust/bevy/bevy_cam/src/lib.rs
@@ -342,7 +342,7 @@ fn setup_camera(
     let texel_pad = 2.0 / render_h as f32;
     let quad_w = aspect + texel_pad * aspect;
     let quad_h = 1.0 + texel_pad;
-    if let Some(mesh) = meshes.get_mut(&mesh_handle) {
+    if let Some(mut mesh) = meshes.get_mut(&mesh_handle) {
         *mesh = Rectangle::new(quad_w, quad_h).into();
     }
     commands.spawn((
@@ -403,14 +403,14 @@ fn resize_render_target_on_window_change(
     let mut new_img =
         Image::new_target_texture(render_w, render_h, TextureFormat::Bgra8UnormSrgb, None);
     new_img.sampler = ImageSampler::nearest();
-    if let Some(slot) = images.get_mut(&assets.image) {
+    if let Some(mut slot) = images.get_mut(&assets.image) {
         *slot = new_img;
     }
 
     let texel_pad = 2.0 / render_h as f32;
     let quad_w = aspect + texel_pad * aspect;
     let quad_h = 1.0 + texel_pad;
-    if let Some(mesh) = meshes.get_mut(&assets.mesh) {
+    if let Some(mut mesh) = meshes.get_mut(&assets.mesh) {
         *mesh = Rectangle::new(quad_w, quad_h).into();
     }
 

--- a/packages/rust/bevy/bevy_chat/Cargo.toml
+++ b/packages/rust/bevy/bevy_chat/Cargo.toml
@@ -20,7 +20,7 @@ prost = "0.14"
 prost-types = "0.14"
 
 # Optional Bevy plugin support (for isometric game)
-bevy = { version = "0.18", default-features = false, features = ["bevy_state"], optional = true }
+bevy = { version = "0.19", default-features = false, features = ["bevy_state"], optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 
 # Native (tokio TCP) — used by Discord bot and lightyear server

--- a/packages/rust/bevy/bevy_db/Cargo.toml
+++ b/packages/rust/bevy/bevy_db/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 bincode = { version = "2", features = ["serde"] }
 
 # Bevy plumbing — only when the `bevy-plugin` feature is on.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }
 bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }

--- a/packages/rust/bevy/bevy_inventory/Cargo.toml
+++ b/packages/rust/bevy/bevy_inventory/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
 # Bevy — only pulled in under the `bevy` feature.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }
 

--- a/packages/rust/bevy/bevy_items/Cargo.toml
+++ b/packages/rust/bevy/bevy_items/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 inventory = ["dep:bevy_inventory"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }

--- a/packages/rust/bevy/bevy_kbve_net/Cargo.toml
+++ b/packages/rust/bevy/bevy_kbve_net/Cargo.toml
@@ -19,21 +19,21 @@ client = ["lightyear/client", "lightyear/websocket", "lightyear/webtransport", "
 creatures = ["npcdb", "dep:bevy_tasker", "dep:crossbeam-channel", "dep:dashmap"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_state", "bevy_render"] }
-lightyear = { version = "0.26", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = ["bevy_state", "bevy_render"] }
+lightyear = { version = "0.28", default-features = false, features = [
     "replication",
     "prediction",
     "interpolation",
     "input_native",
     "netcode",
 ] }
-avian3d = { version = "0.5", default-features = false, features = ["3d", "f32", "parry-f32", "serialize"] }
+avian3d = { version = "0.7", default-features = false, features = ["3d", "f32", "parry-f32", "serialize"] }
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22"
 hex = "0.4"
 bevy_npc = { version = "0.1", path = "../bevy_npc", optional = true }
-aeronet_webtransport = { version = "0.19", optional = true }
-lightyear_aeronet = { version = "0.26", optional = true }
+aeronet_webtransport = { version = "0.21", optional = true }
+lightyear_aeronet = { version = "0.28", optional = true }
 bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "6", optional = true }

--- a/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
@@ -525,16 +525,16 @@ impl Plugin for ProtocolPlugin {
             .add_direction(NetworkDirection::ServerToClient);
 
         // PlayerId: synced once on spawn, predicted + rollback
-        app.register_component::<PlayerId>().add_prediction();
+        app.component::<PlayerId>().replicate().predict();
 
         // PlayerColor: synced once on spawn, predicted
-        app.register_component::<PlayerColor>().add_prediction();
+        app.component::<PlayerColor>().replicate().predict();
 
         // PlayerVitals: server-authoritative, replicated to all clients
-        app.register_component::<PlayerVitals>().add_prediction();
+        app.component::<PlayerVitals>().replicate().predict();
 
         // PlayerName: replicated to all clients
-        app.register_component::<PlayerName>().add_prediction();
+        app.component::<PlayerName>().replicate().predict();
 
         // SetUsernameRequest: client → server
         app.register_message::<SetUsernameRequest>()
@@ -544,13 +544,13 @@ impl Plugin for ProtocolPlugin {
             .add_direction(NetworkDirection::ServerToClient);
 
         // Position: full sync with rollback
-        app.register_component::<Position>().add_prediction();
+        app.component::<Position>().replicate().predict();
 
         // Rotation: full sync with rollback
-        app.register_component::<Rotation>().add_prediction();
+        app.component::<Rotation>().replicate().predict();
 
         // LinearVelocity: predicted with rollback
-        app.register_component::<LinearVelocity>().add_prediction();
+        app.component::<LinearVelocity>().replicate().predict();
     }
 }
 

--- a/packages/rust/bevy/bevy_mapdb/Cargo.toml
+++ b/packages/rust/bevy/bevy_mapdb/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development", "game-engines"]
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }

--- a/packages/rust/bevy/bevy_npc/Cargo.toml
+++ b/packages/rust/bevy/bevy_npc/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 creature = []
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }

--- a/packages/rust/bevy/bevy_pathfinder/Cargo.toml
+++ b/packages/rust/bevy/bevy_pathfinder/Cargo.toml
@@ -32,6 +32,6 @@ tile-graph = []
 serde = { version = "1", features = ["derive"] }
 
 # Bevy — only pulled in under the `bevy` feature.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }

--- a/packages/rust/bevy/bevy_player/Cargo.toml
+++ b/packages/rust/bevy/bevy_player/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["game-development", "simulation"]
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
     "keyboard",
 ] }
-avian3d = { version = "0.5", default-features = false, features = [
+avian3d = { version = "0.7", default-features = false, features = [
     "3d",
     "f32",
     "parry-f32",

--- a/packages/rust/bevy/bevy_quests/Cargo.toml
+++ b/packages/rust/bevy/bevy_quests/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development", "game-engines"]
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }

--- a/packages/rust/bevy/bevy_skills/Cargo.toml
+++ b/packages/rust/bevy/bevy_skills/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Bevy — only pulled in under the `bevy` feature.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
     "bevy_log",
 ], optional = true }

--- a/packages/rust/bevy/bevy_spells/Cargo.toml
+++ b/packages/rust/bevy/bevy_spells/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development", "game-engines"]
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }

--- a/packages/rust/bevy/bevy_statemachine/Cargo.toml
+++ b/packages/rust/bevy/bevy_statemachine/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["dep:serde", "dep:serde_json"]
 bincode = ["dep:serde", "dep:bincode"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_state"] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 bincode = { version = "2", features = ["serde"], optional = true }

--- a/packages/rust/bevy/bevy_supa/Cargo.toml
+++ b/packages/rust/bevy/bevy_supa/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 
 # Bevy — only pulled in under the `bevy` feature. Game consumers that
 # want the plugin opt in; JNI consumers stay skinny.
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ], optional = true }
 


### PR DESCRIPTION
Supersedes dependabot #10073 (wgpu 27→29) and closes the coupled-upgrade work tracked in #10980.

## Why now
Bevy 0.18 hard-pinned wgpu 27 via `bevy_render`, so #10073 could not land standalone. **Bevy 0.19 released** with wgpu 29 alignment — the blocker is gone. This is the full coupled upgrade.

## Version bumps (all move on Bevy's cadence)
| dep | from | to |
|-----|------|-----|
| bevy | 0.18 | 0.19 |
| avian3d | 0.5 | 0.7 |
| lightyear + lightyear_aeronet | 0.26 | 0.28 |
| aeronet_webtransport | 0.19 | 0.21 |
| wgpu | 27 | 29 |

Applied across the app + all 17 `packages/rust/bevy/*` path-dep crates.

## Bevy 0.19 API migration
- `TextFont.font_size`: `f32` → `FontSize::Px(..)`
- Lights `shadows_enabled` → `shadow_maps_enabled`
- `Assets::get_mut` now returns `AssetMut` wrapper — `mut` bindings + reborrows
- `MouseWheel` gained `phase: TouchPhase`
- `ShaderStorageBuffer` removed → `bevy::render::storage::ShaderBuffer`
- `FullscreenMaterial` trait dropped `node_edges`/`sub_graph`/`node_label`; post-process ordering now via default `schedule_configs` (`PostProcess`, before tonemapping)
- wgpu 29 `Instance::new` takes owned `InstanceDescriptor` (no `Default`) → `new_without_display_handle()`

## Deprecation modernization
- lightyear `register_component::<C>().add_prediction()` → `component::<C>().replicate().predict()`
- bevy `SystemCondition::and` → `and_then`; `insert/remove_non_send_resource` → `insert/remove_non_send`

## Incidental fix
- `bevy_kbve_net` pinned nonexistent `crossbeam-channel = "0.7"` (max is 0.5.x) — blocked workspace resolution; corrected to `"0.5"`.

## Verification
- Native: `cargo check -p isometric-game` — clean, no bevy/lightyear deprecation warnings.
- WASM: `cargo +nightly check -p isometric-game --target wasm32-unknown-unknown --no-default-features --lib` — clean.

**Not runtime-verified here** (needs live server+client): lightyear netcode handshake after the 0.26→0.28 bump. Recommend a WS+WT handshake smoke test before merge, per #10980's netcode checklist.