### PR TITLE
fix(content): harden daily content router→builder→auto-merge flow

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -400,6 +400,22 @@ jobs:
                               throw mergeErr;
                             }
                             core.warning(`Merge attempt ${i + 1} failed (status ${status}): ${mergeErr.message}. Retrying…`);
+                            // 405 often means the head branch is behind base
+                            // (branch protection "require up to date"). Bring it
+                            // up to date so the next retry can merge — plain
+                            // waiting never recovers a stale branch.
+                            if (status === 405) {
+                              try {
+                                await github.rest.pulls.updateBranch({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  pull_number: prNumber,
+                                });
+                                core.info(`Updated PR #${prNumber} branch with base before retry.`);
+                              } catch (updErr) {
+                                core.info(`updateBranch failed (${updErr.message}) — continuing retry.`);
+                              }
+                            }
                           }
                         }
                         if (!merged) throw lastErr;

--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -167,20 +167,31 @@ jobs:
                     exit 0
                   fi
 
+                  # Stable per-route/day branch. Force-push so a same-day
+                  # re-run (nightly + manual dispatch, or an Actions re-run)
+                  # updates the existing branch in place instead of failing on
+                  # a non-fast-forward push.
                   BRANCH="auto/daily-${{ matrix.route }}-$(date -u +%Y-%m-%d)"
-                  git checkout -b "${BRANCH}"
+                  git checkout -B "${BRANCH}"
                   git commit -m "chore(content): daily ${{ matrix.route }} scaffold [skip ci]"
-                  git push origin "${BRANCH}"
+                  git push --force origin "${BRANCH}"
 
-                  PR_URL=$(gh pr create \
-                    --base dev \
-                    --head "${BRANCH}" \
-                    --title "chore(content): daily ${{ matrix.route }} scaffold" \
-                    --body "Automated daily content update for route \`${{ matrix.route }}\`." \
-                    --label "auto-pr")
-
-                  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
-                  echo "Created PR #${PR_NUM}"
+                  # Reuse an already-open PR for this branch (force-push updated
+                  # it in place) instead of opening a duplicate.
+                  PR_NUM=$(gh pr list --head "${BRANCH}" --base dev --state open \
+                    --json number --jq '.[0].number // empty')
+                  if [ -z "${PR_NUM}" ]; then
+                    PR_URL=$(gh pr create \
+                      --base dev \
+                      --head "${BRANCH}" \
+                      --title "chore(content): daily ${{ matrix.route }} scaffold" \
+                      --body "Automated daily content update for route \`${{ matrix.route }}\`." \
+                      --label "auto-pr")
+                    PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+                    echo "Created PR #${PR_NUM}"
+                  else
+                    echo "Reusing open PR #${PR_NUM} (force-pushed update)"
+                  fi
                   echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
 
             - name: Dispatch auto-merge

--- a/packages/python/kbve/kbve/nx/routes/graph.py
+++ b/packages/python/kbve/kbve/nx/routes/graph.py
@@ -11,12 +11,23 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from ..builder import BuildContext, BuildResult, PlanResult, repo_root_for
 from ..graph import parse_graph
 from ..render import render_graph_mdx
 from ..router import route
+
+_NX_GRAPH_TIMEOUT = 300
+
+
+class GraphAcquireError(Exception):
+    """Raised when the nx project graph cannot be produced or parsed."""
+
+
+def _warn(msg: str) -> None:
+    print("::warning::graph route: %s" % msg, file=sys.stderr)
 
 
 def _run_nx_graph(repo_root: Path, out_file: Path) -> None:
@@ -26,21 +37,40 @@ def _run_nx_graph(repo_root: Path, out_file: Path) -> None:
         ["pnpm", "nx", "graph", "--file=%s" % out_file, "--open=false"],
         cwd=str(repo_root),
         check=True,
+        timeout=_NX_GRAPH_TIMEOUT,
     )
+
+
+def _validate_graph(raw) -> dict:
+    """Ensure the payload has the expected nx-graph shape before parsing."""
+    if not isinstance(raw, dict) or "nodes" not in (raw.get("graph") or {}):
+        raise GraphAcquireError("unexpected nx graph schema (missing graph.nodes)")
+    if not raw["graph"]["nodes"]:
+        raise GraphAcquireError("nx graph has zero nodes")
+    return raw
 
 
 def _acquire(ctx: BuildContext) -> dict:
     src = ctx.inputs.get("graph_json")
     if src is not None:
-        if isinstance(src, dict):
-            return src
-        return json.loads(Path(src).read_text())
+        raw = src if isinstance(src, dict) else json.loads(Path(src).read_text())
+        return _validate_graph(raw)
 
     repo_root = repo_root_for(ctx.content_root)
     workdir = Path(ctx.workdir) if ctx.workdir else repo_root
     graph_file = workdir / "nx-graph.json"
-    _run_nx_graph(repo_root, graph_file)
-    return json.loads(graph_file.read_text())
+    try:
+        _run_nx_graph(repo_root, graph_file)
+        raw = json.loads(graph_file.read_text())
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise GraphAcquireError("nx graph acquisition failed (%s)" % exc) from exc
+    return _validate_graph(raw)
 
 
 @route("graph", "on-demand", needs=("node",))
@@ -51,7 +81,12 @@ class GraphRoute:
         )
 
     def build(self, ctx: BuildContext) -> BuildResult:
-        raw = _acquire(ctx)
+        try:
+            raw = _acquire(ctx)
+        except GraphAcquireError as exc:
+            _warn("%s — skipping graph regeneration" % exc)
+            return BuildResult("graph", [], True, "acquire failed: %s" % exc)
+
         graph = parse_graph(raw)
 
         public_dir = Path(ctx.public_dir)

--- a/packages/python/kbve/kbve/nx/routes/security.py
+++ b/packages/python/kbve/kbve/nx/routes/security.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from ..alerts import ENDPOINTS, fetch_all, validate
@@ -22,16 +23,35 @@ from ..security import parse_all_ecosystems
 
 _NPM_FALLBACK: dict = {"advisories": {}}
 _CARGO_FALLBACK: dict = {"vulnerabilities": {"found": 0}, "warnings": {}}
+_AUDIT_TIMEOUT = 120
 
 
-def _run_json(cmd: list[str], cwd: Path, fallback):
-    """Run ``cmd`` and parse stdout as JSON; degrade to ``fallback``."""
+def _warn(msg: str) -> None:
+    print("::warning::security route: %s" % msg, file=sys.stderr)
+
+
+def _run_json(cmd: list[str], cwd: Path, fallback, timeout: int = _AUDIT_TIMEOUT):
+    """Run ``cmd`` and parse stdout as JSON; degrade to ``fallback``.
+
+    Audit tools exit non-zero when findings exist — that is fine, we still
+    parse stdout. A missing binary, a hang, or non-JSON output degrades to the
+    empty fallback with a ``::warning::`` so an all-zero dashboard is never
+    silently mistaken for "secure".
+    """
+    tool = cmd[0]
     try:
         proc = subprocess.run(
-            cmd, cwd=str(cwd), capture_output=True, text=True
+            cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout
         )
         return json.loads(proc.stdout)
+    except FileNotFoundError:
+        _warn("%s not found — using empty fallback" % tool)
+        return fallback
+    except subprocess.TimeoutExpired:
+        _warn("%s timed out after %ss — using empty fallback" % (tool, timeout))
+        return fallback
     except (OSError, ValueError, json.JSONDecodeError):
+        _warn("%s produced no valid JSON — using empty fallback" % tool)
         return fallback
 
 
@@ -56,7 +76,8 @@ def _acquire_alerts(endpoint: str):
     try:
         raw = fetch_all(ENDPOINTS[endpoint], token, 100, 30.0)
         return validate(raw)
-    except Exception:
+    except Exception as exc:
+        _warn("%s alert feed failed (%s) — using empty fallback" % (endpoint, exc))
         return []
 
 

--- a/packages/python/kbve/tests/test_nx_graph_route.py
+++ b/packages/python/kbve/tests/test_nx_graph_route.py
@@ -81,3 +81,17 @@ def test_graph_build_accepts_path_input(tmp_path):
     get("graph").build(ctx)
     assert (ctx.content_root / "dashboard" / "graph.mdx").exists()
     assert (ctx.public_dir / "nx-graph.json").exists()
+
+
+def test_graph_build_skips_on_bad_schema(tmp_path):
+    ctx = _ctx(tmp_path, {"graph_json": {"bogus": 1}})
+    result = get("graph").build(ctx)
+    assert result.skipped is True
+    assert not (ctx.content_root / "dashboard" / "graph.mdx").exists()
+
+
+def test_graph_build_skips_on_empty_nodes(tmp_path):
+    ctx = _ctx(tmp_path, {"graph_json": {"graph": {"nodes": {}, "dependencies": {}}}})
+    result = get("graph").build(ctx)
+    assert result.skipped is True
+    assert not (ctx.public_dir / "nx-graph.json").exists()


### PR DESCRIPTION
Hardening follow-up from the flow survey. Fixes all 5 flagged issues.

## Fixes

**#1 Branch collision (HIGH)** + **#4 Duplicate PRs** — `ci-daily-content.yml` builder now `checkout -B` + `push --force` to the stable per-day branch, and reuses an already-open PR for that branch (via `gh pr list --head`) instead of failing the non-fast-forward push or opening a duplicate. Same-day re-run (nightly + manual, or Actions re-run) updates the existing PR in place. Guaranteed breakage before; now idempotent.

**#3 Auto-merge stale branch (MED/HIGH)** — `ci-auto-merge-bot-prs.yml` direct-merge retry loop now calls `pulls.updateBranch` on a `405` (head behind base under "require up to date" protection) before retrying. Plain waiting never recovered a stale branch → 2nd/3rd daily PR would sit open forever.

**#2 Audit subprocess (MED)** — `security.py` audit runs get a 120s `timeout=` and a `::warning::` on missing binary / timeout / non-JSON, so a masked acquisition failure can't silently render an all-zero "secure" dashboard. (Non-zero exit on "vulns found" was already handled correctly.)

**#5 Graph route (MED)** — `graph.py` nx-graph acquisition gets a 300s timeout, validates `graph.nodes` is present + non-empty, and **skips gracefully** (warning + `skipped` result) instead of hard-failing on any nx hiccup / schema drift.

## Verification
- Full python suite **322 passed**; 2 new graph-skip regression tests (bad schema, empty nodes).
- Both workflow YAMLs valid; edited github-script steps parse clean.
- Simulated graph skip paths (empty-nodes, bad-schema → skipped; valid → builds) and confirmed.

## Note
Stacks cleanly on #14306 (stage 3) — touches different lines of `security.py`/`graph.py` than the cadence flip. Merge order doesn't matter.