### PR TITLE
refactor(devops)!: remove deprecated _$gha_* aliases (#13725)

### DIFF
--- a/.github/scripts/commit-utils.mjs
+++ b/.github/scripts/commit-utils.mjs
@@ -2,9 +2,9 @@
 //
 // SOURCE OF TRUTH: packages/npm/devops/src/lib/client/github/pulls.ts
 // This file mirrors the pure functions in @kbve/devops:
-//   - _$gha_categorizeApiCommits  → categorizeCommits
-//   - _$gha_generatePRTitle       → generateTitle
-//   - _$gha_formatDevBody         → formatDevToMainBody
+//   - gha.pulls.categorizeApiCommits  → categorizeCommits
+//   - gha.pulls.generatePRTitle       → generateTitle
+//   - gha.pulls.formatDevBody         → formatDevToMainBody
 //
 // This shim exists because the PR creation jobs don't install npm
 // dependencies. When modifying categorization logic, update BOTH files.

--- a/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/devops.mdx
@@ -11,7 +11,7 @@ tags:
 key: devops
 pipeline: npm
 package_name: devops
-version: "0.0.22"
+version: "0.1.0"
 source_path: packages/npm/devops
 version_toml: packages/npm/devops/version.toml
 author: h0lybyte

--- a/packages/npm/devops-e2e/src/import.spec.ts
+++ b/packages/npm/devops-e2e/src/import.spec.ts
@@ -38,9 +38,9 @@ describe('ESM Import', () => {
 		expect(typeof yt.extractYoutubeId).toBe('function');
 
 		const gh = await import('../../devops/src/lib/client/github');
-		expect(typeof gh._$gha_kbve_ActionProcess).toBe('function');
-		expect(typeof gh._$gha_createIssueComment).toBe('function');
-		expect(typeof gh._$gha_addLabel).toBe('function');
-		expect(typeof gh._$gha_removeLabel).toBe('function');
+		expect(typeof gh.actions.kbveActionProcess).toBe('function');
+		expect(typeof gh.issues.createComment).toBe('function');
+		expect(typeof gh.issues.addLabel).toBe('function');
+		expect(typeof gh.issues.removeLabel).toBe('function');
 	});
 });

--- a/packages/npm/devops/src/lib/client/github/actions.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/actions.spec.ts
@@ -1,12 +1,10 @@
 import {
-	_$gha_findActionInTitle,
-	_$gha_kbve_ActionProcess,
 	findActionInTitleSafe,
 	actions,
 } from './actions';
 import { GithubActionReferenceMap } from './types';
 
-describe('_$gha_findActionInTitle', () => {
+describe('actions.findActionInTitle', () => {
 	const referenceMap: GithubActionReferenceMap[] = [
 		{ keyword: 'Atlas', action: 'atlas_action' },
 		{ keyword: 'Music', action: 'music_action' },
@@ -14,19 +12,19 @@ describe('_$gha_findActionInTitle', () => {
 
 	it('should return the correct action for a keyword found in the title', () => {
 		const title = 'This is a title about Atlas and its features';
-		const result = _$gha_findActionInTitle(title, referenceMap);
+		const result = actions.findActionInTitle(title, referenceMap);
 		expect(result).toEqual('atlas_action');
 	});
 
 	it('should return the correct action for another keyword found in the title', () => {
 		const title = 'A great collection of Music';
-		const result = _$gha_findActionInTitle(title, referenceMap);
+		const result = actions.findActionInTitle(title, referenceMap);
 		expect(result).toEqual('music_action');
 	});
 
 	it('should throw an error if no keywords are found in the title', () => {
 		const title = 'No relevant keyword';
-		expect(() => _$gha_findActionInTitle(title, referenceMap)).toThrow(
+		expect(() => actions.findActionInTitle(title, referenceMap)).toThrow(
 			'No matching keyword found in title',
 		);
 	});
@@ -34,28 +32,28 @@ describe('_$gha_findActionInTitle', () => {
 	it('should throw an error if the reference map is empty', () => {
 		const title = 'This is a title about Atlas and its features';
 		const emptyReferenceMap: GithubActionReferenceMap[] = [];
-		expect(() => _$gha_findActionInTitle(title, emptyReferenceMap)).toThrow(
+		expect(() => actions.findActionInTitle(title, emptyReferenceMap)).toThrow(
 			'No matching keyword found in title',
 		);
 	});
 });
 
-describe('_$gha_kbve_ActionProcess', () => {
+describe('actions.kbveActionProcess', () => {
 	it('should return the correct action for a keyword found in the title using the default reference map', () => {
 		const title = 'This is a title about Atlas and its features';
-		const result = _$gha_kbve_ActionProcess(title);
+		const result = actions.kbveActionProcess(title);
 		expect(result).toEqual('atlas_action');
 	});
 
 	it('should return the correct action for another keyword found in the title using the default reference map', () => {
 		const title = 'A great collection of Music';
-		const result = _$gha_kbve_ActionProcess(title);
+		const result = actions.kbveActionProcess(title);
 		expect(result).toEqual('music_action');
 	});
 
 	it('should throw an error if no keywords are found in the title using the default reference map', () => {
 		const title = 'No relevant keyword';
-		expect(() => _$gha_kbve_ActionProcess(title)).toThrow(
+		expect(() => actions.kbveActionProcess(title)).toThrow(
 			'No matching keyword found in title',
 		);
 	});
@@ -74,10 +72,6 @@ describe('findActionInTitleSafe (v0.0.21)', () => {
 });
 
 describe('gha.actions group (v0.0.22)', () => {
-	it('group members match their _$gha_ aliases', () => {
-		expect(actions.findActionInTitle).toBe(_$gha_findActionInTitle);
-		expect(actions.kbveActionProcess).toBe(_$gha_kbve_ActionProcess);
-	});
 	it('includes findActionInTitleSafe', () => {
 		expect(typeof actions.findActionInTitleSafe).toBe('function');
 	});

--- a/packages/npm/devops/src/lib/client/github/actions.ts
+++ b/packages/npm/devops/src/lib/client/github/actions.ts
@@ -42,8 +42,3 @@ export const actions = {
 	kbveActionProcess,
 	findActionInTitleSafe,
 };
-
-/** @deprecated Use `gha.actions.findActionInTitle`. */
-export const _$gha_findActionInTitle = findActionInTitle;
-/** @deprecated Use `gha.actions.kbveActionProcess`. */
-export const _$gha_kbve_ActionProcess = kbveActionProcess;

--- a/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.spec.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-	_$gha_failureIssueTitle,
-	_$gha_classifyCIFailure,
-	_$gha_parseFailureLog,
-	_$gha_buildFailureIssueBody,
-	_$gha_buildFailureComment,
-	_$gha_buildResolveComment,
-	_$gha_incrementFailureHistory,
 	CI_FAILURE_PATTERNS,
 	ci,
 } from './ci-failure';
@@ -21,44 +14,35 @@ describe('ci namespace', () => {
 		expect(ci.failurePatterns).toBe(CI_FAILURE_PATTERNS);
 	});
 
-	it('deprecated _$gha_* aliases point to the same functions', () => {
-		expect(_$gha_failureIssueTitle).toBe(ci.issueTitle);
-		expect(_$gha_classifyCIFailure).toBe(ci.classifyFailure);
-		expect(_$gha_parseFailureLog).toBe(ci.parseFailureLog);
-		expect(_$gha_buildFailureIssueBody).toBe(ci.buildIssueBody);
-		expect(_$gha_buildFailureComment).toBe(ci.buildComment);
-		expect(_$gha_buildResolveComment).toBe(ci.buildResolveComment);
-		expect(_$gha_incrementFailureHistory).toBe(ci.incrementHistory);
-	});
 });
 
-describe('_$gha_failureIssueTitle', () => {
+describe('ci.issueTitle', () => {
 	it('formats the canonical tracker title', () => {
-		expect(_$gha_failureIssueTitle('CI Main', 'build')).toBe(
+		expect(ci.issueTitle('CI Main', 'build')).toBe(
 			'[CI] CI Main / build — Failed',
 		);
 	});
 });
 
-describe('_$gha_classifyCIFailure', () => {
+describe('ci.classifyFailure', () => {
 	it('classifies Forgejo LFS auth failures', () => {
 		const log =
 			'batch response: Authentication required: ... info/lfs/objects/batch';
-		const reason = _$gha_classifyCIFailure(log);
+		const reason = ci.classifyFailure(log);
 		expect(reason).toContain('Forgejo LFS');
 		expect(reason).toContain('FORGEJO_TOKEN');
 	});
 
 	it('classifies out-of-memory kills', () => {
 		expect(
-			_$gha_classifyCIFailure(
+			ci.classifyFailure(
 				'Killed signal 9 - JavaScript heap out of memory',
 			),
 		).toContain('memory');
 	});
 
 	it('returns null when no pattern matches', () => {
-		expect(_$gha_classifyCIFailure('some unrelated output')).toBeNull();
+		expect(ci.classifyFailure('some unrelated output')).toBeNull();
 	});
 
 	it('matches the first pattern in registry order', () => {
@@ -66,10 +50,10 @@ describe('_$gha_classifyCIFailure', () => {
 	});
 });
 
-describe('_$gha_parseFailureLog', () => {
+describe('ci.parseFailureLog', () => {
 	it('strips ANSI escapes and GH timestamp prefixes', () => {
 		const raw = '2026-06-29T10:00:00.123Z [31mError: boom[0m';
-		const { snippet } = _$gha_parseFailureLog(raw);
+		const { snippet } = ci.parseFailureLog(raw);
 		expect(snippet).toContain('Error: boom');
 		expect(snippet).not.toContain('');
 		expect(snippet).not.toContain('2026-06-29');
@@ -83,7 +67,7 @@ describe('_$gha_parseFailureLog', () => {
 			'real failure here',
 			'##[endgroup]',
 		].join('\n');
-		const { snippet } = _$gha_parseFailureLog(raw);
+		const { snippet } = ci.parseFailureLog(raw);
 		expect(snippet).toContain('real failure here');
 		expect(snippet).not.toContain('Compiling foo');
 		expect(snippet).not.toContain('##[group]');
@@ -95,7 +79,7 @@ describe('_$gha_parseFailureLog', () => {
 		lines.push('error: the real one');
 		lines.push('trailing 1');
 		lines.push('trailing 2');
-		const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+		const { snippet } = ci.parseFailureLog(lines.join('\n'));
 		expect(snippet).toContain('error: the real one');
 		expect(snippet).toContain('trailing 1');
 		expect(snippet).not.toContain('line 10');
@@ -105,7 +89,7 @@ describe('_$gha_parseFailureLog', () => {
 	it('falls back to the tail when no error marker present', () => {
 		const lines: string[] = [];
 		for (let i = 0; i < 50; i++) lines.push(`plain ${i}`);
-		const { snippet } = _$gha_parseFailureLog(lines.join('\n'));
+		const { snippet } = ci.parseFailureLog(lines.join('\n'));
 		expect(snippet).toContain('plain 49');
 		expect(snippet).not.toContain('plain 10');
 	});
@@ -118,18 +102,18 @@ describe('_$gha_parseFailureLog', () => {
 			'',
 			'other text',
 		].join('\n');
-		const { nxTargets } = _$gha_parseFailureLog(raw);
+		const { nxTargets } = ci.parseFailureLog(raw);
 		expect(nxTargets).toBe('devops:lint api:build');
 	});
 
 	it('returns empty nxTargets when none present', () => {
-		expect(_$gha_parseFailureLog('nothing here').nxTargets).toBe('');
+		expect(ci.parseFailureLog('nothing here').nxTargets).toBe('');
 	});
 });
 
-describe('_$gha_buildFailureIssueBody', () => {
+describe('ci.buildIssueBody', () => {
 	it('includes title, metadata, log and history table', () => {
-		const body = _$gha_buildFailureIssueBody({
+		const body = ci.buildIssueBody({
 			title: '[CI] CI Main / build — Failed',
 			workflowName: 'CI Main',
 			jobName: 'build',
@@ -150,7 +134,7 @@ describe('_$gha_buildFailureIssueBody', () => {
 	});
 
 	it('embeds version marker and reason when provided', () => {
-		const body = _$gha_buildFailureIssueBody({
+		const body = ci.buildIssueBody({
 			title: 't',
 			workflowName: 'w',
 			jobName: 'j',
@@ -172,7 +156,7 @@ describe('_$gha_buildFailureIssueBody', () => {
 	});
 
 	it('omits optional lines when absent', () => {
-		const body = _$gha_buildFailureIssueBody({
+		const body = ci.buildIssueBody({
 			title: 't',
 			workflowName: 'w',
 			jobName: 'j',
@@ -190,9 +174,9 @@ describe('_$gha_buildFailureIssueBody', () => {
 	});
 });
 
-describe('_$gha_buildFailureComment', () => {
+describe('ci.buildComment', () => {
 	it('renders a failure comment with run and log', () => {
-		const c = _$gha_buildFailureComment({
+		const c = ci.buildComment({
 			failedStep: 'nx test',
 			runId: '9',
 			runUrl: 'u9',
@@ -207,9 +191,9 @@ describe('_$gha_buildFailureComment', () => {
 	});
 });
 
-describe('_$gha_buildResolveComment', () => {
+describe('ci.buildResolveComment', () => {
 	it('notes plain resolution', () => {
-		const c = _$gha_buildResolveComment({
+		const c = ci.buildResolveComment({
 			runId: '5',
 			runUrl: 'u5',
 			ref: 'r',
@@ -221,7 +205,7 @@ describe('_$gha_buildResolveComment', () => {
 	});
 
 	it('notes shipped version when provided', () => {
-		const c = _$gha_buildResolveComment({
+		const c = ci.buildResolveComment({
 			runId: '5',
 			runUrl: 'u5',
 			ref: 'r',
@@ -233,8 +217,8 @@ describe('_$gha_buildResolveComment', () => {
 	});
 });
 
-describe('_$gha_incrementFailureHistory', () => {
-	const base = _$gha_buildFailureIssueBody({
+describe('ci.incrementHistory', () => {
+	const base = ci.buildIssueBody({
 		title: '[CI] CI Main / build — Failed',
 		workflowName: 'CI Main',
 		jobName: 'build',
@@ -248,7 +232,7 @@ describe('_$gha_incrementFailureHistory', () => {
 	});
 
 	it('bumps the consecutive failure count', () => {
-		const next = _$gha_incrementFailureHistory(base, {
+		const next = ci.incrementHistory(base, {
 			runId: '101',
 			runUrl: 'https://example/run/101',
 			ref: 'refs/heads/dev',
@@ -259,7 +243,7 @@ describe('_$gha_incrementFailureHistory', () => {
 	});
 
 	it('appends a new history table row', () => {
-		const next = _$gha_incrementFailureHistory(base, {
+		const next = ci.incrementHistory(base, {
 			runId: '101',
 			runUrl: 'https://example/run/101',
 			ref: 'refs/heads/dev',
@@ -274,7 +258,7 @@ describe('_$gha_incrementFailureHistory', () => {
 	it('is idempotent on count formatting across multiple increments', () => {
 		let body = base;
 		for (let i = 0; i < 3; i++) {
-			body = _$gha_incrementFailureHistory(body, {
+			body = ci.incrementHistory(body, {
 				runId: `${200 + i}`,
 				runUrl: `u${i}`,
 				ref: 'r',

--- a/packages/npm/devops/src/lib/client/github/ci-failure.ts
+++ b/packages/npm/devops/src/lib/client/github/ci-failure.ts
@@ -358,18 +358,3 @@ export const ci = {
 	buildResolveComment,
 	incrementHistory,
 };
-
-/** @deprecated Use `ci.issueTitle`. */
-export const _$gha_failureIssueTitle = issueTitle;
-/** @deprecated Use `ci.classifyFailure`. */
-export const _$gha_classifyCIFailure = classifyFailure;
-/** @deprecated Use `ci.parseFailureLog`. */
-export const _$gha_parseFailureLog = parseFailureLog;
-/** @deprecated Use `ci.buildIssueBody`. */
-export const _$gha_buildFailureIssueBody = buildIssueBody;
-/** @deprecated Use `ci.buildComment`. */
-export const _$gha_buildFailureComment = buildComment;
-/** @deprecated Use `ci.buildResolveComment`. */
-export const _$gha_buildResolveComment = buildResolveComment;
-/** @deprecated Use `ci.incrementHistory`. */
-export const _$gha_incrementFailureHistory = incrementHistory;

--- a/packages/npm/devops/src/lib/client/github/docker.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.spec.ts
@@ -11,7 +11,7 @@ vi.mock('util', () => ({
 }));
 
 // Import after mocks are set up
-const { _$gha_runDockerContainer, _$gha_stopDockerContainer, docker } =
+const { docker } =
 	await import('./docker');
 
 function mockGitHubContext(): GitHubContext {
@@ -50,7 +50,7 @@ function mockGitHubClient(): GitHubClient {
 	};
 }
 
-describe('_$gha_runDockerContainer', () => {
+describe('docker.runContainer', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -60,7 +60,7 @@ describe('_$gha_runDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_runDockerContainer(
+			docker.runContainer(
 				github,
 				context,
 				0,
@@ -75,7 +75,7 @@ describe('_$gha_runDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_runDockerContainer(
+			docker.runContainer(
 				github,
 				context,
 				443,
@@ -90,7 +90,7 @@ describe('_$gha_runDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_runDockerContainer(github, context, 8080, '', 'nginx:latest'),
+			docker.runContainer(github, context, 8080, '', 'nginx:latest'),
 		).rejects.toThrow('Invalid container name');
 	});
 
@@ -99,7 +99,7 @@ describe('_$gha_runDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_runDockerContainer(github, context, 8080, 'mycontainer', ''),
+			docker.runContainer(github, context, 8080, 'mycontainer', ''),
 		).rejects.toThrow('Invalid container image name');
 	});
 
@@ -108,7 +108,7 @@ describe('_$gha_runDockerContainer', () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_runDockerContainer(
+		await docker.runContainer(
 			github,
 			context,
 			8080,
@@ -138,7 +138,7 @@ describe('_$gha_runDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_runDockerContainer(
+			docker.runContainer(
 				github,
 				context,
 				8080,
@@ -155,7 +155,7 @@ describe('_$gha_runDockerContainer', () => {
 	});
 });
 
-describe('_$gha_stopDockerContainer', () => {
+describe('docker.stopContainer', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -165,7 +165,7 @@ describe('_$gha_stopDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_stopDockerContainer(github, context, ''),
+			docker.stopContainer(github, context, ''),
 		).rejects.toThrow('Invalid container name');
 	});
 
@@ -174,7 +174,7 @@ describe('_$gha_stopDockerContainer', () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_stopDockerContainer(github, context, 'mycontainer');
+		await docker.stopContainer(github, context, 'mycontainer');
 
 		expect(github.rest.issues.createComment).toHaveBeenCalledTimes(2);
 		expect(mockExecAsync).toHaveBeenCalledWith('docker', [
@@ -193,7 +193,7 @@ describe('_$gha_stopDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_stopDockerContainer(github, context, 'mycontainer'),
+			docker.stopContainer(github, context, 'mycontainer'),
 		).rejects.toThrow('Container not running');
 	});
 
@@ -205,14 +205,16 @@ describe('_$gha_stopDockerContainer', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_stopDockerContainer(github, context, 'mycontainer'),
+			docker.stopContainer(github, context, 'mycontainer'),
 		).rejects.toThrow('Remove failed');
 	});
 });
 
 describe('gha.docker group (v0.0.22)', () => {
-	it('members match aliases', () => {
-		expect(docker.runContainer).toBe(_$gha_runDockerContainer);
-		expect(docker.stopContainer).toBe(_$gha_stopDockerContainer);
+	it('exposes all 2 members as functions', () => {
+		for (const n of ['runContainer', 'stopContainer'])
+			expect(typeof (docker as Record<string, unknown>)[n]).toBe(
+				'function',
+			);
 	});
 });

--- a/packages/npm/devops/src/lib/client/github/docker.ts
+++ b/packages/npm/devops/src/lib/client/github/docker.ts
@@ -124,8 +124,3 @@ export const docker = {
 	runContainer,
 	stopContainer,
 };
-
-/** @deprecated Use `gha.docker.runContainer`. */
-export const _$gha_runDockerContainer = runContainer;
-/** @deprecated Use `gha.docker.stopContainer`. */
-export const _$gha_stopDockerContainer = stopContainer;

--- a/packages/npm/devops/src/lib/client/github/issues.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/issues.spec.ts
@@ -1,15 +1,4 @@
 import {
-	_$gha_createIssueComment,
-	_$gha_addReaction,
-	_$gha_removeLabel,
-	_$gha_addLabel,
-	_$gha_verifyMatrixLabel,
-	_$gha_addAssignees,
-	_$gha_removeAssignees,
-	_$gha_closeIssue,
-	_$gha_reopenIssue,
-	_$gha_lockIssue,
-	_$gha_unlockIssue,
 	issues,
 } from './issues';
 import { GitHubClient, GitHubContext } from './types';
@@ -52,12 +41,12 @@ function mockGitHubClient(overrides?: Partial<GitHubClient>): GitHubClient {
 	};
 }
 
-describe('_$gha_createIssueComment', () => {
+describe('issues.createComment', () => {
 	it('should call createComment with correct params', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_createIssueComment(github, context, 'Hello World');
+		await issues.createComment(github, context, 'Hello World');
 
 		expect(github.rest.issues.createComment).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -75,17 +64,17 @@ describe('_$gha_createIssueComment', () => {
 		const context = mockGitHubContext();
 
 		await expect(
-			_$gha_createIssueComment(github, context, 'test'),
+			issues.createComment(github, context, 'test'),
 		).rejects.toThrow('API Error');
 	});
 });
 
-describe('_$gha_addReaction', () => {
+describe('issues.addReaction', () => {
 	it('should call createForIssueComment with correct params', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_addReaction(github, context, 123, '+1');
+		await issues.addReaction(github, context, 123, '+1');
 
 		expect(
 			github.rest.reactions.createForIssueComment,
@@ -98,7 +87,7 @@ describe('_$gha_addReaction', () => {
 	});
 });
 
-describe('_$gha_removeLabel', () => {
+describe('issues.removeLabel', () => {
 	it('should remove label when it exists on the issue', async () => {
 		const github = mockGitHubClient();
 		(
@@ -108,7 +97,7 @@ describe('_$gha_removeLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_removeLabel(github, context, 'bug');
+		await issues.removeLabel(github, context, 'bug');
 
 		expect(github.rest.issues.removeLabel).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -127,13 +116,13 @@ describe('_$gha_removeLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_removeLabel(github, context, 'bug');
+		await issues.removeLabel(github, context, 'bug');
 
 		expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
 	});
 });
 
-describe('_$gha_addLabel', () => {
+describe('issues.addLabel', () => {
 	it('should add label when it does not exist on the issue', async () => {
 		const github = mockGitHubClient();
 		(
@@ -143,7 +132,7 @@ describe('_$gha_addLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_addLabel(github, context, 'bug');
+		await issues.addLabel(github, context, 'bug');
 
 		expect(github.rest.issues.addLabels).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -162,13 +151,13 @@ describe('_$gha_addLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_addLabel(github, context, 'bug');
+		await issues.addLabel(github, context, 'bug');
 
 		expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
 	});
 });
 
-describe('_$gha_verifyMatrixLabel', () => {
+describe('issues.verifyMatrixLabel', () => {
 	it('should add label 0 when no matrix labels are present', async () => {
 		const github = mockGitHubClient();
 		(
@@ -178,9 +167,9 @@ describe('_$gha_verifyMatrixLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_verifyMatrixLabel(github, context);
+		await issues.verifyMatrixLabel(github, context);
 
-		// It calls _$gha_addLabel which calls listLabelsOnIssue again then addLabels
+		// It calls issues.addLabel which calls listLabelsOnIssue again then addLabels
 		expect(github.rest.issues.addLabels).toHaveBeenCalled();
 	});
 
@@ -193,7 +182,7 @@ describe('_$gha_verifyMatrixLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_verifyMatrixLabel(github, context);
+		await issues.verifyMatrixLabel(github, context);
 
 		expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
 		expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
@@ -208,20 +197,20 @@ describe('_$gha_verifyMatrixLabel', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_verifyMatrixLabel(github, context);
+		await issues.verifyMatrixLabel(github, context);
 
 		// Should remove labels '1' and '3', keeping '5'
-		// removeLabel is called via _$gha_removeLabel which lists labels again
+		// removeLabel is called via issues.removeLabel which lists labels again
 		expect(github.rest.issues.listLabelsOnIssue).toHaveBeenCalled();
 	});
 });
 
-describe('_$gha_addAssignees', () => {
+describe('issues.addAssignees', () => {
 	it('should call addAssignees with correct params', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_addAssignees(github, context, ['user1', 'user2']);
+		await issues.addAssignees(github, context, ['user1', 'user2']);
 
 		expect(github.rest.issues.addAssignees).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -232,12 +221,12 @@ describe('_$gha_addAssignees', () => {
 	});
 });
 
-describe('_$gha_removeAssignees', () => {
+describe('issues.removeAssignees', () => {
 	it('should call removeAssignees with correct params', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_removeAssignees(github, context, ['user1']);
+		await issues.removeAssignees(github, context, ['user1']);
 
 		expect(github.rest.issues.removeAssignees).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -248,12 +237,12 @@ describe('_$gha_removeAssignees', () => {
 	});
 });
 
-describe('_$gha_closeIssue', () => {
+describe('issues.closeIssue', () => {
 	it('should update issue state to closed', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_closeIssue(github, context);
+		await issues.closeIssue(github, context);
 
 		expect(github.rest.issues.update).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -264,12 +253,12 @@ describe('_$gha_closeIssue', () => {
 	});
 });
 
-describe('_$gha_reopenIssue', () => {
+describe('issues.reopenIssue', () => {
 	it('should update issue state to open', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_reopenIssue(github, context);
+		await issues.reopenIssue(github, context);
 
 		expect(github.rest.issues.update).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -280,12 +269,12 @@ describe('_$gha_reopenIssue', () => {
 	});
 });
 
-describe('_$gha_lockIssue', () => {
+describe('issues.lockIssue', () => {
 	it('should lock issue without reason', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_lockIssue(github, context);
+		await issues.lockIssue(github, context);
 
 		expect(github.rest.issues.lock).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -299,7 +288,7 @@ describe('_$gha_lockIssue', () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_lockIssue(github, context, 'spam');
+		await issues.lockIssue(github, context, 'spam');
 
 		expect(github.rest.issues.lock).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -310,12 +299,12 @@ describe('_$gha_lockIssue', () => {
 	});
 });
 
-describe('_$gha_unlockIssue', () => {
+describe('issues.unlockIssue', () => {
 	it('should unlock issue', async () => {
 		const github = mockGitHubClient();
 		const context = mockGitHubContext();
 
-		await _$gha_unlockIssue(github, context);
+		await issues.unlockIssue(github, context);
 
 		expect(github.rest.issues.unlock).toHaveBeenCalledWith({
 			owner: 'KBVE',
@@ -326,11 +315,6 @@ describe('_$gha_unlockIssue', () => {
 });
 
 describe('gha.issues group (v0.0.22)', () => {
-	it('group members are the same references as their _$gha_ aliases', () => {
-		expect(issues.createComment).toBe(_$gha_createIssueComment);
-		expect(issues.verifyMatrixLabel).toBe(_$gha_verifyMatrixLabel);
-		expect(issues.unlockIssue).toBe(_$gha_unlockIssue);
-	});
 	it('exposes all 11 members as functions', () => {
 		const names = [
 			'createComment',

--- a/packages/npm/devops/src/lib/client/github/issues.ts
+++ b/packages/npm/devops/src/lib/client/github/issues.ts
@@ -267,26 +267,3 @@ export const issues = {
 	lockIssue,
 	unlockIssue,
 };
-
-/** @deprecated Use `gha.issues.createComment`. */
-export const _$gha_createIssueComment = createComment;
-/** @deprecated Use `gha.issues.addReaction`. */
-export const _$gha_addReaction = addReaction;
-/** @deprecated Use `gha.issues.removeLabel`. */
-export const _$gha_removeLabel = removeLabel;
-/** @deprecated Use `gha.issues.addLabel`. */
-export const _$gha_addLabel = addLabel;
-/** @deprecated Use `gha.issues.verifyMatrixLabel`. */
-export const _$gha_verifyMatrixLabel = verifyMatrixLabel;
-/** @deprecated Use `gha.issues.addAssignees`. */
-export const _$gha_addAssignees = addAssignees;
-/** @deprecated Use `gha.issues.removeAssignees`. */
-export const _$gha_removeAssignees = removeAssignees;
-/** @deprecated Use `gha.issues.closeIssue`. */
-export const _$gha_closeIssue = closeIssue;
-/** @deprecated Use `gha.issues.reopenIssue`. */
-export const _$gha_reopenIssue = reopenIssue;
-/** @deprecated Use `gha.issues.lockIssue`. */
-export const _$gha_lockIssue = lockIssue;
-/** @deprecated Use `gha.issues.unlockIssue`. */
-export const _$gha_unlockIssue = unlockIssue;

--- a/packages/npm/devops/src/lib/client/github/pulls.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.spec.ts
@@ -1,14 +1,5 @@
 import {
-	_$gha_formatCommits,
-	_$gha_createOrUpdatePR,
 	pulls,
-	_$gha_categorizeApiCommits,
-	_$gha_generatePRTitle,
-	_$gha_formatDevBody,
-	_$gha_getPullRequestNumber,
-	_$gha_updatePullRequestBody,
-	_$gha_fetchAndCleanCommits,
-	_$gha_processAndUpdatePR,
 } from './pulls';
 import {
 	GitHubClient,
@@ -73,14 +64,14 @@ function emptyCommitCategory(): CommitCategory {
 	};
 }
 
-describe('_$gha_formatCommits', () => {
+describe('pulls.formatCommits', () => {
 	it('should format commits with all categories empty', () => {
 		const cleanedCommit: CleanedCommit = {
 			branch: 'main',
 			categorizedCommits: emptyCommitCategory(),
 		};
 
-		const result = _$gha_formatCommits(cleanedCommit);
+		const result = pulls.formatCommits(cleanedCommit);
 
 		expect(result).toContain('PR Report for main');
 		expect(result).toContain('KBVE Logo');
@@ -97,7 +88,7 @@ describe('_$gha_formatCommits', () => {
 			categorizedCommits: commits,
 		};
 
-		const result = _$gha_formatCommits(cleanedCommit);
+		const result = pulls.formatCommits(cleanedCommit);
 
 		expect(result).toContain('PR Report for dev');
 		expect(result).toContain('### Features:');
@@ -115,7 +106,7 @@ describe('_$gha_formatCommits', () => {
 			categorizedCommits: commits,
 		};
 
-		const result = _$gha_formatCommits(cleanedCommit);
+		const result = pulls.formatCommits(cleanedCommit);
 
 		expect(result).toContain('### Features:');
 		expect(result).toContain('### Fixes:');
@@ -130,13 +121,13 @@ describe('_$gha_formatCommits', () => {
 			categorizedCommits: emptyCommitCategory(),
 		};
 
-		const result = _$gha_formatCommits(cleanedCommit);
+		const result = pulls.formatCommits(cleanedCommit);
 
 		expect(result).toContain('welcome-to-docs');
 	});
 });
 
-describe('_$gha_createOrUpdatePR', () => {
+describe('pulls.createOrUpdatePR', () => {
 	it('should create a new PR when none exists', async () => {
 		const github = mockGitHubClient({
 			ref: 'refs/heads/feature-branch',
@@ -146,7 +137,7 @@ describe('_$gha_createOrUpdatePR', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_createOrUpdatePR(github, context, 'main');
+		await pulls.createOrUpdatePR(github, context, 'main');
 
 		expect(github.rest.pulls.create).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -167,7 +158,7 @@ describe('_$gha_createOrUpdatePR', () => {
 		});
 		const context = mockGitHubContext();
 
-		await _$gha_createOrUpdatePR(github, context, 'main');
+		await pulls.createOrUpdatePR(github, context, 'main');
 
 		expect(github.rest.pulls.create).not.toHaveBeenCalled();
 		expect(github.rest.issues.createComment).toHaveBeenCalledWith(
@@ -192,7 +183,7 @@ describe('_$gha_createOrUpdatePR', () => {
 			},
 		});
 
-		await _$gha_createOrUpdatePR(github, context, 'main');
+		await pulls.createOrUpdatePR(github, context, 'main');
 
 		expect(github.rest.pulls.create).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -210,7 +201,7 @@ describe('_$gha_createOrUpdatePR', () => {
 			ref: 'refs/heads/fallback-branch',
 		});
 
-		await _$gha_createOrUpdatePR(github, context, 'main');
+		await pulls.createOrUpdatePR(github, context, 'main');
 
 		expect(github.rest.pulls.create).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -227,17 +218,12 @@ describe('_$gha_createOrUpdatePR', () => {
 
 		// context.ref is empty string, github.ref is undefined, no payload
 		await expect(
-			_$gha_createOrUpdatePR(github, context, 'main'),
+			pulls.createOrUpdatePR(github, context, 'main'),
 		).rejects.toThrow();
 	});
 });
 
 describe('gha.pulls group (v0.0.22)', () => {
-	it('group members match their _$gha_ aliases', () => {
-		expect(pulls.formatCommits).toBe(_$gha_formatCommits);
-		expect(pulls.createOrUpdatePR).toBe(_$gha_createOrUpdatePR);
-		expect(pulls.generatePRTitle).toBe(_$gha_generatePRTitle);
-	});
 	it('exposes all 9 members as functions', () => {
 		const names = [
 			'formatCommits',

--- a/packages/npm/devops/src/lib/client/github/pulls.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.ts
@@ -388,22 +388,3 @@ export const pulls = {
 	processAndUpdatePR,
 	createOrUpdatePR,
 };
-
-/** @deprecated Use `gha.pulls.formatCommits`. */
-export const _$gha_formatCommits = formatCommits;
-/** @deprecated Use `gha.pulls.categorizeApiCommits`. */
-export const _$gha_categorizeApiCommits = categorizeApiCommits;
-/** @deprecated Use `gha.pulls.generatePRTitle`. */
-export const _$gha_generatePRTitle = generatePRTitle;
-/** @deprecated Use `gha.pulls.formatDevBody`. */
-export const _$gha_formatDevBody = formatDevBody;
-/** @deprecated Use `gha.pulls.getPullRequestNumber`. */
-export const _$gha_getPullRequestNumber = getPullRequestNumber;
-/** @deprecated Use `gha.pulls.updatePullRequestBody`. */
-export const _$gha_updatePullRequestBody = updatePullRequestBody;
-/** @deprecated Use `gha.pulls.fetchAndCleanCommits`. */
-export const _$gha_fetchAndCleanCommits = fetchAndCleanCommits;
-/** @deprecated Use `gha.pulls.processAndUpdatePR`. */
-export const _$gha_processAndUpdatePR = processAndUpdatePR;
-/** @deprecated Use `gha.pulls.createOrUpdatePR`. */
-export const _$gha_createOrUpdatePR = createOrUpdatePR;

--- a/packages/npm/devops/src/lib/client/github/types.spec.ts
+++ b/packages/npm/devops/src/lib/client/github/types.spec.ts
@@ -1,13 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import {
-	context,
-	_$gha_extractIssueContext,
-	_$gha_extractRepoContext,
-} from './types';
+import { context } from './types';
+import type { GitHubContext } from './types';
 
-describe('gha.context group (v0.0.22)', () => {
-	it('members match aliases', () => {
-		expect(context.extractIssue).toBe(_$gha_extractIssueContext);
-		expect(context.extractRepo).toBe(_$gha_extractRepoContext);
+function mockContext(): GitHubContext {
+	return {
+		repo: { owner: 'KBVE', repo: 'kbve' },
+		issue: { number: 42 },
+		job: 'build',
+	} as GitHubContext;
+}
+
+describe('gha.context group', () => {
+	it('extractIssue returns owner, repo and issue_number', () => {
+		expect(context.extractIssue(mockContext())).toEqual({
+			owner: 'KBVE',
+			repo: 'kbve',
+			issue_number: 42,
+		});
+	});
+
+	it('extractRepo returns owner and repo', () => {
+		expect(context.extractRepo(mockContext())).toEqual({
+			owner: 'KBVE',
+			repo: 'kbve',
+		});
 	});
 });

--- a/packages/npm/devops/src/lib/client/github/types.ts
+++ b/packages/npm/devops/src/lib/client/github/types.ts
@@ -156,10 +156,6 @@ export const context = {
 	extractRepo,
 };
 
-/** @deprecated Use `gha.context.extractIssue`. */
-export const _$gha_extractIssueContext = extractIssue;
-/** @deprecated Use `gha.context.extractRepo`. */
-export const _$gha_extractRepoContext = extractRepo;
 
 export type { CommitCategory, CleanedCommit, ApiCommit, CategorizedResult };
 export { COMMIT_CATEGORY_LABELS } from '../../../types';


### PR DESCRIPTION
## Summary
Removes the 33 `@deprecated` `_$gha_*` alias exports from `@kbve/devops` GitHub client, completing the v0.0.22 grouped-namespace refactor (#13717).

Files: `issues.ts`, `pulls.ts`, `actions.ts`, `docker.ts`, `types.ts`, `ci-failure.ts` (+ their specs, `devops-e2e/import.spec.ts`, and the `commit-utils.mjs` source-of-truth comment).

**BREAKING** — consumers must use the grouped namespace:

| removed alias | replacement |
|---|---|
| `_$gha_createIssueComment` | `gha.issues.createComment` |
| `_$gha_createOrUpdatePR` | `gha.pulls.createOrUpdatePR` |
| `_$gha_kbve_ActionProcess` | `gha.actions.kbveActionProcess` |
| `_$gha_runDockerContainer` | `gha.docker.runContainer` |
| `_$gha_extractIssueContext` | `gha.context.extractIssue` |
| `_$gha_parseFailureLog` | `ci.parseFailureLog` |
| …(33 total) | grouped `gha.*` / `ci.*` members |

## Verification
- [x] No repo consumer references any `_$gha_*` name — only doc comments + historical journals remained; internal callers migrated in 0.0.22.
- [x] Removed all `export const _$gha_X = X;` alias blocks (33).
- [x] Specs rewritten to exercise canonical group members; added `context`/`docker` group coverage where the only test was the alias-equivalence check.
- [x] `vitest run` — devops **89 passed**, devops-e2e **21 passed**.
- [x] Breaking → minor bump `0.0.22` → `0.1.0` via `devops.mdx` (source of truth; CI regen syncs `version.toml` + `package.json`).

Closes #13725. Follow-up to #13717.