### PR TITLE
fix(firecracker): jailer seccomp path for SPO v1.0.0 scheme

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -71,7 +71,7 @@ spec:
                   securityContext:
                       seccompProfile:
                           type: Localhost
-                          localhostProfile: operator/firecracker/firecracker-jailer.json
+                          localhostProfile: operator/firecracker-jailer.json
                       readOnlyRootFilesystem: true
                       # Firecracker jailer requires SYS_ADMIN (mount --make-private for
                       # pivot_root on shared-propagation emptyDir), SYS_CHROOT + MKNOD

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -146,7 +146,7 @@ spec:
                   securityContext:
                       seccompProfile:
                           type: Localhost
-                          localhostProfile: operator/firecracker/firecracker-jailer.json
+                          localhostProfile: operator/firecracker-jailer.json
                       readOnlyRootFilesystem: true
                       # Firecracker jailer requires SYS_ADMIN (mount --make-private for
                       # pivot_root on shared-propagation emptyDir), SYS_CHROOT + MKNOD

--- a/apps/kube/firecracker/manifests/firecracker-seccomp.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-seccomp.yaml
@@ -10,7 +10,7 @@
 # to:
 #   seccompProfile:
 #     type: Localhost
-#     localhostProfile: operator/firecracker/firecracker-jailer.json
+#     localhostProfile: operator/firecracker-jailer.json
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:


### PR DESCRIPTION
## Problem
After upgrading security-profiles-operator to v1.0.0 (#14163), `firecracker-ctl` and `firecracker-ctl-net` stay in **CreateContainerError**:

```
cannot load seccomp profile "/var/lib/kubelet/seccomp/operator/firecracker/firecracker-jailer.json": no such file or directory
```

## Cause
SPO **v1.0.0 changed the SeccompProfile on-disk install path** from `operator/<namespace>/<name>.json` to `operator/<name>.json`. Post-upgrade the profile is installed and Ready:

```
$ kubectl get seccompprofile firecracker-jailer -n firecracker -o jsonpath='{.status.localhostProfile}'
operator/firecracker-jailer.json      # was operator/firecracker/firecracker-jailer.json
```

But the podSpecs still referenced the old `operator/firecracker/...` path.

## Change
Point `localhostProfile` at the new path in both deployments (+ the example comment in the SeccompProfile manifest):
- `firecracker-deployment.yaml`
- `firecracker-net-deployment.yaml`
- `firecracker-seccomp.yaml` (comment)

## After sync
`firecracker-ctl*` pods recreate and find the profile → clear CreateContainerError → Running.

📚 https://kbve.com/docs/