### PR TITLE
fix(netpol): cronjob apiserver egress via Cilium entity, not ClusterIP

### DIFF
--- a/apps/kube/crossplane/providers/cronjob-networkpolicy.yaml
+++ b/apps/kube/crossplane/providers/cronjob-networkpolicy.yaml
@@ -2,9 +2,19 @@
 # CronJobs in crossplane-system (s3-healthcheck) only need kubectl access.
 # Blocks all other outbound traffic (database, internet, other services).
 #
+# Cilium runs with kube-proxy replacement: it translates the kube-apiserver
+# ClusterIP (10.96.0.1:443) to the real control-plane endpoint (host:6443) at
+# the socket layer, BEFORE egress policy is evaluated. A k8s NetworkPolicy
+# ipBlock to 10.96.0.1/32 therefore never matches and every kubectl call times
+# out ("dial tcp 10.96.0.1:443: i/o timeout"), silently breaking the S3 drill.
+# Use a Cilium toEntities: kube-apiserver rule instead — identity-based, on
+# 443/6443, survives control-plane IP changes. Same pattern as
+# github/runners/manifests/runner-apiserver-egress.yaml and
+# kasm/manifest/network-policy.yaml.
+#
 # Resolves: https://github.com/KBVE/kbve/issues/7656
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 metadata:
     name: cronjob-egress-apiserver-only
     namespace: crossplane-system
@@ -15,27 +25,27 @@ metadata:
     annotations:
         argocd.argoproj.io/sync-wave: '10'
 spec:
-    podSelector:
+    endpointSelector:
         matchLabels:
             app.kubernetes.io/component: s3-healthcheck
-    policyTypes:
-        - Egress
     egress:
-        # kube-apiserver (kubectl commands)
-        - to:
-              - ipBlock:
-                    cidr: 10.96.0.1/32
-          ports:
-              - protocol: TCP
-                port: 443
-        # DNS resolution (required for kubectl to resolve kubernetes.default.svc)
-        - to:
-              - namespaceSelector: {}
-                podSelector:
-                    matchLabels:
-                        k8s-app: kube-dns
-          ports:
-              - protocol: UDP
-                port: 53
-              - protocol: TCP
-                port: 53
+        # kube-apiserver (kubectl commands) — identity-based, not ClusterIP
+        - toEntities:
+              - kube-apiserver
+          toPorts:
+              - ports:
+                    - port: '443'
+                      protocol: TCP
+                    - port: '6443'
+                      protocol: TCP
+        # DNS resolution (kube-dns pods, matched by identity not ClusterIP)
+        - toEndpoints:
+              - matchLabels:
+                    k8s:io.kubernetes.pod.namespace: kube-system
+                    k8s-app: kube-dns
+          toPorts:
+              - ports:
+                    - port: '53'
+                      protocol: UDP
+                    - port: '53'
+                      protocol: TCP

--- a/apps/kube/kilobase/manifests/cronjob-networkpolicy.yaml
+++ b/apps/kube/kilobase/manifests/cronjob-networkpolicy.yaml
@@ -2,9 +2,19 @@
 # CronJobs in kilobase (backup-restore-test, backup-watchdog) only need kubectl access.
 # Blocks all other outbound traffic (database, internet, other services).
 #
+# Cilium runs with kube-proxy replacement: it translates the kube-apiserver
+# ClusterIP (10.96.0.1:443) to the real control-plane endpoint (host:6443) at
+# the socket layer, BEFORE egress policy is evaluated. A k8s NetworkPolicy
+# ipBlock to 10.96.0.1/32 therefore never matches and every kubectl call times
+# out ("dial tcp 10.96.0.1:443: i/o timeout"), silently breaking the backup
+# drill. Use a Cilium toEntities: kube-apiserver rule instead — identity-based,
+# on 443/6443, survives control-plane IP changes. Same pattern as
+# github/runners/manifests/runner-apiserver-egress.yaml and
+# kasm/manifest/network-policy.yaml.
+#
 # Resolves: https://github.com/KBVE/kbve/issues/7656
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 metadata:
     name: cronjob-egress-apiserver-only
     namespace: kilobase
@@ -13,31 +23,31 @@ metadata:
         app.kubernetes.io/component: network-policy
         app.kubernetes.io/managed-by: argocd
 spec:
-    podSelector:
+    endpointSelector:
         matchExpressions:
             - key: app.kubernetes.io/component
               operator: In
               values:
                   - backup-testing
                   - backup-watchdog
-    policyTypes:
-        - Egress
     egress:
-        # kube-apiserver (kubectl commands)
-        - to:
-              - ipBlock:
-                    cidr: 10.96.0.1/32
-          ports:
-              - protocol: TCP
-                port: 443
-        # DNS resolution (required for kubectl to resolve kubernetes.default.svc)
-        - to:
-              - namespaceSelector: {}
-                podSelector:
-                    matchLabels:
-                        k8s-app: kube-dns
-          ports:
-              - protocol: UDP
-                port: 53
-              - protocol: TCP
-                port: 53
+        # kube-apiserver (kubectl commands) — identity-based, not ClusterIP
+        - toEntities:
+              - kube-apiserver
+          toPorts:
+              - ports:
+                    - port: '443'
+                      protocol: TCP
+                    - port: '6443'
+                      protocol: TCP
+        # DNS resolution (kube-dns pods, matched by identity not ClusterIP)
+        - toEndpoints:
+              - matchLabels:
+                    k8s:io.kubernetes.pod.namespace: kube-system
+                    k8s-app: kube-dns
+          toPorts:
+              - ports:
+                    - port: '53'
+                      protocol: UDP
+                    - port: '53'
+                      protocol: TCP


### PR DESCRIPTION
## Problem
The **S3 healthcheck** (`crossplane-system/s3-healthcheck`) and the **backup drill** (`kilobase/backup-restore-test`, `backup-watchdog`) CronJobs have silently failed for months. Every `kubectl` inside them times out:

```
E ... couldn't get current server API group list: Get "https://10.96.0.1:443/api": dial tcp 10.96.0.1:443: i/o timeout
Unable to connect to the server: dial tcp 10.96.0.1:443: i/o timeout
```

Both jobs are egress-locked to the apiserver by a k8s NetworkPolicy `ipBlock: 10.96.0.1/32`. **Under Cilium kube-proxy replacement, the apiserver ClusterIP is DNAT'd to the real endpoint (`host:6443`) at the socket layer *before* egress policy is evaluated** — so a rule allowing `10.96.0.1/32` never matches, and the traffic is dropped.

This is the exact gotcha already documented in `github/runners/manifests/runner-apiserver-egress.yaml`. These two cronjob netpols are the last ones never migrated (MIGRATION.md even lists them).

**Impact: the weekly Postgres backup-restore DR drill has not run to completion in ~76 days.**

## Fix
Convert both `cronjob-egress-apiserver-only` from k8s `NetworkPolicy` → `CiliumNetworkPolicy` using `toEntities: kube-apiserver` (ports 443/6443) — identity-based, survives control-plane IP changes. DNS egress preserved but now targets kube-dns by **endpoint identity** (also immune to the ClusterIP-DNAT issue). Pod selectors kept identical:
- crossplane: `app.kubernetes.io/component: s3-healthcheck`
- kilobase: `app.kubernetes.io/component in (backup-testing, backup-watchdog)`

## Validation
- YAML parses; kinds/selectors verified.
- Mirrors the known-good `runner-apiserver-egress` / `kasm-vpn-egress-lockdown` CNPs (both live `Valid`).
- **Recommend live-verifying before merge**: apply the CNP + trigger the s3-healthcheck job, confirm it reaches the apiserver.

⚠️ Selector scoping is deliberate — an empty `endpointSelector` would flip the whole namespace to default-deny (per the runner-apiserver-egress comment). Both are scoped to the cronjob pods only.

📚 https://kbve.com/docs/