### PR TITLE
fix(ci): shallow checkout + step timeout for dev→main PR job

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -20,7 +20,7 @@ jobs:
         name: 'Create/Update Dev to Main PR'
         runs-on: ubuntu-latest
         if: github.event_name == 'push' && github.ref_name == 'dev' && !contains(github.event.head_commit.message, '[skip-release-pr]')
-        timeout-minutes: 10
+        timeout-minutes: 20
         permissions:
             contents: read
             pull-requests: write
@@ -28,8 +28,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
               continue-on-error: true
+              timeout-minutes: 8
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
                   token: ${{ secrets.GITHUB_TOKEN }}
                   lfs: false
 


### PR DESCRIPTION
## Why

`CI - Dev` job `Create/Update Dev to Main PR` shows up as **cancelled** (e.g. commit 020a85c). Root cause: `actions/checkout@v7` with `fetch-depth: 0` hung ~10min on `git fetch` and hit the job's `timeout-minutes: 10`. Timeout-kills report as *cancelled*, not *failed*. Flaky — sibling commits show one run pass, one cancelled.

## Fix

- `fetch-depth: 0` → `1`. Later steps use the GitHub REST API (`compareCommits`) and do their own shallow `git fetch --depth=1 origin main`, so full history is unused.
- Add `timeout-minutes: 8` on the checkout step, paired with existing `continue-on-error: true` — a hang now fails the step, not the whole job.
- Raise job `timeout-minutes` 10 → 20 for breathing room.