### PR TITLE
chore(kbve-gate): RUST_LOG info->warn on studio/windmill/forgejo gates

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-gate-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                                 name: forgejo-gate-supabase-jwt
                                 key: anon-key
                       - name: RUST_LOG
-                        value: info
+                        value: warn
                   resources:
                       requests:
                           memory: 64Mi

--- a/apps/kube/studio/manifests/studio-gate-deployment.yaml
+++ b/apps/kube/studio/manifests/studio-gate-deployment.yaml
@@ -76,7 +76,7 @@ spec:
                                 name: supabase-jwt
                                 key: anon-key
                       - name: RUST_LOG
-                        value: info
+                        value: warn
                   resources:
                       requests:
                           memory: 64Mi

--- a/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
+++ b/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
@@ -79,7 +79,7 @@ spec:
                       - name: GATE_WINDMILL_WORKSPACE
                         value: kbve
                       - name: RUST_LOG
-                        value: info
+                        value: warn
                   resources:
                       requests:
                           memory: 64Mi


### PR DESCRIPTION
## Why
Three kbve-gate sidecars sit in namespaces **not** covered by the Vector `noise_filter` allowlist, so their per-request info lines ship straight to ClickHouse:
- studio-gate (`kilobase`)
- windmill-gate (`windmill`)
- forgejo-gate (`forgejo`)

## What
- `RUST_LOG`: `info` → `warn` on all three (env change → auto rollout)

## Scope
Deliberately small. Left untouched for follow-ups:
- gates in Vector-filtered ns (argocd/grafana/longhorn)
- rareicon, rentearth/chuckrpg configmaps, metrics `met=info`
- Agones game fleets (`X=debug` kept for session debugging)

Follow-up to #14154 / #14156 / #14162 / #14164 / #14168.