### PR TITLE
fix(vm): publish aria2-proxy image (0.1.1) — resolve download-proxy ImagePullBackOff

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -70,7 +70,7 @@
 		{
 			"key": "aria2_proxy",
 			"app_name": "aria2-proxy",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/vm/aria2-proxy/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/aria2-proxy.mdx",
 			"source_path": "apps/vm/aria2-proxy",

--- a/apps/kbve/astro-kbve/src/content/docs/project/aria2-proxy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/aria2-proxy.mdx
@@ -20,7 +20,7 @@ jsonld:
           answer: It runs as uid/gid 1000 (appuser) with workdir /downloads, exposing port 6800 for the aria2 RPC and 8080 for the python file server; the Deployment shares one pod network namespace across both containers.
 pipeline: docker
 app_name: aria2-proxy
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/vm/aria2-proxy
 version_toml: apps/vm/aria2-proxy/version.toml
 runner: arc-runner-set

--- a/apps/kube/kubevirt/download-proxy/deployment.yaml
+++ b/apps/kube/kubevirt/download-proxy/deployment.yaml
@@ -48,7 +48,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: aria2
-                  image: ghcr.io/kbve/aria2-proxy:0.1.0
+                  image: ghcr.io/kbve/aria2-proxy:0.1.1
                   command:
                       - aria2c
                   args:
@@ -89,7 +89,7 @@ spec:
                           drop:
                               - ALL
                 - name: file-server
-                  image: ghcr.io/kbve/aria2-proxy:0.1.0
+                  image: ghcr.io/kbve/aria2-proxy:0.1.1
                   command:
                       [
                           'python3',


### PR DESCRIPTION
## Problem

KubeVirt `download-proxy` Deployment (ns `angelscript`) stuck **ImagePullBackOff** — `ghcr.io/kbve/aria2-proxy:0.1.0` **never existed** (ghcr 404, 0 publishes ever).

## Root cause

aria2-proxy was introduced (#10221) with **both** MDX and `version.toml` at `0.1.0`. The CI publish gate requires the MDX version to **lead** `version.toml` — the delta is the "publish me" signal, and the post-publish bot bumps `version.toml` up to match. Born equal → delta never existed → publish gate always hit:

> `aria2-proxy v0.1.0 matches version.toml — tests will run, publish will be skipped.` — [ci-docker.yml:125](../blob/main/.github/workflows/ci-docker.yml#L125)

So the image was **never built or pushed** despite the source, Dockerfile, container target, and e2e all existing.

## Fix

- Bump MDX `version` `0.1.0 → 0.1.1` — creates the delta over `version.toml` (still `0.1.0`).
- On merge → main: `ci-main` dispatch sees MDX(0.1.1) > toml(0.1.0) → dispatches `ci-docker` → builds + runs `aria2-proxy-e2e` (vitest) → publishes `ghcr.io/kbve/aria2-proxy:0.1.1` → post-publish bot bumps `version.toml` to `0.1.1`.
- Point the `download-proxy` Deployment at `:0.1.1`.
- `ci-dispatch-manifest.json` version field synced to `0.1.1`.

`version.toml` left at `0.1.0` intentionally — the pipeline bot owns that bump post-publish.

## After merge → main

1. Confirm `ci-docker` run "CI - Docker / aria2-proxy" publishes 0.1.1.
2. The stuck download-proxy pod pulls clean once the tag exists + Deployment syncs.

📚 https://kbve.com/application/kubernetes/