### PR TITLE
fix(bevy_supa): gate reqwest .timeout() off wasm32

### DIFF
--- a/packages/rust/bevy/bevy_supa/src/client.rs
+++ b/packages/rust/bevy/bevy_supa/src/client.rs
@@ -62,10 +62,14 @@ impl SupaClient {
         api_key: impl Into<String>,
         timeout: Duration,
     ) -> Self {
-        let http = Client::builder()
-            .timeout(timeout)
-            .build()
-            .unwrap_or_else(|_| Client::new());
+        let mut builder = Client::builder();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            builder = builder.timeout(timeout);
+        }
+        #[cfg(target_arch = "wasm32")]
+        let _ = timeout;
+        let http = builder.build().unwrap_or_else(|_| Client::new());
 
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),


### PR DESCRIPTION
## What

Fixes #14053 — `CI - Publish / crates/bevy_supa` failing at `check-wasm`.

## Root cause

[client.rs](packages/rust/bevy/bevy_supa/src/client.rs) called `Client::builder().timeout(timeout)`. reqwest's **wasm** `ClientBuilder` has no `timeout()` method, so `cargo check --target wasm32-unknown-unknown` failed:

```
error[E0599]: no method named `timeout` found for struct `ClientBuilder`
```

Desktop `test`/`check-desktop` passed; only `check-wasm` (part of `e2e`) broke, failing publish.

## Fix

Apply `.timeout()` only on non-wasm targets; on wasm the browser fetch layer handles timeouts.

## Verification

`nx run bevy_supa:e2e` — **passes** (test + check-wasm + check-desktop green locally).