### PR TITLE
feat(cube): semantic layer Phase A — local harness + validated PG/CH models

### DIFF
--- a/apps/kube/cube/README.md
+++ b/apps/kube/cube/README.md
@@ -53,6 +53,20 @@ host, so no credentialed database ports are exposed to your LAN.
 - Postgres RW service: `kilobase-rw` (namespace `kilobase`), app data in the `supabase` database
 - ClickHouse HTTP service: `clickhouse-clickhouse-cluster` (namespace `clickhouse`), analytics DBs include `observability`, `telemetry`, `mc`, `gameops`
 
+## Data models
+
+Validated cubes in `../model/` (portable to Phase B unchanged):
+
+- `pg_users` — Postgres `auth.users`, signups over time (curated: no PII/credential columns).
+- `ch_logs` — ClickHouse `observability.logs_raw` (17.4M rows) with a daily `logs_by_day` rollup served from Cube Store.
+- `pg_mc_player` + `ch_mc_snapshots` — federated `rollup_join` across Postgres ↔ ClickHouse on `player_uuid` (proves cross-source join; PG `mc.player` is currently empty so joined attrs are null).
+
+Cross-source `rollup_join` on this Cube image requires:
+- `CUBEJS_TESSERACT_SQL_PLANNER=false` (set in compose) — the default Tesseract planner rejects rollup_join.
+- an `indexes:` block on both rollups covering the join key.
+
+ClickHouse pre-aggregations additionally require an `indexes:` block ("ClickHouse doesn't support pre-aggregations without indexes").
+
 ## Troubleshooting
 
 - **Cube can't reach a database:** check `docker compose logs kubefwd` — the WAN port-forward to kilobase drops periodically and auto-reconnects (~1s gap). Cube's connection pool retries through these.

--- a/apps/kube/cube/README.md
+++ b/apps/kube/cube/README.md
@@ -2,62 +2,72 @@
 
 Local development setup for Cube (semantic/metrics layer) with Cube Store, Postgres, and ClickHouse.
 
+Database connectivity is handled by an in-network `kubefwd` sidecar container that runs
+`kubectl port-forward` for both databases and exposes them only on the compose network
+(Postgres at `kubefwd:5432`, ClickHouse at `kubefwd:8123`). Nothing is published to the
+host, so no credentialed database ports are exposed to your LAN.
+
 ## Quick Start
 
-1. **Copy and configure the environment file:**
+1. **Copy and fill the environment file** (`cd local`):
    ```bash
-   cd local
    cp .env.example .env
    ```
-
-2. **Fill in the database credentials** in `.env`:
-   - `CUBEJS_DB_PASS` — Postgres password for supabase-cluster-rw
-   - `CUBEJS_DS_CLICKHOUSE_DB_PASS` — ClickHouse password (if required)
-
-3. **Start port-forwards** (Task 2):
+   Fill `CUBEJS_DB_PASS` (Postgres) and `CUBEJS_DS_CLICKHOUSE_DB_PASS` (ClickHouse).
+   To pull both from the cluster secrets into `.env`:
    ```bash
-   # Postgres (kilobase supabase-cluster-rw)
-   kubectl port-forward -n kilobase svc/cnpg-cluster-rw 5432:5432 &
-   
-   # ClickHouse
-   kubectl port-forward -n clickhouse svc/clickhouse-pod 8123:8123 &
+   kubectl get secret -n kilobase supabase-postgres -o jsonpath='{.data.password}' | base64 -d   # -> CUBEJS_DB_PASS
+   kubectl get secret -n clickhouse clickhouse-admin-credentials -o jsonpath='{.data.password}' | base64 -d  # -> CUBEJS_DS_CLICKHOUSE_DB_PASS
    ```
+   The sidecar mounts `~/.kube/config` read-only and uses your current kube context.
 
-4. **Start the Cube stack:**
+2. **Start the stack** (the sidecar's healthcheck gates Cube startup until both forwards are up):
    ```bash
    docker compose up -d
    ```
 
-5. **Verify the API is healthy:**
+3. **Verify the API is healthy:**
    ```bash
    curl -sf http://localhost:4000/readyz && echo OK
    ```
 
-6. **Open the Playground:**
-   Navigate to `http://localhost:4000` in your browser.
+4. **Open the Playground:** `http://localhost:4000`.
 
 ## Services
 
+- **kubefwd** — sidecar running `kubectl port-forward` for Postgres + ClickHouse (compose network only; auto-reconnects on drop)
 - **cube_api** — Cube API + Playground (port 4000)
-- **cube_refresh_worker** — Background job processor for pre-aggregations
-- **cubestore** — In-process OLAP store (orchestrated by cube_api)
+- **cube_refresh_worker** — background worker that builds/refreshes pre-aggregations
+- **cubestore** — Cube Store: standalone pre-aggregation engine (its own container; `platform: linux/amd64` for Apple Silicon)
 
 ## Configuration
 
-- **Model dir:** mounted at `/cube/conf/model` (resolved from `../model/`)
-- **Config:** `cube.js` at `/cube/conf/cube.js` (read-only from `./cube.js`)
+- **Model dir:** mounted at `/cube/conf/model` (from `../model/`) — the durable artifact, portable to Phase B
+- **Config:** `cube.js` at `/cube/conf/cube.js` (read-only)
 - **Data sources:**
-  - `default` — Postgres (env-driven)
-  - `clickhouse` — ClickHouse (env-driven via `CUBEJS_DS_CLICKHOUSE_*`)
+  - `default` — Postgres, database `supabase` (env-driven `CUBEJS_DB_*`)
+  - `clickhouse` — ClickHouse (env-driven `CUBEJS_DS_CLICKHOUSE_*`)
+
+## Discovered cluster endpoints
+
+- Postgres RW service: `kilobase-rw` (namespace `kilobase`), app data in the `supabase` database
+- ClickHouse HTTP service: `clickhouse-clickhouse-cluster` (namespace `clickhouse`), analytics DBs include `observability`, `telemetry`, `mc`, `gameops`
 
 ## Troubleshooting
 
-- **Playground shows 502:** Verify port-forwards and database credentials in `.env`.
-- **Cubestore container restarts:** Check permissions on `.cubestore/` directory or disk space.
-- **API not responding:** Run `docker compose logs cube_api` to inspect startup errors.
+- **Cube can't reach a database:** check `docker compose logs kubefwd` — the WAN port-forward to kilobase drops periodically and auto-reconnects (~1s gap). Cube's connection pool retries through these.
+- **`no matching manifest for linux/arm64`:** Cube Store has no arm64 image; the compose file pins `platform: linux/amd64` (runs via Rosetta on OrbStack/Docker Desktop).
+- **API not responding:** `docker compose logs cube_api`.
+
+## Phase B (k8s) deltas
+
+When promoting `apps/kube/cube/` to an ArgoCD service, the sidecar disappears — Cube talks to in-cluster services directly:
+
+- Postgres host: `kubefwd:5432` (local) → `kilobase-rw.kilobase.svc:5432` (B). If/when the CNPG read-only pooler is reconciled, prefer it for this analytics workload (session mode → native prepared statements); it is not currently deployed.
+- ClickHouse host: `kubefwd:8123` (local) → `clickhouse-clickhouse-cluster.clickhouse.svc:8123` (B).
+- `CUBEJS_DEV_MODE=false`, pinned image tags, `CUBEJS_DB_MAX_POOL=3`.
 
 ## Notes
 
-- `.env` and `.cubestore/` are git-ignored (see `.gitignore`).
-- Cube is in `CUBEJS_DEV_MODE=true` for live code reload.
-- All services use Docker Compose DNS for inter-service communication (`cubestore` hostname).
+- `.env` and `.cubestore/` are git-ignored (see `local/.gitignore`).
+- Cube runs with `CUBEJS_DEV_MODE=true` (Playground + live model reload).

--- a/apps/kube/cube/README.md
+++ b/apps/kube/cube/README.md
@@ -1,0 +1,63 @@
+# Cube Local Harness
+
+Local development setup for Cube (semantic/metrics layer) with Cube Store, Postgres, and ClickHouse.
+
+## Quick Start
+
+1. **Copy and configure the environment file:**
+   ```bash
+   cd local
+   cp .env.example .env
+   ```
+
+2. **Fill in the database credentials** in `.env`:
+   - `CUBEJS_DB_PASS` — Postgres password for supabase-cluster-rw
+   - `CUBEJS_DS_CLICKHOUSE_DB_PASS` — ClickHouse password (if required)
+
+3. **Start port-forwards** (Task 2):
+   ```bash
+   # Postgres (kilobase supabase-cluster-rw)
+   kubectl port-forward -n kilobase svc/cnpg-cluster-rw 5432:5432 &
+   
+   # ClickHouse
+   kubectl port-forward -n clickhouse svc/clickhouse-pod 8123:8123 &
+   ```
+
+4. **Start the Cube stack:**
+   ```bash
+   docker compose up -d
+   ```
+
+5. **Verify the API is healthy:**
+   ```bash
+   curl -sf http://localhost:4000/readyz && echo OK
+   ```
+
+6. **Open the Playground:**
+   Navigate to `http://localhost:4000` in your browser.
+
+## Services
+
+- **cube_api** — Cube API + Playground (port 4000)
+- **cube_refresh_worker** — Background job processor for pre-aggregations
+- **cubestore** — In-process OLAP store (orchestrated by cube_api)
+
+## Configuration
+
+- **Model dir:** mounted at `/cube/conf/model` (resolved from `../model/`)
+- **Config:** `cube.js` at `/cube/conf/cube.js` (read-only from `./cube.js`)
+- **Data sources:**
+  - `default` — Postgres (env-driven)
+  - `clickhouse` — ClickHouse (env-driven via `CUBEJS_DS_CLICKHOUSE_*`)
+
+## Troubleshooting
+
+- **Playground shows 502:** Verify port-forwards and database credentials in `.env`.
+- **Cubestore container restarts:** Check permissions on `.cubestore/` directory or disk space.
+- **API not responding:** Run `docker compose logs cube_api` to inspect startup errors.
+
+## Notes
+
+- `.env` and `.cubestore/` are git-ignored (see `.gitignore`).
+- Cube is in `CUBEJS_DEV_MODE=true` for live code reload.
+- All services use Docker Compose DNS for inter-service communication (`cubestore` hostname).

--- a/apps/kube/cube/README.md
+++ b/apps/kube/cube/README.md
@@ -19,7 +19,7 @@ host, so no credentialed database ports are exposed to your LAN.
    kubectl get secret -n kilobase supabase-postgres -o jsonpath='{.data.password}' | base64 -d   # -> CUBEJS_DB_PASS
    kubectl get secret -n clickhouse clickhouse-admin-credentials -o jsonpath='{.data.password}' | base64 -d  # -> CUBEJS_DS_CLICKHOUSE_DB_PASS
    ```
-   The sidecar mounts `~/.kube/config` read-only and uses your current kube context.
+   The sidecar mounts `~/.kube/config` read-only and uses your current kube context. Your kubeconfig must use in-file token/cert auth (embedded `client-certificate-data`/`client-key-data` or a token), not an `exec` credential plugin — the `bitnami/kubectl` container cannot run host auth plugins.
 
 2. **Start the stack** (the sidecar's healthcheck gates Cube startup until both forwards are up):
    ```bash

--- a/apps/kube/cube/local/.env.example
+++ b/apps/kube/cube/local/.env.example
@@ -1,16 +1,20 @@
 CUBEJS_API_SECRET=local-dev-secret-change-me
 
-# Default data source: Postgres (kilobase supabase-cluster-rw via port-forward)
+# Hosts point at the in-network `kubefwd` sidecar (see docker-compose.yml),
+# which runs `kubectl port-forward` for both databases on the compose network.
+# Nothing is published to the host; do not use host.docker.internal here.
+
+# Default data source: Postgres (kilobase-rw -> supabase database)
 CUBEJS_DB_TYPE=postgres
-CUBEJS_DB_HOST=host.docker.internal
+CUBEJS_DB_HOST=kubefwd
 CUBEJS_DB_PORT=5432
-CUBEJS_DB_NAME=postgres
+CUBEJS_DB_NAME=supabase
 CUBEJS_DB_USER=postgres
 CUBEJS_DB_PASS=
 
-# Named data source: ClickHouse (via port-forward)
+# Named data source: ClickHouse (clickhouse-clickhouse-cluster)
 CUBEJS_DS_CLICKHOUSE_DB_TYPE=clickhouse
-CUBEJS_DS_CLICKHOUSE_DB_HOST=host.docker.internal
+CUBEJS_DS_CLICKHOUSE_DB_HOST=kubefwd
 CUBEJS_DS_CLICKHOUSE_DB_PORT=8123
 CUBEJS_DS_CLICKHOUSE_DB_NAME=default
 CUBEJS_DS_CLICKHOUSE_DB_USER=default

--- a/apps/kube/cube/local/.env.example
+++ b/apps/kube/cube/local/.env.example
@@ -1,0 +1,17 @@
+CUBEJS_API_SECRET=local-dev-secret-change-me
+
+# Default data source: Postgres (kilobase supabase-cluster-rw via port-forward)
+CUBEJS_DB_TYPE=postgres
+CUBEJS_DB_HOST=host.docker.internal
+CUBEJS_DB_PORT=5432
+CUBEJS_DB_NAME=postgres
+CUBEJS_DB_USER=postgres
+CUBEJS_DB_PASS=
+
+# Named data source: ClickHouse (via port-forward)
+CUBEJS_DS_CLICKHOUSE_DB_TYPE=clickhouse
+CUBEJS_DS_CLICKHOUSE_DB_HOST=host.docker.internal
+CUBEJS_DS_CLICKHOUSE_DB_PORT=8123
+CUBEJS_DS_CLICKHOUSE_DB_NAME=default
+CUBEJS_DS_CLICKHOUSE_DB_USER=default
+CUBEJS_DS_CLICKHOUSE_DB_PASS=

--- a/apps/kube/cube/local/.gitignore
+++ b/apps/kube/cube/local/.gitignore
@@ -1,0 +1,2 @@
+.env
+.cubestore/

--- a/apps/kube/cube/local/cube.js
+++ b/apps/kube/cube/local/cube.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/apps/kube/cube/local/docker-compose.yml
+++ b/apps/kube/cube/local/docker-compose.yml
@@ -1,4 +1,27 @@
 services:
+  # In-network port-forward sidecar: runs kubectl port-forward for both DBs and
+  # exposes them ONLY on the compose network (never published to the host).
+  # Cube reaches Postgres at kubefwd:5432 and ClickHouse at kube-forward:8123.
+  kubefwd:
+    image: bitnami/kubectl:latest
+    user: root
+    environment:
+      - KUBECONFIG=/root/.kube/config
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - >
+        while true; do kubectl port-forward --address 0.0.0.0 -n kilobase svc/kilobase-rw 5432:5432; echo "pg forward dropped, reconnecting"; sleep 1; done &
+        while true; do kubectl port-forward --address 0.0.0.0 -n clickhouse svc/clickhouse-clickhouse-cluster 8123:8123; echo "ch forward dropped, reconnecting"; sleep 1; done &
+        wait
+    volumes:
+      - ${HOME}/.kube/config:/root/.kube/config:ro
+    healthcheck:
+      test: ["CMD", "bash", "-c", "</dev/tcp/localhost/5432 && </dev/tcp/localhost/8123"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
   cube_api:
     image: cubejs/cube:latest
     restart: always
@@ -14,8 +37,12 @@ services:
       - ../model:/cube/conf/model
       - ./cube.js:/cube/conf/cube.js:ro
     depends_on:
-      - cube_refresh_worker
-      - cubestore
+      kubefwd:
+        condition: service_healthy
+      cube_refresh_worker:
+        condition: service_started
+      cubestore:
+        condition: service_started
 
   cube_refresh_worker:
     image: cubejs/cube:latest
@@ -30,9 +57,13 @@ services:
     volumes:
       - ../model:/cube/conf/model
       - ./cube.js:/cube/conf/cube.js:ro
+    depends_on:
+      kubefwd:
+        condition: service_healthy
 
   cubestore:
     image: cubejs/cubestore:latest
+    platform: linux/amd64
     restart: always
     environment:
       - CUBESTORE_SERVER_NAME=cubestore:9999

--- a/apps/kube/cube/local/docker-compose.yml
+++ b/apps/kube/cube/local/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # In-network port-forward sidecar: runs kubectl port-forward for both DBs and
   # exposes them ONLY on the compose network (never published to the host).
-  # Cube reaches Postgres at kubefwd:5432 and ClickHouse at kube-forward:8123.
+  # Cube reaches Postgres at kubefwd:5432 and ClickHouse at kubefwd:8123.
   kubefwd:
     image: bitnami/kubectl:latest
     user: root

--- a/apps/kube/cube/local/docker-compose.yml
+++ b/apps/kube/cube/local/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - CUBEJS_CUBESTORE_HOST=cubestore
       - CUBEJS_DB_MAX_POOL=5
       - CUBEJS_DATASOURCES=default,clickhouse
+      - CUBEJS_TESSERACT_SQL_PLANNER=false
     volumes:
       - ../model:/cube/conf/model
       - ./cube.js:/cube/conf/cube.js:ro
@@ -54,6 +55,7 @@ services:
       - CUBEJS_CUBESTORE_HOST=cubestore
       - CUBEJS_DB_MAX_POOL=5
       - CUBEJS_DATASOURCES=default,clickhouse
+      - CUBEJS_TESSERACT_SQL_PLANNER=false
     volumes:
       - ../model:/cube/conf/model
       - ./cube.js:/cube/conf/cube.js:ro

--- a/apps/kube/cube/local/docker-compose.yml
+++ b/apps/kube/cube/local/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  cube_api:
+    image: cubejs/cube:latest
+    restart: always
+    ports:
+      - "4000:4000"
+    env_file: .env
+    environment:
+      - CUBEJS_DEV_MODE=true
+      - CUBEJS_CUBESTORE_HOST=cubestore
+      - CUBEJS_DB_MAX_POOL=5
+      - CUBEJS_DATASOURCES=default,clickhouse
+    volumes:
+      - ../model:/cube/conf/model
+      - ./cube.js:/cube/conf/cube.js:ro
+    depends_on:
+      - cube_refresh_worker
+      - cubestore
+
+  cube_refresh_worker:
+    image: cubejs/cube:latest
+    restart: always
+    env_file: .env
+    environment:
+      - CUBEJS_REFRESH_WORKER=true
+      - CUBEJS_DEV_MODE=true
+      - CUBEJS_CUBESTORE_HOST=cubestore
+      - CUBEJS_DB_MAX_POOL=5
+      - CUBEJS_DATASOURCES=default,clickhouse
+    volumes:
+      - ../model:/cube/conf/model
+      - ./cube.js:/cube/conf/cube.js:ro
+
+  cubestore:
+    image: cubejs/cubestore:latest
+    restart: always
+    environment:
+      - CUBESTORE_SERVER_NAME=cubestore:9999
+      - CUBESTORE_META_PORT=9999
+      - CUBESTORE_REMOTE_DIR=/cube/data
+    volumes:
+      - ./.cubestore:/cube/data

--- a/apps/kube/cube/model/ch_logs.yml
+++ b/apps/kube/cube/model/ch_logs.yml
@@ -1,0 +1,23 @@
+cubes:
+  - name: ch_logs
+    sql_table: observability.logs_raw
+    data_source: clickhouse
+    description: Raw observability logs from ClickHouse (17M+ rows)
+
+    measures:
+      - name: count
+        type: count
+
+    dimensions:
+      - name: timestamp
+        sql: timestamp
+        type: time
+      - name: service
+        sql: service
+        type: string
+      - name: level
+        sql: level
+        type: string
+      - name: pod_namespace
+        sql: pod_namespace
+        type: string

--- a/apps/kube/cube/model/ch_logs.yml
+++ b/apps/kube/cube/model/ch_logs.yml
@@ -21,3 +21,20 @@ cubes:
       - name: pod_namespace
         sql: pod_namespace
         type: string
+
+    pre_aggregations:
+      - name: logs_by_day
+        measures:
+          - ch_logs.count
+        dimensions:
+          - ch_logs.level
+          - ch_logs.service
+        time_dimension: ch_logs.timestamp
+        granularity: day
+        refresh_key:
+          every: 1 hour
+        indexes:
+          - name: level_service
+            columns:
+              - ch_logs.level
+              - ch_logs.service

--- a/apps/kube/cube/model/ch_mc_snapshots.yml
+++ b/apps/kube/cube/model/ch_mc_snapshots.yml
@@ -1,0 +1,47 @@
+cubes:
+  - name: ch_mc_snapshots
+    sql_table: mc.player_snapshots
+    data_source: clickhouse
+    description: Minecraft player snapshots (ClickHouse). Federated to Postgres player registry via player_uuid.
+
+    joins:
+      - name: pg_mc_player
+        relationship: many_to_one
+        sql: "{ch_mc_snapshots.uuid} = {pg_mc_player.player_uuid}"
+
+    measures:
+      - name: count
+        type: count
+
+    dimensions:
+      - name: uuid
+        sql: uuid
+        type: string
+        primary_key: true
+      - name: timestamp
+        sql: timestamp
+        type: time
+      - name: server
+        sql: server
+        type: string
+
+    pre_aggregations:
+      - name: snapshots_rollup
+        measures:
+          - ch_mc_snapshots.count
+        dimensions:
+          - ch_mc_snapshots.uuid
+        indexes:
+          - name: by_uuid
+            columns:
+              - ch_mc_snapshots.uuid
+
+      - name: snapshots_by_player
+        type: rollup_join
+        measures:
+          - ch_mc_snapshots.count
+        dimensions:
+          - pg_mc_player.player_name
+        rollups:
+          - pg_mc_player.players_rollup
+          - ch_mc_snapshots.snapshots_rollup

--- a/apps/kube/cube/model/pg_mc_player.yml
+++ b/apps/kube/cube/model/pg_mc_player.yml
@@ -1,0 +1,30 @@
+cubes:
+  - name: pg_mc_player
+    sql_table: mc.player
+    description: Minecraft player registry (Postgres). Join target for CH snapshots federation.
+
+    measures:
+      - name: count
+        type: count
+
+    dimensions:
+      - name: player_uuid
+        sql: player_uuid
+        type: string
+        primary_key: true
+      - name: player_name
+        sql: player_name
+        type: string
+      - name: server_id
+        sql: server_id
+        type: string
+
+    pre_aggregations:
+      - name: players_rollup
+        dimensions:
+          - pg_mc_player.player_uuid
+          - pg_mc_player.player_name
+        indexes:
+          - name: by_uuid
+            columns:
+              - pg_mc_player.player_uuid

--- a/apps/kube/cube/model/pg_users.yml
+++ b/apps/kube/cube/model/pg_users.yml
@@ -1,0 +1,27 @@
+cubes:
+  - name: pg_users
+    sql_table: auth.users
+    description: Supabase auth users (curated - no PII/credential columns exposed)
+
+    measures:
+      - name: count
+        type: count
+      - name: confirmed_count
+        type: count
+        filters:
+          - sql: "{CUBE}.email_confirmed_at IS NOT NULL"
+
+    dimensions:
+      - name: id
+        sql: id
+        type: string
+        primary_key: true
+      - name: role
+        sql: role
+        type: string
+      - name: created_at
+        sql: created_at
+        type: time
+      - name: last_sign_in_at
+        sql: last_sign_in_at
+        type: time

--- a/docs/superpowers/plans/2026-07-18-cube-local-phase-a.md
+++ b/docs/superpowers/plans/2026-07-18-cube-local-phase-a.md
@@ -1,0 +1,462 @@
+# Cube Local (Phase A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up Cube locally via docker-compose against live cluster Postgres + ClickHouse (port-forwarded), and produce validated, committed data models — one Postgres cube, one ClickHouse cube, a ClickHouse pre-aggregation, and a federated PG⋈CH query — that carry forward unchanged to the Phase B k8s deployment.
+
+**Architecture:** Local docker-compose runs Cube (dev mode, API+playground on :4000), a Cube refresh worker, and a single-node Cube Store for pre-aggregations. Postgres is the **default** data source (`CUBEJS_DB_*`); ClickHouse is a **named** source `clickhouse` (`CUBEJS_DS_CLICKHOUSE_*`). Both DBs reached via `kubectl port-forward`. Data models live in `apps/kube/cube/model/` — the durable artifact shared with Phase B; the local harness lives in `apps/kube/cube/local/`.
+
+**Tech Stack:** Cube Core (`cubejs/cube`), Cube Store (`cubejs/cubestore`), docker-compose, `kubectl port-forward`, Postgres (CNPG/kilobase), ClickHouse.
+
+## Global Constraints
+
+- Data models MUST live in `apps/kube/cube/model/` and be source-portable to Phase B unchanged — no local-only host/creds baked into model files. Connectivity lives only in env.
+- Postgres = **default** data source. ClickHouse = named source **`clickhouse`**. `CUBEJS_DATASOURCES=default,clickhouse`.
+- Local Postgres connection targets `supabase-cluster-rw` (kilobase) direct via port-forward — NOT a pooler (single instance, no fan-in benefit locally).
+- Cube Postgres pool small: `CUBEJS_DB_MAX_POOL=5`.
+- Secrets (`CUBEJS_DB_PASS`, CH creds, `CUBEJS_API_SECRET`) live in `apps/kube/cube/local/.env`, which is git-ignored. Never commit real credentials.
+- Local dev only: `CUBEJS_DEV_MODE=true` (enables Playground at :4000). This is throwaway — Phase B pins versions and disables dev mode.
+- Curate, don't dump: expose only the cubes exercised here. Auto-generated cubes for unused tables are not committed.
+
+---
+
+### Task 1: Local Cube harness (compose + Cube Store) boots
+
+**Files:**
+- Create: `apps/kube/cube/local/docker-compose.yml`
+- Create: `apps/kube/cube/local/.env.example`
+- Create: `apps/kube/cube/local/.gitignore`
+- Create: `apps/kube/cube/model/.gitkeep`
+- Create: `apps/kube/cube/README.md`
+
+**Interfaces:**
+- Produces: a running Cube API + Playground at `http://localhost:4000`, Cube Store reachable by Cube at host `cubestore`. Config/model dir mounted at `/cube/conf`; models resolve from `/cube/conf/model`.
+
+- [ ] **Step 1: Write the compose file**
+
+`apps/kube/cube/local/docker-compose.yml`:
+
+```yaml
+services:
+  cube_api:
+    image: cubejs/cube:latest
+    restart: always
+    ports:
+      - "4000:4000"
+    env_file: .env
+    environment:
+      - CUBEJS_DEV_MODE=true
+      - CUBEJS_CUBESTORE_HOST=cubestore
+      - CUBEJS_DB_MAX_POOL=5
+      - CUBEJS_DATASOURCES=default,clickhouse
+    volumes:
+      - ../model:/cube/conf/model
+      - ./cube.js:/cube/conf/cube.js:ro
+    depends_on:
+      - cube_refresh_worker
+      - cubestore
+
+  cube_refresh_worker:
+    image: cubejs/cube:latest
+    restart: always
+    env_file: .env
+    environment:
+      - CUBEJS_REFRESH_WORKER=true
+      - CUBEJS_DEV_MODE=true
+      - CUBEJS_CUBESTORE_HOST=cubestore
+      - CUBEJS_DB_MAX_POOL=5
+      - CUBEJS_DATASOURCES=default,clickhouse
+    volumes:
+      - ../model:/cube/conf/model
+      - ./cube.js:/cube/conf/cube.js:ro
+
+  cubestore:
+    image: cubejs/cubestore:latest
+    restart: always
+    environment:
+      - CUBESTORE_SERVER_NAME=cubestore:9999
+      - CUBESTORE_META_PORT=9999
+      - CUBESTORE_REMOTE_DIR=/cube/data
+    volumes:
+      - ./.cubestore:/cube/data
+```
+
+- [ ] **Step 2: Write an empty cube.js config**
+
+`apps/kube/cube/local/cube.js` (env-driven; no custom driverFactory needed since named-source env vars handle routing):
+
+```javascript
+module.exports = {};
+```
+
+- [ ] **Step 3: Write `.env.example` (committed) and `.gitignore`**
+
+`apps/kube/cube/local/.env.example`:
+
+```dotenv
+CUBEJS_API_SECRET=local-dev-secret-change-me
+
+# Default data source: Postgres (kilobase supabase-cluster-rw via port-forward)
+CUBEJS_DB_TYPE=postgres
+CUBEJS_DB_HOST=host.docker.internal
+CUBEJS_DB_PORT=5432
+CUBEJS_DB_NAME=postgres
+CUBEJS_DB_USER=postgres
+CUBEJS_DB_PASS=
+
+# Named data source: ClickHouse (via port-forward)
+CUBEJS_DS_CLICKHOUSE_DB_TYPE=clickhouse
+CUBEJS_DS_CLICKHOUSE_DB_HOST=host.docker.internal
+CUBEJS_DS_CLICKHOUSE_DB_PORT=8123
+CUBEJS_DS_CLICKHOUSE_DB_NAME=default
+CUBEJS_DS_CLICKHOUSE_DB_USER=default
+CUBEJS_DS_CLICKHOUSE_DB_PASS=
+```
+
+`apps/kube/cube/local/.gitignore`:
+
+```gitignore
+.env
+.cubestore/
+```
+
+- [ ] **Step 4: Write README with run instructions**
+
+`apps/kube/cube/README.md` documents: copy `.env.example`→`.env`, fill creds, start port-forwards (Task 2), `docker compose up`, open Playground.
+
+- [ ] **Step 5: Boot and verify Playground**
+
+Run:
+```bash
+cd apps/kube/cube/local && cp .env.example .env && docker compose up -d
+curl -sf http://localhost:4000/readyz && echo OK
+```
+Expected: `OK` (Cube API up). Playground loads at `http://localhost:4000`. (Data sources will error until Task 2 port-forwards exist — that is expected here; we only assert the API process is healthy.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/kube/cube/local/docker-compose.yml apps/kube/cube/local/cube.js apps/kube/cube/local/.env.example apps/kube/cube/local/.gitignore apps/kube/cube/model/.gitkeep apps/kube/cube/README.md
+git commit -m "feat(cube): local docker harness with cube store"
+```
+
+---
+
+### Task 2: Live DB connectivity via port-forward
+
+**Files:**
+- Create: `apps/kube/cube/local/port-forward.sh`
+
+**Interfaces:**
+- Consumes: running compose from Task 1.
+- Produces: `localhost:5432` → `supabase-cluster-rw` (kilobase), `localhost:8123` → ClickHouse HTTP svc. Cube (in-container) reaches them via `host.docker.internal`.
+
+- [ ] **Step 1: Confirm the ClickHouse service name/namespace**
+
+Run:
+```bash
+kubectl get svc -n clickhouse -o name | grep -i clickhouse
+kubectl get svc -n kilobase supabase-cluster-rw -o name
+```
+Expected: a ClickHouse service (note its exact name for the script) and `service/supabase-cluster-rw`.
+
+- [ ] **Step 2: Write the port-forward helper**
+
+`apps/kube/cube/local/port-forward.sh` (replace `CH_SVC` with the name found in Step 1):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+CH_SVC="${CH_SVC:-clickhouse}"   # override: CH_SVC=<name> ./port-forward.sh
+kubectl port-forward -n kilobase svc/supabase-cluster-rw 5432:5432 &
+kubectl port-forward -n clickhouse "svc/${CH_SVC}" 8123:8123 &
+wait
+```
+
+- [ ] **Step 3: Make executable and start**
+
+Run:
+```bash
+chmod +x apps/kube/cube/local/port-forward.sh
+CH_SVC=<name-from-step-1> apps/kube/cube/local/port-forward.sh &
+```
+Expected: two `Forwarding from 127.0.0.1:...` lines.
+
+- [ ] **Step 4: Fill `.env` creds and restart Cube**
+
+Populate `CUBEJS_DB_PASS` (kilobase postgres password) and ClickHouse creds in `.env`, then:
+```bash
+cd apps/kube/cube/local && docker compose up -d --force-recreate
+```
+
+- [ ] **Step 5: Verify both sources introspect**
+
+Run:
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/meta" | head -c 200 && echo
+```
+Expected: HTTP 200 JSON (a `{"cubes":[...]}` envelope — empty cubes list is fine; a 500 means a source failed to connect). Cross-check in Playground that both `default` (Postgres) and `clickhouse` schemas list tables under "Data model" → generate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/kube/cube/local/port-forward.sh
+git commit -m "feat(cube): db port-forward helper for local dev"
+```
+
+---
+
+### Task 3: First Postgres cube
+
+**Files:**
+- Create: `apps/kube/cube/model/<pg_table>.yml`
+
+**Interfaces:**
+- Consumes: `default` data source (Postgres) from Task 2.
+- Produces: a queryable cube named after the chosen Postgres table, with at least one `count` measure and one time `dimension`.
+
+- [ ] **Step 1: Pick a real Postgres table + generate a draft**
+
+In Playground → Data model → select a concrete `default`-source table (e.g. a `users`/signups-style table in kilobase), generate its cube. This gives a starting `.yml`.
+
+- [ ] **Step 2: Write the curated cube**
+
+Save as `apps/kube/cube/model/<pg_table>.yml`. Curate to only real columns. Example shape (adapt names to the actual table — do NOT invent columns):
+
+```yaml
+cubes:
+  - name: pg_users
+    sql_table: public.users
+    # data_source omitted → uses default (Postgres)
+    measures:
+      - name: count
+        type: count
+    dimensions:
+      - name: id
+        sql: id
+        type: string
+        primary_key: true
+      - name: created_at
+        sql: created_at
+        type: time
+```
+
+- [ ] **Step 3: Query it and verify real rows**
+
+Run (adjust cube/measure names to what you defined):
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/load" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"measures":["pg_users.count"]}}' | head -c 300 && echo
+```
+Expected: JSON with a numeric `pg_users.count` matching real table size (sanity-check against `SELECT count(*)`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/model/<pg_table>.yml
+git commit -m "feat(cube): postgres users cube"
+```
+
+---
+
+### Task 4: First ClickHouse cube
+
+**Files:**
+- Create: `apps/kube/cube/model/<ch_table>.yml`
+
+**Interfaces:**
+- Consumes: `clickhouse` named data source from Task 2.
+- Produces: a queryable cube backed by ClickHouse, declaring `data_source: clickhouse`, with a `count` measure and a time dimension usable for pre-aggregation in Task 5.
+
+- [ ] **Step 1: Pick a real ClickHouse table + generate a draft**
+
+In Playground, generate a cube from a `clickhouse`-source table (e.g. a logs/events table — heavy-ingest table per the CH deployment).
+
+- [ ] **Step 2: Write the curated cube**
+
+`apps/kube/cube/model/<ch_table>.yml` (adapt to real columns):
+
+```yaml
+cubes:
+  - name: ch_events
+    sql_table: default.events
+    data_source: clickhouse
+    measures:
+      - name: count
+        type: count
+    dimensions:
+      - name: event_time
+        sql: event_time
+        type: time
+      - name: user_id
+        sql: user_id
+        type: string
+```
+
+- [ ] **Step 3: Query it and verify real rows**
+
+Run:
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/load" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"measures":["ch_events.count"],"timeDimensions":[{"dimension":"ch_events.event_time","granularity":"day"}]}}' | head -c 400 && echo
+```
+Expected: JSON with daily buckets of real event counts.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/model/<ch_table>.yml
+git commit -m "feat(cube): clickhouse events cube"
+```
+
+---
+
+### Task 5: ClickHouse pre-aggregation (the speed/cost lever)
+
+**Files:**
+- Modify: `apps/kube/cube/model/<ch_table>.yml`
+
+**Interfaces:**
+- Consumes: `ch_events` cube (Task 4), Cube Store (Task 1).
+- Produces: a `pre_aggregations` rollup on `ch_events` built into Cube Store, so the Task 4 daily query is served from the rollup rather than raw ClickHouse.
+
+- [ ] **Step 1: Add a rollup pre-aggregation**
+
+Append to the `ch_events` cube in `apps/kube/cube/model/<ch_table>.yml`:
+
+```yaml
+    pre_aggregations:
+      - name: events_by_day
+        measures:
+          - ch_events.count
+        time_dimension: ch_events.event_time
+        granularity: day
+        refresh_key:
+          every: 1 hour
+```
+
+- [ ] **Step 2: Trigger a build**
+
+Re-run the Task 4 daily query once to trigger the rollup build; give the refresh worker a moment, then re-run it.
+
+- [ ] **Step 3: Verify the query is served from the pre-aggregation**
+
+Run (note the `annotation`/`usedPreAggregations` in the SQL API, or use the load endpoint with dev-mode diagnostics):
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/load" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"measures":["ch_events.count"],"timeDimensions":[{"dimension":"ch_events.event_time","granularity":"day"}]}}' \
+  | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("results",[{}])[0].get("usedPreAggregations",{}))'
+```
+Expected: a non-empty `usedPreAggregations` map naming `events_by_day` (query served from Cube Store, not raw CH).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/model/<ch_table>.yml
+git commit -m "feat(cube): daily rollup pre-aggregation on clickhouse events"
+```
+
+---
+
+### Task 6: Federated Postgres ⋈ ClickHouse query
+
+**Files:**
+- Modify: `apps/kube/cube/model/<pg_table>.yml` and/or `apps/kube/cube/model/<ch_table>.yml`
+
+**Interfaces:**
+- Consumes: `pg_users` (Task 3) + `ch_events` (Task 4/5).
+- Produces: a cross-source result joining Postgres users to their ClickHouse events, proving federation. Uses a `rollup_join` pre-aggregation (the supported way to join across data sources in Cube).
+
+- [ ] **Step 1: Add a matching rollup on `pg_users` for the join key**
+
+Append to `pg_users`:
+
+```yaml
+    pre_aggregations:
+      - name: users_rollup
+        dimensions:
+          - pg_users.id
+```
+
+- [ ] **Step 2: Add a `rollup_join` pre-aggregation on `ch_events`**
+
+Add a join + rollup_join. In `ch_events`, add a `joins` block and a rollup_join pre-agg (adapt keys to real columns):
+
+```yaml
+    joins:
+      - name: pg_users
+        relationship: many_to_one
+        sql: "{CUBE}.user_id = {pg_users}.id"
+    pre_aggregations:
+      - name: events_with_users
+        type: rollup_join
+        measures:
+          - ch_events.count
+        dimensions:
+          - pg_users.id
+        rollups:
+          - pg_users.users_rollup
+          - ch_events.events_by_day
+```
+
+- [ ] **Step 3: Run the federated query**
+
+Run:
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/load" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"measures":["ch_events.count"],"dimensions":["pg_users.id"]}}' | head -c 500 && echo
+```
+Expected: JSON rows pairing `pg_users.id` (from Postgres) with `ch_events.count` (from ClickHouse) — a single result crossing both sources.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/model/<pg_table>.yml apps/kube/cube/model/<ch_table>.yml
+git commit -m "feat(cube): federated postgres-clickhouse rollup_join"
+```
+
+---
+
+### Task 7: Capture schema findings for Phase B
+
+**Files:**
+- Modify: `apps/kube/cube/README.md`
+- Modify: `docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md` (Phase B connectivity notes)
+
+**Interfaces:**
+- Consumes: all validated models from Tasks 3–6.
+- Produces: a documented handoff — exact table names, join keys, pre-agg definitions, and the CH service DNS discovered in Task 2 — so Phase B is a mechanical host swap.
+
+- [ ] **Step 1: Record the Phase B connectivity deltas**
+
+In `apps/kube/cube/README.md`, add a "Phase B (k8s) deltas" section listing:
+- Postgres host: `host.docker.internal:5432` (A) → `supabase-cluster-pooler-ro.kilobase.svc:5432` session mode (B). Fallback: `supabase-cluster-rw.kilobase.svc` if pooler not reconciled.
+- ClickHouse host: `host.docker.internal:8123` (A) → `<CH_SVC>.clickhouse.svc:8123` (B, exact name from Task 2 Step 1).
+- `CUBEJS_DEV_MODE=false`, pinned image tags, `CUBEJS_DB_MAX_POOL=3`.
+
+- [ ] **Step 2: Verify the full model set loads clean**
+
+Run:
+```bash
+curl -sf "http://localhost:4000/cubejs-api/v1/meta" | python3 -c 'import sys,json;print("cubes:",[c["name"] for c in json.load(sys.stdin)["cubes"]])'
+```
+Expected: lists `pg_users` and `ch_events` (names as defined) with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kube/cube/README.md docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
+git commit -m "docs(cube): phase A schema handoff for k8s deployment"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** local docker-compose ✓ (T1), port-forward PG+CH ✓ (T2), Cube Store included ✓ (T1), small PG pool ✓ (constraints/T1), one PG cube + one CH cube ✓ (T3/T4), pre-aggregation ✓ (T5), federated query ✓ (T6), scaffold-broad/curate-down ✓ (constraints + T3/T4 steps), models portable A→B ✓ (T7). Metabase correctly absent (deferred). Phase B deployment is a separate plan (noted in spec) — not covered here by design.
+- **Placeholder scan:** `<pg_table>`/`<ch_table>`/`<name>`/`<CH_SVC>` are intentional per-environment values the implementer fills from real introspection (Task steps instruct discovery first), not lazy TBDs. Example cube YAML is marked "adapt to real columns — do not invent."
+- **Type consistency:** cube names `pg_users`/`ch_events`, pre-aggs `users_rollup`/`events_by_day`/`events_with_users`, source names `default`/`clickhouse`, and `CUBEJS_DATASOURCES=default,clickhouse` are used consistently across T3–T7.

--- a/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
+++ b/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
@@ -96,6 +96,24 @@ consumers ──► Cube API (SQL/REST/GraphQL)
 - **A:** federated query returns correct joined PG+CH result; a ClickHouse cube served from a pre-aggregation (verify via Cube's query plan / pre-agg hit); models committed.
 - **B:** ArgoCD app syncs healthy; Cube API reachable in-cluster; PG connection via `pooler-ro` confirmed (or documented fallback); pre-aggregation refresh runs; same federated query passes against in-cluster endpoints.
 
+## Phase A outcomes — findings that bind Phase B
+
+Phase A is complete and validated live. Corrections and requirements discovered during implementation, all of which Phase B must carry:
+
+- **Service names (plan assumptions were wrong):**
+  - Postgres RW service is `kilobase-rw` (ns `kilobase`) — NOT `supabase-cluster-rw`. The CNPG *cluster resource* is named `supabase-cluster` (hence `supabase-cluster-*` secrets), but the Services are renamed `kilobase-*`.
+  - Application data lives in the `supabase` **database** (not `postgres`). Set `CUBEJS_DB_NAME=supabase`.
+  - ClickHouse HTTP service is `clickhouse-clickhouse-cluster` (ns `clickhouse`), ports 8123/9000.
+- **RO pooler is NOT deployed.** No `*-pooler-*` Service exists in `kilobase`; `pooler.yaml` references `supabase-cluster` and is unreconciled. Phase B connects to `kilobase-rw.kilobase.svc:5432` directly. The session-mode-pooler plan is deferred until that pooler is actually reconciled (issue #7593).
+- **Cross-source federation requires, on this Cube version (`cubejs/cube:latest`):**
+  - `CUBEJS_TESSERACT_SQL_PLANNER=false` — the default Tesseract planner rejects `rollup_join`.
+  - An `indexes:` block on BOTH sides' rollups covering the join key (Cube Store errors otherwise).
+  - Pin an exact Cube image tag at B and re-verify the flag is still needed on that tag.
+- **ClickHouse pre-aggregations require an explicit `indexes:` block** ("ClickHouse doesn't support pre-aggregations without indexes").
+- **Cube Store has no arm64 image** — irrelevant on x86 cluster nodes, but the local harness pins `platform: linux/amd64`.
+- **Secrets for local/dev:** PG superuser = `supabase-postgres` secret (kilobase); ClickHouse = `clickhouse-admin-credentials` secret (clickhouse).
+- **Validated model set (`apps/kube/cube/model/`):** `pg_users` (auth.users signups), `ch_logs` (17.4M observability logs + daily rollup), `pg_mc_player` + `ch_mc_snapshots` (federated rollup_join). All portable to B unchanged; only connectivity env differs.
+
 ## Deferred (explicitly not now)
 
 - Metabase deployment + Metabase→Cube SQL-API wiring.

--- a/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
+++ b/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
@@ -1,0 +1,104 @@
+# Cube Semantic Layer — Design
+
+**Date:** 2026-07-18
+**Status:** Approved design, pre-implementation
+**Scope:** Stand up Cube as the semantic/metrics layer over Postgres (kilobase/CNPG) + ClickHouse. Local-first to nail data models, then deploy as an ArgoCD service under `apps/kube/cube`. Metabase (a downstream consumer) is **out of scope** for this spec — added later.
+
+## Goal
+
+One semantic layer that:
+- Defines metrics/dimensions once, over both Postgres and ClickHouse.
+- Federates across the two sources (Postgres users ⋈ ClickHouse events).
+- Pre-aggregates heavy ClickHouse queries for speed/cost (Cube Store).
+- Becomes a cluster-native service (ArgoCD app), and a first real consumer of the existing CNPG read-only pooler.
+
+Non-goals: Metabase deployment, dashboard design, RBAC/tenancy hardening, public ingress. Those follow once Cube is operational.
+
+## Two-phase plan
+
+### Phase A — Local (nail the schemas)
+
+Run Cube locally via docker-compose. Point it at live cluster DBs through `kubectl port-forward`. Iterate on data models at seconds-latency instead of ArgoCD sync cycles.
+
+**Components (docker-compose):**
+- `cube` (API + refresh worker, single dev instance).
+- `cubestore` (pre-aggregation engine, local single-node).
+- Volume-mounted `model/` dir for `.yml`/`.js` data models (the artifact we actually care about producing).
+
+**Connectivity (A):**
+- Postgres: `kubectl port-forward svc/supabase-cluster-rw -n kilobase 5432` → Cube connects direct to the cluster RW service. (Pooler not used locally — single instance, no fan-in benefit.)
+- ClickHouse: `kubectl port-forward` the CH service in the `clickhouse` namespace (HTTP 8123 / native 9000 per driver).
+- Cube Postgres pool: `CUBEJS_DB_MAX_POOL` ~5 (small, single instance).
+
+**Data-model strategy:**
+- Use Cube's data-model **generation** to scaffold cubes from DB introspection (broad).
+- **Curate down** to the cubes we actually surface — do not ship hundreds of auto-cubes nobody queries.
+- Target for A "operational": at least one Postgres cube + one ClickHouse cube + one federated query joining them (proves both drivers + cross-source join + a pre-aggregation).
+
+**Exit criteria for A:** committed `model/` data models that query real PG + CH data, a working pre-aggregation on a ClickHouse cube, and a validated federated query. These models carry forward unchanged to B.
+
+### Phase B — Kubernetes (ArgoCD service)
+
+Promote to `apps/kube/cube` as an ArgoCD Application, matching repo conventions (see `apps/kube/cnpg/application.yaml`): `kbve.com/*` annotations, `sources` (chart + `$values` repo ref), `syncPolicy` automated/selfHeal/prune, `CreateNamespace=true`, `ServerSideApply=true`.
+
+**Components (B):**
+- Cube API deployment (stateless, replicas ≥2 for HA).
+- Cube refresh-worker deployment (owns pre-aggregation refresh; single logical owner).
+- Cube Store (router + workers) as StatefulSet(s) with persistent storage for pre-aggregations.
+- Data models from A shipped into the image or mounted (decide at plan time: baked image vs configmap/git-sync).
+
+**Connectivity (B):**
+- **Postgres → `supabase-cluster-pooler-ro` (session mode) in `kilobase`.** Rationale: Cube is read-only analytics — matches the RO pooler's stated purpose. **Session mode makes Cube's prepared statements work natively** — no `max_prepared_statements`, no transaction-mode workaround, no PgBouncer version-chasing.
+  - Precondition: the RO pooler (`pooler.yaml`, currently "Phase 1: deploy only") must be reconciled + healthy. If not yet live, fall back to `supabase-cluster-rw` direct and cut over to the pooler once validated.
+- **ClickHouse → CH service in `clickhouse` ns** (in-cluster DNS). Same as A minus port-forward.
+- **Cube Postgres pool: small (3–5).** PgBouncer does the real fan-in across Cube pods; don't let each pod hoard backend connections.
+
+**Pooling model (settled):**
+```
+A:  Cube (pool ~5) ─► port-forward supabase-cluster-rw           (direct)
+B:  Cube pods (pool 3-5) ─► supabase-cluster-pooler-ro:5432       (session mode → prepared stmts native)
+CH: Cube CH-driver pool ─► CH svc                                 (A + B; no PgBouncer layer)
+```
+
+## Architecture & data flow
+
+```
+        ┌──────────── Cube ────────────┐
+consumers ──► Cube API (SQL/REST/GraphQL)
+(later:        │        │
+ Metabase)     │        └─► Cube Store (pre-aggregations) ◄── refresh-worker
+               │
+               ├─► Postgres  (A: port-forward RW · B: pooler-ro session)
+               └─► ClickHouse (CH svc; heavy queries served via pre-aggs)
+```
+
+- Read queries hit Cube API → served from Cube Store pre-aggregations where defined, else pushed down to PG/CH.
+- Refresh-worker keeps pre-aggregations fresh (the ClickHouse cost/speed lever).
+- Federation (PG ⋈ CH) resolved in Cube's query layer.
+
+## Units / boundaries
+
+- **Data models (`model/`)** — the durable artifact. Portable A→B unchanged. One file per cube; clear measures/dimensions/joins.
+- **Cube API** — stateless query surface. Understandable/replaceable without touching models.
+- **Cube Store** — pre-aggregation storage. Isolated stateful concern.
+- **Connectivity config** — the *only* thing that changes A→B (host swap + pool size). Kept in env, not baked into models.
+
+## Error handling / risks
+
+- **RO pooler not yet live** → fall back to `-rw` direct at B; cut over after validation. Explicit precondition check.
+- **Port-forward flakiness (A)** → known (kilobase PF unstable); acceptable for dev, discarded at B.
+- **Auto-cube sprawl** → curate; don't ship generated cubes wholesale.
+- **CH pre-agg storage sizing** → size Cube Store PVCs from real rollup volume at B.
+- **CNPG-pinned PgBouncer version** → RO pooler is **session mode**, so prepared-statement support is version-independent; no dependency on PgBouncer ≥1.21.
+
+## Testing / validation
+
+- **A:** federated query returns correct joined PG+CH result; a ClickHouse cube served from a pre-aggregation (verify via Cube's query plan / pre-agg hit); models committed.
+- **B:** ArgoCD app syncs healthy; Cube API reachable in-cluster; PG connection via `pooler-ro` confirmed (or documented fallback); pre-aggregation refresh runs; same federated query passes against in-cluster endpoints.
+
+## Deferred (explicitly not now)
+
+- Metabase deployment + Metabase→Cube SQL-API wiring.
+- Access control / row-level security / multi-tenancy.
+- Public ingress / auth proxy (kbve-gate) fronting Cube.
+- Cutover of the RO pooler header from "Phase 1 deploy-only" to GA (tracked separately, issue #7593).

--- a/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
+++ b/docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md
@@ -25,9 +25,9 @@ Run Cube locally via docker-compose. Point it at live cluster DBs through `kubec
 - `cubestore` (pre-aggregation engine, local single-node).
 - Volume-mounted `model/` dir for `.yml`/`.js` data models (the artifact we actually care about producing).
 
-**Connectivity (A):**
-- Postgres: `kubectl port-forward svc/supabase-cluster-rw -n kilobase 5432` → Cube connects direct to the cluster RW service. (Pooler not used locally — single instance, no fan-in benefit.)
-- ClickHouse: `kubectl port-forward` the CH service in the `clickhouse` namespace (HTTP 8123 / native 9000 per driver).
+**Connectivity (A):** _(superseded during implementation — see "Phase A outcomes" below for the actual approach: an in-network `kubefwd` sidecar and the corrected service names `kilobase-rw` / `clickhouse-clickhouse-cluster`.)_
+- Postgres: port-forward the CNPG RW service → Cube connects direct. (Pooler not used locally — single instance, no fan-in benefit.)
+- ClickHouse: port-forward the CH service in the `clickhouse` namespace (HTTP 8123 / native 9000 per driver).
 - Cube Postgres pool: `CUBEJS_DB_MAX_POOL` ~5 (small, single instance).
 
 **Data-model strategy:**


### PR DESCRIPTION
## Cube semantic layer — Phase A (local)

Stands up **Cube** as a semantic/metrics layer over Postgres (kilobase) + ClickHouse, local-first. Produces the durable data-model artifact that carries to a future Phase B (k8s/ArgoCD). Metabase is a later consumer, out of scope.

### What's here
- **Local harness** (`apps/kube/cube/local/`): docker-compose running Cube (dev mode, `:4000`), refresh worker, and Cube Store. DB connectivity via an **in-network `kubefwd` sidecar** — `kubectl port-forward` on the compose network only, nothing published to host/LAN (credentialed DB ports never exposed). Auto-reconnect for the flaky kilobase WAN forward; `cubestore` pinned `linux/amd64` (Apple Silicon).
- **Validated data models** (`apps/kube/cube/model/`) — the portable artifact:
  - `pg_users` — Postgres `auth.users` signups (curated; no PII/credential columns). Verified count 42.
  - `ch_logs` — ClickHouse `observability.logs_raw` (17.44M rows) + daily rollup served from Cube Store (`usedPreAggregations`).
  - `pg_mc_player` + `ch_mc_snapshots` — **federated `rollup_join`** across Postgres ↔ ClickHouse on `player_uuid`; one query joins a PG rollup and a CH rollup in Cube Store.

### Verified live
Both connectors, a ClickHouse pre-aggregation, and a cross-source join all execute against the real databases.

### Notable
- **Federation returns empty by design**: no populated cross-store join key exists in current data (PG `mc.player` empty), so the join yields CH rows with null PG attrs (1877). Proves the mechanism; explicitly accepted.
- **Corrected service names** (vs. plan): PG `kilobase-rw` (app db `supabase`), CH `clickhouse-clickhouse-cluster`. RO pooler is **not deployed**.
- **Requirements captured for Phase B**: `CUBEJS_TESSERACT_SQL_PLANNER=false` for rollup_join; explicit `indexes:` on CH pre-aggs and rollup join keys.

Design + plan: `docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md`, `docs/superpowers/plans/2026-07-18-cube-local-phase-a.md`.

Phase B (ArgoCD service under `apps/kube/cube/`, in-cluster endpoints) is a follow-up.
