### PR TITLE
feat(windmill): surface/tier workflow model + shared script core

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/windmill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/windmill.mdx
@@ -64,6 +64,8 @@ bento:
           href: '#kbve'
         - label: Deployment
           href: '#deploy'
+        - label: State & runs
+          href: '#state'
     aside:
         icon: route
         title: Code first, low-code second
@@ -101,6 +103,10 @@ bento:
           icon: deploy
           href: '#deploy'
           body: The monorepo-to-cluster sync pipeline, and what it took to ship /wm npm.
+        - title: State & Runs
+          icon: database
+          href: '#state'
+          body: Where Windmill keeps every job — the schema, the run tables, and the lifecycle of one execution.
     related:
         - title: n8n
           href: /application/n8n/
@@ -246,6 +252,8 @@ KBVE self-hosts Windmill on the cluster and drives it two ways: from **Discord**
 
 **Scripts live in the monorepo.** Every `/wm` target is a plain TypeScript file checked into `apps/windmill/` and written for the fast **Bun** runtime with zero dependencies. Each script returns a generic **embed contract** — a `{ embed: { title, description, fields, ... } }` object — and a single renderer in the bot turns that into a Discord message. Adding a new command is just adding a new script.
 
+**One core, many surfaces.** Scripts are organised by the surface that invokes them — `f/discordsh/*` for the Discord bot, `f/web/*` for the website dashboard — with reusable logic factored into a shared parent under `f/shared/*`. A surface script stays a thin wrapper: `f/discordsh/poem` and `f/web/poem` both import the same `fetchPoem()` from `f/shared/poem` and only differ in how they shape the result (a Discord embed versus a plain dashboard object). The logic lives once; each surface keeps its own tightly-scoped entry point.
+
 **Merge, and it syncs.** When a change to `apps/windmill/` lands on `main`, a CI job pushes the versioned scripts into the running Windmill workspace automatically — the repo is the source of truth, and going live is a merge, not a manual deploy.
 
 <Aside type="note">
@@ -279,6 +287,38 @@ Shipping a new `/wm` command is a **merge, not a manual deploy** — but a few p
 
 <Aside type="tip">
 The biggest lesson from the first go-live: a failed push surfaces as a vague *"credentials or instance is invalid"* even when the token is fine — the real cause was **network egress** and a **missing `folder.meta.yaml`**. Any new in-cluster service the runner must reach needs an explicit egress allow.
+</Aside>
+
+</BentoProse>
+
+<BentoProse id="state" eyebrow="Where runs live" heading="State & Runs">
+
+Windmill is **stateless in the container and stateful in Postgres** — there is no separate queue engine (no Redis, no Valkey). Every job, its arguments, its result, and its logs are rows in the database. For KBVE that database is our shared **Supabase Postgres**, and Windmill keeps all of its tables in a dedicated **`windmill` schema** so it never collides with app data.
+
+A single execution is identified by one **job id** (a UUID) and moves through three tables:
+
+| Table | Role in a run's lifecycle |
+| ----- | ------------------------- |
+| **`v2_job`** | The canonical record — created the moment a job is triggered. Holds the id, kind (`script` / `flow`), the runnable path, the caller, and the input args. |
+| **`v2_job_queue`** | The live queue — a row exists here only while the job is **pending or running**. Workers poll this table; when the job finishes the row is deleted. |
+| **`v2_job_completed`** | The terminal record — written when the job exits, carrying the **status** (`success` / `failure`), duration, completion time, and the result payload. |
+
+Log output streams to companion tables (`job_logs`, `job_result_stream_v2`), and per-run stats land in `job_stats` — all keyed off that same job id.
+
+**The lifecycle of one `/wm` run:**
+
+<Steps>
+
+1. **Trigger** — the Discord command calls the Windmill API. A row appears in `v2_job` (the args, the script path, who asked) and one in `v2_job_queue`.
+
+2. **Execute** — a worker claims the queued row, runs the script, and streams logs. For a lightweight `/wm` script this is a few hundred milliseconds.
+
+3. **Complete** — the worker deletes the `v2_job_queue` row and writes `v2_job_completed` with `status = success` and the duration. The result is returned to the bot, which renders the embed.
+
+</Steps>
+
+<Aside type="note">
+Because everything is a Postgres row, a run is fully auditable after the fact — you can trace any job id from `v2_job` (what ran) to `v2_job_completed` (how it ended) without the container being alive. That same durability is what lets the [dashboard workflows canvas](/dashboard/workflows/) reflect real execution state instead of a fire-and-forget call.
 </Aside>
 
 </BentoProse>

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -381,7 +381,9 @@ pub(crate) async fn require_dashboard_view(
     headers: &HeaderMap,
     service_name: &str,
 ) -> Result<(), Response> {
-    require_dashboard_view_with_query(headers, None, service_name).await
+    require_dashboard_view_with_query(headers, None, service_name)
+        .await
+        .map(|_| ())
 }
 
 /// Gate for sensitive proxy routes that need a higher privilege level than
@@ -455,7 +457,7 @@ async fn require_dashboard_view_with_query(
     headers: &HeaderMap,
     query: Option<&str>,
     service_name: &str,
-) -> Result<(), Response> {
+) -> Result<TokenInfo, Response> {
     let auth_token = match extract_auth_token(headers, query) {
         Some(t) => t,
         None => {
@@ -512,7 +514,7 @@ async fn require_dashboard_view_with_query(
             .into_response());
     }
 
-    Ok(())
+    Ok(token_info)
 }
 
 static GRAFANA: OnceLock<ServiceProxy> = OnceLock::new();
@@ -2029,12 +2031,72 @@ pub fn init_windmill_proxy() -> bool {
 /// Proxy for the Windmill dashboard canvas. Staff-gated at axum, then forwards
 /// the caller's Supabase token to windmill-gate, whose SSO bridge impersonates
 /// the user — so Windmill actions carry per-user attribution.
+/// Extract the runnable path from a Windmill job-run proxy path, if the request
+/// is an invocation. Returns the script/flow path (e.g. `f/web/poem`) so the
+/// proxy can enforce the surface boundary. Reads (poll result, scripts/list)
+/// return `None` and stay under the plain DASHBOARD_VIEW gate.
+fn windmill_runnable_path(proxy_path: &str) -> Option<&str> {
+    const MARKERS: [&str; 4] = [
+        "/jobs/run/p/",
+        "/jobs/run_wait_result/p/",
+        "/jobs/run/f/",
+        "/jobs/run_wait_result/f/",
+    ];
+    for marker in MARKERS {
+        if let Some(idx) = proxy_path.find(marker) {
+            return Some(&proxy_path[idx + marker.len()..]);
+        }
+    }
+    None
+}
+
 pub async fn windmill_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
     let headers = req.headers().clone();
     let raw_query = req.uri().query().map(|q| q.to_string());
 
-    if let Err(resp) = require_dashboard_view(&headers, "Windmill").await {
-        return resp;
+    let token_info =
+        match require_dashboard_view_with_query(&headers, raw_query.as_deref(), "Windmill").await {
+            Ok(info) => info,
+            Err(resp) => return resp,
+        };
+
+    // The windmill folder is the hardened invocation boundary. A browser may
+    // only run scripts under `f/web/*`; `f/web/staff/*` additionally requires
+    // DASHBOARD_MANAGE. Everything else (f/discordsh/*, f/shared/*,
+    // f/kilobase/*, u/*) is rejected — those surfaces are never browser-invoked.
+    if let Some(runnable) = path.as_ref().and_then(|Path(p)| windmill_runnable_path(p)) {
+        if !runnable.starts_with("f/web/") {
+            warn!(
+                user_id = %token_info.user_id,
+                runnable,
+                "Windmill proxy blocked invoke outside f/web/*"
+            );
+            return (
+                StatusCode::FORBIDDEN,
+                axum::Json(json!({
+                    "error": "Access restricted",
+                    "message": "This workflow is not invocable from the dashboard"
+                })),
+            )
+                .into_response();
+        }
+        if runnable.starts_with("f/web/staff/")
+            && !token_info.has_permission(staff_perm::DASHBOARD_MANAGE)
+        {
+            warn!(
+                user_id = %token_info.user_id,
+                runnable,
+                "Windmill proxy blocked staff workflow — missing DASHBOARD_MANAGE"
+            );
+            return (
+                StatusCode::FORBIDDEN,
+                axum::Json(json!({
+                    "error": "Access restricted",
+                    "message": "This workflow requires staff access"
+                })),
+            )
+                .into_response();
+        }
     }
 
     let token = match extract_auth_token(&headers, raw_query.as_deref()) {

--- a/apps/windmill/f/discordsh/poem.ts
+++ b/apps/windmill/f/discordsh/poem.ts
@@ -1,43 +1,18 @@
-type Poem = {
-  title: string;
-  author: string;
-  lines: string[];
-  linecount: string;
-};
+import { fetchPoem } from "../shared/poem.ts";
 
-type PoetryDbError = { status: number; reason: string };
-
-const BASE = "https://poetrydb.org";
-const MAX_LINES = 24;
 const POEM_COLOR = 0x8957e5;
 
 export async function main(
   args: string[] = [],
   discord?: Record<string, unknown>,
 ) {
-  const author = args.join(" ").trim();
-  const url = author
-    ? `${BASE}/author/${encodeURIComponent(author)}`
-    : `${BASE}/random/1`;
-
-  const resp = await fetch(url, { headers: { accept: "application/json" } });
-  if (!resp.ok) {
-    throw new Error(`poetrydb ${resp.status}: ${await resp.text()}`);
-  }
-
-  const data = (await resp.json()) as Poem[] | PoetryDbError;
-  if (!Array.isArray(data)) {
-    throw new Error(`no poems found${author ? ` for author "${author}"` : ""}`);
-  }
-
-  const poem = data[Math.floor(Math.random() * data.length)];
-  const lines = poem.lines.slice(0, MAX_LINES);
+  const poem = await fetchPoem(args.join(" ").trim());
   const requestedBy = (discord?.username as string) ?? null;
 
   return {
     embed: {
       title: poem.title,
-      description: lines.join("\n"),
+      description: poem.lines.join("\n"),
       color: POEM_COLOR,
       author: poem.author,
       footer: requestedBy

--- a/apps/windmill/f/shared/folder.meta.yaml
+++ b/apps/windmill/f/shared/folder.meta.yaml
@@ -1,0 +1,2 @@
+owners: []
+extra_perms: {}

--- a/apps/windmill/f/shared/poem.script.yaml
+++ b/apps/windmill/f/shared/poem.script.yaml
@@ -1,0 +1,18 @@
+summary: Fetch a poem from PoetryDB (shared core)
+description: >-
+  Shared library parent. Exports fetchPoem() imported by the surface wrappers
+  (f/discordsh/poem, f/web/poem). SYSTEM tier — never invoked directly from a
+  browser; the proxy rejects any browser call outside f/web/*. Bun, no deps.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - author
+  properties:
+    author:
+      type: string
+      description: Optional author name; blank returns a random poem.
+      default: ''
+  required: []

--- a/apps/windmill/f/shared/poem.ts
+++ b/apps/windmill/f/shared/poem.ts
@@ -1,0 +1,35 @@
+export type Poem = {
+  title: string;
+  author: string;
+  lines: string[];
+  linecount: string;
+};
+
+type PoetryDbError = { status: number; reason: string };
+
+const BASE = "https://poetrydb.org";
+const MAX_LINES = 24;
+
+export async function fetchPoem(author = ""): Promise<Poem> {
+  const who = author.trim();
+  const url = who
+    ? `${BASE}/author/${encodeURIComponent(who)}`
+    : `${BASE}/random/1`;
+
+  const resp = await fetch(url, { headers: { accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`poetrydb ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as Poem[] | PoetryDbError;
+  if (!Array.isArray(data)) {
+    throw new Error(`no poems found${who ? ` for author "${who}"` : ""}`);
+  }
+
+  const poem = data[Math.floor(Math.random() * data.length)];
+  return { ...poem, lines: poem.lines.slice(0, MAX_LINES) };
+}
+
+export async function main(author = ""): Promise<Poem> {
+  return fetchPoem(author);
+}

--- a/apps/windmill/f/web/folder.meta.yaml
+++ b/apps/windmill/f/web/folder.meta.yaml
@@ -1,0 +1,2 @@
+owners: []
+extra_perms: {}

--- a/apps/windmill/f/web/poem.script.yaml
+++ b/apps/windmill/f/web/poem.script.yaml
@@ -1,0 +1,18 @@
+summary: Fetch a poem from PoetryDB (web dashboard)
+description: >-
+  Web-surface wrapper for the workflows canvas. Imports fetchPoem() from the
+  shared core and returns a plain dashboard shape. USER tier — the proxy allows
+  browser invokes under f/web/*. Bun, no dependencies.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - author
+  properties:
+    author:
+      type: string
+      description: Optional author name; blank returns a random poem.
+      default: ''
+  required: []

--- a/apps/windmill/f/web/poem.ts
+++ b/apps/windmill/f/web/poem.ts
@@ -1,0 +1,11 @@
+import { fetchPoem } from "../shared/poem.ts";
+
+export async function main(author = "") {
+  const poem = await fetchPoem(author);
+  return {
+    title: poem.title,
+    author: poem.author,
+    lines: poem.lines,
+    linecount: poem.lines.length,
+  };
+}

--- a/packages/data/codegen/workflow-zod-config.json
+++ b/packages/data/codegen/workflow-zod-config.json
@@ -17,6 +17,12 @@
 			"stripPrefix": "WORKFLOW_TIER_",
 			"caseTransform": "lowercase",
 			"skipUnspecified": true
+		},
+		"kbve.workflow.Surface": {
+			"mode": "const_array",
+			"stripPrefix": "SURFACE_",
+			"caseTransform": "lowercase",
+			"skipUnspecified": true
 		}
 	},
 
@@ -38,6 +44,12 @@
 			"sourceEnum": "kbve.workflow.WorkflowTier",
 			"typeName": "WorkflowTierValue",
 			"zodSchemaName": "WorkflowTierSchema"
+		},
+		{
+			"name": "Surfaces",
+			"sourceEnum": "kbve.workflow.Surface",
+			"typeName": "SurfaceValue",
+			"zodSchemaName": "SurfaceSchema"
 		}
 	]
 }

--- a/packages/data/proto/kbve/workflow.proto
+++ b/packages/data/proto/kbve/workflow.proto
@@ -21,6 +21,21 @@ enum Backend {
   BACKEND_WINDMILL    = 3;  // Windmill script/flow
 }
 
+// Which surface invokes a workflow. Orthogonal to WorkflowTier: a DISCORD and
+// a WEB script can both be USER-tier. Mirrors the windmill folder the script
+// lives in — the folder is the hardened invocation boundary, this enum is the
+// display/routing hint.
+//   DISCORD → f/discordsh/*  (bot /wm only)
+//   WEB     → f/web/*        (dashboard canvas only)
+//   SHARED  → f/shared/*     (a library parent imported by surface wrappers,
+//                             never invoked directly from a browser)
+enum Surface {
+  SURFACE_UNSPECIFIED = 0;
+  SURFACE_DISCORD     = 1;
+  SURFACE_WEB         = 2;
+  SURFACE_SHARED      = 3;
+}
+
 // Live status of a node on the canvas.
 enum NodeStatus {
   NODE_STATUS_UNSPECIFIED = 0;
@@ -30,23 +45,29 @@ enum NodeStatus {
   NODE_STATUS_ERR         = 4;
 }
 
-// Access tier — mirrors the Windmill sub-namespace gate for UX only; the
-// backend proxy is the real boundary.
-//   USER  → f/app/user/*  (any authenticated caller)
-//   STAFF → f/app/staff/* (is_staff)
+// Access tier for UX gating on the canvas. The backend proxy is the REAL
+// boundary and enforces by windmill path prefix — it never trusts this field.
+//   USER   → f/web/*        (any authenticated caller)
+//   STAFF  → f/web/staff/*  (is_staff)
+//   SYSTEM → internal only  (f/shared/*, f/kilobase/*) — never proxied to a
+//            browser; a browser invoke of a SYSTEM path is rejected outright.
 enum WorkflowTier {
   WORKFLOW_TIER_UNSPECIFIED = 0;
   WORKFLOW_TIER_USER        = 1;
   WORKFLOW_TIER_STAFF       = 2;
+  WORKFLOW_TIER_SYSTEM      = 3;
 }
 
 // A single registry entry — a friendly key mapped to a concrete backend ref.
+// `path` is the ONE source of truth for what actually runs; `tier` and
+// `surface` are presentation metadata the dashboard filters/gates on for UX.
 message WorkflowDef {
   string key = 1;            // stable friendly id, e.g. "poem"
   Backend backend = 2;       // which executor runs it
   string path = 3;           // backend-specific ref (windmill script path, edge fn name)
-  WorkflowTier tier = 4;     // access tier for UX gating
-  string label = 5;          // human label for the canvas
+  WorkflowTier tier = 4;     // access tier for UX gating (proxy enforces by path)
+  Surface surface = 5;       // which surface this entry is exposed on
+  string label = 6;          // human label for the canvas
 }
 
 // The full set of workflows exposed to the dashboard.

--- a/packages/npm/rn/src/workflows/constants.ts
+++ b/packages/npm/rn/src/workflows/constants.ts
@@ -5,8 +5,9 @@ export const WORKFLOWS: readonly WorkflowDef[] = [
 	{
 		key: 'poem',
 		backend: 'windmill',
-		path: 'f/app/user/poem',
+		path: 'f/web/poem',
 		tier: 'user',
+		surface: 'web',
 		label: 'Poem',
 	},
 ].map((w) => WorkflowDefSchema.parse(w));

--- a/packages/npm/rn/src/workflows/generated/workflow-schema.ts
+++ b/packages/npm/rn/src/workflows/generated/workflow-schema.ts
@@ -32,11 +32,22 @@ export const NodeStatusSchema = z.enum(NodeStatuses);
 export const WorkflowTiers = [
 	'user',
 	'staff',
+	'system',
 ] as const;
 
 export type WorkflowTierValue = (typeof WorkflowTiers)[number];
 
 export const WorkflowTierSchema = z.enum(WorkflowTiers);
+
+export const Surfaces = [
+	'discord',
+	'web',
+	'shared',
+] as const;
+
+export type SurfaceValue = (typeof Surfaces)[number];
+
+export const SurfaceSchema = z.enum(Surfaces);
 
 // WorkflowDef
 export const WorkflowDefSchema = z
@@ -45,6 +56,7 @@ export const WorkflowDefSchema = z
 		backend: BackendSchema,
 		path: z.string(),
 		tier: WorkflowTierSchema,
+		surface: SurfaceSchema,
 		label: z.string(),
 	});
 

--- a/packages/npm/rn/src/workflows/index.ts
+++ b/packages/npm/rn/src/workflows/index.ts
@@ -7,17 +7,21 @@ export {
 	Backends,
 	NodeStatuses,
 	WorkflowTiers,
+	Surfaces,
 	BackendSchema,
 	NodeStatusSchema,
 	WorkflowTierSchema,
+	SurfaceSchema,
 	WorkflowDefSchema,
 	WorkflowRegistrySchema,
 } from './generated/workflow-schema';
 export type {
 	Backend,
 	NodeStatus,
+	Surface,
 	WorkflowDef,
 	WorkflowTierValue,
+	SurfaceValue,
 	WorkflowNode,
 	WorkflowsState,
 } from './types';

--- a/packages/npm/rn/src/workflows/types.ts
+++ b/packages/npm/rn/src/workflows/types.ts
@@ -1,14 +1,17 @@
 import type {
 	BackendValue,
 	NodeStatusValue,
+	SurfaceValue,
 } from './generated/workflow-schema';
 
 export type Backend = BackendValue;
 export type NodeStatus = NodeStatusValue;
+export type Surface = SurfaceValue;
 
 export type {
 	WorkflowDef,
 	WorkflowTierValue,
+	SurfaceValue,
 } from './generated/workflow-schema';
 
 export interface WorkflowNode {


### PR DESCRIPTION
## What

Follow-up to #14257. Wires the `/dashboard/workflows/` canvas to Windmill and evolves the shared contract so scripts scale across surfaces without logic duplication.

### Proto (`workflow.proto`)
- New **`Surface`** enum — `discord` / `web` / `shared`. Orthogonal to `WorkflowTier`: a Discord and a web script can both be user-tier.
- New **`WORKFLOW_TIER_SYSTEM`** — internal-only, never proxied to a browser.
- `surface` field on `WorkflowDef`. Doc rewritten to state: **the windmill path is the enforced boundary; tier/surface are display metadata.**
- Regenerated zod (`workflow-schema.ts`) + config by hand (worktree has no node_modules) — **CI must re-run `nx run data-proto:generate` to confirm parity.**

### Windmill scripts — one core, many surfaces
- `f/shared/poem` — reusable `fetchPoem()` core (SYSTEM tier).
- `f/discordsh/poem` + `f/web/poem` — thin wrappers importing the core, differing only in output shape (Discord embed vs dashboard object).
- No logic duplication; each surface keeps a tightly-scoped folder.

### Dashboard + proxy
- Registry `poem` repointed to the real **`f/web/poem`** (was a dead `f/app/user/poem` → would 404).
- `windmill_proxy_handler` now enforces the browser invocation boundary by path: only `f/web/**` is runnable, `f/web/staff/**` requires `DASHBOARD_MANAGE`, everything else (discordsh/shared/kilobase) is rejected. Makes the proto's "proxy is the real boundary" true. View-gate refactored to return `TokenInfo`; all other callers use `if let Err` so are unaffected.

### Docs
- New **State & Runs** section (windmill schema, `v2_job`/`v2_job_queue`/`v2_job_completed` lifecycle).
- Surface / shared-core architecture note.

## Verify before merge
Worktree has no node_modules — none of these ran locally:
- [ ] `nx run data-proto:generate` — regen zod+buf, confirm hand-edited schema matches
- [ ] `nx test` rn workflows — vitest (registry now requires `surface`)
- [ ] `cargo check` axum-kbve — proxy edit
- [ ] Windmill sync (`f/**`) bundles cross-folder relative import `../shared/poem.ts` at deploy

Docs: https://kbve.com/application/windmill/