### PR TITLE
feat(windmill): CI sync pipeline + enable /wm allowlist

### DIFF
--- a/.github/workflows/windmill-sync.yml
+++ b/.github/workflows/windmill-sync.yml
@@ -1,0 +1,61 @@
+name: Windmill Sync
+
+# Push the repo-versioned Windmill scripts/flows (apps/windmill) into the
+# `kbve` workspace. Runs on the in-cluster arc runner because the Windmill
+# API (windmill-app:8000) is ClusterIP-only and windmill.kbve.com is behind
+# the staff-JWT gate — an external runner cannot reach it with a token.
+#
+# Prune-safe: apps/windmill/wmill.yaml scopes `includes: f/**`, so the push
+# only manages the f/ tree and never touches user-space (u/) scripts.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/windmill/**
+      - .github/workflows/windmill-sync.yml
+  workflow_dispatch: {}
+
+concurrency:
+  group: windmill-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: wmill sync push
+    runs-on: arc-runner-set-kbve
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      WMILL_BASE_URL: http://windmill-app.windmill.svc.cluster.local:8000
+      WMILL_WORKSPACE: kbve
+      # Pin to match the deployed Windmill server image; bump alongside it.
+      WMILL_CLI_VERSION: "1.751.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure workspace
+        env:
+          WM_TOKEN: ${{ secrets.WINDMILL_SUPERADMIN_TOKEN }}
+        run: |
+          if [ -z "${WM_TOKEN}" ]; then
+            echo "::error::WINDMILL_SUPERADMIN_TOKEN secret is not set"
+            exit 1
+          fi
+          npx --yes "windmill-cli@${WMILL_CLI_VERSION}" workspace add \
+            "${WMILL_WORKSPACE}" "${WMILL_WORKSPACE}" "${WMILL_BASE_URL}" \
+            --token "${WM_TOKEN}"
+
+      - name: Preview (dry-run)
+        working-directory: apps/windmill
+        run: |
+          npx --yes "windmill-cli@${WMILL_CLI_VERSION}" sync push \
+            --workspace "${WMILL_WORKSPACE}" --skip-variables --dry-run
+
+      - name: Push scripts
+        working-directory: apps/windmill
+        run: |
+          npx --yes "windmill-cli@${WMILL_CLI_VERSION}" sync push \
+            --workspace "${WMILL_WORKSPACE}" --skip-variables --yes

--- a/apps/kube/discordsh/manifest/configmap.yaml
+++ b/apps/kube/discordsh/manifest/configmap.yaml
@@ -18,6 +18,6 @@ data:
     RUST_LOG: warn
     WINDMILL_BASE_URL: http://windmill-app.windmill.svc.cluster.local:8000
     WINDMILL_WORKSPACE: kbve
-    WINDMILL_ALLOWED_PATHS: ''
+    WINDMILL_ALLOWED_PATHS: 'f/discordsh/*'
     WM_RATE_LIMIT: '1'
     WM_RATE_WINDOW: '5'


### PR DESCRIPTION
## What
The final piece to make `/wm` live: a CI pipeline that syncs repo-versioned Windmill scripts (`apps/windmill/`) into the `kbve` workspace, plus flipping the `/wm` allowlist on.

Closes the loop: **repo scripts → CI sync → Windmill DB → `/wm` triggers from Discord.**

## Why in-cluster (not a normal GH runner)
The Windmill API (`windmill-app:8000`) is ClusterIP-only, and `windmill.kbve.com` sits behind windmill-gate (Supabase `is_staff` JWT) — an external runner can't token-auth through it. So the job runs on **`arc-runner-set-kbve`** (in-cluster), which reaches `windmill-app.windmill.svc:8000` directly.

## Workflow (`.github/workflows/windmill-sync.yml`)
- `on: push` to **main**, `paths: apps/windmill/**` (+ manual `workflow_dispatch`).
- `wmill` CLI pinned to the deployed server version **1.751.0** (verified `workspace add` / `sync push` syntax against it).
- **Dry-run preview** step, then push.
- `--skip-variables` protects any Windmill-side secrets from the prune.
- `wmill.yaml` scopes `includes: f/**` → the `u/admin2/*` experimental scripts are never touched.
- Token from the `WINDMILL_SUPERADMIN_TOKEN` GitHub secret (already set).

## Allowlist flip
`discordsh` configmap: `WINDMILL_ALLOWED_PATHS: '' → 'f/discordsh/*'`. Bounded to the locked `f/discordsh/` namespace — the command can still only ever reach that folder.

## Go-live sequence (after merge → main)
1. This lands on main → sync workflow pushes `f/discordsh/poem` into the `kbve` workspace.
2. discordsh releases with the flipped allowlist.
3. `/wm poem` → embed. 🎉

## First-run note
Recommend triggering once via **workflow_dispatch** to confirm the runner reaches `windmill-app:8000` and the CLI auth works, before relying on the push trigger.

## Validation
`actionlint` clean; workflow + configmap YAML parse; `wmill@1.751.0` `workspace add`/`sync push` flags verified via `--help`.