### PR TITLE
fix(cube): clickhouse datasource user admin not default

### DIFF
--- a/apps/kube/cube/manifests/cube-values.yaml
+++ b/apps/kube/cube/manifests/cube-values.yaml
@@ -55,7 +55,8 @@ datasources:
         type: clickhouse
         host: clickhouse-clickhouse-cluster.clickhouse.svc
         port: 8123
-        user: default
+        # Matches the clickhouse-admin-credentials secret (user is "admin", not "default").
+        user: admin
         passFromSecret:
             name: cube-ch-secret
             key: ch-password


### PR DESCRIPTION
Live in-cluster verification (Phase B, PR #14297 deployed):

- **Postgres works** — pg_users.count = 42 in-cluster ✓
- **ClickHouse pre-agg builds failed auth**: `default: Authentication failed`. The clickhouse-admin-credentials secret's username is **admin**, but the datasource hardcoded `user: default`. (Phase A pulled the username from the secret; the chart values assumed default.)

Fix: `user: admin` for the clickhouse datasource. Verified render → CUBEJS_DS_CLICKHOUSE_DB_USER=admin.

After merge→main→sync, CH + federated queries should complete (pre-aggregations build under user admin).