### PR TITLE
chore(rentearth,chuckrpg): RUST_LOG info->warn

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/kube/chuckrpg/manifest/configmap.yaml
+++ b/apps/kube/chuckrpg/manifest/configmap.yaml
@@ -11,5 +11,5 @@ metadata:
 data:
     HTTP_HOST: 0.0.0.0
     HTTP_PORT: '4322'
-    RUST_LOG: info
+    RUST_LOG: warn
     ITCH_GAME_ID: '4645098'

--- a/apps/kube/chuckrpg/manifest/deployment.yaml
+++ b/apps/kube/chuckrpg/manifest/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         metadata:
             labels:
                 app: chuckrpg
+            annotations:
+                kbve.com/config-revision: 2026-07-16-log-warn
         spec:
             serviceAccountName: chuckrpg
             automountServiceAccountToken: false

--- a/apps/kube/rentearth/manifest/axum-rentearth-configmap.yaml
+++ b/apps/kube/rentearth/manifest/axum-rentearth-configmap.yaml
@@ -11,5 +11,5 @@ metadata:
 data:
     HTTP_HOST: 0.0.0.0
     HTTP_PORT: '4323'
-    RUST_LOG: info
+    RUST_LOG: warn
     ITCH_GAME_ID: '4147439'

--- a/apps/kube/rentearth/manifest/axum-rentearth-deployment.yaml
+++ b/apps/kube/rentearth/manifest/axum-rentearth-deployment.yaml
@@ -24,6 +24,8 @@ spec:
         metadata:
             labels:
                 app: axum-rentearth
+            annotations:
+                kbve.com/config-revision: 2026-07-16-log-warn
         spec:
             serviceAccountName: rentearth-sa
             automountServiceAccountToken: false


### PR DESCRIPTION
## Why
Both axum game-site services log at `info` via configmap; `rentearth` and `chuckrpg` namespaces are not in the Vector `noise_filter` allowlist, so request lines ship to ClickHouse.

## What
- `axum-rentearth-config` + `chuckrpg-config`: `RUST_LOG` `info` → `warn`
- `config-revision` pod-template annotation bump on both deployments (envFrom doesn't hash configmaps → no auto-rollout otherwise)

## Scope
Scoped pair, same shape as discordsh (#14164). Still untouched: rareicon, metrics `met=info`, Vector-filtered-ns gates, Agones fleets.

Sibling of #14170 (gates).