### PR TITLE
feat(windmill): /wm npm — live @kbve npm package embed

### DIFF
--- a/apps/windmill/f/discordsh/npm.script.yaml
+++ b/apps/windmill/f/discordsh/npm.script.yaml
@@ -1,0 +1,30 @@
+summary: List KBVE's maintained npm packages
+description: >-
+  /wm target. Fetches live metadata from the npm registry for the @kbve
+  packages we ship from the monorepo (packages/npm/*), sorted newest-publish
+  first. Optional first arg filters to a single package name (e.g. laser).
+  Bun runtime, no dependencies, fast cold start.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; args[0] optional package filter.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/npm.ts
+++ b/apps/windmill/f/discordsh/npm.ts
@@ -1,0 +1,102 @@
+type RegistryDoc = {
+  error?: string;
+  description?: string;
+  "dist-tags"?: Record<string, string>;
+  time?: Record<string, string>;
+  homepage?: string;
+};
+
+type PkgInfo = {
+  name: string;
+  version: string;
+  description: string;
+  published: number | null;
+  url: string;
+};
+
+const MAINTAINED = [
+  "chat",
+  "devops",
+  "droid",
+  "khashvault",
+  "laser",
+];
+
+const REGISTRY = "https://registry.npmjs.org";
+const NPM_COLOR = 0xcb3837;
+const DAY = 86_400_000;
+
+function ago(ts: number | null): string {
+  if (ts === null) return "unpublished";
+  const days = Math.floor((Date.now() - ts) / DAY);
+  if (days <= 0) return "today";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${(days / 365).toFixed(1)}y ago`;
+}
+
+async function fetchPkg(short: string): Promise<PkgInfo | null> {
+  const name = `@kbve/${short}`;
+  const resp = await fetch(`${REGISTRY}/${encodeURIComponent(name)}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!resp.ok) return null;
+
+  const doc = (await resp.json()) as RegistryDoc;
+  if (doc.error) return null;
+
+  const version = doc["dist-tags"]?.latest ?? "0.0.0";
+  const pubIso = doc.time?.[version];
+  return {
+    name,
+    version,
+    description: doc.description ?? "",
+    published: pubIso ? Date.parse(pubIso) : null,
+    url: `https://www.npmjs.com/package/${name}`,
+  };
+}
+
+export async function main(
+  args: string[] = [],
+  discord?: Record<string, unknown>,
+) {
+  const filter = args.join(" ").trim().toLowerCase();
+  const targets = filter
+    ? MAINTAINED.filter((p) => p.includes(filter.replace(/^@kbve\//, "")))
+    : MAINTAINED;
+
+  const settled = await Promise.all(targets.map(fetchPkg));
+  const pkgs = settled
+    .filter((p): p is PkgInfo => p !== null)
+    .sort((a, b) => (b.published ?? 0) - (a.published ?? 0));
+
+  if (pkgs.length === 0) {
+    throw new Error(
+      filter
+        ? `no maintained @kbve npm package matches "${filter}"`
+        : "no @kbve npm packages resolved from registry",
+    );
+  }
+
+  const fields = pkgs.map((p) => ({
+    name: `${p.name} \`${p.version}\``,
+    value: `${p.description || "—"}\n${ago(p.published)} · [npm](${p.url})`,
+    inline: false,
+  }));
+
+  const requestedBy = (discord?.username as string) ?? null;
+
+  return {
+    embed: {
+      title: "KBVE · maintained npm packages",
+      description:
+        "Live from the npm registry — packages we ship from the `kbve` monorepo (`packages/npm/*`).",
+      url: "https://www.npmjs.com/org/kbve",
+      color: NPM_COLOR,
+      fields,
+      footer: requestedBy
+        ? `npm registry • ${pkgs.length} shown • requested by ${requestedBy}`
+        : `npm registry • ${pkgs.length} shown`,
+    },
+  };
+}


### PR DESCRIPTION
## What

New `/wm npm` Windmill target: `f/discordsh/npm` (bun, zero-dep).

Fetches **live** npm-registry metadata for the maintained `@kbve` packages we ship from `packages/npm/*`, sorts newest-publish first, returns the generic embed contract.

- Packages: `chat`, `devops`, `droid`, `khashvault`, `laser` (dead/unpublished scaffolds excluded)
- `/wm npm laser` → optional first-arg filter to a single package
- Version + relative last-publish (`today`, `16d ago`, `2.1y ago`) + npm link per field

## Why one-off / no idle cost

Windmill script = trigger → run → exit. No scheduled cron, no long-poll flow, so zero idle CPU. Cost = execution time per `/wm npm` call only.

## No bot change needed

Path is under the existing `f/discordsh/*` allowlist and is a script (`p/` selector). Sync picks it up via `includes: f/**`. Go-live on merge → dev → main (windmill-sync triggers on push to main `apps/windmill/**`).

## Test

Ran `main()` locally under bun — embed renders, sorted newest-first, filter works.

Docs: https://kbve.com/application/discord/