### PR TITLE
fix(forgejo): generate app.ini in oauth-config job so add-oauth works

### DIFF
--- a/apps/kube/forgejo/manifest/forgejo-oauth-config-job.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-oauth-config-job.yaml
@@ -43,6 +43,81 @@ spec:
                               sleep 5
                           done
                           echo "Forgejo is ready!"
+                - name: init-directories
+                  image: codeberg.org/forgejo/forgejo:12
+                  imagePullPolicy: IfNotPresent
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  command:
+                      - /usr/sbin/init_directory_structure.sh
+                  env:
+                      - name: GITEA_APP_INI
+                        value: /data/gitea/conf/app.ini
+                      - name: GITEA_CUSTOM
+                        value: /data/gitea
+                      - name: GITEA_WORK_DIR
+                        value: /data
+                      - name: GITEA_TEMP
+                        value: /tmp/gitea
+                  volumeMounts:
+                      - name: init
+                        mountPath: /usr/sbin
+                      - name: temp
+                        mountPath: /tmp
+                      - name: data
+                        mountPath: /data
+                - name: init-app-ini
+                  image: codeberg.org/forgejo/forgejo:12
+                  imagePullPolicy: IfNotPresent
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  command:
+                      - /usr/sbin/config_environment.sh
+                  env:
+                      - name: GITEA_APP_INI
+                        value: /data/gitea/conf/app.ini
+                      - name: GITEA_CUSTOM
+                        value: /data/gitea
+                      - name: GITEA_WORK_DIR
+                        value: /data
+                      - name: GITEA_TEMP
+                        value: /tmp/gitea
+                      - name: FORGEJO__DATABASE__PASSWD
+                        valueFrom:
+                            secretKeyRef:
+                                name: forgejo-db
+                                key: password
+                      - name: FORGEJO__SERVER__LFS_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: forgejo-lfs-jwt
+                                key: secret
+                      - name: REDIS_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: valkey-auth
+                                key: valkey-password
+                      - name: FORGEJO__CACHE__HOST
+                        value: redis://default:$(REDIS_PASSWORD)@valkey.valkey.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s
+                      - name: FORGEJO__SESSION__PROVIDER_CONFIG
+                        value: redis://default:$(REDIS_PASSWORD)@valkey.valkey.svc.cluster.local:6379/2?pool_size=100&idle_timeout=180s
+                      - name: FORGEJO__QUEUE__CONN_STR
+                        value: redis://default:$(REDIS_PASSWORD)@valkey.valkey.svc.cluster.local:6379/1
+                  volumeMounts:
+                      - name: config
+                        mountPath: /usr/sbin
+                      - name: inline-config-sources
+                        mountPath: /env-to-ini-mounts/inlines/
+                      - name: temp
+                        mountPath: /tmp
+                      - name: data
+                        mountPath: /data
             containers:
                 - name: configure-oauth
                   image: codeberg.org/forgejo/forgejo:12
@@ -53,23 +128,14 @@ spec:
                           drop:
                               - ALL
                   env:
-                      - name: FORGEJO__database__DB_TYPE
-                        value: postgres
-                      - name: FORGEJO__database__HOST
-                        value: kilobase-rw.kilobase.svc.cluster.local:5432
-                      - name: FORGEJO__database__NAME
-                        value: supabase
-                      - name: FORGEJO__database__USER
-                        value: forgejo
-                      - name: FORGEJO__database__SCHEMA
-                        value: forgejo
-                      - name: FORGEJO__database__SSL_MODE
-                        value: require
-                      - name: FORGEJO__database__PASSWD
-                        valueFrom:
-                            secretKeyRef:
-                                name: forgejo-db
-                                key: password
+                      - name: GITEA_APP_INI
+                        value: /data/gitea/conf/app.ini
+                      - name: GITEA_CUSTOM
+                        value: /data/gitea
+                      - name: GITEA_WORK_DIR
+                        value: /data
+                      - name: GITEA_TEMP
+                        value: /tmp/gitea
                       - name: OAUTH_CLIENT_ID
                         valueFrom:
                             secretKeyRef:
@@ -87,8 +153,6 @@ spec:
                           set -e
 
                           echo "==> Checking if OAuth source 'kbve' already exists..."
-
-                          # Try to list auth sources and check if 'kbve' exists
                           if /usr/local/bin/forgejo admin auth list 2>/dev/null | grep -q "kbve"; then
                               echo "OAuth authentication source 'kbve' already exists. Skipping configuration."
                               exit 0
@@ -105,3 +169,24 @@ spec:
 
                           echo "==> OAuth authentication source 'kbve' configured successfully!"
                           echo "==> Users can now sign in with KBVE credentials"
+                  volumeMounts:
+                      - name: data
+                        mountPath: /data
+                      - name: temp
+                        mountPath: /tmp
+            volumes:
+                - name: init
+                  secret:
+                      secretName: forgejo-init
+                      defaultMode: 0755
+                - name: config
+                  secret:
+                      secretName: forgejo
+                      defaultMode: 0755
+                - name: inline-config-sources
+                  secret:
+                      secretName: forgejo-inline-config
+                - name: temp
+                  emptyDir: {}
+                - name: data
+                  emptyDir: {}


### PR DESCRIPTION
## Problem
`forgejo-oauth-config` (PostSync hook Job) has crash-looped for **7h54m**. It passes readiness, then dies:

```
MustInstalled() [F] Unable to load config file for a installed Forgejo instance,
  use "--config" to set your config file (app.ini), or run "forgejo web"
```

The job overrides the container `command`, which **bypasses the forgejo image entrypoint that generates `app.ini`**. So `forgejo admin auth add-oauth` has no config and refuses to run. (Its sibling `forgejo-oauth-register`, which uses curl+kubectl instead of the forgejo CLI, works fine.)

The server's `app.ini` lives on `gitea-shared-storage`, which is **ReadWriteOnce** and held by the server pod — the job can't co-mount it.

## Fix
Replicate the Helm chart's app.ini generation inside the job, against an `emptyDir`:

- **initContainer `init-directories`** → runs the chart's `init_directory_structure.sh` (from the `forgejo-init` secret).
- **initContainer `init-app-ini`** → runs the chart's `config_environment.sh` (from the `forgejo` secret) with the same env and the `forgejo-inline-config` secret mounted at `/env-to-ini-mounts/inlines/`, writing `app.ini` to the shared `emptyDir`.
- **`configure-oauth`** → reads that `app.ini` (`GITEA_APP_INI`/`GITEA_WORK_DIR`/`GITEA_CUSTOM` set) and runs `add-oauth`.

Because the ini is generated from the **same `forgejo-inline-config` secret** the server uses, it carries the **same `SECRET_KEY`** — so the OAuth client secret `add-oauth` writes stays decryptable by the running instance (a mismatched key would silently break OIDC login).

## Validation
- `kubectl kustomize apps/kube/forgejo/manifest/` builds clean.
- Script paths verified against the secret keys (`init_directory_structure.sh` ∈ `forgejo-init`, `config_environment.sh` ∈ `forgejo`).
- **Not yet verified against a live run** — the job executes on the next forgejo PostSync. Can test-apply once before merge if desired.

📚 https://kbve.com/docs/