### PR TITLE
fix(rn): export NavItem from nav barrel (fixes axum-kbve Docker build #14236)

### DIFF
--- a/packages/npm/rn/src/ui/nav/NavItem.tsx
+++ b/packages/npm/rn/src/ui/nav/NavItem.tsx
@@ -1,0 +1,41 @@
+import { memo, useState } from 'react';
+import { Pressable } from 'react-native';
+import { tokens } from '../theme';
+import { Text } from '../primitives/Text';
+
+export interface NavItemProps {
+	label: string;
+	icon?: string;
+	active?: boolean;
+	onPress: () => void;
+	mode?: 'auto' | 'expanded' | 'compact';
+}
+
+export const NavItem = memo(function NavItem({
+	label,
+	active,
+	onPress,
+}: NavItemProps) {
+	const [hover, setHover] = useState(false);
+	const color =
+		active || hover ? tokens.color.primary : tokens.color.textMuted;
+
+	return (
+		<Pressable
+			accessibilityRole="link"
+			accessibilityLabel={label}
+			onPress={onPress}
+			onHoverIn={() => setHover(true)}
+			onHoverOut={() => setHover(false)}
+			style={{
+				flexDirection: 'row',
+				alignItems: 'center',
+				gap: tokens.space.xs,
+				paddingVertical: tokens.space.xs,
+			}}>
+			<Text style={{ fontSize: 15, fontWeight: '600', color }}>
+				{label}
+			</Text>
+		</Pressable>
+	);
+});

--- a/packages/npm/rn/src/ui/nav/index.ts
+++ b/packages/npm/rn/src/ui/nav/index.ts
@@ -4,3 +4,4 @@ export * from './TabBar';
 export * from './Footer';
 export * from './NavShell';
 export * from './NavBar';
+export * from './NavItem';


### PR DESCRIPTION
## Problem

CI `CI - Docker / axum-kbve` fails at the astro build stage:

```
[MISSING_EXPORT] "NavItem" is not exported by "packages/npm/rn/src/ui/index.ts"
```

Downstream symptom in the Dockerfile: astro build produces no `dist/askama/`, so [Dockerfile:228](apps/kbve/axum-kbve/Dockerfile#L228) `cp -a .../templates/dist/askama/.` fails with `No such file or directory` and NX e2e exits 1. Tracked in #14236.

## Cause

#14232 added `NavItem` to the `@kbve/rn/ui` re-export list in [rn-astro components.ts](packages/npm/rn-astro/src/components.ts), but `NavItem` existed only as `NavItem.web.tsx` and was **not** listed in [ui/nav/index.ts](packages/npm/rn/src/ui/nav/index.ts).

astro/vite resolves `@kbve/rn/ui` through the package `exports` map to the non-web `src/ui/index.ts` → `export * from './nav'` → `nav/index.ts`. NavBar/AppBar/TabBar work because the barrel re-exports them extensionless and vite's `.web.tsx` extension picks the web variant. NavItem was missing from the barrel entirely, and had no native `.tsx`.

## Fix

- Add native `packages/npm/rn/src/ui/nav/NavItem.tsx` (label-only, no `NavIcon.web` dependency), mirroring the NavBar native/web split.
- Add `export * from './NavItem'` to the nav barrel.

Web build resolves `./NavItem` → `NavItem.web.tsx` (extension priority); native → `NavItem.tsx`. No export clashes; `index.web.ts` path is unaffected.

Validation gate: the axum-kbve Docker astro build that currently fails.