### PR TITLE
feat(discordsh-bot): /wm reroll button — interactive embeds phase 1 (0.1.27)

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -141,6 +141,9 @@ async fn event_handler(
             } else if custom_id.starts_with("chart|") {
                 components::chart_buttons::handle_chart_component(ctx, component, &data.app).await;
                 Ok(())
+            } else if custom_id.starts_with("wm|") {
+                components::handle_windmill_component(ctx, component, &data.app).await;
+                Ok(())
             } else {
                 Ok(())
             };

--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -1,8 +1,10 @@
 use poise::CreateReply;
+use poise::serenity_prelude as serenity;
 use serde_json::Value;
 use tracing::{info, warn};
 
 use crate::discord::bot::{Context, Error};
+use crate::discord::components::build_wm_action_row;
 use crate::discord::windmill::{DiscordContext, RunError, split_args, suggest_command};
 use crate::discord::windmill_embed;
 
@@ -51,7 +53,9 @@ pub async fn wm(
                 args = arg_count,
                 "windmill run ok"
             );
-            send_value_reply(ctx, &value, &path_for_log, None).await?;
+            // Public embed + reroll button so anyone in the channel can re-run.
+            let row = build_wm_action_row(&wm_path, &args);
+            send_value_reply(ctx, &value, &path_for_log, None, row, false).await?;
         }
         // Unknown or blocked command name (and the defensive empty-path case)
         // → render the help menu itself, prefixed with a closest-match hint,
@@ -82,7 +86,10 @@ pub async fn wm(
             } else {
                 match cfg.run(WM_INDEX_PATH, &[], &discord).await {
                     Ok(value) => {
-                        send_value_reply(ctx, &value, WM_INDEX_PATH, Some(hint)).await?;
+                        // Hint is invoker-specific → keep the fallback ephemeral
+                        // and without a reroll button.
+                        send_value_reply(ctx, &value, WM_INDEX_PATH, Some(hint), None, true)
+                            .await?;
                     }
                     Err(help_err) => {
                         warn!(error = %help_err, "help menu fallback also failed");
@@ -123,6 +130,8 @@ async fn send_value_reply(
     value: &Value,
     label: &str,
     prefix: Option<String>,
+    action_row: Option<serenity::CreateActionRow>,
+    ephemeral: bool,
 ) -> Result<(), Error> {
     let json_reply = || {
         let body = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
@@ -131,16 +140,19 @@ async fn send_value_reply(
             Some(p) => format!("{p}\n`/wm {label}` ok:\n```json\n{trimmed}\n```"),
             None => format!("`/wm {label}` ok:\n```json\n{trimmed}\n```"),
         };
-        CreateReply::default().content(content).ephemeral(true)
+        CreateReply::default().content(content).ephemeral(ephemeral)
     };
 
     // Try the rich embed first; if Discord rejects it (total size, bad URL,
     // empty field), fall back to the JSON block so the job result is never lost.
     match windmill_embed::embed_from_value(value) {
         Some(embed) => {
-            let mut reply = CreateReply::default().embed(embed).ephemeral(true);
+            let mut reply = CreateReply::default().embed(embed).ephemeral(ephemeral);
             if let Some(p) = &prefix {
                 reply = reply.content(p.clone());
+            }
+            if let Some(row) = action_row {
+                reply = reply.components(vec![row]);
             }
             if ctx.send(reply).await.is_err() {
                 warn!(label, "embed send rejected; falling back to JSON");

--- a/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
@@ -2,5 +2,7 @@ pub mod chart_buttons;
 pub mod class_picker;
 pub mod github_components;
 mod status_buttons;
+pub mod windmill_components;
 
 pub use status_buttons::{build_status_action_row, handle_status_component};
+pub use windmill_components::{build_wm_action_row, handle_windmill_component};

--- a/apps/discordsh/discordsh-bot/src/discord/components/windmill_components.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/windmill_components.rs
@@ -1,0 +1,152 @@
+//! `/wm` interactive component layer — Phase 1 of the interactive-embed epic.
+//!
+//! Every successful `/wm` embed carries a reroll button whose `custom_id`
+//! encodes the command to re-run (`wm|r|<path> <args...>`). Pressing it re-runs
+//! the same command and edits the message in place. The embeds are public
+//! (non-ephemeral) so anyone in the channel can reroll.
+
+use poise::serenity_prelude as serenity;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::discord::windmill::DiscordContext;
+use crate::discord::windmill_embed;
+use crate::state::AppState;
+
+const REROLL_PREFIX: &str = "wm|r|";
+/// Discord hard-caps `custom_id` at 100 bytes.
+const CUSTOM_ID_MAX: usize = 100;
+
+/// Build the action row for a `/wm` result: a single reroll button whose
+/// `custom_id` encodes the command to re-run. Returns `None` when the encoded
+/// id would exceed Discord's limit, so the caller omits the row rather than
+/// sending an invalid component.
+pub fn build_wm_action_row(path: &str, args: &[String]) -> Option<serenity::CreateActionRow> {
+    let mut payload = path.to_owned();
+    if !args.is_empty() {
+        payload.push(' ');
+        payload.push_str(&args.join(" "));
+    }
+    let custom_id = format!("{REROLL_PREFIX}{payload}");
+    if custom_id.len() > CUSTOM_ID_MAX {
+        return None;
+    }
+    Some(serenity::CreateActionRow::Buttons(vec![
+        serenity::CreateButton::new(custom_id)
+            .label("Reroll")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F504}".to_owned())),
+    ]))
+}
+
+/// Decode a `wm|r|` custom_id back into `(path, args)`.
+fn decode_reroll(custom_id: &str) -> Option<(String, Vec<String>)> {
+    let payload = custom_id.strip_prefix(REROLL_PREFIX)?;
+    let mut it = payload.split_whitespace();
+    let path = it.next()?.to_owned();
+    let args = it.map(str::to_owned).collect();
+    Some((path, args))
+}
+
+/// Handle a component interaction whose `custom_id` starts with `"wm|"`.
+/// Re-runs the encoded command and edits the message in place.
+pub async fn handle_windmill_component(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    app: &Arc<AppState>,
+) {
+    let custom_id = component.data.custom_id.clone();
+    let Some((path, args)) = decode_reroll(&custom_id) else {
+        warn!(custom_id = %custom_id, "unrecognized wm component id");
+        return;
+    };
+
+    let Some(cfg) = app.windmill.clone() else {
+        warn!("wm reroll pressed but windmill runner not configured");
+        return;
+    };
+
+    // Deferred message update — acknowledge now, edit the original message
+    // once the re-run returns (a few hundred ms).
+    if let Err(e) = component
+        .create_response(&ctx.http, serenity::CreateInteractionResponse::Acknowledge)
+        .await
+    {
+        warn!(error = %e, "failed to ack wm reroll");
+        return;
+    }
+
+    let discord = DiscordContext {
+        user_id: component.user.id.get().to_string(),
+        username: component.user.name.clone(),
+        guild_id: component.guild_id.map(|g| g.get().to_string()),
+        channel_id: component.channel_id.get().to_string(),
+    };
+
+    match cfg.run(&path, &args, &discord).await {
+        Ok(value) => {
+            let Some(embed) = windmill_embed::embed_from_value(&value) else {
+                warn!(path = %path, "wm reroll result had no embed; leaving message unchanged");
+                return;
+            };
+            let mut edit = serenity::EditInteractionResponse::new().embed(embed);
+            if let Some(row) = build_wm_action_row(&path, &args) {
+                edit = edit.components(vec![row]);
+            }
+            if let Err(e) = component.edit_response(&ctx.http, edit).await {
+                warn!(error = %e, path = %path, "failed to edit message after wm reroll");
+            } else {
+                info!(path = %path, user = %discord.username, "wm reroll ok");
+            }
+        }
+        Err(e) => {
+            // Keep the existing embed intact on failure (rate-limit, upstream);
+            // surface a quiet ephemeral follow-up to the presser only.
+            let _ = component
+                .create_followup(
+                    &ctx.http,
+                    serenity::CreateInteractionResponseFollowup::new()
+                        .content(format!("Reroll failed: {e}"))
+                        .ephemeral(true),
+                )
+                .await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_row_none_when_id_too_long() {
+        let long = "x".repeat(120);
+        assert!(build_wm_action_row(&long, &[]).is_none());
+    }
+
+    #[test]
+    fn action_row_some_for_normal_command() {
+        assert!(build_wm_action_row("joke", &[]).is_some());
+        assert!(build_wm_action_row("joke", &["chuck".to_owned()]).is_some());
+    }
+
+    #[test]
+    fn decode_roundtrip_no_args() {
+        let (p, a) = decode_reroll("wm|r|joke").unwrap();
+        assert_eq!(p, "joke");
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn decode_roundtrip_with_args() {
+        let (p, a) = decode_reroll("wm|r|ud yeet street").unwrap();
+        assert_eq!(p, "ud");
+        assert_eq!(a, vec!["yeet", "street"]);
+    }
+
+    #[test]
+    fn decode_rejects_foreign_prefix() {
+        assert!(decode_reroll("dng|r|joke").is_none());
+        assert!(decode_reroll("wm|r|").is_none());
+    }
+}

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.26"
+version: "0.1.27"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## What

First slice of the interactive-embed epic (#14289). Every successful `/wm` embed now carries a **🔄 Reroll** button — pressing it re-runs the same command and **edits the message in place**.

- New `wm|` component namespace + handler (`discord/components/windmill_components.rs`), routed in `bot.rs` alongside `dng|`/`status_`/`chart|`.
- `custom_id` encodes the command: `wm|r|<path> <args>`. Omitted gracefully when the id would exceed Discord's 100-char cap.
- Reroll re-runs through the same `WindmillConfig::run` path — so the namespace gate, allowlist, and **per-user rate limit** all still apply.
- Reroll-bearing embeds are **public (non-ephemeral)** so anyone in the channel can reroll (per the epic decision). The help-fallback stays ephemeral (invoker-specific hint).
- Failure on reroll (rate-limit, upstream) keeps the existing embed intact + a quiet ephemeral follow-up.

## Behavior change
`/wm` command output is now **public** instead of ephemeral. This is required for anyone-in-channel reroll. Errors and the bad-path help fallback remain ephemeral.

## Deferred to later epic phases
Help select-menu, per-command controls (joke source picker), script-declared `components` in the embed contract.

## Version
Bumps `0.1.27` (dev carries `0.1.26` from #14288).

## Verified
- `cargo build` clean.
- `cargo test windmill_components` → 5/5 pass (custom_id encode/decode roundtrip, length guard, foreign-prefix rejection).

Epic #14289.