### PR TITLE
test(rn): mount @kbve/rn NavBar as a footer test strip

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -1,5 +1,6 @@
 ---
 import AstroDroidFooter from './AstroDroidFooter.astro';
+import ReactNavBarStrip from '@/components/rnweb/ReactNavBarStrip.tsx';
 import SocialTooltip from '@kbve/astro/components/tooltip/social/SocialTooltip.astro';
 import SocialIcon from '@kbve/astro/components/social/icons/SocialIcon.astro';
 import { SOCIALS, withUtm } from '@kbve/astro/data/socials';
@@ -55,6 +56,9 @@ const currentYear = new Date().getFullYear();
 ---
 
 <footer id="kbve-footer" class="kf-footer not-content">
+	<div class="kf-rn-navbar" aria-label="react-native-web nav (test strip)">
+		<ReactNavBarStrip client:only="react" />
+	</div>
 	<div class="kf-container bento-frame">
 		<div class="kf-grid">
 			<div class="kf-brand">
@@ -225,6 +229,11 @@ const currentYear = new Date().getFullYear();
 
 	.kf-container {
 		padding: 0;
+	}
+
+	/* react-native-web NavBar test strip — sits above the bento footer grid */
+	.kf-rn-navbar {
+		border-bottom: 1px solid var(--bento-hairline);
 	}
 
 	/* Main grid: bento seams — 1px hairline gaps between cells */

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactNavBarStrip.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactNavBarStrip.tsx
@@ -1,0 +1,11 @@
+import { NavBar } from '@kbve/rn-astro';
+
+export default function ReactNavBarStrip() {
+	return (
+		<NavBar
+			onNavigate={(href) => {
+				window.location.href = href;
+			}}
+		/>
+	);
+}


### PR DESCRIPTION
Low-risk trial of the unified react-native-web `NavBar` on the web site, per the "can we utilize the unified nav bar" idea.

## Approach

**Header untouched.** The Starlight `Header.astro` override (SiteTitle + auth NavCluster + search + `transition:persist`) does far more than the RN `NavBar` and stays exactly as-is. Instead the RN `NavBar` mounts as a **`client:only="react"` island at the top of `AstroFooter.astro`** — a safe place to see it render live without touching primary chrome.

- `ReactNavBarStrip.tsx` — thin island wrapping `NavBar` from `@kbve/rn-astro`, `onNavigate` → `window.location`.
- `AstroFooter.astro` — one wrapper div (`.kf-rn-navbar`, hairline divider) above the bento grid. Removing the trial = delete the div + the import.

## Verification

Focused esbuild of the island's web graph (react-native→react-native-web alias, `.web.tsx` resolution):

```
BUILD OK — modules: 373
NavBar pulled: NavBar.tsx ✅
@expo/vector-icons in graph: NONE ✅
```

`NavBar` was already web-safe (icon-free, shipped in the web barrel), so no new native-only deps enter the bundle. Local dev-server visual render was noisy in the worktree (vite `504 Outdated Optimize Dep` churn + `@fs` 403s hitting all islands, a known worktree/optimizeDeps issue — not this change), so the deploy preview is the intended visual check.

## Notes

This is a **test strip**, not a final placement. If we like it, next step is deciding real home (dedicated marketing/landing pages, or evolving `NavBar` toward header parity — auth cluster + search + mobile). Merge is optional; the preview build is the point.