### PR TITLE
fix(herbmail): unblock vite-game dispatch (version.toml sentinel 0.0.1)

### DIFF
--- a/apps/herbmail/herbmail-game/version.toml
+++ b/apps/herbmail/herbmail-game/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Problem

`ci-vite-game.yml` never fired for herbmail-game despite MDX bump to 0.1.2 (#14041).

## Root cause

`ci-main.yml` `is_newer()` treats `0.0.0` as "not ready" and short-circuits:

```bash
if [ -z "$pub_v" ] || [ "$pub_v" = "0.0.0" ]; then echo "false"; return; fi
```

With `version.toml = 0.0.0`, the version-gate path returns false → no dispatch. The `altered` fallback also can't fire: the alteration key is `vite_herbmail`, but Alpha Alters only emits `herbmail`/`astro_herbmail`, so `is_altered vite_herbmail` = false. Both paths dead → skipped:

```
· herbmail-game — no changes, version published, skipping
```

## Fix

Bump `version.toml` sentinel `0.0.0 → 0.0.1`. `is_newer(0.1.2, 0.0.1)` = true → dispatch fires. CI overwrites version.toml on publish anyway.