### PR TITLE
chore(spo): split CRDs into own Application to prevent graduation deadlock

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -100,6 +100,9 @@ resources:
     - forgejo/application.yaml
 
     # Security Profiles Operator — SeccompProfile CRDs for Talos (no Localhost profiles)
+    # CRDs split into their own app (sync-wave 1) so a CRD apiVersion graduation
+    # applies ahead of the operator (wave 2) instead of wedging the whole app.
+    - security-profiles-operator/application-crds.yaml
     - security-profiles-operator/application.yaml
 
     # Firecracker — microVM runtime service (edge function Tier 2 isolation)

--- a/apps/kube/security-profiles-operator/application-crds.yaml
+++ b/apps/kube/security-profiles-operator/application-crds.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: security-profiles-operator-crds
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+        kbve.com/source-path: kube/security-profiles-operator
+        kbve.com/manifest-path: kube/security-profiles-operator
+        kbve.com/application-file: kube/security-profiles-operator/application-crds.yaml
+        kbve.com/managed-by: argocd
+        kbve.com/schema-version: v1
+        kbve.com/category: security
+        kbve.com/stack: core
+spec:
+    project: default
+    sources:
+        - repoURL: https://github.com/kubernetes-sigs/security-profiles-operator
+          targetRevision: v1.0.0
+          path: deploy/helm/crds
+          directory:
+              recurse: false
+              include: crds.yaml
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: security-profiles-operator
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: false
+        syncOptions:
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+    ignoreDifferences:
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          jqPathExpressions:
+              - .spec.conversion.webhook.clientConfig.caBundle

--- a/apps/kube/security-profiles-operator/application.yaml
+++ b/apps/kube/security-profiles-operator/application.yaml
@@ -4,6 +4,7 @@ metadata:
     name: security-profiles-operator
     namespace: argocd
     annotations:
+        argocd.argoproj.io/sync-wave: '2'
         kbve.com/source-path: kube/security-profiles-operator
         kbve.com/manifest-path: kube/security-profiles-operator
         kbve.com/application-file: kube/security-profiles-operator/application.yaml
@@ -19,6 +20,7 @@ spec:
           path: deploy/helm
           helm:
               releaseName: security-profiles-operator
+              skipCrds: true
               valueFiles:
                   - $values/apps/kube/security-profiles-operator/manifests/values.yaml
         - repoURL: https://github.com/kbve/kbve


### PR DESCRIPTION
## Why
The v0.9.1 → v1.0.0 upgrade (#14163) **wedged the entire `security-profiles-operator` Application**. CRDs and the `SecurityProfilesOperatorDaemon` CR were bundled in one app, so when the CRD graduated `v1alpha1 → v1`, ArgoCD couldn't diff the CR against the not-yet-applied v1 CRD schema:

```
ComparisonError: unable to resolve parseableType for GroupVersionKind:
  security-profiles-operator.x-k8s.io/v1, Kind=SecurityProfilesOperatorDaemon
```

That blocked sync of *everything* — including the CRD update that would have fixed it. Resolving it needed manual live CRD surgery. This hardens against a repeat.

## Change
Decouple CRDs from the operator:

| File | Change |
|------|--------|
| `application-crds.yaml` (new, sync-wave 1) | directory source over the chart's `deploy/helm/crds/crds.yaml` at the pinned tag; `prune:false` (never GC a CRD out from under its CRs); `ignoreDifferences` on `conversion.webhook.clientConfig.caBundle` (operator injects it at runtime) |
| `application.yaml` | `helm.skipCrds: true` + `sync-wave: '2'` — operator app stops managing CRDs, syncs after them |
| `kustomization.yaml` | register `application-crds.yaml` ahead of `application.yaml` |

## Effect
- CRDs apply via their own app (wave 1) **before** the operator (wave 2).
- The operator app only manages workloads → can no longer wedge on a CRD schema diff.
- Future CRD apiVersion graduations apply cleanly instead of blocking the whole app.

## Notes
- `crds.yaml` is plain YAML (no helm templating), so a directory source applies it verbatim.
- No behavioral change to the running operator; the CRDs are identical content, just managed by a separate Application.
- Validated: `kubectl kustomize apps/kube/` builds clean.

📚 https://kbve.com/docs/