### PR TITLE
chore(kube): trim source log verbosity for top INFO emitters

### DIFF
--- a/apps/kube/agones/factorio/manifests/factorio-ctl.yaml
+++ b/apps/kube/agones/factorio/manifests/factorio-ctl.yaml
@@ -127,7 +127,7 @@ spec:
                                 key: password
                                 optional: true
                       - name: RUST_LOG
-                        value: factorio_ctl=info,tower_http=info
+                        value: factorio_ctl=info,tower_http=warn
                   livenessProbe:
                       httpGet:
                           path: /health

--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -66,6 +66,8 @@ spec:
                         value: '10001'
                       - name: FC_JAILER_GID
                         value: '10001'
+                      - name: RUST_LOG
+                        value: 'info,tower_http=warn'
                   securityContext:
                       seccompProfile:
                           type: Unconfined

--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -40,7 +40,7 @@ spec:
                       - name: DOCS_PORT
                         value: '4323'
                       - name: RUST_LOG
-                        value: info
+                        value: 'info,tower_http=warn'
                       - name: DATABASE_URL
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                       - name: METRICS_PORT
                         value: '4324'
                       - name: RUST_LOG
-                        value: 'info'
+                        value: 'info,tower_http=warn'
                       - name: DB_MAX_CONNECTIONS
                         value: '20'
                       - name: OWS_API_KEY

--- a/apps/kube/windmill/application.yaml
+++ b/apps/kube/windmill/application.yaml
@@ -53,6 +53,8 @@ spec:
                             extraEnv:
                                 - name: PG_SCHEMA
                                   value: windmill
+                                - name: RUST_LOG
+                                  value: warn
                             resources:
                                 requests:
                                     memory: 512Mi
@@ -72,6 +74,8 @@ spec:
                                   value: 'true'
                                 - name: SLEEP_QUEUE
                                   value: '200'
+                                - name: RUST_LOG
+                                  value: warn
                             resources:
                                 requests:
                                     memory: 256Mi


### PR DESCRIPTION
## Approach

Keep the broad vector net (catch-all) — reduce noise at the **source** for the apps that dominate the INFO firehose. Volumes measured from `observability.logs_distributed` (metallb-system, the former 46%-info/97%-error dominator, is already removed).

## Changes (scoped, low-risk log-level only)

| App | Was | Now | Silences (~/day) |
|---|---|---|---|
| `firecracker-ctl` | *(default)* | `RUST_LOG=info,tower_http=warn` | ~130k — tower_http `incoming request`/`request completed` |
| `rows` main + chuckrpg tenants | `info` | `info,tower_http=warn` | ~113k — per-request HTTP trace |
| `factorio-ctl` (+rotator) | `tower_http=info` | `tower_http=warn` | ~29k |
| `windmill` default+native workers | *(info)* | `RUST_LOG=warn` | ~165k — `ping update, memory` heartbeat + `Log file sent` |

**App-level info is preserved** — only the hot per-request and heartbeat lines drop (~400k+ rows/day at source). Windmill job logs still land in its own store, not stdout.

## Deliberately left out (your call)

- **kubevirt** virt-operator (187k) + virt-api (54k): reconcile loop re-patching steady-state components every ~6s at klog v=2 (`Handling KubeVirt resource`, `… patched`, `labels in sync`). Reducible via the KubeVirt CR `logVerbosity`, but the every-6s re-patch cadence may indicate churn worth understanding before just quieting it. Separate investigation.
- **ergo/irc** (52k): dropping to `warn` loses IRC connection/join info — left for you to decide if that's wanted.
- Smaller tier: `kilobase/realtime` (52k), `angelscript/gluetun` (45k, `LOG_LEVEL`), `kilobase/postgres` (36k, `log_min_messages`).

📚 https://kbve.com/application/kubernetes/