### PR TITLE
refactor(python-kbve): lazy top-level imports (PEP 562)

### DIFF
--- a/packages/python/kbve/kbve/__init__.py
+++ b/packages/python/kbve/kbve/__init__.py
@@ -1,14 +1,60 @@
-"""KBVE - Core library for async servers, Nx workspace tooling, and MDX rendering."""
+"""KBVE - Core library for async servers, Nx workspace tooling, and MDX rendering.
 
-from .models.server_models import ServerConfig  # noqa: F401
-from .server.app_server import AppServer  # noqa: F401
-from .server.grpc_server import GrpcServer  # noqa: F401
-from .server.http_server import HttpServer  # noqa: F401
-from .server.services.health_service import HealthServicer  # noqa: F401
-from .server.services.echo_service import EchoServicer  # noqa: F401
+Top-level names are resolved lazily (PEP 562) so importing a leaf subpackage
+(e.g. ``kbve.nx``, ``kbve.mdx``) does not drag in the server stack
+(pydantic/fastapi/uvicorn/grpc). ``from kbve import AppServer`` still works —
+the backing module loads on first attribute access.
+"""
 
-from .config import EnvConfig  # noqa: F401
-from .health import HealthCheck, HealthStatus, CheckResult  # noqa: F401
-from .tasks import TaskRunner, TaskState, TaskResult  # noqa: F401
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
 
 __version__ = "0.1.0"
+
+_LAZY = {
+    "ServerConfig": ".models.server_models",
+    "AppServer": ".server.app_server",
+    "GrpcServer": ".server.grpc_server",
+    "HttpServer": ".server.http_server",
+    "HealthServicer": ".server.services.health_service",
+    "EchoServicer": ".server.services.echo_service",
+    "EnvConfig": ".config",
+    "HealthCheck": ".health",
+    "HealthStatus": ".health",
+    "CheckResult": ".health",
+    "TaskRunner": ".tasks",
+    "TaskState": ".tasks",
+    "TaskResult": ".tasks",
+}
+
+__all__ = list(_LAZY)
+
+
+def __getattr__(name: str):
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module, __name__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from .config import EnvConfig  # noqa: F401
+    from .health import (  # noqa: F401
+        CheckResult, HealthCheck, HealthStatus)
+    from .models.server_models import ServerConfig  # noqa: F401
+    from .server.app_server import AppServer  # noqa: F401
+    from .server.grpc_server import GrpcServer  # noqa: F401
+    from .server.http_server import HttpServer  # noqa: F401
+    from .server.services.echo_service import EchoServicer  # noqa: F401
+    from .server.services.health_service import (  # noqa: F401
+        HealthServicer)
+    from .tasks import (  # noqa: F401
+        TaskResult, TaskRunner, TaskState)


### PR DESCRIPTION
## What

Root `kbve/__init__.py` now resolves top-level names lazily via module `__getattr__` (PEP 562) instead of eagerly importing the server stack.

## Why

Importing a leaf subpackage (`kbve.nx`, `kbve.mdx`) used to execute `from .server.app_server import AppServer` etc., dragging in pydantic/fastapi/uvicorn/grpc at import time — even though the nx dashboard tooling is stdlib-only. Lazy loading keeps those subpackages clean.

This is the prerequisite for **Lever 1** (splitting the server stack into a `[server]` optional-dependency) so a bare `pip install kbve` stays lean for dashboard/nx use. That split rides a later version-bump/workflow-flip PR.

## Safety

- **Non-breaking:** no dependency change, no public-API change. `from kbve import AppServer` still works — the backing module loads on first attribute access.
- Unknown attribute raises `AttributeError` (same as before).
- `TYPE_CHECKING` block preserves IDE/type-checker resolution.

## Verification

- `import kbve.nx.cli` → neither `pydantic` nor `fastapi` in `sys.modules` (proven lean).
- `from kbve import AppServer` → works, lazy-loads pydantic on access.
- flake8 clean; 73 nx tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)