### PR TITLE
feat(discordsh): lock /wm to f/discordsh namespace + seed windmill script tree

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -7,7 +7,7 @@ use crate::discord::windmill::{DiscordContext, split_args};
 #[poise::command(slash_command, rename = "wm")]
 pub async fn wm(
     ctx: Context<'_>,
-    #[description = "Windmill path, e.g. f/deploy/restart or p/ops/status"] wm_path: String,
+    #[description = "Script name (e.g. poem) → f/discordsh/; only the f/discordsh/ folder is reachable"] wm_path: String,
     #[description = "Space-separated args"] args: Option<String>,
 ) -> Result<(), Error> {
     let Some(cfg) = ctx.data().app.windmill.clone() else {

--- a/apps/discordsh/discordsh-bot/src/discord/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/windmill.rs
@@ -204,7 +204,7 @@ fn is_path_safe(path: &str) -> bool {
     }
     if path
         .split('/')
-        .any(|seg| seg == ".." || seg == ".")
+        .any(|seg| seg.is_empty() || seg == ".." || seg == ".")
     {
         return false;
     }
@@ -587,6 +587,29 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err, RunError::PathNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn run_rejects_empty_leaf_and_segments() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "f/discordsh/**", 10, 60);
+        // Folder root (empty leaf) and empty interior segment both rejected.
+        assert_eq!(
+            cfg.run("f/discordsh/", &[], &discord_ctx()).await.unwrap_err(),
+            RunError::PathNotAllowed
+        );
+        assert_eq!(
+            cfg.run("f/discordsh//x", &[], &discord_ctx())
+                .await
+                .unwrap_err(),
+            RunError::PathNotAllowed
+        );
     }
 
     #[tokio::test]

--- a/apps/discordsh/discordsh-bot/src/discord/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/windmill.rs
@@ -122,14 +122,18 @@ impl WindmillConfig {
         args: &[String],
         discord: &DiscordContext,
     ) -> Result<Value, RunError> {
-        let path = wm_path.trim().trim_start_matches('/');
-        if path.is_empty() {
+        let raw = wm_path.trim().trim_start_matches('/');
+        if raw.is_empty() {
             return Err(RunError::EmptyPath);
         }
-        if !is_path_safe(path) {
+        let path = resolve_path(raw);
+        if !is_path_safe(&path) {
             return Err(RunError::PathNotAllowed);
         }
-        if !self.path_allowed(path) {
+        if !path.starts_with(BOT_NAMESPACE) {
+            return Err(RunError::PathNotAllowed);
+        }
+        if !self.path_allowed(&path) {
             return Err(RunError::PathNotAllowed);
         }
         if args.len() > ARG_LIMIT {
@@ -170,7 +174,26 @@ impl WindmillConfig {
     }
 }
 
-/// Strict validation applied to the *trimmed* path before it is glob-matched
+/// The single Windmill folder the bot may ever reach. The trailing slash is
+/// load-bearing: it confines the namespace gate to children of the folder and
+/// blocks prefix-confusion (`f/discordshEVIL/...`). Bare `/wm` paths collapse
+/// into it; explicit paths outside it are rejected.
+const BOT_NAMESPACE: &str = "f/discordsh/";
+
+/// Collapse a bare path into the bot namespace. A path already carrying an
+/// `f/` or `p/` kind prefix is returned unchanged (and later rejected by the
+/// namespace gate unless it lives under [`BOT_NAMESPACE`]); anything else is
+/// prefixed with `f/discordsh/`. Collapse happens BEFORE [`is_path_safe`], so
+/// traversal via a bare path (`../x` → `f/discordsh/../x`) is still rejected.
+fn resolve_path(raw: &str) -> String {
+    if raw.starts_with("f/") || raw.starts_with("p/") {
+        raw.to_owned()
+    } else {
+        format!("{BOT_NAMESPACE}{raw}")
+    }
+}
+
+/// Strict validation applied to the *resolved* path before it is glob-matched
 /// or interpolated into the Windmill API URL. This is the last line of
 /// defense against path-traversal (`..`) and request-injection (`?`, `#`,
 /// whitespace, etc.) since `reqwest`/`url` normalize `..` segments *after*
@@ -250,6 +273,19 @@ mod tests {
         assert!(split_args("").is_empty());
     }
 
+    #[test]
+    fn resolve_path_collapses_bare_into_namespace() {
+        assert_eq!(resolve_path("poem"), "f/discordsh/poem");
+        assert_eq!(resolve_path("deploy/restart"), "f/discordsh/deploy/restart");
+    }
+
+    #[test]
+    fn resolve_path_leaves_explicit_prefixed_unchanged() {
+        assert_eq!(resolve_path("f/deploy/x"), "f/deploy/x");
+        assert_eq!(resolve_path("p/ops/x"), "p/ops/x");
+        assert_eq!(resolve_path("f/discordsh/poem"), "f/discordsh/poem");
+    }
+
     // ── Integration tests against a wiremock'd fake Windmill ────────
 
     use wiremock::matchers::{header, method, path};
@@ -282,7 +318,7 @@ mod tests {
     async fn run_success_calls_windmill() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/deploy-prod"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/poem"))
             .and(header("authorization", "Bearer topsecret"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "ok": true,
@@ -292,15 +328,29 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "f/deploy-*", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/*", 10, 60);
         let args = vec!["alpha".to_owned(), "beta".to_owned()];
         let resp = cfg
-            .run("f/deploy-prod", &args, &discord_ctx())
+            .run("f/discordsh/poem", &args, &discord_ctx())
             .await
             .expect("run ok");
 
         assert_eq!(resp["ok"], serde_json::Value::Bool(true));
         assert_eq!(resp["echo"], serde_json::Value::String("hello".into()));
+    }
+
+    #[tokio::test]
+    async fn run_collapses_bare_path_into_namespace() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/poem"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "f/discordsh/*", 10, 60);
+        cfg.run("poem", &[], &discord_ctx()).await.unwrap();
     }
 
     #[tokio::test]
@@ -312,9 +362,61 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/allowed-*", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/allowed-*", 10, 60);
         let err = cfg
-            .run("p/blocked", &[], &discord_ctx())
+            .run("f/discordsh/blocked", &[], &discord_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err, RunError::PathNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn run_rejects_explicit_path_outside_namespace() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        // Permissive allowlist — the namespace gate, not the glob, must reject.
+        let cfg = make_cfg(server.uri(), "f/**", 10, 60);
+        let err = cfg
+            .run("f/deploy/restart", &[], &discord_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err, RunError::PathNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn run_rejects_p_scripts_outside_namespace() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "p/**", 10, 60);
+        let err = cfg
+            .run("p/ops/anything", &[], &discord_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err, RunError::PathNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn run_rejects_namespace_prefix_confusion() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "f/**", 10, 60);
+        let err = cfg
+            .run("f/discordshEVIL/x", &[], &discord_ctx())
             .await
             .unwrap_err();
         assert_eq!(err, RunError::PathNotAllowed);
@@ -324,14 +426,14 @@ mod tests {
     async fn run_strips_leading_slash() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/kbve/start"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/start"))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "f/kbve/**", 10, 60);
-        cfg.run("/f/kbve/start", &[], &discord_ctx())
+        let cfg = make_cfg(server.uri(), "f/discordsh/**", 10, 60);
+        cfg.run("/f/discordsh/start", &[], &discord_ctx())
             .await
             .unwrap();
     }
@@ -340,15 +442,20 @@ mod tests {
     async fn run_rate_limited_second_call() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/p/foo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/foo"))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/foo", 1, 60);
-        cfg.run("p/foo", &[], &discord_ctx()).await.unwrap();
-        let err = cfg.run("p/foo", &[], &discord_ctx()).await.unwrap_err();
+        let cfg = make_cfg(server.uri(), "f/discordsh/foo", 1, 60);
+        cfg.run("f/discordsh/foo", &[], &discord_ctx())
+            .await
+            .unwrap();
+        let err = cfg
+            .run("f/discordsh/foo", &[], &discord_ctx())
+            .await
+            .unwrap_err();
         assert_eq!(err, RunError::RateLimited);
     }
 
@@ -356,14 +463,17 @@ mod tests {
     async fn run_upstream_error_propagates() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/p/foo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/foo"))
             .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
             .expect(1)
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/foo", 10, 60);
-        let err = cfg.run("p/foo", &[], &discord_ctx()).await.unwrap_err();
+        let cfg = make_cfg(server.uri(), "f/discordsh/foo", 10, 60);
+        let err = cfg
+            .run("f/discordsh/foo", &[], &discord_ctx())
+            .await
+            .unwrap_err();
         match err {
             RunError::Upstream(s) => {
                 assert!(s.contains("500"));
@@ -382,9 +492,12 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/foo", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/foo", 10, 60);
         let args: Vec<String> = (0..ARG_LIMIT + 1).map(|i| i.to_string()).collect();
-        let err = cfg.run("p/foo", &args, &discord_ctx()).await.unwrap_err();
+        let err = cfg
+            .run("f/discordsh/foo", &args, &discord_ctx())
+            .await
+            .unwrap_err();
         assert_eq!(err, RunError::TooManyArgs);
     }
 
@@ -397,16 +510,19 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/foo", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/foo", 10, 60);
         let big = "x".repeat(ARG_LEN_LIMIT + 1);
-        let err = cfg.run("p/foo", &[big], &discord_ctx()).await.unwrap_err();
+        let err = cfg
+            .run("f/discordsh/foo", &[big], &discord_ctx())
+            .await
+            .unwrap_err();
         assert_eq!(err, RunError::ArgTooLong);
     }
 
     #[tokio::test]
     async fn run_empty_path_rejected() {
         let server = MockServer::start().await;
-        let cfg = make_cfg(server.uri(), "*", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/*", 10, 60);
         let err = cfg.run("   ", &[], &discord_ctx()).await.unwrap_err();
         assert_eq!(err, RunError::EmptyPath);
     }
@@ -415,7 +531,7 @@ mod tests {
     async fn run_body_contains_args_and_discord_context() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/p/echo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/echo"))
             .respond_with(|req: &Request| {
                 let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
                 assert_eq!(body["discord"]["user_id"], "999");
@@ -429,8 +545,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "p/echo", 10, 60);
-        cfg.run("p/echo", &["hello".to_owned()], &discord_ctx())
+        let cfg = make_cfg(server.uri(), "f/discordsh/echo", 10, 60);
+        cfg.run("f/discordsh/echo", &["hello".to_owned()], &discord_ctx())
             .await
             .unwrap();
     }
@@ -446,16 +562,16 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "f/ok/**", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/**", 10, 60);
         let err = cfg
-            .run("f/ok/../../p/evil", &[], &discord_ctx())
+            .run("f/discordsh/ok/../../p/evil", &[], &discord_ctx())
             .await
             .unwrap_err();
         assert_eq!(err, RunError::PathNotAllowed);
     }
 
     #[tokio::test]
-    async fn run_rejects_traversal_via_wildcard_allowlist() {
+    async fn run_rejects_traversal_via_bare_collapse() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(200))
@@ -463,26 +579,11 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "f/deploy-*", 10, 60);
+        // Bare path collapses to f/discordsh/../../p/x, then the `..` segment
+        // is rejected — the collapse cannot be used to escape the namespace.
+        let cfg = make_cfg(server.uri(), "f/discordsh/**", 10, 60);
         let err = cfg
-            .run("deploy-prod/../../p/x", &[], &discord_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err, RunError::PathNotAllowed);
-    }
-
-    #[tokio::test]
-    async fn run_rejects_missing_kind_prefix() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let cfg = make_cfg(server.uri(), "deploy-*", 10, 60);
-        let err = cfg
-            .run("deploy-prod", &[], &discord_ctx())
+            .run("../../p/x", &[], &discord_ctx())
             .await
             .unwrap_err();
         assert_eq!(err, RunError::PathNotAllowed);
@@ -497,9 +598,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = make_cfg(server.uri(), "f/**", 10, 60);
+        let cfg = make_cfg(server.uri(), "f/discordsh/**", 10, 60);
         let err = cfg
-            .run("f/ok?token=leak", &[], &discord_ctx())
+            .run("f/discordsh/ok?token=leak", &[], &discord_ctx())
             .await
             .unwrap_err();
         assert_eq!(err, RunError::PathNotAllowed);

--- a/apps/windmill/f/discordsh/poem.script.yaml
+++ b/apps/windmill/f/discordsh/poem.script.yaml
@@ -1,0 +1,28 @@
+summary: Fetch a poem from PoetryDB
+description: >-
+  Demo /wm target. Optional first arg = author (random poem by them),
+  otherwise a random poem. Bun runtime, no dependencies, fast cold start.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; args[0] optional author.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/poem.ts
+++ b/apps/windmill/f/discordsh/poem.ts
@@ -1,0 +1,38 @@
+type Poem = {
+  title: string;
+  author: string;
+  lines: string[];
+  linecount: string;
+};
+
+type PoetryDbError = { status: number; reason: string };
+
+const BASE = "https://poetrydb.org";
+
+export async function main(
+  args: string[] = [],
+  discord?: Record<string, unknown>,
+) {
+  const author = args.join(" ").trim();
+  const url = author
+    ? `${BASE}/author/${encodeURIComponent(author)}`
+    : `${BASE}/random/1`;
+
+  const resp = await fetch(url, { headers: { accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`poetrydb ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as Poem[] | PoetryDbError;
+  if (!Array.isArray(data)) {
+    throw new Error(`no poems found${author ? ` for author "${author}"` : ""}`);
+  }
+
+  const poem = data[Math.floor(Math.random() * data.length)];
+  return {
+    title: poem.title,
+    author: poem.author,
+    lines: poem.lines.length > 24 ? poem.lines.slice(0, 24) : poem.lines,
+    requestedBy: (discord?.username as string) ?? null,
+  };
+}

--- a/apps/windmill/wmill.yaml
+++ b/apps/windmill/wmill.yaml
@@ -1,0 +1,5 @@
+defaultTs: bun
+includes:
+  - f/**
+excludes: []
+codebases: []


### PR DESCRIPTION
## What
Hardens the `/wm` Windmill runner into a **namespaced, folder-locked** command, and seeds the `apps/windmill/` sync tree with a demo script. Follows #14159 (the `/wm` command) and #14132.

## Namespace lock (security)
The bot uses a **superadmin** Windmill token with **no Discord role gate** — so the allowlist was the only boundary, and a misconfigured glob could expose the whole workspace. This change makes **the `f/discordsh/` folder itself the boundary**:

- `resolve_path`: bare paths collapse — `/wm poem` → `f/discordsh/poem`. Explicit `f/…`/`p/…` pass through unchanged.
- `run()` order: collapse → `is_path_safe` (reject `..`/`.`/**empty** segments + strict charset) → **namespace gate** (`path` must start with `f/discordsh/`) → allowlist → args/rate-limit → URL. The gate runs *before* the allowlist, so no broad allowlist can escape.
- Trailing slash in `f/discordsh/` is load-bearing: blocks prefix-confusion (`f/discordshEVIL/…`) and the folder root.

**Net:** the only Windmill paths `/wm` can ever reach are `f/discordsh/*`. `/wm f/deploy/x`, `/wm p/ops/x`, `/wm ../../p/x` → all rejected, no HTTP request made.

Adversarially reviewed (opus): the string gated is byte-identical to the string sent, so the reqwest `..`-late-normalization class of bug is closed; boundary verified airtight.

## Tests
761→ crate green; 27 in the windmill module. New/updated: collapse, explicit-outside-namespace, `p/`-outside, prefix-confusion, bare-collapse-traversal, empty-leaf/`//`, `resolve_path` units. Boundary tests assert `expect(0)` on the mock — proving no request escapes, not just an error value.

## Script seed (`apps/windmill/`)
- `wmill.yaml` + `f/discordsh/poem.ts` — bun, zero-dependency PoetryDB demo matching the `/wm` `{args, discord}` contract.
  - `/wm poem` → random poem; `/wm poem Emily Dickinson` → by author (args joined).
- `poem.script.yaml` metadata sidecar (regenerated authoritatively by `wmill sync pull` on first real sync).

## Not in this PR
- `WINDMILL_ALLOWED_PATHS` stays empty (command disabled) — no `wmill` sync pipeline exists yet, so enabling would only 404. Flip to `f/discordsh/*` when the CI sync + scripts land.
- CI `wmill sync push` workflow — follow-up.