### PR TITLE
fix(ci): herbmail-game LFS 404 + missing failure ticket

### DIFF
--- a/.github/workflows/ci-vite-game.yml
+++ b/.github/workflows/ci-vite-game.yml
@@ -217,3 +217,19 @@ jobs:
             version_toml_path: ${{ fromJSON(inputs.version).toml }}
         secrets:
             TRIGGER_PAT: ${{ secrets.UNITY_PAT }}
+
+    track_build:
+        name: Track build
+        if: always() && needs.build.result != 'cancelled' && needs.build.result != 'skipped'
+        needs: [version_gate, build]
+        permissions:
+            issues: write
+            contents: read
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        with:
+            workflow_name: 'CI - Vite Game'
+            job_name: ${{ fromJSON(inputs.engine).app_name }}
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.build.result }}
+            version: ${{ needs.version_gate.outputs.local_version }}

--- a/kbve.sh
+++ b/kbve.sh
@@ -1096,7 +1096,7 @@ EOF
             ;;
         herbmail)
             url="https://git.kbve.com/KBVE/herbmail.git/info/lfs"
-            path_prefix="apps/herbmail/herbmail-game/public"
+            path_prefix="apps/herbmail/herbmail-game"
             ;;
         *)
             echo "Unknown game '$game'. Known: chuck, rareicon, rentearth, arpg, cryptothrone, cleanroom, herbmail" >&2


### PR DESCRIPTION
## Context

[CI run 29292697653](https://github.com/KBVE/kbve/actions/runs/29292697653) — `CI - Vite Game / herbmail-game` failed at **Pull vite-game LFS blobs** with `[404] Not Found` on all 28 objects, and produced **no issue ticket**.

## Root causes

1. **LFS 404** — the 28 herbmail LFS blobs were committed to the monorepo as pointers but never uploaded to the Forgejo `KBVE/herbmail` LFS store (store was empty). **Fixed out-of-band**: pushed all 28 objects (80 MB) to `git.kbve.com/KBVE/herbmail`; targeted `lfs pull -I 'apps/herbmail/herbmail-game/**'` now exits 0.
2. **Wrapper skipped art blobs** — `kbve.sh` herbmail `path_prefix` was `apps/herbmail/herbmail-game/public`, so `register`/`push` missed the 4 blobs under `/art/**` (arms.blend, retarget_ready.blend, crate.blend/.fbx). CI pulls the whole game tree, so those would 404 even after a `/public`-only push. Broadened to `apps/herbmail/herbmail-game`.
3. **No issue ticket** — `ci-vite-game.yml` never invoked `utils-ci-failure-tracker.yml` (21 other CI workflows do). Added a `track_build` job mirroring the ci-bevy pattern: opens an issue on failure, auto-closes on success.

## Verification
- `actionlint` clean (pre-existing SC2086 on line 144 unrelated).
- Forgejo blob push confirmed: CI-path pull `EXIT=0`.
