### PR TITLE
feat(windmill): /wm ud + urbandictionary + self-listing /wm help menu

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -5,10 +5,14 @@ use crate::discord::bot::{Context, Error};
 use crate::discord::windmill::{DiscordContext, split_args};
 use crate::discord::windmill_embed;
 
+/// Windmill script run when `/wm` is invoked with no script name — renders the
+/// self-listing command menu (`f/discordsh/help`).
+const WM_INDEX_PATH: &str = "help";
+
 #[poise::command(slash_command, rename = "wm")]
 pub async fn wm(
     ctx: Context<'_>,
-    #[description = "Script name (e.g. poem) → f/discordsh/; only the f/discordsh/ folder is reachable"] wm_path: String,
+    #[description = "Script name (e.g. poem) → f/discordsh/; blank lists every command"] wm_path: Option<String>,
     #[description = "Space-separated args"] args: Option<String>,
 ) -> Result<(), Error> {
     let Some(cfg) = ctx.data().app.windmill.clone() else {
@@ -21,6 +25,10 @@ pub async fn wm(
         return Ok(());
     };
 
+    let wm_path = wm_path
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| WM_INDEX_PATH.to_owned());
     let args = args.map(|s| split_args(&s)).unwrap_or_default();
     let path_for_log = wm_path.clone();
     let arg_count = args.len();

--- a/apps/kbve/astro-kbve/src/content/docs/application/windmill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/windmill.mdx
@@ -247,10 +247,16 @@ KBVE self-hosts Windmill on the cluster and drives it two ways: from **Discord**
 
 | Command | What it does |
 | ------- | ------------ |
+| `/wm` | With no script name, lists every available command — see [the index below](#index) |
 | `/wm poem` | Fetches a random poem from PoetryDB — `/wm poem Emily Dickinson` filters by author |
 | `/wm npm` | Lists the maintained `@kbve` npm packages live from the registry — `/wm npm laser` filters to one |
+| `/wm ud` | Defines a term via Urban Dictionary — `/wm ud yeet`; `/wm urbandictionary` is a long-form alias |
 
 **Scripts live in the monorepo.** Every `/wm` target is a plain TypeScript file checked into `apps/windmill/` and written for the fast **Bun** runtime with zero dependencies. Each script returns a generic **embed contract** — a `{ embed: { title, description, fields, ... } }` object — and a single renderer in the bot turns that into a Discord message. Adding a new command is just adding a new script.
+
+<span id="index" />
+
+**A self-listing menu.** Invoking `/wm` with no script name runs `f/discordsh/help`, which queries Windmill's own scripts API (`scripts/list`, scoped to the `f/discordsh/` folder) and renders each surface script's `summary` as an embed field. The menu is **self-updating** — the moment a new command syncs into the workspace it appears in `/wm`, with no bot rebuild. The bot simply substitutes the `help` path when the slash-command argument is blank; the listing itself is a script like any other, so it uses the job-scoped `WM_TOKEN` and reaches the API over the cluster-internal address.
 
 **One core, many surfaces.** Scripts are organised by the surface that invokes them — `f/discordsh/*` for the Discord bot, `f/web/*` for the website dashboard — with reusable logic factored into a shared parent under `f/shared/*`. A surface script stays a thin wrapper: `f/discordsh/poem` and `f/web/poem` both import the same `fetchPoem()` from `f/shared/poem` and only differ in how they shape the result (a Discord embed versus a plain dashboard object). The logic lives once; each surface keeps its own tightly-scoped entry point.
 

--- a/apps/windmill/f/discordsh/help.script.yaml
+++ b/apps/windmill/f/discordsh/help.script.yaml
@@ -1,0 +1,30 @@
+summary: List every available /wm command
+description: >-
+  /wm index. Queries the Windmill scripts API for the f/discordsh/ folder and
+  renders each surface script's summary as an embed — the menu bare /wm shows.
+  Self-updating: a new command appears here the moment its script syncs, no bot
+  rebuild. Uses the job-scoped WM_TOKEN. Bun runtime, no dependencies.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Ignored; present so the bot's generic {args, discord} call shape works.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/help.ts
+++ b/apps/windmill/f/discordsh/help.ts
@@ -1,0 +1,73 @@
+type ScriptListing = {
+  path: string;
+  summary?: string;
+};
+
+const HELP_COLOR = 0x5865f2;
+const NAMESPACE = "f/discordsh/";
+
+const HIDDEN = new Set(["help", "index"]);
+
+function baseUrl(): string {
+  return (
+    process.env.BASE_INTERNAL_URL ??
+    process.env.BASE_URL ??
+    "http://localhost:8000"
+  ).replace(/\/$/, "");
+}
+
+async function listCommands(): Promise<ScriptListing[]> {
+  const token = process.env.WM_TOKEN;
+  const workspace = process.env.WM_WORKSPACE ?? "kbve";
+  if (!token) throw new Error("WM_TOKEN not available to help script");
+
+  const url =
+    `${baseUrl()}/api/w/${workspace}/scripts/list` +
+    `?path_start=${encodeURIComponent(NAMESPACE)}&per_page=200`;
+
+  const resp = await fetch(url, {
+    headers: { accept: "application/json", authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    throw new Error(`scripts/list ${resp.status}: ${await resp.text()}`);
+  }
+  return (await resp.json()) as ScriptListing[];
+}
+
+export async function main(
+  _args: string[] = [],
+  discord?: Record<string, unknown>,
+) {
+  const scripts = await listCommands();
+
+  const commands = scripts
+    .map((s) => ({ name: s.path.slice(NAMESPACE.length), summary: s.summary }))
+    .filter((c) => c.name && !c.name.includes("/") && !HIDDEN.has(c.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (commands.length === 0) {
+    throw new Error("no /wm commands resolved from the workspace");
+  }
+
+  const fields = commands.map((c) => ({
+    name: `/wm ${c.name}`,
+    value: c.summary?.trim() || "—",
+    inline: false,
+  }));
+
+  const requestedBy = (discord?.username as string) ?? null;
+
+  return {
+    embed: {
+      title: "KBVE · /wm commands",
+      description:
+        "Run any of these with `/wm <name>`. Most take optional args — " +
+        "`/wm poem Emily Dickinson`, `/wm ud yeet`, `/wm npm laser`.",
+      color: HELP_COLOR,
+      fields,
+      footer: requestedBy
+        ? `${commands.length} commands • requested by ${requestedBy}`
+        : `${commands.length} commands`,
+    },
+  };
+}

--- a/apps/windmill/f/discordsh/ud.script.yaml
+++ b/apps/windmill/f/discordsh/ud.script.yaml
@@ -1,0 +1,29 @@
+summary: Define a term via Urban Dictionary
+description: >-
+  /wm target. Fetches the top-voted Urban Dictionary definition for a term —
+  /wm ud yeet. Blank returns a random entry. Aliased by /wm urbandictionary.
+  Bun runtime, no dependencies, fast cold start.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; joined into the term to define.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/ud.ts
+++ b/apps/windmill/f/discordsh/ud.ts
@@ -1,0 +1,35 @@
+import { fetchDefinition } from "../shared/urban.ts";
+
+const UD_COLOR = 0x1d2439;
+
+export async function main(
+  args: string[] = [],
+  discord?: Record<string, unknown>,
+) {
+  const entry = await fetchDefinition(args.join(" ").trim());
+  const requestedBy = (discord?.username as string) ?? null;
+
+  const fields = [];
+  if (entry.example) {
+    fields.push({ name: "Example", value: entry.example, inline: false });
+  }
+  fields.push({
+    name: "Votes",
+    value: `👍 ${entry.thumbsUp} · 👎 ${entry.thumbsDown}`,
+    inline: false,
+  });
+
+  return {
+    embed: {
+      title: entry.word,
+      description: entry.definition,
+      url: entry.permalink,
+      color: UD_COLOR,
+      author: entry.author ? `by ${entry.author}` : undefined,
+      fields,
+      footer: requestedBy
+        ? `Urban Dictionary • requested by ${requestedBy}`
+        : "Urban Dictionary",
+    },
+  };
+}

--- a/apps/windmill/f/discordsh/urbandictionary.script.yaml
+++ b/apps/windmill/f/discordsh/urbandictionary.script.yaml
@@ -1,0 +1,28 @@
+summary: Define a term via Urban Dictionary (alias of ud)
+description: >-
+  /wm target. Long-form alias for /wm ud — re-exports the same handler so
+  /wm urbandictionary yeet works identically. Bun runtime, no dependencies.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; joined into the term to define.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/urbandictionary.ts
+++ b/apps/windmill/f/discordsh/urbandictionary.ts
@@ -1,0 +1,1 @@
+export { main } from "./ud.ts";

--- a/apps/windmill/f/shared/urban.script.yaml
+++ b/apps/windmill/f/shared/urban.script.yaml
@@ -1,0 +1,19 @@
+summary: Fetch a definition from Urban Dictionary (shared core)
+description: >-
+  Shared library parent. Exports fetchDefinition() imported by the surface
+  wrappers (f/discordsh/ud, f/discordsh/urbandictionary). SYSTEM tier — never
+  invoked directly from a browser; the proxy rejects any browser call outside
+  f/web/*. Bun, no deps.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - term
+  properties:
+    term:
+      type: string
+      description: Term to define; blank returns a random entry.
+      default: ''
+  required: []

--- a/apps/windmill/f/shared/urban.ts
+++ b/apps/windmill/f/shared/urban.ts
@@ -1,0 +1,64 @@
+export type UrbanEntry = {
+  word: string;
+  definition: string;
+  example: string;
+  author: string;
+  permalink: string;
+  thumbsUp: number;
+  thumbsDown: number;
+};
+
+type UrbanApiEntry = {
+  word: string;
+  definition: string;
+  example: string;
+  author: string;
+  permalink: string;
+  thumbs_up: number;
+  thumbs_down: number;
+};
+
+type UrbanApiResponse = { list: UrbanApiEntry[] };
+
+const BASE = "https://api.urbandictionary.com/v0";
+const MAX_LEN = 900;
+
+function clean(raw: string): string {
+  return raw
+    .replace(/\[([^\]]+)\]/g, "$1")
+    .replace(/\r/g, "")
+    .trim()
+    .slice(0, MAX_LEN);
+}
+
+export async function fetchDefinition(term = ""): Promise<UrbanEntry> {
+  const who = term.trim();
+  const url = who
+    ? `${BASE}/define?term=${encodeURIComponent(who)}`
+    : `${BASE}/random`;
+
+  const resp = await fetch(url, { headers: { accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`urbandictionary ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as UrbanApiResponse;
+  if (!Array.isArray(data.list) || data.list.length === 0) {
+    throw new Error(`no definition found${who ? ` for "${who}"` : ""}`);
+  }
+
+  const top = data.list.reduce((a, b) => (b.thumbs_up > a.thumbs_up ? b : a));
+  return {
+    word: top.word,
+    definition: clean(top.definition),
+    example: clean(top.example),
+    author: top.author,
+    permalink: top.permalink,
+    thumbsUp: top.thumbs_up,
+    thumbsDown: top.thumbs_down,
+  };
+}
+
+export async function main(term = ""): Promise<UrbanEntry> {
+  return fetchDefinition(term);
+}


### PR DESCRIPTION
## What

Two additions to the `/wm` Discord command surface.

### New commands
- **`/wm ud <term>`** — top-voted Urban Dictionary definition (`/wm ud yeet`); blank returns a random entry.
- **`/wm urbandictionary`** — long-form alias, re-exports `main` from `ud.ts`.
- Shared zero-dep Bun core in `f/shared/urban.ts` (`fetchDefinition()`), matching the poem `shared`→`discordsh` pattern.

### Self-listing menu
- **`/wm`** (no script name) now runs `f/discordsh/help`, which queries Windmill's `scripts/list` API scoped to `f/discordsh/` and renders each command's `summary` as an embed field.
- Self-updating: a new command appears in the menu the moment its script syncs — no bot rebuild.

### Bot
- `/wm` script argument is now optional; a blank invocation substitutes the `help` path.

## Notes
- Scripts sync to the workspace on merge to `main` via `windmill-sync.yml`. The bot change (blank `/wm`) needs a bot redeploy; `ud`/`help` work standalone via explicit `/wm ud` / `/wm help` once synced.
- Allowlist `f/discordsh/*` already covers all new scripts — no manifest change.
- `help` uses the job-scoped `WM_TOKEN` over `BASE_INTERNAL_URL` (cluster-internal) — no egress change. Assumes the bot token's user has read/list on `f/discordsh/`; if blank `/wm` returns HTTP 403, grant read on that folder.

## Verified
- `cargo build` clean on the bot (pre-existing warnings only).
- All new TS scripts pass `bun build`.