### PR TITLE
fix(ci): include vite_game in auto-merge manifest lookup

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -210,6 +210,7 @@ jobs:
                           ...(manifest.unity || []),
                           ...(manifest.godot || []),
                           ...(manifest.bevy_game || []),
+                          ...(manifest.vite_game || []),
                         ];
                         const entry = allEntries.find(
                           e => e.app_name === appName || e.package_name === appName


### PR DESCRIPTION
## Problem

Atom PR #14068 (`Atomic: herbmail-game v0.1.2 post-publish sync`) passed all checks but never auto-merged.

Root cause: the auto-merge validator in `ci-auto-merge-bot-prs.yml` builds `allEntries` from every manifest section **except** `vite_game`. `herbmail-game` lives under `vite_game`, so the lookup failed:

```
##[error]App 'herbmail-game' not found in dispatch manifest
```

validate job fails → merge job skipped → auto-merge never enabled.

## Fix

Add `...(manifest.vite_game || [])` to the `allEntries` list. Future vite_game post-publish atom PRs now validate and auto-merge.

## Follow-up

PR #14068 needs a manual re-dispatch of the auto-merge workflow (or manual merge) once this lands, since it already failed validation.