### PR TITLE
fix(rn-dash): level chips requery clickhouse feed + section dividers

### DIFF
--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -6,6 +6,7 @@ import { ErrorState } from '../ui/feedback/ErrorState';
 import { LoadingState } from '../ui/feedback/LoadingState';
 import { VirtualList } from '../ui/lists/VirtualList';
 import { StatGrid } from './StatGrid';
+import { SectionDivider } from './shared';
 import { ControlBar } from './controls/ControlBar';
 import { SavedViewTabs } from './controls/SavedViewTabs';
 import { useStream, useStreamLifecycle, useStreamSelector } from './useStream';
@@ -211,6 +212,17 @@ export function StreamView<TItem>({
 	useStreamLifecycle(store);
 	const state = useStream(store);
 
+	const pickFilter = (id: string | null) => {
+		const prev = lens.filters?.find((f) => f.id === state.filterId);
+		const next = lens.filters?.find((f) => f.id === id);
+		store.setFilter(id);
+		const patch: Record<string, string | number | undefined> = {};
+		if (prev?.params)
+			for (const k of Object.keys(prev.params)) patch[k] = undefined;
+		if (next?.params) Object.assign(patch, next.params);
+		if (Object.keys(patch).length) store.setParams(patch);
+	};
+
 	const visible = useMemo(() => {
 		const q = state.search.trim().toLowerCase();
 		const filter = lens.filters?.find((f) => f.id === state.filterId);
@@ -248,9 +260,17 @@ export function StreamView<TItem>({
 
 	return (
 		<Stack gap="md">
-			{stats.length ? <StatGrid stats={stats} /> : null}
+			{stats.length ? (
+				<>
+					<SectionDivider label="Summary" />
+					<StatGrid stats={stats} />
+				</>
+			) : null}
 			{lens.metaPanel ? lens.metaPanel(state.meta) : null}
 
+			{state.views.length || lens.controls?.length ? (
+				<SectionDivider label="Query" />
+			) : null}
 			{state.views.length ? (
 				<SavedViewTabs
 					store={storeU}
@@ -267,6 +287,7 @@ export function StreamView<TItem>({
 				/>
 			) : null}
 
+			<SectionDivider label="Feed" />
 			<Stack direction="row" gap="sm" align="center" wrap>
 				{lens.filters?.length ? (
 					<FilterChips
@@ -274,7 +295,7 @@ export function StreamView<TItem>({
 							lens.filters as readonly StreamFilter<unknown>[]
 						}
 						active={state.filterId}
-						onPick={store.setFilter}
+						onPick={pickFilter}
 					/>
 				) : null}
 				{lens.searchText ? (
@@ -286,8 +307,12 @@ export function StreamView<TItem>({
 						style={styles.search}
 					/>
 				) : null}
-				<Pressable onPress={() => void store.refresh()} style={styles.refresh}>
-					<Text variant="caption" tone="muted">↻ Refresh</Text>
+				<Pressable
+					onPress={() => void store.refresh()}
+					style={styles.refresh}>
+					<Text variant="caption" tone="muted">
+						↻ Refresh
+					</Text>
 				</Pressable>
 			</Stack>
 

--- a/packages/npm/rn/src/dash/adapters/__tests__/clickhouse.test.ts
+++ b/packages/npm/rn/src/dash/adapters/__tests__/clickhouse.test.ts
@@ -59,6 +59,15 @@ describe('ClickHouse Adapter', () => {
 			expect(warnFilter.predicate(warnLog)).toBe(true);
 		});
 
+		it('level chips carry server-side level params so the feed requeries', () => {
+			const byId = Object.fromEntries(
+				clickhouseLens.filters.map((f) => [f.id, f.params]),
+			);
+			expect(byId['error']).toEqual({ level: 'error' });
+			expect(byId['warn']).toEqual({ level: 'warn' });
+			expect(byId['info']).toEqual({ level: 'info' });
+		});
+
 		it('computes stats correctly', () => {
 			const items = [
 				{ level: 'error' },

--- a/packages/npm/rn/src/dash/adapters/clickhouse.tsx
+++ b/packages/npm/rn/src/dash/adapters/clickhouse.tsx
@@ -106,18 +106,21 @@ export const clickhouseLens: StreamLens<LogItem> = {
 			label: 'Errors',
 			tone: 'danger',
 			predicate: (it) => it.level === 'error',
+			params: { level: 'error' },
 		},
 		{
 			id: 'warn',
 			label: 'Warnings',
 			tone: 'warning',
 			predicate: (it) => it.level === 'warn' || it.level === 'warning',
+			params: { level: 'warn' },
 		},
 		{
 			id: 'info',
 			label: 'Info',
 			tone: 'neutral',
 			predicate: (it) => it.level === 'info',
+			params: { level: 'info' },
 		},
 	],
 	stats: (items, meta) => {
@@ -133,7 +136,12 @@ export const clickhouseLens: StreamLens<LogItem> = {
 		return [
 			{ id: 'total', label: 'Total Logs', value: t.total },
 			{ id: 'errors', label: 'Errors', tone: 'danger', value: t.errors },
-			{ id: 'warnings', label: 'Warnings', tone: 'warning', value: t.warnings },
+			{
+				id: 'warnings',
+				label: 'Warnings',
+				tone: 'warning',
+				value: t.warnings,
+			},
 		];
 	},
 	controls: CH_CONTROLS,

--- a/packages/npm/rn/src/dash/clickhouse/ClickHouseView.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/ClickHouseView.tsx
@@ -6,36 +6,73 @@ import { createClickHouseStream } from './clickhouseStream';
 import { createErrorGroupsStream } from './errorGroupsStream';
 import { makeNamespaceGrid } from './NamespaceGrid';
 import { ErrorDigest } from './ErrorDigest';
+import { SectionDivider } from '../shared';
 
 export interface ClickHouseViewProps {
 	getToken: () => Promise<string | null>;
 	baseUrl?: string;
 }
 
-export function ClickHouseView({ getToken, baseUrl = '' }: ClickHouseViewProps) {
-	const primary = useMemo(() => createClickHouseStream({ getToken, baseUrl }), [getToken, baseUrl]);
-	const errors = useMemo(() => createErrorGroupsStream({ getToken, baseUrl }), [getToken, baseUrl]);
+export function ClickHouseView({
+	getToken,
+	baseUrl = '',
+}: ClickHouseViewProps) {
+	const primary = useMemo(
+		() => createClickHouseStream({ getToken, baseUrl }),
+		[getToken, baseUrl],
+	);
+	const errors = useMemo(
+		() => createErrorGroupsStream({ getToken, baseUrl }),
+		[getToken, baseUrl],
+	);
 
 	// Keep the error-groups window in sync with the primary time range + namespace.
-	const lastSyncRef = useRef<{ minutes: unknown; pod_namespace: unknown }>({ minutes: undefined, pod_namespace: undefined });
+	const lastSyncRef = useRef<{ minutes: unknown; pod_namespace: unknown }>({
+		minutes: undefined,
+		pod_namespace: undefined,
+	});
 	useEffect(() => {
 		const unsub = primary.subscribe(() => {
 			const p = primary.get().params;
 			const minutes = p['minutes'];
 			const pod_namespace = p['pod_namespace'];
 			const prev = lastSyncRef.current;
-			if (prev.minutes === minutes && prev.pod_namespace === pod_namespace) return;
+			if (
+				prev.minutes === minutes &&
+				prev.pod_namespace === pod_namespace
+			)
+				return;
 			lastSyncRef.current = { minutes, pod_namespace };
 			errors.setParams({ minutes, pod_namespace });
 		});
 		return unsub;
 	}, [primary, errors]);
 
-	const lens = useMemo(() => ({ ...clickhouseLens, metaPanel: makeNamespaceGrid(primary) }), [primary]);
+	const lens = useMemo(() => {
+		const grid = makeNamespaceGrid(primary);
+		return {
+			...clickhouseLens,
+			metaPanel: (meta: unknown) => {
+				const panel = grid(meta);
+				if (!panel) return null;
+				return (
+					<Stack gap="xs">
+						<SectionDivider label="Namespaces" />
+						{panel}
+					</Stack>
+				);
+			},
+		};
+	}, [primary]);
 
 	return (
 		<Stack gap="md">
-			<StreamView store={primary} lens={lens} layout="rows" searchPlaceholder="filter by namespace / level / message" />
+			<StreamView
+				store={primary}
+				lens={lens}
+				layout="rows"
+				searchPlaceholder="filter by namespace / level / message"
+			/>
 			<ErrorDigest store={errors} primary={primary} />
 		</Stack>
 	);

--- a/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
@@ -1,9 +1,10 @@
 import { Pressable } from 'react-native';
-import { Stack, Text } from '../_ui';
+import { Stack } from '../_ui';
 import { useStream, useStreamLifecycle } from '../useStream';
 import type { StreamStore } from '../types';
 import type { LogItem } from '../adapters/clickhouse';
 import { errorGroupsLens, type ErrorGroupItem } from './errorGroupsStream';
+import { SectionDivider } from '../shared';
 
 export function ErrorDigest({
 	store,
@@ -17,16 +18,16 @@ export function ErrorDigest({
 	if (!state.items.length) return null;
 	return (
 		<Stack gap="xs">
-			<Text variant="label" tone="muted">
-				Error digest
-			</Text>
+			<SectionDivider label="Error Digest" />
 			{state.items.map((it) => (
 				<Pressable
 					key={store.id(it)}
 					onPress={() =>
-						primary.setParams({ pod_namespace: it.namespace || undefined, level: 'error' })
-					}
-				>
+						primary.setParams({
+							pod_namespace: it.namespace || undefined,
+							level: 'error',
+						})
+					}>
 					{errorGroupsLens.row(it, false)}
 				</Pressable>
 			))}

--- a/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
+++ b/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
@@ -1,5 +1,10 @@
 import { createStreamSource } from '../createStreamSource';
-import type { StreamControl, SavedView, StreamParams, StreamStore } from '../types';
+import type {
+	StreamControl,
+	SavedView,
+	StreamParams,
+	StreamStore,
+} from '../types';
 import { normalize } from '../adapters/clickhouse';
 import type { LogItem, RawLogRow } from '../adapters/clickhouse';
 
@@ -11,18 +16,36 @@ export interface ClickHouseStreamOptions {
 
 const PROXY = '/dashboard/clickhouse/proxy';
 
-function buildBody(command: string, params: StreamParams): Record<string, unknown> {
+function buildBody(
+	command: string,
+	params: StreamParams,
+): Record<string, unknown> {
 	const body: Record<string, unknown> = { command };
-	for (const k of ['minutes', 'limit', 'pod_namespace', 'service', 'level', 'search']) {
+	for (const k of [
+		'minutes',
+		'limit',
+		'pod_namespace',
+		'service',
+		'level',
+		'search',
+	]) {
 		if (params[k] !== undefined && params[k] !== '') body[k] = params[k];
 	}
 	return body;
 }
 
-async function post(baseUrl: string, token: string | null, body: unknown, signal: AbortSignal) {
+async function post(
+	baseUrl: string,
+	token: string | null,
+	body: unknown,
+	signal: AbortSignal,
+) {
 	const res = await fetch(`${baseUrl}${PROXY}`, {
 		method: 'POST',
-		headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), 'Content-Type': 'application/json' },
+		headers: {
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
+			'Content-Type': 'application/json',
+		},
 		body: JSON.stringify(body),
 		signal,
 	});
@@ -31,11 +54,18 @@ async function post(baseUrl: string, token: string | null, body: unknown, signal
 	return res.json();
 }
 
-export interface StatsTotals { total: number; errors: number; warnings: number; }
+export interface StatsTotals {
+	total: number;
+	errors: number;
+	warnings: number;
+}
 
 export function buildStatsTotals(meta: unknown): StatsTotals {
-	const rows = (meta as { rows?: { level?: string; cnt?: number }[] })?.rows ?? [];
-	let total = 0, errors = 0, warnings = 0;
+	const rows =
+		(meta as { rows?: { level?: string; cnt?: number }[] })?.rows ?? [];
+	let total = 0,
+		errors = 0,
+		warnings = 0;
 	for (const r of rows) {
 		const cnt = Number(r.cnt ?? 0);
 		total += cnt;
@@ -47,30 +77,64 @@ export function buildStatsTotals(meta: unknown): StatsTotals {
 }
 
 export const CH_CONTROLS: readonly StreamControl[] = [
-	{ kind: 'segmented', param: 'minutes', options: [
-		{ label: '6h', value: 360 }, { label: '12h', value: 720 },
-		{ label: '24h', value: 1440 }, { label: '72h', value: 4320 }, { label: 'ALL', value: 0 },
-	] },
-	{ kind: 'select', param: 'pod_namespace', placeholder: 'namespace',
+	{
+		kind: 'segmented',
+		param: 'minutes',
+		options: [
+			{ label: '6h', value: 360 },
+			{ label: '12h', value: 720 },
+			{ label: '24h', value: 1440 },
+			{ label: '72h', value: 4320 },
+			{ label: 'ALL', value: 0 },
+		],
+	},
+	{
+		kind: 'select',
+		param: 'pod_namespace',
+		placeholder: 'namespace',
 		optionsFromMeta: (m) => {
-			const rows = (m as { rows?: { pod_namespace?: string }[] })?.rows ?? [];
-			const set = [...new Set(rows.map((r) => r.pod_namespace).filter(Boolean) as string[])].sort();
-			return [{ label: 'all namespaces', value: '' }, ...set.map((v) => ({ label: v, value: v }))];
-		} },
-	{ kind: 'select', param: 'level', placeholder: 'level', options: [
-		{ label: 'all levels', value: '' }, { label: 'error', value: 'error' },
-		{ label: 'warn', value: 'warn' }, { label: 'info', value: 'info' },
-	] },
+			const rows =
+				(m as { rows?: { pod_namespace?: string }[] })?.rows ?? [];
+			const set = [
+				...new Set(
+					rows
+						.map((r) => r.pod_namespace)
+						.filter(Boolean) as string[],
+				),
+			].sort();
+			return [
+				{ label: 'all namespaces', value: '' },
+				...set.map((v) => ({ label: v, value: v })),
+			];
+		},
+	},
 	{ kind: 'search', param: 'search', placeholder: 'filter message…' },
 ];
 
 export const CH_DEFAULT_VIEWS: SavedView[] = [
-	{ id: 'errors-24h', name: 'Errors · 24h', params: { minutes: 1440, level: 'error', limit: 500 }, seeded: true },
-	{ id: 'all-6h', name: 'All · 6h', params: { minutes: 360, limit: 500 }, seeded: true },
-	{ id: 'warnings-24h', name: 'Warnings · 24h', params: { minutes: 1440, level: 'warn', limit: 500 }, seeded: true },
+	{
+		id: 'errors-24h',
+		name: 'Errors · 24h',
+		params: { minutes: 1440, level: 'error', limit: 500 },
+		seeded: true,
+	},
+	{
+		id: 'all-6h',
+		name: 'All · 6h',
+		params: { minutes: 360, limit: 500 },
+		seeded: true,
+	},
+	{
+		id: 'warnings-24h',
+		name: 'Warnings · 24h',
+		params: { minutes: 1440, level: 'warn', limit: 500 },
+		seeded: true,
+	},
 ];
 
-export function createClickHouseStream(opts: ClickHouseStreamOptions): StreamStore<LogItem> {
+export function createClickHouseStream(
+	opts: ClickHouseStreamOptions,
+): StreamStore<LogItem> {
 	const { getToken, baseUrl = '', pollMs = 30_000 } = opts;
 	return createStreamSource<RawLogRow, LogItem>({
 		key: 'clickhouse:logs',
@@ -83,14 +147,26 @@ export function createClickHouseStream(opts: ClickHouseStreamOptions): StreamSto
 		normalize,
 		fetch: async ({ signal }, params: StreamParams) => {
 			const token = await getToken();
-			const json = (await post(baseUrl, token, buildBody('query', params), signal)) as { rows?: RawLogRow[] };
-			return (json?.rows ?? []).sort((a, b) =>
-				new Date(b.timestamp.replace(' ', 'T') + 'Z').getTime() -
-				new Date(a.timestamp.replace(' ', 'T') + 'Z').getTime());
+			const json = (await post(
+				baseUrl,
+				token,
+				buildBody('query', params),
+				signal,
+			)) as { rows?: RawLogRow[] };
+			return (json?.rows ?? []).sort(
+				(a, b) =>
+					new Date(b.timestamp.replace(' ', 'T') + 'Z').getTime() -
+					new Date(a.timestamp.replace(' ', 'T') + 'Z').getTime(),
+			);
 		},
 		fetchMeta: async ({ signal }, params: StreamParams) => {
 			const token = await getToken();
-			return post(baseUrl, token, buildBody('stats', { minutes: params['minutes'] }), signal);
+			return post(
+				baseUrl,
+				token,
+				buildBody('stats', { minutes: params['minutes'] }),
+				signal,
+			);
 		},
 	});
 }

--- a/packages/npm/rn/src/dash/shared.tsx
+++ b/packages/npm/rn/src/dash/shared.tsx
@@ -1,10 +1,24 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Stack, Text, tokens } from './_ui';
 import type { BadgeTone } from './_ui';
 
 // ---------------------------------------------------------------------------
 // Shared Components
 // ---------------------------------------------------------------------------
+
+/** Hairline divider with a small uppercase section label — visual break between dashboard sections */
+export function SectionDivider({ label }: { label?: string }) {
+	if (!label) return <View style={styles.dividerLine} />;
+	return (
+		<Stack direction="row" gap="sm" align="center" style={styles.divider}>
+			<View style={styles.dividerLine} />
+			<Text variant="caption" tone="faint" style={styles.dividerLabel}>
+				{label}
+			</Text>
+			<View style={styles.dividerLine} />
+		</Stack>
+	);
+}
 
 /** Two-column fact display (label + value) — used in detail panels */
 export function Fact({ label, value }: { label: string; value: string }) {
@@ -119,6 +133,28 @@ export function statusColor(
 // ---------------------------------------------------------------------------
 
 /** Common adapter row/card/detail styles — reuse across all adapters */
+const styles = StyleSheet.create({
+	divider: {
+		marginTop: tokens.space.xs,
+	},
+	dividerLine: {
+		flexGrow: 1,
+		flexShrink: 1,
+		height: StyleSheet.hairlineWidth,
+		backgroundColor: tokens.color.border,
+	},
+	dividerLabel: {
+		fontSize: 10,
+		textTransform: 'uppercase',
+		letterSpacing: 1,
+		flexShrink: 0,
+	},
+	factValue: {
+		flexShrink: 1,
+		textAlign: 'right',
+	},
+});
+
 export const adapterStyles = StyleSheet.create({
 	row: {
 		flexDirection: 'row',

--- a/packages/npm/rn/src/dash/types.ts
+++ b/packages/npm/rn/src/dash/types.ts
@@ -33,7 +33,9 @@ export type StreamControl =
 			label?: string;
 			placeholder?: string;
 			options?: { label: string; value: string }[];
-			optionsFromMeta?: (meta: unknown) => { label: string; value: string }[];
+			optionsFromMeta?: (
+				meta: unknown,
+			) => { label: string; value: string }[];
 	  }
 	| {
 			kind: 'search';
@@ -164,6 +166,12 @@ export interface StreamFilter<TItem> {
 	label: string;
 	tone?: BadgeTone;
 	predicate: (item: TItem) => boolean;
+	/**
+	 * Optional server-side params applied while this filter is active (e.g.
+	 * `{ level: 'error' }`). Selecting the chip patches params + refetches;
+	 * deselecting (or switching chips) clears this filter's keys first.
+	 */
+	params?: StreamParams;
 }
 
 /**


### PR DESCRIPTION
## Bug
Errors/Warnings/Info chips on /dashboard/clickhouse/ only filtered the already-loaded ≤500-row window client-side (`store.setFilter` → predicate). No `level` param, no refetch — feed looked frozen and disagreed with server-side stat totals from meta.

## Fix
- `StreamFilter.params` (optional) in dash types: chip pick patches stream params + refetches; switching/deselecting clears the prior chip's param keys (`StreamView.pickFilter`).
- ClickHouse chips wired: error/warn/info → `level` param (server filter in jedi `build_query_sql`).
- Removed now-redundant level select from `CH_CONTROLS`.

## UI
- New `SectionDivider` (hairline + small uppercase label) in dash shared.
- Sections labeled: Summary → Namespaces → Query (views+controls) → Feed → Error Digest. Generic dashboards get Summary/Query/Feed for free.
- Fixes latent `styles.factValue` reference in shared.tsx (no `styles` const existed).

## Tests
- rn:test 66/66 (new test: chips carry level params).
- Known gap (separate): CH rows stored as `warning` escape server `level='warn'` exact match; jedi SQL `IN ('warn','warning')` would need axum-kbve redeploy.