### PR TITLE
fix(herbmail): stabilize pagefind e2e against slow CI index load

### DIFF
--- a/apps/herbmail/herbmail-e2e/e2e/pagefind.spec.ts
+++ b/apps/herbmail/herbmail-e2e/e2e/pagefind.spec.ts
@@ -19,6 +19,7 @@ test.describe('Smoke: Pagefind Search', () => {
 	});
 
 	test('searching "getting started" returns results', async ({ page }) => {
+		test.setTimeout(60_000);
 		await page.locator('button[data-open-modal]').click();
 
 		const dialog = page.locator('dialog[aria-label="Search"]');
@@ -29,7 +30,7 @@ test.describe('Smoke: Pagefind Search', () => {
 		await input.pressSequentially('getting started', { delay: 50 });
 
 		const results = dialog.locator('.pagefind-ui__result');
-		await expect(results.first()).toBeVisible({ timeout: 15_000 });
+		await expect(results.first()).toBeVisible({ timeout: 30_000 });
 
 		const count = await results.count();
 		expect(count).toBeGreaterThan(0);
@@ -38,6 +39,7 @@ test.describe('Smoke: Pagefind Search', () => {
 	test('clicking a search result navigates to a valid page', async ({
 		page,
 	}) => {
+		test.setTimeout(60_000);
 		await page.locator('button[data-open-modal]').click();
 
 		const dialog = page.locator('dialog[aria-label="Search"]');
@@ -46,7 +48,7 @@ test.describe('Smoke: Pagefind Search', () => {
 		await input.pressSequentially('getting started', { delay: 50 });
 
 		const firstResult = dialog.locator('.pagefind-ui__result a').first();
-		await expect(firstResult).toBeVisible({ timeout: 15_000 });
+		await expect(firstResult).toBeVisible({ timeout: 30_000 });
 
 		const href = await firstResult.getAttribute('href');
 		expect(href).toBeTruthy();


### PR DESCRIPTION
## What

Fixes #14058 — `CI - Docker / herbmail` failing at `Nx e2e herbmail` on [pagefind.spec.ts](apps/herbmail/herbmail-e2e/e2e/pagefind.spec.ts).

## Root cause

Not a build/index bug. Verified locally the pagefind index is fully valid — `pagefind.js`, `wasm.en.pagefind`, `page_count: 2`, getting-started page indexed. Pagefind lazily fetches its index + compiles WASM **on first keystroke**. On a CPU-starved single-worker CI docker run that async chain exceeded the 15s result-visible timeout, failing all 3 retries.

## Fix

- `test.setTimeout(60_000)` on both search tests (default per-test timeout is 30s — too tight once the assertion needs to wait longer).
- Raise result-visible assertion `15s → 30s`.

Test-only; conservative timing relaxation.

## Verification

Ran `nx e2e herbmail-e2e --grep Pagefind` locally against the real axum server + real pagefind index — all 3 pagefind tests pass (17s). Docker e2e reproduction skipped: local `nx container` cross-build (arm64→amd64) fails at `cargo chef cook`, unrelated to this change; CI itself builds the image fine (the failing run reached the Playwright step).