### PR TITLE
chore(rareicon,metrics): RUST_LOG info->warn

### DIFF
--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -57,7 +57,7 @@ spec:
                       - name: HTTP_PORT
                         value: '5500'
                       - name: RUST_LOG
-                        value: met=info,tower_http=warn
+                        value: met=warn,tower_http=warn
                       - name: CLICKHOUSE_DATABASE
                         value: telemetry
                       - name: METRICS_ERRORS_TABLE

--- a/apps/kube/rareicon/manifest/deployment.yaml
+++ b/apps/kube/rareicon/manifest/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                       - name: HTTP_PORT
                         value: '4323'
                       - name: RUST_LOG
-                        value: info
+                        value: warn
                   resources:
                       requests:
                           memory: 128Mi


### PR DESCRIPTION
## Why
Next scoped pair in the log-noise sweep. Neither `rareicon` nor `kbve` ns is in the Vector `noise_filter` allowlist, so info request lines ship to ClickHouse:
- rareicon deployment: `RUST_LOG=info`
- metrics ingest service (:5500): `RUST_LOG=met=info,tower_http=warn`

## What
- rareicon: `info` → `warn`
- metrics: `met=info` → `met=warn` (directive shape kept)
- inline env → auto rollout, no annotation needed

## Scope
Still untouched: Vector-filtered-ns gates (argocd/grafana/longhorn — cosmetic), Agones fleets (`X=debug` kept for session debugging).

Sibling of #14170 / #14171.