### PR TITLE
fix(cube): duplicate CUBEJS_DATASOURCES + cubestore exporter crashloop

### DIFF
--- a/apps/kube/cube/manifests/cube-values.yaml
+++ b/apps/kube/cube/manifests/cube-values.yaml
@@ -31,9 +31,9 @@ config:
 cubestore:
     host: cubestore-router
 
+# NOTE: the chart auto-emits CUBEJS_DATASOURCES from the datasources map,
+# so do NOT set it here (duplicate env keys are rejected by ServerSideApply).
 extraEnvVars:
-    - name: CUBEJS_DATASOURCES
-      value: "default,clickhouse"
     # Required for cross-source rollup_join on this Cube version (verify on 1.5.3).
     - name: CUBEJS_TESSERACT_SQL_PLANNER
       value: "false"

--- a/apps/kube/cube/manifests/cubestore-values.yaml
+++ b/apps/kube/cube/manifests/cubestore-values.yaml
@@ -4,6 +4,11 @@
 config:
     logLevel: "error"
 
+# statsd-prometheus-exporter sidecar crashloops without a configured metrics
+# UDP port; we don't collect Cube Store statsd metrics yet, so disable it.
+exporter:
+    enabled: false
+
 # Shared metadata + datasets volume (router + workers mount it, RWX).
 remoteDir:
     persistence:


### PR DESCRIPTION
Phase B live-sync fixes (ArgoCD caught two issues `helm template` masked):

1. **Cube Deployment rejected** — `duplicate entries for key CUBEJS_DATASOURCES`. The gadsme cube chart auto-emits `CUBEJS_DATASOURCES` from the datasources map; my `extraEnvVars` added a second. ServerSideApply rejects duplicate env keys, so no cube API/worker pods deployed. Dropped the manual entry.
2. **cubestore statsd-exporter CrashLoopBackOff** — `invalid UDP listen address 0.0.0.0:` (empty metrics port). Disabled the exporter sidecar (`exporter.enabled: false`); not needed yet. Cube Store container itself was healthy.

Verified via `helm template`: single `CUBEJS_DATASOURCES`, `TESSERACT=false` intact, no statsd-exporter container.

After dev→main merge, ArgoCD re-syncs; then I verify cube API/worker pods Running + run the PG/CH/federated queries in-cluster.