### PR TITLE
feat(cube): semantic layer Phase B — ArgoCD k8s service (gadsme charts)

### DIFF
--- a/apps/kube/clickhouse/manifests/cube-external-secrets-rbac.yaml
+++ b/apps/kube/clickhouse/manifests/cube-external-secrets-rbac.yaml
@@ -1,0 +1,35 @@
+---
+# Allows the cube namespace external-secrets SA to read the ClickHouse
+# admin credentials in the clickhouse namespace (for the Cube datasource).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: clickhouse-secrets-reader-for-cube
+    namespace: clickhouse
+    labels:
+        app.kubernetes.io/name: clickhouse
+        app.kubernetes.io/component: rbac
+        app.kubernetes.io/managed-by: argocd
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['clickhouse-admin-credentials']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: cube-read-clickhouse-secrets
+    namespace: clickhouse
+    labels:
+        app.kubernetes.io/name: clickhouse
+        app.kubernetes.io/component: rbac
+        app.kubernetes.io/managed-by: argocd
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: clickhouse-secrets-reader-for-cube
+subjects:
+    - kind: ServiceAccount
+      name: cube-external-secrets
+      namespace: cube

--- a/apps/kube/clickhouse/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
     - clickhouse-keeper.yaml
     - clickhouse-installation.yaml
     - external-secrets-rbac.yaml
+    - cube-external-secrets-rbac.yaml
     - postgres-externalsecret.yaml
     - sealed-clickhouse-admin.yaml
     - ch-ingest-grants-job.yaml

--- a/apps/kube/cube/application.yaml
+++ b/apps/kube/cube/application.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: cube
+    namespace: argocd
+    annotations:
+        kbve.com/source-path: kube/cube
+        kbve.com/manifest-path: apps/kube/cube
+        kbve.com/application-file: kube/cube/application.yaml
+        kbve.com/managed-by: argocd
+        kbve.com/schema-version: v1
+        kbve.com/category: observability
+        kbve.com/stack: core
+spec:
+    project: default
+    sources:
+        # Cube Store (pre-aggregation engine)
+        - repoURL: https://gadsme.github.io/charts
+          targetRevision: 1.2.0
+          chart: cubestore
+          helm:
+              releaseName: cubestore
+              valueFiles:
+                  - $values/apps/kube/cube/manifests/cubestore-values.yaml
+        # Cube API + refresh worker
+        - repoURL: https://gadsme.github.io/charts
+          targetRevision: 3.3.0
+          chart: cube
+          helm:
+              releaseName: cube
+              valueFiles:
+                  - $values/apps/kube/cube/manifests/cube-values.yaml
+        # Raw manifests: schema ConfigMap (from model/), external-secrets, sealed api secret
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          path: apps/kube/cube
+        # Values reference for the helm sources above
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: cube
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 10s
+                factor: 2
+                maxDuration: 5m

--- a/apps/kube/cube/kustomization.yaml
+++ b/apps/kube/cube/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cube
+
+# Raw manifests (secrets/RBAC-in-cube). The gadsme cube + cubestore helm
+# charts are separate ArgoCD sources; application.yaml is intentionally not
+# listed here so kustomize does not render the Application itself.
+resources:
+    - manifests/external-secret.yaml
+    - manifests/api-secret-sealed.yaml
+
+# Generate the Cube data-model ConfigMap from the Phase A models (single
+# source of truth). Mounted at /cube/conf/model by the cube helm values.
+configMapGenerator:
+    - name: cube-schema
+      files:
+          - model/ch_logs.yml
+          - model/ch_mc_snapshots.yml
+          - model/pg_mc_player.yml
+          - model/pg_users.yml
+
+generatorOptions:
+    disableNameSuffixHash: true

--- a/apps/kube/cube/manifests/api-secret-sealed.yaml
+++ b/apps/kube/cube/manifests/api-secret-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cube-api-secret
+  namespace: cube
+spec:
+  encryptedData:
+    api-secret: AgDIeLxwKNFSiJWHyNrtcDjfI46nnWCEUsmWMQG1kXcUNZY3+999l1kLUDevO9Kisbi9ykdWdOrOQ++bTiBWa2VamvK2s8eM+z33A69eGfR87hpMks0MQw1Lz6DrU6L9U6ZDCUhoJBtfD5CkIRquUY2gGJQg7s79U0ZxzhPdObIJTn6qqjQeSQD+0ApRoKtV4oIcmEn0OtmrnBz6HIArxSvLWOn5lV5DlU1eQo78+keu3Eci1ukD/L4JI5jXa5GyNer1+fdvpVXNO8Vj7pkGngfD+mh3BHRgpRqzl1orjUNvR9Ibktzf2UICChVMb5Khwo/6AR8ceBk5jeepCVpGfk1SzEAHU+457jz1CqszGV9iCsSBIPYMwzSMGPPVSvc/OEwMOMM63/U10DwBPSdclx6nVcCpLAvu8pMk4Tx/twpEuW3/b7Nr6QRNUvOWxUks+URKpJsfuJs2nnehk1KYF25AqFXZ126UcPosKeC6DlA2SDze/D8efVIpbYBuot5fsEKhxKP24L1IAh39L1+jdNoecR/kKMtdHh+H0N7vCXQ59SoOd8IMc6D1ODNiqwQbFsAArdKgAatDzmuEb3iVrZZg0l/MA/5bMwB7Q/btFf2P1LgnsnrbGn/z54FOQEL9fsXHa5muFAOQIKYpBeiCOeNqwzNUoD2bFFCtV08Wz3wb/sEWGz0WkhGxvfr2df8VtY4mpgnioCSiSLcZivU8yx1XIAtYTn3T01hSqtuZH3zs1FrK5mNazQNx47+yeXZ+n2W14E4aVV6KymrmQw2Xgtvb
+  template:
+    metadata:
+      name: cube-api-secret
+      namespace: cube

--- a/apps/kube/cube/manifests/cube-values.yaml
+++ b/apps/kube/cube/manifests/cube-values.yaml
@@ -1,6 +1,12 @@
 # Cube API + refresh worker (gadsme/cube).
 # image.tag left unset -> chart uses appVersion (Cube 1.5.3), not latest.
 
+# Stakater Reloader restarts the deployments when the schema ConfigMap or
+# the credential Secrets change (the ConfigMap name is stable, so pods would
+# not otherwise pick up model edits).
+commonAnnotations:
+    reloader.stakater.com/auto: "true"
+
 config:
     devMode: false
     logLevel: "warn"

--- a/apps/kube/cube/manifests/cube-values.yaml
+++ b/apps/kube/cube/manifests/cube-values.yaml
@@ -1,0 +1,59 @@
+# Cube API + refresh worker (gadsme/cube).
+# image.tag left unset -> chart uses appVersion (Cube 1.5.3), not latest.
+
+config:
+    devMode: false
+    logLevel: "warn"
+    telemetry: false
+    # Load data models from the mounted ConfigMap at /cube/conf/model.
+    schemaPath: "model"
+    cacheAndQueueDriver: cubestore
+    apiSecretFromSecret:
+        name: cube-api-secret
+        key: api-secret
+    # Mount the cube-schema ConfigMap (generated from apps/kube/cube/model/).
+    volumes:
+        - name: schema
+          configMap:
+              name: cube-schema
+    volumeMounts:
+        - name: schema
+          readOnly: true
+          mountPath: /cube/conf/model
+
+# Cube API connects to the Cube Store router (same namespace).
+cubestore:
+    host: cubestore-router
+
+extraEnvVars:
+    - name: CUBEJS_DATASOURCES
+      value: "default,clickhouse"
+    # Required for cross-source rollup_join on this Cube version (verify on 1.5.3).
+    - name: CUBEJS_TESSERACT_SQL_PLANNER
+      value: "false"
+
+datasources:
+    # Default: Postgres (kilobase-rw -> supabase database)
+    default:
+        type: postgres
+        host: kilobase-rw.kilobase.svc
+        port: 5432
+        name: supabase
+        user: postgres
+        maxPool: 3
+        passFromSecret:
+            name: cube-pg-secret
+            key: pg-password
+    # Named: ClickHouse (renders as CUBEJS_DS_CLICKHOUSE_*)
+    clickhouse:
+        type: clickhouse
+        host: clickhouse-clickhouse-cluster.clickhouse.svc
+        port: 8123
+        user: default
+        passFromSecret:
+            name: cube-ch-secret
+            key: ch-password
+
+api:
+    # Number of Cube API replicas (chart key is apiCount). Worker is always 1.
+    apiCount: 2

--- a/apps/kube/cube/manifests/cubestore-values.yaml
+++ b/apps/kube/cube/manifests/cubestore-values.yaml
@@ -1,0 +1,37 @@
+# Cube Store — pre-aggregation engine (gadsme/cubestore).
+# image.tag left unset -> chart uses appVersion (Cube Store 1.5.3), not latest.
+
+config:
+    logLevel: "error"
+
+# Shared metadata + datasets volume (router + workers mount it, RWX).
+remoteDir:
+    persistence:
+        resourcePolicy: keep
+        size: 10Gi
+        accessModes:
+            - ReadWriteMany
+        storageClass: longhorn-sdb
+
+router:
+    httpPort: 3030
+    metaPort: 9999
+    # Expose the MySQL-protocol port so the Cube API can connect to the router.
+    mysqlPort: 3306
+    resources:
+        requests:
+            cpu: 200m
+            memory: 512Mi
+        limits:
+            cpu: "1"
+            memory: 1Gi
+
+workers:
+    workersCount: 1
+    resources:
+        requests:
+            cpu: 200m
+            memory: 512Mi
+        limits:
+            cpu: "1"
+            memory: 2Gi

--- a/apps/kube/cube/manifests/external-secret.yaml
+++ b/apps/kube/cube/manifests/external-secret.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: cube-external-secrets
+    namespace: cube
+---
+# Reads the Postgres superuser password from kilobase.
+# RBAC granted in apps/kube/kilobase/manifests/cube-external-secrets-rbac.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: cube-kilobase-store
+    namespace: cube
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: cube-external-secrets
+                    namespace: cube
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# Reads the ClickHouse admin password from the clickhouse namespace.
+# RBAC granted in apps/kube/clickhouse/manifests/cube-external-secrets-rbac.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: cube-clickhouse-store
+    namespace: cube
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: clickhouse
+            auth:
+                serviceAccount:
+                    name: cube-external-secrets
+                    namespace: cube
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: cube-pg-credentials
+    namespace: cube
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: cube-kilobase-store
+        kind: SecretStore
+    target:
+        name: cube-pg-secret
+        creationPolicy: Owner
+    data:
+        - secretKey: pg-password
+          remoteRef:
+              key: supabase-postgres
+              property: password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: cube-ch-credentials
+    namespace: cube
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: cube-clickhouse-store
+        kind: SecretStore
+    target:
+        name: cube-ch-secret
+        creationPolicy: Owner
+    data:
+        - secretKey: ch-password
+          remoteRef:
+              key: clickhouse-admin-credentials
+              property: password

--- a/apps/kube/kilobase/manifests/cube-external-secrets-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cube-external-secrets-rbac.yaml
@@ -1,0 +1,35 @@
+---
+# Allows the cube namespace external-secrets SA to read the Postgres
+# superuser secret in kilobase (for the Cube semantic layer datasource).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: kilobase-secrets-reader-for-cube
+    namespace: kilobase
+    labels:
+        app.kubernetes.io/name: kilobase
+        app.kubernetes.io/component: rbac
+        app.kubernetes.io/managed-by: argocd
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-postgres']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: cube-read-kilobase-secrets
+    namespace: kilobase
+    labels:
+        app.kubernetes.io/name: kilobase
+        app.kubernetes.io/component: rbac
+        app.kubernetes.io/managed-by: argocd
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kilobase-secrets-reader-for-cube
+subjects:
+    - kind: ServiceAccount
+      name: cube-external-secrets
+      namespace: cube

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -46,6 +46,7 @@ resources:
     - clickhouse-crds/application.yaml
     - clickhouse-operator/application.yaml
     - clickhouse/application.yaml
+    - cube/application.yaml
 
     - cityvote/application.yaml
     - herbmail/application.yaml

--- a/docs/superpowers/plans/2026-07-19-cube-phase-b-argocd.md
+++ b/docs/superpowers/plans/2026-07-19-cube-phase-b-argocd.md
@@ -1,0 +1,461 @@
+# Cube Phase B (ArgoCD k8s service) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Deploy Cube as a cluster-native ArgoCD service under `apps/kube/cube/`, using the `gadsme/cube` + `gadsme/cubestore` Helm charts, serving the Phase-A data models over the in-cluster Postgres (kilobase) + ClickHouse, with pre-aggregations in Cube Store.
+
+**Architecture:** One ArgoCD Application, multi-source: the two gadsme Helm charts (values from repo via `$values`), plus a repo path (kustomize) for the schema ConfigMap + external-secrets wiring. Models are delivered as a ConfigMap (kustomize `configMapGenerator` from `apps/kube/cube/model/*.yml`) mounted at `/cube/conf/model`. DB credentials come from existing cluster secrets via external-secrets. In-cluster ClusterIP Service only (no ingress this phase).
+
+**Tech Stack:** ArgoCD, Helm (`gadsme/cube` v3.3.0 / `gadsme/cubestore` v1.2.0, appVersion Cube 1.5.3), external-secrets, kustomize, Longhorn (`longhorn-sdb`).
+
+## Global Constraints
+
+- Cube image pinned via chart appVersion **1.5.3** (chart-default) — do NOT use `latest`. If overriding `image.tag`, pin an exact version.
+- Namespace: `cube`. ArgoCD `Application` in `argocd` namespace, matching `apps/kube/cnpg/application.yaml` conventions (`kbve.com/*` annotations, `sources` with `$values` ref, `syncPolicy` automated/selfHeal/prune, `CreateNamespace=true`, `ServerSideApply=true`).
+- Postgres (default datasource): host `kilobase-rw.kilobase.svc`, port `5432`, database `supabase`, user `postgres`, password from secret (external-secrets). Pool small: `maxPool: 3`.
+- ClickHouse (named datasource `clickhouse`): host `clickhouse-clickhouse-cluster.clickhouse.svc`, port `8123`, user `default`, password from secret. Renders as `CUBEJS_DS_CLICKHOUSE_*` via the chart's `cube.env.decorated`.
+- `CUBEJS_DATASOURCES=default,clickhouse`, `CUBEJS_DEV_MODE=false`, `CUBEJS_TESSERACT_SQL_PLANNER=false` (required for cross-source rollup_join — verify still needed on 1.5.3), via `extraEnvVars`.
+- Cube Store PVC on storageClass `longhorn-sdb`.
+- Secrets never committed. External-secrets pulls PG password from `supabase-postgres` (ns kilobase, key `password`) and ClickHouse password from `clickhouse-admin-credentials` (ns clickhouse, key `password`). `CUBEJS_API_SECRET` from a committed SealedSecret or generated ExternalSecret target — never plaintext.
+- ArgoCD Apps track `main`; this lands on `dev` via PR, then dev→main, then ArgoCD reconciles. No `kubectl apply`.
+- No "Co-Authored-By"/"Generated with Claude Code" commit trailer.
+
+## File Structure
+
+```
+apps/kube/cube/
+  application.yaml              # ArgoCD Application (multi-source)
+  manifests/
+    kustomization.yaml         # configMapGenerator (schema) + resources (externalsecret, service)
+    cube-values.yaml           # gadsme/cube helm values
+    cubestore-values.yaml      # gadsme/cubestore helm values
+    external-secret.yaml       # SA + SecretStores + ExternalSecret -> cube-db-credentials
+  model/                       # (already merged in Phase A) 4 .yml cubes
+```
+
+`apps/kube/kustomization.yaml` gains the `apps/kube/cube/application.yaml` registration.
+
+---
+
+### Task 1: External-secrets — sync DB credentials into the `cube` namespace
+
+**Files:**
+- Create: `apps/kube/cube/manifests/external-secret.yaml`
+
+**Interfaces:**
+- Produces: a Kubernetes Secret `cube-db-credentials` (ns `cube`) with keys `pg-password`, `ch-password`, `api-secret`. The chart's `passFromSecret` / `apiSecretFromSecret` reference these.
+
+- [ ] **Step 1: Write the external-secrets manifest**
+
+Model on `apps/kube/discordsh/manifest/discordsh-externalsecret.yaml` (per-namespace `kubernetes`-provider SecretStore + dedicated ServiceAccount). Two SecretStores (kilobase + clickhouse remote namespaces) and one ExternalSecret assembling all three keys. `api-secret` is a fixed value here is NOT allowed (no plaintext) — instead generate it as a SealedSecret in Task 1a OR source from an existing secret. Use this shape:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cube-external-secrets
+  namespace: cube
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: cube-kilobase-store
+  namespace: cube
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: kilobase
+      auth:
+        serviceAccount:
+          name: cube-external-secrets
+          namespace: cube
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: cube-clickhouse-store
+  namespace: cube
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: clickhouse
+      auth:
+        serviceAccount:
+          name: cube-external-secrets
+          namespace: cube
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cube-pg-credentials
+  namespace: cube
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: cube-kilobase-store
+    kind: SecretStore
+  target:
+    name: cube-db-credentials
+    creationPolicy: Merge
+  data:
+    - secretKey: pg-password
+      remoteRef:
+        key: supabase-postgres
+        property: password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cube-ch-credentials
+  namespace: cube
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: cube-clickhouse-store
+    kind: SecretStore
+  target:
+    name: cube-db-credentials
+    creationPolicy: Merge
+  data:
+    - secretKey: ch-password
+      remoteRef:
+        key: clickhouse-admin-credentials
+        property: password
+```
+
+Note: both ExternalSecrets target `cube-db-credentials` with `creationPolicy: Merge` so they co-populate one Secret. The `api-secret` key is added in Task 1a.
+
+Also grant the `cube-external-secrets` SA RBAC to read secrets in the remote namespaces — mirror exactly how the discordsh manifest grants it (Role/RoleBinding in kilobase; replicate for clickhouse). Copy that RBAC shape from the discordsh reference file into this manifest.
+
+- [ ] **Step 2: Verify manifest renders**
+
+Run: `kubectl --dry-run=client -o yaml apply -f apps/kube/cube/manifests/external-secret.yaml`
+Expected: valid YAML, no schema errors. (Live sync verified post-ArgoCD in Task 6.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kube/cube/manifests/external-secret.yaml
+git commit -m "feat(cube): external-secrets for db credentials"
+```
+
+---
+
+### Task 1a: API secret via SealedSecret
+
+**Files:**
+- Create: `apps/kube/cube/manifests/api-secret-sealed.yaml`
+- Modify: `apps/kube/cube/manifests/external-secret.yaml` (add `api-secret` merge — OR fold into the SealedSecret's own target)
+
+**Interfaces:**
+- Produces: `api-secret` key present in `cube-db-credentials` (or a dedicated `cube-api-secret` Secret the chart references).
+
+- [ ] **Step 1: Generate + seal the API secret**
+
+Use the repo's sealing tooling (mirror `apps/kube/kilobase/seal-*.sh` or the sealed-secrets controller). Generate a random 32-byte hex, create a Secret `cube-api-secret` (ns `cube`, key `api-secret`), seal it with `kubeseal` against the cluster's sealed-secrets controller, write the SealedSecret to `api-secret-sealed.yaml`. Do NOT commit the plaintext.
+
+Run: `openssl rand -hex 32` → feed into `kubectl create secret generic cube-api-secret -n cube --from-literal=api-secret=<hex> --dry-run=client -o yaml | kubeseal ... -o yaml > apps/kube/cube/manifests/api-secret-sealed.yaml`
+
+- [ ] **Step 2: Verify SealedSecret shape**
+
+Run: `grep -q 'kind: SealedSecret' apps/kube/cube/manifests/api-secret-sealed.yaml && echo OK`
+Expected: `OK`, and no plaintext `api-secret` value in git.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kube/cube/manifests/api-secret-sealed.yaml
+git commit -m "feat(cube): sealed api secret"
+```
+
+---
+
+### Task 2: Schema ConfigMap via kustomize + Service
+
+**Files:**
+- Create: `apps/kube/cube/manifests/kustomization.yaml`
+- Create: `apps/kube/cube/manifests/service.yaml`
+
+**Interfaces:**
+- Consumes: `apps/kube/cube/model/*.yml` (Phase A).
+- Produces: ConfigMap `cube-schema` (the 4 model files) + ClusterIP Service `cube-api` (port 4000). The cube-values mounts `cube-schema` at `/cube/conf/model`.
+
+- [ ] **Step 1: Write kustomization with configMapGenerator**
+
+`apps/kube/cube/manifests/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cube
+resources:
+  - external-secret.yaml
+  - api-secret-sealed.yaml
+  - service.yaml
+configMapGenerator:
+  - name: cube-schema
+    files:
+      - ../model/ch_logs.yml
+      - ../model/ch_mc_snapshots.yml
+      - ../model/pg_mc_player.yml
+      - ../model/pg_users.yml
+generatorOptions:
+  disableNameSuffixHash: true
+```
+
+`disableNameSuffixHash: true` keeps the ConfigMap name stable (`cube-schema`) so the chart's volume reference is fixed. (Trade-off: pod restart on model change must be triggered by ArgoCD sync / rollout; acceptable — refresh worker reloads.)
+
+- [ ] **Step 2: Write the Service**
+
+`apps/kube/cube/manifests/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cube-api
+  namespace: cube
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: cube
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000
+```
+
+Note: confirm the chart's API pod labels in Task 5's `helm template` render; adjust the selector to match the chart's actual labels if different. (The gadsme chart may already create its own Service — if so, DROP this file and use the chart's Service instead; decide in Task 5.)
+
+- [ ] **Step 3: Verify kustomize builds**
+
+Run: `kubectl kustomize apps/kube/cube/manifests/`
+Expected: renders the ConfigMap `cube-schema` with all 4 model files inlined, the Service, external-secret, and sealed secret. No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/manifests/kustomization.yaml apps/kube/cube/manifests/service.yaml
+git commit -m "feat(cube): schema configmap generator + api service"
+```
+
+---
+
+### Task 3: Cube Store Helm values
+
+**Files:**
+- Create: `apps/kube/cube/manifests/cubestore-values.yaml`
+
+**Interfaces:**
+- Produces: a Cube Store deployment (router + workers) with a `longhorn-sdb` PVC. Cube API/worker connect to it via its Service DNS (used in Task 4's `CUBEJS_CUBESTORE_HOST`).
+
+- [ ] **Step 1: Fetch the cubestore chart's values reference**
+
+Run: `curl -sf https://raw.githubusercontent.com/gadsme/charts/main/charts/cubestore/values.yaml | sed -n '1,120p'`
+Read it to learn the exact keys for: router/worker replicas, persistence (storageClass, size), resources, and the router Service name.
+
+- [ ] **Step 2: Write cubestore-values.yaml**
+
+Set: 1 router, 1–2 workers (sufficient for current rollup volume), persistence enabled on `storageClass: longhorn-sdb` sized ~10Gi (revisit from real rollup volume), modest resources. Use the exact keys discovered in Step 1 — do NOT guess key names.
+
+- [ ] **Step 3: Verify render**
+
+Run: `helm template cubestore gadsme/cubestore -f apps/kube/cube/manifests/cubestore-values.yaml` (after `helm repo add gadsme https://gadsme.github.io/charts && helm repo update`)
+Expected: renders a StatefulSet/Deployment with the `longhorn-sdb` PVC and a router Service; note the router Service DNS name for Task 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/manifests/cubestore-values.yaml
+git commit -m "feat(cube): cubestore helm values (longhorn-sdb pvc)"
+```
+
+---
+
+### Task 4: Cube Helm values (datasources, env, schema mount)
+
+**Files:**
+- Create: `apps/kube/cube/manifests/cube-values.yaml`
+
+**Interfaces:**
+- Consumes: `cube-db-credentials` secret (Task 1), `cube-api-secret` (Task 1a), `cube-schema` ConfigMap (Task 2), cubestore router Service (Task 3).
+- Produces: Cube API + refresh-worker deployments wired to both datasources, Cube Store, and the schema mount.
+
+- [ ] **Step 1: Write cube-values.yaml**
+
+```yaml
+image:
+  # chart appVersion pins Cube 1.5.3; omit tag to use it, or pin explicitly:
+  tag: "v1.5.3"
+
+config:
+  devMode: false
+  logLevel: "warn"
+  telemetry: false
+  schemaPath: "model"          # loads from /cube/conf/model
+  cacheAndQueueDriver: cubestore
+  apiSecretFromSecret:
+    name: cube-api-secret
+    key: api-secret
+  # mount the schema ConfigMap into api + worker
+  volumes:
+    - name: schema
+      configMap:
+        name: cube-schema
+  volumeMounts:
+    - name: schema
+      readOnly: true
+      mountPath: /cube/conf/model
+
+cubestore:
+  # point Cube at the cubestore router Service (name from Task 3 Step 3)
+  host: <cubestore-router-service-dns>
+
+extraEnvVars:
+  - name: CUBEJS_DATASOURCES
+    value: "default,clickhouse"
+  - name: CUBEJS_TESSERACT_SQL_PLANNER
+    value: "false"
+
+datasources:
+  default:
+    type: postgres
+    host: kilobase-rw.kilobase.svc
+    port: 5432
+    name: supabase
+    user: postgres
+    maxPool: 3
+    passFromSecret:
+      name: cube-db-credentials
+      key: pg-password
+  clickhouse:
+    type: clickhouse
+    host: clickhouse-clickhouse-cluster.clickhouse.svc
+    port: 8123
+    user: default
+    passFromSecret:
+      name: cube-db-credentials
+      key: ch-password
+
+api:
+  replicas: 2
+worker:
+  replicas: 1
+```
+
+Adjust `cubestore.host`, the exact `cubestore:` value key, and `api`/`worker`/`schemaPath` key names to the chart's real schema (verified in Task 5). The chart's `cube.env.decorated` renders `datasources.clickhouse` as `CUBEJS_DS_CLICKHOUSE_*`.
+
+- [ ] **Step 2: Render + verify the env is correct (critical)**
+
+Run: `helm template cube gadsme/cube -f apps/kube/cube/manifests/cube-values.yaml | grep -E 'CUBEJS_DB_|CUBEJS_DS_CLICKHOUSE_|CUBEJS_TESSERACT|CUBEJS_DATASOURCES|CUBEJS_CUBESTORE_HOST|secretKeyRef|mountPath'`
+Expected: `CUBEJS_DB_HOST=kilobase-rw...`, `CUBEJS_DB_NAME=supabase`, `CUBEJS_DS_CLICKHOUSE_DB_HOST=clickhouse-clickhouse-cluster...`, `CUBEJS_TESSERACT_SQL_PLANNER=false`, `CUBEJS_DATASOURCES=default,clickhouse`, cubestore host set, `secretKeyRef` for both passwords + api secret, and the schema volume mounted at `/cube/conf/model`. Fix values until this render is correct.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kube/cube/manifests/cube-values.yaml
+git commit -m "feat(cube): cube helm values (datasources, tesseract off, schema mount)"
+```
+
+---
+
+### Task 5: ArgoCD Application + registration
+
+**Files:**
+- Create: `apps/kube/cube/application.yaml`
+- Modify: `apps/kube/kustomization.yaml` (register the app)
+
+**Interfaces:**
+- Produces: an ArgoCD `Application` that syncs cubestore + cube charts + the manifests kustomize dir into ns `cube`.
+
+- [ ] **Step 1: Write application.yaml (multi-source)**
+
+Mirror `apps/kube/cnpg/application.yaml`. Sources:
+1. `repoURL: https://gadsme.github.io/charts`, `chart: cubestore`, `targetRevision: 1.2.0`, helm `releaseName: cubestore`, `valueFiles: [$values/apps/kube/cube/manifests/cubestore-values.yaml]`.
+2. `repoURL: https://gadsme.github.io/charts`, `chart: cube`, `targetRevision: 3.3.0`, helm `releaseName: cube`, `valueFiles: [$values/apps/kube/cube/manifests/cube-values.yaml]`.
+3. `repoURL: https://github.com/kbve/kbve`, `targetRevision: main`, `path: apps/kube/cube/manifests` (kustomize: configmap + externalsecret + sealed secret + service).
+4. `repoURL: https://github.com/kbve/kbve`, `targetRevision: main`, `ref: values`.
+
+`destination.namespace: cube`, `syncPolicy` automated/selfHeal/prune + `CreateNamespace=true`, `ServerSideApply=true`, retry. Add `kbve.com/*` annotations (`category: observability`, `stack: core`).
+
+Note: source 3 (kustomize) must NOT also try to template the helm charts — keep the kustomize `resources` limited to the raw manifests. Confirm ArgoCD renders sources independently.
+
+- [ ] **Step 2: Register in the app-of-apps**
+
+Add `apps/kube/cube/application.yaml` to `apps/kube/kustomization.yaml` resources (match how other apps are listed).
+
+- [ ] **Step 3: Verify YAML + kustomize**
+
+Run: `kubectl --dry-run=client -o yaml apply -f apps/kube/cube/application.yaml >/dev/null && echo APP_OK`
+Run: `kubectl kustomize apps/kube/ >/dev/null && echo ROOT_OK`
+Expected: both `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kube/cube/application.yaml apps/kube/kustomization.yaml
+git commit -m "feat(cube): argocd application + app-of-apps registration"
+```
+
+---
+
+### Task 6: Ship + verify sync
+
+**Files:** none (integration).
+
+- [ ] **Step 1: PR to dev**
+
+Push branch, open PR → `dev`. Include the docs link per repo convention.
+
+- [ ] **Step 2: After dev→main merge, watch ArgoCD reconcile**
+
+The Apps track `main`. Once merged to main, ArgoCD auto-syncs. Verify:
+```bash
+kubectl get application cube -n argocd -o jsonpath='{.status.sync.status} {.status.health.status}'
+kubectl get pods -n cube
+kubectl get externalsecret -n cube
+kubectl get pvc -n cube
+```
+Expected: Application `Synced`/`Healthy`; cube-api (2), cube-worker (1), cubestore pods Running; `cube-db-credentials` secret populated (both keys); PVC bound on `longhorn-sdb`.
+
+- [ ] **Step 3: Validate the models in-cluster (incl. re-verify Tesseract/rollup_join on 1.5.3)**
+
+```bash
+kubectl port-forward -n cube svc/cube-api 4000:4000 &
+curl -sf localhost:4000/cubejs-api/v1/meta | python3 -c 'import sys,json;print(sorted(c["name"] for c in json.load(sys.stdin)["cubes"]))'
+# pg + ch + federated queries (same as Phase A)
+```
+Expected: 4 cubes; `pg_users.count` 42; `ch_logs.count` ~17M served from a pre-agg; federated `rollup_join` executes (uses both rollups). If rollup_join fails on 1.5.3 without the Tesseract flag change, adjust `cube-values.yaml` extraEnvVars and re-sync.
+
+- [ ] **Step 4: Update spec status**
+
+Mark Phase B live in `docs/superpowers/specs/2026-07-18-cube-semantic-layer-design.md`; note the resolved cubestore host + any chart-key corrections. Commit.
+
+---
+
+## Self-Review
+
+- **Coverage:** ArgoCD app ✓ (T5), gadsme cube+cubestore charts ✓ (T3/T4/T5), models via kustomize configMapGenerator ✓ (T2), external-secrets from existing secrets ✓ (T1), API secret sealed ✓ (T1a), in-cluster Service only ✓ (T2, no ingress), Tesseract flag + datasource env verified by `helm template` ✓ (T4 Step 2), PVC on `longhorn-sdb` ✓ (T3), pinned versions ✓ (constraints), sync-not-apply ✓ (T6).
+- **Placeholder scan:** `<cubestore-router-service-dns>` and the chart-key adjustments are explicitly resolved by the `helm template` / values-reference steps (T3 Step 1/3, T4 Step 2) before commit — each carries a discovery command, not a lazy TBD.
+- **Consistency:** secret `cube-db-credentials` keys `pg-password`/`ch-password` referenced identically in T1 and T4; `cube-api-secret`/`api-secret` in T1a and T4; ConfigMap `cube-schema` + mount `/cube/conf/model` consistent T2↔T4; namespace `cube` throughout.
+
+## Open items to confirm during execution (not blockers)
+
+1. Whether the gadsme `cube` chart ships its own Service (then drop `service.yaml`) — resolved in T5 render.
+2. Exact `cubestore` host value key + whether the cube chart auto-wires it when both are in one release namespace — resolved in T3/T4 renders.
+3. Whether Cube 1.5.3 still needs `CUBEJS_TESSERACT_SQL_PLANNER=false` for rollup_join — resolved in T6 Step 3 (adjust + re-sync if not).


### PR DESCRIPTION
## Cube semantic layer — Phase B (ArgoCD k8s service)

Promotes Cube (Phase A models) to a cluster-native ArgoCD service under `apps/kube/cube/`, using the `gadsme/cube` + `gadsme/cubestore` Helm charts. No custom image — stock Cube **1.5.3** + models delivered as a ConfigMap.

### What's here
- **ArgoCD Application** (`apps/kube/cube/application.yaml`) — multi-source: gadsme cubestore (1.2.0) + cube (3.3.0) charts + repo kustomize (configmap/secrets) + `$values` ref. Registered in the app-of-apps.
- **Schema ConfigMap** via kustomize `configMapGenerator` from `apps/kube/cube/model/*.yml` (single source of truth) → mounted `/cube/conf/model`.
- **Credentials via external-secrets** — `cube-external-secrets` SA reads `supabase-postgres` (kilobase) + `clickhouse-admin-credentials` (clickhouse) into `cube-pg-secret` / `cube-ch-secret`. Isolated additive RBAC in each remote namespace. API secret as a **SealedSecret** (no plaintext).
- **Cube Store** on `longhorn-sdb` RWX PVC.

### Config (verified via `helm template`)
- PG default: `kilobase-rw.kilobase.svc` / db `supabase` / pool 3
- CH named: `clickhouse-clickhouse-cluster.clickhouse.svc:8123` → `CUBEJS_DS_CLICKHOUSE_*`
- `CUBEJS_TESSERACT_SQL_PLANNER=false`, `CUBEJS_CUBESTORE_HOST=cubestore-router`, API replicas 2, prod mode
- Reloader annotation → pods restart on schema/secret change

### Deploy = ArgoCD reconcile (no kubectl apply)
Apps track `main`; merges dev→main → ArgoCD auto-syncs. Post-sync verification (in the plan's Task 6): app Synced/Healthy, secrets populated, PVC bound, then re-run the PG/CH/federated queries in-cluster. Also **re-confirm the Tesseract flag is still needed on 1.5.3** (validated on `latest` in Phase A).

Plan: `docs/superpowers/plans/2026-07-19-cube-phase-b-argocd.md`.

### Notes
- Postgres uses the superuser secret (matches Phase A). A dedicated read-only analytics role is future hardening.
- All manifests validated locally (`helm template`, `kubectl kustomize`, `--dry-run`); live sync happens after dev→main merge.
