### PR TITLE
feat(ci): GitHub -> Forgejo main mirror (belt-and-suspenders)

### DIFF
--- a/.github/workflows/ci-forgejo-mirror.yml
+++ b/.github/workflows/ci-forgejo-mirror.yml
@@ -1,0 +1,62 @@
+name: CI - Forgejo Mirror
+
+on:
+    push:
+        branches: [main, dev]
+        tags: ['**']
+    workflow_dispatch:
+
+concurrency:
+    group: forgejo-mirror-${{ github.ref }}
+    cancel-in-progress: false
+
+jobs:
+    mirror:
+        name: 'Mirror to Forgejo'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout (full history, no LFS)
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  lfs: false
+              env:
+                  GIT_LFS_SKIP_SMUDGE: 1
+
+            - name: Push ref and tags to Forgejo
+              env:
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+                  REF_TYPE: ${{ github.ref_type }}
+                  REF_NAME: ${{ github.ref_name }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -z "${FORGEJO_USER:-}" ] || [ -z "${FORGEJO_TOKEN:-}" ]; then
+                      echo "::error::FORGEJO_USER / FORGEJO_TOKEN secrets are not set"
+                      exit 1
+                  fi
+
+                  REMOTE="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/KBVE/kbve.git"
+
+                  echo "::notice::Mirroring ${REF_TYPE} '${REF_NAME}' to Forgejo (pointers only, non-destructive)"
+
+                  if [ "${REF_TYPE}" = "branch" ]; then
+                      git push "${REMOTE}" "HEAD:refs/heads/${REF_NAME}"
+                  fi
+
+                  git push "${REMOTE}" --tags
+
+    track-mirror:
+        name: Track Mirror
+        if: always()
+        needs: [mirror]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Forgejo Mirror'
+            job_name: 'Mirror to Forgejo'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.mirror.result }}

--- a/.github/workflows/ci-forgejo-mirror.yml
+++ b/.github/workflows/ci-forgejo-mirror.yml
@@ -2,7 +2,7 @@ name: CI - Forgejo Mirror
 
 on:
     push:
-        branches: [main, dev]
+        branches: [main]
         tags: ['**']
     workflow_dispatch:
 
@@ -41,8 +41,8 @@ jobs:
 
                   echo "::notice::Mirroring ${REF_TYPE} '${REF_NAME}' to Forgejo (pointers only, non-destructive)"
 
-                  if [ "${REF_TYPE}" = "branch" ]; then
-                      git push "${REMOTE}" "HEAD:refs/heads/${REF_NAME}"
+                  if [ "${REF_TYPE}" = "branch" ] && [ "${REF_NAME}" = "main" ]; then
+                      git push "${REMOTE}" "HEAD:refs/heads/main"
                   fi
 
                   git push "${REMOTE}" --tags


### PR DESCRIPTION
Closes part of #13179 (belt). **GitHub is the single source of truth. Forgejo mirrors `main` only** — `dev` (and all other WIP/atomic branches) stay GitHub-only. Forgejo is a read-only replica of the deployable branch.

## Current drift (measured via kubectl, 2026-07-14)

Forgejo `KBVE/kbve.git` was badly stale — **no automated sync existed**:

| | GitHub | Forgejo (before) |
|---|---|---|
| `main` | `12ab9fbe` | absent |
| `dev` | `1ef61c55` | `d7aa7b1e` (frozen 2026-06-17, 1847 behind) |
| tags | present | 0 |
| mirror config | — | none |

## Decision: main-only

Forgejo tracks `main` (stable, deployable, what ArgoCD/apps follow). `dev` is high-churn integration and belongs only on GitHub. The replica should default to what you'd restore/deploy from.

## Belt (this PR)

`.github/workflows/ci-forgejo-mirror.yml` — on push to `main` and on any tag:
- Pushes `main` + all tags to `git.kbve.com/KBVE/kbve.git`. Branch push guarded to `main` (a `workflow_dispatch` from another branch won't leak it).
- **Non-destructive**: fast-forward only, no `--force`/`--mirror`/prune. Divergence -> push fails -> failure tracker opens an issue (never silently overwrites Forgejo).
- **Pointers only**: `lfs: false` + `GIT_LFS_SKIP_SMUDGE=1`; per-game LFS endpoints untouched.
- Reuses `FORGEJO_USER` / `FORGEJO_TOKEN`; runs on `ubuntu-latest` vs public `git.kbve.com` (independent of cluster health).
- Failures surface via `utils-ci-failure-tracker.yml`.

## Manual follow-ups (Forgejo admin — not in this PR)

1. **Suspenders**: native pull-mirror on `KBVE/kbve` from `https://github.com/KBVE/kbve.git`, `main` only, interval ~10m, mirror-LFS off — scheduled full-parity backstop.
2. **Set Forgejo default branch = `main`.**
3. **Delete the stale Forgejo `dev` branch** (main-only replica; dev is GitHub-only now).
4. Verify: `git --git-dir=/data/git/gitea-repositories/kbve/kbve.git rev-parse main` == GitHub main.

Both mechanisms run GitHub->Forgejo only; no bidirectional writes, no conflict surface.