### PR TITLE
perf(axum-kbve): drop redundant header-map rebuilds in proxy forward

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy/core.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/core.rs
@@ -170,7 +170,7 @@ impl ServiceProxy {
             }
         };
 
-        self.forward(&upstream_url, method, &headers, body_bytes)
+        self.forward(&upstream_url, method, headers, body_bytes)
             .await
     }
 
@@ -179,15 +179,17 @@ impl ServiceProxy {
         &self,
         upstream_url: &str,
         method: axum::http::Method,
-        headers: &HeaderMap,
+        headers: HeaderMap,
         body_bytes: Bytes,
     ) -> Response {
         debug!(%upstream_url, %method, "proxying to {}", self.name);
 
+        // axum and reqwest both ride `http::HeaderMap`, so the prepared header
+        // map is handed to reqwest directly — no per-header re-parse/rebuild.
         let upstream_req = self
             .client
             .request(method.clone(), upstream_url)
-            .headers(reqwest_headers(headers))
+            .headers(headers)
             .body(body_bytes);
 
         let upstream_resp = match upstream_req.send().await {
@@ -222,15 +224,9 @@ impl ServiceProxy {
         let status =
             StatusCode::from_u16(upstream_status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-        // `append` preserves multi-value headers (Set-Cookie, Vary).
-        let mut resp_headers = HeaderMap::new();
-        for (k, v) in upstream_resp.headers() {
-            if let Ok(name) = axum::http::HeaderName::from_bytes(k.as_str().as_bytes()) {
-                if let Ok(val) = HeaderValue::from_bytes(v.as_bytes()) {
-                    resp_headers.append(name, val);
-                }
-            }
-        }
+        // reqwest's response headers are the same `http::HeaderMap` axum uses,
+        // so clone directly — multi-value headers (Set-Cookie, Vary) are kept.
+        let mut resp_headers = upstream_resp.headers().clone();
 
         // RFC 7230 §6.1: strip hop-by-hop headers from the upstream response.
         // transfer-encoding — body is buffered; axum will set content-length.
@@ -489,20 +485,6 @@ pub(super) async fn require_dashboard_view_with_query(
         "You do not have permission to access the dashboard",
     )
     .await
-}
-
-
-pub(super) fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
-    let mut out = reqwest::header::HeaderMap::new();
-    for (k, v) in headers {
-        if let Ok(name) = reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()) {
-            if let Ok(val) = reqwest::header::HeaderValue::from_bytes(v.as_bytes()) {
-                // `append` preserves multi-value headers (Accept, Cookie, ...).
-                out.append(name, val);
-            }
-        }
-    }
-    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The proxy forward path rebuilt `http::HeaderMap` twice per request, byte-by-byte, into the same type it started as. axum 0.8 and reqwest 0.12 both ride **http v1.4.0**, so `axum::http::HeaderMap` *is* `reqwest::header::HeaderMap` — the round-trip through `from_bytes` re-parsed and re-validated every header for nothing.

- **Request:** `forward()` now takes the prepared `HeaderMap` by value and hands it straight to reqwest; `reqwest_headers()` deleted.
- **Response:** clone the upstream `HeaderMap` instead of reconstructing it header-by-header.

Both inputs are already valid `http::HeaderMap`s, so nothing was ever dropped by the rebuild — behavior is identical, multi-value Set-Cookie / Vary / Cookie preserved. This runs on **every proxied request** across all 13 targets.

## Evaluated, deferred (documented in #14269)

- **KASM parts/body clone** — the `body_bytes` clone is already cheap (`Bytes` is refcount, not a copy); only a small request-header `HeaderMap` clone remains, and making it conditional needs manual `http::Parts` reconstruction on the rare 401-retry path — awkward + risky in an auth path for marginal gain.
- **Firecracker `resolve_account_for_token` double-hop** — fc-net is DASHBOARD_MANAGE-only (tiny user set, low QPS); caching the user→account mapping would risk stale billing routing if it ever changes. Low ROI, correctness risk.

## Verify

`cargo check` + `cargo clippy -p axum-kbve` clean; 13 proxy unit tests pass.