### PR TITLE
feat(embeddb): parameterized writes + transactions

### DIFF
--- a/docs/superpowers/plans/2026-07-19-embeddb-params-tx.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb-params-tx.md
@@ -1,0 +1,266 @@
+# embeddb v2 (params + transactions) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add parameterized writes and handle-style transactions to the `embeddb` crate.
+
+**Architecture:** `EmbedDb::execute` gains an `impl IntoParams` argument. A new `EmbedTx<'a>` wraps `turso::Transaction`, obtained via `Connection::unchecked_transaction(&self)`, exposing `execute`/`commit`/`rollback`.
+
+**Tech Stack:** Rust, `turso` 0.7, `duckdb` 1.x, `tokio`, `thiserror`.
+
+## Global Constraints
+
+- Work only in `packages/rust/embeddb` (crate already exists, v1 merged).
+- No inline comments in source (repo convention).
+- No panics on the library path; all fallible ops return `Result`.
+- Build/test scoped: `cargo test -p embeddb`. Never build the whole workspace.
+- Turso 0.7 facts (verified): `Connection: Clone`; `execute(&self, sql, params: impl IntoParams) -> Result<u64>`; `unchecked_transaction(&self) -> Result<Transaction<'_>>`; `Transaction` derefs to `Connection`, has `commit(self)`/`rollback(self)`; drop-without-commit rolls back. Re-export path: `pub use turso::IntoParams;`.
+- Commit after every task. No direct pushes to dev/main.
+
+---
+
+### Task 1: Parameterized `execute` + re-export `IntoParams`
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/db.rs`
+- Modify: `packages/rust/embeddb/src/lib.rs`
+
+**Interfaces:**
+- Produces: `pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64>`; `pub use turso::IntoParams;` from crate root.
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `src/db.rs` tests mod, update the existing `execute_creates_and_inserts` test to the new arity and add a bound-param assertion:
+
+```rust
+#[tokio::test]
+async fn execute_creates_and_inserts() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("w.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, 10.0)", ()).await.unwrap();
+    let n = db.execute("INSERT INTO t VALUES (?, ?)", (2_i64, 20.0_f64)).await.unwrap();
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+async fn execute_bound_param_preserves_quote() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("q.db")).await.unwrap();
+    db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (?)", ("o'brien",)).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let n = db.analytics_scalar_i64("SELECT count(*) FROM t WHERE name = 'o''brien'").await.unwrap();
+    assert_eq!(n, 1);
+}
+```
+
+Note: EVERY other existing call to `db.execute(...)` in the whole test module (Tasks from v1: `open`, checkpoint, analytics, quoted-path tests) must also be updated from `execute(sql)` to `execute(sql, ())`. Grep the file for `.execute(` and fix all call sites.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p embeddb`
+Expected: compile error — `execute` takes 1 arg but 2 given (old signature), or the new call sites don't compile.
+
+- [ ] **Step 3: Change the `execute` signature**
+
+In `src/db.rs`:
+
+```rust
+pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64> {
+    let affected = self.conn.execute(sql, params).await?;
+    Ok(affected)
+}
+```
+
+- [ ] **Step 4: Re-export `IntoParams`**
+
+In `src/lib.rs`, add:
+
+```rust
+pub use turso::IntoParams;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p embeddb`
+Expected: all tests PASS (existing + two updated/new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/rust/embeddb/src/db.rs packages/rust/embeddb/src/lib.rs
+git commit -m "feat(embeddb): parameterized execute + re-export IntoParams"
+```
+
+---
+
+### Task 2: `EmbedTx` transaction handle
+
+**Files:**
+- Create: `packages/rust/embeddb/src/tx.rs`
+- Modify: `packages/rust/embeddb/src/db.rs` (add `begin`)
+- Modify: `packages/rust/embeddb/src/lib.rs` (module + export)
+
+**Interfaces:**
+- Consumes: `EmbedDb` (holds `conn: turso::Connection`), `Result`.
+- Produces:
+  - `pub async fn begin(&self) -> Result<EmbedTx<'_>>` on `EmbedDb`.
+  - `pub struct EmbedTx<'a>` with `pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64>`, `pub async fn commit(self) -> Result<()>`, `pub async fn rollback(self) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/db.rs` tests mod:
+
+```rust
+#[tokio::test]
+async fn tx_commit_persists() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("c.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    let tx = db.begin().await.unwrap();
+    tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+    tx.execute("INSERT INTO t VALUES (?)", (2_i64,)).await.unwrap();
+    tx.commit().await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn tx_rollback_discards() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("r.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    let tx = db.begin().await.unwrap();
+    tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+    tx.rollback().await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn tx_drop_without_commit_rolls_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("d.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    {
+        let tx = db.begin().await.unwrap();
+        tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+    }
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p embeddb`
+Expected: compile error — no `begin` method, no `EmbedTx`.
+
+- [ ] **Step 3: Create `src/tx.rs`**
+
+```rust
+use crate::Result;
+
+pub struct EmbedTx<'a> {
+    tx: turso::Transaction<'a>,
+}
+
+impl<'a> EmbedTx<'a> {
+    pub(crate) fn new(tx: turso::Transaction<'a>) -> Self {
+        EmbedTx { tx }
+    }
+
+    pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64> {
+        let affected = self.tx.execute(sql, params).await?;
+        Ok(affected)
+    }
+
+    pub async fn commit(self) -> Result<()> {
+        self.tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn rollback(self) -> Result<()> {
+        self.tx.rollback().await?;
+        Ok(())
+    }
+}
+```
+
+If `self.tx.execute(...)` does not resolve directly (method lives on the
+`Connection` reached via `Deref`), call it through the deref target — the
+`Transaction` derefs to `Connection`, so `(&*self.tx).execute(sql, params)` or
+`self.tx.execute(sql, params)` both reach it; use whichever compiles. Keep the
+`EmbedTx::execute` signature unchanged.
+
+- [ ] **Step 4: Add `begin` on `EmbedDb`**
+
+In `src/db.rs`:
+
+```rust
+pub async fn begin(&self) -> Result<crate::EmbedTx<'_>> {
+    let tx = self.conn.unchecked_transaction().await?;
+    Ok(crate::EmbedTx::new(tx))
+}
+```
+
+- [ ] **Step 5: Wire module + export in `lib.rs`**
+
+```rust
+mod tx;
+pub use tx::EmbedTx;
+```
+
+(Add alongside the existing `mod`/`pub use` lines; keep `mod db; mod error; mod analytics;` etc. intact.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p embeddb`
+Expected: all tests PASS, including the three transaction tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/rust/embeddb/src/tx.rs packages/rust/embeddb/src/db.rs packages/rust/embeddb/src/lib.rs
+git commit -m "feat(embeddb): EmbedTx transaction handle (begin/commit/rollback)"
+```
+
+---
+
+### Task 3: README update
+
+**Files:**
+- Modify: `packages/rust/embeddb/README.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Update the usage example**
+
+Replace/extend the usage section so it shows:
+- a bound-parameter write: `db.execute("INSERT INTO t VALUES (?, ?)", (1_i64, "a")).await?;`
+- a transaction: `let tx = db.begin().await?; tx.execute(...).await?; tx.commit().await?;`
+- a one-line note: dropping an `EmbedTx` without `commit` rolls back.
+
+Keep the existing "Deployment note: DuckDB sqlite extension" and
+"Checkpoint-then-read model" sections intact.
+
+- [ ] **Step 2: Verify the crate still builds and all tests pass**
+
+Run: `cargo test -p embeddb`
+Expected: all PASS (README change does not affect tests, but confirm no stray edits broke anything).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/rust/embeddb/README.md
+git commit -m "docs(embeddb): README examples for params + transactions"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** parameterized execute + IntoParams re-export (T1); EmbedTx begin/commit/rollback + drop-rollback (T2); README (T3). All five spec tests mapped: bound insert + quote-preservation (T1), commit/rollback/drop (T2).
+- **Placeholder scan:** none; the Deref note in T2 Step 3 is deliberate compile-adaptation guidance, not missing content.
+- **Type consistency:** `EmbedTx<'a>`, `EmbedTx::new`, `begin`, `execute(sql, params)`, `commit`, `rollback`, `IntoParams` names consistent across tasks and match the spec.

--- a/docs/superpowers/specs/2026-07-19-embeddb-params-tx-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-params-tx-design.md
@@ -1,0 +1,99 @@
+# embeddb v2 — Parameterized Writes + Transactions Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+Builds on: `packages/rust/embeddb` (v1, merged PR #14292)
+
+## Purpose
+
+Close the top deferred item from the embeddb v1 spec: the write path currently
+only exposes `execute(&self, sql: &str)` with no parameter binding, forcing
+consumers to string-format SQL (injection footgun, review finding M5). This
+increment adds parameterized writes and multi-statement transactions.
+
+Non-goals (still deferred): checkpoint busy-check, live concurrent write/read,
+backend-swap trait (Turso ↔ rusqlite).
+
+## Turso 0.7 facts (verified against installed crate source)
+
+- `turso::Connection` is `Clone`.
+- `Connection::execute(&self, sql, params: impl IntoParams) -> Result<u64>` —
+  parameter binding already exists; v1 just passed `()`.
+- `turso::IntoParams` is implemented for `()`, tuples `(T, ...)`, `[T; N]`,
+  `Vec<T>`, named `[(&'static str, T); N]`, `Vec<(String, T)>`, and `Params`.
+- `Connection::unchecked_transaction(&self) -> Result<Transaction<'_>>` obtains a
+  transaction from a shared `&self` (no `&mut` needed).
+- `Transaction<'conn>` derefs to `Connection` (so `tx.execute(...)` works),
+  and has `commit(self)`, `rollback(self)`. Dropping without commit rolls back
+  (turso default drop behavior).
+
+## Changes
+
+### 1. Parameterized `execute`
+
+Change the signature on `EmbedDb`:
+
+```rust
+pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64>
+```
+
+- Body: `self.conn.execute(sql, params).await.map_err(Into::into)`.
+- Re-export `turso::IntoParams` from the crate root (`pub use turso::IntoParams;`)
+  so consumers can name the bound without a direct turso dependency.
+- This is a breaking change to `execute`'s arity. Acceptable at version `0.0.1`
+  with no external consumers. All existing no-parameter call sites become
+  `execute(sql, ())`.
+
+### 2. Transactions — handle style
+
+New public type `EmbedTx<'a>` wrapping `turso::Transaction<'a>`.
+
+```rust
+impl EmbedDb {
+    pub async fn begin(&self) -> Result<EmbedTx<'_>>;
+}
+
+pub struct EmbedTx<'a> { tx: turso::Transaction<'a> }
+
+impl<'a> EmbedTx<'a> {
+    pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64>;
+    pub async fn commit(self) -> Result<()>;
+    pub async fn rollback(self) -> Result<()>;
+}
+```
+
+- `begin` uses `self.conn.unchecked_transaction().await?`.
+- `EmbedTx::execute` delegates to the transaction (via its `Deref` to
+  `Connection`, or directly): `self.tx.execute(sql, params).await`.
+- Dropping an `EmbedTx` without calling `commit` rolls back (turso default) —
+  documented, and covered by a test.
+- Handle style chosen over a `write_tx(|tx| async { ... })` closure to avoid
+  async-closure lifetime friction; idiomatic (sqlx-like).
+
+Placement: `EmbedTx` lives in a new `src/tx.rs`, exported from `lib.rs`.
+
+### 3. Error handling
+
+No new error variants — `turso::Error` already maps via the existing
+`EmbedError::Turso(#[from] turso::Error)`.
+
+## Testing
+
+1. **Parameterized insert:** create table, `execute("INSERT INTO t VALUES (?, ?)", (1_i64, 42.0_f64))`, checkpoint, assert DuckDB `count`/value matches. Proves binding works (no string interpolation).
+2. **Param avoids injection-style breakage:** insert a text value containing a single quote via a bound param (e.g. `("o'brien",)`), read back, assert intact — a raw `format!` would have broken.
+3. **Transaction commit:** `begin` → two `execute` inserts → `commit` → checkpoint → DuckDB count == 2.
+4. **Transaction rollback:** `begin` → insert → `rollback` → checkpoint → count == 0.
+5. **Drop without commit rolls back:** `begin` → insert → drop the `EmbedTx` (no commit) → checkpoint → count == 0.
+
+All via `cargo test -p embeddb`. Existing v1 tests updated for the new
+`execute(sql, ())` arity.
+
+## README
+
+Update the usage section: show a bound-parameter `execute` and a
+`begin`/`execute`/`commit` transaction example. Note drop-without-commit =
+rollback.
+
+## Deferred (unchanged)
+
+checkpoint busy-check, live concurrent read, backend-swap trait, WASM target.

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -40,8 +40,8 @@ use embeddb::EmbedDb;
 async fn main() -> embeddb::Result<()> {
     let db = EmbedDb::open("data.db").await?;
 
-    db.execute("CREATE TABLE t (v REAL)").await?;
-    db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)").await?;
+    db.execute("CREATE TABLE t (v REAL)", ()).await?;
+    db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)", ()).await?;
 
     db.checkpoint().await?;
 
@@ -52,3 +52,23 @@ async fn main() -> embeddb::Result<()> {
     Ok(())
 }
 ```
+
+`execute` takes a SQL string and anything implementing `turso::IntoParams` — `()` for no parameters, or a tuple of bound values:
+
+```rust
+db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await?;
+db.execute("INSERT INTO t VALUES (?, ?)", (1_i64, "a")).await?;
+```
+
+### Transactions
+
+`EmbedDb::begin` returns an `EmbedTx` handle with its own `execute`, plus `commit`/`rollback` to end it:
+
+```rust
+let tx = db.begin().await?;
+tx.execute("INSERT INTO t VALUES (?, ?)", (2_i64, "b")).await?;
+tx.execute("INSERT INTO t VALUES (?, ?)", (3_i64, "c")).await?;
+tx.commit().await?;
+```
+
+Dropping an `EmbedTx` without calling `commit` discards the transaction's writes (rolled back on the connection's next use, not synchronously at drop).

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -72,3 +72,5 @@ tx.commit().await?;
 ```
 
 Dropping an `EmbedTx` without calling `commit` discards the transaction's writes (rolled back on the connection's next use, not synchronously at drop).
+
+`EmbedDb::execute` and `EmbedDb::begin` share the same underlying `turso::Connection`. While a transaction is open, use the `tx` handle for writes — calling `db.execute(...)` on the same `EmbedDb` runs that statement inside the open transaction instead of autocommitting independently.

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -48,6 +48,11 @@ impl EmbedDb {
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
 
+    pub async fn begin(&self) -> Result<crate::EmbedTx<'_>> {
+        let tx = self.conn.unchecked_transaction().await?;
+        Ok(crate::EmbedTx::new(tx))
+    }
+
     pub async fn close(self) -> Result<()> {
         drop(self.conn);
         Ok(())
@@ -137,5 +142,43 @@ mod tests {
         let avg = db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap();
         assert!((avg - 20.0).abs() < 1e-9);
         db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tx_commit_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("c.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        let tx = db.begin().await.unwrap();
+        tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+        tx.execute("INSERT INTO t VALUES (?)", (2_i64,)).await.unwrap();
+        tx.commit().await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn tx_rollback_discards() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("r.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        let tx = db.begin().await.unwrap();
+        tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+        tx.rollback().await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn tx_drop_without_commit_rolls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("d.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        {
+            let tx = db.begin().await.unwrap();
+            tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+        }
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -21,8 +21,8 @@ impl EmbedDb {
         &self.path
     }
 
-    pub async fn execute(&self, sql: &str) -> Result<u64> {
-        let affected = self.conn.execute(sql, ()).await?;
+    pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64> {
+        let affected = self.conn.execute(sql, params).await?;
         Ok(affected)
     }
 
@@ -71,9 +71,20 @@ mod tests {
     async fn execute_creates_and_inserts() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("w.db")).await.unwrap();
-        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
-        db.execute("INSERT INTO t VALUES (1, 10.0)").await.unwrap();
-        let n = db.execute("INSERT INTO t VALUES (2, 20.0)").await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 10.0)", ()).await.unwrap();
+        let n = db.execute("INSERT INTO t VALUES (?, ?)", (2_i64, 20.0_f64)).await.unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn execute_bound_param_preserves_quote() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("q.db")).await.unwrap();
+        db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", ("o'brien",)).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let n = db.analytics_scalar_i64("SELECT count(*) FROM t WHERE name = 'o''brien'").await.unwrap();
         assert_eq!(n, 1);
     }
 
@@ -81,8 +92,8 @@ mod tests {
     async fn checkpoint_after_write_ok() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("c.db")).await.unwrap();
-        db.execute("CREATE TABLE t (id INTEGER)").await.unwrap();
-        db.execute("INSERT INTO t VALUES (1)").await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
     }
 
@@ -90,9 +101,9 @@ mod tests {
     async fn duckdb_reads_turso_written_file() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("x.db")).await.unwrap();
-        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
         for i in 1..=5 {
-            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10)).await.unwrap();
+            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10), ()).await.unwrap();
         }
         db.checkpoint().await.unwrap();
 
@@ -106,9 +117,9 @@ mod tests {
         let quoted_dir = dir.path().join("o'brien");
         std::fs::create_dir_all(&quoted_dir).unwrap();
         let db = EmbedDb::open(quoted_dir.join("q.db")).await.unwrap();
-        db.execute("CREATE TABLE t (id INTEGER, v REAL)").await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
         for i in 1..=3 {
-            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10)).await.unwrap();
+            db.execute(&format!("INSERT INTO t VALUES ({}, {}.0)", i, i * 10), ()).await.unwrap();
         }
         db.checkpoint().await.unwrap();
 
@@ -120,8 +131,8 @@ mod tests {
     async fn duckdb_avg_matches() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("a.db")).await.unwrap();
-        db.execute("CREATE TABLE t (v REAL)").await.unwrap();
-        db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)").await.unwrap();
+        db.execute("CREATE TABLE t (v REAL)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (10.0), (20.0), (30.0)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
         let avg = db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap();
         assert!((avg - 20.0).abs() < 1e-9);

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -163,10 +163,18 @@ mod tests {
         let db = EmbedDb::open(dir.path().join("r.db")).await.unwrap();
         db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
         let tx = db.begin().await.unwrap();
-        tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+        let n = tx.execute("INSERT INTO t VALUES (?)", (1_i64,)).await.unwrap();
+        assert_eq!(n, 1);
         tx.rollback().await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+
+        let tx2 = db.begin().await.unwrap();
+        let n2 = tx2.execute("INSERT INTO t VALUES (?)", (2_i64,)).await.unwrap();
+        assert_eq!(n2, 1);
+        tx2.commit().await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -4,3 +4,4 @@ mod analytics;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
+pub use turso::IntoParams;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -1,7 +1,9 @@
 mod error;
 mod db;
 mod analytics;
+mod tx;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
+pub use tx::EmbedTx;
 pub use turso::IntoParams;

--- a/packages/rust/embeddb/src/tx.rs
+++ b/packages/rust/embeddb/src/tx.rs
@@ -1,0 +1,26 @@
+use crate::Result;
+
+pub struct EmbedTx<'a> {
+    tx: turso::transaction::Transaction<'a>,
+}
+
+impl<'a> EmbedTx<'a> {
+    pub(crate) fn new(tx: turso::transaction::Transaction<'a>) -> Self {
+        EmbedTx { tx }
+    }
+
+    pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<u64> {
+        let affected = self.tx.execute(sql, params).await?;
+        Ok(affected)
+    }
+
+    pub async fn commit(self) -> Result<()> {
+        self.tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn rollback(self) -> Result<()> {
+        self.tx.rollback().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## embeddb v2 — parameterized writes + transactions

Follow-up to #14292 (embeddb v1). Closes the top deferred item: the write path was string-only (SQL-injection footgun, v1 review finding M5).

### Added
- **Parameterized `execute`**: `execute(&self, sql, params: impl IntoParams) -> Result<u64>`. Bound values, no string interpolation. `turso::IntoParams` re-exported from the crate root so consumers name the bound without a direct turso dep.
- **Handle-style transactions**: `EmbedDb::begin() -> EmbedTx`, with `tx.execute(sql, params)`, `tx.commit()`, `tx.rollback()`.
  ```rust
  let tx = db.begin().await?;
  tx.execute("INSERT INTO t VALUES (?, ?)", (1_i64, "a")).await?;
  tx.commit().await?;
  ```

### Behavior notes (documented in README)
- Dropping an `EmbedTx` without `commit` discards its writes — turso applies the ROLLBACK on the connection's **next** operation (deferred `dangling_tx`), not synchronously at drop.
- `EmbedDb::execute` and `begin` share one `turso::Connection`: while a tx is open, `db.execute(...)` joins that transaction rather than autocommitting. Use the `tx` handle for writes mid-transaction.
- Opening a second `begin()` while one is live returns an `Err` (turso runtime single-tx check) — no corruption, no panic.

### Breaking
`execute` arity changed (`0.0.1`, no external consumers). All v1 call sites → `execute(sql, ())`.

### Tests
11 passing (`cargo test -p embeddb`): bound-param insert, quote-preservation, tx commit/rollback/drop-rollback (rollback test strengthened to distinguish explicit ROLLBACK from deferred cleanup). Spec + plan under `docs/superpowers/`.

Still deferred: checkpoint busy-check, live concurrent read, backend-swap trait.
