### PR TITLE
fix(ci): reclaim runner disk in lint/test (rmi images + free space)

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -35,8 +35,8 @@ jobs:
                   android: true
                   dotnet: true
                   haskell: true
-                  large-packages: false
-                  swap-storage: false
+                  large-packages: true
+                  swap-storage: true
                   docker-images: true
 
             - name: Checkout

--- a/packages/docker/arc-runner/project.json
+++ b/packages/docker/arc-runner/project.json
@@ -46,7 +46,8 @@
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'zip -v' | grep -q 'Zip ' && echo 'PASS: zip on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'xz --version' | grep -q 'xz (XZ Utils)' && echo 'PASS: xz on PATH'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/arc-runner:latest bash -lc 'gh --version' | grep -q 'gh version' && echo 'PASS: gh on PATH'",
-					"echo '=== arc-runner image OK ==='"
+					"echo '=== arc-runner image OK ==='",
+					"docker rmi -f ghcr.io/kbve/arc-runner:latest || true"
 				],
 				"parallel": false
 			}

--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -129,7 +129,8 @@
 					"docker inspect ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1$' && echo 'PASS: Playwright browser download disabled'",
 					"echo '=== All chisel base image tests passed ==='",
 					"echo 'Runtime: user, workdir, jemalloc, libpq, CA bundle, no-shell, size<40MiB'",
-					"echo 'Builder: rustc 1.96, cargo-chef, sccache, mold, protoc, brotli, gzip, libpq-dev, libssl-dev, node 24, pnpm, real-TLS, env hygiene'"
+					"echo 'Builder: rustc 1.96, cargo-chef, sccache, mold, protoc, brotli, gzip, libpq-dev, libssl-dev, node 24, pnpm, real-TLS, env hygiene'",
+					"docker rmi -f ghcr.io/kbve/chisel-ubuntu-axum:24.04 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder || true"
 				],
 				"parallel": false
 			}

--- a/packages/docker/kasm-cloakbrowser/project.json
+++ b/packages/docker/kasm-cloakbrowser/project.json
@@ -57,7 +57,8 @@
 					"docker inspect ghcr.io/kbve/kasm-cloakbrowser:dev --format '{{.Config.User}}' | grep -q '^1000$' && echo 'PASS: drops to uid 1000'",
 					"docker run --rm --entrypoint /opt/cloakbrowser/cloakbrowser ghcr.io/kbve/kasm-cloakbrowser:dev --version && echo 'PASS: cloakbrowser binary runs --version'",
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-cloakbrowser:dev /dockerstartup/custom_startup.sh | grep -q CLOAK_BIN && echo 'PASS: custom_startup.sh installed'",
-					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-cloakbrowser:dev -c 'from cloakbrowser import launch; print(\"sdk-import-ok\")' | grep -q sdk-import-ok && echo 'PASS: python cloakbrowser sdk importable'"
+					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-cloakbrowser:dev -c 'from cloakbrowser import launch; print(\"sdk-import-ok\")' | grep -q sdk-import-ok && echo 'PASS: python cloakbrowser sdk importable'",
+					"docker rmi -f ghcr.io/kbve/kasm-cloakbrowser:dev || true"
 				],
 				"parallel": false
 			}

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -100,7 +100,8 @@
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); size=$(stat -c %s \"$real\"); [ \"$size\" -gt 1048576 ] || { echo \"Discord binary suspiciously small: $size bytes ($real)\" >&2; exit 1; }' && echo 'PASS: Discord binary larger than 1 MiB (not a stub)'",
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); missing=$(ldd \"$real\" 2>/dev/null | grep \"not found\" || true); [ -z \"$missing\" ] || { echo \"missing libs: $missing\" >&2; exit 1; }' && echo 'PASS: Discord shared lib deps resolve'",
 					"bash packages/docker/kasm-void/tests/nav-shim-smoke.sh",
-					"bash packages/docker/kasm-void/tests/full-session-smoke.sh"
+					"bash packages/docker/kasm-void/tests/full-session-smoke.sh",
+					"docker rmi -f ghcr.io/kbve/kasm-void:dev || true"
 				],
 				"parallel": false
 			}

--- a/packages/docker/steamcmd-ubuntu/project.json
+++ b/packages/docker/steamcmd-ubuntu/project.json
@@ -46,7 +46,8 @@
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/steamcmd-ubuntu:24.04 steamcmd +quit | grep -q 'Steam Console Client' && echo 'PASS: steamcmd boots'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/steamcmd-ubuntu:24.04 bash -lc 'locale | grep -q en_US.UTF-8' && echo 'PASS: en_US.UTF-8 locale active'",
 					"docker run --rm --platform linux/amd64 ghcr.io/kbve/steamcmd-ubuntu:24.04 bash -lc 'which steamcmd' | grep -q /usr/local/bin/steamcmd && echo 'PASS: steamcmd on PATH'",
-					"echo '=== steamcmd-ubuntu image OK ==='"
+					"echo '=== steamcmd-ubuntu image OK ==='",
+					"docker rmi -f ghcr.io/kbve/steamcmd-ubuntu:24.04 || true"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Problem

`Validate Dev→Main / Lint and Test` (run 29468745482) failed — **not code, runner disk exhaustion**. Every failure = `No space left on device (os error 28)` / ENOSPC:

- `kasm-void:containerx` → `ResourceExhausted: ... no space left on device`
- `kasm-cloakbrowser:containerx` → `failed to register layer ...: no space left`
- `steamcmd-ubuntu:containerx` → apt `GPG error: Splitting up InRelease` exit 100 (disk-full corruption)
- `jedi:test` / `kbve:test` / `bevy_inventory:test` → `failed to build archive .../dist/target/...: No space left`

All 3 rust tests pass locally in a clean worktree — confirmed env, not code.

## Root cause

`nx affected --target=test` runs docker projects whose `test` target `dependsOn: container` then executes `docker inspect`/`docker run` smoke checks against the **loaded** image. So `load: true` is required (can't drop it). The multi-GB KASM/steamcmd/chisel images were retained for the whole job → `/var/lib/docker` filled → everything after cascaded.

## Fix

- `free-disk-space`: enable `large-packages` + `swap-storage` (~7GB more one-time headroom)
- Each docker project's `test` target now ends with `docker rmi -f <img> || true` — releases the image right after its smoke test instead of hoarding it. nx cleans up after itself.

`--parallel=1` on the docker lane held in reserve if ENOSPC recurs (projects still run in parallel, so 2-3 images can briefly coexist).