### PR TITLE
fix(kbve): add herbmail.com HTTPS listeners to kbve-gateway

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -250,6 +250,34 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-herbmail
+          protocol: HTTPS
+          port: 443
+          hostname: herbmail.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: herbmail-tls
+                    namespace: herbmail
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-herbmail-www
+          protocol: HTTPS
+          port: 443
+          hostname: www.herbmail.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: herbmail-tls
+                    namespace: herbmail
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
## Why

herbmail.com and www.herbmail.com are down — Cloudflare returns **521** for all traffic, and the `herbmail-tls-2` renewal (HTTP-01) has been stuck pending for 7+ days with `propagation check failed … wrong status code '521'` in cert-manager logs.

Root cause: the `herbmail` namespace has the Certificate (`herbmail-tls`, SANs `herbmail.com` + `www.herbmail.com`), the ReferenceGrant (`allow-gateway-tls`), and the HTTPRoute (`herbmail-route`) — but `kbve-gateway` never got an HTTPS listener for either hostname. Origin `:443` resets the TLS handshake for herbmail SNI (verified with `curl --resolve herbmail.com:443:142.132.206.71` → connection failure, while `:80` serves 200), so Cloudflare in Full SSL mode can't reach the origin → 521 → both live traffic and ACME self-checks fail.

## Fix

Add `https-herbmail` + `https-herbmail-www` listeners sharing the multi-SAN `herbmail-tls` cert — same apex+www pattern as rentearth (#13669), verified working live on current Cilium (both rentearth hosts 200 direct-to-origin).

Existing HTTPRoute and ReferenceGrant need no changes. Will also be applied live via kubectl since ArgoCD tracks `main` and the site is down now.