### PR TITLE
fix(kube): allow arc-runner egress to windmill-app:8000 (fixes windmill-sync)

### DIFF
--- a/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
+++ b/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
@@ -103,3 +103,20 @@ spec:
           ports:
               - port: 1234
                 protocol: TCP
+        # windmill-sync.yml → windmill-app (windmill-app.windmill.svc:8000) for
+        # `wmill sync push`. The public rule only opens 443/80/22 and excepts
+        # every private CIDR, so the in-cluster Windmill API (ClusterIP in
+        # 10.0.0.0/8, port 8000) is otherwise unreachable — `workspace add`
+        # dies with "fetch failed", which the CLI surfaces as "Credentials or
+        # instance is invalid". Scoped to the windmill-app pod in the windmill
+        # ns on 8000 only.
+        - to:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: windmill
+                podSelector:
+                    matchLabels:
+                        app.kubernetes.io/name: windmill-app
+          ports:
+              - port: 8000
+                protocol: TCP


### PR DESCRIPTION
## Root cause of #14234

`windmill-sync.yml` runs on `arc-runner-set-kbve` and every run failed at the `workspace add` step:
```
! Credentials or instance is invalid. Aborting.
fetch failed
```

Not the token, not the svc, not Kyverno. The `arc-runner-egress` NetworkPolicy (scoped to every runner pod via `actions.github.com/scale-set-name`) is **default-deny egress** and only re-allows:
- DNS, Valkey:6379, registry-mirror(-ghcr):5000, buildkitd:1234
- ports **443/80/22 to `0.0.0.0/0` with all RFC1918 excepted** (incl. `10.0.0.0/8`)

`windmill-app` is a **ClusterIP `10.104.120.95:8000`** — inside the excepted `10.0.0.0/8`, and port 8000 is in no allow rule. So runner→windmill egress is dropped → `fetch failed`. The CLI reports any failed fetch as "Credentials or instance is invalid," which is why it looked like a token problem.

### Verified in-cluster
A plain curl pod in `arc-runners` (no runner label → policy doesn't apply) reached `http://windmill-app.windmill.svc.cluster.local:8000/api/version` → **HTTP 200**. DNS + reachability are fine; only labeled runner pods are blocked. Confirms the netpol is the sole gate.

## Fix

Add one scoped egress rule: windmill-app pod in the `windmill` ns on **8000** only. Mirrors the existing valkey/registry-mirror allow idiom. Client-side `kubectl apply --dry-run` validates.

## Note

This unblocks the sync (Bug A). The independent bot run-type-selector fix (Bug B) is #14237. Both must land for `/wm poem` to work end to end. After this + #14237 merge to main, re-dispatch `windmill-sync.yml` to push `f/discordsh/poem`, then `/wm poem`.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)