### PR TITLE
fix(axum-kbve): cap headless Bevy gameserver runner at 60 Hz

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -44,7 +44,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.234",
+			"version": "1.0.235",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.234"
+version = "1.0.235"
 dependencies = [
  "anyhow",
  "askama 0.16.0",

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.234"
+version: "1.0.235"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.234"
+version = "1.0.235"
 edition = "2021"
 rust-version.workspace = true
 publish = false

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use avian3d::prelude::*;
+use bevy::app::ScheduleRunnerPlugin;
 use bevy::prelude::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
@@ -792,7 +793,9 @@ fn run_bevy_app(
     let mut app = App::new();
 
     // Minimal headless Bevy — no window, no renderer
-    app.add_plugins(MinimalPlugins);
+    app.add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(
+        Duration::from_secs_f64(1.0 / 60.0),
+    )));
     app.add_plugins(bevy::state::app::StatesPlugin);
     app.add_plugins(bevy::transform::TransformPlugin);
 


### PR DESCRIPTION
## Problem

\`axum-kbve\` sits at **~123% CPU** (a full core pinned, 17 threads) on the control-plane node — the top CPU consumer.

Root cause: the embedded headless Bevy gameserver (\`run_bevy_app\`) adds \`MinimalPlugins\` with no runner pacing. Bevy's \`ScheduleRunnerPlugin\` defaults to \`RunMode::Loop { wait: None }\`, so the ECS schedule spins **as fast as the CPU allows**. The authoritative server tick is only 20 Hz (\`TICK_DURATION = 50ms\`), so the loop burns a core doing nothing useful.

Symptom in logs — the app has stepped **3.2 billion** times:
\`\`\`
System '...' has not run for 3258167296 ticks. Changes older than 3258167295 ticks will not be detected.
\`\`\`

## Fix

Pace the runner at 60 Hz so it sleeps between steps:

\`\`\`rust
app.add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(
    Duration::from_secs_f64(1.0 / 60.0),
)));
\`\`\`

60 Hz keeps inbound packet I/O responsive (server tick is 20 Hz) while dropping CPU from ~123% to low single digits. Also silences the bevy change-tick overflow warning flood.

Bump \`axum-kbve\` 1.0.234 → 1.0.235.

## Rollout

Merge → drift-check → CI builds+publishes \`ghcr.io/kbve/kbve:1.0.235\` → ArgoCD syncs \`kbve-deployment\` → new pod runs paced loop.

Docs: https://kbve.com/project/api/