### PR TITLE
chore(rows): RUST_LOG info->warn on base + tenant base

### DIFF
--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -40,7 +40,7 @@ spec:
                       - name: DOCS_PORT
                         value: '4323'
                       - name: RUST_LOG
-                        value: 'info,tower_http=warn'
+                        value: 'warn,tower_http=warn'
                       - name: DATABASE_URL
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                       - name: METRICS_PORT
                         value: '4324'
                       - name: RUST_LOG
-                        value: 'info,tower_http=warn'
+                        value: 'warn,tower_http=warn'
                       - name: DB_MAX_CONNECTIONS
                         value: '20'
                       - name: OWS_API_KEY


### PR DESCRIPTION
## Why
Both rows deployments log at `info,tower_http=warn`:
- shared `apps/kube/rows/manifest/rows-deployment.yaml`
- tenant base `apps/kube/rows/tenants/base/deployment.yaml`

rows/tenant namespaces aren't in the Vector `noise_filter` allowlist, so every request line ships to ClickHouse.

## What
- `RUST_LOG`: `info,tower_http=warn` → `warn,tower_http=warn` on both
- all tenant overlays (chuckrpg dev/beta/prod, rentearth) inherit the base — no per-tenant edit

## Effect
- info dropped at source, never reaches CH
- warn/error → still logged, kept
- No Vector change

Follow-up to #14154 forgejo / #14156 realtime / #14162 windmill / #14164 discordsh.