### PR TITLE
feat(discordsh): friendly /wm unknown-command hint + did-you-mean

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -2,7 +2,7 @@ use poise::CreateReply;
 use tracing::{info, warn};
 
 use crate::discord::bot::{Context, Error};
-use crate::discord::windmill::{DiscordContext, split_args};
+use crate::discord::windmill::{DiscordContext, RunError, split_args, suggest_command};
 use crate::discord::windmill_embed;
 
 /// Windmill script run when `/wm` is invoked with no script name — renders the
@@ -88,15 +88,37 @@ pub async fn wm(
                 error = %e,
                 "windmill run failed"
             );
-            ctx.send(
-                CreateReply::default()
-                    .content(format!("windmill error: {e}"))
-                    .ephemeral(true),
-            )
-            .await?;
+            let content = match e {
+                // Unknown or blocked command name → guide to the menu rather
+                // than leaking that an allowlist rejected it, and suggest the
+                // closest real command when the miss looks like a typo.
+                RunError::PathNotAllowed => {
+                    let attempted = command_leaf(&path_for_log);
+                    let mut msg = format!("❓ Unknown command `/wm {attempted}`.");
+                    if let Some(near) = suggest_command(&attempted, &cfg.list_command_names().await) {
+                        msg.push_str(&format!(" Did you mean `/wm {near}`?"));
+                    }
+                    msg.push_str(" Run `/wm help` for the full list.");
+                    msg
+                }
+                other => format!("windmill error: {other}"),
+            };
+            ctx.send(CreateReply::default().content(content).ephemeral(true))
+                .await?;
         }
     }
     Ok(())
+}
+
+/// Reduce whatever the user typed to a safe, bare command name for display in
+/// the unknown-command hint: drop any folder/kind prefix (`f/discordsh/`,
+/// `p/…`) and remove every backtick so it can't break out of the code span.
+fn command_leaf(raw: &str) -> String {
+    raw.trim_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or(raw)
+        .replace('`', "")
 }
 
 fn truncate_for_discord(s: &str) -> String {
@@ -113,7 +135,21 @@ fn truncate_for_discord(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_for_discord;
+    use super::{command_leaf, truncate_for_discord};
+
+    #[test]
+    fn command_leaf_strips_prefix() {
+        assert_eq!(command_leaf("poem"), "poem");
+        assert_eq!(command_leaf("f/discordsh/poem"), "poem");
+        assert_eq!(command_leaf("/f/discordsh/poem/"), "poem");
+    }
+
+    #[test]
+    fn command_leaf_removes_backticks() {
+        // A code-span breakout attempt collapses to a bare token.
+        assert_eq!(command_leaf("po`em"), "poem");
+        assert_eq!(command_leaf("`inject`"), "inject");
+    }
 
     #[test]
     fn truncate_passthrough() {

--- a/apps/discordsh/discordsh-bot/src/discord/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/windmill.rs
@@ -172,6 +172,63 @@ impl WindmillConfig {
         }
         Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
     }
+
+    /// Best-effort list of the command leaf names reachable under the bot
+    /// namespace (`f/discordsh/*`), pulled live from Windmill's script index.
+    /// Used only to power the did-you-mean hint on an unknown command, so any
+    /// failure degrades to an empty list rather than surfacing an error.
+    pub async fn list_command_names(&self) -> Vec<String> {
+        let url = format!(
+            "{}/api/w/{}/scripts/list",
+            self.base_url.trim_end_matches('/'),
+            self.workspace
+        );
+        let Ok(resp) = self.client.get(&url).bearer_auth(&self.token).send().await else {
+            return Vec::new();
+        };
+        if !resp.status().is_success() {
+            return Vec::new();
+        }
+        let Ok(rows) = resp.json::<Vec<Value>>().await else {
+            return Vec::new();
+        };
+        rows.iter()
+            .filter_map(|r| r.get("path").and_then(Value::as_str))
+            .filter_map(|p| p.strip_prefix(BOT_NAMESPACE))
+            .filter(|leaf| !leaf.is_empty() && !leaf.contains('/'))
+            .map(str::to_owned)
+            .collect()
+    }
+}
+
+/// Suggest the closest known command to a mistyped one. Returns `Some(name)`
+/// only when a candidate is within a small edit distance, so an unrelated
+/// typo yields no misleading suggestion.
+pub fn suggest_command(attempted: &str, names: &[String]) -> Option<String> {
+    let attempted = attempted.to_lowercase();
+    let max_dist = 3usize;
+    names
+        .iter()
+        .map(|n| (levenshtein(&attempted, &n.to_lowercase()), n))
+        .filter(|(d, _)| *d <= max_dist && *d < attempted.len().max(1))
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, n)| n.clone())
+}
+
+/// Standard iterative Levenshtein edit distance over Unicode scalar values.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = if ca == *cb { 0 } else { 1 };
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
 }
 
 /// The single Windmill folder the bot may ever reach. The trailing slash is
@@ -241,6 +298,35 @@ pub fn split_args(raw: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("poem", "poem"), 0);
+        assert_eq!(levenshtein("pomm", "poem"), 1);
+        assert_eq!(levenshtein("", "poem"), 4);
+        assert_eq!(levenshtein("npm", "ud"), 3);
+    }
+
+    #[test]
+    fn suggest_command_matches_close_typo() {
+        let names = vec!["poem".to_owned(), "npm".to_owned(), "ud".to_owned()];
+        assert_eq!(suggest_command("pomm", &names).as_deref(), Some("poem"));
+        assert_eq!(suggest_command("POEM", &names).as_deref(), Some("poem"));
+        assert_eq!(suggest_command("nmp", &names).as_deref(), Some("npm"));
+    }
+
+    #[test]
+    fn suggest_command_rejects_unrelated() {
+        let names = vec!["poem".to_owned(), "npm".to_owned(), "ud".to_owned()];
+        // Too far from any command, and a miss shorter than its own length.
+        assert_eq!(suggest_command("weather", &names), None);
+        assert_eq!(suggest_command("xy", &names), None);
+    }
+
+    #[test]
+    fn suggest_command_empty_list() {
+        assert_eq!(suggest_command("poem", &[]), None);
+    }
 
     #[test]
     fn globset_exact_match() {


### PR DESCRIPTION
## What

An unknown or blocked `/wm` command name (e.g. `/wm pomm`) returned a blunt **`windmill error: Path not in allowlist.`** — unhelpful, and it leaked that an allowlist did the rejecting.

Now the `PathNotAllowed` arm guides the user to the menu and, when the miss looks like a typo, suggests the closest real command:

> ❓ Unknown command `/wm pomm`. Did you mean `/wm poem`? Run `/wm help` for the full list.

## How
- **`list_command_names()`** — pulls the live `f/discordsh/*` leaf names from Windmill's script index. Best-effort: any failure degrades to no suggestion (never an error on the error path).
- **`suggest_command()`** — nearest name within a small Levenshtein distance; unrelated input yields no misleading hint.
- **`command_leaf()`** — sanitizes the echoed name (strips folder/kind prefix + every backtick) so it can't break out of the Discord code span. Also stops confirming whether a blocked path exists.
- Blank `/wm` already renders the help menu (`f/discordsh/help`) — unchanged. All other `RunError` variants keep their real messages.

## Tests
Added unit tests for `levenshtein`, `suggest_command` (close typo / unrelated / empty), and `command_leaf` (prefix strip / backtick removal). Full crate suite green: `cargo test -p discordsh-bot` → 44 passed.

## Deploy
Needs a discordsh-bot build to go live (bot version bump handled by release pipeline, not this PR).