### PR TITLE
chore(discordsh-bot): bump to 0.1.25 — deploy blank /wm help menu

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## Why

The bare `/wm` → `f/discordsh/help` handler landed in #14266 and is on `main`, but the bot image never redeploys because its version was unchanged — `ci-docker`'s version gate skips publish when local == published (`0.1.24`).

## What

Bump the MDX source of truth (`discordsh-bot.mdx`) `0.1.24 → 0.1.25`. CI syncs MDX → `Cargo.toml`; on merge to `main` the version gate publishes and `ci-docker` deploys the new bot image.

## Effect once merged to main
- Bot redeploys → bare `/wm` (no script name) renders the self-listing command menu.
- `/wm ud`, `/wm urbandictionary`, `/wm help` (already synced via windmill-sync) unchanged.

No code change — version bump only.