### PR TITLE
fix(herbmail-game): resolve react-hooks lint errors in Goblins

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/npc/Goblins.tsx
+++ b/apps/herbmail/herbmail-game/src/game/npc/Goblins.tsx
@@ -81,14 +81,11 @@ const NOOP_MOVER = (): void => void 0;
 
 export function Goblins() {
 	const slots = useRef<Slot[]>([]);
-	const [, force] = useState(0);
+	const [view, setView] = useState<Slot[]>([]);
 
 	useEffect(() => {
 		const world = getDungeon().world;
 		resetProgress();
-		for (const [x, z] of farSpawnPoints(enemyBudget()))
-			slots.current.push({ x, z, eid: makeGoblin(world, x, z), gen: 0, respawnAt: 0 });
-		force((n) => n + 1);
 		const list = slots.current;
 		return () => {
 			for (const s of list) if (s.eid >= 0) despawnGoblin(world, s.eid);
@@ -128,12 +125,12 @@ export function Goblins() {
 				changed = true;
 			}
 		}
-		if (changed) force((n) => n + 1);
+		if (changed) setView(slots.current.slice());
 	});
 
 	return (
 		<>
-			{slots.current.map((s, i) =>
+			{view.map((s, i) =>
 				s.eid < 0 ? null : (
 					<Character
 						key={`${i}-${s.gen}`}


### PR DESCRIPTION
Fixes the 3 lint errors failing `nx run herbmail-game:lint`:

- `react-hooks/refs` ×2: render read `slots.current.map` directly — now renders from a `view` state snapshot updated in `useFrame` when the slot list changes.
- `react-hooks/set-state-in-effect`: mount effect spawned goblins then called `force()` — initial spawn now folds into the existing `useFrame` budget-grow path (spawns to `enemyBudget()` on first frame), effect keeps `resetProgress()` and despawn cleanup only.

Verified: eslint on source → 0 errors (54 pre-existing warnings remain, non-blocking); `tsc --noEmit` clean; headless playwright boot of vite dev — canvas renders, no page errors.