### PR TITLE
fix(jedi): clickhouse level filter matches warn/warning interchangeably

### DIFF
--- a/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
@@ -107,6 +107,17 @@ fn clamped_search(raw: &str) -> String {
     escape_clickhouse_string(&trimmed)
 }
 
+/// Level predicate — `warn` and `warning` are stored interchangeably by
+/// different emitters, so either input matches both spellings.
+fn level_condition(raw: &str) -> String {
+    let lvl = raw.to_lowercase();
+    if lvl == "warn" || lvl == "warning" {
+        "level IN ('warn', 'warning')".to_string()
+    } else {
+        format!("level = '{}'", escape_clickhouse_string(&lvl))
+    }
+}
+
 /// Build the `query` SQL — filtered SELECT against logs_distributed,
 /// ordered by timestamp DESC.
 pub fn build_query_sql(params: &LogsQueryParams) -> String {
@@ -130,10 +141,7 @@ pub fn build_query_sql(params: &LogsQueryParams) -> String {
         conditions.push(format!("service = '{}'", escape_clickhouse_string(svc)));
     }
     if let Some(lvl) = params.level.as_deref().filter(|s| !s.is_empty()) {
-        conditions.push(format!(
-            "level = '{}'",
-            escape_clickhouse_string(&lvl.to_lowercase())
-        ));
+        conditions.push(level_condition(lvl));
     }
     if let Some(search) = params.search.as_deref().filter(|s| !s.is_empty()) {
         conditions.push(format!("message ILIKE '%{}%'", clamped_search(search)));
@@ -483,6 +491,25 @@ mod tests {
         assert!(sql.contains("level = 'error'"));
         assert!(sql.contains("message ILIKE '%panic%'"));
         assert!(sql.contains("LIMIT 50"));
+    }
+
+    #[test]
+    fn warn_level_matches_warning_alias() {
+        for input in ["warn", "WARNING"] {
+            let sql = build_query_sql(&LogsQueryParams {
+                level: Some(input.into()),
+                ..Default::default()
+            });
+            assert!(
+                sql.contains("level IN ('warn', 'warning')"),
+                "level={input} should match both spellings: {sql}"
+            );
+        }
+        let sql = build_query_sql(&LogsQueryParams {
+            level: Some("error".into()),
+            ..Default::default()
+        });
+        assert!(sql.contains("level = 'error'"));
     }
 
     #[test]


### PR DESCRIPTION
## Bug
`build_query_sql` level predicate was exact-match (`level = 'warn'`), but emitters store warnings under both `warn` and `warning` — filtering by either spelling silently dropped the other's rows. Follow-up to #14172 (rn-dash chips now drive the `level` param server-side).

## Fix
- `level_condition()`: `warn`/`warning` input → `level IN ('warn', 'warning')`; all other levels keep exact match (lowercased, escaped).

## Tests
- New `warn_level_matches_warning_alias` (fails on old code).
- `cargo test -p jedi --features clickhouse`: 81 passed.

## Deploy note
Takes effect on next axum-kbve build/rollout — jedi is vendored via workspace, no crate publish needed for the site proxy.