### PR TITLE
refactor(astro-kbve): shared dashboard chartTheme primitives

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAlerts.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAlerts.tsx
@@ -15,10 +15,10 @@ import {
 	Cell,
 	LabelList,
 	ResponsiveContainer,
-	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts';
+import { ChartTooltip, POLL_MS } from './chartTheme';
 import {
 	$alertsFiring,
 	$alertsFiringStatus,
@@ -41,14 +41,6 @@ import {
 	type AlertsRange,
 } from './alertsService';
 
-const POLL_MS = 30_000;
-const tooltipStyle = {
-	background: 'var(--sl-color-bg-nav, #111)',
-	border: '1px solid var(--sl-color-gray-5, #262626)',
-	borderRadius: '0.375rem',
-	fontSize: '0.75rem',
-	color: 'var(--sl-color-text, #e6edf3)',
-};
 
 export type AlertsVariant = 'compact' | 'full';
 
@@ -285,8 +277,7 @@ export default function ReactAlerts({ variant = 'full' }: Props) {
 									tickLine={false}
 									width={32}
 								/>
-								<Tooltip
-									contentStyle={tooltipStyle}
+								<ChartTooltip
 									cursor={{
 										fill: 'color-mix(in srgb, var(--sl-color-gray-4) 18%, transparent)',
 									}}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
@@ -15,10 +15,10 @@ import {
 	AreaChart,
 	CartesianGrid,
 	ResponsiveContainer,
-	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts';
+import { AXIS_STROKE, ChartTooltip, GRID_STROKE } from './chartTheme';
 import {
 	fetchAlerts,
 	fetchPodMetrics,
@@ -57,15 +57,8 @@ const tickFormatter = (t: number) =>
 const tooltipLabelFormatter = (t: number) =>
 	new Date(t * 1000).toLocaleString();
 
-const tooltipStyle = {
-	background: 'var(--sl-color-bg-nav, #111)',
-	border: '1px solid var(--sl-color-gray-5, #262626)',
-	borderRadius: '8px',
-	color: 'var(--sl-color-text, #e6edf3)',
-};
-
-const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
-const gridStroke = 'var(--sl-color-gray-5, #262626)';
+const axisStroke = AXIS_STROKE;
+const gridStroke = GRID_STROKE;
 
 function formatBytesAbs(bytes: number | null): string {
 	if (bytes == null) return '--';
@@ -699,8 +692,7 @@ export default function ReactArgoGrafanaPanel({
 											formatBytesAbs(v)
 										}
 									/>
-									<Tooltip
-										contentStyle={tooltipStyle}
+									<ChartTooltip
 										labelFormatter={tooltipLabelFormatter}
 										formatter={(v: number, n: string) =>
 											n === 'CPU'
@@ -767,8 +759,7 @@ export default function ReactArgoGrafanaPanel({
 											formatBytes(v).replace('/s', '')
 										}
 									/>
-									<Tooltip
-										contentStyle={tooltipStyle}
+									<ChartTooltip
 										labelFormatter={tooltipLabelFormatter}
 										formatter={(v: number) =>
 											formatBytes(v)

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
@@ -26,9 +26,9 @@ import {
 	XAxis,
 	YAxis,
 	CartesianGrid,
-	Tooltip,
 	ResponsiveContainer,
 } from 'recharts';
+import { AXIS_STROKE, ChartTooltip, GRID_STROKE } from './chartTheme';
 
 // ---------------------------------------------------------------------------
 // Chart helpers
@@ -43,15 +43,8 @@ const tickFormatter = (t: number) =>
 const tooltipLabelFormatter = (t: number) =>
 	new Date(t * 1000).toLocaleString();
 
-const tooltipStyle = {
-	background: 'var(--sl-color-bg-nav, #111)',
-	border: '1px solid var(--sl-color-gray-5, #262626)',
-	borderRadius: '8px',
-	color: 'var(--sl-color-text, #e6edf3)',
-};
-
-const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
-const gridStroke = 'var(--sl-color-gray-5, #262626)';
+const axisStroke = AXIS_STROKE;
+const gridStroke = GRID_STROKE;
 
 // Skeleton keeps the chart container height reserved while the first
 // range query is in flight, preventing the late-arriving pods chart
@@ -394,8 +387,7 @@ export default function ReactGrafanaK8s() {
 								fontSize={12}
 							/>
 							<YAxis stroke={axisStroke} fontSize={12} />
-							<Tooltip
-								contentStyle={tooltipStyle}
+							<ChartTooltip
 								labelFormatter={tooltipLabelFormatter}
 							/>
 							<Area

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
@@ -29,9 +29,9 @@ import {
 	XAxis,
 	YAxis,
 	CartesianGrid,
-	Tooltip,
 	ResponsiveContainer,
 } from 'recharts';
+import { AXIS_STROKE, ChartTooltip, GRID_STROKE } from './chartTheme';
 
 // ---------------------------------------------------------------------------
 // Chart helpers
@@ -46,15 +46,8 @@ const tickFormatter = (t: number) =>
 const tooltipLabelFormatter = (t: number) =>
 	new Date(t * 1000).toLocaleString();
 
-const tooltipStyle = {
-	background: 'var(--sl-color-bg-nav, #111)',
-	border: '1px solid var(--sl-color-gray-5, #262626)',
-	borderRadius: '8px',
-	color: 'var(--sl-color-text, #e6edf3)',
-};
-
-const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
-const gridStroke = 'var(--sl-color-gray-5, #262626)';
+const axisStroke = AXIS_STROKE;
+const gridStroke = GRID_STROKE;
 
 // Skeleton sized to the parent chart's exact height — keeps the page
 // layout stable while the first range query is in flight (prevents the
@@ -476,8 +469,7 @@ export default function ReactGrafanaNodes() {
 								stroke={axisStroke}
 								fontSize={12}
 							/>
-							<Tooltip
-								contentStyle={tooltipStyle}
+							<ChartTooltip
 								labelFormatter={tooltipLabelFormatter}
 							/>
 							<Area
@@ -542,8 +534,7 @@ export default function ReactGrafanaNodes() {
 								stroke={axisStroke}
 								fontSize={12}
 							/>
-							<Tooltip
-								contentStyle={tooltipStyle}
+							<ChartTooltip
 								labelFormatter={tooltipLabelFormatter}
 								formatter={(v: number) => formatBytes(v)}
 							/>
@@ -608,8 +599,7 @@ export default function ReactGrafanaNodes() {
 								stroke={axisStroke}
 								fontSize={12}
 							/>
-							<Tooltip
-								contentStyle={tooltipStyle}
+							<ChartTooltip
 								labelFormatter={tooltipLabelFormatter}
 							/>
 							<Area

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsTelemetry.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsTelemetry.tsx
@@ -16,10 +16,10 @@ import {
 	CartesianGrid,
 	Cell,
 	ResponsiveContainer,
-	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts';
+import { ChartTooltip, POLL_MS } from './chartTheme';
 import {
 	$requestRate,
 	$requestRateStatus,
@@ -39,21 +39,12 @@ import {
 	type TelemetryRange,
 } from './rowsTelemetryService';
 
-const POLL_MS = 30_000;
-
 const STATUS_BAR_COLOR = (status: number): string => {
 	if (status >= 500) return '#ef4444';
 	if (status >= 400) return '#f59e0b';
 	if (status >= 300) return '#3b82f6';
 	if (status >= 200) return '#10b981';
 	return '#6b7280';
-};
-
-const tooltipStyle = {
-	background: 'var(--sl-color-bg-nav, #111)',
-	border: '1px solid var(--sl-color-gray-5, #262626)',
-	borderRadius: '0.375rem',
-	fontSize: '0.75rem',
 };
 
 function PanelShell({
@@ -192,8 +183,7 @@ export default function ReactRowsTelemetry() {
 								<YAxis
 									tick={{ fontSize: 10, fill: '#9ca3af' }}
 								/>
-								<Tooltip
-									contentStyle={tooltipStyle}
+								<ChartTooltip
 									labelFormatter={(v) =>
 										new Date(v as string).toLocaleString()
 									}
@@ -233,7 +223,7 @@ export default function ReactRowsTelemetry() {
 								<YAxis
 									tick={{ fontSize: 10, fill: '#9ca3af' }}
 								/>
-								<Tooltip contentStyle={tooltipStyle} />
+								<ChartTooltip />
 								<Bar dataKey="n">
 									{statusHistogram.map((s, i) => (
 										<Cell

--- a/apps/kbve/astro-kbve/src/components/dashboard/chartTheme.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/chartTheme.tsx
@@ -1,0 +1,19 @@
+import type { ComponentProps } from 'react';
+import { Tooltip } from 'recharts';
+
+export const POLL_MS = 30_000;
+
+export const AXIS_STROKE = 'var(--sl-color-gray-3, #8b949e)';
+export const GRID_STROKE = 'var(--sl-color-gray-5, #262626)';
+
+export const tooltipStyle = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: '8px',
+	fontSize: '0.75rem',
+	color: 'var(--sl-color-text, #e6edf3)',
+} as const;
+
+export function ChartTooltip(props: ComponentProps<typeof Tooltip>) {
+	return <Tooltip contentStyle={tooltipStyle} {...props} />;
+}


### PR DESCRIPTION
## What
Extracts recharts boilerplate duplicated across 5 dashboard telemetry islands into a shared `chartTheme.tsx`.

New `chartTheme.tsx` exports:
- `POLL_MS` (was duped in ReactAlerts + ReactRowsTelemetry)
- `AXIS_STROKE` / `GRID_STROKE` tokens (was duped in Grafana Nodes/K8s/Argo)
- `tooltipStyle` (canonical — was duped 5× with drift)
- `<ChartTooltip>` — `<Tooltip contentStyle={tooltipStyle} {...props} />` preset

Refactored: ReactAlerts, ReactArgoGrafanaPanel, ReactGrafanaK8s, ReactGrafanaNodes, ReactRowsTelemetry.

Net **−27 lines**.

## Intentional visual unification
Canonical `tooltipStyle` merges prior drift → all chart tooltips now share `borderRadius: 8px`, `fontSize: 0.75rem`, `color`. Prior variants: some `0.375rem`, some no `fontSize`, RowsTelemetry lacked `color`. Cosmetic only.

## Left alone
- `ReactNxReport` — unique slate tooltip (`#0f172a`), no CSS-var theme, no POLL. Not part of the shared set.
- Per-chart `XAxis`/`YAxis` styling kept inline — 3 distinct idioms (local stroke vars / hardcoded `tick.fill` / `axisLine={false}`), unifying would change visuals.

## Verify
`nx build astro-kbve` green (7367 pages). Follows the recharts v3 bump (#14076).