### PR TITLE
fix(clickhouse): kbve_ingest grants on gameops/firecracker/logflare

### DIFF
--- a/apps/kube/clickhouse/manifests/ch-ingest-grants-job.yaml
+++ b/apps/kube/clickhouse/manifests/ch-ingest-grants-job.yaml
@@ -8,21 +8,45 @@ metadata:
         kbve.com/stack: clickhouse
         kbve.com/managed-by: argocd
 data:
-    grants.sh:
-        "#!/bin/sh\nset -eu\n\necho \"Verifying ClickHouse admin connectivity...\"\
-        \ncurl -sf --max-time 10 \\\n  \"${CH_ADMIN_URL}/?user=${CH_ADMIN_USERNAME}&password=${CH_ADMIN_PASSWORD}\"\
-        \ \\\n  -d \"SELECT 1\" >/dev/null || {\n  echo \"ERROR: Cannot connect to ClickHouse\
-        \ at ${CH_ADMIN_URL} with admin user\"\n  exit 1\n}\necho \"Admin connection OK.\"\
-        \n\ngrant() {\n  echo \"GRANT: $1\"\n  curl -sf --max-time 30 \\\n    \"${CH_ADMIN_URL}/?user=${CH_ADMIN_USERNAME}&password=${CH_ADMIN_PASSWORD}\"\
-        \ \\\n    -d \"$1\" || {\n    echo \"ERROR: grant failed: $1\"\n    exit 1\n \
-        \ }\n}\n\n# CLUSTER privilege is required for every ON CLUSTER statement (CH 25.x);\n\
-        # without it the per-pipeline setup jobs fail ACCESS_DENIED (Code 497).\ngrant\
-        \ \"GRANT CLUSTER ON *.* TO kbve_ingest ON CLUSTER 'cluster'\"\n\n# Data access for\
-        \ each direct-write pipeline. Creating a table does not\n# grant the creator data\
-        \ rights in CH RBAC.\ngrant \"GRANT ALL ON telemetry.* TO kbve_ingest ON CLUSTER 'cluster'\"\ngrant \"\
-        GRANT ALL ON observability.* TO kbve_ingest ON CLUSTER 'cluster'\"\ngrant \"GRANT\
-        \ ALL ON mc.* TO kbve_ingest ON CLUSTER 'cluster'\"\n\necho \"\"\necho \"Ingest-user\
-        \ grants applied.\"\n"
+    grants.sh: |
+        #!/bin/sh
+        set -eu
+
+        echo "Verifying ClickHouse admin connectivity..."
+        curl -sf --max-time 10 \
+          "${CH_ADMIN_URL}/?user=${CH_ADMIN_USERNAME}&password=${CH_ADMIN_PASSWORD}" \
+          -d "SELECT 1" >/dev/null || {
+          echo "ERROR: Cannot connect to ClickHouse at ${CH_ADMIN_URL} with admin user"
+          exit 1
+        }
+        echo "Admin connection OK."
+
+        grant() {
+          echo "GRANT: $1"
+          curl -sf --max-time 30 \
+            "${CH_ADMIN_URL}/?user=${CH_ADMIN_USERNAME}&password=${CH_ADMIN_PASSWORD}" \
+            -d "$1" || {
+            echo "ERROR: grant failed: $1"
+            exit 1
+          }
+        }
+
+        # CLUSTER privilege is required for every ON CLUSTER statement (CH 25.x);
+        # without it the per-pipeline setup jobs fail ACCESS_DENIED (Code 497).
+        grant "GRANT CLUSTER ON *.* TO kbve_ingest ON CLUSTER 'cluster'"
+
+        # Data access for each direct-write pipeline plus the read-side dashboard
+        # proxy (axum-kbve reads gameops.*). Creating a table does not grant the
+        # creator data rights in CH RBAC, so every database is granted explicitly.
+        grant "GRANT ALL ON telemetry.* TO kbve_ingest ON CLUSTER 'cluster'"
+        grant "GRANT ALL ON observability.* TO kbve_ingest ON CLUSTER 'cluster'"
+        grant "GRANT ALL ON mc.* TO kbve_ingest ON CLUSTER 'cluster'"
+        grant "GRANT ALL ON gameops.* TO kbve_ingest ON CLUSTER 'cluster'"
+        grant "GRANT ALL ON firecracker.* TO kbve_ingest ON CLUSTER 'cluster'"
+        grant "GRANT ALL ON logflare.* TO kbve_ingest ON CLUSTER 'cluster'"
+
+        echo ""
+        echo "Ingest-user grants applied."
 ---
 apiVersion: batch/v1
 kind: Job

--- a/apps/kube/vector/seal-ch-credentials.sh
+++ b/apps/kube/vector/seal-ch-credentials.sh
@@ -42,7 +42,7 @@ fi
 # --- Get credentials ---
 
 CH_ENDPOINT="${CH_ENDPOINT:-http://clickhouse-clickhouse-cluster.clickhouse.svc.cluster.local:8123}"
-CH_USERNAME="${CH_USERNAME:-logflare}"
+CH_USERNAME="${CH_USERNAME:-kbve_ingest}"
 
 if [[ -z "${CH_PASSWORD:-}" ]]; then
     echo -n "Enter ClickHouse password: "

--- a/packages/data/ch/schemas/grants.sql
+++ b/packages/data/ch/schemas/grants.sql
@@ -6,6 +6,9 @@
 --   • apps/metrics  (Rust frontend telemetry)  → telemetry.*
 --   • Vector (DaemonSet)                        → observability.*
 --   • mc presence snapshots (apps/kbve)         → mc.*
+--   • factorio relay + factorio-ctl (agones)    → gameops.* (write)
+--   • firecracker microVM telemetry             → firecracker.*
+--   • axum-kbve dashboard proxy (apps/kbve)     → gameops.* (read)
 --
 -- `CREATE USER kbve_ingest ... IDENTIFIED WITH sha256_password` is issued by the
 -- bootstrap Job from a sealed secret (password never lands in git). This file
@@ -26,3 +29,8 @@ GRANT ALL ON logflare.* TO kbve_ingest ON CLUSTER 'cluster';
 GRANT ALL ON telemetry.* TO kbve_ingest ON CLUSTER 'cluster';
 GRANT ALL ON observability.* TO kbve_ingest ON CLUSTER 'cluster';
 GRANT ALL ON mc.* TO kbve_ingest ON CLUSTER 'cluster';
+-- gameops: factorio + sim telemetry (schemas/factorio.sql). Written by the
+-- relay/factorio-ctl pipelines, read by the axum-kbve dashboard proxy.
+GRANT ALL ON gameops.* TO kbve_ingest ON CLUSTER 'cluster';
+-- firecracker: microVM lifecycle telemetry (schemas/firecracker.sql).
+GRANT ALL ON firecracker.* TO kbve_ingest ON CLUSTER 'cluster';


### PR DESCRIPTION
## Problem

The factorio gameops dashboard (`kbve.com/dashboard/gameops/factorio/`) returns **502**. Root cause: axum-kbve's ClickHouse proxy queries as the legacy **`logflare`** user, which had no `SELECT` on the `gameops` database → `ACCESS_DENIED (Code 497)` on every `gameops.factorio_*` read.

Investigation surfaced two IaC gaps:
1. The `ch-ingest-grants` job + `grants.sql` were **stale** — they granted `kbve_ingest` only `telemetry`/`observability`/`mc`, but the live `kbve_ingest` user already has `gameops`, `firecracker` and `logflare` (granted out-of-band). So IaC didn't match reality and never covered `gameops`.
2. The `logflare → kbve_ingest` rename is half-done: vector already uses `kbve_ingest`, but axum/factorio-ctl/metrics still authenticate as `logflare` (the sealed-secret username).

## Changes (codified — no prod mutation here)

- **`ch-ingest-grants-job.yaml`** — rewrite the escaped one-liner `grants.sh` into a readable block scalar and add `GRANT ALL` on `gameops.*`, `firecracker.*`, `logflare.*` TO `kbve_ingest`. IaC now matches the live cluster.
- **`grants.sql`** — mirror the same grants (canonical record).
- **`seal-ch-credentials.sh`** — default `CH_USERNAME` `logflare` → `kbve_ingest` so a re-seal cuts consumers over to the intended user.

## Not in this PR (operator runbook — needs the plaintext CH password)

3. Re-seal `clickhouse-vector-credentials` with `CH_USERNAME=kbve_ingest` (same password) → ExternalSecrets propagate → axum/factorio-ctl/metrics reconnect as `kbve_ingest` (which has every grant).
4. Verify dashboard + telemetry writes + vector.
5. `DROP USER logflare` once verified.

An immediate `GRANT SELECT ON gameops.* TO logflare` was applied to unblock the dashboard now; it becomes moot after the cutover.

## Data safety

`kbve_ingest` already holds every grant, so no consumer loses access on the username swap; writers buffer across the brief secret-reload reconnect. Rollback = revert the sealed-secret commit (back to `logflare`, still fully granted).

📚 https://kbve.com/application/kubernetes/