### PR TITLE
fix(python-kbve): drop unused BuildContext import (flake8 F401)

### DIFF
--- a/packages/python/kbve/tests/test_nx_router.py
+++ b/packages/python/kbve/tests/test_nx_router.py
@@ -1,7 +1,7 @@
 import pytest
 
 from kbve.nx.router import ROUTES, Route, route, select, get
-from kbve.nx.builder import BuildContext, PlanResult, BuildResult
+from kbve.nx.builder import PlanResult, BuildResult
 
 
 @pytest.fixture


### PR DESCRIPTION
`nx run python-kbve:lint` failed:

```
./tests/test_nx_router.py:4:1: F401 'kbve.nx.builder.BuildContext' imported but unused
```

`BuildContext` was imported but never referenced in the test. Dropped it from the import (`PlanResult`, `BuildResult` are still used).

Verified: `flake8 kbve tests` → exit 0.