### PR TITLE
feat(dashboard): Cube analytics dashboard via RN-web charts + gated proxy

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroCubeDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroCubeDashboard.astro
@@ -1,0 +1,40 @@
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import ReactCubeDashRN from '@/components/rnweb/ReactCubeDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+---
+
+<BentoShell
+	id="cube-dashboard-wrapper"
+	eyebrow="Analytics"
+	heading="Cube semantic layer.">
+	<div class="svc-dash not-content">
+		<div class="svc-dash__stream not-content">
+			<ReactCubeDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactCubeDashRN>
+		</div>
+	</div>
+</BentoShell>
+
+<style>
+	.svc-dash {
+		padding: 1.5rem 1rem 3rem;
+	}
+
+	@media (min-width: 640px) {
+		.svc-dash {
+			padding-inline: 1.5rem;
+		}
+	}
+
+	.svc-dash__stream {
+		min-height: 60vh;
+	}
+
+	:global(@keyframes spin) {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactCubeDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactCubeDashRN.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { CubeView } from '@kbve/rn/dash';
+import { initSupa, getSupa } from '@/lib/supa';
+import { DASH_PROXY_BASE } from './dashProxyBase';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export default function ReactCubeDashRN() {
+	const token = useCallback(getToken, []);
+	return <CubeView getToken={token} baseUrl={DASH_PROXY_BASE} />;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/cube/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/cube/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Cube Analytics
+description: KBVE semantic-layer metrics over Postgres + ClickHouse
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+sidebar:
+    label: Cube
+    order: 6
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - analytics
+    - cube
+---
+
+import AstroCubeDashboard from '@/components/dashboard/AstroCubeDashboard.astro';
+
+<AstroCubeDashboard />

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -187,6 +187,12 @@ async fn main() -> anyhow::Result<()> {
         warn!("Forgejo proxy not configured (FORGEJO_UPSTREAM_URL not set)");
     }
 
+    if transport::proxy::init_cube_proxy() {
+        info!("Cube proxy initialized - /dashboard/cube/proxy enabled");
+    } else {
+        warn!("Cube proxy not configured (CUBE_API_TOKEN not set)");
+    }
+
     if transport::forgejo_api::init_forgejo_api() {
         info!("Forgejo typed API initialized - /dashboard/forgejo/api/* enabled");
     }

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -670,6 +670,14 @@ fn router(state: AppState) -> Router {
             any(super::proxy::clickhouse_logs_proxy_handler),
         )
         .route(
+            "/dashboard/cube/proxy/{*path}",
+            any(super::proxy::cube_proxy_handler),
+        )
+        .route(
+            "/dashboard/cube/proxy",
+            any(super::proxy::cube_proxy_handler),
+        )
+        .route(
             "/dashboard/forgejo/proxy/{*path}",
             any(super::proxy::forgejo_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy/simple.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/simple.rs
@@ -218,6 +218,29 @@ simple_proxy!(
     }
 );
 
+simple_proxy!(
+    CUBE,
+    CUBE_SPEC,
+    init_cube_proxy,
+    cube_proxy_handler,
+    ProxySpec {
+        name: "Cube",
+        upstream_env: "CUBE_UPSTREAM_URL",
+        upstream_default: Some("http://cube.cube.svc.cluster.local:4000"),
+        // The dashboard kit posts to /dashboard/cube/proxy/load, which forwards
+        // to <upstream>/cubejs-api/v1/load — Cube's REST load endpoint.
+        upstream_suffix: Some("/cubejs-api/v1"),
+        // Static long-lived Cube JWT (HS256, signed with CUBEJS_API_SECRET),
+        // injected as the upstream Bearer. Cube runs in production mode so a
+        // token is required.
+        token_env: Some("CUBE_API_TOKEN"),
+        ca_cert_env: None,
+        connect_timeout: Duration::from_secs(5),
+        timeout: Duration::from_secs(30),
+        gate: GateMode::View,
+    }
+);
+
 static FACTORIO: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_factorio_proxy() -> bool {

--- a/apps/kube/kbve/manifest/cube-credentials-sealed.yaml
+++ b/apps/kube/kbve/manifest/cube-credentials-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cube-credentials
+  namespace: kbve
+spec:
+  encryptedData:
+    api-token: AgA247Kdm/eV+8Cq8lniehPsfgbt5gpbGwp6o8LXlsSTMibNSZQhdLXupWzDqUJWN7NlTai9/zu3v+aiIzAGwklGgrZxpFTWioSWVrCduRLtMbPom2yVLN0ZkI5mxR4Ok190RcPlpvhQ05IaNuNBND2FNLsBVcB1wSqtaSxL3mY0IWRXeEefDbffv4fTJNGAQ/N+394TJds860a0dkR8NZEQKlOTJWJ7zA47b9vOiiUKfAaiQniUCPPmozK02fiQEd2jWImcZNPkznEDnBz85JxRLEYmWs+dKq7eKdQaetR3Dvdw0Ygk+aUPz/BQzBqSkDavh8VA0RVsCW37etSvTWTQ6YbCunhkwKPbVXGE6Ie1ObjfwpeSXmGlgxv/IxkI8WocsnxnPDsos4KSlFxoGxtD9KewqL607cp7vKu0wanGjaF8/XJq/lg6FBIQm/o79JNwgtJVVArTUIonIBTPXQz2yBiNGAe7XiGjHAXXImU7WgtKRYN0E+I2GmXnl3pGGm5kciofAdFOPyCfg3ZQy7wv/yxFT6MF3nL/JmEcZebHIy88eNoUzDnHUY6SOtIty4FfM4ghG35/tDPt3Fie8O+ngc5v4K+MQo2VsX3F1ieFJg0mIBIqte2+cQt03fQqhZsba9rfuiQDtOJvoNyqteYIWKgKVOTx8hf1Nq4Q+wNRJC3GFMsbqeoqpm9c2lOtfOy8mRFSwSHcW9fAZ48SmZI/0nea0/ddj1nujwbj3RbjWks4O8rSXUq7g7uKqtzS3u0SqwE/+NCi30KPWr8MHMxVpAGTTYiBggIM0I/SQRq3sZkVOt1FmLv4vR9Zzzoc3Q37U2wzWJBs3oNmJ6z96vKpW1kZTtAsd24Nt2wLi2J3R5rBNw==
+  template:
+    metadata:
+      name: cube-credentials
+      namespace: kbve

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
         kbve.com/managed-by: argocd
     annotations:
         configmap.reloader.stakater.com/reload: kube-root-ca.crt
-        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials,vibeshine-config
+        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials,vibeshine-config,cube-credentials
 spec:
     replicas: 1
     strategy:
@@ -113,6 +113,13 @@ spec:
                         valueFrom:
                             secretKeyRef:
                                 name: forgejo-deploy-keys
+                                key: api-token
+                      - name: CUBE_UPSTREAM_URL
+                        value: http://cube.cube.svc.cluster.local:4000
+                      - name: CUBE_API_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: cube-credentials
                                 key: api-token
                       - name: KUBEVIRT_API_URL
                         value: https://kubernetes.default.svc

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
     - kilobase-s3-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - vibeshine-sealedsecret.yaml
+    - cube-credentials-sealed.yaml
     - kbve-internal-ca-cert.yaml
     - kbve-wt-cert.yaml
     - direct-git-cert.yaml

--- a/packages/npm/rn/src/dash/adapters/cube.tsx
+++ b/packages/npm/rn/src/dash/adapters/cube.tsx
@@ -1,0 +1,80 @@
+// Transforms Cube `/v1/load` rows into the dash kit's chart + stat models.
+// Row keys are Cube's flattened `cube.member` / `cube.timeDim.granularity`
+// identifiers (e.g. `ch_logs.count`, `ch_logs.timestamp.day`).
+
+import { tokens } from '../_ui';
+import type { TrendSeries } from '../TrendChart';
+import type { StatModel } from '../types';
+import type { CubeRow } from '../cube/cubeApi';
+import { fmtInt } from '../cube/cubeApi';
+
+const num = (v: unknown): number => {
+	const n = Number(v ?? 0);
+	return Number.isFinite(n) ? n : 0;
+};
+
+const ms = (v: unknown): number => {
+	const t = new Date(String(v)).getTime();
+	return Number.isFinite(t) ? t : 0;
+};
+
+const LEVEL_COLOR: Record<string, string> = {
+	error: tokens.color.danger,
+	warn: tokens.color.warning,
+	warning: tokens.color.warning,
+	info: tokens.color.primary,
+	debug: tokens.color.textMuted,
+};
+
+/** `ch_logs.count` by day, one series per `ch_logs.level`. */
+export function logsByDayToSeries(rows: CubeRow[]): TrendSeries[] {
+	const byLevel = new Map<string, { t: number; v: number }[]>();
+	for (const r of rows) {
+		const level = String(r['ch_logs.level'] ?? 'other').toLowerCase();
+		const t = ms(r['ch_logs.timestamp.day'] ?? r['ch_logs.timestamp']);
+		if (!t) continue;
+		const arr = byLevel.get(level) ?? [];
+		arr.push({ t, v: num(r['ch_logs.count']) });
+		byLevel.set(level, arr);
+	}
+	return [...byLevel.entries()]
+		.map(([level, points]) => ({
+			label: level,
+			color: LEVEL_COLOR[level] ?? tokens.color.textMuted,
+			points: points.sort((a, b) => a.t - b.t),
+		}))
+		.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/** `pg_users.count` by month as a single signups series. */
+export function signupsToSeries(rows: CubeRow[]): TrendSeries[] {
+	const points = rows
+		.map((r) => ({
+			t: ms(r['pg_users.created_at.month'] ?? r['pg_users.created_at']),
+			v: num(r['pg_users.count']),
+		}))
+		.filter((p) => p.t)
+		.sort((a, b) => a.t - b.t);
+	return points.length
+		? [{ label: 'signups', color: tokens.color.success, points }]
+		: [];
+}
+
+/** Flat stat tiles: total logs, error logs, total users. */
+export function buildCubeStats(logs: CubeRow[], signups: CubeRow[]): StatModel[] {
+	let total = 0;
+	let errors = 0;
+	for (const r of logs) {
+		const c = num(r['ch_logs.count']);
+		total += c;
+		if (String(r['ch_logs.level'] ?? '').toLowerCase() === 'error') {
+			errors += c;
+		}
+	}
+	const users = signups.reduce((a, r) => a + num(r['pg_users.count']), 0);
+	return [
+		{ id: 'logs', label: 'Total logs', value: fmtInt(total), tone: 'primary' },
+		{ id: 'errors', label: 'Errors', value: fmtInt(errors), tone: 'danger' },
+		{ id: 'users', label: 'Users', value: fmtInt(users), tone: 'success' },
+	];
+}

--- a/packages/npm/rn/src/dash/cube/CubeView.tsx
+++ b/packages/npm/rn/src/dash/cube/CubeView.tsx
@@ -1,0 +1,115 @@
+// Cube semantic-layer dashboard: live log-volume + signup trends over the
+// Cube REST API, rendered with the shared TrendChart + StatGrid primitives.
+// Polls on an interval (default 30s) so the graphs update with live data.
+
+import { useEffect, useMemo, useState } from 'react';
+import { Stack, Text } from '../_ui';
+import { TrendChart } from '../TrendChart';
+import { StatGrid } from '../StatGrid';
+import { cubeLoad, fmtInt } from './cubeApi';
+import {
+	buildCubeStats,
+	logsByDayToSeries,
+	signupsToSeries,
+} from '../adapters/cube';
+import type { CubeRow } from './cubeApi';
+
+export interface CubeViewProps {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	/** Poll interval in ms. Defaults to 30s. */
+	pollMs?: number;
+}
+
+export function CubeView({ getToken, baseUrl = '', pollMs = 30_000 }: CubeViewProps) {
+	const [logs, setLogs] = useState<CubeRow[]>([]);
+	const [signups, setSignups] = useState<CubeRow[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let active = true;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const ctrl = new AbortController();
+
+		async function tick() {
+			try {
+				const token = await getToken();
+				const [l, s] = await Promise.all([
+					cubeLoad(
+						baseUrl,
+						token,
+						{
+							measures: ['ch_logs.count'],
+							dimensions: ['ch_logs.level'],
+							timeDimensions: [
+								{ dimension: 'ch_logs.timestamp', granularity: 'day' },
+							],
+							order: { 'ch_logs.timestamp': 'asc' },
+						},
+						ctrl.signal,
+					),
+					cubeLoad(
+						baseUrl,
+						token,
+						{
+							measures: ['pg_users.count'],
+							timeDimensions: [
+								{ dimension: 'pg_users.created_at', granularity: 'month' },
+							],
+							order: { 'pg_users.created_at': 'asc' },
+						},
+						ctrl.signal,
+					),
+				]);
+				if (!active) return;
+				setLogs(l);
+				setSignups(s);
+				setError(null);
+				setLoading(false);
+			} catch (e) {
+				if (!active || (e as Error).name === 'AbortError') return;
+				setError((e as Error).message);
+				setLoading(false);
+			} finally {
+				if (active) timer = setTimeout(tick, pollMs);
+			}
+		}
+
+		tick();
+		return () => {
+			active = false;
+			ctrl.abort();
+			if (timer) clearTimeout(timer);
+		};
+	}, [getToken, baseUrl, pollMs]);
+
+	const logSeries = useMemo(() => logsByDayToSeries(logs), [logs]);
+	const signupSeries = useMemo(() => signupsToSeries(signups), [signups]);
+	const stats = useMemo(() => buildCubeStats(logs, signups), [logs, signups]);
+
+	return (
+		<Stack gap="md">
+			{error ? (
+				<Text tone="muted">Cube error: {error}</Text>
+			) : loading ? (
+				<Text tone="muted">Loading Cube metrics…</Text>
+			) : null}
+			<StatGrid stats={stats} />
+			<TrendChart
+				title="Log volume by level · per day"
+				series={logSeries}
+				format={fmtInt}
+				zeroFloor
+				height={200}
+			/>
+			<TrendChart
+				title="User signups · per month"
+				series={signupSeries}
+				format={fmtInt}
+				zeroFloor
+				height={180}
+			/>
+		</Stack>
+	);
+}

--- a/packages/npm/rn/src/dash/cube/cubeApi.ts
+++ b/packages/npm/rn/src/dash/cube/cubeApi.ts
@@ -1,0 +1,48 @@
+// Thin client for Cube's REST `/v1/load`, reached through the staff-gated
+// axum-kbve proxy at `/dashboard/cube/proxy`. The proxy injects the upstream
+// Cube JWT server-side; the browser only carries its supabase session token.
+
+const PROXY = '/dashboard/cube/proxy/load';
+
+export interface CubeTimeDimension {
+	dimension: string;
+	granularity?: 'day' | 'week' | 'month' | 'hour';
+	dateRange?: string | [string, string];
+}
+
+export interface CubeQuery {
+	measures?: string[];
+	dimensions?: string[];
+	timeDimensions?: CubeTimeDimension[];
+	order?: Record<string, 'asc' | 'desc'>;
+	limit?: number;
+}
+
+export type CubeRow = Record<string, unknown>;
+
+export async function cubeLoad(
+	baseUrl: string,
+	token: string | null,
+	query: CubeQuery,
+	signal?: AbortSignal,
+): Promise<CubeRow[]> {
+	const res = await fetch(`${baseUrl}${PROXY}`, {
+		method: 'POST',
+		headers: {
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ query }),
+		signal,
+	});
+	if (res.status === 403) throw new Error('Access restricted');
+	if (!res.ok) throw new Error(`Cube API error: ${res.status}`);
+	const json = (await res.json()) as { data?: CubeRow[] };
+	return json?.data ?? [];
+}
+
+export function fmtInt(v: number): string {
+	if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+	if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+	return String(Math.round(v));
+}

--- a/packages/npm/rn/src/dash/cube/index.ts
+++ b/packages/npm/rn/src/dash/cube/index.ts
@@ -1,0 +1,4 @@
+export { CubeView } from './CubeView';
+export type { CubeViewProps } from './CubeView';
+export { cubeLoad, fmtInt } from './cubeApi';
+export type { CubeQuery, CubeRow, CubeTimeDimension } from './cubeApi';

--- a/packages/npm/rn/src/dash/index.ts
+++ b/packages/npm/rn/src/dash/index.ts
@@ -20,6 +20,8 @@ export * from './adapters/factorio';
 export * from './adapters/minecraft';
 export * from './adapters/kilobaseBackup';
 export * from './clickhouse';
+export * from './adapters/cube';
+export * from './cube';
 export * from './S3BackupPanel';
 export { McView, ServerCard, RconConsole, createRconExec } from './mc';
 export type { McViewProps, RconExecFn } from './mc';


### PR DESCRIPTION
## Cube dashboard — own RN-Web/Native charts over the Cube semantic layer

Instead of Metabase (its app DB can't safely live in a non-public schema — Liquibase splits tables), this reuses the existing dashboard pattern: our own `@kbve/rn/dash` charts fed by Cube's REST API through the staff-gated `axum-kbve` proxy. No BI server, no app DB, gated identically to `/dashboard/grafana` and `/dashboard/clickhouse`. Runs on web now, Expo native later.

### 5 layers (all mirror the ClickHouse dashboard)
1. **Rust proxy** — Cube added as a `simple_proxy!` target in `axum-kbve` (`/dashboard/cube/proxy` → `cube.cube.svc:4000/cubejs-api/v1`, `DASHBOARD_VIEW` gate). Injects a static Cube JWT server-side (`CUBE_API_TOKEN`); the browser only carries its supabase token.
2. **Deploy** — `CUBE_UPSTREAM_URL` + `CUBE_API_TOKEN` env on the kbve deployment; sealed `cube-credentials` (long-lived Cube JWT signed with the Cube api-secret); reloader tracks it.
3. **Kit** — `dash/cube/{CubeView,cubeApi}` + `adapters/cube`: polls Cube REST (30s) and renders `TrendChart` (log volume by level/day, signups by month) + `StatGrid` (total logs, errors, users). Reuses the shared primitives.
4. **Astro** — `ReactCubeDashRN` + `AstroCubeDashboard` + `/dashboard/cube/` page.

### Live data
The kit polls on an interval → graphs update live off Cube's pre-agg cache. Cube serves `ch_logs` from a Cube Store rollup (verified in-cluster earlier).

### Validation
YAML/kustomize + Rust name-consistency verified locally; the worktree has no node_modules and a cold cargo check compiles the whole tree, so **CI runs the TS typecheck + rust build**. The Rust change is a faithful mirror of the existing Grafana/Forgejo simple targets.

### Notes
- First views: logs trend + signups + stat row. More cubes = add queries to `CubeView`.
- Uses Cube's REST API (not SQL API) — nothing extra to enable on the Cube deployment.
