### PR TITLE
chore(forgejo): log level warn + disable router log

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -43,12 +43,15 @@ spec:
                       accessModes:
                           - ReadWriteOnce
                   podAnnotations:
-                      kbve.com/config-revision: 2026-06-29-restricted-default-no-org
+                      kbve.com/config-revision: 2026-07-16-log-level-warn
                   gitea:
                       admin:
                           existingSecret: forgejo-admin
                       config:
+                          log:
+                              LEVEL: warn
                           server:
+                              DISABLE_ROUTER_LOG: true
                               DOMAIN: git.kbve.com
                               ROOT_URL: https://git.kbve.com
                               SSH_DOMAIN: forgejo.kbve.com


### PR DESCRIPTION
## Why
Forgejo (`forgejo` ns) emits healthcheck `200 OK` router lines and other INFO chatter. That namespace is **not** in the Vector `noise_filter` allowlist, so every line ships straight into ClickHouse. Enclosed system — only care about WARN/ERROR.

## What
- `log.LEVEL: warn` — pod emits only warn/error/fatal
- `server.DISABLE_ROUTER_LOG: true` — kills `completed GET ...` router lines
- bump `config-revision` podAnnotation → rollout

## Effect
- Healthcheck 200 (INFO) → dropped at source, never reaches CH
- Failed healthcheck / 5xx → still logged (error) → kept
- No Vector change needed