### PR TITLE
fix(herbmail-game): asset URL rewrite + itch post-publish version sync

### DIFF
--- a/.github/workflows/ci-vite-game.yml
+++ b/.github/workflows/ci-vite-game.yml
@@ -180,3 +180,19 @@ jobs:
                   itchGameId: ${{ fromJSON(inputs.publish).itch_game }}
                   buildChannel: ${{ fromJSON(inputs.publish).itch_channel != '' && fromJSON(inputs.publish).itch_channel || 'html5' }}
                   buildNumber: ${{ needs.version_gate.outputs.local_version }}
+
+    post_publish_sync:
+        name: Post-publish version sync
+        needs: [version_gate, build, itch]
+        if: ${{ always() && needs.version_gate.outputs.should_publish == 'true' && needs.build.result == 'success' && (needs.itch.result == 'success' || needs.itch.result == 'skipped') && fromJSON(inputs.version).toml != '' }}
+        permissions:
+            contents: write
+            pull-requests: write
+            actions: write
+        uses: KBVE/kbve/.github/workflows/utils-post-publish.yml@main
+        with:
+            app_name: ${{ fromJSON(inputs.engine).app_name }}
+            version: ${{ fromJSON(inputs.version).manifest }}
+            version_toml_path: ${{ fromJSON(inputs.version).toml }}
+        secrets:
+            TRIGGER_PAT: ${{ secrets.UNITY_PAT }}

--- a/apps/herbmail/herbmail-game/src/game/assetBase.ts
+++ b/apps/herbmail/herbmail-game/src/game/assetBase.ts
@@ -1,0 +1,9 @@
+import * as THREE from 'three';
+
+const ASSET_BASE = import.meta.env.BASE_URL;
+
+THREE.DefaultLoadingManager.setURLModifier((url) =>
+	url.startsWith('/') && !url.startsWith('//')
+		? ASSET_BASE + url.slice(1)
+		: url,
+);

--- a/apps/herbmail/herbmail-game/src/main.tsx
+++ b/apps/herbmail/herbmail-game/src/main.tsx
@@ -1,15 +1,8 @@
+import './game/assetBase';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import * as THREE from 'three';
 import { App } from './app/App';
 import { verifySab } from './game/sab/verify';
-
-const ASSET_BASE = import.meta.env.BASE_URL;
-THREE.DefaultLoadingManager.setURLModifier((url) =>
-	url.startsWith('/') && !url.startsWith('//')
-		? ASSET_BASE + url.slice(1)
-		: url,
-);
 
 verifySab();
 


### PR DESCRIPTION
## Two fixes for the herbmail-game itch pipeline

### 1. Deploy 403s — eager asset URLs bypass the URL modifier
`main.tsx` registered `THREE.DefaultLoadingManager.setURLModifier` **after** `import { App }`. ES import statements evaluate in source order, so App's transitive module-scope loads fired first with raw `/textures` + `/models` paths:
- `useGLTF.preload(...)` in CratePlacer/TorchPlacer/PhysicsBodies/Character/PropRenderer
- module-level `new THREE.TextureLoader().load('/textures/...')` in MeshPool/crateDecal

On itch's subpath those absolute paths 403 (`dark_rock_diff_256.png`, `torch.glb`, `sword.glb`, `crate.glb`, `wood_14_256_.png`, …).

Fix: extracted the modifier to a side-effect module `game/assetBase.ts`, imported as the **first** statement in `main.tsx` → modifier is registered before any transitive eager load. Verified against a production `nx run herbmail-game:build` (exit 0, bundle contains the modifier + relative `./assets` base).

### 2. No post-publish writeback — itch re-uploads every push
`ci-vite-game.yml` ended at the itch job; `version.toml` stayed at `0.0.1` while the MDX gate saw `0.1.2 > 0.0.1` forever → re-dispatch + re-upload on every push. Added a `post_publish_sync` job (mirrors ci-godot/ci-unity) calling `utils-post-publish.yml@main`, which opens a PR bumping `version.toml` to the published version. Adapted the `with:` inputs for vite_game's JSON-blob dispatch inputs.