### PR TITLE
ci(publish): retry cargo publish on crates.io 429 rate limit

### DIFF
--- a/.github/workflows/rust-publish-crate.yml
+++ b/.github/workflows/rust-publish-crate.yml
@@ -111,4 +111,29 @@ jobs:
             - name: Cargo Publish
               if: steps.version_check.outputs.should_publish == 'true'
               run: |
-                  cargo publish -p ${{ inputs.package }} --allow-dirty
+                  set -o pipefail
+                  max=6
+                  attempt=0
+                  while true; do
+                    attempt=$((attempt + 1))
+                    if cargo publish -p ${{ inputs.package }} --allow-dirty 2>publish.err; then
+                      cat publish.err >&2 || true
+                      exit 0
+                    fi
+                    cat publish.err >&2
+                    if grep -qiE "already (exists|uploaded)|crate version .* is already" publish.err; then
+                      echo "::notice::${{ inputs.package }} already published — treating as success."
+                      exit 0
+                    fi
+                    if ! grep -qi "429 Too Many Requests" publish.err; then
+                      echo "::error::cargo publish failed with a non-retryable error."
+                      exit 1
+                    fi
+                    if [ "$attempt" -ge "$max" ]; then
+                      echo "::error::cargo publish still rate-limited after $max attempts."
+                      exit 1
+                    fi
+                    wait=$((attempt * 120))
+                    echo "::warning::crates.io rate limit (429); attempt $attempt/$max — sleeping ${wait}s."
+                    sleep "$wait"
+                  done


### PR DESCRIPTION
## What

Fixes #14059 — `CI - Publish / crates/bevy_cam` failed.

## Root cause

Not a code bug. The batch publish created many **new** crates at once and tripped crates.io's new-crate burst limit:

```
error: failed to publish bevy_cam v0.1.0 to registry at https://crates.io
Caused by:
  status 429 Too Many Requests: You have published too many new crates in a
  short period of time. Please try again after Mon, 13 Jul 2026 19:14:55 GMT
```

The [publish step](.github/workflows/rust-publish-crate.yml) ran a bare `cargo publish`, so a transient 429 hard-failed the job.

## Fix

Wrap `cargo publish` in a bounded backoff retry:
- Retries **only** on `429 Too Many Requests` — sleeps 120s → 240s → … → 600s (6 attempts).
- Treats `already exists / already uploaded` as **success** (idempotent re-runs).
- Fails fast on any other (real) error.

## Notes

- bevy_cam's own `0.1.0` publish just needs a re-run of the publish workflow — the rate-limit window (19:14 GMT) has long passed. Left for a maintainer to trigger (crates.io publish = prod action).
- Validated: `python yaml` parse + `actionlint` (shellcheck) clean.