### PR TITLE
feat(kbve-nx): proto route, retire ci-dashboard proto_drift

### DIFF
--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -142,6 +142,15 @@ jobs:
                   pip install pip-audit
                   echo "pip-audit installed: $(pip-audit --version)"
 
+            - name: Install protoc
+              if: contains(matrix.needs, 'protoc')
+              run: |
+                  set -euo pipefail
+                  PROTOC_VERSION=29.5
+                  curl -sLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+                  sudo unzip -o "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local
+                  protoc --version
+
             - name: Build route ${{ matrix.route }}
               working-directory: packages/python/kbve
               env:

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -753,98 +753,13 @@ jobs:
                       apps/kbve/astro-kbve/src/data/nx-kanban.json
                       apps/kbve/astro-kbve/public/data/nx/nx-kanban.json
 
-    # ══════════════════════════════════════════════════════════
-    # Job 4: Proto Drift Check (regenerate schemas, verify no drift)
-    # ══════════════════════════════════════════════════════════
-    proto_drift:
-        name: Proto Drift Check
-        needs: guard
-        if: needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        permissions:
-            contents: read
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v7
-              with:
-                  ref: dev
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Install protoc
-              run: |
-                  PROTOC_VERSION=29.5
-                  curl -sLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
-                  sudo unzip -o "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local
-                  protoc --version
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
-              with:
-                  version: 10.33.0
-                  run_install: false
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Regenerate all proto schemas
-              run: npx tsx packages/data/codegen/gen-all.mjs
-
-            - name: Format generated schemas
-              run: npx prettier --write 'packages/data/codegen/generated/*.ts'
-
-            - name: Generate proto registry
-              run: npx tsx packages/data/codegen/generate-proto-registry.mjs > /tmp/nx-proto.json
-
-            - name: Check for drift
-              id: drift
-              run: |
-                  DRIFT="false"
-                  DRIFT_FILES=""
-                  if git diff -- packages/data/codegen/generated/ | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -v '^\s*[+-]\s*\* Generated:' | grep -q '^[+-]'; then
-                    echo "::error::Proto drift detected! Generated schemas differ from committed versions. Run: npx tsx packages/data/codegen/gen-all.mjs"
-                    DRIFT="true"
-                    DRIFT_FILES=$(git diff --name-only -- packages/data/codegen/generated/ | tr '\n' ', ')
-                    git diff --stat -- packages/data/codegen/generated/
-                  else
-                    echo "No drift detected — generated schemas match committed versions"
-                  fi
-                  echo "drift=$DRIFT" >> "$GITHUB_OUTPUT"
-                  echo "drift_files=$DRIFT_FILES" >> "$GITHUB_OUTPUT"
-
-            - name: Build proto dashboard JSON
-              run: |
-                  set -euo pipefail
-                  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  DEST="apps/kbve/astro-kbve/public/data/nx/nx-proto.json"
-                  mkdir -p "$(dirname "$DEST")"
-                  jq --arg ts "$TIMESTAMP" \
-                     --arg drift "${{ steps.drift.outputs.drift }}" \
-                     --arg drift_files "${{ steps.drift.outputs.drift_files }}" \
-                     '. + {checked_at: $ts, drift_detected: ($drift == "true"), drift_files: ($drift_files | split(",") | map(select(. != "")))}' \
-                     /tmp/nx-proto.json > "$DEST"
-                  echo "Proto dashboard JSON written ($(wc -c < "$DEST" | xargs) bytes)"
-
-            - name: Upload proto artifacts
-              if: always()
-              uses: actions/upload-artifact@v7
-              with:
-                  name: dashboard-proto
-                  retention-days: 1
-                  path: |
-                      apps/kbve/astro-kbve/public/data/nx/nx-proto.json
 
     # ══════════════════════════════════════════════════════════
     # Job 5: Commit & PR (collects all artifacts, single PR)
     # ══════════════════════════════════════════════════════════
     commit:
         name: Commit & PR
-        needs: [guard, report, kanban, proto_drift]
+        needs: [guard, report, kanban]
         if: always() && needs.guard.outputs.allowed == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -893,7 +808,6 @@ jobs:
                         kanban-data.mdx) DEST="apps/kbve/astro-kbve/src/content/docs/dashboard/kanban-data.mdx" ;;
                         nx-report.json)   DEST="apps/kbve/astro-kbve/public/data/nx/nx-report.json" ;;
                         nx-kanban.json)   DEST="apps/kbve/astro-kbve/src/data/nx-kanban.json" ;;
-                        nx-proto.json)    DEST="apps/kbve/astro-kbve/public/data/nx/nx-proto.json" ;;
                         *) echo "  SKIP: $BASENAME (unknown)"; continue ;;
                       esac
                       mkdir -p "$(dirname "$DEST")"
@@ -923,7 +837,6 @@ jobs:
                     apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx \
                     apps/kbve/astro-kbve/src/content/docs/dashboard/kanban-data.mdx \
                     apps/kbve/astro-kbve/public/data/nx/nx-report.json \
-                    apps/kbve/astro-kbve/public/data/nx/nx-proto.json \
                     apps/kbve/astro-kbve/src/data/nx-kanban.json \
                     apps/kbve/astro-kbve/public/data/nx/nx-kanban.json; do
                     if [ -f "$f" ]; then
@@ -1124,16 +1037,3 @@ jobs:
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             status: ${{ needs.kanban.result }}
 
-    track-proto-drift:
-        name: Track Proto Drift
-        if: always()
-        needs: [proto_drift]
-        permissions:
-            issues: write
-        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
-        with:
-            workflow_name: 'CI - Daily Dashboard'
-            job_name: 'Proto Drift Check'
-            run_id: ${{ github.run_id }}
-            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            status: ${{ needs.proto_drift.result }}

--- a/packages/python/kbve/kbve/nx/routes/__init__.py
+++ b/packages/python/kbve/kbve/nx/routes/__init__.py
@@ -3,3 +3,4 @@
 from . import journal  # noqa: F401
 from . import graph  # noqa: F401
 from . import security  # noqa: F401
+from . import proto  # noqa: F401

--- a/packages/python/kbve/kbve/nx/routes/proto.py
+++ b/packages/python/kbve/kbve/nx/routes/proto.py
@@ -1,0 +1,124 @@
+"""The ``proto`` route — proto schema registry + drift report (JSON only).
+
+Mirrors the ``ci-dashboard`` proto_drift job: regenerate the proto schemas,
+build the registry via the codegen ``.mjs`` scripts, detect drift against the
+committed generated sources, and merge the drift metadata into the registry
+JSON. No MDX — the output feeds the proto dashboard's client fetch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ..builder import BuildContext, BuildResult, PlanResult, repo_root_for
+from ..router import route
+
+_GEN_TIMEOUT = 300
+_GENERATED_DIR = "packages/data/codegen/generated"
+
+
+class ProtoAcquireError(Exception):
+    """Raised when the proto registry cannot be regenerated."""
+
+
+def _warn(msg: str) -> None:
+    print("::warning::proto route: %s" % msg, file=sys.stderr)
+
+
+def _run(cmd: list[str], cwd: Path, timeout: int = _GEN_TIMEOUT) -> str:
+    proc = subprocess.run(
+        cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout
+    )
+    if proc.returncode != 0:
+        raise ProtoAcquireError(
+            "%s failed (exit %d): %s"
+            % (" ".join(cmd), proc.returncode, proc.stderr.strip()[:300])
+        )
+    return proc.stdout
+
+
+def _detect_drift(repo_root: Path) -> dict:
+    """Diff the generated sources, ignoring the ``* Generated:`` timestamp."""
+    diff = subprocess.run(
+        ["git", "diff", "--", _GENERATED_DIR],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+    ).stdout
+    changed = False
+    for line in diff.splitlines():
+        if not line or line[0] not in "+-":
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        if line.lstrip("+-").strip().startswith("* Generated:"):
+            continue
+        changed = True
+        break
+    files: list[str] = []
+    if changed:
+        names = subprocess.run(
+            ["git", "diff", "--name-only", "--", _GENERATED_DIR],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        ).stdout
+        files = [f for f in names.splitlines() if f]
+    return {"detected": changed, "files": files}
+
+
+def _acquire(repo_root: Path) -> tuple[dict, dict]:
+    _run(["npx", "tsx", "packages/data/codegen/gen-all.mjs"], repo_root)
+    _run(
+        ["npx", "prettier", "--write", "%s/*.ts" % _GENERATED_DIR],
+        repo_root,
+    )
+    registry_json = _run(
+        ["npx", "tsx", "packages/data/codegen/generate-proto-registry.mjs"],
+        repo_root,
+    )
+    try:
+        registry = json.loads(registry_json)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ProtoAcquireError("registry output was not valid JSON (%s)" % exc)
+    return registry, _detect_drift(repo_root)
+
+
+@route("proto", "daily", needs=("node", "protoc"))
+class ProtoRoute:
+    def plan(self, ctx: BuildContext) -> PlanResult:
+        return PlanResult(
+            "proto", True, "regenerate (git-diff guard drops no-ops)", []
+        )
+
+    def build(self, ctx: BuildContext) -> BuildResult:
+        repo_root = repo_root_for(ctx.content_root)
+        registry = ctx.inputs.get("proto_registry")
+        drift = ctx.inputs.get("proto_drift")
+        if registry is None:
+            try:
+                registry, drift = _acquire(repo_root)
+            except (ProtoAcquireError, subprocess.TimeoutExpired, OSError) as exc:
+                _warn("%s — skipping proto regeneration" % exc)
+                return BuildResult("proto", [], True, "acquire failed: %s" % exc)
+        if drift is None:
+            drift = {"detected": False, "files": []}
+
+        data = dict(registry)
+        data["checked_at"] = ctx.timestamp
+        data["drift_detected"] = bool(drift.get("detected"))
+        data["drift_files"] = list(drift.get("files", []))
+
+        public_dir = Path(ctx.public_dir)
+        json_out = public_dir / "nx-proto.json"
+        if not ctx.dry_run:
+            public_dir.mkdir(parents=True, exist_ok=True)
+            with open(json_out, "w") as f:
+                json.dump(data, f, indent=2)
+
+        changed = [os.path.relpath(json_out, repo_root)]
+        return BuildResult("proto", changed, False, "generated")

--- a/packages/python/kbve/tests/test_nx_proto_route.py
+++ b/packages/python/kbve/tests/test_nx_proto_route.py
@@ -1,0 +1,58 @@
+"""Tests for the ``proto`` route (codegen subprocess bypassed via inputs)."""
+
+from __future__ import annotations
+
+import json
+
+from kbve.nx.builder import BuildContext
+from kbve.nx.router import get
+
+
+def _ctx(tmp_path, inputs):
+    content_root = tmp_path / "apps/kbve/astro-kbve/src/content/docs"
+    public_dir = tmp_path / "apps/kbve/astro-kbve/public/data/nx"
+    content_root.mkdir(parents=True)
+    # mark repo root so repo_root_for resolves cleanly
+    (tmp_path / "nx.json").write_text("{}")
+    return BuildContext(
+        content_root=content_root,
+        public_dir=public_dir,
+        timestamp="2026-07-19T00:00:00Z",
+        inputs=inputs,
+    )
+
+
+def test_proto_needs_tags():
+    assert get("proto").needs == ("node", "protoc")
+
+
+def test_proto_plan_needs_work(tmp_path):
+    assert get("proto").plan(_ctx(tmp_path, {})).needs_work is True
+
+
+def test_proto_build_merges_drift_metadata(tmp_path):
+    ctx = _ctx(
+        tmp_path,
+        {
+            "proto_registry": {"schemas": [{"name": "kbve"}], "count": 1},
+            "proto_drift": {"detected": True, "files": ["a.ts", "b.ts"]},
+        },
+    )
+    result = get("proto").build(ctx)
+    assert result.skipped is False
+
+    out = ctx.public_dir / "nx-proto.json"
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["count"] == 1
+    assert data["checked_at"] == "2026-07-19T00:00:00Z"
+    assert data["drift_detected"] is True
+    assert data["drift_files"] == ["a.ts", "b.ts"]
+
+
+def test_proto_build_defaults_no_drift(tmp_path):
+    ctx = _ctx(tmp_path, {"proto_registry": {"schemas": []}})
+    get("proto").build(ctx)
+    data = json.loads((ctx.public_dir / "nx-proto.json").read_text())
+    assert data["drift_detected"] is False
+    assert data["drift_files"] == []


### PR DESCRIPTION
Stage 1 of 3 finishing the ci-dashboard → router/builder migration (proto → report → kanban). Converts the **proto drift/registry** generator.

## Changes
- **`routes/proto.py`** — `@route('proto','daily',needs=('node','protoc'))`. `build` regenerates schemas (`gen-all.mjs` + prettier + `generate-proto-registry.mjs`), detects drift via `git diff` (ignoring the `Generated:` timestamp line), merges `checked_at`/`drift_detected`/`drift_files` into the registry, writes `public/data/nx/nx-proto.json`. `ctx.inputs` test seam (`proto_registry`/`proto_drift`); graceful skip + `::warning::` on codegen failure/timeout (mirrors graph route).
- **`ci-daily-content.yml` builder** — new **`protoc` capability tag** → a `contains(matrix.needs,'protoc')` install step. Data-driven, so future routes needing protoc require zero workflow edits.
- **`ci-dashboard.yml`** — remove the `proto_drift` job, `track-proto-drift`, and its `commit` job `needs`/copy-map/stage refs. `report` + `kanban` remain (stages 2–3).

## Verification
- **331 python tests** pass (4 new proto route tests).
- Router: `--route proto` → `{"route":"proto","needs":"node,protoc"}`.
- Both workflows YAML-valid + **actionlint `-S error` clean**; zero proto survivors in ci-dashboard; remaining jobs guard/report/kanban/commit/track-report/track-kanban intact.

## Note
nx-proto.json regenerates on the next `ci-daily-content` nightly (proto now runs in the daily matrix). report/kanban still generate in ci-dashboard until their stages land.