### PR TITLE
fix(firecracker): seccomp Unconfined -> Localhost jailer profile (#13089)

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -70,8 +70,13 @@ spec:
                         value: 'info,tower_http=warn'
                   securityContext:
                       seccompProfile:
-                          type: Unconfined
+                          type: Localhost
+                          localhostProfile: operator/firecracker/firecracker-jailer.json
                       readOnlyRootFilesystem: true
+                      # Firecracker jailer requires SYS_ADMIN (mount --make-private for
+                      # pivot_root on shared-propagation emptyDir), SYS_CHROOT + MKNOD
+                      # (create /dev/kvm, /dev/net/tun inside the chroot). These replace
+                      # privileged: true — not removable without a rootless-jailer rearchitect.
                       capabilities:
                           drop:
                               - ALL

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -145,8 +145,13 @@ spec:
                                 key: db-url-ro
                   securityContext:
                       seccompProfile:
-                          type: Unconfined
+                          type: Localhost
+                          localhostProfile: operator/firecracker/firecracker-jailer.json
                       readOnlyRootFilesystem: true
+                      # Firecracker jailer requires SYS_ADMIN (mount --make-private for
+                      # pivot_root on shared-propagation emptyDir), SYS_CHROOT + MKNOD
+                      # (create /dev/kvm, /dev/net/tun inside the chroot). These replace
+                      # privileged: true — not removable without a rootless-jailer rearchitect.
                       capabilities:
                           drop:
                               - ALL


### PR DESCRIPTION
## Firecracker seccomp hardening — closes ①+② of #13089

Security audit split-out from #12973. Traced to source; full plan in [issue comment](https://github.com/KBVE/kbve/issues/13089#issuecomment-4985011172).

### ① Seccomp `Unconfined` → `Localhost`
Both `firecracker-ctl` deployments (`firecracker-deployment.yaml`, `firecracker-net-deployment.yaml`) flipped to the `firecracker-jailer` Localhost profile. The `SeccompProfile` CRD was already written (`firecracker-seccomp.yaml`) and wired into `kustomization.yaml`; SPO is already deployed (`apps/kube/security-profiles-operator`, v0.9.1, auto-sync). This was the last remaining step.

```yaml
seccompProfile:
  type: Localhost
  localhostProfile: operator/firecracker/firecracker-jailer.json
```

### ② Justify the cap set
`SYS_ADMIN`+`SYS_CHROOT`+`MKNOD` are inherent to the Firecracker jailer (`mount --make-private` for `pivot_root`, mknod `/dev/kvm` + `/dev/net/tun` in the chroot — `firecracker-ctl/src/main.rs:2814,2987-2990`). These already replaced `privileged: true`; not removable without a rootless-jailer rearchitect. Documented inline in both manifests.

### Deferred — ③ `/dev/net/tun` hostPath → device plugin
Blocked on confirming the tap path is live at runtime (`tap.rs` is `#![allow(dead_code)]`, "unused until Phase 2c"). Tracked in #13089.

### Validation
- `kubectl kustomize apps/kube/firecracker/manifests` renders clean; both deployments carry the profile.

### Rollout watch
After sync: confirm `kubectl get seccompprofile -n firecracker firecracker-jailer` is Installed, then watch for seccomp `EPERM` denials on jailer start and widen the allowlist if a syscall is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
