### PR TITLE
fix(astro): resolveStaffFlag retries session token + drops stale-state clobber

### DIFF
--- a/packages/npm/astro/src/auth/bootAuth.ts
+++ b/packages/npm/astro/src/auth/bootAuth.ts
@@ -178,6 +178,31 @@ export async function bootAuth(
 	}
 }
 
+const STAFF_TOKEN_ATTEMPTS = 6;
+const STAFF_TOKEN_DELAY_MS = 300;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Poll the gateway for an access token. resolveStaffFlag is fired
+ * fire-and-forget right after bootAuth, so on a cold load the
+ * worker-backed session may not be hydrated yet. Retry a few times
+ * instead of giving up on the first empty read.
+ */
+async function waitForAccessToken(
+	gateway: SupabaseGateway,
+): Promise<string | null> {
+	for (let attempt = 0; attempt < STAFF_TOKEN_ATTEMPTS; attempt++) {
+		const session = await gateway.getSession().catch(() => null);
+		const token = session?.session?.access_token;
+		if (token) return token;
+		if (attempt < STAFF_TOKEN_ATTEMPTS - 1) {
+			await sleep(STAFF_TOKEN_DELAY_MS);
+		}
+	}
+	return null;
+}
+
 /**
  * Resolve staff permissions for the current authenticated user.
  * Calls the Supabase RPC `staff_permissions` and upgrades auth flags
@@ -193,14 +218,14 @@ export async function resolveStaffFlag(
 ): Promise<void> {
 	const state = $auth.get();
 	if (state.tone !== 'auth' || !state.id) return;
+	const userId = state.id;
 
 	// Cache fast path — apply STAFF synchronously if the bitmask is
 	// still fresh, so the UI doesn't flicker while the RPC is in flight.
-	applyStaffFlagFromCache(state.id);
+	applyStaffFlagFromCache(userId);
 
 	try {
-		const session = await gateway.getSession().catch(() => null);
-		const token = session?.session?.access_token;
+		const token = await waitForAccessToken(gateway);
 		if (!token) {
 			console.warn('[resolveStaffFlag] No access token available');
 			return;
@@ -227,16 +252,22 @@ export async function resolveStaffFlag(
 		const permissions = await res.json();
 		// staff_permissions returns an integer bitmask; any non-zero value means staff
 		if (typeof permissions === 'number') {
-			setStaffPermsCache(state.id, permissions);
+			setStaffPermsCache(userId, permissions);
 			if (permissions > 0) {
 				console.log(
 					'[resolveStaffFlag] Staff permissions resolved:',
 					permissions,
 				);
-				$auth.set({
-					...state,
-					flags: AuthPresets.STAFF,
-				});
+				// Re-read $auth after the await — the pre-fetch snapshot is
+				// stale and may clobber concurrent auth updates. Only upgrade
+				// if the same user is still authenticated.
+				const current = $auth.get();
+				if (current.tone === 'auth' && current.id === userId) {
+					$auth.set({
+						...current,
+						flags: AuthPresets.STAFF,
+					});
+				}
 			}
 		}
 	} catch {

--- a/packages/npm/astro/src/auth/resolveStaffFlag.spec.ts
+++ b/packages/npm/astro/src/auth/resolveStaffFlag.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	$auth,
+	AuthFlags,
+	AuthPresets,
+	hasAuthFlag,
+	clearStaffPermsCache,
+	type SupabaseGateway,
+} from '@kbve/droid';
+import { resolveStaffFlag } from './bootAuth';
+
+const URL = 'https://supabase.test';
+const KEY = 'anon-key';
+const USER = 'user-1';
+
+function authState(id = USER) {
+	$auth.set({
+		tone: 'auth',
+		flags: AuthPresets.USER,
+		name: 'n',
+		username: undefined,
+		avatar: undefined,
+		id,
+		error: undefined,
+	});
+}
+
+function gatewayWithToken(
+	tokenSequence: Array<string | null>,
+): SupabaseGateway {
+	let i = 0;
+	return {
+		getSession: vi.fn(async () => {
+			const token = tokenSequence[Math.min(i, tokenSequence.length - 1)];
+			i++;
+			return token ? { session: { access_token: token } } : null;
+		}),
+	} as unknown as SupabaseGateway;
+}
+
+function mockRpc(value: unknown, ok = true) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => ({
+			ok,
+			status: ok ? 200 : 403,
+			json: async () => value,
+		})),
+	);
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	clearStaffPermsCache();
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+	vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.runOnlyPendingTimers();
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('resolveStaffFlag', () => {
+	it('sets STAFF flag when RPC returns a non-zero bitmask', async () => {
+		authState();
+		mockRpc(0x40000001);
+		const gw = gatewayWithToken(['tok']);
+		await resolveStaffFlag(gw, URL, KEY);
+		expect(hasAuthFlag($auth.get().flags, AuthFlags.STAFF)).toBe(true);
+	});
+
+	it('does not set STAFF when RPC returns 0', async () => {
+		authState();
+		mockRpc(0);
+		const gw = gatewayWithToken(['tok']);
+		await resolveStaffFlag(gw, URL, KEY);
+		expect(hasAuthFlag($auth.get().flags, AuthFlags.STAFF)).toBe(false);
+	});
+
+	it('retries the session until a token hydrates (race fix)', async () => {
+		authState();
+		mockRpc(0x40000001);
+		const gw = gatewayWithToken([null, null, 'tok']);
+		const p = resolveStaffFlag(gw, URL, KEY);
+		await vi.advanceTimersByTimeAsync(1000);
+		await p;
+		expect(gw.getSession).toHaveBeenCalledTimes(3);
+		expect(hasAuthFlag($auth.get().flags, AuthFlags.STAFF)).toBe(true);
+	});
+
+	it('gives up after exhausting attempts when no token arrives', async () => {
+		authState();
+		mockRpc(0x40000001);
+		const gw = gatewayWithToken([null]);
+		const p = resolveStaffFlag(gw, URL, KEY);
+		await vi.advanceTimersByTimeAsync(3000);
+		await p;
+		expect(fetch).not.toHaveBeenCalled();
+		expect(hasAuthFlag($auth.get().flags, AuthFlags.STAFF)).toBe(false);
+	});
+
+	it('does not clobber a different user that signed in mid-flight', async () => {
+		authState('user-1');
+		mockRpc(0x40000001);
+		const gw = gatewayWithToken([null, 'tok']);
+		const p = resolveStaffFlag(gw, URL, KEY);
+		// Another user signs in while the RPC is in flight.
+		authState('user-2');
+		await vi.advanceTimersByTimeAsync(1000);
+		await p;
+		const state = $auth.get();
+		expect(state.id).toBe('user-2');
+		expect(hasAuthFlag(state.flags, AuthFlags.STAFF)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem
Staff-gated dashboard pages (e.g. `kbve.com/dashboard/gameops/mc/`) showed **Staff Access Required** even for confirmed superadmins, and stayed locked after clearing storage.

Root cause is in the **shared** staff-resolution primitive `resolveStaffFlag` (runs on every `initSupa` → covers all pages, so this is the single correct place to fix — no per-page duplication):

1. **No-token race, no retry.** `resolveStaffFlag` is fired fire-and-forget right after `bootAuth`. On a cold load the worker-backed Supabase session isn't hydrated yet, so `gateway.getSession()` returns no token — the function logged *"No access token available"* and **bailed with no retry**. With an empty `cache:staff:perms`, the STAFF flag was never set and the gate never opened. (Visiting the profile page appeared to "fix" it only because the session was warm by then.)
2. **Stale-state clobber.** It captured `$auth.get()` *before* the `await`, then wrote `{ ...state, flags: STAFF }` after — clobbering any concurrent auth update (e.g. a sign-in mid-flight).

## Fix (one place, all pages inherit)
- Poll the session for a token up to **6× / 300ms** (`waitForAccessToken`) before giving up.
- **Re-read `$auth` after the RPC await** and only upgrade if the same user is still authenticated.

## Test
New `resolveStaffFlag.spec.ts` (5 tests, fake timers): sets STAFF on non-zero bitmask; no STAFF on 0; **retries until the token hydrates**; gives up (no `fetch`) when no token arrives; **does not clobber** a different user who signed in mid-flight. All pass.

## Related
Companion to #14225 (clear-storage button actually wiping IndexedDB). Clearing storage exposed this latent race; both are needed for staff access to unlock reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)