### PR TITLE
feat(vector): basic auth on alertmanager webhook (:9002) — closes #14126

### DIFF
--- a/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
+++ b/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
@@ -26,3 +26,11 @@ spec:
               - url: http://vector.vector.svc.cluster.local:9002/alertmanager
                 sendResolved: true
                 maxAlerts: 0
+                httpConfig:
+                    basicAuth:
+                        username:
+                            name: vector-webhook-auth
+                            key: username
+                        password:
+                            name: vector-webhook-auth
+                            key: password

--- a/apps/kube/monitoring/manifests/kustomization.yaml
+++ b/apps/kube/monitoring/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
     - grafana-admin-sealedsecret.yaml
     - grafana-dashboards-configmap.yaml
     - redis-dashboard-configmap.yaml
+    - sealed-vector-webhook-auth.yaml
     - alertmanagerconfig-vector.yaml
     - grafana-gate-externalsecret.yaml
     - grafana-gate-deployment.yaml

--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -4,8 +4,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-06-29T00:00:00Z'
-        kbve.sh/config-version: v8-structured-metadata
+        kbve.sh/last-updated: '2026-07-17T00:00:00Z'
+        kbve.sh/config-version: v9-webhook-auth
     labels:
         kbve.com/category: observability
         kbve.com/stack: core
@@ -17,7 +17,7 @@ data:
         \    exclude_paths_glob_patterns:\n      - \"**/vector_*/**\"\n      - \"**/kube-system_*/**\"\
         \n    auto_partial_merge: true\n    data_dir: \"/vector-data-dir\"\n  alertmanager_webhook:\n\
         \    type: http_server\n    address: 0.0.0.0:9002\n    path: /alertmanager\n \
-        \   method: POST\n    decoding:\n      codec: json\n\ntransforms:\n  # mc-fabric\
+        \   method: POST\n    auth:\n      strategy: basic\n      username: alertmanager\n      password: \"${ALERTMANAGER_WEBHOOK_PASSWORD}\"\n    decoding:\n      codec: json\n\ntransforms:\n  # mc-fabric\
         \ multiline aggregation. Java stack traces emit one line\n  # per frame; the default\
         \ per-line ingest makes exception search\n  # useless. Route mc-fabric pods through\
         \ a `reduce` that joins\n  # continuation lines onto the preceding `[HH:MM:SS]`\

--- a/apps/kube/vector/manifests/vector-daemonset.yaml
+++ b/apps/kube/vector/manifests/vector-daemonset.yaml
@@ -61,6 +61,11 @@ spec:
                             secretKeyRef:
                                 name: clickhouse-vector-credentials
                                 key: password
+                      - name: ALERTMANAGER_WEBHOOK_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: vector-alertmanager-webhook
+                                key: password
                   args:
                       - --config-dir
                       - /etc/vector/

--- a/apps/kube/vector/seal-alertmanager-webhook.sh
+++ b/apps/kube/vector/seal-alertmanager-webhook.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# seal-alertmanager-webhook.sh — Seal the shared basic-auth credential that
+# gates Vector's alertmanager_webhook source on :9002.
+#
+# Alertmanager (monitoring ns) POSTs alerts to the Vector http_server source
+# (vector ns). This seals ONE random password into BOTH namespaces so the
+# caller and the listener share the secret:
+#
+#   vector ns     secret vector-alertmanager-webhook  key password
+#                 -> Vector reads it as ${ALERTMANAGER_WEBHOOK_PASSWORD}
+#   monitoring ns secret vector-webhook-auth          keys username + password
+#                 -> AlertmanagerConfig httpConfig.basicAuth references it
+#
+# Username is the fixed non-secret literal "alertmanager" (matches the Vector
+# source config). Rotate by re-running this script, commit, ArgoCD syncs both.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#   - kubeseal installed (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#
+# Usage:
+#   ./seal-alertmanager-webhook.sh
+#   # or supply your own: WEBHOOK_PASSWORD=<value> ./seal-alertmanager-webhook.sh
+#
+# Output:
+#   apps/kube/vector/manifests/sealed-alertmanager-webhook.yaml
+#   apps/kube/monitoring/manifests/sealed-vector-webhook-auth.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+VECTOR_OUT="${SCRIPT_DIR}/manifests/sealed-alertmanager-webhook.yaml"
+MONITORING_OUT="${REPO_ROOT}/apps/kube/monitoring/manifests/sealed-vector-webhook-auth.yaml"
+
+WEBHOOK_USER="alertmanager"
+
+for cmd in kubectl kubeseal openssl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is not installed or not in PATH" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl cluster-info &>/dev/null; then
+    echo "Error: Cannot connect to Kubernetes cluster" >&2
+    exit 1
+fi
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system namespace" >&2
+    exit 1
+fi
+
+WEBHOOK_PASSWORD="${WEBHOOK_PASSWORD:-$(openssl rand -hex 24)}"
+
+echo "Sealing alertmanager webhook credential into vector + monitoring..."
+
+kubectl create secret generic vector-alertmanager-webhook \
+    --namespace=vector \
+    --from-literal=password="${WEBHOOK_PASSWORD}" \
+    --dry-run=client -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${VECTOR_OUT}"
+
+kubectl create secret generic vector-webhook-auth \
+    --namespace=monitoring \
+    --from-literal=username="${WEBHOOK_USER}" \
+    --from-literal=password="${WEBHOOK_PASSWORD}" \
+    --dry-run=client -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${MONITORING_OUT}"
+
+unset WEBHOOK_PASSWORD
+
+echo ""
+echo "Sealed secrets written to:"
+echo "  ${VECTOR_OUT}"
+echo "  ${MONITORING_OUT}"
+echo "Plaintext password was never written to disk."
+echo ""
+echo "Next steps:"
+echo "  1. git add the two sealed manifests"
+echo "  2. Commit and push — ArgoCD syncs both namespaces"
+echo "  3. Vector rejects unauthenticated POST to :9002 (401)"


### PR DESCRIPTION
## What

Closes #14126 (LOW/security). Adds app-layer HTTP basic auth to the Vector `alertmanager_webhook` `http_server` source on `:9002`, which previously accepted any unauthenticated POST straight into ClickHouse `alerts_distributed`. NetworkPolicy from #13695 scoped ingress to the `monitoring` namespace but is network-layer — it can't authenticate the caller. This closes the in-namespace forge gap (Option A from the issue).

## Changes

- **vector-config.yaml** — `auth: {strategy: basic, username: alertmanager, password: ${ALERTMANAGER_WEBHOOK_PASSWORD}}` on the source; config-version bumped so reloader rolls the daemonset.
- **vector-daemonset.yaml** — inject `ALERTMANAGER_WEBHOOK_PASSWORD` from secret `vector-alertmanager-webhook` (vector ns).
- **alertmanagerconfig-vector.yaml** — `httpConfig.basicAuth` referencing secret `vector-webhook-auth` (monitoring ns).
- **monitoring/kustomization.yaml** — register `sealed-vector-webhook-auth.yaml`.
- **seal-alertmanager-webhook.sh** — seals one random password into BOTH namespaces.
- **sealed-alertmanager-webhook.yaml** (vector) + **sealed-vector-webhook-auth.yaml** (monitoring) — SealedSecrets holding the shared credential.

NetworkPolicy (#13695) retained — belt + braces. Health probes hit `:9001`, unaffected by `:9002` auth.

## Deploy note

SealedSecrets sealed against the live `kube-system/sealed-secrets-controller` and included — branch is complete and self-contained. Kube apps track `main`, so this dev PR does not deploy; it promotes normally on dev→main.

## Acceptance (#14126)

- [x] `:9002` rejects unauthenticated POST (401) — auth block added
- [ ] Alertmanager delivers end-to-end → row in `alerts_distributed` (verify after sync)
- [x] Secret sourced from SealedSecret, not plaintext ConfigMap
- [x] NetworkPolicy from #13695 retained

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)