### PR TITLE
ci(rust): belt-and-suspenders retry for transient crates.io fetch failures

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -12,6 +12,11 @@ concurrency:
 
 permissions: {}
 
+env:
+    CARGO_NET_RETRY: '10'
+    CARGO_NET_TIMEOUT: '60'
+    RUSTUP_MAX_RETRIES: '10'
+
 jobs:
     # ---------------------------------------------------------------------------
     # Guard: skip if triggered by a failed CI - Main run.

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -53,6 +53,11 @@ on:
 
 permissions: {}
 
+env:
+    CARGO_NET_RETRY: '10'
+    CARGO_NET_TIMEOUT: '60'
+    RUSTUP_MAX_RETRIES: '10'
+
 jobs:
     # ---------------------------------------------------------------------------
     # Queue Guard — fail loudly if this run has been waiting > 2 hours.

--- a/.github/workflows/ci-uniti.yml
+++ b/.github/workflows/ci-uniti.yml
@@ -23,6 +23,16 @@ concurrency:
 permissions:
     contents: read
 
+# Belt: make every cargo/rustup registry fetch in this workflow retry transient
+# network failures (e.g. "Could not resolve host: index.crates.io" on a runner
+# with a DNS blip). Suspenders: the cross-compile build steps below also wrap
+# their build command in a shell retry loop, since a hard DNS failure can abort
+# cargo before net.retry engages.
+env:
+    CARGO_NET_RETRY: '10'
+    CARGO_NET_TIMEOUT: '60'
+    RUSTUP_MAX_RETRIES: '10'
+
 jobs:
     verify:
         name: Verify (fmt + clippy + tests)
@@ -206,7 +216,14 @@ jobs:
                   targets: x86_64-unknown-linux-gnu
 
             - name: cargo build (release)
-              run: cargo build -p uniti --release --target x86_64-unknown-linux-gnu
+              run: |
+                  n=0
+                  until cargo build -p uniti --release --target x86_64-unknown-linux-gnu; do
+                      n=$((n + 1))
+                      [ "$n" -ge 4 ] && { echo "::error::cargo build failed after $n attempts"; exit 1; }
+                      echo "::warning::cargo build attempt $n failed (transient network?); retrying in 20s"
+                      sleep 20
+                  done
 
             - name: Upload Linux libuniti.so
               uses: actions/upload-artifact@v7
@@ -264,8 +281,14 @@ jobs:
                   ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk-path }}
               run: |
                   cd packages/rust/bevy/uniti
-                  cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 \
-                      -o ./android-out build -p uniti --release
+                  n=0
+                  until cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 \
+                      -o ./android-out build -p uniti --release; do
+                      n=$((n + 1))
+                      [ "$n" -ge 4 ] && { echo "::error::cargo ndk build failed after $n attempts"; exit 1; }
+                      echo "::warning::cargo ndk build attempt $n failed (transient network?); retrying in 20s"
+                      sleep 20
+                  done
 
             - name: Upload Android per-ABI .so
               uses: actions/upload-artifact@v7
@@ -300,8 +323,14 @@ jobs:
             - name: cargo build (device + sim)
               run: |
                   cd packages/rust/bevy/uniti
-                  cargo build -p uniti --release --target aarch64-apple-ios
-                  cargo build -p uniti --release --target aarch64-apple-ios-sim
+                  n=0
+                  until cargo build -p uniti --release --target aarch64-apple-ios \
+                      && cargo build -p uniti --release --target aarch64-apple-ios-sim; do
+                      n=$((n + 1))
+                      [ "$n" -ge 4 ] && { echo "::error::cargo build (ios) failed after $n attempts"; exit 1; }
+                      echo "::warning::cargo build (ios) attempt $n failed (transient network?); retrying in 20s"
+                      sleep 20
+                  done
 
             - name: Build XCFramework
               run: |

--- a/.github/workflows/rust-publish-crate.yml
+++ b/.github/workflows/rust-publish-crate.yml
@@ -20,6 +20,11 @@ on:
             CRATES_TOKEN:
                 required: true
 
+env:
+    CARGO_NET_RETRY: '10'
+    CARGO_NET_TIMEOUT: '60'
+    RUSTUP_MAX_RETRIES: '10'
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -7,6 +7,11 @@ on:
                 required: true
                 type: string
 
+env:
+    CARGO_NET_RETRY: '10'
+    CARGO_NET_TIMEOUT: '60'
+    RUSTUP_MAX_RETRIES: '10'
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
The release run for #14050 failed **only** because an Android build runner hit `Could not resolve host: index.crates.io` while updating the registry index — a transient DNS blip before any compilation, not a code error. Every other job (verify/clippy, linux cdylib, iOS, fuzz, miri, asan) reached crates.io fine. This hardens the rust CI + publish workflows so a single registry flake doesn't fail the build.

## Belt — workflow-level env (all 5 rust workflows)
`CARGO_NET_RETRY=10`, `CARGO_NET_TIMEOUT=60`, `RUSTUP_MAX_RETRIES=10` so **every** cargo/rustup registry fetch retries transient network errors. Added to: `ci-uniti`, `ci-bevy`, `rust-publish-crate`, `ci-publish`, `rust-test-crate`.

`rust-publish-crate.yml` matters most — a registry flake there would fail an actual **crates.io publish** mid-run (the whole point of the recent crate-publish work).

## Suspenders — shell retry loop (ci-uniti cross-compile builds)
The three heavy fresh-fetch build steps — Linux cdylib, Android NDK (the one that failed), iOS device+sim — now wrap their build command in a retry loop (4 attempts, 20s backoff). Covers the case where a hard DNS failure aborts cargo before `net.retry` engages.

No code changes; CI resilience only. All 5 workflow files validated as well-formed YAML.