### PR TITLE
fix(rn): clear-storage button wipes IndexedDB session, not just localStorage

### DIFF
--- a/packages/npm/rn/src/account/StorageSection.tsx
+++ b/packages/npm/rn/src/account/StorageSection.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useRef, useState } from 'react';
 import { Surface } from '../ui/primitives/Surface';
 import { Stack } from '../ui/primitives/Stack';
 import { Text } from '../ui/primitives/Text';
@@ -7,8 +8,39 @@ import type { StatModel } from '../dash/types';
 import { formatBytes } from '../dash/shared';
 import { useStorageInfo } from './useStorageInfo';
 
+type ClearState = 'idle' | 'armed' | 'clearing' | 'done' | 'error';
+
+const ARM_TIMEOUT_MS = 4000;
+const DONE_TIMEOUT_MS = 2500;
+
 export function StorageSection() {
 	const { data, loading, clear } = useStorageInfo();
+	const [state, setState] = useState<ClearState>('idle');
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const resetTimer = useCallback((next: ClearState, ms: number) => {
+		if (timer.current) clearTimeout(timer.current);
+		timer.current = setTimeout(() => setState(next), ms);
+	}, []);
+
+	const onPress = useCallback(async () => {
+		if (state === 'clearing') return;
+		if (state !== 'armed') {
+			setState('armed');
+			resetTimer('idle', ARM_TIMEOUT_MS);
+			return;
+		}
+		if (timer.current) clearTimeout(timer.current);
+		setState('clearing');
+		try {
+			await clear();
+			setState('done');
+			resetTimer('idle', DONE_TIMEOUT_MS);
+		} catch {
+			setState('error');
+			resetTimer('idle', DONE_TIMEOUT_MS);
+		}
+	}, [state, clear, resetTimer]);
 
 	const stats: StatModel[] = data
 		? [
@@ -18,6 +50,15 @@ export function StorageSection() {
 				{ id: 'items', label: 'Items', value: data.itemCount },
 			]
 		: [];
+
+	const title =
+		state === 'armed'
+			? 'Tap again to confirm'
+			: state === 'done'
+				? 'Cleared'
+				: state === 'error'
+					? 'Failed — try again'
+					: 'Clear local storage';
 
 	return (
 		<Surface>
@@ -30,9 +71,18 @@ export function StorageSection() {
 				)}
 				<Button
 					variant="danger"
-					title="Clear local storage"
-					onPress={() => void clear()}
+					title={title}
+					loading={state === 'clearing'}
+					onPress={() => void onPress()}
+					accessibilityLabel="Clear local storage"
+					accessibilityHint="Signs you out and clears all cached data on this device"
 				/>
+				{state === 'armed' ? (
+					<Text tone="muted">
+						This signs you out and clears all cached data on this
+						device.
+					</Text>
+				) : null}
 			</Stack>
 		</Surface>
 	);

--- a/packages/npm/rn/src/account/__tests__/clearStorage.test.ts
+++ b/packages/npm/rn/src/account/__tests__/clearStorage.test.ts
@@ -1,0 +1,57 @@
+import 'fake-indexeddb/auto';
+import Dexie from 'dexie';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearStorage } from '../clearStorage';
+
+async function seedIdb(name: string) {
+	const db = new Dexie(name);
+	db.version(1).stores({ kv: 'key' });
+	await db.table('kv').put({ key: 'sb-auth-token', value: 'x' });
+	db.close();
+}
+
+afterEach(async () => {
+	localStorage.clear();
+	sessionStorage.clear();
+	vi.restoreAllMocks();
+	await Dexie.delete('sb-auth-v2');
+	await Dexie.delete('sb-auth');
+});
+
+describe('clearStorage', () => {
+	it('clears localStorage', async () => {
+		localStorage.setItem('cache:staff:perms', '{"bitmask":1}');
+		await clearStorage();
+		expect(localStorage.length).toBe(0);
+	});
+
+	it('clears sessionStorage', async () => {
+		sessionStorage.setItem('k', 'v');
+		await clearStorage();
+		expect(sessionStorage.length).toBe(0);
+	});
+
+	it('deletes IndexedDB databases including the session store', async () => {
+		await seedIdb('sb-auth-v2');
+		await clearStorage();
+		const names = (await indexedDB.databases()).map((d) => d.name);
+		expect(names).not.toContain('sb-auth-v2');
+	});
+
+	it('falls back to known db names when databases() is unavailable', async () => {
+		await seedIdb('sb-auth-v2');
+		const spy = vi
+			.spyOn(indexedDB, 'databases')
+			.mockImplementation(() => {
+				throw new Error('unsupported');
+			});
+		await clearStorage();
+		spy.mockRestore();
+		const names = (await indexedDB.databases()).map((d) => d.name);
+		expect(names).not.toContain('sb-auth-v2');
+	});
+
+	it('resolves without throwing when APIs are missing', async () => {
+		await expect(clearStorage()).resolves.toBeUndefined();
+	});
+});

--- a/packages/npm/rn/src/account/clearStorage.ts
+++ b/packages/npm/rn/src/account/clearStorage.ts
@@ -1,0 +1,5 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function clearStorage(): Promise<void> {
+	await AsyncStorage.clear();
+}

--- a/packages/npm/rn/src/account/clearStorage.web.ts
+++ b/packages/npm/rn/src/account/clearStorage.web.ts
@@ -1,0 +1,88 @@
+const KNOWN_IDB_NAMES = ['sb-auth-v2', 'sb-auth'];
+const SYNC_CHANNEL = 'kbve-droid-sync';
+
+function clearStorageBuckets(): void {
+	try {
+		localStorage.clear();
+	} catch {
+		void 0;
+	}
+	try {
+		sessionStorage.clear();
+	} catch {
+		void 0;
+	}
+}
+
+function clearCookies(): void {
+	if (typeof document === 'undefined') return;
+	try {
+		const cookies = document.cookie ? document.cookie.split(';') : [];
+		for (const cookie of cookies) {
+			const name = cookie.split('=')[0]?.trim();
+			if (!name) continue;
+			document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+		}
+	} catch {
+		void 0;
+	}
+}
+
+function deleteDatabase(name: string): Promise<void> {
+	return new Promise((resolve) => {
+		try {
+			const req = indexedDB.deleteDatabase(name);
+			req.onsuccess = () => resolve();
+			req.onerror = () => resolve();
+			req.onblocked = () => resolve();
+		} catch {
+			resolve();
+		}
+	});
+}
+
+async function clearIndexedDb(): Promise<void> {
+	if (typeof indexedDB === 'undefined') return;
+	let names = KNOWN_IDB_NAMES;
+	try {
+		if (typeof indexedDB.databases === 'function') {
+			const dbs = await indexedDB.databases();
+			const found = dbs
+				.map((d) => d.name)
+				.filter((n): n is string => typeof n === 'string' && n.length > 0);
+			if (found.length > 0) names = found;
+		}
+	} catch {
+		names = KNOWN_IDB_NAMES;
+	}
+	await Promise.all(names.map(deleteDatabase));
+}
+
+async function clearCacheApi(): Promise<void> {
+	if (typeof caches === 'undefined') return;
+	try {
+		const keys = await caches.keys();
+		await Promise.all(keys.map((k) => caches.delete(k)));
+	} catch {
+		void 0;
+	}
+}
+
+function notifyOtherTabs(): void {
+	if (typeof BroadcastChannel === 'undefined') return;
+	try {
+		const channel = new BroadcastChannel(SYNC_CHANNEL);
+		channel.postMessage({ type: 'profile-clear' });
+		channel.close();
+	} catch {
+		void 0;
+	}
+}
+
+export async function clearStorage(): Promise<void> {
+	clearStorageBuckets();
+	clearCookies();
+	await clearIndexedDb();
+	await clearCacheApi();
+	notifyOtherTabs();
+}

--- a/packages/npm/rn/src/account/useStorageInfo.ts
+++ b/packages/npm/rn/src/account/useStorageInfo.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { StorageHook, StorageInfo } from './types';
 import { toStorageInfo } from './storageMath';
+import { clearStorage } from './clearStorage';
 
 async function read(): Promise<StorageInfo> {
 	let itemCount = 0;
@@ -37,11 +38,10 @@ export function useStorageInfo(): StorageHook {
 
 	const clear = useCallback(async () => {
 		try {
-			await AsyncStorage.clear();
-		} catch {
-			void 0;
+			await clearStorage();
+		} finally {
+			refresh();
 		}
-		refresh();
 	}, [refresh]);
 
 	return { data, loading, refresh, clear };

--- a/packages/npm/rn/src/account/useStorageInfo.web.ts
+++ b/packages/npm/rn/src/account/useStorageInfo.web.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { StorageHook, StorageInfo } from './types';
 import { toStorageInfo } from './storageMath';
+import { clearStorage } from './clearStorage';
 
 async function read(): Promise<StorageInfo> {
 	let itemCount = 0;
@@ -41,19 +42,7 @@ export function useStorageInfo(): StorageHook {
 	}, [refresh]);
 
 	const clear = useCallback(async () => {
-		try {
-			localStorage.clear();
-		} catch {
-			void 0;
-		}
-		try {
-			if (typeof caches !== 'undefined') {
-				const keys = await caches.keys();
-				await Promise.all(keys.map((k) => caches.delete(k)));
-			}
-		} catch {
-			void 0;
-		}
+		await clearStorage();
 		refresh();
 	}, [refresh]);
 


### PR DESCRIPTION
## Problem
The account **Clear local storage** button (`kbve.com/dashboard/account/`, `@kbve/rn` `StorageSection`) appeared to do nothing. On web it cleared only `localStorage` + Cache API — but the Supabase **session lives in IndexedDB** (Dexie `sb-auth-v2` via `persistSession`). So the session survived, the user stayed logged in, and `navigator.storage.estimate()` (dominated by IndexedDB) barely moved.

## Fix
- **`clearStorage.web.ts`** (new) — full web wipe: `localStorage`, `sessionStorage`, **IndexedDB** (`indexedDB.databases()` enumerate + delete, fallback to `sb-auth-v2`/`sb-auth`), Cache API, cookies, and `BroadcastChannel` notify to other tabs.
- **`clearStorage.ts`** (new) — native variant (`AsyncStorage.clear()`); also gives tsc a resolution target for the bare `./clearStorage` import.
- **`useStorageInfo.web.ts` / `.ts`** — both route through `clearStorage()`; native path no longer swallows errors (try/finally + rethrow so the UI reacts).
- **`StorageSection.tsx`** — responsive: arm-to-confirm (two-tap, cross-platform — no `window.confirm`), loading spinner while clearing, "Cleared" / "Failed — try again" result, and a11y label/hint.

## Test
- New `clearStorage.test.ts` (5 tests, `fake-indexeddb`) covering localStorage/sessionStorage/IndexedDB clear + `databases()` fallback + missing-API safety.
- Account suite: **19/19 pass**. `tsc` clean on touched files (pre-existing unrelated tsc errors in `rows.tsx`/`ClusterChartsPanel`/`Sheet.tsx` untouched).
