### PR TITLE
feat(agones-factorio): enable kbve-orc in mod-list

### DIFF
--- a/apps/agones/factorio/mods/mod-list.json
+++ b/apps/agones/factorio/mods/mod-list.json
@@ -3,6 +3,7 @@
 		{ "name": "base", "enabled": true },
 		{ "name": "kbve", "enabled": true },
 		{ "name": "kbve-spider", "enabled": true },
+		{ "name": "kbve-orc", "enabled": true },
 		{ "name": "elevated-rails", "enabled": true },
 		{ "name": "quality", "enabled": true },
 		{ "name": "space-age", "enabled": true },


### PR DESCRIPTION
Enable `kbve-orc` in the baked `apps/agones/factorio/mods/mod-list.json` now that it is published on the Factorio mod portal.

- `kbve-orc` source lives in `mods-src/` (not baked into the image), so the `agones-shim` sync loop downloads it from the portal at container start — same path as `kbve-spider`. Enabling it in mod-list is all that's required.
- No version bump: rides the pending agones-factorio `0.0.14` (main is at 0.0.13). When dev→main promotes, one dispatch rebuilds the image with this enable + the 0.0.2 mod tweaks and publishes orc 0.0.2.
- The shim needs `FACTORIO_USERNAME`/`FACTORIO_TOKEN` to download (already set for kbve-spider).