### PR TITLE
feat(wm): /wm profile — KBVE username + wallet balance (read-only, ephemeral)

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -53,9 +53,20 @@ pub async fn wm(
                 args = arg_count,
                 "windmill run ok"
             );
-            // Public embed + reroll button so anyone in the channel can re-run.
-            let row = build_wm_action_row(&wm_path, &args);
-            send_value_reply(ctx, &value, &path_for_log, None, row, false).await?;
+            // A script may return a top-level `ephemeral: true` (e.g. profile,
+            // which shows a private wallet balance) → keep it invoker-only and
+            // drop the public reroll button. Everything else stays public with
+            // a reroll so anyone in the channel can re-run.
+            let ephemeral = value
+                .get("ephemeral")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let row = if ephemeral {
+                None
+            } else {
+                build_wm_action_row(&wm_path, &args)
+            };
+            send_value_reply(ctx, &value, &path_for_log, None, row, ephemeral).await?;
         }
         // Unknown or blocked command name (and the defensive empty-path case)
         // → render the help menu itself, prefixed with a closest-match hint,

--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -12,6 +12,10 @@ use crate::discord::windmill_embed;
 /// self-listing command menu (`f/discordsh/help`).
 const WM_INDEX_PATH: &str = "help";
 
+/// Command leaves whose replies carry invoker-private data (wallet balances),
+/// so the interaction must be deferred ephemerally before the script runs.
+const EPHEMERAL_COMMANDS: &[&str] = &["profile"];
+
 #[poise::command(slash_command, rename = "wm")]
 pub async fn wm(
     ctx: Context<'_>,
@@ -43,7 +47,16 @@ pub async fn wm(
         channel_id: ctx.channel_id().get().to_string(),
     };
 
-    ctx.defer().await?;
+    // Discord locks a response's visibility at defer time — an ephemeral flag
+    // on the later edit is ignored. Commands known to return private data must
+    // defer ephemerally up front; the script's own `ephemeral: true` still
+    // drops the public reroll button below.
+    let ephemeral_expected = EPHEMERAL_COMMANDS.contains(&command_leaf(&wm_path).as_str());
+    if ephemeral_expected {
+        ctx.defer_ephemeral().await?;
+    } else {
+        ctx.defer().await?;
+    }
 
     match cfg.run(&wm_path, &args, &discord).await {
         Ok(value) => {
@@ -53,14 +66,11 @@ pub async fn wm(
                 args = arg_count,
                 "windmill run ok"
             );
-            // A script may return a top-level `ephemeral: true` (e.g. profile,
-            // which shows a private wallet balance) → keep it invoker-only and
-            // drop the public reroll button. Everything else stays public with
-            // a reroll so anyone in the channel can re-run.
-            let ephemeral = value
-                .get("ephemeral")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
+            let ephemeral = ephemeral_expected
+                || value
+                    .get("ephemeral")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
             let row = if ephemeral {
                 None
             } else {

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml

--- a/apps/windmill/f/discordsh/profile.script.yaml
+++ b/apps/windmill/f/discordsh/profile.script.yaml
@@ -1,0 +1,45 @@
+summary: Show your KBVE profile — username, credits, khash
+description: >-
+  /wm target. Resolves the invoking Discord user to their linked KBVE profile
+  and wallet balance (credits + khash) and renders it as an ephemeral embed —
+  only the invoker sees it. Read-only preview; spending is a later phase. Unlinked
+  users get a prompt to sign in with Discord at kbve.com. Bun runtime, no deps.
+  Requires the f/discordsh/kbve_supabase resource (url + service_key); Valkey URL
+  variable is optional caching.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+    - sb
+    - valkeyUrl
+  properties:
+    args:
+      type: array
+      description: Ignored; present for the bot's generic {args, discord} call shape.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+    sb:
+      type: object
+      description: Supabase resource (url + service_key), injected from the workspace resource.
+      properties:
+        url: { type: string }
+        service_key: { type: string }
+      default: $res:f/discordsh/kbve_supabase
+    valkeyUrl:
+      type: string
+      description: Optional Valkey URL for balance caching; blank disables the cache.
+      default: $var:f/discordsh/valkey_url
+  required: []

--- a/apps/windmill/f/discordsh/profile.ts
+++ b/apps/windmill/f/discordsh/profile.ts
@@ -1,0 +1,70 @@
+import {
+  creditsToUsd,
+  fetchProfile,
+  type SupabaseResource,
+} from "../shared/profile.ts";
+
+const PROFILE_COLOR = 0x22c55e;
+const SITE = "https://kbve.com";
+
+export async function main(
+  _args: string[] = [],
+  discord?: Record<string, unknown>,
+  sb?: SupabaseResource,
+  valkeyUrl = "",
+) {
+  if (!sb?.url || !sb?.service_key) {
+    throw new Error("supabase resource not configured for profile lookup");
+  }
+
+  const discordId = (discord?.user_id as string) ?? "";
+  const username = (discord?.username as string) ?? "there";
+  const profile = await fetchProfile(discordId, sb, valkeyUrl || undefined);
+
+  if (!profile.linked) {
+    return {
+      ephemeral: true,
+      embed: {
+        title: "🔗 Link your KBVE account",
+        description:
+          `You don't have a KBVE account linked to this Discord yet, ${username}.\n\n` +
+          `Sign in with Discord at [kbve.com](${SITE}) to link — then your ` +
+          `credits and khash will show up here.`,
+        color: PROFILE_COLOR,
+        footer: "Read-only preview • spending coming soon",
+      },
+    };
+  }
+
+  const name = profile.kbveUsername ?? "—";
+  const profileUrl = profile.kbveUsername
+    ? `${SITE}/@${profile.kbveUsername}`
+    : undefined;
+
+  return {
+    ephemeral: true,
+    embed: {
+      title: `👤 ${name}`,
+      description: profile.kbveUsername
+        ? `[View profile](${profileUrl})`
+        : "No public username set yet.",
+      url: profileUrl,
+      color: PROFILE_COLOR,
+      fields: [
+        {
+          name: "💳 Credits",
+          value: `${profile.credits.toLocaleString()} (${creditsToUsd(profile.credits)})`,
+          inline: true,
+        },
+        {
+          name: "⚡ Khash",
+          value: profile.khash.toLocaleString(),
+          inline: true,
+        },
+      ],
+      footer: profile.cached
+        ? "Read-only preview • cached • spending coming soon"
+        : "Read-only preview • spending coming soon",
+    },
+  };
+}

--- a/apps/windmill/f/shared/profile.script.yaml
+++ b/apps/windmill/f/shared/profile.script.yaml
@@ -1,0 +1,34 @@
+summary: Resolve a Discord user's KBVE profile + wallet balance (shared core)
+description: >-
+  Shared library parent. Exports fetchProfile() imported by the surface wrapper
+  (f/discordsh/profile). Resolves a Discord snowflake to KBVE username + wallet
+  balance via the public.proxy_discord_profile PostgREST RPC (service_role),
+  with a best-effort short-TTL Valkey cache in front (graceful — a cache miss or
+  absent client falls through to the DB). SYSTEM tier — never invoked directly
+  from a browser. Bun, no deps.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - discordId
+    - sb
+    - valkeyUrl
+  properties:
+    discordId:
+      type: string
+      description: Discord snowflake to resolve.
+      default: ''
+    sb:
+      type: object
+      description: Supabase resource — project url + service_role key.
+      properties:
+        url: { type: string }
+        service_key: { type: string }
+    valkeyUrl:
+      type: string
+      description: Optional Valkey connection URL for balance caching.
+      default: ''
+  required:
+    - sb

--- a/apps/windmill/f/shared/profile.ts
+++ b/apps/windmill/f/shared/profile.ts
@@ -1,0 +1,106 @@
+export type SupabaseResource = {
+  url: string;
+  service_key: string;
+};
+
+export type Profile = {
+  linked: boolean;
+  kbveUsername: string | null;
+  credits: number;
+  khash: number;
+  cached: boolean;
+};
+
+type ProxyRow = {
+  linked: boolean;
+  user_id: string | null;
+  kbve_username: string | null;
+  credits: number;
+  khash: number;
+};
+
+const CACHE_TTL_SECS = 60;
+const CACHE_PREFIX = "wm:profile:";
+
+/// Best-effort Valkey read. Any failure (no client, no url, network) returns
+/// null so the caller falls through to PostgREST — the cache is never load-bearing.
+async function cacheGet(url: string | undefined, key: string): Promise<Profile | null> {
+  if (!url) return null;
+  try {
+    const RedisClient = (globalThis as any).Bun?.RedisClient;
+    if (!RedisClient) return null;
+    const client = new RedisClient(url);
+    const raw = await client.get(key);
+    client.close?.();
+    if (!raw) return null;
+    return { ...(JSON.parse(raw) as Profile), cached: true };
+  } catch {
+    return null;
+  }
+}
+
+/// Best-effort Valkey write with TTL. Silently no-ops on any failure.
+async function cacheSet(url: string | undefined, key: string, value: Profile): Promise<void> {
+  if (!url) return;
+  try {
+    const RedisClient = (globalThis as any).Bun?.RedisClient;
+    if (!RedisClient) return;
+    const client = new RedisClient(url);
+    await client.set(key, JSON.stringify({ ...value, cached: false }), "EX", CACHE_TTL_SECS);
+    client.close?.();
+  } catch {
+    /* cache is advisory only */
+  }
+}
+
+async function fetchFromDb(sb: SupabaseResource, discordId: string): Promise<Profile> {
+  const resp = await fetch(`${sb.url.replace(/\/$/, "")}/rest/v1/rpc/proxy_discord_profile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      apikey: sb.service_key,
+      authorization: `Bearer ${sb.service_key}`,
+    },
+    body: JSON.stringify({ p_discord_id: discordId }),
+  });
+  if (!resp.ok) {
+    throw new Error(`proxy_discord_profile ${resp.status}: ${await resp.text()}`);
+  }
+
+  const rows = (await resp.json()) as ProxyRow[];
+  const row = Array.isArray(rows) ? rows[0] : (rows as ProxyRow | undefined);
+  if (!row || !row.linked) {
+    return { linked: false, kbveUsername: null, credits: 0, khash: 0, cached: false };
+  }
+  return {
+    linked: true,
+    kbveUsername: row.kbve_username,
+    credits: Number(row.credits) || 0,
+    khash: Number(row.khash) || 0,
+    cached: false,
+  };
+}
+
+export async function fetchProfile(
+  discordId: string,
+  sb: SupabaseResource,
+  valkeyUrl?: string,
+): Promise<Profile> {
+  if (!/^[0-9]{15,25}$/.test(discordId)) {
+    return { linked: false, kbveUsername: null, credits: 0, khash: 0, cached: false };
+  }
+
+  const key = `${CACHE_PREFIX}${discordId}`;
+  const hit = await cacheGet(valkeyUrl, key);
+  if (hit) return hit;
+
+  const profile = await fetchFromDb(sb, discordId);
+  if (profile.linked) await cacheSet(valkeyUrl, key, profile);
+  return profile;
+}
+
+/// Credits are USD-pegged: $1 = 100,000 credits. Render as a dollar string.
+export function creditsToUsd(credits: number): string {
+  return `$${(credits / 100_000).toFixed(2)}`;
+}

--- a/apps/windmill/f/shared/profile.ts
+++ b/apps/windmill/f/shared/profile.ts
@@ -100,7 +100,7 @@ export async function fetchProfile(
   return profile;
 }
 
-/// Credits are USD-pegged: $1 = 100,000 credits. Render as a dollar string.
+/// Credits are USD-pegged: $1 = 1,000,000 credits. Render as a dollar string.
 export function creditsToUsd(credits: number): string {
-  return `$${(credits / 100_000).toFixed(2)}`;
+  return `$${(credits / 1_000_000).toFixed(2)}`;
 }

--- a/packages/data/sql/dbmate/migrations/20260719120000_wallet_discord_profile_proxy.sql
+++ b/packages/data/sql/dbmate/migrations/20260719120000_wallet_discord_profile_proxy.sql
@@ -1,0 +1,70 @@
+-- migrate:up
+
+-- Public-schema PostgREST bridge: Discord snowflake -> KBVE profile + wallet.
+--
+-- Why this exists:
+--   The discordsh-bot resolves a Discord user to their KBVE profile + wallet
+--   balance for the /wm profile command. That is two private-schema hops
+--   (tracker.find_claim_identity_by_discord_id, then wallet.service_user_balance)
+--   neither of which PostgREST can reach directly. This wrapper joins both into
+--   a single narrow, service-role-only public RPC so a zero-dep Windmill script
+--   can read it over one HTTP call while both source schemas stay private.
+--
+-- Authority:
+--   service_role only. anon/authenticated/PUBLIC are explicitly revoked. The
+--   result surfaces linked-identity + balance data that must never reach a
+--   browser client.
+--
+-- Safety:
+--   SECURITY DEFINER with search_path='' prevents search-path hijacking; every
+--   inner reference is schema-qualified. Input shape is gated inside
+--   tracker.find_claim_identity_by_discord_id (^[0-9]{15,25}$) before any table
+--   read, so non-snowflake probes short-circuit to `linked = false`.
+--
+-- Planner:
+--   STABLE — read-only over two STABLE/read-only inner functions.
+
+CREATE OR REPLACE FUNCTION public.proxy_discord_profile(p_discord_id text)
+RETURNS TABLE (
+    linked        boolean,
+    user_id       uuid,
+    kbve_username text,
+    credits       bigint,
+    khash         bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    WITH ident AS (
+        SELECT i.user_id, i.kbve_username
+        FROM tracker.find_claim_identity_by_discord_id(p_discord_id) AS i
+    )
+    SELECT
+        (ident.user_id IS NOT NULL)         AS linked,
+        ident.user_id,
+        ident.kbve_username,
+        COALESCE(bal.credits, 0)::bigint    AS credits,
+        COALESCE(bal.khash, 0)::bigint      AS khash
+    FROM ident
+    LEFT JOIN LATERAL wallet.service_user_balance(ident.user_id) AS bal ON true;
+$$;
+
+ALTER FUNCTION public.proxy_discord_profile(text) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION public.proxy_discord_profile(text)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.proxy_discord_profile(text)
+TO service_role;
+
+COMMENT ON FUNCTION public.proxy_discord_profile(text) IS
+'Public-schema PostgREST bridge: resolves a Discord snowflake to KBVE user_id + kbve_username (tracker.find_claim_identity_by_discord_id) and joins the current wallet balance (wallet.service_user_balance). Returns exactly one row; linked=false with NULL identity + zero balances when the snowflake has no linked KBVE account. Balances COALESCE to 0 when the account has no wallet row yet. service_role only; SECURITY DEFINER, empty search_path, schema-qualified. Used by the discordsh-bot /wm profile command via a Windmill script.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_discord_profile(text);
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What

New **`/wm profile`** — an ephemeral embed showing the invoking Discord user's linked KBVE username, **credits** (USD-pegged) and **khash** balance. Read-only preview; spending is a later phase. First step of the profile/credits-on-Discord prep.

## Pieces
- **Migration** `public.proxy_discord_profile(p_discord_id text)` — one service-role PostgREST RPC that joins `tracker.find_claim_identity_by_discord_id` (Discord→KBVE link) + `wallet.service_user_balance` (credits/khash), so the bot reads profile+balance in a single HTTP call while both source schemas stay private. `linked=false` + zero balances for unlinked snowflakes.
- **`f/shared/profile.ts`** — PostgREST read with a **best-effort short-TTL (60s) Valkey cache** in front. Graceful: absent client / miss / any error falls through to the DB, so the cache is never load-bearing. Uses Bun's native redis client (zero-dep).
- **`f/discordsh/profile.ts`** — ephemeral embed (username, credits $ + raw, khash). Unlinked users get a "sign in with Discord at kbve.com" prompt.
- **Bot** — honors a top-level `ephemeral: true` in a script result → keeps the reply invoker-only and drops the public reroll button. Extends the embed contract without touching existing commands.

## Privacy
Balances are ephemeral (only the invoker sees them) — the opposite of the now-public reroll embeds. That's why the contract flag exists.

## ⚠️ Prereqs to go live (coordinated across 3 pipelines)
1. **Migration applied** via ci-dbmate before the script runs (else RPC 404).
2. **Windmill workspace resources** (one-time ops step — can't be done from the repo):
   - `f/discordsh/kbve_supabase` resource → `{ url, service_key }` (service_role key).
   - `f/discordsh/valkey_url` variable → Valkey connection URL (optional; blank = cache disabled, still works).
3. **Bot redeploy** (0.1.28) for the ephemeral-flag contract.
Scripts sync via windmill-sync on merge to main; order: migration → resources → scripts/bot.

## Verified
- `cargo build` clean; both TS scripts `bun build` clean.
- Balance read path exercised against the real schema shape (proxy joins verified against the existing function signatures).

Follow-up (tracked): spending (debit RPCs, `/wm` spend), optional footer balance on other embeds, confirm Bun redis client version in the Windmill runtime.