### PR TITLE
fix(windmill): add folder.meta.yaml for f/kilobase (unblocks sync)

### DIFF
--- a/apps/windmill/f/kilobase/folder.meta.yaml
+++ b/apps/windmill/f/kilobase/folder.meta.yaml
@@ -1,0 +1,2 @@
+owners: []
+extra_perms: {}


### PR DESCRIPTION
## Context

With egress (#14238), bot selector (#14237), and the discordsh folder meta (#14242) all merged, `windmill-sync.yml` now reaches the server and gets past discordsh — but hits the **next** missing folder meta:

```
remote (kbve) <- local: 7 changes to apply
Missing folder.meta.yaml for:
  - kilobase
##[error]Process completed with exit code 1.
```

`f/kilobase/` (S3-backup viewer scripts) was merged to main without a `folder.meta.yaml`. Every `apps/windmill/f/**` folder needs one.

## Fix

Add `apps/windmill/f/kilobase/folder.meta.yaml` (empty `owners` + `extra_perms`), same as #14242 did for discordsh.

## Verified (no deletion risk)

Queried the live workspace: remote has **0 folders** and **no `f/` scripts** (only `u/admin2/*`, which `includes: f/**` excludes). So `sync push` will **create** the discordsh + kilobase scripts, prune nothing. Nothing has been pushed yet — all prior runs failed before the push step.

## Follow-up worth considering

This is the 2nd missing-meta papercut. A tiny CI check (fail if any `apps/windmill/f/*/` lacks `folder.meta.yaml`) would stop new folders from landing without it.

Refs #14234