### PR TITLE
chore(windmill): RUST_LOG=warn on app server

### DIFF
--- a/apps/kube/windmill/application.yaml
+++ b/apps/kube/windmill/application.yaml
@@ -37,6 +37,8 @@ spec:
                           extraEnv:
                               - name: PG_SCHEMA
                                 value: windmill
+                              - name: RUST_LOG
+                                value: warn
                           resources:
                               requests:
                                   memory: 512Mi


### PR DESCRIPTION
## Why
The windmill **app/server** container has no `RUST_LOG`, so it defaults to `info` and logs request-completed lines. `windmill` ns is not in the Vector `noise_filter` allowlist → every line ships to ClickHouse. The worker groups (`default`, `native`) already set `RUST_LOG=warn`; the server was the odd one out.

## What
- add `RUST_LOG=warn` to `windmill.app.extraEnv`

## Effect
- app server INFO dropped at source, never reaches CH
- warn/error → still logged, kept
- No Vector change

Follow-up to #14154 (forgejo) / #14156 (realtime).