### PR TITLE
fix(deathslayer-launcher): resolve lint failures

### DIFF
--- a/apps/deathslayer/deathslayer-launcher/.eslintrc.json
+++ b/apps/deathslayer/deathslayer-launcher/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+	"extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
+	"ignorePatterns": [
+		"!**/*",
+		"**/vite.config.*.timestamp*",
+		"**/vitest.config.*.timestamp*",
+		"src-tauri/**"
+	],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/apps/deathslayer/deathslayer-launcher/src/App.tsx
+++ b/apps/deathslayer/deathslayer-launcher/src/App.tsx
@@ -13,10 +13,6 @@ function App() {
 	const [loading, setLoading] = useState(false);
 	const [message, setMessage] = useState('');
 
-	useEffect(() => {
-		loadGameStatus();
-	}, []);
-
 	const loadGameStatus = async () => {
 		try {
 			const status = await invoke<GameStatus>('get_game_status');
@@ -26,6 +22,21 @@ function App() {
 			setMessage('Failed to load game status');
 		}
 	};
+
+	useEffect(() => {
+		let active = true;
+		invoke<GameStatus>('get_game_status')
+			.then((status) => {
+				if (active) setGameStatus(status);
+			})
+			.catch((error) => {
+				console.error('Failed to load game status:', error);
+				if (active) setMessage('Failed to load game status');
+			});
+		return () => {
+			active = false;
+		};
+	}, []);
 
 	const handleCheckUpdates = async () => {
 		setLoading(true);

--- a/apps/deathslayer/deathslayer-launcher/src/main.tsx
+++ b/apps/deathslayer/deathslayer-launcher/src/main.tsx
@@ -3,7 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+	throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,


### PR DESCRIPTION
## Problem

`nx run deathslayer-launcher:lint` failed with:

> All files matching the following patterns are ignored: `apps/deathslayer/deathslayer-launcher/src/**/*.{ts,tsx}`

Root `.eslintrc.json` sets `ignorePatterns: ["**/*"]`; every project must un-ignore its own files with a project-local config. `deathslayer-launcher` had none, so ESLint ignored every source file.

## Fix

- Add project-local `.eslintrc.json` (mirrors `apps/kbve/isometric`): `extends plugin:@nx/react` + base, `ignorePatterns: ["!**/*", "src-tauri/**"]`.
- Once linting ran, real violations surfaced and were fixed:
  - `App.tsx` — `loadGameStatus` accessed before declaration → hoisted above `useEffect`.
  - `App.tsx` — `react-hooks/set-state-in-effect` → mount fetch moved to a promise-callback with an active-guard cleanup.
  - `main.tsx` — `@typescript-eslint/no-non-null-assertion` → replaced `!` with a root-element null guard.

## Verify

`nx run deathslayer-launcher:lint` → `✔ All files pass linting`.