### PR TITLE
chore(agones-factorio-relay): bump to 0.0.8 — ship telemetry vertical

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -32,7 +32,7 @@
 		{
 			"key": "agones_factorio_relay",
 			"app_name": "agones-factorio-relay",
-			"version": "0.0.7",
+			"version": "0.0.8",
 			"version_toml": "apps/agones/factorio/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx",
 			"source_path": "apps/agones/factorio/relay",
@@ -44,7 +44,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.235",
+			"version": "1.0.238",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -181,7 +181,7 @@
 		{
 			"key": "discordsh",
 			"app_name": "discordsh",
-			"version": "0.1.44",
+			"version": "0.1.45",
 			"version_toml": "apps/discordsh/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx",
 			"version_target": "apps/discordsh/axum-discordsh/Cargo.toml",
@@ -195,7 +195,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.21",
+			"version": "0.1.22",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -1338,7 +1338,7 @@
 				]
 			},
 			"source_path": "apps/herbmail/herbmail-game",
-			"version": "0.1.9",
+			"version": "0.1.11",
 			"version_toml": "apps/herbmail/herbmail-game/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/herbmail-game.mdx",
 			"runner": "ubuntu-latest",

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_factorio_relay
 pipeline: docker
 app_name: agones-factorio-relay
-version: "0.0.7"
+version: "0.0.8"
 source_path: apps/agones/factorio/relay
 version_toml: apps/agones/factorio/relay/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Why

[kbve.com/dashboard/gameops/factorio](https://kbve.com/dashboard/gameops/factorio/) shows **0 servers** while the GameServer is Ready (41d). Root cause is two stale layers:

1. **Relay image predates telemetry.** `ghcr.io/kbve/agones-factorio-relay:0.0.7` was published before #12766 wired the telemetry vertical (lua → relay ch_writer → ClickHouse `gameops.factorio_*` → dashboard). MDX version was never bumped, so 0.0.8 never built.
2. **Running pod predates manifest env.** The GameServer pod (created 2026-06-06) lacks all `CLICKHOUSE_*` env added to `apps/kube/agones/factorio/manifests/gameserver.yaml` on 2026-06-18 — GameServer specs are immutable, and the rotator only rotates on `agones-factorio` image changes. Relay logs confirm: `ch_writer disabled: CLICKHOUSE_URL not set`.

## What

- MDX `version: 0.0.7 → 0.0.8` (source of truth) for `agones-factorio-relay`
- Regenerated `.github/ci-dispatch-manifest.json` (rides pending bumps for axum-kbve, discordsh, discordsh-bot, herbmail-game already merged on dev)

## After merge to main

1. Docker pipeline publishes `agones-factorio-relay:0.0.8`; post-publish sync updates the gameserver manifest tag + version.toml
2. **Manual step:** recreate the `factorio` GameServer (disruptive — server restart) so the pod picks up the new relay image and `CLICKHOUSE_*` env

Docs: [agones-factorio-relay](https://kbve.com/project/agones-factorio-relay/)