### PR TITLE
ci(auto-merge): allow manifest-sync PRs through the bot merge queue

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -164,19 +164,25 @@ jobs:
                         return;
                       }
 
-                      // 4. Title — three supported patterns:
+                      // 4. Title — four supported patterns:
                       //    a) "Atomic: <APP> v<VER> ..." — post-publish sync (manifest-validated)
                       //    b) "chore(<PKG>): update version.toml to <VER>" — post-publish version sync
                       //    c) "deploy(<SCOPE>): ..." — automated deploy PRs (path-prefix-validated)
+                      //    d) "chore(ci): sync ci-dispatch-manifest" — leading-edge manifest
+                      //       regen (ci-manifest-sync.yml). Manifest-only; closes the publish
+                      //       deadlock where a bumped MDX never triggers a publish because the
+                      //       manifest that gates it is still stale.
                       const atomicMatch = title.match(/^Atomic:\s+(.+?)\s+v(\d+\.\d+\.\d+)/);
                       const choreMatch = title.match(/^chore\(([a-zA-Z0-9_-]+)\):\s+update version\.toml to (\d+\.\d+\.\d+)/);
                       const deployMatch = title.match(/^deploy\(([a-zA-Z0-9_-]+)\):/);
+                      const manifestSyncMatch = title.match(/^chore\(ci\):\s+sync ci-dispatch-manifest$/);
 
-                      if (!atomicMatch && !choreMatch && !deployMatch) {
+                      if (!atomicMatch && !choreMatch && !deployMatch && !manifestSyncMatch) {
                         core.setFailed(
                           `Title '${title}' does not match "Atomic: <app> v<semver> ...", ` +
                           `"chore(<pkg>): update version.toml to <semver>", ` +
-                          `or "deploy(<scope>): ..." — aborting.`
+                          `"deploy(<scope>): ...", ` +
+                          `or "chore(ci): sync ci-dispatch-manifest" — aborting.`
                         );
                         return;
                       }
@@ -252,6 +258,18 @@ jobs:
                           return;
                         }
 
+                        blocked = changedFiles.filter(f => !allowedFiles.has(f));
+                      } else if (manifestSyncMatch) {
+                        // --- Path C: leading-edge manifest sync (manifest-only) ---
+                        // ci-manifest-sync.yml regenerates the dispatch manifest on
+                        // dev when the MDX bumps a version the stale manifest hasn't
+                        // caught up to. The ONLY permitted change is the manifest file
+                        // itself — anything else is out of scope and blocks.
+                        appName = 'ci-dispatch-manifest';
+                        core.info('[manifest-sync] manifest-only regen PR');
+                        const allowedFiles = new Set(
+                          ['.github/ci-dispatch-manifest.json'].map(sanitize)
+                        );
                         blocked = changedFiles.filter(f => !allowedFiles.has(f));
                       } else {
                         // --- Path B: deploy PRs (path-prefix-validated) ---


### PR DESCRIPTION
## Problem

#14226 shipped \`ci-manifest-sync.yml\` (leading-edge manifest regen). It worked — merging #14226 fired the workflow, which opened #14227 (\`chore(ci): sync ci-dispatch-manifest\`) and dispatched auto-merge. But the auto-merge bot **rejected the PR title**:

\`\`\`
##[error]Title 'chore(ci): sync ci-dispatch-manifest' does not match
"Atomic: <app> v<semver> ...", "chore(<pkg>): update version.toml to <semver>",
or "deploy(<scope>): ..." — aborting.
\`\`\`

The validator (\`ci-auto-merge-bot-prs.yml\`) whitelists three title patterns + per-pattern file allowlists. Manifest-only sync PRs matched none, so #14227 sat OPEN/BLOCKED.

## Fix

Add a fourth accepted pattern + validation path:

- **Title:** \`chore(ci): sync ci-dispatch-manifest\` (exact)
- **Path C:** manifest-only — the sole permitted changed file is \`.github/ci-dispatch-manifest.json\`; anything else blocks.

Same author/base/label gates as the other paths (github-actions[bot], base dev, \`auto-pr\` label). actionlint clean.

Once merged, the stuck #14227 can be re-dispatched (or the next manifest-sync PR flows through untouched), and the full leading-edge auto-publish chain works end to end.