### PR TITLE
fix(spo): upgrade security-profiles-operator v0.9.1 → v1.0.0

### DIFF
--- a/apps/kube/security-profiles-operator/application.yaml
+++ b/apps/kube/security-profiles-operator/application.yaml
@@ -15,7 +15,7 @@ spec:
     project: default
     sources:
         - repoURL: https://github.com/kubernetes-sigs/security-profiles-operator
-          targetRevision: v0.9.1
+          targetRevision: v1.0.0
           path: deploy/helm
           helm:
               releaseName: security-profiles-operator

--- a/apps/kube/security-profiles-operator/manifests/values.yaml
+++ b/apps/kube/security-profiles-operator/manifests/values.yaml
@@ -2,15 +2,16 @@
 # Manages SeccompProfile CRDs so pods can reference custom profiles
 # without placing files on node filesystems (required for Talos).
 
-# Pin the operator image to the chart's release (v0.9.1). The chart default
-# is gcr.io/k8s-staging-sp-operator/...:latest, a floating staging tag that
-# drifted to 1.0.1-dev, which expects the SecurityProfilesOperatorDaemon
-# kind in v1 while the v0.9.1 chart only ships v1alpha1 -> operator
-# crashlooped (3000+ restarts) on "no matches for kind ... v1".
+# Pin the operator image to the chart's release. Keep this tag identical to
+# the Application targetRevision so the chart CRDs and the operator image
+# agree on the SecurityProfilesOperatorDaemon kind. v1.0.0 graduates all CRDs
+# to v1 and ships runc v1.5.0 (v0.9.1's spod hit StartError:128 on the Talos
+# 6.18 kernel: statx(STATX_MNT_ID) "operation not permitted", never installing
+# the firecracker-jailer profile). Never point at the floating staging :latest.
 spoImage:
     registry: registry.k8s.io
     repository: security-profiles-operator/security-profiles-operator
-    tag: v0.9.1
+    tag: v1.0.0
 
 enableLogEnricher: false
 enableRecordingHook: false


### PR DESCRIPTION
## Problem
`spod` (SecurityProfilesOperatorDaemon) has been **CrashLoopBackOff with 6079 restarts** for 21d. It never starts — `StartError:128`:

```
reopen exec fifo: get safe /proc/thread-self/fd handle ... statx(STATX_MNT_ID_...) ... operation not permitted
```

This is a **runc-vs-kernel-6.18** `/proc` mount-id bug. Because spod never runs, it never writes the `firecracker-jailer` Localhost seccomp profile to node disk, so **firecracker-ctl fails to start**:

```
cannot load seccomp profile "/var/lib/kubelet/seccomp/operator/firecracker/firecracker-jailer.json": no such file or directory
```

The `firecracker-jailer` SeccompProfile CR sits with a blank (uninstalled) status as a result.

## Why v1.0.0
- **runc v1.4.2 → v1.5.0** — fixes the newer-kernel `/proc` handling behind the `statx` StartError.
- **"Graduate all CRD APIs from alpha/beta to v1"** — resolves the v1alpha1-vs-v1 `SecurityProfilesOperatorDaemon` kind skew that originally forced the v0.9.1 pin (see the old `values.yaml` comment). Chart + image both move to v1.0.0 so CRDs and operator agree.

## Changes
- `application.yaml`: chart `targetRevision` v0.9.1 → v1.0.0
- `values.yaml`: `spoImage.tag` v0.9.1 → v1.0.0 + rewrite the pin comment

## Blast radius / rollout
- v0.9.1 spod is already 100% broken on this kernel — upgrade can't regress firecracker (already down).
- CRDs graduate alpha/beta → v1 on sync; the existing `firecracker-jailer` SeccompProfile re-applies via ArgoCD (`ServerSideApply`, `selfHeal`, `prune`).
- **Expected cascade once synced:** spod starts → installs `firecracker-jailer.json` → firecracker-ctl clears `CreateContainerError`; removes the 6079-restart kubelet/containerd/runc churn.

## Verify after sync
```
kubectl get pods -n security-profiles-operator          # spod Running, restarts stop climbing
kubectl get seccompprofile -n firecracker               # firecracker-jailer STATUS=Installed
kubectl get pods -n firecracker                         # firecracker-ctl no longer CreateContainerError
```

📚 https://kbve.com/docs/ (kube GitOps)