### PR TITLE
fix(discordsh): /wm scripts hit the p/ run-type selector (fixes 'flow not found')

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/windmill.rs
@@ -150,7 +150,7 @@ impl WindmillConfig {
 
         let body = serde_json::json!({ "args": args, "discord": discord });
         let url = format!(
-            "{}/api/w/{}/jobs/run_wait_result/{}",
+            "{}/api/w/{}/jobs/run_wait_result/{RUN_KIND_SCRIPT}/{}",
             self.base_url.trim_end_matches('/'),
             self.workspace,
             path
@@ -179,6 +179,15 @@ impl WindmillConfig {
 /// blocks prefix-confusion (`f/discordshEVIL/...`). Bare `/wm` paths collapse
 /// into it; explicit paths outside it are rejected.
 const BOT_NAMESPACE: &str = "f/discordsh/";
+
+/// Windmill's `run_wait_result/{kind}/{path}` route reads the segment right
+/// after `run_wait_result/` as the run-TYPE selector — `p` for a script, `f`
+/// for a flow — SEPARATE from the storage path (which itself starts with the
+/// `f/` folder root). Every path the bot reaches is a `f/discordsh/*` script,
+/// so the selector is always `p`; sending the bare storage path made Windmill
+/// read its leading `f/` folder root as "run a flow" and 404 with
+/// `flow not found`. Flow support would add an `f` selector variant.
+const RUN_KIND_SCRIPT: &str = "p";
 
 /// Collapse a bare path into the bot namespace. A path already carrying an
 /// `f/` or `p/` kind prefix is returned unchanged (and later rejected by the
@@ -318,7 +327,7 @@ mod tests {
     async fn run_success_calls_windmill() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/poem"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/poem"))
             .and(header("authorization", "Bearer topsecret"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "ok": true,
@@ -343,7 +352,7 @@ mod tests {
     async fn run_collapses_bare_path_into_namespace() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/poem"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/poem"))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
@@ -426,7 +435,7 @@ mod tests {
     async fn run_strips_leading_slash() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/start"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/start"))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
@@ -442,7 +451,7 @@ mod tests {
     async fn run_rate_limited_second_call() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/foo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/foo"))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
@@ -463,7 +472,7 @@ mod tests {
     async fn run_upstream_error_propagates() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/foo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/foo"))
             .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
             .expect(1)
             .mount(&server)
@@ -531,7 +540,7 @@ mod tests {
     async fn run_body_contains_args_and_discord_context() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/w/kbve/jobs/run_wait_result/f/discordsh/echo"))
+            .and(path("/api/w/kbve/jobs/run_wait_result/p/f/discordsh/echo"))
             .respond_with(|req: &Request| {
                 let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
                 assert_eq!(body["discord"]["user_id"], "999");


### PR DESCRIPTION
## Problem

`/wm poem` returns:
```
windmill error: windmill upstream error: HTTP 404 Not Found: flow not found at name discordsh/poem (lib.rs:1823)
```

Windmill's `run_wait_result/{kind}/{path}` route reads the segment right after `run_wait_result/` as the **run-TYPE selector** — `p` = script, `f` = flow — which is **separate** from the storage path (that itself starts with the `f/` folder root).

The bot interpolated the bare storage path:
```rust
// before — windmill.rs
"{base}/api/w/{ws}/jobs/run_wait_result/{}"   // path = f/discordsh/poem
// → .../run_wait_result/f/discordsh/poem
```
Windmill read the leading `f/` of the storage path as "run a **flow**", leaving `discordsh/poem` as the flow name → `flow not found at name discordsh/poem`. (`lib.rs:1823` is Windmill's own source location, echoed back — there is no `lib.rs` in the bot.)

`poem` is a **script** (`kind: script`), so the correct URL is `.../run_wait_result/`**`p/`**`f/discordsh/poem`.

## Fix

Prepend the `p/` script run-type selector. Every path the bot can reach is namespace-gated to `f/discordsh/*` (all scripts today), so the selector is always `p`. Added `RUN_KIND_SCRIPT` const with a doc comment explaining the selector-vs-storage-path distinction; flow support would add an `f` variant later.

Updated the 6 baked-in test URLs that asserted the (incorrect) selector-less shape. `cargo test -p discordsh-bot windmill` → **38 passed, 0 failed**.

## Note — this alone does NOT make `/wm poem` work yet

There is a **second, independent** bug: `windmill-sync.yml` has never successfully pushed scripts to the live server (fails at `workspace add` with `Credentials or instance is invalid / fetch failed`), so `f/discordsh/poem` isn't on the server at all. Tracked in #14234. Both must land for `/wm poem` to succeed.