### PR TITLE
feat(embeddb): single-file Turso+DuckDB embedded crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aegis"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58541132f980da31e9aa99f7bdee69bc84bf1e168b9b91ef2dbe8abb7b4ce5dd"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
 name = "aeronet_io"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +392,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "agones"
 version = "1.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,11 +444,23 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -461,6 +497,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "alsa"
@@ -585,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -611,7 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
  "anstyle",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -662,6 +704,22 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antithesis_sdk"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "linkme",
+ "once_cell",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -736,6 +794,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aristo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdeefa800110050103e2459a2f8dbdbd560ad046e30f1f87e24ce19c2cb8bde"
+dependencies = [
+ "aristo-macros",
+]
+
+[[package]]
+name = "aristo-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64a66d21a80182b35b1741997a6d2456911f54b7eb1918aa4e2382fc205268d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arpg-server"
 version = "0.1.27"
 dependencies = [
@@ -767,6 +845,169 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half 2.7.1",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half 2.7.1",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half 2.7.1",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half 2.7.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half 2.7.1",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -948,6 +1189,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "async-broadcast"
@@ -4078,6 +4325,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,6 +4359,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -4112,7 +4395,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -4166,6 +4449,15 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "bytemuck",
  "serde_core",
+]
+
+[[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4299,6 +4591,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,6 +4659,28 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -4564,14 +4911,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -4583,6 +4930,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cesu8"
@@ -4637,6 +4990,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "cgl"
@@ -4819,7 +5178,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "polonius-the-crab",
  "serde",
  "thiserror 2.0.18",
@@ -4911,7 +5270,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4922,7 +5281,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4954,6 +5313,17 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5311,6 +5681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,6 +5794,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -5540,6 +5941,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -5746,6 +6156,12 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "deadpool"
@@ -6187,6 +6603,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6277,7 +6711,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6e995b8e434d65aefd12c4519221be3e8f38efd77804ef39ca10553f4ad7063"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -6316,7 +6750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34aaf627da598dfadd64b0fee6101d22e9c451d1e5348157312720b7f459f0f"
 dependencies = [
  "accesskit",
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.11.0",
  "emath",
  "epaint",
@@ -6335,7 +6769,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71033ff78b041c9c363450f4498ff95468ef3ecbcc71a62f67036a6207d98fa4"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -6471,6 +6905,17 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embeddb"
+version = "0.0.1"
+dependencies = [
+ "duckdb",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "turso",
+]
 
 [[package]]
 name = "embedded-io"
@@ -6652,12 +7097,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter 2.0.0",
+ "log",
+]
+
+[[package]]
 name = "epaint"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f3017dd67f147a697ee0c8484fb568fd9553e2a0c114be5020dbbc11962841"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "ecolor",
  "emath",
@@ -6841,6 +7306,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
 name = "fastnoise-lite"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6928,6 +7410,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -7219,6 +7711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7484,6 +7986,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7556,6 +8088,16 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -8181,6 +8723,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -8188,8 +8733,8 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
- "allocator-api2",
+ "ahash 0.8.12",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]
@@ -8198,7 +8743,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.1.5",
 ]
@@ -8209,7 +8754,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
  "serde",
@@ -8222,7 +8767,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -8234,6 +8779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -8445,6 +8999,12 @@ dependencies = [
  "log",
  "markup5ever 0.38.0",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "httlib-huffman"
@@ -8687,6 +9247,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8746,6 +9331,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -8975,12 +9563,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -9467,7 +10075,7 @@ version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytecount",
  "data-encoding",
  "email_address",
@@ -9778,7 +10386,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-broadcast",
  "async-stream",
  "backon",
@@ -9855,6 +10463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leafwing-input-manager"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9889,6 +10503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "lewton"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9897,6 +10517,63 @@ dependencies = [
  "byteorder",
  "ogg",
  "tinyvec",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
 ]
 
 [[package]]
@@ -9930,6 +10607,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip 6.0.0",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9954,6 +10648,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -10665,6 +11368,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "linkme"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10710,6 +11433,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10747,6 +11483,12 @@ name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "mac"
@@ -10921,6 +11663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10948,7 +11699,7 @@ dependencies = [
 name = "met"
 version = "0.1.5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "anyhow",
  "axum 0.8.9",
  "dotenvy",
@@ -10975,7 +11726,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "portable-atomic",
 ]
 
@@ -11010,7 +11761,7 @@ dependencies = [
  "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
- "sketches-ddsketch",
+ "sketches-ddsketch 0.3.1",
 ]
 
 [[package]]
@@ -11018,6 +11769,37 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -11131,6 +11913,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "mutants"
@@ -12216,6 +13004,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12269,6 +13072,15 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "pack1"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -12644,7 +13456,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "cc",
  "clang-sys",
  "eyre",
@@ -12652,7 +13464,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
  "walkdir",
 ]
@@ -12679,7 +13491,7 @@ dependencies = [
  "codepage",
  "encoding_rs",
  "eyre",
- "owo-colors",
+ "owo-colors 4.3.0",
  "pathsearch",
  "serde",
  "serde_json",
@@ -12728,7 +13540,7 @@ dependencies = [
  "clap-cargo",
  "eyre",
  "libc",
- "owo-colors",
+ "owo-colors 4.3.0",
  "paste",
  "pgrx",
  "pgrx-macros",
@@ -12739,7 +13551,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
  "sysinfo 0.34.2",
  "tempfile",
  "thiserror 2.0.18",
@@ -13177,6 +13989,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
@@ -13651,6 +14475,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13890,7 +14734,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -14027,6 +14871,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14049,6 +14902,15 @@ name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "rapier2d"
@@ -14271,7 +15133,7 @@ version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
@@ -14316,6 +15178,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "renderdoc-sys"
@@ -14372,6 +15243,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -14527,6 +15399,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmcp"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14615,6 +15516,16 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
 ]
 
 [[package]]
@@ -14751,7 +15662,7 @@ dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -14801,6 +15712,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14818,6 +15756,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
  "semver",
 ]
 
@@ -15781,6 +16729,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors 3.5.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_pcg 0.3.1",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15881,6 +16855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15912,6 +16895,15 @@ name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "skrifa"
@@ -16054,6 +17046,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "softaes"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
 
 [[package]]
 name = "softbuffer"
@@ -16206,7 +17204,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.14.5",
- "hashlink",
+ "hashlink 0.9.1",
  "hex",
  "indexmap 2.13.1",
  "log",
@@ -16506,6 +17504,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16559,6 +17600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16574,6 +17621,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16716,6 +17774,154 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tantivy"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "datasketches",
+ "downcast-rs 2.0.2",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru 0.16.3",
+ "lz4_flex 0.13.1",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch 0.4.0",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "typetag",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
+dependencies = [
+ "downcast-rs 2.0.2",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "ordered-float 5.3.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tao"
 version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16769,6 +17975,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -17961,6 +19178,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18218,6 +19448,199 @@ dependencies = [
 ]
 
 [[package]]
+name = "turso"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac8d131650c1bf6a2721202208b3dfba218be25c975f48bebda766173fbdc3b"
+dependencies = [
+ "mimalloc",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "allocator-api2 0.4.0",
+ "antithesis_sdk",
+ "arc-swap",
+ "aristo",
+ "bigdecimal",
+ "bitflags 2.11.0",
+ "branches",
+ "bumpalo",
+ "bytemuck",
+ "cfg_aliases 0.2.1",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "either",
+ "fallible-iterator 0.3.0",
+ "fastbloom",
+ "hex",
+ "icu_collator",
+ "icu_locale",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading 0.8.9",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "pastey 0.2.2",
+ "polling",
+ "rand 0.9.2",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tantivy",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
+dependencies = [
+ "chrono",
+ "getrandom 0.4.2",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "miette",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea1abf8f42cf5c40f9777982c8dfda776242397250eb48f99d524c383b1b641a"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_ext",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372ce1889d2729223886f805638a4357f389756d6b64e26487af5a78b3e92e2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4157da3af3730e3cf5109668dc29b58b673f99fbbac3db3a682a4b87d56b9c4a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "genawaiter",
+ "http 1.4.0",
+ "libc",
+ "prost 0.14.3",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa3b4dee7f50c671ca757d1ac1ea7c99a7a9dec819a98bb1ad6a055e7d0234f"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
 name = "twitch-irc"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18247,6 +19670,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "type-map"
@@ -18305,6 +19731,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "typetag"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90e86058a30d42a1a928dfb4b49bb33c98c3a2b4909492e6b0881cd94798ec2"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
 name = "typewit"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18344,6 +19794,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unescape"
@@ -18460,6 +19919,12 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -18653,6 +20118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18710,7 +20187,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -18946,6 +20423,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -19602,6 +21080,18 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -20275,7 +21765,7 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",
@@ -20489,6 +21979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20670,6 +22166,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -20998,6 +22504,20 @@ name = "zip"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [workspace]
 resolver = '2'
 members = [
+	'packages/rust/embeddb',
 	'packages/rust/kbve',
 	'packages/rust/erust',
 	'packages/rust/holy',

--- a/docs/superpowers/plans/2026-07-19-embeddb.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb.md
@@ -1,0 +1,529 @@
+# embeddb Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `embeddb`, a Rust library crate that pairs Turso (async write) and DuckDB (analytics read) over one SQLite-format file.
+
+**Architecture:** A single `EmbedDb` struct owns a Turso connection for writes. Analytics run by opening a fresh read-only DuckDB connection that `ATTACH`es the same file (`TYPE sqlite`), executed on a blocking thread so the public API stays uniformly async. v1 uses a checkpoint-then-read concurrency model.
+
+**Tech Stack:** Rust, `turso` 0.7, `duckdb` 1.x (bundled), `tokio`, `thiserror`.
+
+## Global Constraints
+
+- Crate lives at `packages/rust/embeddb`; add as member in root `Cargo.toml`.
+- Library only — no binary target, no service.
+- `duckdb` MUST use `features = ["bundled"]` — static link, ship no `.so`.
+- No panics on the library path; every fallible op returns `Result`.
+- No inline comments in source (repo convention: drop all comments).
+- **API reconciliation:** code below targets `turso` 0.7 and `duckdb` 1.x. If a
+  method name/signature differs from the installed crate version, adapt to the
+  real signature — the intent (open/execute/query/attach) is the contract, exact
+  symbols may shift. Verify against `cargo doc` for the pinned versions.
+- Build/test via `cargo` scoped to the crate: `cargo test -p embeddb`. (Root
+  workspace is large; never build the whole workspace for this crate.)
+- Commit after every task. No direct pushes to dev/main.
+
+---
+
+### Task 1: Scaffold crate + workspace membership
+
+**Files:**
+- Create: `packages/rust/embeddb/Cargo.toml`
+- Create: `packages/rust/embeddb/src/lib.rs`
+- Modify: root `Cargo.toml` (add member)
+
+**Interfaces:**
+- Produces: compiling empty `embeddb` lib crate reachable via `cargo build -p embeddb`.
+
+- [ ] **Step 1: Create `Cargo.toml`**
+
+```toml
+[package]
+name = "embeddb"
+version = "0.0.1"
+edition = "2021"
+description = "Single-file embedded DB: Turso write path + DuckDB analytics read path"
+license = "MIT"
+
+[dependencies]
+turso = "0.7"
+duckdb = { version = "1", features = ["bundled"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+```
+
+- [ ] **Step 2: Create minimal `src/lib.rs`**
+
+```rust
+mod error;
+
+pub use error::{EmbedError, Result};
+```
+
+Create `src/error.rs` as a stub so the module resolves:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum EmbedError {
+    #[error("placeholder")]
+    Placeholder,
+}
+
+pub type Result<T> = std::result::Result<T, EmbedError>;
+```
+
+- [ ] **Step 3: Add member to root `Cargo.toml`**
+
+Add `'packages/rust/embeddb',` to the `members` array.
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cargo build -p embeddb`
+Expected: compiles clean (may take a while first time — `duckdb` bundled compiles C once).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb Cargo.toml
+git commit -m "feat(embeddb): scaffold crate + workspace membership"
+```
+
+---
+
+### Task 2: Error enum
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/error.rs`
+
+**Interfaces:**
+- Produces: `EmbedError` with `Turso`, `Duck`, `Io` variants and `From` conversions; `Result<T>` alias.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/error.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_maps() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "nope");
+        let e: EmbedError = io.into();
+        assert!(matches!(e, EmbedError::Io(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p embeddb io_error_maps`
+Expected: FAIL — `EmbedError::Io` does not exist.
+
+- [ ] **Step 3: Replace the stub enum**
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum EmbedError {
+    #[error("turso error: {0}")]
+    Turso(#[from] turso::Error),
+    #[error("duckdb error: {0}")]
+    Duck(#[from] duckdb::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, EmbedError>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p embeddb io_error_maps`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/error.rs
+git commit -m "feat(embeddb): typed error enum with From conversions"
+```
+
+---
+
+### Task 3: `EmbedDb::open` + pragmas
+
+**Files:**
+- Create: `packages/rust/embeddb/src/db.rs`
+- Modify: `packages/rust/embeddb/src/lib.rs`
+- Test: in `src/db.rs`
+
+**Interfaces:**
+- Consumes: `Result`, `EmbedError` from Task 2.
+- Produces: `pub struct EmbedDb { path: PathBuf, conn: turso::Connection }`; `pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/db.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+use crate::Result;
+
+pub struct EmbedDb {
+    path: PathBuf,
+    conn: turso::Connection,
+}
+
+impl EmbedDb {
+    pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
+        unimplemented!()
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn open_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("t.db");
+        let db = EmbedDb::open(&p).await.unwrap();
+        assert_eq!(db.path(), p.as_path());
+        assert!(p.exists());
+    }
+}
+```
+
+- [ ] **Step 2: Wire module in `lib.rs`**
+
+```rust
+mod error;
+mod db;
+
+pub use error::{EmbedError, Result};
+pub use db::EmbedDb;
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p embeddb open_creates_file`
+Expected: FAIL — `unimplemented!()` panics.
+
+- [ ] **Step 4: Implement `open`**
+
+```rust
+pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
+    let path = path.as_ref().to_path_buf();
+    let db = turso::Builder::new_local(path.to_str().unwrap())
+        .build()
+        .await?;
+    let conn = db.connect()?;
+    conn.execute("PRAGMA journal_mode=WAL", ()).await.ok();
+    Ok(EmbedDb { path, conn })
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p embeddb open_creates_file`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/rust/embeddb/src/db.rs packages/rust/embeddb/src/lib.rs
+git commit -m "feat(embeddb): EmbedDb::open with WAL pragma"
+```
+
+---
+
+### Task 4: `execute` write path
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/db.rs`
+
+**Interfaces:**
+- Consumes: `EmbedDb` from Task 3.
+- Produces: `pub async fn execute(&self, sql: &str) -> Result<u64>` — returns rows affected.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` mod in `src/db.rs`:
+
+```rust
+#[tokio::test]
+async fn execute_creates_and_inserts() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("w.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10.0)").await.unwrap();
+    let n = db.execute("INSERT INTO t VALUES (2, 20.0)").await.unwrap();
+    assert_eq!(n, 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p embeddb execute_creates_and_inserts`
+Expected: FAIL — no `execute` method.
+
+- [ ] **Step 3: Implement `execute`**
+
+```rust
+pub async fn execute(&self, sql: &str) -> Result<u64> {
+    let affected = self.conn.execute(sql, ()).await?;
+    Ok(affected)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p embeddb execute_creates_and_inserts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): execute write path via Turso"
+```
+
+---
+
+### Task 5: `checkpoint`
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/db.rs`
+
+**Interfaces:**
+- Consumes: `EmbedDb` from Task 3.
+- Produces: `pub async fn checkpoint(&self) -> Result<()>` — flush WAL into the main file so a fresh reader sees a consistent image.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn checkpoint_after_write_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("c.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)").await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)").await.unwrap();
+    db.checkpoint().await.unwrap();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p embeddb checkpoint_after_write_ok`
+Expected: FAIL — no `checkpoint` method.
+
+- [ ] **Step 3: Implement `checkpoint`**
+
+```rust
+pub async fn checkpoint(&self) -> Result<()> {
+    self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
+    Ok(())
+}
+```
+
+If `PRAGMA wal_checkpoint` is unsupported by the installed Turso version, fall
+back to closing and reopening the connection to force a flush; adapt the body
+but keep the signature.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p embeddb checkpoint_after_write_ok`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): checkpoint flushes WAL to file"
+```
+
+---
+
+### Task 6: `analytics` read path (the crux)
+
+**Files:**
+- Create: `packages/rust/embeddb/src/analytics.rs`
+- Modify: `packages/rust/embeddb/src/db.rs`, `src/lib.rs`
+
+**Interfaces:**
+- Consumes: `EmbedDb`, `Result`.
+- Produces: `pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64>` — opens a fresh read-only DuckDB conn, ATTACHes the file (TYPE sqlite), returns a single i64 scalar. (v1 keeps the read surface minimal; richer row shapes are future work.)
+
+- [ ] **Step 1: Write the failing integration test**
+
+This test is the go/no-go for the whole crate — Turso writes, DuckDB reads the same file.
+
+```rust
+#[tokio::test]
+async fn duckdb_reads_turso_written_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("x.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+    for i in 1..=5 {
+        db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10)).await.unwrap();
+    }
+    db.checkpoint().await.unwrap();
+
+    let count = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+    assert_eq!(count, 5);
+}
+```
+
+- [ ] **Step 2: Create `src/analytics.rs`**
+
+```rust
+use std::path::Path;
+use crate::Result;
+
+pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", path.display());
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+```
+
+- [ ] **Step 3: Wire module + async wrapper**
+
+In `src/lib.rs` add `mod analytics;`. In `src/db.rs`:
+
+```rust
+pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    tokio::task::spawn_blocking(move || crate::analytics::scalar_i64(&path, &sql))
+        .await
+        .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails then passes**
+
+Run: `cargo test -p embeddb duckdb_reads_turso_written_file`
+Expected: initially FAIL (method missing), then PASS after Steps 2-3.
+
+**If it fails on the ATTACH/read step** (Turso file-format incompatibility), that
+is the documented risk. Fallback per spec: export via Turso dump into a standard
+SQLite image before ATTACH, or swap write backend to `rusqlite`. Record findings
+in the journal and stop for a decision — do not silently work around.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/analytics.rs packages/rust/embeddb/src/db.rs packages/rust/embeddb/src/lib.rs
+git commit -m "feat(embeddb): DuckDB analytics read over Turso file"
+```
+
+---
+
+### Task 7: `analytics_scalar_f64` + close, and doc README
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/analytics.rs`, `src/db.rs`
+- Create: `packages/rust/embeddb/README.md`
+
+**Interfaces:**
+- Produces: `pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64>`; `pub async fn close(self) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn duckdb_avg_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("a.db")).await.unwrap();
+    db.execute("CREATE TABLE t (v REAL)").await.unwrap();
+    db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)").await.unwrap();
+    db.checkpoint().await.unwrap();
+    let avg = db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap();
+    assert!((avg - 20.0).abs() < 1e-9);
+    db.close().await.unwrap();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p embeddb duckdb_avg_matches`
+Expected: FAIL — methods missing.
+
+- [ ] **Step 3: Implement**
+
+In `src/analytics.rs`:
+
+```rust
+pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", path.display());
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+```
+
+In `src/db.rs`:
+
+```rust
+pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    tokio::task::spawn_blocking(move || crate::analytics::scalar_f64(&path, &sql))
+        .await
+        .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+
+pub async fn close(self) -> Result<()> {
+    drop(self.conn);
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p embeddb duckdb_avg_matches`
+Expected: PASS.
+
+- [ ] **Step 5: Write README**
+
+Create `packages/rust/embeddb/README.md` documenting: purpose, the write/read split, the checkpoint-then-read model, and a minimal usage example mirroring the tests.
+
+- [ ] **Step 6: Run the full crate test suite**
+
+Run: `cargo test -p embeddb`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/rust/embeddb
+git commit -m "feat(embeddb): f64 analytics + close + README"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** location/packaging (T1), error enum (T2), open+pragmas (T3), execute write (T4), checkpoint (T5), DuckDB analytics over Turso file + risk gate (T6), close + docs (T7). `write_tx` from the spec API is deferred — v1 proves the combo with single-statement `execute`; transaction closure lands once the base plumbing is green (noted as future, not silently dropped).
+- **Placeholder scan:** no TBD/TODO; API-reconciliation notes are deliberate adaptation guidance, not missing content.
+- **Type consistency:** `EmbedDb`, `Result`, `EmbedError::Other`, `analytics::scalar_i64`/`scalar_f64` names consistent across tasks.

--- a/docs/superpowers/specs/2026-07-19-embeddb-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-design.md
@@ -1,0 +1,123 @@
+# embeddb — Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+
+## Purpose
+
+Foundational Rust library crate providing an embedded, single-file database that
+pairs two engines over one SQLite-format file:
+
+- **Turso** (`turso` 0.7, pure-Rust SQLite rewrite, async) — the write path.
+- **DuckDB** (`duckdb` 1.x, bundled/static) — the analytics read path (columnar scans, aggregations).
+
+The crate is agnostic plumbing: no consumer-specific logic, no networked service.
+It exists so future consumers (e.g. Windmill, axum services, bundled datasets)
+can depend on a proven single-file write+analytics combo without re-solving the
+wiring each time.
+
+Non-goals for v1: WASM target, connection pooling, a standalone service/app,
+backend-swap trait (rusqlite fallback), live concurrent write-while-read.
+
+## Scope (Option A — plumbing only)
+
+v1 delivers the thinnest thing that proves the combo works, structured so
+ergonomics (migrations, config) and batteries (async pool, backend trait) can
+bolt on later without breaking the public API.
+
+## Location & Packaging
+
+- New crate at `packages/rust/embeddb`.
+- Added as a member in the root workspace `Cargo.toml`.
+- Library only (`src/lib.rs`). No binary target.
+- Dependencies:
+  - `turso = "0.7"`
+  - `duckdb = { version = "1", features = ["bundled"] }` — static link, no shipped `.so`
+  - `tokio` (async runtime; Turso is async)
+  - `thiserror` (error enum)
+- Rationale for pure-Rust write side: no C toolchain drama, clean cross-compile,
+  distroless/`FROM scratch` friendly. Fits ARC-runner / buildkit / distroless setup.
+
+## Public API
+
+Uniform async surface. DuckDB is synchronous, so its calls run inside
+`tokio::task::spawn_blocking`. The `ATTACH` wiring is hidden from consumers.
+
+```rust
+pub struct EmbedDb { /* turso connection + file path */ }
+
+impl EmbedDb {
+    /// Open or create the file; set required pragmas (e.g. WAL).
+    pub async fn open(path: impl AsRef<Path>) -> Result<Self>;
+
+    /// Execute a single write statement via Turso.
+    pub async fn execute(&self, sql: &str, params: /* param type */) -> Result<u64>;
+
+    /// Run a closure inside a Turso transaction.
+    pub async fn write_tx<F, T>(&self, f: F) -> Result<T>;
+
+    /// Analytics read: fresh read-only DuckDB conn, ATTACH the same file
+    /// (TYPE sqlite), run SQL, return rows. Runs on a blocking thread.
+    pub async fn analytics(&self, sql: &str) -> Result<Rows>;
+
+    /// Flush Turso state to the file so a DuckDB read sees a consistent image.
+    pub async fn checkpoint(&self) -> Result<()>;
+
+    /// Close the Turso connection cleanly.
+    pub async fn close(self) -> Result<()>;
+}
+```
+
+Exact param/`Rows`/`write_tx` closure types are settled during implementation to
+match the `turso` 0.7 and `duckdb` 1.x APIs. The shape above is the contract.
+
+## Data Flow & Concurrency
+
+- Turso owns all writes to the file.
+- `analytics()` opens a **fresh read-only** DuckDB connection per call,
+  `ATTACH '<path>' (TYPE sqlite)`, runs the query, drops the connection.
+- v1 concurrency model is **checkpoint-then-read**, NOT live concurrent
+  write-and-read. Caller writes → `checkpoint()` → `analytics()`. This is the
+  safe, provable path. Live concurrency is deferred to a future version, gated
+  on a real consumer need.
+
+## Error Handling
+
+- Single `thiserror` enum, e.g.:
+  ```rust
+  pub enum EmbedError { Turso(..), Duck(..), Io(..) }
+  pub type Result<T> = std::result::Result<T, EmbedError>;
+  ```
+- No panics on the library path; all fallible operations return `Result`.
+
+## Testing
+
+The integration test IS the go/no-go for the whole concept — it validates the
+one real risk: **DuckDB reading a Turso-written SQLite-format file.**
+
+1. `open` a temp-file DB.
+2. Turso: `CREATE TABLE`, insert N known rows.
+3. `checkpoint()`.
+4. DuckDB via `analytics("SELECT count(*), avg(x), ... FROM attached table")`.
+5. Assert the aggregate matches the known input.
+
+Additional unit coverage: error mapping, open/create of a fresh file, pragma set.
+
+## Known Risk & Fallback
+
+- Turso is pre-1.0; SQLite file-format compatibility is claimed but not
+  guaranteed. The integration test is the gate.
+- If DuckDB cannot read the Turso file directly, documented fallbacks (NOT built
+  in v1, recorded for the plan):
+  1. Turso export (`.dump` / copy) into a standard SQLite image DuckDB reads.
+  2. Swap the write backend to `rusqlite` (real SQLite) behind the same API —
+     the deferred backend-trait, promoted only if Turso's format blocks us.
+
+## Future (explicitly deferred — YAGNI)
+
+- Backend-swap trait (Turso ↔ rusqlite).
+- Migration/schema helper, config struct.
+- Async connection pool.
+- WASM / browser DuckDB target.
+- Live concurrent write-while-read.
+- Windmill integration (first likely consumer, but not built here).

--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "embeddb"
+version = "0.0.1"
+edition = "2021"
+description = "Single-file embedded DB: Turso write path + DuckDB analytics read path"
+license = "MIT"
+
+[dependencies]
+turso = "0.7"
+duckdb = { version = "1", features = ["bundled"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -13,11 +13,23 @@ Turso (`libsql`) writes a real SQLite-format file, and DuckDB can attach to and 
 
 Because DuckDB attaches read-only and Turso owns all writes, only one process ever mutates the file, avoiding write contention between the two engines.
 
+The Turso write path is pure Rust and statically linked — no shared library to manage. The DuckDB analytics read path is *not* fully static end-to-end: `duckdb`'s `bundled` Cargo feature statically links DuckDB's core engine only. The `sqlite`/`sqlite_scanner` extension it loads at runtime is a separate artifact — see "Deployment note" below.
+
 ## Checkpoint-then-read model
 
 Turso writes to the file's WAL. DuckDB's SQLite reader sees the main database file, not the WAL, so a checkpoint must run before DuckDB can observe recent writes. Call `EmbedDb::checkpoint` (which issues `PRAGMA wal_checkpoint(TRUNCATE)`) after writes and before running analytics queries — skipping this step means DuckDB may read stale or incomplete data.
 
+`checkpoint` does not inspect the `(busy, log, checkpointed)` row that `PRAGMA wal_checkpoint(TRUNCATE)` returns. If the checkpoint comes back busy (another reader holding the WAL), the flush may be incomplete and a subsequent analytics read could see stale data. This is safe under the v1 single-writer/no-concurrent-live-reader model this crate assumes; a future revision may want to surface the busy state to callers.
+
 When done, call `EmbedDb::close` to drop the connection and release the file.
+
+## Deployment note: DuckDB sqlite extension
+
+`analytics_scalar_i64` / `analytics_scalar_f64` run `INSTALL sqlite; LOAD sqlite;` against the in-memory DuckDB connection before attaching the file. The `bundled` feature on the `duckdb` crate statically links DuckDB's core engine, but it does **not** include the `sqlite_scanner` extension. On first use, DuckDB downloads `sqlite_scanner.duckdb_extension` from `extensions.duckdb.org` into `~/.duckdb/extensions/...` and caches it there for subsequent calls.
+
+In an offline, distroless, or egress-denied deployment — the target environment for this crate — that download fails and every `analytics_*` call returns `EmbedError::Duck`, even though the write path and all local tests are unaffected.
+
+To support that environment, pre-stage `sqlite_scanner.duckdb_extension` (matching the DuckDB version pulled in by this crate) in a directory on the target, and set the `EMBEDDB_DUCKDB_EXTENSION_DIR` environment variable to that directory before calling any `analytics_*` method. When set, `embeddb` runs `SET extension_directory = '<dir>';` on the DuckDB connection before `INSTALL sqlite`, so `INSTALL` resolves from the pre-staged directory instead of the network and becomes a no-op if the extension is already present there. When unset (the default, including in this crate's own test suite), behavior is unchanged from before this note.
 
 ## Usage
 

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -1,0 +1,42 @@
+# embeddb
+
+Single-file embedded database: a Turso write path and a DuckDB analytics read path over the same SQLite-format file.
+
+## Why
+
+Turso (`libsql`) writes a real SQLite-format file, and DuckDB can attach to and query that same file via its `sqlite` extension. `embeddb` wires these two together so a single file gets fast row-oriented writes from Turso and fast columnar/analytical scans from DuckDB, without running a separate server or duplicating storage.
+
+## Write / read split
+
+- **Writes** go through `EmbedDb`, backed by a `turso::Connection`. `EmbedDb::open` opens (creating if needed) the file in WAL journal mode. `EmbedDb::execute` runs a single write/DDL statement and returns the affected row count.
+- **Reads for analytics** go through DuckDB. `EmbedDb::analytics_scalar_i64` / `EmbedDb::analytics_scalar_f64` open a fresh in-memory DuckDB connection, `ATTACH` the same file read-only via the `sqlite` extension, and run a scalar query against it.
+
+Because DuckDB attaches read-only and Turso owns all writes, only one process ever mutates the file, avoiding write contention between the two engines.
+
+## Checkpoint-then-read model
+
+Turso writes to the file's WAL. DuckDB's SQLite reader sees the main database file, not the WAL, so a checkpoint must run before DuckDB can observe recent writes. Call `EmbedDb::checkpoint` (which issues `PRAGMA wal_checkpoint(TRUNCATE)`) after writes and before running analytics queries — skipping this step means DuckDB may read stale or incomplete data.
+
+When done, call `EmbedDb::close` to drop the connection and release the file.
+
+## Usage
+
+```rust
+use embeddb::EmbedDb;
+
+#[tokio::main]
+async fn main() -> embeddb::Result<()> {
+    let db = EmbedDb::open("data.db").await?;
+
+    db.execute("CREATE TABLE t (v REAL)").await?;
+    db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)").await?;
+
+    db.checkpoint().await?;
+
+    let avg = db.analytics_scalar_f64("SELECT avg(v) FROM t").await?;
+    assert!((avg - 20.0).abs() < 1e-9);
+
+    db.close().await?;
+    Ok(())
+}
+```

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+use crate::Result;
+
+pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", path.display());
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -3,7 +3,7 @@ use crate::Result;
 
 pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    prepare_sqlite_scanner(&conn)?;
     let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
@@ -13,7 +13,7 @@ pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
 
 pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    prepare_sqlite_scanner(&conn)?;
     let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
@@ -21,6 +21,19 @@ pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
     Ok(val)
 }
 
+fn prepare_sqlite_scanner(conn: &duckdb::Connection) -> Result<()> {
+    if let Ok(dir) = std::env::var("EMBEDDB_DUCKDB_EXTENSION_DIR") {
+        let set_dir = format!("SET extension_directory = '{}';", sql_quote_str(&dir));
+        conn.execute_batch(&set_dir)?;
+    }
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    Ok(())
+}
+
+fn sql_quote_str(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
 fn sql_quote_path(path: &Path) -> String {
-    path.display().to_string().replace('\'', "''")
+    sql_quote_str(&path.display().to_string())
 }

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -4,9 +4,13 @@ use crate::Result;
 pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
     let conn = duckdb::Connection::open_in_memory()?;
     conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
-    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", path.display());
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
     let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
+}
+
+fn sql_quote_path(path: &Path) -> String {
+    path.display().to_string().replace('\'', "''")
 }

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -11,6 +11,16 @@ pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
     Ok(val)
 }
 
+pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+
 fn sql_quote_path(path: &Path) -> String {
     path.display().to_string().replace('\'', "''")
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+use crate::Result;
+
+pub struct EmbedDb {
+    path: PathBuf,
+    conn: turso::Connection,
+}
+
+impl EmbedDb {
+    pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
+        let path = path.as_ref().to_path_buf();
+        let db = turso::Builder::new_local(path.to_str().unwrap())
+            .build()
+            .await?;
+        let conn = db.connect()?;
+        conn.execute("PRAGMA journal_mode=WAL", ()).await.ok();
+        Ok(EmbedDb { path, conn })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn open_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("t.db");
+        let db = EmbedDb::open(&p).await.unwrap();
+        assert_eq!(db.path(), p.as_path());
+        assert!(p.exists());
+    }
+}

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -39,6 +39,19 @@ impl EmbedDb {
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
+
+    pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_f64(&path, &sql))
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
+    pub async fn close(self) -> Result<()> {
+        drop(self.conn);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -101,5 +114,17 @@ mod tests {
 
         let count = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
         assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn duckdb_avg_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("a.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v REAL)").await.unwrap();
+        db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)").await.unwrap();
+        db.checkpoint().await.unwrap();
+        let avg = db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap();
+        assert!((avg - 20.0).abs() < 1e-9);
+        db.close().await.unwrap();
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -20,6 +20,11 @@ impl EmbedDb {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    pub async fn execute(&self, sql: &str) -> Result<u64> {
+        let affected = self.conn.execute(sql, ()).await?;
+        Ok(affected)
+    }
 }
 
 #[cfg(test)]
@@ -33,5 +38,15 @@ mod tests {
         let db = EmbedDb::open(&p).await.unwrap();
         assert_eq!(db.path(), p.as_path());
         assert!(p.exists());
+    }
+
+    #[tokio::test]
+    async fn execute_creates_and_inserts() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("w.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10.0)").await.unwrap();
+        let n = db.execute("INSERT INTO t VALUES (2, 20.0)").await.unwrap();
+        assert_eq!(n, 1);
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -25,6 +25,12 @@ impl EmbedDb {
         let affected = self.conn.execute(sql, ()).await?;
         Ok(affected)
     }
+
+    pub async fn checkpoint(&self) -> Result<()> {
+        let mut rows = self.conn.query("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
+        while rows.next().await?.is_some() {}
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -48,5 +54,14 @@ mod tests {
         db.execute("INSERT INTO t VALUES (1, 10.0)").await.unwrap();
         let n = db.execute("INSERT INTO t VALUES (2, 20.0)").await.unwrap();
         assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_after_write_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("c.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)").await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)").await.unwrap();
+        db.checkpoint().await.unwrap();
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -86,4 +86,20 @@ mod tests {
         let count = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
         assert_eq!(count, 5);
     }
+
+    #[tokio::test]
+    async fn analytics_handles_quoted_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let quoted_dir = dir.path().join("o'brien");
+        std::fs::create_dir_all(&quoted_dir).unwrap();
+        let db = EmbedDb::open(quoted_dir.join("q.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+        for i in 1..=3 {
+            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10)).await.unwrap();
+        }
+        db.checkpoint().await.unwrap();
+
+        let count = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+        assert_eq!(count, 3);
+    }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -31,6 +31,14 @@ impl EmbedDb {
         while rows.next().await?.is_some() {}
         Ok(())
     }
+
+    pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_i64(&path, &sql))
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
 }
 
 #[cfg(test)]
@@ -63,5 +71,19 @@ mod tests {
         db.execute("CREATE TABLE t (id INTEGER)").await.unwrap();
         db.execute("INSERT INTO t VALUES (1)").await.unwrap();
         db.checkpoint().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn duckdb_reads_turso_written_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("x.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+        for i in 1..=5 {
+            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10)).await.unwrap();
+        }
+        db.checkpoint().await.unwrap();
+
+        let count = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+        assert_eq!(count, 5);
     }
 }

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, thiserror::Error)]
+pub enum EmbedError {
+    #[error("placeholder")]
+    Placeholder,
+}
+
+pub type Result<T> = std::result::Result<T, EmbedError>;

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -1,7 +1,25 @@
 #[derive(Debug, thiserror::Error)]
 pub enum EmbedError {
-    #[error("placeholder")]
-    Placeholder,
+    #[error("turso error: {0}")]
+    Turso(#[from] turso::Error),
+    #[error("duckdb error: {0}")]
+    Duck(#[from] duckdb::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Other(String),
 }
 
 pub type Result<T> = std::result::Result<T, EmbedError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_maps() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "nope");
+        let e: EmbedError = io.into();
+        assert!(matches!(e, EmbedError::Io(_)));
+    }
+}

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod db;
+mod analytics;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -1,0 +1,3 @@
+mod error;
+
+pub use error::{EmbedError, Result};

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -1,3 +1,5 @@
 mod error;
+mod db;
 
 pub use error::{EmbedError, Result};
+pub use db::EmbedDb;


### PR DESCRIPTION
## embeddb — single-file Turso + DuckDB crate

New foundational Rust library crate at `packages/rust/embeddb`. Pairs two engines over **one** SQLite-format file:

- **Turso** (`turso` 0.7, pure-Rust SQLite rewrite, async) — write path
- **DuckDB** (`duckdb` 1.x, bundled) — analytics read path (columnar scans)

Agnostic plumbing, no consumer-specific logic — ready for future consumers (e.g. Windmill).

### API (v1 — Option A plumbing)
- `EmbedDb::open(path)` — open/create, WAL pragma
- `execute(sql)` — Turso write, rows affected
- `checkpoint()` — flush WAL → file (Turso `execute` rejects row-returning stmts, so uses `query` + drain)
- `analytics_scalar_i64/f64(sql)` — fresh read-only DuckDB conn, `ATTACH (TYPE sqlite)`, run on `spawn_blocking`
- `close()`

### The gate — proven
Integration test `duckdb_reads_turso_written_file`: Turso writes rows → `checkpoint()` → DuckDB reads back the aggregate. **DuckDB reads Turso-written files directly, no format incompatibility.** That was the go/no-go risk; it passed.

### Notable findings baked into the code/docs
- ATTACH path is single-quote-escaped (`sql_quote_path`) — paths like `o'brien` are tested.
- **Distroless caveat:** DuckDB's `sqlite_scanner` extension is fetched over the network on first `analytics_*` call — NOT covered by the `bundled` static link. For offline/egress-denied deploys, pre-stage the extension and set `EMBEDDB_DUCKDB_EXTENSION_DIR`. Documented in the crate README; the Turso write path stays pure-Rust/static.

### Deferred (YAGNI, v2)
`execute` params / `write_tx`, checkpoint busy-check, live concurrent read, backend-swap trait (Turso ↔ rusqlite).

### Tests
7 passing (`cargo test -p embeddb`). Spec + plan under `docs/superpowers/`.
