### PR TITLE
feat(windmill): /wm joke — rotating joke sources (dad, chuck, twopart)

### DIFF
--- a/apps/windmill/f/discordsh/joke.script.yaml
+++ b/apps/windmill/f/discordsh/joke.script.yaml
@@ -1,0 +1,29 @@
+summary: Tell a joke from a rotating set of sources
+description: >-
+  /wm target. Returns a joke — blank picks a random source, or pin one:
+  /wm joke dad, /wm joke chuck (Chuck Norris), /wm joke twopart. Two-part
+  jokes hide the punchline behind a spoiler. Bun runtime, no dependencies.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; args[0] optional joke source.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/joke.ts
+++ b/apps/windmill/f/discordsh/joke.ts
@@ -1,0 +1,23 @@
+import { fetchJoke } from "../shared/joke.ts";
+
+const JOKE_COLOR = 0xf1c40f;
+
+export async function main(
+  args: string[] = [],
+  discord?: Record<string, unknown>,
+) {
+  const joke = await fetchJoke(args.join(" ").trim());
+  const requestedBy = (discord?.username as string) ?? null;
+
+  return {
+    embed: {
+      title: "😂 Joke",
+      description: joke.text,
+      url: joke.url,
+      color: JOKE_COLOR,
+      footer: requestedBy
+        ? `${joke.label} • requested by ${requestedBy}`
+        : joke.label,
+    },
+  };
+}

--- a/apps/windmill/f/shared/joke.script.yaml
+++ b/apps/windmill/f/shared/joke.script.yaml
@@ -1,0 +1,19 @@
+summary: Fetch a joke from a rotating set of sources (shared core)
+description: >-
+  Shared library parent. Exports fetchJoke() imported by the surface wrapper
+  (f/discordsh/joke). Sources: dad (icanhazdadjoke), chuck (api.chucknorris.io),
+  twopart (official-joke-api). Blank picks a random source; a name/alias pins
+  one. SYSTEM tier — never invoked directly from a browser. Bun, no deps.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - source
+  properties:
+    source:
+      type: string
+      description: Optional source (dad, chuck, twopart); blank returns a random one.
+      default: ''
+  required: []

--- a/apps/windmill/f/shared/joke.ts
+++ b/apps/windmill/f/shared/joke.ts
@@ -1,0 +1,64 @@
+export type Joke = {
+  text: string;
+  source: string;
+  label: string;
+  url?: string;
+};
+
+const SOURCES = ["dad", "chuck", "twopart"] as const;
+export type JokeSource = (typeof SOURCES)[number];
+
+const ALIASES: Record<string, JokeSource> = {
+  dad: "dad",
+  dadjoke: "dad",
+  chuck: "chuck",
+  chucknorris: "chuck",
+  norris: "chuck",
+  twopart: "twopart",
+  setup: "twopart",
+  general: "twopart",
+};
+
+export const JOKE_SOURCES = SOURCES;
+
+function resolveSource(raw: string): JokeSource {
+  const key = raw.trim().toLowerCase();
+  if (key && ALIASES[key]) return ALIASES[key];
+  return SOURCES[Math.floor(Math.random() * SOURCES.length)];
+}
+
+async function getJson(url: string, accept = "application/json"): Promise<any> {
+  const resp = await fetch(url, { headers: { accept } });
+  if (!resp.ok) throw new Error(`${url} ${resp.status}: ${await resp.text()}`);
+  return resp.json();
+}
+
+export async function fetchJoke(source = ""): Promise<Joke> {
+  const pick = resolveSource(source);
+
+  if (pick === "dad") {
+    const d = await getJson("https://icanhazdadjoke.com/");
+    return { text: String(d.joke).trim(), source: "dad", label: "Dad joke" };
+  }
+
+  if (pick === "chuck") {
+    const d = await getJson("https://api.chucknorris.io/jokes/random");
+    return {
+      text: String(d.value).trim(),
+      source: "chuck",
+      label: "Chuck Norris",
+      url: d.url,
+    };
+  }
+
+  const d = await getJson("https://official-joke-api.appspot.com/random_joke");
+  return {
+    text: `${String(d.setup).trim()}\n\n||${String(d.punchline).trim()}||`,
+    source: "twopart",
+    label: "Two-part joke",
+  };
+}
+
+export async function main(source = ""): Promise<Joke> {
+  return fetchJoke(source);
+}


### PR DESCRIPTION
## What

New `/wm joke` command, first of the supybot-Fun port batch (#14278).

- Zero-dep Bun core `f/shared/joke.ts` + surface `f/discordsh/joke.ts`, same pattern as `ud`/`poem`/`npm`.
- Sources: **dad** (icanhazdadjoke), **chuck** (api.chucknorris.io), **twopart** (official-joke-api).
- Blank `/wm joke` → random source. Arg pins one: `/wm joke dad`, `/wm joke chuck`, `/wm joke twopart` (+ aliases: chucknorris, norris, dadjoke…).
- Two-part punchlines are spoiler-wrapped (`||…||`).
- **Chuck Norris folded in as a source, not a standalone command** — avoids colliding with the UE `chuck` game.

## Notes
- No bot change — the existing `f/discordsh/*` allowlist + generic `{args, discord}` call shape cover it. Also auto-appears in the `/wm` help menu on sync.
- Ships on merge to main via windmill-sync.

## Verified
- `bun build` clean on both scripts.
- Live smoke test — all 3 sources returned real jokes (dad / chuck / twopart).

Tracks #14278.