### PR TITLE
feat(dashboard): SSR skeleton fallback for all RN-web dashboard islands

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroArgoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroArgoDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactArgoDashRN from '@/components/rnweb/ReactArgoDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactArgoDashRN from '@/components/rnweb/ReactArgoDashRN';
 	heading="ArgoCD — application sync & health.">
 	<div class="argo-dash not-content">
 		<div class="argo-dash__stream not-content">
-			<ReactArgoDashRN client:only="react" />
+			<ReactArgoDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactArgoDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactClickHouseDashRN from '@/components/rnweb/ReactClickHouseDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactClickHouseDashRN from '@/components/rnweb/ReactClickHouseDashRN';
 	heading="ClickHouse cluster logs.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactClickHouseDashRN client:only="react" />
+			<ReactClickHouseDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactClickHouseDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactEdgeDashRN from '@/components/rnweb/ReactEdgeDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactEdgeDashRN from '@/components/rnweb/ReactEdgeDashRN';
 	heading="Supabase serverless health.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactEdgeDashRN client:only="react" />
+			<ReactEdgeDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactEdgeDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroFactorioDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroFactorioDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactFactorioDashRN from '@/components/rnweb/ReactFactorioDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactFactorioDashRN from '@/components/rnweb/ReactFactorioDashRN';
 	heading="Factorio server operations.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactFactorioDashRN client:only="react" />
+			<ReactFactorioDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactFactorioDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactForgejoDashRN from '@/components/rnweb/ReactForgejoDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactForgejoDashRN from '@/components/rnweb/ReactForgejoDashRN';
 	heading="Forgejo git repositories.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactForgejoDashRN client:only="react" />
+			<ReactForgejoDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactForgejoDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactGrafanaDashRN from '@/components/rnweb/ReactGrafanaDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactGrafanaDashRN from '@/components/rnweb/ReactGrafanaDashRN';
 	heading="Grafana alerts & cluster health.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactGrafanaDashRN client:only="react" />
+			<ReactGrafanaDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactGrafanaDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroMcDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroMcDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactMinecraftDashRN from '@/components/rnweb/ReactMinecraftDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactMinecraftDashRN from '@/components/rnweb/ReactMinecraftDashRN';
 	heading="Minecraft server operations.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactMinecraftDashRN client:only="react" />
+			<ReactMinecraftDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactMinecraftDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactRowsDashRN from '@/components/rnweb/ReactRowsDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactRowsDashRN from '@/components/rnweb/ReactRowsDashRN';
 	heading="ROWS game server operations.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactRowsDashRN client:only="react" />
+			<ReactRowsDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactRowsDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactVMDashRN from '@/components/rnweb/ReactVMDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <BentoShell
@@ -9,7 +10,9 @@ import ReactVMDashRN from '@/components/rnweb/ReactVMDashRN';
 	heading="KubeVirt virtual machines.">
 	<div class="svc-dash not-content">
 		<div class="svc-dash__stream not-content">
-			<ReactVMDashRN client:only="react" />
+			<ReactVMDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactVMDashRN>
 		</div>
 	</div>
 </BentoShell>

--- a/apps/kbve/astro-kbve/src/components/dashboard/RnDashSkeleton.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/RnDashSkeleton.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * Reusable SSR skeleton for RN-web dashboard islands.
+ *
+ * Dropped into a `client:only="react"` island via `slot="fallback"`, it fills
+ * the reserved dashboard box (60vh) with a shimmer placeholder — a header row,
+ * a stat-tile strip, and list rows — so hydration of the heavy RN island shows
+ * no blank flash and no layout shift. Pure HTML/CSS: renders server-side with
+ * no JS. Honors `prefers-reduced-motion`.
+ *
+ * @prop tiles  number of stat tiles (default 4)
+ * @prop rows   number of list rows (default 6)
+ */
+interface Props {
+	tiles?: number;
+	rows?: number;
+}
+const { tiles = 4, rows = 6 } = Astro.props;
+---
+
+<div class="rnsk" aria-hidden="true">
+	<div class="rnsk__header">
+		<span class="rnsk__title rnsk__b"></span>
+		<div class="rnsk__controls">
+			<span class="rnsk__chip rnsk__b"></span>
+			<span class="rnsk__chip rnsk__b"></span>
+		</div>
+	</div>
+
+	<div class="rnsk__tiles">
+		{Array.from({ length: tiles }).map(() => <span class="rnsk__tile rnsk__b" />)}
+	</div>
+
+	<div class="rnsk__rows">
+		{
+			Array.from({ length: rows }).map(() => (
+				<div class="rnsk__row">
+					<span class="rnsk__dot rnsk__b" />
+					<span class="rnsk__line rnsk__b" />
+					<span class="rnsk__pill rnsk__b" />
+				</div>
+			))
+		}
+	</div>
+</div>
+
+<style>
+	.rnsk {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		width: 100%;
+		height: 100%;
+		min-height: inherit;
+		padding: 1.25rem;
+		box-sizing: border-box;
+	}
+
+	.rnsk__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.rnsk__controls {
+		display: flex;
+		gap: 0.75rem;
+	}
+
+	.rnsk__title {
+		width: 40%;
+		max-width: 18rem;
+		height: 1.5rem;
+	}
+
+	.rnsk__chip {
+		width: 5rem;
+		height: 2rem;
+	}
+
+	.rnsk__tiles {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.rnsk__tile {
+		height: 5.5rem;
+	}
+
+	.rnsk__rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+
+	.rnsk__row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.rnsk__dot {
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
+		flex-shrink: 0;
+	}
+
+	.rnsk__line {
+		flex: 1 1 auto;
+		height: 1rem;
+	}
+
+	.rnsk__pill {
+		width: 4.5rem;
+		height: 1.25rem;
+		flex-shrink: 0;
+	}
+
+	/* Shimmer block — bento tokens keep it on-theme in light + dark. */
+	.rnsk__b {
+		display: inline-block;
+		border-radius: 0.5rem;
+		background: linear-gradient(
+			90deg,
+			var(--bento-cell-bg, rgba(255, 255, 255, 0.04)) 0%,
+			var(--bento-hairline, rgba(255, 255, 255, 0.1)) 50%,
+			var(--bento-cell-bg, rgba(255, 255, 255, 0.04)) 100%
+		);
+		background-size: 200% 100%;
+		animation: rnsk-shimmer 1.3s ease-in-out infinite;
+	}
+
+	@keyframes rnsk-shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.rnsk__b {
+			animation: none;
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/rnweb/AstroAccountRN.astro
+++ b/apps/kbve/astro-kbve/src/components/rnweb/AstroAccountRN.astro
@@ -1,5 +1,16 @@
 ---
 import ReactAccountRN from './ReactAccountRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
-<ReactAccountRN client:only="react" />
+<div class="acct-rn not-content">
+	<ReactAccountRN client:only="react">
+		<RnDashSkeleton slot="fallback" tiles={2} rows={4} />
+	</ReactAccountRN>
+</div>
+
+<style>
+	.acct-rn {
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/rnweb/AstroArgoDashRN.astro
+++ b/apps/kbve/astro-kbve/src/components/rnweb/AstroArgoDashRN.astro
@@ -1,5 +1,16 @@
 ---
 import ReactArgoDashRN from './ReactArgoDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
-<ReactArgoDashRN client:only="react" />
+<div class="argo-rn not-content">
+	<ReactArgoDashRN client:only="react">
+		<RnDashSkeleton slot="fallback" />
+	</ReactArgoDashRN>
+</div>
+
+<style>
+	.argo-rn {
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/rnweb/AstroGrafanaDashRN.astro
+++ b/apps/kbve/astro-kbve/src/components/rnweb/AstroGrafanaDashRN.astro
@@ -1,5 +1,16 @@
 ---
 import ReactGrafanaDashRN from './ReactGrafanaDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
-<ReactGrafanaDashRN client:only="react" />
+<div class="grafana-rn not-content">
+	<ReactGrafanaDashRN client:only="react">
+		<RnDashSkeleton slot="fallback" />
+	</ReactGrafanaDashRN>
+</div>
+
+<style>
+	.grafana-rn {
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/rnweb/AstroWorkflowsDashRN.astro
+++ b/apps/kbve/astro-kbve/src/components/rnweb/AstroWorkflowsDashRN.astro
@@ -1,9 +1,12 @@
 ---
 import ReactWorkflowsDashRN from './ReactWorkflowsDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
 ---
 
 <div class="wf-canvas not-content">
-	<ReactWorkflowsDashRN client:only="react" />
+	<ReactWorkflowsDashRN client:only="react">
+		<RnDashSkeleton slot="fallback" tiles={3} rows={5} />
+	</ReactWorkflowsDashRN>
 </div>
 
 <style>


### PR DESCRIPTION
Loops the footer-NavBar CLS standard (#14232) across the rest of the RN-web components.

## Problem

Every dashboard mounts a heavy `client:only="react"` RN island (reanimated + svg → slow hydrate). client:only renders **nothing** server-side, so each one showed a blank box (or, for Account, a full layout jump — it had no reserved height at all) until React mounted.

## Fix — one reusable skeleton, applied everywhere

`RnDashSkeleton.astro` — pure SSR HTML/CSS shimmer (header row + stat-tile strip + list rows; `tiles`/`rows` props; honors `prefers-reduced-motion`). Dropped into each island via `slot="fallback"`. No JS, renders server-side, fills the reserved box → no blank flash, no shift.

**Covered (13 mounts):**
- Service dashboards: Factorio, MC, ClickHouse, Edge, Forgejo, Rows, VM, Argo, Grafana (already reserved 60vh — now filled).
- `-rn` doc pages: Argo, Grafana (were bare — now reserved + skeleton), Workflows (had 70vh — now filled).
- **Account** — gained a 60vh reserved wrapper it never had (worst CLS offender).

## Verification

Dev server, curl across route types:

```
dashboard/gameops/factorio/ -> HTTP 200 | skeleton shimmer blocks present
dashboard/argo-rn/          -> HTTP 200 | skeleton shimmer blocks present
dashboard/account/          -> HTTP 200 | skeleton shimmer blocks present
```

Astro compiles clean. Skeleton is SSR (no-JS baseline), so the fallback is guaranteed regardless of the island's hydration timing. Live skeleton→dashboard swap is visible on the deploy preview (local dev-server hydration blocked by the known worktree optimizeDeps churn, unrelated).

Same standard, now uniform across the RN-web surface.