### PR TITLE
chore(realtime): LOG_LEVEL=warning

### DIFF
--- a/apps/kube/realtime/manifests/realtime-statefulset.yaml
+++ b/apps/kube/realtime/manifests/realtime-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
                       - containerPort: 9110
                         name: dist-end
                   env:
+                      - name: LOG_LEVEL
+                        value: warning
                       - name: HOSTNAME
                         valueFrom:
                             fieldRef:


### PR DESCRIPTION
## Why
Supabase realtime (`kilobase` ns, `realtime-prod-*`) logs Phoenix `Sent 200 in ...` request lines and other INFO at default level. `kilobase` is not in the Vector `noise_filter` allowlist, so every line ships to ClickHouse. Enclosed system — only want WARN/ERROR.

## What
- `LOG_LEVEL=warning` env on the realtime StatefulSet (Elixir Logger uses `warning`, not `warn`)
- env change → rolling restart

## Effect
- `Sent 200` + all INFO dropped at source, never reaches CH
- warn/error/fatal → still logged, kept + on dashboard
- No Vector change

Follow-up to #14154 (forgejo).