### PR TITLE
feat(discordsh-bot): /wm unknown path throws the help menu (0.1.26)

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -1,4 +1,5 @@
 use poise::CreateReply;
+use serde_json::Value;
 use tracing::{info, warn};
 
 use crate::discord::bot::{Context, Error};
@@ -50,61 +51,104 @@ pub async fn wm(
                 args = arg_count,
                 "windmill run ok"
             );
-            let json_reply = || {
-                let body =
-                    serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
-                let trimmed = truncate_for_discord(&body);
-                CreateReply::default()
-                    .content(format!("`/wm {path_for_log}` ok:\n```json\n{trimmed}\n```"))
-                    .ephemeral(true)
-            };
-
-            // Try the rich embed first; if Discord rejects it (total size, bad
-            // URL, empty field), fall back to the JSON block so the job result
-            // is never lost.
-            match windmill_embed::embed_from_value(&value) {
-                Some(embed) => {
-                    if ctx
-                        .send(CreateReply::default().embed(embed).ephemeral(true))
-                        .await
-                        .is_err()
-                    {
-                        warn!(
-                            wm_path = %path_for_log,
-                            "embed send rejected; falling back to JSON"
-                        );
-                        ctx.send(json_reply()).await?;
-                    }
-                }
-                None => {
-                    ctx.send(json_reply()).await?;
-                }
-            }
+            send_value_reply(ctx, &value, &path_for_log, None).await?;
         }
-        Err(e) => {
+        // Unknown or blocked command name (and the defensive empty-path case)
+        // → render the help menu itself, prefixed with a closest-match hint,
+        // rather than erroring out. The menu is the recovery path.
+        Err(e @ (RunError::PathNotAllowed | RunError::EmptyPath)) => {
             warn!(
                 wm_path = %path_for_log,
                 user = %discord.username,
                 error = %e,
+                "windmill run rejected; falling back to help menu"
+            );
+            let attempted = command_leaf(&path_for_log);
+            let mut hint = format!("❓ Unknown command `/wm {attempted}`.");
+            if let Some(near) = suggest_command(&attempted, &cfg.list_command_names().await) {
+                hint.push_str(&format!(" Did you mean `/wm {near}`?"));
+            }
+            hint.push_str(" Here's every command:");
+
+            // Guard against re-running the help path when the miss *was* help
+            // (e.g. help not yet synced) — that would just error again.
+            if wm_path == WM_INDEX_PATH {
+                ctx.send(
+                    CreateReply::default()
+                        .content(format!("{hint} (menu unavailable — try again shortly)"))
+                        .ephemeral(true),
+                )
+                .await?;
+            } else {
+                match cfg.run(WM_INDEX_PATH, &[], &discord).await {
+                    Ok(value) => {
+                        send_value_reply(ctx, &value, WM_INDEX_PATH, Some(hint)).await?;
+                    }
+                    Err(help_err) => {
+                        warn!(error = %help_err, "help menu fallback also failed");
+                        ctx.send(
+                            CreateReply::default()
+                                .content(format!("{hint} Run `/wm help` for the full list."))
+                                .ephemeral(true),
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+        Err(other) => {
+            warn!(
+                wm_path = %path_for_log,
+                user = %discord.username,
+                error = %other,
                 "windmill run failed"
             );
-            let content = match e {
-                // Unknown or blocked command name → guide to the menu rather
-                // than leaking that an allowlist rejected it, and suggest the
-                // closest real command when the miss looks like a typo.
-                RunError::PathNotAllowed => {
-                    let attempted = command_leaf(&path_for_log);
-                    let mut msg = format!("❓ Unknown command `/wm {attempted}`.");
-                    if let Some(near) = suggest_command(&attempted, &cfg.list_command_names().await) {
-                        msg.push_str(&format!(" Did you mean `/wm {near}`?"));
-                    }
-                    msg.push_str(" Run `/wm help` for the full list.");
-                    msg
-                }
-                other => format!("windmill error: {other}"),
-            };
-            ctx.send(CreateReply::default().content(content).ephemeral(true))
-                .await?;
+            ctx.send(
+                CreateReply::default()
+                    .content(format!("windmill error: {other}"))
+                    .ephemeral(true),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Render a Windmill job result as a reply: the rich embed when the result
+/// carries an `embed` contract, otherwise a pretty-printed JSON block. An
+/// optional `prefix` is prepended as message content (used by the help-menu
+/// fallback to surface the closest-match hint above the menu).
+async fn send_value_reply(
+    ctx: Context<'_>,
+    value: &Value,
+    label: &str,
+    prefix: Option<String>,
+) -> Result<(), Error> {
+    let json_reply = || {
+        let body = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+        let trimmed = truncate_for_discord(&body);
+        let content = match &prefix {
+            Some(p) => format!("{p}\n`/wm {label}` ok:\n```json\n{trimmed}\n```"),
+            None => format!("`/wm {label}` ok:\n```json\n{trimmed}\n```"),
+        };
+        CreateReply::default().content(content).ephemeral(true)
+    };
+
+    // Try the rich embed first; if Discord rejects it (total size, bad URL,
+    // empty field), fall back to the JSON block so the job result is never lost.
+    match windmill_embed::embed_from_value(value) {
+        Some(embed) => {
+            let mut reply = CreateReply::default().embed(embed).ephemeral(true);
+            if let Some(p) = &prefix {
+                reply = reply.content(p.clone());
+            }
+            if ctx.send(reply).await.is_err() {
+                warn!(label, "embed send rejected; falling back to JSON");
+                ctx.send(json_reply()).await?;
+            }
+        }
+        None => {
+            ctx.send(json_reply()).await?;
         }
     }
     Ok(())

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.25"
+version: "0.1.26"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## What

When `/wm <bad-or-missing-path>` is rejected (`PathNotAllowed` / `EmptyPath`), render the **`f/discordsh/help` menu embed** instead of a bare text error. The menu is prefixed with the existing closest-match hint ("Did you mean `/wm poem`?"), so a mistyped command lands the user on the full command list rather than a dead end.

- Refactored result rendering into `send_value_reply()` — reused by both the normal path and the fallback (with an optional content prefix).
- Guards against re-running `help` when the miss *was* `help` (e.g. not yet synced) → plain text hint instead of a loop.
- Other errors (upstream, rate-limit) still surface as errors.

## Version
Bumps `0.1.26` (dev already carries `0.1.25` from #14270). Ensures this deploys regardless of #14270's order reaching main.

## Verified
- `cargo build` clean (only a pre-existing unrelated unused-import warning).

Relates to the /wm batch #14278.