### PR TITLE
ci(content): auto-merge daily content route PRs

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -176,13 +176,15 @@ jobs:
                       const choreMatch = title.match(/^chore\(([a-zA-Z0-9_-]+)\):\s+update version\.toml to (\d+\.\d+\.\d+)/);
                       const deployMatch = title.match(/^deploy\(([a-zA-Z0-9_-]+)\):/);
                       const manifestSyncMatch = title.match(/^chore\(ci\):\s+sync ci-dispatch-manifest$/);
+                      const contentMatch = title.match(/^chore\(content\):\s+daily\s+([a-z0-9-]+)\s+scaffold$/);
 
-                      if (!atomicMatch && !choreMatch && !deployMatch && !manifestSyncMatch) {
+                      if (!atomicMatch && !choreMatch && !deployMatch && !manifestSyncMatch && !contentMatch) {
                         core.setFailed(
                           `Title '${title}' does not match "Atomic: <app> v<semver> ...", ` +
                           `"chore(<pkg>): update version.toml to <semver>", ` +
                           `"deploy(<scope>): ...", ` +
-                          `or "chore(ci): sync ci-dispatch-manifest" — aborting.`
+                          `"chore(ci): sync ci-dispatch-manifest", ` +
+                          `or "chore(content): daily <route> scaffold" — aborting.`
                         );
                         return;
                       }
@@ -271,7 +273,7 @@ jobs:
                           ['.github/ci-dispatch-manifest.json'].map(sanitize)
                         );
                         blocked = changedFiles.filter(f => !allowedFiles.has(f));
-                      } else {
+                      } else if (deployMatch) {
                         // --- Path B: deploy PRs (path-prefix-validated) ---
                         // Allowed deploy scopes and their permitted file prefixes.
                         // Each scope maps to a directory — all files must be under it.
@@ -294,6 +296,24 @@ jobs:
                         core.info(`[deploy] Allowed prefix: '${allowedPrefix}'`);
 
                         blocked = changedFiles.filter(f => !f.startsWith(allowedPrefix));
+                      } else {
+                        // --- Path D: daily content routes (path-prefix-validated) ---
+                        // kbve.nx router→builder (ci-daily-content.yml) generates docs
+                        // MDX + companion JSON. All changed files must live under the
+                        // content docs tree or the public nx-data dir — nothing else.
+                        const route = contentMatch[1];
+                        appName = `content:${route}`;
+                        core.info(`[content] Extracted route: '${route}'`);
+
+                        const allowedPrefixes = [
+                          'apps/kbve/astro-kbve/src/content/docs/',
+                          'apps/kbve/astro-kbve/public/data/nx/',
+                        ];
+                        core.info(`[content] Allowed prefixes: ${allowedPrefixes.join(', ')}`);
+
+                        blocked = changedFiles.filter(
+                          f => !allowedPrefixes.some(p => f.startsWith(p))
+                        );
                       }
                       if (blocked.length > 0) {
                         core.setFailed(

--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -18,6 +18,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
+    actions: write
 
 concurrency:
     group: daily-content
@@ -153,6 +154,7 @@ jobs:
                     --content-root "$GITHUB_WORKSPACE/apps/kbve/astro-kbve/src/content/docs"
 
             - name: Create PR
+              id: pr
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -170,9 +172,21 @@ jobs:
                   git commit -m "chore(content): daily ${{ matrix.route }} scaffold [skip ci]"
                   git push origin "${BRANCH}"
 
-                  gh pr create \
+                  PR_URL=$(gh pr create \
                     --base dev \
                     --head "${BRANCH}" \
                     --title "chore(content): daily ${{ matrix.route }} scaffold" \
-                    --body "Automated daily content update for route \`${{ matrix.route }}\`. Review and fill in before merge." \
-                    --label "auto-pr"
+                    --body "Automated daily content update for route \`${{ matrix.route }}\`." \
+                    --label "auto-pr")
+
+                  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+                  echo "Created PR #${PR_NUM}"
+                  echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+            - name: Dispatch auto-merge
+              if: steps.pr.outputs.pr_number != ''
+              uses: ./.github/actions/dispatch-auto-merge
+              with:
+                  pr_number: ${{ steps.pr.outputs.pr_number }}
+                  ref: dev
+                  github_token: ${{ github.token }}


### PR DESCRIPTION
## What

Enables **auto-approve + squash-merge** for the daily content route PRs (journal/graph/security) produced by `ci-daily-content.yml` — bringing stage-3 auto-merge forward so the router→builder system runs fully end-to-end.

## Changes

**`ci-daily-content.yml`** (builder job):
- Capture the PR number from `gh pr create`, then a `Dispatch auto-merge` step invokes `./.github/actions/dispatch-auto-merge` with **`ref: dev`** (so it runs the *dev* validator, which has the new content pattern below — not main's).
- Adds `actions: write` (needed for the workflow-dispatch API call).

**`ci-auto-merge-bot-prs.yml`** (validator):
- New fifth accepted title pattern: `chore(content): daily <route> scaffold`.
- **Tight path-prefix allowlist** — every changed file must live under `apps/kbve/astro-kbve/src/content/docs/` or `apps/kbve/astro-kbve/public/data/nx/`. Anything else blocks the merge. Mirrors the existing `deploy(<scope>)` prefix precedent.
- Unchanged gates still apply: author must be `github-actions[bot]`, base `dev`, label `auto-pr`.

## Safety

Validator decision simulated across cases:
- `daily graph/security/journal scaffold` + in-prefix files → **APPROVE**
- content title + a `.github/…` or `packages/…` file → **REJECT (blocked)**
- non-matching title → **REJECT**

No auto-merge for anything outside the two content prefixes.

## Note

This PR touches workflow files (outside the content allowlist) so it does **not** self-merge — it needs a manual review + merge. Once merged to `dev`, the daily content routes (and the E2E validation dispatches) auto-merge as designed.