### PR TITLE
feat(dashboard): bento-native security + graph MDX

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/graph.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/graph.mdx
@@ -2,56 +2,127 @@
 title: NX Dependency Graph
 description: |
     Daily auto-generated NX project dependency graph for the KBVE monorepo.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
 sidebar:
     label: Graph
     order: 101
-editUrl: false
 ---
 
-import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
 
-## NX Dependency Graph
+<div class="graph-report" data-dash-report>
 
-:::note[Auto-generated]
-Last generated: **2026-07-19T06:30:28Z** — updated daily by `ci-dashboard`.
-:::
+<section class="bento-hero bento-section not-content" aria-label="NX dependency graph">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3v12M18 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9" /></svg>
+					<span>auto-generated · daily</span>
+				</span>
+				<h1 class="bento-title">
+					Dependency graph
+					<span class="bento-title__accent">across the monorepo.</span>
+				</h1>
+				<p class="bento-lede"><strong>138</strong> projects wired by <strong>154</strong> dependency edges.</p>
+				<p class="bento-lede">Last generated <strong>2026-07-19T00:00:00Z</strong>.</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#diagram">
+						View diagram
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#hubs">Top hubs</a>
+					<a class="bento-btn bento-btn--ghost" href="#project-index">Projects</a>
+				</div>
+			</div>
 
-<CardGrid>
-  <Card title="58 Apps" icon="rocket">
-    @kbve/source, agones-factorio, agones-factorio-relay, angelscript, arpg, arpg-server + 52 more
-  </Card>
-  <Card title="24 E2es" icon="approve-check-circle">
-    arc-runner-e2e, aria2-proxy-e2e, arpg-e2e, astro-cryptothrone-e2e, astro-e2e, astro-kbve-e2e + 18 more
-  </Card>
-  <Card title="56 Libs" icon="puzzle">
-    arc-runner, aria2-proxy, astro, behavior_statetree, bevy_battle, bevy_behavior + 50 more
-  </Card>
-  <Card title="154 Dependencies" icon="random">
-    Across 138 projects in the monorepo.
-  </Card>
-</CardGrid>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" /></svg>
+					</span>
+					<span class="bento-stat__value">58</span>
+					<span class="bento-stat__label">Apps</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+					</span>
+					<span class="bento-stat__value">56</span>
+					<span class="bento-stat__label">Libs</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14M22 4 12 14.01l-3-3" /></svg>
+					</span>
+					<span class="bento-stat__value">24</span>
+					<span class="bento-stat__label">E2E</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" /></svg>
+					</span>
+					<span class="bento-stat__value">154</span>
+					<span class="bento-stat__label">Dependencies</span>
+				</div>
+		</div>
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#hubs">Hubs</a>
+			<a class="bento-chip" href="#diagram">Diagram</a>
+			<a class="bento-chip" href="#project-index">Projects</a>
+		</nav>
+	</div>
+</section>
 
-### Most Depended-On Projects
+<BentoShell id="hubs" eyebrow="Connectivity" heading="Most depended-on">
+	<div class="bento-board bento-board--cols-3">
+		<div class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">jedi</span>
+			<span class="bento-linkcard__copy">17 projects depend on this lib · packages/rust/jedi</span>
+		</div>
+		<div class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">droid</span>
+			<span class="bento-linkcard__copy">13 projects depend on this lib · packages/npm/droid</span>
+		</div>
+		<div class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">kbve</span>
+			<span class="bento-linkcard__copy">12 projects depend on this lib · packages/rust/kbve</span>
+		</div>
+		<div class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">astro</span>
+			<span class="bento-linkcard__copy">11 projects depend on this lib · packages/npm/astro</span>
+		</div>
+		<div class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">laser</span>
+			<span class="bento-linkcard__copy">8 projects depend on this lib · packages/npm/laser</span>
+		</div>
+	</div>
+</BentoShell>
 
-<CardGrid>
-  <Card title="jedi" icon="puzzle">
-    **17** projects depend on this lib. Located at `packages/rust/jedi`.
-  </Card>
-  <Card title="droid" icon="puzzle">
-    **13** projects depend on this lib. Located at `packages/npm/droid`.
-  </Card>
-  <Card title="kbve" icon="puzzle">
-    **12** projects depend on this lib. Located at `packages/rust/kbve`.
-  </Card>
-  <Card title="astro" icon="puzzle">
-    **11** projects depend on this lib. Located at `packages/npm/astro`.
-  </Card>
-  <Card title="laser" icon="puzzle">
-    **8** projects depend on this lib. Located at `packages/npm/laser`.
-  </Card>
-</CardGrid>
+<BentoProse id="diagram" heading="Dependency diagram">
 
-### Project Distribution
+### Project distribution
 
 ```mermaid
 pie showData
@@ -61,7 +132,7 @@ pie showData
     "Libs" : 56
 ```
 
-### Hub Connectivity
+### Hub connectivity
 
 ```mermaid
 pie showData
@@ -73,8 +144,7 @@ pie showData
     "laser" : 8
 ```
 
-<Tabs>
-  <TabItem label="Diagram">
+### Graph
 
 ```mermaid
 graph LR
@@ -244,8 +314,9 @@ graph LR
 **Blue** = Application &nbsp; **Green** = Library &nbsp; **Amber** = E2E Test
 :::
 
-  </TabItem>
-  <TabItem label="Project Index">
+</BentoProse>
+
+<BentoProse id="project-index" heading="Project index">
 
 | Project | Type | Root | Deps | Dependents |
 |---------|------|------|:----:|:----------:|
@@ -387,9 +458,6 @@ graph LR
 | **unity-rareicon** | app | `apps/rareicon/unity-rareicon` | 0 | 0 |
 | **unreal-cleanroom** | app | `apps/chuckrpg/unreal-cleanroom` | 0 | 0 |
 | **unreal-rentearth** | app | `apps/rentearth/unreal-rentearth` | 0 | 0 |
-
-  </TabItem>
-  <TabItem label="Details">
 
 #### App Projects
 
@@ -1170,9 +1238,16 @@ graph LR
 
 </details>
 
-  </TabItem>
-</Tabs>
+</BentoProse>
+
+<BentoProse id="about">
 
 ---
 
-*Auto-generated by [ci-dashboard.yml](https://github.com/KBVE/kbve/actions/workflows/ci-dashboard.yml)*
+*Auto-generated by [ci-daily-content.yml](https://github.com/KBVE/kbve/actions/workflows/ci-daily-content.yml)*
+
+</BentoProse>
+
+</div>
+
+<style is:global>{`.graph-report{--bento-accent:#a78bfa;--bento-accent-2:#38bdf8}`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/security.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/security.mdx
@@ -2,62 +2,148 @@
 title: Security Audit Report
 description: |
     Daily auto-generated security audit for the KBVE monorepo.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
 sidebar:
     label: Security
     order: 102
-editUrl: false
 ---
 
-import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
 
-## Security Audit Report
+<div class="sec-report" data-dash-report>
 
-:::note[Auto-generated]
-Last generated: **2026-07-19T06:37:07Z** — updated daily by `ci-dashboard`.
-:::
+<section class="bento-hero bento-section not-content" aria-label="Security audit">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5z" /></svg>
+					<span>auto-generated · daily</span>
+				</span>
+				<h1 class="bento-title">
+					Security posture
+					<span class="bento-title__accent">across every ecosystem.</span>
+				</h1>
+				<p class="bento-lede"><strong>28</strong> critical/high severity findings across the monorepo — triage before merge.</p>
+				<p class="bento-lede">Last generated <strong>2026-07-19T00:00:00Z</strong>.</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#findings">
+						View findings
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#ecosystems">Ecosystems</a>
+					<a class="bento-btn bento-btn--ghost" href="/dashboard/">Dashboard home</a>
+				</div>
+			</div>
 
-:::caution[Action Required]
-**28** critical/high severity findings across the monorepo.
-:::
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0zM12 9v4M12 17h.01" /></svg>
+					</span>
+					<span class="bento-stat__value">3</span>
+					<span class="bento-stat__label">Critical</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 8v4M12 16h.01" /></svg>
+					</span>
+					<span class="bento-stat__value">25</span>
+					<span class="bento-stat__label">High</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 16v-4M12 8h.01" /></svg>
+					</span>
+					<span class="bento-stat__value">53</span>
+					<span class="bento-stat__label">Medium</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14M22 4 12 14.01l-3-3" /></svg>
+					</span>
+					<span class="bento-stat__value">8</span>
+					<span class="bento-stat__label">Low</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1zM4 22v-7" /></svg>
+					</span>
+					<span class="bento-stat__value">38</span>
+					<span class="bento-stat__label">Info</span>
+				</div>
+		</div>
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#ecosystems">Ecosystems</a>
+			<a class="bento-chip" href="#findings">Findings</a>
+		</nav>
+	</div>
+</section>
 
-### Severity Overview
+<BentoShell id="ecosystems" eyebrow="Coverage" heading="Ecosystem breakdown">
+	<div class="bento-board bento-board--cols-3">
+		<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href="#eco-npm">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96 12 12.01l8.73-5.05M12 22.08V12" /></svg>
+			</span>
+			<span class="bento-linkcard__title">npm</span>
+			<span class="bento-linkcard__copy">64 advisories</span>
+			<span class="bento-linkcard__go" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+			</span>
+		</a>
+		<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href="#eco-cargo">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5" /></svg>
+			</span>
+			<span class="bento-linkcard__title">Cargo</span>
+			<span class="bento-linkcard__copy">63 advisories</span>
+			<span class="bento-linkcard__go" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+			</span>
+		</a>
+		<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href="#eco-python">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 18l6-6-6-6M8 6l-6 6 6 6" /></svg>
+			</span>
+			<span class="bento-linkcard__title">Python</span>
+			<span class="bento-linkcard__copy">0 advisories</span>
+			<span class="bento-linkcard__go" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+			</span>
+		</a>
+		<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href="#eco-codeql">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 21l-6-6M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z" /></svg>
+			</span>
+			<span class="bento-linkcard__title">CodeQL</span>
+			<span class="bento-linkcard__copy">0 alerts</span>
+			<span class="bento-linkcard__go" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+			</span>
+		</a>
+		<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href="#eco-dependabot">
+			<span class="bento-icon-tile">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3v12M18 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9" /></svg>
+			</span>
+			<span class="bento-linkcard__title">Dependabot</span>
+			<span class="bento-linkcard__copy">0 alerts</span>
+			<span class="bento-linkcard__go" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+			</span>
+		</a>
+	</div>
+</BentoShell>
 
-<CardGrid>
-  <Card title="3 Critical" icon="warning">
-    Critical-severity findings across all ecosystems.
-  </Card>
-  <Card title="25 High" icon="error">
-    High-severity findings across all ecosystems.
-  </Card>
-  <Card title="53 Medium" icon="information">
-    Medium-severity findings across all ecosystems.
-  </Card>
-  <Card title="8 Low" icon="approve-check-circle">
-    Low-severity findings across all ecosystems.
-  </Card>
-</CardGrid>
+<BentoProse id="findings" heading="Advisories">
 
-### Ecosystem Breakdown
-
-<CardGrid>
-  <Card title="npm" icon="seti:npm">
-    **64** advisories
-  </Card>
-  <Card title="Cargo" icon="seti:rust">
-    **63** advisories
-  </Card>
-  <Card title="Python" icon="seti:python">
-    **0** advisories
-  </Card>
-  <Card title="CodeQL" icon="magnifier">
-    **0** alerts
-  </Card>
-  <Card title="Dependabot" icon="github">
-    **0** alerts
-  </Card>
-</CardGrid>
-
-### Severity Distribution
+### Severity distribution
 
 ```mermaid
 pie showData
@@ -68,7 +154,7 @@ pie showData
     "Low" : 8
 ```
 
-### Findings by Ecosystem
+### Findings by ecosystem
 
 ```mermaid
 pie showData
@@ -77,8 +163,7 @@ pie showData
     "Cargo" : 63
 ```
 
-<Tabs>
-  <TabItem label="Summary">
+### Summary
 
 | Ecosystem | Critical | High | Medium | Low | Total |
 |-----------|:--------:|:----:|:------:|:---:|:-----:|
@@ -89,8 +174,9 @@ pie showData
 | **Dependabot** | 0 | 0 | 0 | 0 | 0 |
 | **Total** | 3 | 25 | 53 | 8 | 127 |
 
-  </TabItem>
-  <TabItem label="npm">
+<span id="eco-npm"></span>
+
+### npm
 
 | Severity | Package | Advisory | Link |
 |----------|---------|----------|------|
@@ -159,8 +245,9 @@ pie showData
 | Low | `undici` | undici vulnerable to Set-Cookie SameSite attribute downgr... | [Details](https://github.com/advisories/GHSA-g8m3-5g58-fq7m) |
 | Low | `@babel/core` | @babel/core: Arbitrary File Read via sourceMappingURL Com... | [Details](https://github.com/advisories/GHSA-4x5r-pxfx-6jf8) |
 
-  </TabItem>
-  <TabItem label="Cargo">
+<span id="eco-cargo"></span>
+
+### Cargo
 
 | Severity | Package | Advisory | Link |
 |----------|---------|----------|------|
@@ -228,30 +315,40 @@ pie showData
 | Info | `spin` |  |  |
 | Info | `spin` |  |  |
 
-  </TabItem>
-  <TabItem label="Python">
+<span id="eco-python"></span>
+
+### Python
 
 :::tip[All Clear]
 No python advisories found.
 :::
 
-  </TabItem>
-  <TabItem label="CodeQL">
+<span id="eco-codeql"></span>
+
+### CodeQL
 
 :::tip[All Clear]
 No open CodeQL alerts.
 :::
 
-  </TabItem>
-  <TabItem label="Dependabot">
+<span id="eco-dependabot"></span>
+
+### Dependabot
 
 :::tip[All Clear]
 No open Dependabot alerts.
 :::
 
-  </TabItem>
-</Tabs>
+</BentoProse>
+
+<BentoProse id="about">
 
 ---
 
-*Auto-generated by [ci-dashboard.yml](https://github.com/KBVE/kbve/actions/workflows/ci-dashboard.yml)*
+*Auto-generated by [ci-daily-content.yml](https://github.com/KBVE/kbve/actions/workflows/ci-daily-content.yml)*
+
+</BentoProse>
+
+</div>
+
+<style is:global>{`.sec-report{--bento-accent:#f59e0b;--bento-accent-2:#f43f5e}`}</style>

--- a/docs/superpowers/specs/2026-07-19-bento-security-graph-mdx-design.md
+++ b/docs/superpowers/specs/2026-07-19-bento-security-graph-mdx-design.md
@@ -1,0 +1,70 @@
+# Bento-native security + graph dashboard MDX
+
+**Date:** 2026-07-19
+**Status:** Approved
+
+## Problem
+
+`render_security_mdx` + `render_graph_mdx` (`packages/python/kbve/kbve/nx/render.py`) emit plain Starlight `Card/CardGrid/Tabs` under the default doc layout. The rest of the dashboard (portal.mdx, infrastructure.mdx) uses the site's **Bento** design system (`template: splash` + `BentoShell` + `bento.css` classes). Make the two generated pages match.
+
+## Decisions
+
+- **Hand-rolled BentoShell** pattern (matches infrastructure.mdx / portal.mdx), NOT BentoDoc (avoids the proto icon-key schema; better for generated per-ecosystem data).
+- **Keep tables + mermaid** — wrap the existing markdown tables and mermaid charts in `<BentoProse>` sections (prose styling preserved). Only the hero, KPI counts, and breakdown become Bento cards.
+- **Static markup** — the Python builder emits repeated card markup in a loop (no `export const` + `{arr.map()}` JSX); deterministic and safe for generated content.
+- **Verify structurally** (regenerate + assert markup), no live browser.
+
+## Target markup (emulate infrastructure.mdx)
+
+**Frontmatter** (both pages): `template: splash`, `tableOfContents: false`, `editUrl: false`, `lastUpdated: false`, `next: false`, `prev: false`, keep `title`/`description`/`sidebar {label, order}`. security order 102, graph order 101.
+
+**Imports:** `import BentoShell from '@/components/hero/BentoShell.astro';` + `import BentoProse from '@/components/hero/BentoProse.astro';`
+
+**Wrapper:** `<div class="dash-report" style={...}>` … `</div>` + a trailing `<style is:global>{`.dash-report{--bento-accent:…;--bento-accent-2:…}`}</style>`. security accent amber/red (`#f59e0b`/`#f43f5e`), graph accent violet/blue (`#a78bfa`/`#38bdf8`).
+
+**Hero band** — `<section class="bento-hero bento-section not-content">` › `bento-hero__frame bento-frame` › `bento-board bento-board--hero`:
+- `bento-cell bento-hero-copy bento-card bento-card--glass` with a `bento-badge bento-chip` (icon + "auto-generated · daily"), `bento-title` + `bento-title__accent`, `bento-lede` (the summary sentence — e.g. "28 critical/high findings" for security), and a `bento-cta` with jump buttons.
+- The stat tiles as the hero's right-side cells (see below), OR a dedicated stat strip in a BentoShell.
+
+**KPI stat tiles** (security: critical/high/medium/low/info; graph: apps/libs/e2e/dependencies) — a `bento-board bento-board--cols-5` (or 4) of:
+```
+<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+  <span class="bento-icon-tile"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="…"/></svg></span>
+  <span class="bento-stat__value">3</span>
+  <span class="bento-stat__label">Critical</span>
+</div>
+```
+
+**Breakdown cards** — `<BentoShell id="…" eyebrow="…" heading="…">` › `bento-board bento-board--cols-3` of `bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive` (security: one per ecosystem with count + `#eco-<name>` anchor; graph: top-hub projects with dependent counts). Each: `bento-icon-tile` + `bento-linkcard__title` + `bento-linkcard__copy` + `bento-linkcard__go` arrow.
+
+**Prose sections** — `<BentoProse id="findings" heading="…">` wrapping the existing mermaid pies + per-ecosystem tables (security) / mermaid `graph LR` + project-index + details tables (graph). Move the current `<Tabs>` content into prose (either keep `<Tabs>` inside BentoProse, or flatten to `###` subsections — flatten preferred so it reads as one scannable page).
+
+**Footer:** keep the `---` + italic auto-generated link inside a final BentoProse or plain band.
+
+## Inline SVG icon set (path `d` strings)
+
+Provide a small dict in render.py (24×24 stroke paths), e.g.:
+- severity: critical/high `M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z` (triangle-alert); medium `M12 16v-4M12 8h.01M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20z` (info-circle); low/info `M20 6 9 17l-5-5` (check).
+- ecosystems: npm/cargo/python/codeql/dependabot — reuse simple box/package/search/git paths.
+- graph types: app `M9 11 3 3 3-3M12 2v12` rocket-ish / lib puzzle / e2e check / dependencies `M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3…`.
+Exact paths are the implementer's choice as long as they're valid 24×24 stroke paths (copy from infrastructure.mdx / bento-icons where handy).
+
+## Data shapes (unchanged — consume as today)
+
+- security: `data["summary"]` = `{critical,high,medium,low,info}`; `data["ecosystems"][eco]` = `{total, severities{…}, advisories|alerts[…]}`.
+- graph: `GraphData` — `by_type{ptype:set}`, `rows[Row(name,project_type,root,dep_count,dependent_count)]`, `edges`, `edges_by_source`, `deps`, `nodes`; `top_hubs(rows,5)`.
+
+## Tests
+
+Update `render.py` tests: assert the new structure — `template: splash`, `import BentoShell`, `bento-stat`, `bento-linkcard`, `BentoProse`, absence of `<CardGrid>`. Keep asserting the real data values render (counts, ecosystem names, project names). Full suite stays green.
+
+## Regenerate for review
+
+Re-render both committed pages from the committed JSON so the PR diff shows the real new look:
+- `render_security_mdx(json.load(nx-security.json), <ts>)` → `dashboard/security.mdx`
+- graph: parse `nx-graph.json` via `parse_graph` → `render_graph_mdx(…, <ts>)` → `dashboard/graph.mdx`
+Use a fixed timestamp string for a stable diff.
+
+## Out of scope
+
+report.mdx (separate ci-dashboard generator); the JSON renderers (`render_security_json`, `render_graph_json`) — unchanged.

--- a/packages/python/kbve/kbve/nx/render.py
+++ b/packages/python/kbve/kbve/nx/render.py
@@ -3,6 +3,12 @@
 The parse layer (:mod:`kbve.nx.security`, :mod:`kbve.nx.graph`) produces
 plain data; these renderers turn that data into the exact MDX/JSON emitted
 by the ``ci-daily-content`` workflow (router → builder routes).
+
+The MDX pages use the site's Bento design system (``template: splash`` +
+``BentoShell``/``BentoProse`` + ``bento.css`` classes) to match the rest of
+the dashboard. Card markup is emitted statically per item (no ``export
+const`` + ``{arr.map()}`` JSX) so generated content stays deterministic and
+JSX-runtime-free.
 """
 
 from __future__ import annotations
@@ -14,19 +20,25 @@ from ..mdx.escape import escape_mdx
 from .graph import GraphData, mermaid_id, top_hubs
 from .security import SEVERITY_ORDER
 
-SEVERITY_ICONS = {
-    "critical": "warning",
-    "high": "error",
-    "medium": "information",
-    "low": "approve-check-circle",
+SEVERITY_LABELS = {
+    "critical": "Critical",
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+    "info": "Info",
 }
 
-ECOSYSTEM_ICONS = {
-    "npm": "seti:npm",
-    "cargo": "seti:rust",
-    "python": "seti:python",
-    "codeql": "magnifier",
-    "dependabot": "github",
+SEVERITY_SVG = {
+    "critical": (
+        "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71"
+        " 3.86a2 2 0 0 0-3.42 0zM12 9v4M12 17h.01"
+    ),
+    "high": "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 8v4M12 16h.01",
+    "medium": "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 16v-4M12 8h.01",
+    "low": "M22 11.08V12a10 10 0 1 1-5.93-9.14M22 4 12 14.01l-3-3",
+    "info": (
+        "M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1zM4 22v-7"
+    ),
 }
 
 ECOSYSTEM_LABELS = {
@@ -37,21 +49,95 @@ ECOSYSTEM_LABELS = {
     "dependabot": "Dependabot",
 }
 
+ECOSYSTEM_SVG = {
+    "npm": (
+        "M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2"
+        " 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96"
+        " 12 12.01l8.73-5.05M12 22.08V12"
+    ),
+    "cargo": "M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+    "python": "M16 18l6-6-6-6M8 6l-6 6 6 6",
+    "codeql": (
+        "M21 21l-6-6M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z"
+    ),
+    "dependabot": (
+        "M6 3v12M18 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM6 21a3 3 0 1 0 0-6 3 3 0 0"
+        " 0 0 6zM15 6a9 9 0 0 1-9 9"
+    ),
+}
+
+ECOSYSTEM_ORDER = ["npm", "cargo", "python", "codeql", "dependabot"]
+
 TYPE_STYLES = {
     "app": (":::app", "fill:#3b82f6,stroke:#1d4ed8,color:#fff"),
     "lib": (":::lib", "fill:#10b981,stroke:#059669,color:#fff"),
     "e2e": (":::e2e", "fill:#f59e0b,stroke:#d97706,color:#fff"),
 }
 
-TYPE_ICONS = {
-    "app": "rocket",
-    "lib": "puzzle",
-    "e2e": "approve-check-circle",
+TYPE_LABELS = {"app": "Apps", "lib": "Libs", "e2e": "E2E"}
+
+TYPE_SVG = {
+    "app": (
+        "M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18"
+        " 2.18 0 0 0-2.91-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1"
+        " 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"
+    ),
+    "lib": "M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z",
+    "e2e": "M22 11.08V12a10 10 0 1 1-5.93-9.14M22 4 12 14.01l-3-3",
+    "deps": (
+        "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5"
+        " 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+    ),
 }
 
 
 def _empty_severities() -> dict[str, int]:
     return {s: 0 for s in SEVERITY_ORDER}
+
+
+def _stat_tile(out: TextIO, path: str, value, label: str) -> None:
+    out.write(
+        '\t\t\t\t<div class="bento-cell bento-stat bento-card'
+        ' bento-card--glass bento-card--interactive">\n'
+        '\t\t\t\t\t<span class="bento-icon-tile">\n'
+        '\t\t\t\t\t\t<svg viewBox="0 0 24 24" width="16" height="16"'
+        ' fill="none" stroke="currentColor" stroke-width="1.75"'
+        ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        f'<path d="{path}" /></svg>\n'
+        '\t\t\t\t\t</span>\n'
+        f'\t\t\t\t\t<span class="bento-stat__value">{value}</span>\n'
+        f'\t\t\t\t\t<span class="bento-stat__label">{label}</span>\n'
+        '\t\t\t\t</div>\n'
+    )
+
+
+def _linkcard(out: TextIO, path: str, title: str, copy: str,
+              href: str | None = None) -> None:
+    tag = "a" if href else "div"
+    attrs = f' href="{href}"' if href else ""
+    out.write(
+        f'\t\t<{tag} class="bento-cell bento-linkcard bento-card'
+        ' bento-card--glass bento-card--interactive"'
+        f'{attrs}>\n'
+        '\t\t\t<span class="bento-icon-tile">\n'
+        '\t\t\t\t<svg viewBox="0 0 24 24" width="18" height="18" fill="none"'
+        ' stroke="currentColor" stroke-width="1.75" stroke-linecap="round"'
+        ' stroke-linejoin="round" aria-hidden="true">'
+        f'<path d="{path}" /></svg>\n'
+        '\t\t\t</span>\n'
+        f'\t\t\t<span class="bento-linkcard__title">{title}</span>\n'
+        f'\t\t\t<span class="bento-linkcard__copy">{copy}</span>\n'
+    )
+    if href:
+        out.write(
+            '\t\t\t<span class="bento-linkcard__go" aria-hidden="true">\n'
+            '\t\t\t\t<svg viewBox="0 0 24 24" width="16" height="16"'
+            ' fill="none" stroke="currentColor" stroke-width="2"'
+            ' stroke-linecap="round" stroke-linejoin="round">'
+            '<path d="M5 12h14M13 6l6 6-6 6" /></svg>\n'
+            '\t\t\t</span>\n'
+        )
+    out.write(f'\t\t</{tag}>\n')
 
 
 # ── Security ─────────────────────────────────────────────────────────
@@ -62,12 +148,13 @@ def render_security_json(data: dict) -> str:
 
 
 def render_security_mdx(data: dict, timestamp: str) -> str:
-    """Render the Starlight MDX security report."""
+    """Render the Bento-native MDX security report."""
     from io import StringIO
 
     summary = data["summary"]
     ecosystems = data["ecosystems"]
     total = sum(summary.values())
+    crit_high = summary["critical"] + summary["high"]
     out = StringIO()
 
     out.write(
@@ -76,95 +163,131 @@ def render_security_mdx(data: dict, timestamp: str) -> str:
         "description: |\n"
         "    Daily auto-generated security audit"
         " for the KBVE monorepo.\n"
+        "template: splash\n"
+        "tableOfContents: false\n"
+        "editUrl: false\n"
+        "lastUpdated: false\n"
+        "next: false\n"
+        "prev: false\n"
         "sidebar:\n"
         "    label: Security\n"
         "    order: 102\n"
-        "editUrl: false\n"
         "---\n\n"
     )
     out.write(
-        "import { Card, CardGrid, Tabs, TabItem }"
-        " from '@astrojs/starlight/components';\n\n"
-    )
-    out.write("## Security Audit Report\n\n")
-    out.write(
-        ":::note[Auto-generated]\n"
-        f"Last generated: **{timestamp}** — "
-        "updated daily by `ci-daily-content`.\n"
-        ":::\n\n"
+        "import BentoShell from '@/components/hero/BentoShell.astro';\n"
+        "import BentoProse from '@/components/hero/BentoProse.astro';\n\n"
     )
 
-    crit_high = summary["critical"] + summary["high"]
     if crit_high > 0:
-        out.write(
-            ":::caution[Action Required]\n"
-            f"**{crit_high}** critical/high severity"
+        lede = (
+            f"<strong>{crit_high}</strong> critical/high severity"
             f" finding{'s' if crit_high != 1 else ''}"
-            " across the monorepo.\n"
-            ":::\n\n"
+            " across the monorepo — triage before merge."
         )
     elif total > 0:
-        out.write(
-            ":::note[Findings Present]\n"
-            f"**{total}** finding{'s' if total != 1 else ''}"
-            " found — none critical or high.\n"
-            ":::\n\n"
+        lede = (
+            f"<strong>{total}</strong> finding{'s' if total != 1 else ''}"
+            " tracked — none critical or high."
         )
     else:
-        out.write(
-            ":::tip[All Clear]\n"
-            "No security findings detected"
-            " across any ecosystem.\n"
-            ":::\n\n"
+        lede = "No security findings detected across any ecosystem."
+
+    out.write(
+        '<div class="sec-report" data-dash-report>\n\n'
+    )
+
+    out.write(
+        '<section class="bento-hero bento-section not-content"'
+        ' aria-label="Security audit">\n'
+        '\t<div class="bento-hero__bg" aria-hidden="true"></div>\n'
+        '\t<div class="bento-hero__frame bento-frame">\n'
+        '\t\t<div class="bento-board bento-board--hero">\n'
+        '\t\t\t<div class="bento-cell bento-hero-copy bento-card'
+        ' bento-card--glass">\n'
+        '\t\t\t\t<span class="bento-badge bento-chip">\n'
+        '\t\t\t\t\t<svg viewBox="0 0 24 24" width="14" height="14"'
+        ' fill="none" stroke="currentColor" stroke-width="1.75"'
+        ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5z" /></svg>\n'
+        '\t\t\t\t\t<span>auto-generated · daily</span>\n'
+        '\t\t\t\t</span>\n'
+        '\t\t\t\t<h1 class="bento-title">\n'
+        '\t\t\t\t\tSecurity posture\n'
+        '\t\t\t\t\t<span class="bento-title__accent">across every'
+        ' ecosystem.</span>\n'
+        '\t\t\t\t</h1>\n'
+        f'\t\t\t\t<p class="bento-lede">{lede}</p>\n'
+        f'\t\t\t\t<p class="bento-lede">Last generated'
+        f' <strong>{timestamp}</strong>.</p>\n'
+        '\t\t\t\t<div class="bento-cta">\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--primary" href="#findings">\n'
+        '\t\t\t\t\t\tView findings\n'
+        '\t\t\t\t\t\t<svg viewBox="0 0 24 24" fill="none"'
+        ' stroke="currentColor" aria-hidden="true"><path'
+        ' stroke-linecap="round" stroke-linejoin="round" stroke-width="2"'
+        ' d="M5 12h14M13 6l6 6-6 6" /></svg>\n'
+        '\t\t\t\t\t</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="#ecosystems">Ecosystems</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="/dashboard/">Dashboard home</a>\n'
+        '\t\t\t\t</div>\n'
+        '\t\t\t</div>\n\n'
+    )
+
+    for sev in SEVERITY_ORDER:
+        _stat_tile(
+            out, SEVERITY_SVG[sev], summary[sev], SEVERITY_LABELS[sev]
         )
 
-    out.write("### Severity Overview\n\n")
-    out.write("<CardGrid>\n")
-    for sev in SEVERITY_ORDER[:4]:
-        icon = SEVERITY_ICONS.get(sev, "information")
-        count = summary[sev]
-        label = sev.capitalize()
-        out.write(
-            f'  <Card title="{count} {label}" icon="{icon}">\n'
-            f"    {label}-severity findings"
-            f" across all ecosystems.\n"
-            "  </Card>\n"
-        )
-    out.write("</CardGrid>\n\n")
+    out.write(
+        '\t\t</div>\n'
+        '\t\t<nav class="bento-jump" aria-label="On this page">\n'
+        '\t\t\t<a class="bento-chip" href="#ecosystems">Ecosystems</a>\n'
+        '\t\t\t<a class="bento-chip" href="#findings">Findings</a>\n'
+        '\t\t</nav>\n'
+        '\t</div>\n'
+        '</section>\n\n'
+    )
 
-    out.write("### Ecosystem Breakdown\n\n")
-    out.write("<CardGrid>\n")
-    for eco_name in ["npm", "cargo", "python", "codeql", "dependabot"]:
+    out.write(
+        '<BentoShell id="ecosystems" eyebrow="Coverage"'
+        ' heading="Ecosystem breakdown">\n'
+        '\t<div class="bento-board bento-board--cols-3">\n'
+    )
+    for eco_name in ECOSYSTEM_ORDER:
         eco = ecosystems.get(eco_name, {})
-        icon = ECOSYSTEM_ICONS.get(eco_name, "document")
         count = eco.get("total", 0)
-        label = ECOSYSTEM_LABELS.get(eco_name, eco_name.capitalize())
+        label = ECOSYSTEM_LABELS[eco_name]
         item_word = "alerts" if eco_name in (
             "codeql", "dependabot") else "advisories"
-        out.write(
-            f'  <Card title="{label}" icon="{icon}">\n'
-            f"    **{count}** {item_word}\n"
-            "  </Card>\n"
+        copy = f"{count} {item_word}"
+        _linkcard(
+            out, ECOSYSTEM_SVG[eco_name], label, copy,
+            href=f"#eco-{eco_name}",
         )
-    out.write("</CardGrid>\n\n")
+    out.write("\t</div>\n</BentoShell>\n\n")
+
+    out.write('<BentoProse id="findings" heading="Advisories">\n\n')
 
     has_findings = any(summary[s] > 0 for s in SEVERITY_ORDER[:4])
     if has_findings:
-        out.write("### Severity Distribution\n\n")
+        out.write("### Severity distribution\n\n")
         out.write("```mermaid\n")
         out.write("pie showData\n")
         out.write("    title Findings by Severity\n")
         for sev in SEVERITY_ORDER[:4]:
             if summary[sev] > 0:
-                out.write(f'    "{sev.capitalize()}" : {summary[sev]}\n')
+                out.write(f'    "{SEVERITY_LABELS[sev]}" : {summary[sev]}\n')
         out.write("```\n\n")
 
     eco_totals = {
         ECOSYSTEM_LABELS[e]: ecosystems.get(e, {}).get("total", 0)
-        for e in ["npm", "cargo", "python", "codeql", "dependabot"]
+        for e in ECOSYSTEM_ORDER
     }
     if any(v > 0 for v in eco_totals.values()):
-        out.write("### Findings by Ecosystem\n\n")
+        out.write("### Findings by ecosystem\n\n")
         out.write("```mermaid\n")
         out.write("pie showData\n")
         out.write("    title Findings by Ecosystem\n")
@@ -173,18 +296,16 @@ def render_security_mdx(data: dict, timestamp: str) -> str:
                 out.write(f'    "{label}" : {count}\n')
         out.write("```\n\n")
 
-    out.write("<Tabs>\n")
-
-    out.write('  <TabItem label="Summary">\n\n')
+    out.write("### Summary\n\n")
     out.write(
         "| Ecosystem | Critical | High | Medium | Low | Total |\n"
         "|-----------|:--------:|:----:|:------:|:---:|:-----:|\n"
     )
-    for eco_name in ["npm", "cargo", "python", "codeql", "dependabot"]:
+    for eco_name in ECOSYSTEM_ORDER:
         eco = ecosystems.get(eco_name, {})
         sevs = eco.get("severities", _empty_severities())
         eco_total = eco.get("total", 0)
-        label = ECOSYSTEM_LABELS.get(eco_name, eco_name.capitalize())
+        label = ECOSYSTEM_LABELS[eco_name]
         out.write(
             f"| **{label}** "
             f"| {sevs.get('critical', 0)} "
@@ -199,32 +320,41 @@ def render_security_mdx(data: dict, timestamp: str) -> str:
         f"| {summary['high']} "
         f"| {summary['medium']} "
         f"| {summary['low']} "
-        f"| {total} |\n"
+        f"| {total} |\n\n"
     )
-    out.write("\n  </TabItem>\n")
 
-    _write_advisory_tab(out, "npm", ecosystems.get("npm", {}))
-    _write_advisory_tab(out, "Cargo", ecosystems.get("cargo", {}))
-    _write_advisory_tab(out, "Python", ecosystems.get("python", {}))
-    _write_codeql_tab(out, ecosystems.get("codeql", {}))
-    _write_dependabot_tab(out, ecosystems.get("dependabot", {}))
+    _write_advisory_section(out, "npm", "npm", ecosystems.get("npm", {}))
+    _write_advisory_section(out, "cargo", "Cargo", ecosystems.get("cargo", {}))
+    _write_advisory_section(
+        out, "python", "Python", ecosystems.get("python", {}))
+    _write_codeql_section(out, ecosystems.get("codeql", {}))
+    _write_dependabot_section(out, ecosystems.get("dependabot", {}))
 
-    out.write("</Tabs>\n\n")
+    out.write("</BentoProse>\n\n")
 
+    out.write('<BentoProse id="about">\n\n')
     out.write("---\n\n")
     out.write(
         "*Auto-generated by "
         "[ci-daily-content.yml]"
         "(https://github.com/KBVE/kbve/actions/"
-        "workflows/ci-daily-content.yml)*\n"
+        "workflows/ci-daily-content.yml)*\n\n"
+    )
+    out.write("</BentoProse>\n\n")
+
+    out.write("</div>\n\n")
+    out.write(
+        "<style is:global>{`.sec-report{--bento-accent:#f59e0b;"
+        "--bento-accent-2:#f43f5e}`}</style>\n"
     )
 
     return out.getvalue()
 
 
-def _write_advisory_tab(out: TextIO, label: str, eco: dict,
-                        key: str = "advisories") -> None:
-    out.write(f'  <TabItem label="{label}">\n\n')
+def _write_advisory_section(out: TextIO, eco_name: str, label: str,
+                            eco: dict, key: str = "advisories") -> None:
+    out.write(f'<span id="eco-{eco_name}"></span>\n\n')
+    out.write(f"### {label}\n\n")
     items = eco.get(key, [])
     if not items:
         out.write(
@@ -232,28 +362,28 @@ def _write_advisory_tab(out: TextIO, label: str, eco: dict,
             f"No {label.lower()} advisories found.\n"
             ":::\n\n"
         )
-    else:
-        out.write(
-            "| Severity | Package | Advisory | Link |\n"
-            "|----------|---------|----------|------|\n"
-        )
-        for item in sorted(items, key=lambda x: SEVERITY_ORDER.index(
-                x.get("severity", "medium"))):
-            sev = item.get("severity", "medium").capitalize()
-            pkg = item.get("package", "")
-            title = item.get("title", item.get("id", ""))
-            if len(title) > 60:
-                title = title[:57] + "..."
-            title = escape_mdx(title)
-            url = item.get("url", "")
-            link = f"[Details]({url})" if url else ""
-            out.write(f"| {sev} | `{pkg}` | {title} | {link} |\n")
-        out.write("\n")
-    out.write("  </TabItem>\n")
+        return
+    out.write(
+        "| Severity | Package | Advisory | Link |\n"
+        "|----------|---------|----------|------|\n"
+    )
+    for item in sorted(items, key=lambda x: SEVERITY_ORDER.index(
+            x.get("severity", "medium"))):
+        sev = item.get("severity", "medium").capitalize()
+        pkg = item.get("package", "")
+        title = item.get("title", item.get("id", ""))
+        if len(title) > 60:
+            title = title[:57] + "..."
+        title = escape_mdx(title)
+        url = item.get("url", "")
+        link = f"[Details]({url})" if url else ""
+        out.write(f"| {sev} | `{pkg}` | {title} | {link} |\n")
+    out.write("\n")
 
 
-def _write_codeql_tab(out: TextIO, eco: dict) -> None:
-    out.write('  <TabItem label="CodeQL">\n\n')
+def _write_codeql_section(out: TextIO, eco: dict) -> None:
+    out.write('<span id="eco-codeql"></span>\n\n')
+    out.write("### CodeQL\n\n")
     alerts = eco.get("alerts", [])
     if not alerts:
         out.write(
@@ -261,27 +391,27 @@ def _write_codeql_tab(out: TextIO, eco: dict) -> None:
             "No open CodeQL alerts.\n"
             ":::\n\n"
         )
-    else:
-        out.write(
-            "| Severity | Rule | Path | Link |\n"
-            "|----------|------|------|------|\n"
-        )
-        for alert in sorted(alerts, key=lambda x: SEVERITY_ORDER.index(
-                x.get("severity", "medium"))):
-            sev = alert.get("severity", "medium").capitalize()
-            rule = alert.get("rule_id", "")
-            path = alert.get("path", "")
-            if len(path) > 50:
-                path = "..." + path[-47:]
-            url = alert.get("url", "")
-            link = f"[Details]({url})" if url else ""
-            out.write(f"| {sev} | `{rule}` | `{path}` | {link} |\n")
-        out.write("\n")
-    out.write("  </TabItem>\n")
+        return
+    out.write(
+        "| Severity | Rule | Path | Link |\n"
+        "|----------|------|------|------|\n"
+    )
+    for alert in sorted(alerts, key=lambda x: SEVERITY_ORDER.index(
+            x.get("severity", "medium"))):
+        sev = alert.get("severity", "medium").capitalize()
+        rule = alert.get("rule_id", "")
+        path = alert.get("path", "")
+        if len(path) > 50:
+            path = "..." + path[-47:]
+        url = alert.get("url", "")
+        link = f"[Details]({url})" if url else ""
+        out.write(f"| {sev} | `{rule}` | `{path}` | {link} |\n")
+    out.write("\n")
 
 
-def _write_dependabot_tab(out: TextIO, eco: dict) -> None:
-    out.write('  <TabItem label="Dependabot">\n\n')
+def _write_dependabot_section(out: TextIO, eco: dict) -> None:
+    out.write('<span id="eco-dependabot"></span>\n\n')
+    out.write("### Dependabot\n\n")
     alerts = eco.get("alerts", [])
     if not alerts:
         out.write(
@@ -289,33 +419,32 @@ def _write_dependabot_tab(out: TextIO, eco: dict) -> None:
             "No open Dependabot alerts.\n"
             ":::\n\n"
         )
-    else:
+        return
+    out.write(
+        "| Severity | Package | Ecosystem | Summary | Link |\n"
+        "|----------|---------|-----------|---------|------|\n"
+    )
+    for alert in sorted(alerts, key=lambda x: SEVERITY_ORDER.index(
+            x.get("severity", "medium"))):
+        sev = alert.get("severity", "medium").capitalize()
+        pkg = alert.get("package", "")
+        eco_name = alert.get("ecosystem", "")
+        summary = alert.get("summary", "")
+        if len(summary) > 50:
+            summary = summary[:47] + "..."
+        url = alert.get("url", "")
+        link = f"[Details]({url})" if url else ""
         out.write(
-            "| Severity | Package | Ecosystem | Summary | Link |\n"
-            "|----------|---------|-----------|---------|------|\n"
+            f"| {sev} | `{pkg}` | {eco_name}"
+            f" | {summary} | {link} |\n"
         )
-        for alert in sorted(alerts, key=lambda x: SEVERITY_ORDER.index(
-                x.get("severity", "medium"))):
-            sev = alert.get("severity", "medium").capitalize()
-            pkg = alert.get("package", "")
-            eco_name = alert.get("ecosystem", "")
-            summary = alert.get("summary", "")
-            if len(summary) > 50:
-                summary = summary[:47] + "..."
-            url = alert.get("url", "")
-            link = f"[Details]({url})" if url else ""
-            out.write(
-                f"| {sev} | `{pkg}` | {eco_name}"
-                f" | {summary} | {link} |\n"
-            )
-        out.write("\n")
-    out.write("  </TabItem>\n")
+    out.write("\n")
 
 
 # ── Graph ────────────────────────────────────────────────────────────
 
 def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
-    """Render the Starlight MDX Nx dependency-graph page."""
+    """Render the Bento-native MDX Nx dependency-graph page."""
     from io import StringIO
 
     nodes = graph.nodes
@@ -333,59 +462,113 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
         "description: |\n"
         "    Daily auto-generated NX project dependency graph"
         " for the KBVE monorepo.\n"
+        "template: splash\n"
+        "tableOfContents: false\n"
+        "editUrl: false\n"
+        "lastUpdated: false\n"
+        "next: false\n"
+        "prev: false\n"
         "sidebar:\n"
         "    label: Graph\n"
         "    order: 101\n"
-        "editUrl: false\n"
         "---\n\n"
     )
     out.write(
-        "import { Card, CardGrid, Tabs, TabItem }"
-        " from '@astrojs/starlight/components';\n\n"
-    )
-    out.write("## NX Dependency Graph\n\n")
-    out.write(
-        ":::note[Auto-generated]\n"
-        f"Last generated: **{timestamp}** — "
-        "updated daily by `ci-daily-content`.\n"
-        ":::\n\n"
+        "import BentoShell from '@/components/hero/BentoShell.astro';\n"
+        "import BentoProse from '@/components/hero/BentoProse.astro';\n\n"
     )
 
-    out.write("<CardGrid>\n")
-    for ptype in sorted(by_type):
-        icon = TYPE_ICONS.get(ptype, "document")
-        count = len(by_type[ptype])
-        label = ptype.capitalize() + ("s" if count != 1 else "")
-        out.write(f'  <Card title="{count} {label}" icon="{icon}">\n')
-        names = ", ".join(sorted(by_type[ptype])[:6])
-        if len(by_type[ptype]) > 6:
-            names += f" + {len(by_type[ptype]) - 6} more"
-        out.write(f"    {names}\n")
-        out.write("  </Card>\n")
-    out.write(
-        f'  <Card title="{len(seen_edges)} Dependencies" icon="random">\n'
-        f"    Across {len(nodes)} projects in the monorepo.\n"
-        "  </Card>\n"
+    lede = (
+        f"<strong>{len(nodes)}</strong> projects wired by"
+        f" <strong>{len(seen_edges)}</strong> dependency"
+        f" edge{'s' if len(seen_edges) != 1 else ''}."
     )
-    out.write("</CardGrid>\n\n")
 
-    out.write("### Most Depended-On Projects\n\n")
-    out.write("<CardGrid>\n")
+    out.write('<div class="graph-report" data-dash-report>\n\n')
+
+    out.write(
+        '<section class="bento-hero bento-section not-content"'
+        ' aria-label="NX dependency graph">\n'
+        '\t<div class="bento-hero__bg" aria-hidden="true"></div>\n'
+        '\t<div class="bento-hero__frame bento-frame">\n'
+        '\t\t<div class="bento-board bento-board--hero">\n'
+        '\t\t\t<div class="bento-cell bento-hero-copy bento-card'
+        ' bento-card--glass">\n'
+        '\t\t\t\t<span class="bento-badge bento-chip">\n'
+        '\t\t\t\t\t<svg viewBox="0 0 24 24" width="14" height="14"'
+        ' fill="none" stroke="currentColor" stroke-width="1.75"'
+        ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<path d="M6 3v12M18 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM6 21a3 3 0 1 0'
+        ' 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9" /></svg>\n'
+        '\t\t\t\t\t<span>auto-generated · daily</span>\n'
+        '\t\t\t\t</span>\n'
+        '\t\t\t\t<h1 class="bento-title">\n'
+        '\t\t\t\t\tDependency graph\n'
+        '\t\t\t\t\t<span class="bento-title__accent">across the'
+        ' monorepo.</span>\n'
+        '\t\t\t\t</h1>\n'
+        f'\t\t\t\t<p class="bento-lede">{lede}</p>\n'
+        f'\t\t\t\t<p class="bento-lede">Last generated'
+        f' <strong>{timestamp}</strong>.</p>\n'
+        '\t\t\t\t<div class="bento-cta">\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--primary" href="#diagram">\n'
+        '\t\t\t\t\t\tView diagram\n'
+        '\t\t\t\t\t\t<svg viewBox="0 0 24 24" fill="none"'
+        ' stroke="currentColor" aria-hidden="true"><path'
+        ' stroke-linecap="round" stroke-linejoin="round" stroke-width="2"'
+        ' d="M5 12h14M13 6l6 6-6 6" /></svg>\n'
+        '\t\t\t\t\t</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="#hubs">Top hubs</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="#project-index">Projects</a>\n'
+        '\t\t\t\t</div>\n'
+        '\t\t\t</div>\n\n'
+    )
+
+    _stat_tile(out, TYPE_SVG["app"], len(by_type.get("app", set())), "Apps")
+    _stat_tile(out, TYPE_SVG["lib"], len(by_type.get("lib", set())), "Libs")
+    _stat_tile(out, TYPE_SVG["e2e"], len(by_type.get("e2e", set())), "E2E")
+    _stat_tile(out, TYPE_SVG["deps"], len(seen_edges), "Dependencies")
+
+    out.write(
+        '\t\t</div>\n'
+        '\t\t<nav class="bento-jump" aria-label="On this page">\n'
+        '\t\t\t<a class="bento-chip" href="#hubs">Hubs</a>\n'
+        '\t\t\t<a class="bento-chip" href="#diagram">Diagram</a>\n'
+        '\t\t\t<a class="bento-chip" href="#project-index">Projects</a>\n'
+        '\t\t</nav>\n'
+        '\t</div>\n'
+        '</section>\n\n'
+    )
+
+    out.write(
+        '<BentoShell id="hubs" eyebrow="Connectivity"'
+        ' heading="Most depended-on">\n'
+        '\t<div class="bento-board bento-board--cols-3">\n'
+    )
+    any_hub = False
     for row in top_depended:
         if row.dependent_count == 0:
             continue
-        icon = TYPE_ICONS.get(row.project_type, "document")
-        out.write(
-            f'  <Card title="{row.name}" icon="{icon}">\n'
-            f"    **{row.dependent_count}** project"
-            f"{'s' if row.dependent_count != 1 else ''}"
-            f" depend on this {row.project_type}."
-            f" Located at `{row.root}`.\n"
-            "  </Card>\n"
+        any_hub = True
+        path = TYPE_SVG.get(row.project_type, TYPE_SVG["deps"])
+        copy = (
+            f"{row.dependent_count} project"
+            f"{'s' if row.dependent_count != 1 else ''} depend on this"
+            f" {row.project_type} · {row.root}"
         )
-    out.write("</CardGrid>\n\n")
+        _linkcard(out, path, row.name, copy)
+    if not any_hub:
+        _linkcard(
+            out, TYPE_SVG["deps"], "No hubs",
+            "No project is depended on by another yet.",
+        )
+    out.write("\t</div>\n</BentoShell>\n\n")
 
-    out.write("### Project Distribution\n\n")
+    out.write('<BentoProse id="diagram" heading="Dependency diagram">\n\n')
+
+    out.write("### Project distribution\n\n")
     out.write("```mermaid\n")
     out.write("pie showData\n")
     out.write("    title Projects by Type\n")
@@ -395,7 +578,7 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
     out.write("```\n\n")
 
     if top_depended and top_depended[0].dependent_count > 0:
-        out.write("### Hub Connectivity\n\n")
+        out.write("### Hub connectivity\n\n")
         out.write("```mermaid\n")
         out.write("pie showData\n")
         out.write("    title Dependents per Hub\n")
@@ -404,9 +587,7 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
                 out.write(f'    "{row.name}" : {row.dependent_count}\n')
         out.write("```\n\n")
 
-    out.write("<Tabs>\n")
-    out.write('  <TabItem label="Diagram">\n\n')
-
+    out.write("### Graph\n\n")
     if len(seen_edges) <= 200:
         mermaid_lines = ["graph LR"]
         for ptype, (_, style) in TYPE_STYLES.items():
@@ -442,9 +623,9 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
             ":::\n\n"
         )
 
-    out.write("  </TabItem>\n")
-    out.write('  <TabItem label="Project Index">\n\n')
+    out.write("</BentoProse>\n\n")
 
+    out.write('<BentoProse id="project-index" heading="Project index">\n\n')
     out.write(
         "| Project | Type | Root | Deps | Dependents |\n"
         "|---------|------|------|:----:|:----------:|\n"
@@ -455,9 +636,6 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
             f"| {row.dep_count} | {row.dependent_count} |\n"
         )
     out.write("\n")
-
-    out.write("  </TabItem>\n")
-    out.write('  <TabItem label="Details">\n\n')
 
     for ptype in sorted(by_type):
         type_projects = [
@@ -480,15 +658,22 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
                 out.write(f"| {d['target']} | {d['type']} |\n")
             out.write("\n</details>\n\n")
 
-    out.write("  </TabItem>\n")
-    out.write("</Tabs>\n\n")
+    out.write("</BentoProse>\n\n")
 
+    out.write('<BentoProse id="about">\n\n')
     out.write("---\n\n")
     out.write(
         "*Auto-generated by "
         "[ci-daily-content.yml]"
         "(https://github.com/KBVE/kbve/actions/"
-        "workflows/ci-daily-content.yml)*\n"
+        "workflows/ci-daily-content.yml)*\n\n"
+    )
+    out.write("</BentoProse>\n\n")
+
+    out.write("</div>\n\n")
+    out.write(
+        "<style is:global>{`.graph-report{--bento-accent:#a78bfa;"
+        "--bento-accent-2:#38bdf8}`}</style>\n"
     )
 
     return out.getvalue()

--- a/packages/python/kbve/tests/test_nx_render.py
+++ b/packages/python/kbve/tests/test_nx_render.py
@@ -54,6 +54,52 @@ def test_security_mdx_frontmatter_and_clear():
     assert TS in mdx
 
 
+def test_security_mdx_bento_structure():
+    data = _security_data({})
+    mdx = render_security_mdx(data, TS)
+    assert "template: splash" in mdx
+    assert "import BentoShell from '@/components/hero/BentoShell.astro';" in mdx
+    assert "import BentoProse from '@/components/hero/BentoProse.astro';" in mdx
+    assert "bento-stat" in mdx
+    assert "bento-linkcard" in mdx
+    assert "<BentoProse" in mdx
+    assert "<CardGrid>" not in mdx
+    assert "<Card " not in mdx
+    assert 'id="findings"' in mdx
+    assert 'id="ecosystems"' in mdx
+
+
+def test_security_mdx_renders_counts_and_ecosystems():
+    data = {
+        "generated_at": TS,
+        "summary": {"critical": 2, "high": 1, "medium": 0,
+                    "low": 0, "info": 0},
+        "ecosystems": {
+            "npm": {
+                "total": 3,
+                "severities": {"critical": 2, "high": 1, "medium": 0,
+                               "low": 0, "info": 0},
+                "advisories": [
+                    {"severity": "critical", "package": "leftpad",
+                     "title": "RCE", "url": "https://x", "id": 1},
+                ],
+            },
+            "cargo": {"total": 0, "severities": {}, "advisories": []},
+            "python": {"total": 0, "severities": {}, "advisories": []},
+            "codeql": {"total": 0, "severities": {}, "alerts": []},
+            "dependabot": {"total": 0, "severities": {}, "alerts": []},
+        },
+    }
+    mdx = render_security_mdx(data, TS)
+    assert ">Critical<" in mdx
+    assert 'id="eco-npm"' in mdx
+    assert "Cargo" in mdx and "Python" in mdx
+    assert "CodeQL" in mdx and "Dependabot" in mdx
+    assert '"Critical" : 2' in mdx
+    assert "leftpad" in mdx
+    assert '<span class="bento-stat__value">2</span>' in mdx
+
+
 def test_security_json_roundtrip():
     data = _security_data({})
     out = json.loads(render_security_json(data))
@@ -86,6 +132,23 @@ def test_graph_mdx_render():
     assert mdx.startswith("---\ntitle: NX Dependency Graph\n")
     assert "web" in mdx and "ui" in mdx
     assert "```mermaid" in mdx
+
+
+def test_graph_mdx_bento_structure():
+    graph = parse_graph(_graph_fixture())
+    mdx = render_graph_mdx(graph, TS)
+    assert "template: splash" in mdx
+    assert "import BentoShell from '@/components/hero/BentoShell.astro';" in mdx
+    assert "import BentoProse from '@/components/hero/BentoProse.astro';" in mdx
+    assert "bento-stat" in mdx
+    assert "bento-linkcard" in mdx
+    assert "<BentoProse" in mdx
+    assert "<CardGrid>" not in mdx
+    assert "<Card " not in mdx
+    assert 'id="diagram"' in mdx
+    assert 'id="project-index"' in mdx
+    assert "graph LR" in mdx
+    assert '<span class="bento-stat__label">Apps</span>' in mdx
 
 
 # ── CLI entry points ────────────────────────────────────────────────

--- a/packages/python/kbve/tests/test_nx_security_route.py
+++ b/packages/python/kbve/tests/test_nx_security_route.py
@@ -108,7 +108,7 @@ def test_security_build_writes_mdx_and_json(tmp_path):
     text = mdx.read_text()
     assert text.startswith("---\n")
     assert "title: Security Audit Report" in text
-    assert "### Ecosystem Breakdown" in text
+    assert 'heading="Ecosystem breakdown"' in text
 
     payload = json.loads(js.read_text())
     assert "summary" in payload


### PR DESCRIPTION
## What

Redesigns the auto-generated **security** and **graph** dashboard pages to use the site's **Bento** design system (`template: splash` + `BentoShell` + `bento.css`) instead of plain Starlight `Card/CardGrid/Tabs` — so they match `portal.mdx` / `infrastructure.mdx`.

Generator: `render_security_mdx` / `render_graph_mdx` in `packages/python/kbve/kbve/nx/render.py`.

## Look

- **Hero band** — badge chip + `bento-title`/`__accent` + lede (live summary sentence) + `bento-cta` jump nav.
- **KPI stat tiles** (`bento-stat`) — security: Critical/High/Medium/Low/Info; graph: Apps/Libs/E2E/Dependencies.
- **Breakdown** — ecosystem (security) / top-hub (graph) `bento-linkcard` grid inside a `<BentoShell>`.
- **Findings** — the existing per-ecosystem tables + mermaid charts preserved inside `<BentoProse>` sections (old `<Tabs>` flattened to `###` subsections with `#eco-<name>` anchors the linkcards jump to).
- Inline 24×24 SVG icons; per-page accent (`sec-report` amber/red, `graph-report` violet/blue) via `<style is:global>`.

## Preserved

All data logic unchanged — `SEVERITY_ORDER`, `escape_mdx`, the 200-edge mermaid cap, `top_hubs`, severity ordering, every count/table. JSON renderers untouched.

## Verification

- **327 python tests pass** (3 new bento-structure tests asserting `template: splash`, `BentoShell`/`BentoProse`, `bento-stat`, `bento-linkcard`, absence of `CardGrid`, plus real data values).
- Committed `security.mdx` / `graph.mdx` **regenerated from the real committed nx JSON** (fixed ts) so the diff shows the actual redesign — security 28 crit/high, 5 tiles (3/25/53/8/38), 5 ecosystem cards; graph 138 projects / 154 edges.
- Structural checks: zero `CardGrid`/`Card ` survivors; `BentoShell`/`BentoProse` tags balanced; `<style is:global>` matches infrastructure.mdx's proven pattern.

Nightly `ci-daily-content` regenerates these with the new template going forward.

## Note

Verified structurally per plan (no live browser). The Bento markup mirrors the already-rendering `infrastructure.mdx` line-for-line, so CSS coverage is known-good.