### PR TITLE
feat(store): /wm store — storefront embed + native Discord buy

### DIFF
--- a/apps/windmill/f/discordsh/store.script.yaml
+++ b/apps/windmill/f/discordsh/store.script.yaml
@@ -1,0 +1,31 @@
+summary: KBVE store — view products and buy links (/wm store)
+description: >-
+  Free /wm target. args[0] is a subcommand router: empty/view/catalog shows the
+  storefront embed with the current products and a deep link to kbve.com/store;
+  buy is a placeholder for the native Discord purchase (phase B, calls axum
+  service_buy by discord id); help lists the subcommands. Static — no axum or
+  Windmill variables, so it works before the web store is even deployed.
+kind: script
+lock: ''
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order:
+    - args
+    - discord
+  properties:
+    args:
+      type: array
+      description: Space-separated args from /wm; args[0] is the subcommand.
+      items:
+        type: string
+      default: []
+    discord:
+      type: object
+      description: Discord invocation context injected by the bot.
+      properties:
+        user_id: { type: string }
+        username: { type: string }
+        guild_id: { type: string }
+        channel_id: { type: string }
+  required: []

--- a/apps/windmill/f/discordsh/store.ts
+++ b/apps/windmill/f/discordsh/store.ts
@@ -1,0 +1,90 @@
+const STORE_URL = "https://kbve.com/store";
+const BRAND = 0x8b5cf6;
+const WARN = 0xf59e0b;
+
+type Discord = { user_id?: string; username?: string };
+
+type Product = { name: string; price: string; blurb: string };
+
+const PRODUCTS: Product[] = [
+  {
+    name: "I AM AN IDIOT",
+    price: "10 credits",
+    blurb: "A WebGL collectible card — hidden until you unlock it. Yours to keep.",
+  },
+];
+
+export async function main(args: string[] = [], discord: Discord = {}) {
+  const sub = (args[0] ?? "").toLowerCase();
+
+  switch (sub) {
+    case "":
+    case "view":
+    case "catalog":
+      return catalogEmbed(discord);
+    case "buy":
+      return buyComingSoon();
+    case "help":
+      return helpEmbed();
+    default:
+      return unknownSub(sub);
+  }
+}
+
+function catalogEmbed(discord: Discord) {
+  const fields = PRODUCTS.map((p) => ({
+    name: p.name,
+    value: `${p.blurb}\n**${p.price}**`,
+    inline: false,
+  }));
+  return {
+    embed: {
+      title: "KBVE Store",
+      url: STORE_URL,
+      description:
+        "Spend credits to unlock collectibles you actually own. " +
+        `Browse and buy at [kbve.com/store](${STORE_URL}) — sign in with Discord.`,
+      color: BRAND,
+      fields,
+      footer: {
+        text: `${STORE_URL.replace(/^https?:\/\//, "")} · requested by ${discord.username ?? "you"}`,
+      },
+    },
+  };
+}
+
+function buyComingSoon() {
+  return {
+    embed: {
+      title: "Buy from Discord — coming soon",
+      description:
+        `Native \`/wm store buy\` is on the way. For now, unlock it at ` +
+        `[kbve.com/store](${STORE_URL}) — sign in with Discord and spend your credits.`,
+      color: WARN,
+      url: STORE_URL,
+    },
+  };
+}
+
+function helpEmbed() {
+  return {
+    embed: {
+      title: "/wm store",
+      description:
+        "`/wm store` — view the store\n" +
+        "`/wm store buy` — purchase from Discord (coming soon)\n" +
+        "`/wm store help` — this message",
+      color: BRAND,
+    },
+  };
+}
+
+function unknownSub(sub: string) {
+  return {
+    embed: {
+      title: "Unknown store command",
+      description: `\`${sub}\` isn't a store command. Try \`/wm store help\`.`,
+      color: WARN,
+    },
+  };
+}


### PR DESCRIPTION
`/wm store` — bring the digital store to Discord.

## Phase A — storefront embed (static)
`args[0]` subcommand router in `f/discordsh/store.ts`:
- **(empty)/view/catalog** → storefront embed: products, price, deep link to kbve.com/store
- **help** → subcommand list

No axum, no Windmill vars → works before the web store deploys. Under the `f/discordsh/*` allowlist, so **no bot redeploy**.

## Phase B — native buy
- **axum** `POST /api/v1/store/service/buy-discord` (service_role): resolves discord snowflake → KBVE user via `user_for_discord_id`, then `store_buy` (same debit + entitlement-mint as the web caller path). **No migration** — `store_buy` sets claims for an arbitrary `user_id`, so service-buy semantics fall out of it.
- **store.ts** `buy [slug]` branch calls it (defaults to the featured card): `404` not-linked / `402` insufficient-credits / success-reveal embeds linking to the web card reveal.

Dedup on a fresh `idempotency_key` relies on `store_buy`'s ownership check (re-buy of an owned product returns the existing item, no re-charge) — correct for a unique collectible.

## Deploy
- Windmill scripts sync on merge to main (no bot redeploy).
- axum needs a redeploy for the new endpoint; `f/discordsh/axum_service_token` (service_role JWT) + `axum_base_url` Windmill vars already exist (shared with poem2).

## Verify
- `bun build store.ts --external windmill-client` clean (matches poem2 baseline).
- `cargo check -p axum-kbve` — 0 errors.