### PR TITLE
feat(dashboard): wire + secure Cloud > AWS > S3 backup panel

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroS3Dashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroS3Dashboard.astro
@@ -1,0 +1,40 @@
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import ReactS3BackupRN from '@/components/rnweb/ReactS3BackupRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+---
+
+<BentoShell
+	id="s3-backup-dashboard-wrapper"
+	eyebrow="Cloud · AWS"
+	heading="S3 backup storage.">
+	<div class="svc-dash not-content">
+		<div class="svc-dash__stream not-content">
+			<ReactS3BackupRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactS3BackupRN>
+		</div>
+	</div>
+</BentoShell>
+
+<style>
+	.svc-dash {
+		padding: 1.5rem 1rem 3rem;
+	}
+
+	@media (min-width: 640px) {
+		.svc-dash {
+			padding-inline: 1.5rem;
+		}
+	}
+
+	.svc-dash__stream {
+		min-height: 60vh;
+	}
+
+	:global(@keyframes spin) {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/navigation/dashboardMenu.ts
+++ b/apps/kbve/astro-kbve/src/components/navigation/dashboardMenu.ts
@@ -51,6 +51,18 @@ export const dashboardNav: NavNode[] = [
 			{ label: 'Minecraft', link: '/dashboard/gameops/mc/' },
 		],
 	},
+	{
+		label: 'Cloud',
+		staff: true,
+		items: [
+			{
+				label: 'AWS',
+				items: [
+					{ label: 'S3', link: '/dashboard/cloud/aws/s3/' },
+				],
+			},
+		],
+	},
 ];
 
 export const appsNav: NavNode[] = [

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import { ShieldOff } from 'lucide-react';
+import { S3BackupPanel } from '@kbve/rn/dash';
+import { homeService } from '@/components/dashboard/homeService';
+import { initSupa, getSupa } from '@/lib/supa';
+import { DASH_PROXY_BASE } from './dashProxyBase';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: {
+		margin: 0,
+		fontSize: '1.75rem',
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	sub: {
+		margin: 0,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		maxWidth: '40rem',
+	},
+};
+
+export default function ReactS3BackupRN() {
+	const isStaff = useStore(homeService.$isStaff);
+	const token = useMemo(() => getToken, []);
+
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>
+					The AWS S3 backup panel is restricted to KBVE staff.
+				</p>
+			</div>
+		);
+	}
+
+	return <S3BackupPanel getToken={token} baseUrl={DASH_PROXY_BASE} />;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/cloud/aws/s3/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/cloud/aws/s3/index.mdx
@@ -1,0 +1,26 @@
+---
+title: AWS S3 Dashboard
+description: KBVE hybrid-cloud control — AWS S3 backup storage (kilobase database backups). Staff panel.
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+sidebar:
+    label: S3
+    order: 1
+unsplash: 1451187580459-43490279c0fa
+img: https://images.unsplash.com/photo-1451187580459-43490279c0fa?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - cloud
+    - aws
+    - s3
+    - staff
+---
+
+import AstroS3Dashboard from '@/components/dashboard/AstroS3Dashboard.astro';
+
+<AstroS3Dashboard />

--- a/apps/kbve/axum-kbve/src/s3backup/routes.rs
+++ b/apps/kbve/axum-kbve/src/s3backup/routes.rs
@@ -1,6 +1,11 @@
+use crate::db::forum::get_forum_service;
 use crate::s3backup::client::{list_all, list_page, make_client, S3Config};
 use crate::s3backup::summary::summarize;
-use axum::{extract::Query, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use crate::transport::https::auth_user_id;
+use axum::{
+    extract::Query, http::HeaderMap, http::StatusCode, response::IntoResponse,
+    response::Response, routing::get, Json, Router,
+};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -11,7 +16,30 @@ fn now_secs() -> i64 {
         .unwrap_or(0)
 }
 
-async fn summary_handler() -> impl IntoResponse {
+/// Bearer-authed staff gate. These endpoints expose the database backup
+/// bucket, so we verify the caller in-process (defense-in-depth) rather
+/// than trusting only the upstream gateway.
+async fn require_staff(headers: &HeaderMap) -> Result<(), Response> {
+    let user_id = auth_user_id(headers).await?;
+    let is_staff = match get_forum_service() {
+        Some(svc) => svc.is_staff(&user_id).await.unwrap_or(false),
+        None => false,
+    };
+    if is_staff {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "staff_required"})),
+        )
+            .into_response())
+    }
+}
+
+async fn summary_handler(headers: HeaderMap) -> Response {
+    if let Err(resp) = require_staff(&headers).await {
+        return resp;
+    }
     let cfg = S3Config::from_env();
     let client = make_client(&cfg).await;
     match list_all(&client, &cfg.bucket, &cfg.prefix).await {
@@ -34,7 +62,10 @@ struct ObjectsQuery {
     limit: Option<i32>,
 }
 
-async fn objects_handler(Query(q): Query<ObjectsQuery>) -> impl IntoResponse {
+async fn objects_handler(headers: HeaderMap, Query(q): Query<ObjectsQuery>) -> Response {
+    if let Err(resp) = require_staff(&headers).await {
+        return resp;
+    }
     let cfg = S3Config::from_env();
     let client = make_client(&cfg).await;
     let prefix = q.prefix.unwrap_or_default();

--- a/docs/superpowers/specs/2026-07-19-cloud-aws-s3-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloud-aws-s3-dashboard-design.md
@@ -1,0 +1,48 @@
+# Cloud > AWS > S3 dashboard panel
+
+Date: 2026-07-19
+Status: implemented (this PR)
+
+## Goal
+
+Surface the AWS S3 **database-backup** bucket (`s3://kilobase`, barman) inside
+`kbve.com/dashboard/` as a staff-gated, proxy-only panel — matching the existing
+infra panels (Argo, Grafana, ClickHouse, VM). No direct S3 access from the
+browser; the IAM creds stay server-side. First step toward a hybrid-cloud
+management surface (`Cloud > AWS > …`, later GCP / Cloudflare).
+
+## Scope
+
+Architect for full control, ship the read path first, iterate on the look.
+This PR wires the already-merged pieces from #14244 into a reachable, secured
+panel — it does not add mutation (upload/delete) yet.
+
+## Architecture
+
+```
+Browser (dashboard, $isStaff gate)
+  → DASH_PROXY_BASE /dashboard/kilobase/s3/{summary,objects}
+    → gateway/kbve-gate
+      → axum-kbve  s3backup::routes  (in-process staff gate — defense in depth)
+        → aws-sdk-s3  (creds from kilobase-s3-secret; bucket kilobase, us-east-1)
+          → AWS S3
+```
+
+- Backend logic: `apps/kbve/axum-kbve/src/s3backup/` (client, summary, routes).
+  `summary::summarize` is a pure, unit-tested aggregation over the object list.
+- Auth: handlers verify the bearer JWT (`auth_user_id`) and `forum.is_staff`
+  (→ `staff.members`) before any AWS call. 403 on non-staff. This does not rely
+  on the upstream gateway alone.
+- Frontend: `@kbve/rn` `S3BackupPanel` + `kilobaseBackup` adapter (both from
+  #14244), mounted via `AstroS3Dashboard.astro` → `ReactS3BackupRN` (clones the
+  Minecraft panel: `$isStaff` gate + `getToken` + `DASH_PROXY_BASE`).
+- Route: `/dashboard/cloud/aws/s3/`; nav entry `Cloud > AWS > S3` (staff).
+
+## Follow-ups (not in this PR)
+
+- Move the reusable S3 logic into `jedi` behind an `aws` Cargo feature so other
+  services/CLI can share it; axum-kbve becomes the thin HTTP shell.
+- Object browser drill-down + presigned download; later, mutation (full control).
+- Generalize `Cloud` to more providers (GCP, Cloudflare/R2) and AWS services.
+- Confirm gateway path coverage for `/dashboard/kilobase/s3/*` (in-process gate
+  already makes this non-load-bearing for security).


### PR DESCRIPTION
## Context
#14244 landed the S3 backup **backend** (`axum s3backup`: client + `summarize` + routes) and the **RN panel** (`S3BackupPanel` + `kilobaseBackup` adapter), but left them (a) **unauthenticated** and (b) **unwired** — no dashboard route, wrapper, or nav entry. This PR resolves both and stands up the first node of the hybrid-cloud surface.

## Security (the important part)
The `s3backup` handlers exposed the **database-backup bucket** (`s3://kilobase`) with **no in-process auth** — they relied entirely on upstream gateway path coverage, which is fragile for a brand-new path. Now:
- `require_staff(headers)` verifies the bearer JWT (`auth_user_id`) + `forum.is_staff` (→ `staff.members`) before any AWS call; **403** otherwise.
- Defense-in-depth: correct regardless of gateway topology. The RN adapter already sends `Authorization: Bearer` and already handles 403.

## Wiring
- `AstroS3Dashboard.astro` → `ReactS3BackupRN` mounts `@kbve/rn` `S3BackupPanel`, cloning the Minecraft panel pattern (`$isStaff` gate + `getToken` + `DASH_PROXY_BASE`).
- New route **`/dashboard/cloud/aws/s3/`** + nav entry **Cloud > AWS > S3** (staff-gated; `filterNav`/`NavMenu` already recurse, so the 2-level nesting renders).

## Verify
- `cargo check -p axum-kbve` — OK.
- `@kbve/rn` `kilobaseBackup` adapter tests — 19/19.
- Frontend clones the proven `/dashboard/gameops/mc/` mount chain.

## Backend today / follow-ups
- Bucket `kilobase`, `us-east-1`, creds from `kilobase-s3-secret` (already provisioned). Read-only (list + backup summary).
- **jedi move:** relocate the reusable S3 logic into `jedi` behind an `aws` Cargo feature so axum-kbve is a thin HTTP shell and other services/CLI can share it. Deferred to keep this PR focused (backend already merged in #14244).
- Object drill-down + presigned download; later mutation (full control). Generalize `Cloud` to GCP / Cloudflare R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)