### PR TITLE
fix(windmill): add folder.meta.yaml for f/discordsh (unblocks sync)

### DIFF
--- a/apps/windmill/f/discordsh/folder.meta.yaml
+++ b/apps/windmill/f/discordsh/folder.meta.yaml
@@ -1,0 +1,2 @@
+owners: []
+extra_perms: {}


### PR DESCRIPTION
## Context

With the runner egress fix (#14238) live, `windmill-sync.yml` now **reaches the Windmill server** (confirmed: `Remote version: CE v1.751.0`, `2 changes to apply`). But the dry-run then aborts:

```
Missing folder.meta.yaml for:
  - discordsh
Run 'wmill folder add-missing' to create them locally, then push again.
##[error]Process completed with exit code 1.
```

`windmill-cli sync push` requires a `folder.meta.yaml` for every folder under `apps/windmill/f/**`. The `discordsh` folder never had one.

## Fix

Add `apps/windmill/f/discordsh/folder.meta.yaml` (the `wmill folder add-missing` default: empty `owners` + `extra_perms`).

## Remaining

Dry-run also warns (non-fatal) about stale metadata on `f/discordsh/poem`; can be regenerated later with `wmill generate-metadata`. Not blocking.

After this merges to main → re-dispatch `windmill-sync.yml` → `f/discordsh/poem` publishes → `/wm poem` works (with the bot selector fix #14237 already merged).

Refs #14234