### PR TITLE
fix(discordsh): lock threads atomically on close + backfill recent-first

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
@@ -489,11 +489,10 @@ async fn backfill_closed_threads(store: &Arc<GithubStore>, http: &Arc<serenity::
 /// reopen→unarchive+unlock). Event-driven only (never a reconcile loop), so a
 /// human who manually re-opens a thread is not repeatedly re-archived.
 ///
-/// On close the archive and lock are SEPARATE best-effort calls: the archive
-/// lands first, then (if `GH_SYNC_LOCK_ON_CLOSE`) a second call re-asserts
-/// archived + adds the lock, so a lock failure (e.g. missing MANAGE_THREADS)
-/// never costs us the archive. All steps log + continue without failing the
-/// event delivery.
+/// Archive and lock are applied in ONE edit: Discord rejects any edit to an
+/// already-archived thread ("Thread is archived"), so a separate follow-up lock
+/// call can never land. Setting `archived` + `locked` together on the still-open
+/// thread locks it atomically. Best-effort — logs and continues on failure.
 async fn set_thread_archived(http: &Arc<serenity::Http>, issue: &CachedIssue, archived: bool) {
     let Some(thread_id) = issue.discord_thread_id else {
         return;
@@ -501,7 +500,6 @@ async fn set_thread_archived(http: &Arc<serenity::Http>, issue: &CachedIssue, ar
     let thread = serenity::ChannelId::new(thread_id as u64);
 
     if !archived {
-        // Reopen: unarchive + unlock in one call.
         edit_thread_step(
             http,
             thread,
@@ -514,29 +512,12 @@ async fn set_thread_archived(http: &Arc<serenity::Http>, issue: &CachedIssue, ar
         return;
     }
 
-    // Close: archive first so it lands even if a later lock is rejected.
-    let archived_ok = edit_thread_step(
-        http,
-        thread,
-        EditThread::new().archived(true),
-        issue.number,
-        thread_id,
-        "archive",
-    )
-    .await;
-
-    // Then try to lock (re-assert archived so the thread stays archived).
-    if archived_ok && lock_on_close_enabled() {
-        edit_thread_step(
-            http,
-            thread,
-            EditThread::new().archived(true).locked(true),
-            issue.number,
-            thread_id,
-            "lock",
-        )
-        .await;
-    }
+    let builder = if lock_on_close_enabled() {
+        EditThread::new().archived(true).locked(true)
+    } else {
+        EditThread::new().archived(true)
+    };
+    edit_thread_step(http, thread, builder, issue.number, thread_id, "archive").await;
 }
 
 async fn edit_thread_step(

--- a/packages/data/sql/dbmate/migrations/20260719000000_gh_list_closed_threads_recent_first.sql
+++ b/packages/data/sql/dbmate/migrations/20260719000000_gh_list_closed_threads_recent_first.sql
@@ -1,0 +1,61 @@
+-- migrate:up
+
+SET search_path = '';
+
+-- Re-order the backfill enumeration most-recently-closed first. The prior
+-- (owner, repo, number) ASC ordering front-loaded the OLDEST closed issues, so
+-- an active repo (thousands of closed rows) exhausted the cap before reaching
+-- recent closes — leaving newly-closed PRs/issues (e.g. #14193) unreconciled
+-- when their live `closed` event was missed. closed_at DESC surfaces those.
+CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
+RETURNS SETOF gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 500
+COST 50
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL
+    ORDER BY closed_at DESC NULLS LAST, owner, repo, number DESC
+    LIMIT LEAST(GREATEST(p_limit, 1), 2000);
+$$;
+
+ALTER FUNCTION gh.list_closed_issue_threads(INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
+
+COMMENT ON FUNCTION gh.list_closed_issue_threads(INT) IS
+'Closed issues that still carry a discord_thread_id, most-recently-closed first (closed_at DESC), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+SET search_path = '';
+
+CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
+RETURNS SETOF gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 500
+COST 50
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL
+    ORDER BY owner, repo, number
+    LIMIT LEAST(GREATEST(p_limit, 1), 2000);
+$$;
+
+ALTER FUNCTION gh.list_closed_issue_threads(INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260719000000_gh_list_closed_threads_recent_first.sql
+++ b/packages/data/sql/dbmate/migrations/20260719000000_gh_list_closed_threads_recent_first.sql
@@ -2,11 +2,26 @@
 
 SET search_path = '';
 
+-- Backing index so the enumeration is an index-only-ish range scan + LIMIT
+-- instead of a full scan-and-sort of every eligible closed issue. Column order
+-- and direction MUST match the ORDER BY below exactly (closed_at DESC NULLS
+-- LAST, owner, repo, number DESC) for the planner to skip the sort.
+CREATE INDEX IF NOT EXISTS issue_closed_thread_backfill_idx
+    ON gh.issue (closed_at DESC NULLS LAST, owner, repo, number DESC)
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL;
+
 -- Re-order the backfill enumeration most-recently-closed first. The prior
 -- (owner, repo, number) ASC ordering front-loaded the OLDEST closed issues, so
 -- an active repo (thousands of closed rows) exhausted the cap before reaching
 -- recent closes — leaving newly-closed PRs/issues (e.g. #14193) unreconciled
 -- when their live `closed` event was missed. closed_at DESC surfaces those.
+--
+-- NULL closed_at handling is DELIBERATE: such rows (legacy pre-VS6 closes whose
+-- upsert never carried a closed_at) sort LAST — lowest reconcile priority. They
+-- stay eligible; only if the eligible set exceeds the cap do they drop out, at
+-- which point widen the caller's cap or add keyset pagination (follow-up). They
+-- are NOT excluded — they are valid backfill targets, just least urgent.
 CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
 RETURNS SETOF gh.issue
 LANGUAGE sql
@@ -57,5 +72,10 @@ $$;
 ALTER FUNCTION gh.list_closed_issue_threads(INT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
+
+COMMENT ON FUNCTION gh.list_closed_issue_threads(INT) IS
+'Closed issues that still carry a discord_thread_id, ordered (owner,repo,number), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
+
+DROP INDEX IF EXISTS gh.issue_closed_thread_backfill_idx;
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/gh/gh_list_closed_threads.sql
+++ b/packages/data/sql/schema/gh/gh_list_closed_threads.sql
@@ -10,6 +10,14 @@
 -- new dbmate migration when ready. Depends on gh_core.sql.
 -- ============================================================================
 
+CREATE INDEX IF NOT EXISTS issue_closed_thread_backfill_idx
+    ON gh.issue (closed_at DESC NULLS LAST, owner, repo, number DESC)
+    WHERE state = 'closed'
+      AND discord_thread_id IS NOT NULL;
+
+-- NULL closed_at rows sort LAST (lowest reconcile priority), kept eligible not
+-- excluded. Index column order/direction mirrors the ORDER BY so the scan skips
+-- the sort.
 CREATE OR REPLACE FUNCTION gh.list_closed_issue_threads(p_limit INT DEFAULT 500)
 RETURNS SETOF gh.issue
 LANGUAGE sql

--- a/packages/data/sql/schema/gh/gh_list_closed_threads.sql
+++ b/packages/data/sql/schema/gh/gh_list_closed_threads.sql
@@ -23,7 +23,7 @@ AS $$
     FROM gh.issue
     WHERE state = 'closed'
       AND discord_thread_id IS NOT NULL
-    ORDER BY owner, repo, number
+    ORDER BY closed_at DESC NULLS LAST, owner, repo, number DESC
     LIMIT LEAST(GREATEST(p_limit, 1), 2000);
 $$;
 
@@ -32,6 +32,6 @@ REVOKE ALL ON FUNCTION gh.list_closed_issue_threads(INT) FROM PUBLIC, anon, auth
 GRANT EXECUTE ON FUNCTION gh.list_closed_issue_threads(INT) TO service_role;
 
 COMMENT ON FUNCTION gh.list_closed_issue_threads(INT) IS
-'Closed issues that still carry a discord_thread_id, ordered (owner,repo,number), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
+'Closed issues that still carry a discord_thread_id, most-recently-closed first (closed_at DESC), capped at 2000. Feeds the one-shot GH_SYNC_BACKFILL_ON_START sweep that archives/locks threads for issues closed before VS6 was live.';
 
 NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Problem
PR #14193 closed on GitHub but its Discord forum thread (`1527544855574614159`) stayed open. Two bugs in the GH→Discord thread lifecycle (`gh_sync.rs`), config was fine (0.1.27, `GH_SYNC_LOCK_ON_CLOSE=true`).

### Bug 1 — lock never lands
`set_thread_archived` archived the thread, then issued a **separate** `edit_thread` to add the lock. Discord rejects any edit to an already-archived thread, so every close logged:
```
gh sync: thread lifecycle step failed error=Thread is archived step="lock"
```
Threads ended up soft-archived (unlocked) → auto-reopen on any activity. Not a MANAGE_THREADS perms issue — the archive step itself succeeded.

**Fix:** archive + lock in one edit on the still-open thread (`.archived(true).locked(true)`).

### Bug 2 — backfill never reaches recent closes
`gh.list_closed_issue_threads` ordered `(owner,repo,number)` ASC + cap 1000. `kbve/kbve` has thousands of closed rows → the cap is exhausted on the OLDEST numbers, so recent closes (#14193, high number) are never reconciled (`backfill hit cap cap=1000`).

**Fix:** new migration `20260719000000_gh_list_closed_threads_recent_first.sql` reorders `closed_at DESC NULLS LAST` (+ schema mirror updated).

## Ship order
1. Apply migration via ci-dbmate-deploy **before** the new bot image (backfill calls the RPC).
2. Bot image bump (CI publish on main + ArgoCD) picks up the lock fix.
3. UNSET `GH_SYNC_BACKFILL_ON_START` after one converged run so restarts stop re-sweeping.

## Verification
- `cargo check -p discordsh-bot` clean (0 errors; warnings pre-existing dead-code).
- Prod DB read blocked by policy — root cause confirmed from bot logs + code, not a DB dump.

Docs: https://kbve.com/