### PR TITLE
feat(embeddb): v3 robustness + richer reads + migrations/config

### DIFF
--- a/docs/superpowers/plans/2026-07-19-embeddb-v3-hardening.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb-v3-hardening.md
@@ -1,0 +1,591 @@
+# embeddb v3 (robustness + richer reads + migrations/config) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `embeddb` (remove panics, honest checkpoint), add richer typed reads, add config + a migration runner — staying Turso+DuckDB only.
+
+**Architecture:** Extend the existing `EmbedDb`/`EmbedTx`/`analytics.rs`. New `src/value.rs` (`EmbedValue`/`EmbedRow`), new `src/config.rs` (`EmbedConfig`). `EmbedDb` gains a stored `EmbedConfig`. Read path stays a fresh read-only DuckDB conn per call.
+
+**Tech Stack:** Rust, `turso` 0.7, `duckdb` 1.x, `tokio`, `thiserror`.
+
+## Global Constraints
+
+- Work only in `packages/rust/embeddb`.
+- No inline comments in source (repo convention).
+- No panics on the library path — every fallible op returns `Result`.
+- Build/test scoped: `cargo test -p embeddb`. Never build the whole workspace.
+- Keep all existing v1/v2 tests green; update call sites when signatures change.
+- Verified API facts:
+  - turso `Row::get::<T>(idx) -> Result<T>`, `Row::get_value(idx) -> Result<turso::Value>` (Value: `Null|Integer(i64)|Real(f64)|Text(String)|Blob(Vec<u8>)`), `Rows::column_count()`, `Rows::next().await? -> Option<Row>`.
+  - duckdb `Row::get_ref(idx) -> Result<ValueRef>` (variants incl `Null, Boolean(bool), TinyInt..BigInt(i64), HugeInt(i128), UTinyInt..UBigInt, Float(f32), Double(f64), Text(&[u8]), Blob(&[u8])`, plus Decimal/Timestamp/Date/Time/Interval), `Statement::column_count()`, `Rows::next()? -> Option<&Row>`.
+- Commit after every task. No direct pushes to dev/main.
+
+---
+
+## Phase 1 — Robustness
+
+### Task 1: Non-UTF8 path → error (no panic)
+
+**Files:** Modify `src/error.rs`, `src/db.rs`, `src/analytics.rs`.
+
+**Interfaces:**
+- Produces: `EmbedError::NonUtf8Path(std::path::PathBuf)`; `pub(crate) fn path_str(path: &Path) -> Result<&str>` in `db.rs`; `analytics.rs` fns take `&str` path (or use a shared `path_str`).
+
+- [ ] **Step 1: Failing test** — add to `db.rs` tests (unix-only; guard with `#[cfg(unix)]`):
+
+```rust
+#[cfg(unix)]
+#[tokio::test]
+async fn open_non_utf8_path_errors() {
+    use std::os::unix::ffi::OsStrExt;
+    use std::ffi::OsStr;
+    let dir = tempfile::tempdir().unwrap();
+    let bad = dir.path().join(OsStr::from_bytes(b"bad\xFFname.db"));
+    let err = EmbedDb::open(&bad).await.unwrap_err();
+    assert!(matches!(err, EmbedError::NonUtf8Path(_)));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`open` panics or wrong error). `cargo test -p embeddb open_non_utf8_path_errors`
+
+- [ ] **Step 3: Add error variant** in `src/error.rs`:
+
+```rust
+    #[error("non-utf8 path: {0}")]
+    NonUtf8Path(std::path::PathBuf),
+```
+
+- [ ] **Step 4: Add helper + use it.** In `src/db.rs` add:
+
+```rust
+pub(crate) fn path_str(path: &std::path::Path) -> Result<&str> {
+    path.to_str().ok_or_else(|| crate::EmbedError::NonUtf8Path(path.to_path_buf()))
+}
+```
+
+Change `open` to use it:
+
+```rust
+let db = turso::Builder::new_local(crate::db::path_str(&path)?)
+    .build()
+    .await?;
+```
+
+In `src/analytics.rs`, replace `sql_quote_path(path)` usage so the path first goes through `path_str`. Update `scalar_i64`/`scalar_f64` (and any new read fns) to build the ATTACH string from `sql_quote_str(crate::db::path_str(path)?)` instead of the lossy `path.display()`. Remove the now-unused `sql_quote_path` if nothing else uses it (keep `sql_quote_str`).
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 6: Commit** — `feat(embeddb): non-utf8 path returns error instead of panic`
+
+---
+
+### Task 2: Checkpoint busy-check + retry
+
+**Files:** Modify `src/error.rs`, `src/db.rs`.
+
+**Interfaces:**
+- Produces: `EmbedError::CheckpointBusy`; `checkpoint` retries and errors when busy. Uses module const `const DEFAULT_CHECKPOINT_RETRIES: u32 = 5;` (Phase 3 Task 5 replaces this read with `self.config.checkpoint_max_retries`).
+
+- [ ] **Step 1: Failing test** — normal checkpoint still succeeds AND returns Ok; add a test asserting a checkpoint on a fresh written DB is Ok (guards against a regression where we always error):
+
+```rust
+#[tokio::test]
+async fn checkpoint_reports_success_on_idle_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("cp.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+}
+```
+
+(The busy path is hard to force deterministically in a unit test; it is covered by inspection + the retry loop. Document this in the report.)
+
+- [ ] **Step 2: Run — expect PASS already** for the success test (checkpoint currently returns Ok). This test locks in behavior before we add the busy branch. Proceed to implement the busy inspection.
+
+- [ ] **Step 3: Add error variant** in `src/error.rs`:
+
+```rust
+    #[error("checkpoint busy after retries")]
+    CheckpointBusy,
+```
+
+- [ ] **Step 4: Rewrite `checkpoint`** in `src/db.rs`:
+
+```rust
+const DEFAULT_CHECKPOINT_RETRIES: u32 = 5;
+
+pub async fn checkpoint(&self) -> Result<()> {
+    for _ in 0..=DEFAULT_CHECKPOINT_RETRIES {
+        let mut rows = self.conn.query("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
+        let mut busy = 0_i64;
+        if let Some(row) = rows.next().await? {
+            busy = row.get::<i64>(0).unwrap_or(0);
+        }
+        while rows.next().await?.is_some() {}
+        if busy == 0 {
+            return Ok(());
+        }
+        tokio::task::yield_now().await;
+    }
+    Err(crate::EmbedError::CheckpointBusy)
+}
+```
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 6: Commit** — `feat(embeddb): checkpoint inspects busy + retries, errors if stuck`
+
+---
+
+## Phase 2 — Richer analytics reads
+
+### Task 3: `EmbedValue` + `EmbedRow`
+
+**Files:** Create `src/value.rs`; modify `src/lib.rs`.
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Debug, Clone, PartialEq)]
+  pub enum EmbedValue { Null, Int(i64), Float(f64), Text(String), Blob(Vec<u8>) }
+  #[derive(Debug, Clone, PartialEq)]
+  pub struct EmbedRow(pub Vec<EmbedValue>);
+  ```
+  with `EmbedRow::get(idx) -> Option<&EmbedValue>`, `as_i64/as_f64/as_str(idx) -> Option<..>`. Exported from lib.rs.
+
+- [ ] **Step 1: Failing test** — in `src/value.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn row_accessors() {
+        let r = EmbedRow(vec![EmbedValue::Int(7), EmbedValue::Text("hi".into()), EmbedValue::Null]);
+        assert_eq!(r.as_i64(0), Some(7));
+        assert_eq!(r.as_str(1), Some("hi"));
+        assert_eq!(r.get(2), Some(&EmbedValue::Null));
+        assert_eq!(r.as_i64(1), None);
+        assert_eq!(r.get(9), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (module doesn't exist). Add `mod value; pub use value::{EmbedValue, EmbedRow};` to `lib.rs` first so it compiles to the failure.
+
+- [ ] **Step 3: Implement `src/value.rs`:**
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbedValue {
+    Null,
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedRow(pub Vec<EmbedValue>);
+
+impl EmbedRow {
+    pub fn get(&self, idx: usize) -> Option<&EmbedValue> {
+        self.0.get(idx)
+    }
+    pub fn as_i64(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Int(v)) => Some(*v),
+            _ => None,
+        }
+    }
+    pub fn as_f64(&self, idx: usize) -> Option<f64> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Float(v)) => Some(*v),
+            _ => None,
+        }
+    }
+    pub fn as_str(&self, idx: usize) -> Option<&str> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Text(v)) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.** `cargo test -p embeddb row_accessors`
+
+- [ ] **Step 5: Commit** — `feat(embeddb): EmbedValue/EmbedRow generic result types`
+
+---
+
+### Task 4: `analytics_rows` + `analytics_scalar_string`
+
+**Files:** Modify `src/analytics.rs`, `src/db.rs`.
+
+**Interfaces:**
+- Consumes: `EmbedValue`, `EmbedRow`, `path_str`.
+- Produces: `analytics::rows(path, sql) -> Result<Vec<EmbedRow>>`, `analytics::scalar_string(path, sql) -> Result<String>`; `EmbedDb::analytics_rows(&self, sql) -> Result<Vec<EmbedRow>>`, `EmbedDb::analytics_scalar_string(&self, sql) -> Result<String>`.
+
+- [ ] **Step 1: Failing test** — in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn analytics_rows_mixed_types() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("rows.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL, name TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (?, ?, ?)", (1_i64, 1.5_f64, "a")).await.unwrap();
+    db.execute("INSERT INTO t VALUES (?, ?, ?)", (2_i64, 2.5_f64, "b")).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let rows = db.analytics_rows("SELECT id, v, name FROM t ORDER BY id").await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].as_i64(0), Some(1));
+    assert_eq!(rows[0].as_f64(1), Some(1.5));
+    assert_eq!(rows[0].as_str(2), Some("a"));
+    assert_eq!(rows[1].as_str(2), Some("b"));
+}
+
+#[tokio::test]
+async fn analytics_rows_handles_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("null.db")).await.unwrap();
+    db.execute("CREATE TABLE t (a INTEGER, b TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, NULL)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let rows = db.analytics_rows("SELECT a, b FROM t").await.unwrap();
+    assert_eq!(rows[0].get(1), Some(&crate::EmbedValue::Null));
+}
+
+#[tokio::test]
+async fn analytics_scalar_string_reads_text() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("s.db")).await.unwrap();
+    db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (?)", ("hello",)).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_string("SELECT name FROM t").await.unwrap(), "hello");
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (methods missing).
+
+- [ ] **Step 3: Implement `analytics::rows` + `scalar_string`** in `src/analytics.rs`. Add a helper to open+attach (factor the repeated open/INSTALL/ATTACH/USE into one `fn attached_conn(path) -> Result<duckdb::Connection>`), then:
+
+```rust
+fn attached_conn(path: &Path) -> Result<duckdb::Connection> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    prepare_sqlite_scanner(&conn)?;
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    Ok(conn)
+}
+
+pub fn rows(path: &Path, sql: &str) -> Result<Vec<crate::EmbedRow>> {
+    let conn = attached_conn(path)?;
+    let mut stmt = conn.prepare(sql)?;
+    let ncols = stmt.column_count();
+    let mut out = Vec::new();
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(value_from_ref(row.get_ref(i)?)?);
+        }
+        out.push(crate::EmbedRow(vals));
+    }
+    Ok(out)
+}
+
+pub fn scalar_string(path: &Path, sql: &str) -> Result<String> {
+    let conn = attached_conn(path)?;
+    let val: String = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+
+fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
+    use duckdb::types::ValueRef as V;
+    Ok(match v {
+        V::Null => crate::EmbedValue::Null,
+        V::Boolean(b) => crate::EmbedValue::Int(b as i64),
+        V::TinyInt(n) => crate::EmbedValue::Int(n as i64),
+        V::SmallInt(n) => crate::EmbedValue::Int(n as i64),
+        V::Int(n) => crate::EmbedValue::Int(n as i64),
+        V::BigInt(n) => crate::EmbedValue::Int(n),
+        V::UTinyInt(n) => crate::EmbedValue::Int(n as i64),
+        V::USmallInt(n) => crate::EmbedValue::Int(n as i64),
+        V::UInt(n) => crate::EmbedValue::Int(n as i64),
+        V::Float(n) => crate::EmbedValue::Float(n as f64),
+        V::Double(n) => crate::EmbedValue::Float(n),
+        V::Text(b) => crate::EmbedValue::Text(String::from_utf8_lossy(b).into_owned()),
+        V::Blob(b) => crate::EmbedValue::Blob(b.to_vec()),
+        other => return Err(crate::EmbedError::Other(format!("unmapped duckdb type: {:?}", other))),
+    })
+}
+```
+
+Refactor the existing `scalar_i64`/`scalar_f64` to also use `attached_conn` (removes duplication). Adjust the exact `ValueRef`/`prepare`/`query` calls to compile against duckdb 1.x — the shapes above match the installed source but reconcile if a method name differs (e.g. `query` vs `query([])`).
+
+- [ ] **Step 4: Add async wrappers** in `src/db.rs` (mirror the existing scalar wrappers):
+
+```rust
+pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    tokio::task::spawn_blocking(move || crate::analytics::rows(&path, &sql))
+        .await
+        .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+
+pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    tokio::task::spawn_blocking(move || crate::analytics::scalar_string(&path, &sql))
+        .await
+        .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+```
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 6: Commit** — `feat(embeddb): analytics_rows + analytics_scalar_string`
+
+---
+
+## Phase 3 — Config + migrations
+
+### Task 5: `EmbedConfig` + `open_with`
+
+**Files:** Create `src/config.rs`; modify `src/db.rs`, `src/analytics.rs`, `src/lib.rs`.
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Debug, Clone)]
+  pub struct EmbedConfig { pub journal_mode: String, pub duckdb_extension_dir: Option<std::path::PathBuf>, pub checkpoint_max_retries: u32 }
+  impl Default for EmbedConfig { .. } // "WAL", None, 5
+  ```
+  `EmbedDb::open_with(path, config) -> Result<EmbedDb>`; `open` delegates. `EmbedDb` stores `config`. `checkpoint` uses `self.config.checkpoint_max_retries`. Read path receives `duckdb_extension_dir`.
+
+- [ ] **Step 1: Failing test** — in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn open_with_custom_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = crate::EmbedConfig { journal_mode: "WAL".into(), duckdb_extension_dir: None, checkpoint_max_retries: 1 };
+    let db = EmbedDb::open_with(dir.path().join("cfg.db"), cfg).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`open_with`, `EmbedConfig` missing).
+
+- [ ] **Step 3: Create `src/config.rs`:**
+
+```rust
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    pub journal_mode: String,
+    pub duckdb_extension_dir: Option<PathBuf>,
+    pub checkpoint_max_retries: u32,
+}
+
+impl Default for EmbedConfig {
+    fn default() -> Self {
+        EmbedConfig { journal_mode: "WAL".to_string(), duckdb_extension_dir: None, checkpoint_max_retries: 5 }
+    }
+}
+```
+
+Add to `lib.rs`: `mod config; pub use config::EmbedConfig;`.
+
+- [ ] **Step 4: Thread config through `EmbedDb`.** Add `config: EmbedConfig` field. Rework:
+
+```rust
+pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
+    EmbedDb::open_with(path, crate::EmbedConfig::default()).await
+}
+
+pub async fn open_with(path: impl AsRef<Path>, config: crate::EmbedConfig) -> Result<EmbedDb> {
+    let path = path.as_ref().to_path_buf();
+    let db = turso::Builder::new_local(path_str(&path)?).build().await?;
+    let conn = db.connect()?;
+    let pragma = format!("PRAGMA journal_mode={}", config.journal_mode);
+    conn.execute(&pragma, ()).await.ok();
+    Ok(EmbedDb { path, conn, config })
+}
+```
+
+Change `checkpoint`'s loop bound from `DEFAULT_CHECKPOINT_RETRIES` to `self.config.checkpoint_max_retries` (remove the const, or keep it only as `EmbedConfig::default`'s value). Change the read-path wrappers (`analytics_rows`, `analytics_scalar_i64/f64/string`) to pass `self.config.duckdb_extension_dir.clone()` into the analytics fns; update `analytics::*` signatures to accept `ext_dir: Option<&Path>` and have `prepare_sqlite_scanner` prefer it over the env var (env var remains the fallback when `None`).
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 6: Commit** — `feat(embeddb): EmbedConfig + open_with (journal mode, ext dir, retries)`
+
+---
+
+### Task 6: Migration runner
+
+**Files:** Create `src/migrate.rs`; modify `src/db.rs`, `src/lib.rs`.
+
+**Interfaces:**
+- Produces: `EmbedDb::migrate(&self, migrations: &[&str]) -> Result<()>`. Private table `_embeddb_migrations(version INTEGER PRIMARY KEY, applied_at TEXT)`.
+
+- [ ] **Step 1: Failing tests** — in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn migrate_applies_and_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("m.db")).await.unwrap();
+    let m = ["CREATE TABLE a (id INTEGER)", "CREATE TABLE b (id INTEGER)"];
+    db.migrate(&m).await.unwrap();
+    db.migrate(&m).await.unwrap();
+    db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
+    db.execute("INSERT INTO b VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn migrate_appended_applies_only_new() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("m2.db")).await.unwrap();
+    db.migrate(&["CREATE TABLE a (id INTEGER)"]).await.unwrap();
+    db.migrate(&["CREATE TABLE a (id INTEGER)", "CREATE TABLE c (id INTEGER)"]).await.unwrap();
+    db.execute("INSERT INTO c VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM c").await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn migrate_failure_rolls_back_that_migration() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("m3.db")).await.unwrap();
+    let err = db.migrate(&["CREATE TABLE a (id INTEGER)", "NOT VALID SQL"]).await;
+    assert!(err.is_err());
+    db.migrate(&["CREATE TABLE a (id INTEGER)"]).await.unwrap();
+    db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`migrate` missing).
+
+- [ ] **Step 3: Create `src/migrate.rs`** with a free async fn the method delegates to:
+
+```rust
+use crate::{EmbedDb, Result};
+
+pub(crate) async fn run(db: &EmbedDb, migrations: &[&str]) -> Result<()> {
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS _embeddb_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)",
+        (),
+    ).await?;
+    let applied = db
+        .analytics_applied_migrations()
+        .await
+        .unwrap_or(-1);
+    for (i, sql) in migrations.iter().enumerate() {
+        let version = i as i64;
+        if version <= applied {
+            continue;
+        }
+        let tx = db.begin().await?;
+        if let Err(e) = tx.execute(sql, ()).await {
+            tx.rollback().await.ok();
+            return Err(e);
+        }
+        if let Err(e) = tx.execute(
+            "INSERT INTO _embeddb_migrations (version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        ).await {
+            tx.rollback().await.ok();
+            return Err(e);
+        }
+        tx.commit().await?;
+    }
+    Ok(())
+}
+```
+
+Reading the highest applied version must NOT go through DuckDB (that requires a
+checkpoint and read-only attach — heavy and stale). Instead read it directly on
+the turso write connection. Add a small private helper on `EmbedDb` in `db.rs`:
+
+```rust
+pub(crate) async fn max_migration_version(&self) -> Result<i64> {
+    let mut rows = self
+        .conn
+        .query("SELECT COALESCE(MAX(version), -1) FROM _embeddb_migrations", ())
+        .await?;
+    let mut v = -1_i64;
+    if let Some(row) = rows.next().await? {
+        v = row.get::<i64>(0).unwrap_or(-1);
+    }
+    while rows.next().await?.is_some() {}
+    Ok(v)
+}
+```
+
+Then in `migrate.rs` call `db.max_migration_version().await?` (replace the
+`analytics_applied_migrations`/`unwrap_or(-1)` placeholder above with this call;
+the table is guaranteed to exist because it is created immediately before).
+Add `EmbedDb::migrate`:
+
+```rust
+pub async fn migrate(&self, migrations: &[&str]) -> Result<()> {
+    crate::migrate::run(self, migrations).await
+}
+```
+
+Add `mod migrate;` to `lib.rs`.
+
+- [ ] **Step 4: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 5: Commit** — `feat(embeddb): idempotent migration runner`
+
+---
+
+## Phase 4 — Comprehensive tests + README
+
+### Task 7: Coverage hardening + README
+
+**Files:** Modify `src/error.rs` (test), `src/db.rs` (tests), `packages/rust/embeddb/README.md`.
+
+**Interfaces:** none new (tests + docs only).
+
+- [ ] **Step 1: Add error-mapping + edge tests.** In `error.rs` tests add coverage that `NonUtf8Path` and `CheckpointBusy` format via `Display` (`format!("{}", ..)` non-empty). In `db.rs` tests add:
+  - `analytics_rows` on an empty table returns an empty `Vec`.
+  - `analytics_scalar_string` round-trips a value containing a single quote (bound param) — e.g. insert `"o'brien"`, read back equal.
+  - `EmbedRow` blob column round-trips (`CREATE TABLE t (b BLOB)`, insert via `execute` with a `Vec<u8>` param if `IntoParams` supports it, else `X'00FF'` literal; assert `EmbedValue::Blob`).
+  - Multi-row ordering: 3 rows, assert full `Vec<EmbedRow>` contents in order.
+
+  Write each as a `#[tokio::test]`. Every test must assert concrete expected values (no bare `is_ok()`).
+
+- [ ] **Step 2: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 3: Update README** — add sections/examples for: `EmbedConfig` + `open_with`; `analytics_rows`/`EmbedRow`/`EmbedValue` and `analytics_scalar_string`; the `migrate` runner (append-only, idempotent). Keep existing sections (Deployment note, Checkpoint-then-read, Transactions) intact. Note that `checkpoint` now errors with `CheckpointBusy` after retries, and non-UTF8 paths error rather than panic.
+
+- [ ] **Step 4: Run full suite — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 5: Commit** — `test(embeddb): coverage hardening + README for v3`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Phase 1 non-utf8 (T1) + checkpoint busy (T2); Phase 2 value types (T3) + rows/scalar_string (T4); Phase 3 config (T5) + migrations (T6); Phase 4 coverage+README (T7). All spec test items mapped.
+- **Placeholder scan:** the `analytics_applied_migrations` name in T6 Step 3's first code block is explicitly replaced by `max_migration_version` in the same step — no dangling placeholder in the final code.
+- **Type consistency:** `EmbedValue`, `EmbedRow`, `EmbedConfig`, `path_str`, `max_migration_version`, `analytics::{rows, scalar_string, attached_conn, value_from_ref}`, error variants `NonUtf8Path`/`CheckpointBusy` used consistently across tasks.
+- **Ordering note:** T2 introduces `DEFAULT_CHECKPOINT_RETRIES` const; T5 replaces it with `self.config.checkpoint_max_retries`. Intentional, called out in both tasks.

--- a/docs/superpowers/specs/2026-07-19-embeddb-v3-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-v3-hardening-design.md
@@ -1,0 +1,110 @@
+# embeddb v3 — Robustness + Richer Reads + Migrations/Config Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+Builds on: `packages/rust/embeddb` (v1 #14292, v2 #14313 merged)
+
+## Purpose
+
+Harden the crate and close the remaining ergonomics gaps that a real consumer
+(e.g. Windmill) would hit, while staying strictly **Turso (write) + DuckDB
+(read) only** — no rusqlite / backend-swap trait (rejected: reintroduces the C
+toolchain the crate deliberately avoids).
+
+Four phases, landed as ordered commits on one branch:
+
+1. Robustness — remove known panics, make `checkpoint` honest about `busy`.
+2. Richer analytics reads — multi-row / multi-column typed results.
+3. Migrations + config — `EmbedConfig` and an idempotent migration runner.
+4. Comprehensive tests — cover every public method, error paths, edge cases.
+
+## Current surface (v2)
+
+`EmbedDb`: `open`, `path`, `execute(sql, params)`, `checkpoint`, `begin -> EmbedTx`,
+`analytics_scalar_i64/f64`, `close`. `EmbedTx`: `execute`, `commit`, `rollback`.
+`EmbedError`: `Turso | Duck | Io | Other`. Read side (`analytics.rs`) opens a
+fresh read-only DuckDB conn per call, `ATTACH (TYPE sqlite)`, honors
+`EMBEDDB_DUCKDB_EXTENSION_DIR`.
+
+---
+
+## Phase 1 — Robustness
+
+### 1.1 Non-UTF8 path panic
+`open()` calls `path.to_str().unwrap()` (panics on non-UTF8 path); `analytics.rs`
+uses `path.display()` (lossy). Both are the "no panic on library path" violation.
+
+- Add error variant `EmbedError::NonUtf8Path(PathBuf)`.
+- Add a shared helper (in `db.rs` or a small `util.rs`) `path_str(path: &Path) -> Result<&str>` returning `Err(NonUtf8Path)` when `to_str()` is `None`.
+- Use it in `open()` (feeding `Builder::new_local`) and in `analytics.rs` (feeding the ATTACH string, replacing the lossy `display()`).
+
+### 1.2 Checkpoint busy-check
+`checkpoint()` drains `PRAGMA wal_checkpoint(TRUNCATE)` rows but ignores the
+returned `(busy, log, checkpointed)` row. If `busy != 0`, the WAL was not fully
+truncated → a subsequent reader can see stale data with `Ok(())` returned.
+
+- Read column 0 (`busy`) from the returned row via the turso `Rows`/`Row` API.
+- Retry up to `checkpoint_max_retries` times (default from config, e.g. 5), yielding via `tokio::task::yield_now()` between attempts.
+- If still busy after retries, return `EmbedError::CheckpointBusy`.
+- Add error variant `EmbedError::CheckpointBusy`.
+
+---
+
+## Phase 2 — Richer analytics reads
+
+Current reads return a single scalar. Add generic multi-row/column reads with a
+self-contained value type (no `duckdb` types leaked across the API).
+
+- New `EmbedValue` enum in a new `src/value.rs`:
+  ```rust
+  #[derive(Debug, Clone, PartialEq)]
+  pub enum EmbedValue { Null, Int(i64), Float(f64), Text(String), Blob(Vec<u8>) }
+  ```
+- New `EmbedRow(pub Vec<EmbedValue>)` with helper accessors `get(idx) -> Option<&EmbedValue>`, and typed convenience `as_i64/as_f64/as_str(idx) -> Option<...>`.
+- `EmbedDb::analytics_rows(&self, sql: &str) -> Result<Vec<EmbedRow>>` — runs the query on the read DuckDB conn, reads all columns of every row generically by inspecting each column's DuckDB type and mapping to `EmbedValue` (Null/Int/Float/Text/Blob; other types fall back to `Text` via string rendering or error — decide during impl, prefer erroring on genuinely unmappable types over silent lossy coercion).
+- Add `EmbedDb::analytics_scalar_string(&self, sql) -> Result<String>` for text scalars (mirrors the existing i64/f64 scalars).
+- Keep `analytics_scalar_i64/f64` unchanged.
+- All read methods keep the `spawn_blocking` async wrapper pattern.
+
+## Phase 3 — Migrations + config
+
+### 3.1 `EmbedConfig`
+```rust
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    pub journal_mode: String,              // default "WAL"
+    pub duckdb_extension_dir: Option<PathBuf>, // overrides EMBEDDB_DUCKDB_EXTENSION_DIR when set
+    pub checkpoint_max_retries: u32,       // default 5
+}
+impl Default for EmbedConfig { /* WAL, None, 5 */ }
+```
+- `EmbedDb::open_with(path, config) -> Result<EmbedDb>`; `open(path)` delegates with `EmbedConfig::default()`.
+- `EmbedDb` stores the config; `checkpoint` uses `checkpoint_max_retries`; the read path passes `duckdb_extension_dir` (falling back to the env var when `None`) to `prepare_sqlite_scanner`.
+
+### 3.2 Migration runner
+```rust
+pub async fn migrate(&self, migrations: &[&str]) -> Result<()>;
+```
+- Maintains a private table `_embeddb_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)`.
+- On call: read the highest applied `version`; for each migration at index `i >= next`, run it and record `version = i` — each migration wrapped in a transaction (`begin`/`commit`, rollback on error).
+- Idempotent: re-running with the same slice is a no-op; appending new entries applies only the new tail.
+- Ordered: index = version. Callers must only append, never reorder (documented).
+
+## Phase 4 — Comprehensive tests
+
+Add tests covering, at minimum:
+- Phase 1: non-UTF8 path returns `NonUtf8Path` error (construct an invalid path via `OsStr`/bytes on unix); checkpoint returns `Ok` on normal write (busy path is hard to force — document if not directly testable).
+- Phase 2: `analytics_rows` with multiple rows and mixed column types (int, float, text, null); `EmbedRow` accessors; `analytics_scalar_string`.
+- Phase 3: `open_with` custom config (non-default retries); `duckdb_extension_dir` config path used; `migrate` applies all on fresh DB, re-run is no-op, appended migration applies only the new one, a failing migration leaves prior state intact (rollback).
+- Error mapping for each new variant.
+- Keep all existing v1/v2 tests green.
+
+## Error additions (summary)
+
+`EmbedError::NonUtf8Path(PathBuf)`, `EmbedError::CheckpointBusy`. No change to
+existing variants.
+
+## Deferred (unchanged)
+
+Live concurrent write/read, WASM target, backend-swap trait (rejected —
+Turso+DuckDB only), connection pooling.

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -127,3 +127,5 @@ db.migrate(&migrations).await?;
 ```
 
 `migrate` is append-only and idempotent: calling it again with the same slice is a no-op, and calling it with the same prefix plus new entries appended applies only the new entries. Each migration runs in its own transaction; if a migration fails, that transaction is rolled back and the error is returned, leaving previously-applied migrations intact and no partial record for the failed one — so migrating with the same (or a fixed) slice afterward will retry it.
+
+Each migration string is executed as a single statement via `tx.execute`. A string containing multiple statements (e.g. `"CREATE TABLE x (id INTEGER); CREATE INDEX idx_x ON x (id)"`) will only apply the first statement, yet the whole string is still recorded as applied — so the remaining statements silently never run. Callers must split multi-statement migrations into one array entry per statement.

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -9,6 +9,8 @@ Turso (`libsql`) writes a real SQLite-format file, and DuckDB can attach to and 
 ## Write / read split
 
 - **Writes** go through `EmbedDb`, backed by a `turso::Connection`. `EmbedDb::open` opens (creating if needed) the file in WAL journal mode. `EmbedDb::execute` runs a single write/DDL statement and returns the affected row count.
+
+`EmbedDb::open` (and `open_with`) require the path to be valid UTF-8. A non-UTF-8 path returns `EmbedError::NonUtf8Path` rather than panicking.
 - **Reads for analytics** go through DuckDB. `EmbedDb::analytics_scalar_i64` / `EmbedDb::analytics_scalar_f64` open a fresh in-memory DuckDB connection, `ATTACH` the same file read-only via the `sqlite` extension, and run a scalar query against it.
 
 Because DuckDB attaches read-only and Turso owns all writes, only one process ever mutates the file, avoiding write contention between the two engines.
@@ -19,7 +21,7 @@ The Turso write path is pure Rust and statically linked — no shared library to
 
 Turso writes to the file's WAL. DuckDB's SQLite reader sees the main database file, not the WAL, so a checkpoint must run before DuckDB can observe recent writes. Call `EmbedDb::checkpoint` (which issues `PRAGMA wal_checkpoint(TRUNCATE)`) after writes and before running analytics queries — skipping this step means DuckDB may read stale or incomplete data.
 
-`checkpoint` does not inspect the `(busy, log, checkpointed)` row that `PRAGMA wal_checkpoint(TRUNCATE)` returns. If the checkpoint comes back busy (another reader holding the WAL), the flush may be incomplete and a subsequent analytics read could see stale data. This is safe under the v1 single-writer/no-concurrent-live-reader model this crate assumes; a future revision may want to surface the busy state to callers.
+`checkpoint` inspects the `(busy, log, checkpointed)` row that `PRAGMA wal_checkpoint(TRUNCATE)` returns. If it comes back busy (another reader holding the WAL), `checkpoint` retries (yielding between attempts) up to `EmbedConfig::checkpoint_max_retries` times. If it is still busy after retries, `checkpoint` returns `EmbedError::CheckpointBusy` instead of silently returning `Ok` over a possibly-incomplete flush.
 
 When done, call `EmbedDb::close` to drop the connection and release the file.
 
@@ -74,3 +76,54 @@ tx.commit().await?;
 Dropping an `EmbedTx` without calling `commit` discards the transaction's writes (rolled back on the connection's next use, not synchronously at drop).
 
 `EmbedDb::execute` and `EmbedDb::begin` share the same underlying `turso::Connection`. While a transaction is open, use the `tx` handle for writes — calling `db.execute(...)` on the same `EmbedDb` runs that statement inside the open transaction instead of autocommitting independently.
+
+### Configuration: `EmbedConfig` + `open_with`
+
+`EmbedDb::open` uses `EmbedConfig::default()` (`journal_mode: "WAL"`, no `duckdb_extension_dir`, `checkpoint_max_retries: 5`). To override any of these, build an `EmbedConfig` and pass it to `EmbedDb::open_with`:
+
+```rust
+use embeddb::{EmbedConfig, EmbedDb};
+
+let cfg = EmbedConfig {
+    journal_mode: "WAL".into(),
+    duckdb_extension_dir: None,
+    checkpoint_max_retries: 10,
+};
+let db = EmbedDb::open_with("data.db", cfg).await?;
+```
+
+`checkpoint_max_retries` controls how many times `EmbedDb::checkpoint` retries a busy WAL checkpoint before returning `EmbedError::CheckpointBusy` (see "Checkpoint-then-read model" above). `duckdb_extension_dir` is a per-`EmbedDb` override for the `EMBEDDB_DUCKDB_EXTENSION_DIR` environment variable described in "Deployment note" below.
+
+### Analytics rows: `analytics_rows`, `EmbedRow`, `EmbedValue`, `analytics_scalar_string`
+
+Alongside the scalar helpers (`analytics_scalar_i64`, `analytics_scalar_f64`), `analytics_scalar_string` reads a single text value, and `analytics_rows` reads an entire result set into `Vec<EmbedRow>`:
+
+```rust
+db.execute("CREATE TABLE t (id INTEGER, v REAL, name TEXT)", ()).await?;
+db.execute("INSERT INTO t VALUES (?, ?, ?)", (1_i64, 1.5_f64, "a")).await?;
+db.checkpoint().await?;
+
+let name = db.analytics_scalar_string("SELECT name FROM t WHERE id = 1").await?;
+assert_eq!(name, "a");
+
+let rows = db.analytics_rows("SELECT id, v, name FROM t ORDER BY id").await?;
+assert_eq!(rows[0].as_i64(0), Some(1));
+assert_eq!(rows[0].as_f64(1), Some(1.5));
+assert_eq!(rows[0].as_str(2), Some("a"));
+```
+
+Each `EmbedRow` wraps a `Vec<EmbedValue>`, one per selected column. `EmbedValue` is `Null | Int(i64) | Float(f64) | Text(String) | Blob(Vec<u8>)`. Use `EmbedRow::get` for the raw `&EmbedValue`, or the typed `as_i64` / `as_f64` / `as_str` accessors, which return `None` if the column is absent or holds a different variant.
+
+### Schema migrations: `migrate`
+
+`EmbedDb::migrate` takes an ordered slice of DDL/DML strings and applies only the ones not yet recorded as applied, tracked in an internal `_embeddb_migrations` table keyed by index:
+
+```rust
+let migrations = [
+    "CREATE TABLE a (id INTEGER)",
+    "CREATE TABLE b (id INTEGER)",
+];
+db.migrate(&migrations).await?;
+```
+
+`migrate` is append-only and idempotent: calling it again with the same slice is a no-op, and calling it with the same prefix plus new entries appended applies only the new entries. Each migration runs in its own transaction; if a migration fails, that transaction is rolled back and the error is returned, leaving previously-applied migrations intact and no partial record for the failed one — so migrating with the same (or a fixed) slice afterward will retry it.

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -1,26 +1,26 @@
 use std::path::Path;
 use crate::Result;
 
-pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
-    let conn = attached_conn(path)?;
+pub fn scalar_i64(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<i64> {
+    let conn = attached_conn(path, ext_dir)?;
     let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
-    let conn = attached_conn(path)?;
+pub fn scalar_f64(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<f64> {
+    let conn = attached_conn(path, ext_dir)?;
     let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn scalar_string(path: &Path, sql: &str) -> Result<String> {
-    let conn = attached_conn(path)?;
+pub fn scalar_string(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<String> {
+    let conn = attached_conn(path, ext_dir)?;
     let val: String = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn rows(path: &Path, sql: &str) -> Result<Vec<crate::EmbedRow>> {
-    let conn = attached_conn(path)?;
+pub fn rows(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<Vec<crate::EmbedRow>> {
+    let conn = attached_conn(path, ext_dir)?;
     let mut stmt = conn.prepare(sql)?;
     let mut out = Vec::new();
     let mut rows = stmt.query([])?;
@@ -57,17 +57,21 @@ fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
     })
 }
 
-fn attached_conn(path: &Path) -> Result<duckdb::Connection> {
+fn attached_conn(path: &Path, ext_dir: Option<&Path>) -> Result<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory()?;
-    prepare_sqlite_scanner(&conn)?;
+    prepare_sqlite_scanner(&conn, ext_dir)?;
     let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
     Ok(conn)
 }
 
-fn prepare_sqlite_scanner(conn: &duckdb::Connection) -> Result<()> {
-    if let Ok(dir) = std::env::var("EMBEDDB_DUCKDB_EXTENSION_DIR") {
+fn prepare_sqlite_scanner(conn: &duckdb::Connection, ext_dir: Option<&Path>) -> Result<()> {
+    let dir = match ext_dir {
+        Some(p) => Some(p.to_string_lossy().into_owned()),
+        None => std::env::var("EMBEDDB_DUCKDB_EXTENSION_DIR").ok(),
+    };
+    if let Some(dir) = dir {
         let set_dir = format!("SET extension_directory = '{}';", sql_quote_str(&dir));
         conn.execute_batch(&set_dir)?;
     }

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -2,23 +2,68 @@ use std::path::Path;
 use crate::Result;
 
 pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
-    let conn = duckdb::Connection::open_in_memory()?;
-    prepare_sqlite_scanner(&conn)?;
-    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
-    conn.execute_batch(&attach)?;
-    conn.execute_batch("USE src;")?;
+    let conn = attached_conn(path)?;
     let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
 pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
+    let conn = attached_conn(path)?;
+    let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+
+pub fn scalar_string(path: &Path, sql: &str) -> Result<String> {
+    let conn = attached_conn(path)?;
+    let val: String = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+
+pub fn rows(path: &Path, sql: &str) -> Result<Vec<crate::EmbedRow>> {
+    let conn = attached_conn(path)?;
+    let mut stmt = conn.prepare(sql)?;
+    let mut out = Vec::new();
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let ncols = row.as_ref().column_count();
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(value_from_ref(row.get_ref(i)?)?);
+        }
+        out.push(crate::EmbedRow(vals));
+    }
+    Ok(out)
+}
+
+fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
+    use duckdb::types::ValueRef as V;
+    Ok(match v {
+        V::Null => crate::EmbedValue::Null,
+        V::Boolean(b) => crate::EmbedValue::Int(b as i64),
+        V::TinyInt(n) => crate::EmbedValue::Int(n as i64),
+        V::SmallInt(n) => crate::EmbedValue::Int(n as i64),
+        V::Int(n) => crate::EmbedValue::Int(n as i64),
+        V::BigInt(n) => crate::EmbedValue::Int(n),
+        V::HugeInt(n) => crate::EmbedValue::Int(n as i64),
+        V::UTinyInt(n) => crate::EmbedValue::Int(n as i64),
+        V::USmallInt(n) => crate::EmbedValue::Int(n as i64),
+        V::UInt(n) => crate::EmbedValue::Int(n as i64),
+        V::UBigInt(n) => crate::EmbedValue::Int(n as i64),
+        V::Float(n) => crate::EmbedValue::Float(n as f64),
+        V::Double(n) => crate::EmbedValue::Float(n),
+        V::Text(b) => crate::EmbedValue::Text(String::from_utf8_lossy(b).into_owned()),
+        V::Blob(b) => crate::EmbedValue::Blob(b.to_vec()),
+        other => return Err(crate::EmbedError::Other(format!("unmapped duckdb type: {:?}", other))),
+    })
+}
+
+fn attached_conn(path: &Path) -> Result<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory()?;
     prepare_sqlite_scanner(&conn)?;
     let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
-    let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
-    Ok(val)
+    Ok(conn)
 }
 
 fn prepare_sqlite_scanner(conn: &duckdb::Connection) -> Result<()> {

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -44,11 +44,15 @@ fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
         V::SmallInt(n) => crate::EmbedValue::Int(n as i64),
         V::Int(n) => crate::EmbedValue::Int(n as i64),
         V::BigInt(n) => crate::EmbedValue::Int(n),
-        V::HugeInt(n) => crate::EmbedValue::Int(n as i64),
+        V::HugeInt(n) => i64::try_from(n)
+            .map(crate::EmbedValue::Int)
+            .map_err(|_| crate::EmbedError::Other(format!("i128 value out of i64 range: {}", n)))?,
         V::UTinyInt(n) => crate::EmbedValue::Int(n as i64),
         V::USmallInt(n) => crate::EmbedValue::Int(n as i64),
         V::UInt(n) => crate::EmbedValue::Int(n as i64),
-        V::UBigInt(n) => crate::EmbedValue::Int(n as i64),
+        V::UBigInt(n) => i64::try_from(n)
+            .map(crate::EmbedValue::Int)
+            .map_err(|_| crate::EmbedError::Other(format!("u64 value out of i64 range: {}", n)))?,
         V::Float(n) => crate::EmbedValue::Float(n as f64),
         V::Double(n) => crate::EmbedValue::Float(n),
         V::Text(b) => crate::EmbedValue::Text(String::from_utf8_lossy(b).into_owned()),

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -4,7 +4,7 @@ use crate::Result;
 pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
     let conn = duckdb::Connection::open_in_memory()?;
     prepare_sqlite_scanner(&conn)?;
-    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
     let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
@@ -14,7 +14,7 @@ pub fn scalar_i64(path: &Path, sql: &str) -> Result<i64> {
 pub fn scalar_f64(path: &Path, sql: &str) -> Result<f64> {
     let conn = duckdb::Connection::open_in_memory()?;
     prepare_sqlite_scanner(&conn)?;
-    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_path(path));
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
     let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
@@ -32,8 +32,4 @@ fn prepare_sqlite_scanner(conn: &duckdb::Connection) -> Result<()> {
 
 fn sql_quote_str(s: &str) -> String {
     s.replace('\'', "''")
-}
-
-fn sql_quote_path(path: &Path) -> String {
-    sql_quote_str(&path.display().to_string())
 }

--- a/packages/rust/embeddb/src/config.rs
+++ b/packages/rust/embeddb/src/config.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    pub journal_mode: String,
+    pub duckdb_extension_dir: Option<PathBuf>,
+    pub checkpoint_max_retries: u32,
+}
+
+impl Default for EmbedConfig {
+    fn default() -> Self {
+        EmbedConfig { journal_mode: "WAL".to_string(), duckdb_extension_dir: None, checkpoint_max_retries: 5 }
+    }
+}

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use crate::Result;
 
+const DEFAULT_CHECKPOINT_RETRIES: u32 = 5;
+
 #[derive(Debug)]
 pub struct EmbedDb {
     path: PathBuf,
@@ -32,9 +34,19 @@ impl EmbedDb {
     }
 
     pub async fn checkpoint(&self) -> Result<()> {
-        let mut rows = self.conn.query("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
-        while rows.next().await?.is_some() {}
-        Ok(())
+        for _ in 0..=DEFAULT_CHECKPOINT_RETRIES {
+            let mut rows = self.conn.query("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
+            let mut busy = 0_i64;
+            if let Some(row) = rows.next().await? {
+                busy = row.get::<i64>(0).unwrap_or(0);
+            }
+            while rows.next().await?.is_some() {}
+            if busy == 0 {
+                return Ok(());
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(crate::EmbedError::CheckpointBusy)
     }
 
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
@@ -116,6 +128,16 @@ mod tests {
         db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
         db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn checkpoint_reports_success_on_idle_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("cp.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -65,6 +65,22 @@ impl EmbedDb {
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
 
+    pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || crate::analytics::rows(&path, &sql))
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
+    pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_string(&path, &sql))
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
     pub async fn begin(&self) -> Result<crate::EmbedTx<'_>> {
         let tx = self.conn.unchecked_transaction().await?;
         Ok(crate::EmbedTx::new(tx))
@@ -213,6 +229,43 @@ mod tests {
         tx2.commit().await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_mixed_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("rows.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL, name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?, ?, ?)", (1_i64, 1.5_f64, "a")).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?, ?, ?)", (2_i64, 2.5_f64, "b")).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT id, v, name FROM t ORDER BY id").await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].as_i64(0), Some(1));
+        assert_eq!(rows[0].as_f64(1), Some(1.5));
+        assert_eq!(rows[0].as_str(2), Some("a"));
+        assert_eq!(rows[1].as_str(2), Some("b"));
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_handles_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("null.db")).await.unwrap();
+        db.execute("CREATE TABLE t (a INTEGER, b TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, NULL)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT a, b FROM t").await.unwrap();
+        assert_eq!(rows[0].get(1), Some(&crate::EmbedValue::Null));
+    }
+
+    #[tokio::test]
+    async fn analytics_scalar_string_reads_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("s.db")).await.unwrap();
+        db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", ("hello",)).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_string("SELECT name FROM t").await.unwrap(), "hello");
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -407,6 +407,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn analytics_rows_large_int_in_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("bigint.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", (i64::MAX,)).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT v FROM t").await.unwrap();
+        assert_eq!(rows[0].get(0), Some(&crate::EmbedValue::Int(i64::MAX)));
+    }
+
+    #[tokio::test]
     async fn migrate_failure_rolls_back_that_migration() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("m3.db")).await.unwrap();

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -342,6 +342,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn analytics_rows_empty_table_returns_empty_vec() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("empty.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT id FROM t").await.unwrap();
+        assert_eq!(rows, Vec::<crate::EmbedRow>::new());
+    }
+
+    #[tokio::test]
+    async fn analytics_scalar_string_round_trips_quote() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("quote_string.db")).await.unwrap();
+        db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", ("o'brien",)).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let name = db.analytics_scalar_string("SELECT name FROM t").await.unwrap();
+        assert_eq!(name, "o'brien");
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_blob_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("blob.db")).await.unwrap();
+        db.execute("CREATE TABLE t (b BLOB)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (X'00FF')", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT b FROM t").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get(0), Some(&crate::EmbedValue::Blob(vec![0x00, 0xFF])));
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_multi_row_ordering() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("order.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, v REAL, name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?, ?, ?)", (3_i64, 30.0_f64, "c")).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?, ?, ?)", (1_i64, 10.0_f64, "a")).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?, ?, ?)", (2_i64, 20.0_f64, "b")).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT id, v, name FROM t ORDER BY id").await.unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                crate::EmbedRow(vec![
+                    crate::EmbedValue::Int(1),
+                    crate::EmbedValue::Float(10.0),
+                    crate::EmbedValue::Text("a".into()),
+                ]),
+                crate::EmbedRow(vec![
+                    crate::EmbedValue::Int(2),
+                    crate::EmbedValue::Float(20.0),
+                    crate::EmbedValue::Text("b".into()),
+                ]),
+                crate::EmbedRow(vec![
+                    crate::EmbedValue::Int(3),
+                    crate::EmbedValue::Float(30.0),
+                    crate::EmbedValue::Text("c".into()),
+                ]),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn migrate_failure_rolls_back_that_migration() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("m3.db")).await.unwrap();

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,12 +1,11 @@
 use std::path::{Path, PathBuf};
 use crate::Result;
 
-const DEFAULT_CHECKPOINT_RETRIES: u32 = 5;
-
 #[derive(Debug)]
 pub struct EmbedDb {
     path: PathBuf,
     conn: turso::Connection,
+    config: crate::EmbedConfig,
 }
 
 pub(crate) fn path_str(path: &Path) -> Result<&str> {
@@ -15,13 +14,18 @@ pub(crate) fn path_str(path: &Path) -> Result<&str> {
 
 impl EmbedDb {
     pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
+        EmbedDb::open_with(path, crate::EmbedConfig::default()).await
+    }
+
+    pub async fn open_with(path: impl AsRef<Path>, config: crate::EmbedConfig) -> Result<EmbedDb> {
         let path = path.as_ref().to_path_buf();
         let db = turso::Builder::new_local(path_str(&path)?)
             .build()
             .await?;
         let conn = db.connect()?;
-        conn.execute("PRAGMA journal_mode=WAL", ()).await.ok();
-        Ok(EmbedDb { path, conn })
+        let pragma = format!("PRAGMA journal_mode={}", config.journal_mode);
+        conn.execute(&pragma, ()).await.ok();
+        Ok(EmbedDb { path, conn, config })
     }
 
     pub fn path(&self) -> &Path {
@@ -34,7 +38,7 @@ impl EmbedDb {
     }
 
     pub async fn checkpoint(&self) -> Result<()> {
-        for _ in 0..=DEFAULT_CHECKPOINT_RETRIES {
+        for _ in 0..=self.config.checkpoint_max_retries {
             let mut rows = self.conn.query("PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
             let mut busy = 0_i64;
             if let Some(row) = rows.next().await? {
@@ -52,7 +56,8 @@ impl EmbedDb {
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_i64(&path, &sql))
+        let ext_dir = self.config.duckdb_extension_dir.clone();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_i64(&path, &sql, ext_dir.as_deref()))
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -60,7 +65,8 @@ impl EmbedDb {
     pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_f64(&path, &sql))
+        let ext_dir = self.config.duckdb_extension_dir.clone();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_f64(&path, &sql, ext_dir.as_deref()))
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -68,7 +74,8 @@ impl EmbedDb {
     pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        tokio::task::spawn_blocking(move || crate::analytics::rows(&path, &sql))
+        let ext_dir = self.config.duckdb_extension_dir.clone();
+        tokio::task::spawn_blocking(move || crate::analytics::rows(&path, &sql, ext_dir.as_deref()))
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -76,7 +83,8 @@ impl EmbedDb {
     pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_string(&path, &sql))
+        let ext_dir = self.config.duckdb_extension_dir.clone();
+        tokio::task::spawn_blocking(move || crate::analytics::scalar_string(&path, &sql, ext_dir.as_deref()))
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -266,6 +274,17 @@ mod tests {
         db.execute("INSERT INTO t VALUES (?)", ("hello",)).await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_string("SELECT name FROM t").await.unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn open_with_custom_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = crate::EmbedConfig { journal_mode: "WAL".into(), duckdb_extension_dir: None, checkpoint_max_retries: 1 };
+        let db = EmbedDb::open_with(dir.path().join("cfg.db"), cfg).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,15 +1,20 @@
 use std::path::{Path, PathBuf};
 use crate::Result;
 
+#[derive(Debug)]
 pub struct EmbedDb {
     path: PathBuf,
     conn: turso::Connection,
 }
 
+pub(crate) fn path_str(path: &Path) -> Result<&str> {
+    path.to_str().ok_or_else(|| crate::EmbedError::NonUtf8Path(path.to_path_buf()))
+}
+
 impl EmbedDb {
     pub async fn open(path: impl AsRef<Path>) -> Result<EmbedDb> {
         let path = path.as_ref().to_path_buf();
-        let db = turso::Builder::new_local(path.to_str().unwrap())
+        let db = turso::Builder::new_local(path_str(&path)?)
             .build()
             .await?;
         let conn = db.connect()?;
@@ -62,6 +67,17 @@ impl EmbedDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_non_utf8_path_errors() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::ffi::OsStr;
+        let dir = tempfile::tempdir().unwrap();
+        let bad = dir.path().join(OsStr::from_bytes(b"bad\xFFname.db"));
+        let err = EmbedDb::open(&bad).await.unwrap_err();
+        assert!(matches!(err, crate::EmbedError::NonUtf8Path(_)));
+    }
 
     #[tokio::test]
     async fn open_creates_file() {

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -98,6 +98,23 @@ impl EmbedDb {
         drop(self.conn);
         Ok(())
     }
+
+    pub(crate) async fn max_migration_version(&self) -> Result<i64> {
+        let mut rows = self
+            .conn
+            .query("SELECT COALESCE(MAX(version), -1) FROM _embeddb_migrations", ())
+            .await?;
+        let mut v = -1_i64;
+        if let Some(row) = rows.next().await? {
+            v = row.get::<i64>(0).unwrap_or(-1);
+        }
+        while rows.next().await?.is_some() {}
+        Ok(v)
+    }
+
+    pub async fn migrate(&self, migrations: &[&str]) -> Result<()> {
+        crate::migrate::run(self, migrations).await
+    }
 }
 
 #[cfg(test)]
@@ -298,5 +315,41 @@ mod tests {
         }
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn migrate_applies_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("m.db")).await.unwrap();
+        let m = ["CREATE TABLE a (id INTEGER)", "CREATE TABLE b (id INTEGER)"];
+        db.migrate(&m).await.unwrap();
+        db.migrate(&m).await.unwrap();
+        db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
+        db.execute("INSERT INTO b VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn migrate_appended_applies_only_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("m2.db")).await.unwrap();
+        db.migrate(&["CREATE TABLE a (id INTEGER)"]).await.unwrap();
+        db.migrate(&["CREATE TABLE a (id INTEGER)", "CREATE TABLE c (id INTEGER)"]).await.unwrap();
+        db.execute("INSERT INTO c VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM c").await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn migrate_failure_rolls_back_that_migration() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("m3.db")).await.unwrap();
+        let err = db.migrate(&["CREATE TABLE a (id INTEGER)", "NOT VALID SQL"]).await;
+        assert!(err.is_err());
+        db.migrate(&["CREATE TABLE a (id INTEGER)"]).await.unwrap();
+        db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
     }
 }

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -8,6 +8,8 @@ pub enum EmbedError {
     Io(#[from] std::io::Error),
     #[error("non-utf8 path: {0}")]
     NonUtf8Path(std::path::PathBuf),
+    #[error("checkpoint busy after retries")]
+    CheckpointBusy,
     #[error("{0}")]
     Other(String),
 }

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -26,4 +26,20 @@ mod tests {
         let e: EmbedError = io.into();
         assert!(matches!(e, EmbedError::Io(_)));
     }
+
+    #[test]
+    fn non_utf8_path_displays() {
+        let e = EmbedError::NonUtf8Path(std::path::PathBuf::from("bad\u{FFFD}name.db"));
+        let msg = format!("{}", e);
+        assert!(!msg.is_empty());
+        assert!(msg.contains("non-utf8 path"));
+    }
+
+    #[test]
+    fn checkpoint_busy_displays() {
+        let e = EmbedError::CheckpointBusy;
+        let msg = format!("{}", e);
+        assert!(!msg.is_empty());
+        assert_eq!(msg, "checkpoint busy after retries");
+    }
 }

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -6,6 +6,8 @@ pub enum EmbedError {
     Duck(#[from] duckdb::Error),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("non-utf8 path: {0}")]
+    NonUtf8Path(std::path::PathBuf),
     #[error("{0}")]
     Other(String),
 }

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -3,9 +3,11 @@ mod db;
 mod analytics;
 mod tx;
 mod value;
+mod config;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
 pub use tx::EmbedTx;
 pub use value::{EmbedValue, EmbedRow};
 pub use turso::IntoParams;
+pub use config::EmbedConfig;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -2,8 +2,10 @@ mod error;
 mod db;
 mod analytics;
 mod tx;
+mod value;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
 pub use tx::EmbedTx;
+pub use value::{EmbedValue, EmbedRow};
 pub use turso::IntoParams;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -4,6 +4,7 @@ mod analytics;
 mod tx;
 mod value;
 mod config;
+mod migrate;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;

--- a/packages/rust/embeddb/src/migrate.rs
+++ b/packages/rust/embeddb/src/migrate.rs
@@ -1,0 +1,29 @@
+use crate::{EmbedDb, Result};
+
+pub(crate) async fn run(db: &EmbedDb, migrations: &[&str]) -> Result<()> {
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS _embeddb_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)",
+        (),
+    ).await?;
+    let applied = db.max_migration_version().await?;
+    for (i, sql) in migrations.iter().enumerate() {
+        let version = i as i64;
+        if version <= applied {
+            continue;
+        }
+        let tx = db.begin().await?;
+        if let Err(e) = tx.execute(sql, ()).await {
+            tx.rollback().await.ok();
+            return Err(e);
+        }
+        if let Err(e) = tx.execute(
+            "INSERT INTO _embeddb_migrations (version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        ).await {
+            tx.rollback().await.ok();
+            return Err(e);
+        }
+        tx.commit().await?;
+    }
+    Ok(())
+}

--- a/packages/rust/embeddb/src/value.rs
+++ b/packages/rust/embeddb/src/value.rs
@@ -1,0 +1,49 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbedValue {
+    Null,
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbedRow(pub Vec<EmbedValue>);
+
+impl EmbedRow {
+    pub fn get(&self, idx: usize) -> Option<&EmbedValue> {
+        self.0.get(idx)
+    }
+    pub fn as_i64(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Int(v)) => Some(*v),
+            _ => None,
+        }
+    }
+    pub fn as_f64(&self, idx: usize) -> Option<f64> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Float(v)) => Some(*v),
+            _ => None,
+        }
+    }
+    pub fn as_str(&self, idx: usize) -> Option<&str> {
+        match self.0.get(idx) {
+            Some(EmbedValue::Text(v)) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn row_accessors() {
+        let r = EmbedRow(vec![EmbedValue::Int(7), EmbedValue::Text("hi".into()), EmbedValue::Null]);
+        assert_eq!(r.as_i64(0), Some(7));
+        assert_eq!(r.as_str(1), Some("hi"));
+        assert_eq!(r.get(2), Some(&EmbedValue::Null));
+        assert_eq!(r.as_i64(1), None);
+        assert_eq!(r.get(9), None);
+    }
+}


### PR DESCRIPTION
## embeddb v3 — robustness + richer reads + migrations/config

Follow-up to v1 (#14292) and v2 (#14313). Hardening + the remaining ergonomics gaps a real consumer hits. Stays **Turso (write) + DuckDB (read) only** — backend-swap/rusqlite rejected (reintroduces the C toolchain the crate avoids).

### Phase 1 — Robustness
- Non-UTF8 path now returns `EmbedError::NonUtf8Path` instead of panicking (`to_str().unwrap()` gone; analytics no longer uses lossy `display()`).
- `checkpoint()` inspects the `busy` column of `wal_checkpoint(TRUNCATE)`, retries `config.checkpoint_max_retries+1` times, returns `EmbedError::CheckpointBusy` if still stuck — no more silent stale-read.

### Phase 2 — Richer analytics reads
- `EmbedValue` (`Null/Int/Float/Text/Blob`) + `EmbedRow` (accessors `get`/`as_i64`/`as_f64`/`as_str`) — self-contained, no DuckDB types leaked.
- `analytics_rows(sql) -> Vec<EmbedRow>` — generic multi-row/column reads; out-of-i64-range HugeInt/UBigInt error rather than silently wrap.
- `analytics_scalar_string(sql)`.

### Phase 3 — Config + migrations
- `EmbedConfig { journal_mode, duckdb_extension_dir, checkpoint_max_retries }` + `open_with`. `duckdb_extension_dir` overrides the `EMBEDDB_DUCKDB_EXTENSION_DIR` env (env still the fallback).
- `migrate(&[&str])` — idempotent, append-only, `_embeddb_migrations` tracking table; each migration + its version record commit in one transaction (partial failure rolls back, re-run is a no-op). One statement per entry (documented).

### Phase 4 — Tests + README
28 passing (`cargo test -p embeddb`), up from 8. Covers null/blob/empty/ordering/quote-roundtrip reads, config, migration idempotency + rollback, error Display. README updated for all new API.

### Notable gotchas found
- turso `execute` rejects row-returning statements → checkpoint/version-read use `query`+drain.
- duckdb `Statement::column_count()` **panics if called before `query()`** (crate FIXME) → read per-row via `row.as_ref().column_count()`.

Still deferred: live concurrent read, WASM, i128 in EmbedValue.
