### PR TITLE
fix(kasm): disable smartcard bridge to stop bridge->relay log spam

### DIFF
--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -186,6 +186,8 @@ spec:
                   env:
                       - name: KASM_PORT
                         value: '6901'
+                      - name: KASM_SVC_SMARTCARD
+                        value: '0'
                       - name: VNC_PW
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Why

`kasm-vpn` workspace container logs `ERROR - bridge->relay: timeout: 0x01` every 7.5 seconds, nonstop (~11.5k error rows/day into ClickHouse via Vector — `kasm` is not in the noise filter).

Traced to `kasm_smartcard_bridge` (PyInstaller-packed, so the string doesn't grep from the binary): KasmVNC's `vnc_startup.sh` launches it by default (`KASM_SVC_SMARTCARD:-1`), it polls Xvnc's `-UnixRelay smartcard:/tmp/smartcard` socket, and with no smartcard/VNC peer attached it times out on every poll. The Discord workspace never uses smartcard passthrough.

## Fix

Set `KASM_SVC_SMARTCARD=0` on the workspace container — `vnc_startup.sh` then skips launching the bridge entirely.

Note: takes effect on next pod recreation. The current pod holds a 36-day-old live Discord session; not restarting it as part of this PR.