### PR TITLE
chore(discordsh): RUST_LOG debug->warn on web + bot

### DIFF
--- a/apps/kube/discordsh/manifest/configmap.yaml
+++ b/apps/kube/discordsh/manifest/configmap.yaml
@@ -15,7 +15,7 @@ data:
     PUBLIC_WS_URL: wss://ws.kbve.com
     PUBLIC_DISCORD_CLIENT_ID: placeholder-discord-client-id
     PUBLIC_ENV: production
-    RUST_LOG: debug
+    RUST_LOG: warn
     WINDMILL_BASE_URL: http://windmill-app.windmill.svc.cluster.local:8000
     WINDMILL_WORKSPACE: kbve
     WINDMILL_ALLOWED_PATHS: ''

--- a/apps/kube/discordsh/manifest/deployment.yaml
+++ b/apps/kube/discordsh/manifest/deployment.yaml
@@ -42,6 +42,8 @@ spec:
             labels:
                 app: discordsh
                 tier: frontend
+            annotations:
+                kbve.com/config-revision: 2026-07-16-log-warn
         spec:
             serviceAccountName: discordsh-sa
             automountServiceAccountToken: false

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                             optional: true
                   env:
                       - name: RUST_LOG
-                        value: discordsh_bot=debug,kbve=debug
+                        value: discordsh_bot=warn,kbve=warn
                       - name: FONT_PATH
                         value: /app/alagard.ttf
                       - name: SYMBOL_FONT_PATH


### PR DESCRIPTION
## Why
Both discordsh deployments log at `debug`:
- **web/axum** — `RUST_LOG=debug` in the `discordsh-config` configmap
- **bot** — `discordsh_bot=debug,kbve=debug` inline env

`discordsh` ns is not in the Vector `noise_filter` allowlist, so all of it ships to ClickHouse.

## What
- configmap `RUST_LOG`: `debug` → `warn`
- bot env: `discordsh_bot=warn,kbve=warn`
- bump web pod-template `config-revision` annotation so the configmap change rolls out (envFrom doesn't hash the configmap)

## Effect
- debug/info dropped at source, never reaches CH
- warn/error → still logged, kept
- No Vector change

Follow-up to #14154 forgejo / #14156 realtime / #14162 windmill.