### PR TITLE
fix(kube): kbve/kubectl 0.1.6 with bash+openssl+coreutils for failing cronjobs

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -44,7 +44,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.232",
+			"version": "1.0.234",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -392,7 +392,7 @@
 		{
 			"key": "kubectl",
 			"app_name": "kbve-kubectl",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"version_toml": "apps/vm/kubectl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx",
 			"version_target": "apps/vm/kubectl/Cargo.toml",
@@ -408,6 +408,7 @@
 				"apps/kube/kubevirt/keda/scaled-jobs.yaml",
 				"apps/kube/agones/factorio/manifests/rotation-deployment.yaml",
 				"apps/kube/namespace/manifests/pod-gc-cronjob.yaml",
+				"apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml",
 				"apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml",
 				"apps/kube/github/runners/manifests/runner-reaper.yaml",
 				"apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml",
@@ -1337,7 +1338,7 @@
 				]
 			},
 			"source_path": "apps/herbmail/herbmail-game",
-			"version": "0.1.4",
+			"version": "0.1.9",
 			"version_toml": "apps/herbmail/herbmail-game/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/herbmail-game.mdx",
 			"runner": "ubuntu-latest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "kbve-kubectl"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -21,7 +21,7 @@ jsonld:
           answer: The image tag is pinned across every manifest listed in the deployment_yamls frontmatter field, and all of them auto-bump on each publish via the post-publish version sync.
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml
@@ -35,6 +35,7 @@ deployment_yamls:
     - apps/kube/kubevirt/keda/scaled-jobs.yaml
     - apps/kube/agones/factorio/manifests/rotation-deployment.yaml
     - apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+    - apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
     - apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
     - apps/kube/github/runners/manifests/runner-reaper.yaml
     - apps/kube/forgejo/manifest/forgejo-oauth-register-job.yaml

--- a/apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
+++ b/apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
@@ -101,7 +101,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: scan
-                          image: alpine/k8s:1.33.0
+                          image: ghcr.io/kbve/kubectl:0.1.6
                           imagePullPolicy: IfNotPresent
                           securityContext:
                               allowPrivilegeEscalation: false

--- a/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+++ b/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
@@ -87,7 +87,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: gc
-                          image: ghcr.io/kbve/kubectl:0.1.5
+                          image: ghcr.io/kbve/kubectl:0.1.6
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/vm/kubectl/Cargo.toml
+++ b/apps/vm/kubectl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbve-kubectl"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version.workspace = true
 publish = false

--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -6,10 +6,11 @@
 #   [B] cargo-chef cook (cache musl deps)
 #   [C] Build kbve-kubectl static musl binary
 #   [D] Download kubectl static binary
-#   [Z] Alpine runtime with shell, curl, jq, kubectl, kbve-kubectl
+#   [Z] Alpine runtime with shell, curl, jq, bash, coreutils, openssl, kubectl, kbve-kubectl
 #
 # Features:
 #   - /bin/sh, sleep, sed, grep from Alpine base
+#   - bash, GNU coreutils (date -d), openssl for Job scripts
 #   - curl, jq via apk
 #   - kubectl static binary
 #   - kbve-kubectl: musl-static, no glibc dependency
@@ -92,7 +93,7 @@ RUN curl -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kub
 # ============================================================================
 FROM --platform=linux/amd64 alpine:3.21 AS runtime
 
-RUN apk add --no-cache ca-certificates curl jq && \
+RUN apk add --no-cache ca-certificates curl jq bash coreutils openssl && \
     addgroup -g 10001 appgroup && \
     adduser -D -u 10001 -G appgroup -s /sbin/nologin appuser && \
     mkdir -p /app /scripts && \


### PR DESCRIPTION
## Problem

Two kube-system CronJobs failing repeatedly:

- **pod-gc** (\`ghcr.io/kbve/kubectl:0.1.5\`) — \`StartError\` exit 128: \`exec: "/bin/bash": no such file or directory\`. Image is Alpine with \`/bin/sh\` only; script needs bash (\`<<<\` here-strings).
- **ca-staleness-monitor** (\`alpine/k8s:1.33.0\`) — exit 127: \`openssl: command not found\`. Image dropped openssl; script parses CA cert \`notBefore\` via \`openssl x509\`.

Both pods run \`readOnlyRootFilesystem: true\` + \`runAsNonRoot\` → **cannot \`apk add\` at runtime**. Missing binaries must ship in the image.

## Fix

Unify both cronjobs onto the kbve/kubectl image (the FAQ already documents it as the replacement for distroless images that break Job scripts):

- **Dockerfile**: add \`bash\`, \`coreutils\` (GNU \`date -d\`), \`openssl\` to the runtime stage
- bump \`kbve-kubectl\` \`0.1.5\` → \`0.1.6\` (Cargo.toml + kubectl.mdx)
- **ca-staleness-monitor**: repoint \`alpine/k8s:1.33.0\` → \`ghcr.io/kbve/kubectl:0.1.6\`
- **pod-gc**: bump image → \`0.1.6\`
- add ca-staleness manifest to kubectl \`deployment_yamls\`; regenerate \`ci-dispatch-manifest.json\`

\`version.toml\` left at 0.1.5 (last-published marker; post-publish sync bumps it).

## Rollout

Merge → drift-check sees Cargo.toml 0.1.6 > version.toml 0.1.5 → CI builds+publishes \`ghcr.io/kbve/kubectl:0.1.6\` → post-publish auto-bumps all 13 \`deployment_yamls\` tags → ArgoCD syncs → next cron tick runs clean. No live-cluster edits (GitOps).

## Verification

Both scripts use only bash / \`<<<\` / openssl / \`date -d\` / jq / kubectl — all present in 0.1.6. \`/tmp\` emptyDir already mounted for ca-staleness writes; pod-gc writes nothing.

Docs: https://kbve.com/project/kubectl/