### PR TITLE
fix(ci): pull per-game LFS blobs before vite-game build

### DIFF
--- a/.github/workflows/ci-vite-game.yml
+++ b/.github/workflows/ci-vite-game.yml
@@ -112,6 +112,21 @@ jobs:
                   chmod 600 "$HOME/.netrc"
                   git lfs install --local
 
+            - name: Pull vite-game LFS blobs
+              run: |
+                  CFG=$(git ls-files -- '**/.lfsconfig' | grep "^${PROJECT_PATH}/" | head -1)
+                  if [ -z "$CFG" ]; then
+                    echo "::error::No nested .lfsconfig under ${PROJECT_PATH} — cannot resolve per-game LFS endpoint"
+                    exit 1
+                  fi
+                  URL=$(git config -f "$CFG" lfs.url)
+                  if [ -z "$URL" ]; then
+                    echo "::error::$CFG has no lfs.url"
+                    exit 1
+                  fi
+                  echo "::notice::Pulling LFS for ${PROJECT_PATH} from $URL"
+                  git -c lfs.url="$URL" lfs pull -I "${PROJECT_PATH}/**"
+
             - name: Setup Node.js ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v6
               with:
@@ -146,6 +161,12 @@ jobs:
               run: |
                   if [ ! -f "dist/${PROJECT_PATH}/index.html" ]; then
                     echo "::error::Build output missing dist/${PROJECT_PATH}/index.html"
+                    exit 1
+                  fi
+                  STUBS=$(grep -rl 'git-lfs.github.com/spec' "dist/${PROJECT_PATH}" || true)
+                  if [ -n "$STUBS" ]; then
+                    echo "::error::LFS pointer stubs shipped in build output — assets were not smudged. Offending files:"
+                    echo "$STUBS"
                     exit 1
                   fi
                   ls -la "dist/${PROJECT_PATH}"


### PR DESCRIPTION
## Problem

herbmail-game v0.1.3 (and prior itch builds) fail on itch — GLTFLoader throws `JSON Parse error: Unexpected identifier "version"` on `/models/torch.glb`. The served `.glb` is a git-LFS pointer stub (`version https://git-lfs.github.com/spec/v1 …`), not binary.

## Root cause

The build **does** pull LFS: `herbmail-game:build` dependsOn the nx `lfs-pull` target, which runs `./kbve.sh -lfs herbmail pull`. But that target ends with `|| echo 'herbmail LFS pull skipped … assets may be pointer stubs'` — it **swallows any failure and exits 0**. So when the pull fails or comes back empty in CI (creds/glob/missing remote objects), the build continues and ships pointer stubs to itch with no signal. The `|| echo` fallback is deliberate for local dev (offline devs shouldn't get a hard build failure), but in CI it silently produces a broken deploy.

Note the repo-root `.lfsconfig` points at `KBVE/rareicon.git`; herbmail blobs live on `KBVE/herbmail.git`, resolved via the nested `.lfsconfig` under `PROJECT_PATH`.

## Fix

1. **Explicit hard-failing LFS pull in CI** — resolve the per-game endpoint from the nested `.lfsconfig` and `git -c lfs.url=… lfs pull -I "${PROJECT_PATH}/**"`. Unlike the nx target it does NOT swallow errors, so a failed pull surfaces the real git-lfs error and reddens the build instead of shipping stubs. Generic across all vite games.
2. **Stub guard** in Verify — fail if any `git-lfs.github.com/spec` pointer reaches `dist/`. Second net that catches a stub regardless of cause. This is the check that would have caught v0.1.3.

## Verification

- YAML validated.
- Guard grep pattern confirmed to match a real pointer stub.

After merge, re-dispatch the herbmail-game itch publish to reship v0.1.3 with real blobs. If the explicit pull fails, the CI log will now show the real cause (creds vs. missing remote objects).