### PR TITLE
chore(ci): regen ci-dispatch-manifest for devops 0.1.0

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -539,7 +539,7 @@
 		{
 			"key": "devops",
 			"package_name": "devops",
-			"version": "0.0.22",
+			"version": "0.1.0",
 			"version_toml": "packages/npm/devops/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/devops.mdx",
 			"version_target": "packages/npm/devops/package.json"


### PR DESCRIPTION
## Problem
#14207 bumped `@kbve/devops` `0.0.22 → 0.1.0` by editing `devops.mdx` (source of truth) but **did not regenerate `.github/ci-dispatch-manifest.json`**. That manifest is what `CI - Publish` reads for the dispatch version. It still held `0.0.22`, so after #14209 merged to main the publish job computed `manifest_version: 0.0.22` — already on npm — and **skipped the 0.1.0 publish**. `version.toml` never advanced either.

The manifest-guard only hard-fails on *structural* drift; a version-only diff slips through, so the stale version rode all the way to publish.

## Fix
Regenerated the manifest from the MDX via `nx run astro-kbve:gen:ci-manifest`. Sole diff:

```
-  "version": "0.0.22",
+  "version": "0.1.0",
```

On merge to dev → main, `CI - Publish` reads `0.1.0`, bumps `version.toml` + `package.json`, and publishes `@kbve/devops@0.1.0`.

Follow-up to #13725 / #14207.