### PR TITLE
chore(kube): remove MetalLB leftovers after Cilium LB-IPAM migration

### DIFF
--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -65,7 +65,6 @@ gameservers:
         - arpg
 
     # Port range for game server host ports.
-    # Capped at 7900 to avoid MetalLB speaker memberlist port (7946).
     minPort: 7000
     maxPort: 7900
 

--- a/apps/kube/cilium/MIGRATION.md
+++ b/apps/kube/cilium/MIGRATION.md
@@ -12,7 +12,7 @@ Cluster: Talos Linux, Kubernetes 1.33.2, dual /32 external IPs
 | Phase 1 | Cilium as CNI + WireGuard                     | DONE (2026-03-19)                                               |
 | Phase 2 | Replace ingress-nginx with Cilium Gateway API | DONE in PR #11551; residual cluster cleanup pending — see below |
 | Phase 3 | WebTransport / QUIC validation                | Pending                                                         |
-| Phase 4 | MetalLB replacement                           | N/A — MetalLB never adopted on this cluster after Phase 1       |
+| Phase 4 | MetalLB replacement                           | DONE (2026-07-14) — stale controller/speaker removed from cluster; Cilium LB IPAM owns all VIPs |
 | Phase 5 | Gateway API modernization                     | DONE — all live routes are HTTPRoute via `kbve-gateway`         |
 
 **Residual Phase 2 cleanup (operational, not repo):**

--- a/apps/kube/cilium/values.yaml
+++ b/apps/kube/cilium/values.yaml
@@ -70,7 +70,7 @@ gatewayAPI:
     enableAlpn: true
     enableAppProtocol: true
 
-# L2 announcements — replaces MetalLB
+# L2 announcements
 # Includes ^br.* for bridge interface support
 l2announcements:
     enabled: true

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -91,7 +91,7 @@ resources:
     - gateway-api/application.yaml
     # Cilium CNI + WireGuard + Gateway API
     - cilium/application.yaml
-    # Cilium LB IPAM — IP pools + L2 announcements (replaces MetalLB)
+    # Cilium LB IPAM — IP pools + L2 announcements
     - cilium/lb-application.yaml
 
     # ECK (Elastic Cloud on Kubernetes) fully retired — ES + Kibana were

--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -47,12 +47,12 @@ data:
         \ }\n          if exists(parsed.msg) { .event_message = string(parsed.msg) ??\
         \ .event_message }\n          .metadata = parsed\n      }\n  # Drop info/debug\
         \ from noisy infra namespaces; keep warn+/error+ from\n  # them and everything\
-        \ from app namespaces. Cost discipline — these\n  # 13 namespaces emit massive\
+        \ from app namespaces. Cost discipline — these\n  # 12 namespaces emit massive\
         \ low-signal chatter.\n  noise_filter:\n    type: filter\n    inputs:\n      -\
         \ project_logs\n    condition:\n      type: vrl\n      source: |-\n        noisy\
         \ = [\"argocd\", \"clickhouse\", \"arc-systems\", \"arc-runners\", \"monitoring\"\
         ,\n                 \"kube-system\", \"kube-node-lease\", \"kube-public\",\n \
-        \                \"longhorn-system\", \"metallb-system\", \"cnpg-system\",\n \
+        \                \"longhorn-system\", \"cnpg-system\",\n \
         \                \"cert-manager\", \"external-secrets-system\"]\n        ns =\
         \ string(.pod_namespace) ?? \"\"\n        if !includes(noisy, ns) {\n        \
         \    true\n        } else {\n            msg = string(.event_message) ?? \"\"\n\


### PR DESCRIPTION
## Why

Stale MetalLB controller/speaker (349 days old, raw manifests, never Argo-tracked, no helm release) was still running in `metallb-system` and fighting Cilium LB-IPAM over `arpg/arpg-game-udp` service status — MetalLB repeatedly assigned `142.132.206.74` (the node IP, forbidden as a Service VIP per #11811) while Cilium wrote `.71` back, producing an endless `Reconciler error` conflict loop.

MetalLB was fully removed from the cluster via kubectl on 2026-07-14 (deployment, daemonset, pool/l2advertisement CRs, webhook config, RBAC, all `metallb.io` CRDs, namespace). Verified after removal: arpg-game-udp holds `.71` via Cilium, kbve.com/supabase/git all reachable.

## Repo changes

- **vector-config.yaml** — drop `metallb-system` from the noise-filter namespace list (namespace no longer exists), count 13 → 12
- **agones/values.yaml** — remove obsolete comment about capping gameserver port range below MetalLB speaker memberlist port 7946; the 7000–7900 range itself is unchanged
- **cilium/values.yaml, kustomization.yaml** — drop "replaces MetalLB" comments
- **cilium/MIGRATION.md** — mark Phase 4 DONE (2026-07-14); the prior "MetalLB never adopted" status was incorrect

Refs #13821