### PR TITLE
perf(jedi): store TokenInfo behind Arc to avoid per-hit clone

### DIFF
--- a/apps/agones/arpg/server/src/auth.rs
+++ b/apps/agones/arpg/server/src/auth.rs
@@ -24,8 +24,8 @@ impl TokenVerifier for GotrueVerifier {
             .await
             .map_err(|e| e.to_string())?;
         Ok(VerifiedUser {
-            sub: info.user_id,
-            kbve_username: info.kbve_username,
+            sub: info.user_id.clone(),
+            kbve_username: info.kbve_username.clone(),
         })
     }
 }

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -3098,7 +3098,7 @@ pub(crate) async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response
     cache
         .verify_and_cache(&token)
         .await
-        .map(|info| info.user_id)
+        .map(|info| info.user_id.clone())
         .map_err(|e| {
             tracing::warn!(error = %e, "JWT verify failed in forum write");
             (

--- a/apps/kbve/axum-kbve/src/transport/proxy/core.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/core.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use reqwest::Client;
 use serde_json::json;
+use std::sync::Arc;
 use tracing::{debug, warn};
 
 use crate::auth::{
@@ -395,7 +396,7 @@ pub(super) async fn require_dashboard_permission(
     required_perm: i32,
     perm_label: &str,
     denied_message: &str,
-) -> Result<TokenInfo, Response> {
+) -> Result<Arc<TokenInfo>, Response> {
     let auth_token = match extract_auth_token(headers, query) {
         Some(t) => t,
         None => {
@@ -462,7 +463,7 @@ pub(crate) async fn require_dashboard_manage_with_query(
     headers: &HeaderMap,
     query: Option<&str>,
     service_name: &str,
-) -> Result<TokenInfo, Response> {
+) -> Result<Arc<TokenInfo>, Response> {
     require_dashboard_permission(
         headers,
         query,
@@ -478,7 +479,7 @@ pub(super) async fn require_dashboard_view_with_query(
     headers: &HeaderMap,
     query: Option<&str>,
     service_name: &str,
-) -> Result<TokenInfo, Response> {
+) -> Result<Arc<TokenInfo>, Response> {
     require_dashboard_permission(
         headers,
         query,

--- a/packages/rust/jedi/src/jwt_cache.rs
+++ b/packages/rust/jedi/src/jwt_cache.rs
@@ -75,7 +75,9 @@ impl TokenInfo {
 /// JWT verification cache backed by GoTrue + a token-keyed DashMap.
 #[derive(Clone)]
 pub struct JwtCache {
-    tokens: Arc<DashMap<String, TokenInfo>>,
+    /// Verified tokens keyed by the raw JWT. Stored behind `Arc` so a cache hit
+    /// clones a refcount, not the whole `TokenInfo` (several owned `String`s).
+    tokens: Arc<DashMap<String, Arc<TokenInfo>>>,
     /// Tokens currently being verified against GoTrue. Lets concurrent cold
     /// requests for the same token wait on one round-trip (single-flight)
     /// instead of each stampeding Supabase.
@@ -101,7 +103,7 @@ impl JwtCache {
     }
 
     /// Return a cached, non-expired token if present.
-    pub fn get(&self, token: &str) -> Option<TokenInfo> {
+    pub fn get(&self, token: &str) -> Option<Arc<TokenInfo>> {
         if let Some(entry) = self.tokens.get(token) {
             let info = entry.value().clone();
             if !info.is_expired() {
@@ -115,7 +117,7 @@ impl JwtCache {
 
     /// Cache hit returns immediately; a miss verifies with GoTrue then caches.
     /// Concurrent misses for the same token are coalesced into one round-trip.
-    pub async fn verify_and_cache(&self, token: &str) -> Result<TokenInfo, JwtCacheError> {
+    pub async fn verify_and_cache(&self, token: &str) -> Result<Arc<TokenInfo>, JwtCacheError> {
         if let Some(info) = self.get(token) {
             return Ok(info);
         }
@@ -145,7 +147,7 @@ impl JwtCache {
         };
 
         let api_start = Instant::now();
-        let result = self.verify_with_supabase(token).await;
+        let result = self.verify_with_supabase(token).await.map(Arc::new);
         if let Ok(ref token_info) = result {
             self.insert(token.to_string(), token_info.clone());
             info!(
@@ -267,7 +269,7 @@ impl JwtCache {
         }
     }
 
-    fn insert(&self, token: String, info: TokenInfo) {
+    fn insert(&self, token: String, info: Arc<TokenInfo>) {
         if self.tokens.len() >= MAX_CACHE_SIZE {
             self.evict_oldest(MAX_CACHE_SIZE / 10);
         }


### PR DESCRIPTION
## What

Store verified tokens as `Arc<TokenInfo>` in the JWT cache. A cache *hit* — the common case behind every authenticated axum-kbve proxy route and arpg game-server request — previously cloned the whole `TokenInfo` (`user_id`, `kbve_username`, `email`, `role`: several owned `String`s → ~4 heap allocs). Now `get()`/`verify_and_cache()` return a refcount bump.

## Blast radius

The return type flips to `Arc<TokenInfo>`, which ripples to the proxy dashboard gates (`Result<Arc<TokenInfo>, Response>`). Every consumer reads the value through `Deref` (field access, `has_permission`, `is_staff`, `role`) so needs no change — **except two field-move sites** that now `.clone()` the `String` they extract:
- `https.rs` forum-write: `info.user_id` → `info.user_id.clone()`
- `arpg-server` `VerifiedUser`: `info.user_id`/`kbve_username` → `.clone()`

`firecracker`'s `resolve_account_for_token(&TokenInfo)` binds via deref coercion (`&Arc<TokenInfo>` → `&TokenInfo`), unchanged.

## Context

Third and final jedi `jwt_cache` win from #14269, after single-flight + concurrent verify (#14281). Closes the jedi items there.

## Verify

`cargo check` + `cargo clippy` clean across **jedi, axum-kbve, arpg-server**; jedi (6) and proxy (13) unit tests pass.