### PR TITLE
fix(kasm-void): guard Discord supervisor against duplicate spawns (fork storm + OOM)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -348,7 +348,7 @@
 		{
 			"key": "kasm_void",
 			"app_name": "kasm-void",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"version_toml": "packages/docker/kasm-void/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx",
 			"source_path": "packages/docker/kasm-void",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -14,7 +14,7 @@ tags:
 key: kasm_void
 pipeline: docker
 app_name: kasm-void
-version: "0.0.5"
+version: "0.0.6"
 source_path: packages/docker/kasm-void
 version_toml: packages/docker/kasm-void/version.toml
 runner: ubuntu-latest

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -154,7 +154,7 @@ spec:
                           memory: 384Mi
                           cpu: 500m
                 - name: workspace
-                  image: ghcr.io/kbve/kasm-void:0.0.5
+                  image: ghcr.io/kbve/kasm-void:0.0.6
                   imagePullPolicy: IfNotPresent
                   securityContext:
                       runAsNonRoot: true

--- a/packages/docker/kasm-void/custom_startup.sh
+++ b/packages/docker/kasm-void/custom_startup.sh
@@ -83,9 +83,11 @@ discord_loop() {
     [ -x "$DISCORD_SEED" ] && "$DISCORD_SEED" || true
     while true; do
         if ! pgrep -fa Discord 2>/dev/null | grep -qv "$DISCORD_SEED" ; then
-            echo "[startup] launching discord at $(date -Iseconds)"
-            [ -x "$DISCORD_SEED" ] && "$DISCORD_SEED" || true
-            "$DISCORD_STARTUP" >>/tmp/discord.log 2>&1 &
+            if ! pgrep -f "$DISCORD_STARTUP" >/dev/null 2>&1; then
+                echo "[startup] launching discord at $(date -Iseconds)"
+                [ -x "$DISCORD_SEED" ] && "$DISCORD_SEED" || true
+                "$DISCORD_STARTUP" >>/tmp/discord.log 2>&1 &
+            fi
         fi
         sleep 3
     done


### PR DESCRIPTION
## Problem

The `kasm-vpn` workspace container drives host **PID 1 (`/sbin/init`) to ~58% CPU** and gets **OOMKilled repeatedly** (10× at 8Gi).

Root cause — a process/memory leak in the Discord supervisor:

- Dockerfile renames the base image's stock KASM launcher to `discord_startup.sh`:
  ```
  mv /dockerstartup/custom_startup.sh /dockerstartup/discord_startup.sh
  ```
  That launcher is a **persistent keep-alive supervisor** carrying its own `pgrep -x Discord` loop.
- `discord_loop` in `custom_startup.sh` re-spawned it (`"$DISCORD_STARTUP" &`) on **every 3s Discord miss with no guard**.
- Under OOM pressure / slow start, Discord isn't detected for several 3s cycles → each cycle spawns **another** launcher. They accumulate — snapshot showed **13 concurrent `pgrep -x Discord`** — each a perpetual loop. That floods PID 1 reaping (58% CPU) and leaks memory until the container OOMKills, which triggers *more* misses → more spawns. One bug, both symptoms.

## Fix

Only spawn `discord_startup.sh` when one is not already in flight:

```bash
if ! pgrep -fa Discord 2>/dev/null | grep -qv "$DISCORD_SEED" ; then
    if ! pgrep -f "$DISCORD_STARTUP" >/dev/null 2>&1; then
        ...
        "$DISCORD_STARTUP" >>/tmp/discord.log 2>&1 &
    fi
fi
```

Collapses the pile-up to a single supervisor. Self-healing preserved: if the launcher truly dies, the guard clears and one respawns. `bash -n` clean.

Bump `kasm-void` 0.0.5 → 0.0.6.

## Rollout

`replicas: 0` in GitOps — the live pod is a manual scale-up with an active session, so this does **not** disturb it. The fix ships in the image for the next workspace bring-up. Merge → CI publishes `ghcr.io/kbve/kasm-void:0.0.6` → post-publish bumps the deployment tag.

Docs: https://kbve.com/project/kasm-void/