### PR TITLE
feat(kbve-nx): report route (bento), retire ci-dashboard report job

### DIFF
--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -68,6 +68,8 @@ jobs:
         needs: router
         if: needs.router.outputs.has_work == 'true'
         runs-on: ubuntu-latest
+        # report runs `nx run-many -t coverage` across several projects — slow.
+        timeout-minutes: 120
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.router.outputs.matrix) }}

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -54,264 +54,6 @@ jobs:
                       }
 
     # ══════════════════════════════════════════════════════════
-    # Job 2: NX Report (versions, LOC, coverage, deps)
-    # ══════════════════════════════════════════════════════════
-    report:
-        name: NX Report
-        needs: guard
-        if: needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
-        timeout-minutes: 120
-        permissions:
-            contents: read
-
-        steps:
-            - name: Audit log
-              run: |
-                  echo "::notice::Dashboard report: actor=${{ github.actor }}, event=${{ github.event_name }}, run=${{ github.run_id }}, time=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-            - name: Checkout dev branch
-              uses: actions/checkout@v7
-              with:
-                  ref: dev
-                  fetch-depth: 1
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
-              with:
-                  version: 10.33.0
-                  run_install: false
-
-            - name: Get pnpm Store Path
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v6
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Setup Nx Cache
-              uses: actions/cache@v6
-              with:
-                  path: .nx/cache
-                  key: ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
-                  restore-keys: |
-                      ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-
-                      ${{ runner.os }}-nx-
-
-            - name: Generate NX Report
-              id: nx-report
-              run: |
-                  set -euo pipefail
-                  pnpm nx report 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > /tmp/nx-report-raw.txt || true
-                  echo "report_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
-                  echo "report_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-
-            - name: Validate NX Report output
-              run: |
-                  set -euo pipefail
-                  if [ ! -s /tmp/nx-report-raw.txt ]; then
-                    echo "::error::NX report output is empty"
-                    exit 1
-                  fi
-                  echo "NX report validated ($(wc -l < /tmp/nx-report-raw.txt) lines)"
-
-            - name: Install scc
-              run: |
-                  set -euo pipefail
-                  if command -v scc &>/dev/null; then
-                    echo "scc already installed: $(scc --version)"
-                  else
-                    SCC_VERSION="3.5.0"
-                    curl -fsSL "https://github.com/boyter/scc/releases/download/v${SCC_VERSION}/scc_Linux_x86_64.tar.gz" \
-                      | tar xz -C /usr/local/bin scc
-                    chmod +x /usr/local/bin/scc
-                    echo "scc installed: $(scc --version)"
-                  fi
-
-            - name: Generate LOC Stats
-              run: |
-                  set -euo pipefail
-                  scc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres --no-cocomo 2>&1 \
-                    | sed 's/\x1b\[[0-9;]*m//g' > /tmp/loc-stats.txt \
-                    || npx --yes cloc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres 2>&1 \
-                      > /tmp/loc-stats.txt
-                  echo "LOC stats generated ($(wc -l < /tmp/loc-stats.txt) lines)"
-
-            - name: Run Coverage for npm packages
-              run: |
-                  set -euo pipefail
-                  pnpm nx run-many -t coverage --projects=droid,devops,khashvault,laser 2>&1 \
-                    | sed 's/\x1b\[[0-9;]*m//g' > /tmp/coverage-report.txt || true
-                  echo "Coverage report generated ($(wc -l < /tmp/coverage-report.txt) lines)"
-
-            - name: Build NX Report MDX
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  REPORT_DATE="${{ steps.nx-report.outputs.report_date }}"
-                  REPORT_TIMESTAMP="${{ steps.nx-report.outputs.report_timestamp }}"
-                  DEST="apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx"
-                  mkdir -p "$(dirname "$DEST")"
-
-                  NODE_VER=$(grep "^Node" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-                  OS_INFO=$(grep "^OS" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-                  NX_VER=$(grep "^nx " /tmp/nx-report-raw.txt | awk '{print $NF}' | xargs)
-                  PNPM_VER=$(grep "^pnpm" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-
-                  {
-                    printf '%s\n' '---'
-                    printf '%s\n' 'title: NX Workspace Report'
-                    printf '%s\n' 'description: |'
-                    printf '%s\n' '    Daily auto-generated NX workspace report for the KBVE monorepo.'
-                    printf '%s\n' 'sidebar:'
-                    printf '%s\n' '    label: Report'
-                    printf '%s\n' '    order: 100'
-                    printf '%s\n' 'editUrl: false'
-                    printf '%s\n' '---'
-                    printf '\n'
-                    printf '%s\n' "import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';"
-                    printf '%s\n' "import AstroNxReport from '@/components/dashboard/AstroNxReport.astro';"
-                    printf '\n'
-                    printf '%s\n' "## NX Workspace Report"
-                    printf '\n'
-                    printf '%s\n' ":::note[Auto-generated]"
-                    printf '%s\n' "Last generated: **${REPORT_TIMESTAMP}** — updated daily by \`ci-dashboard\`."
-                    printf '%s\n' ":::"
-                    printf '\n'
-                    printf '%s\n' "### Environment"
-                    printf '\n'
-                    printf '%s\n' "<CardGrid>"
-                    printf '%s\n' "  <Card title=\"Node\" icon=\"seti:nodejs\">"
-                    printf '%s\n' "    ${NODE_VER}"
-                    printf '%s\n' "  </Card>"
-                    printf '%s\n' "  <Card title=\"Nx\" icon=\"setting\">"
-                    printf '%s\n' "    ${NX_VER}"
-                    printf '%s\n' "  </Card>"
-                    printf '%s\n' "  <Card title=\"pnpm\" icon=\"rocket\">"
-                    printf '%s\n' "    ${PNPM_VER}"
-                    printf '%s\n' "  </Card>"
-                    printf '%s\n' "  <Card title=\"OS\" icon=\"linux\">"
-                    printf '%s\n' "    ${OS_INFO}"
-                    printf '%s\n' "  </Card>"
-                    printf '%s\n' "</CardGrid>"
-                    printf '\n'
-                    printf '%s\n' "<AstroNxReport />"
-                    printf '\n'
-                    printf '%s\n' "### Raw output"
-                    printf '\n'
-                    printf '%s\n' "<Tabs>"
-                    printf '%s\n' '  <TabItem label="NX Report">'
-                    printf '\n'
-                    printf '%s\n' '```'
-                    cat /tmp/nx-report-raw.txt
-                    printf '%s\n' '```'
-                    printf '\n'
-                    printf '%s\n' '  </TabItem>'
-                    printf '%s\n' '  <TabItem label="LOC Statistics">'
-                    printf '\n'
-                    printf '%s\n' '```'
-                    cat /tmp/loc-stats.txt
-                    printf '%s\n' '```'
-                    printf '\n'
-                    printf '%s\n' '  </TabItem>'
-                    if [ -s /tmp/coverage-report.txt ]; then
-                      printf '%s\n' '  <TabItem label="Coverage">'
-                      printf '\n'
-                      printf '%s\n' '```'
-                      sed 's/<\([/a-zA-Z]\)/\&lt;\1/g' /tmp/coverage-report.txt
-                      echo ""
-                      printf '%s\n' '```'
-                      printf '\n'
-                      printf '%s\n' '  </TabItem>'
-                    fi
-                    printf '%s\n' '</Tabs>'
-                    printf '\n'
-                    printf '%s\n' '---'
-                    printf '\n'
-                    printf '%s\n' '*Auto-generated by [ci-dashboard.yml](https://github.com/KBVE/kbve/actions/workflows/ci-dashboard.yml)*'
-                  } > "$DEST"
-
-            - name: Build NX Report JSON
-              run: |
-                  set -euo pipefail
-                  REPORT_TIMESTAMP="${{ steps.nx-report.outputs.report_timestamp }}"
-                  DEST="apps/kbve/astro-kbve/public/data/nx/nx-report.json"
-                  mkdir -p "$(dirname "$DEST")"
-
-                  NODE_VER=$(grep "^Node" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-                  OS_INFO=$(grep "^OS" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-                  NX_VER=$(grep "^nx " /tmp/nx-report-raw.txt | awk '{print $NF}' | xargs)
-                  PNPM_VER=$(grep "^pnpm" /tmp/nx-report-raw.txt | awk -F: '{print $2}' | xargs)
-
-                  LOC_STATS=$(cat /tmp/loc-stats.txt)
-                  COVERAGE=""
-                  if [ -s /tmp/coverage-report.txt ]; then
-                    COVERAGE=$(cat /tmp/coverage-report.txt)
-                  fi
-
-                  python3 -c "
-                  import json, sys
-                  report = {
-                      'generated_at': sys.argv[1],
-                      'environment': {
-                          'node': sys.argv[2],
-                          'nx': sys.argv[3],
-                          'pnpm': sys.argv[4],
-                          'os': sys.argv[5],
-                      },
-                      'nx_report': open('/tmp/nx-report-raw.txt').read(),
-                      'loc_stats': sys.argv[6],
-                      'coverage': sys.argv[7] if sys.argv[7] else None,
-                  }
-                  json.dump(report, open(sys.argv[8], 'w'), indent=2)
-                  " "$REPORT_TIMESTAMP" "$NODE_VER" "$NX_VER" "$PNPM_VER" "$OS_INFO" \
-                    "$LOC_STATS" "$COVERAGE" "$DEST"
-
-                  echo "NX report JSON written ($(wc -c < "$DEST" | xargs) bytes)"
-
-            - name: Validate generated MDX files
-              run: |
-                  set -euo pipefail
-                  REPORT="apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx"
-
-                  if [ ! -s "$REPORT" ]; then
-                    echo "::error::Generated file is empty: $REPORT"
-                    exit 1
-                  fi
-                  if ! head -1 "$REPORT" | grep -q '^---$'; then
-                    echo "::error::Missing YAML frontmatter in $REPORT"
-                    exit 1
-                  fi
-                  echo "OK: $REPORT ($(wc -c < "$REPORT" | xargs) bytes)"
-
-            - name: Upload report artifacts
-              uses: actions/upload-artifact@v7
-              with:
-                  name: dashboard-report
-                  retention-days: 1
-                  path: |
-                      apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx
-                      apps/kbve/astro-kbve/public/data/nx/nx-report.json
-
-            - name: Cleanup
-              if: always()
-              run: |
-                  rm -f /tmp/nx-report-raw.txt /tmp/loc-stats.txt /tmp/coverage-report.txt
-
-    # ══════════════════════════════════════════════════════════
     # Job 3: Kanban Sync (GitHub Projects v2)
     # ══════════════════════════════════════════════════════════
     kanban:
@@ -759,7 +501,7 @@ jobs:
     # ══════════════════════════════════════════════════════════
     commit:
         name: Commit & PR
-        needs: [guard, report, kanban]
+        needs: [guard, kanban]
         if: always() && needs.guard.outputs.allowed == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -804,9 +546,7 @@ jobs:
                       # Artifact path was stripped — match by filename
                       BASENAME="$(basename "$f")"
                       case "$BASENAME" in
-                        report.mdx)   DEST="apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx" ;;
                         kanban-data.mdx) DEST="apps/kbve/astro-kbve/src/content/docs/dashboard/kanban-data.mdx" ;;
-                        nx-report.json)   DEST="apps/kbve/astro-kbve/public/data/nx/nx-report.json" ;;
                         nx-kanban.json)   DEST="apps/kbve/astro-kbve/src/data/nx-kanban.json" ;;
                         *) echo "  SKIP: $BASENAME (unknown)"; continue ;;
                       esac
@@ -822,7 +562,7 @@ jobs:
               run: |
                   set -euo pipefail
                   DASHBOARD="apps/kbve/astro-kbve/src/content/docs/dashboard"
-                  for old in nx-report.mdx nx-kanban.mdx; do
+                  for old in nx-kanban.mdx; do
                     if [ -f "$DASHBOARD/$old" ]; then
                       git rm "$DASHBOARD/$old" 2>/dev/null || rm -f "$DASHBOARD/$old"
                       echo "Removed old $old"
@@ -834,9 +574,7 @@ jobs:
                   set -euo pipefail
                   STAGED=0
                   for f in \
-                    apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx \
                     apps/kbve/astro-kbve/src/content/docs/dashboard/kanban-data.mdx \
-                    apps/kbve/astro-kbve/public/data/nx/nx-report.json \
                     apps/kbve/astro-kbve/src/data/nx-kanban.json \
                     apps/kbve/astro-kbve/public/data/nx/nx-kanban.json; do
                     if [ -f "$f" ]; then
@@ -898,16 +636,14 @@ jobs:
                     --title "chore(dashboard): daily sync — ${REPORT_DATE}" \
                     --body "$(cat <<'PRBODY'
                   ## Summary
-                  - Daily consolidated dashboard sync: NX report, kanban board
-                  - Report: NX environment, LOC stats, coverage
+                  - Daily consolidated dashboard sync: kanban board
                   - Kanban: project board snapshot with pipeline flow diagrams
 
                   ## Content
-                  - `dashboard/report.mdx` — NX workspace report
                   - `dashboard/kanban-data.mdx` — project board static data snapshot
 
                   ## Test plan
-                  - Verify all dashboard pages render at `/dashboard/{report,kanban}/`
+                  - Verify all dashboard pages render at `/dashboard/{kanban}/`
                   - Check mermaid diagrams render correctly
                   - Verify JSON data files are valid
 
@@ -1009,20 +745,6 @@ jobs:
                       }
 
     # ── Failure tracker ──────────────────────────────────────
-    track-report:
-        name: Track Report Job
-        if: always()
-        needs: [report]
-        permissions:
-            issues: write
-        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
-        with:
-            workflow_name: 'CI - Daily Dashboard'
-            job_name: 'NX Report'
-            run_id: ${{ github.run_id }}
-            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            status: ${{ needs.report.result }}
-
     track-kanban:
         name: Track Kanban Job
         if: always()

--- a/apps/kbve/astro-kbve/public/data/nx/nx-report.json
+++ b/apps/kbve/astro-kbve/public/data/nx/nx-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-19T09:55:46Z",
+  "generated_at": "2026-07-19T00:00:00Z",
   "environment": {
     "node": "24.18.0",
     "nx": "23.0.2",

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx
@@ -2,44 +2,91 @@
 title: NX Workspace Report
 description: |
     Daily auto-generated NX workspace report for the KBVE monorepo.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
 sidebar:
     label: Report
     order: 100
-editUrl: false
 ---
 
-import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
 import AstroNxReport from '@/components/dashboard/AstroNxReport.astro';
 
-## NX Workspace Report
+<div class="nx-report" data-dash-report>
 
-:::note[Auto-generated]
-Last generated: **2026-07-19T09:55:46Z** — updated daily by `ci-dashboard`.
-:::
+<section class="bento-hero bento-section not-content" aria-label="NX workspace report">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5" /></svg>
+					<span>auto-generated · daily</span>
+				</span>
+				<h1 class="bento-title">
+					NX workspace
+					<span class="bento-title__accent">report.</span>
+				</h1>
+				<p class="bento-lede">Node <strong>24.18.0</strong> · Nx <strong>23.0.2</strong> · pnpm <strong>10.33.0</strong> on <strong>linux-x64</strong>.</p>
+				<p class="bento-lede">Last generated <strong>2026-07-19T00:00:00Z</strong>.</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#insights">
+						View insights
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#raw">Raw output</a>
+					<a class="bento-btn bento-btn--ghost" href="/dashboard/">Dashboard home</a>
+				</div>
+			</div>
 
-### Environment
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96 12 12.01l8.73-5.05M12 22.08V12" /></svg>
+					</span>
+					<span class="bento-stat__value">24.18.0</span>
+					<span class="bento-stat__label">Node</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+					</span>
+					<span class="bento-stat__value">23.0.2</span>
+					<span class="bento-stat__label">Nx</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5" /></svg>
+					</span>
+					<span class="bento-stat__value">10.33.0</span>
+					<span class="bento-stat__label">pnpm</span>
+				</div>
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h20v14H2zM8 21h8M12 17v4" /></svg>
+					</span>
+					<span class="bento-stat__value">linux-x64</span>
+					<span class="bento-stat__label">OS</span>
+				</div>
+		</div>
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#insights">Insights</a>
+			<a class="bento-chip" href="#raw">Raw output</a>
+		</nav>
+	</div>
+</section>
 
-<CardGrid>
-  <Card title="Node" icon="seti:nodejs">
-    24.18.0
-  </Card>
-  <Card title="Nx" icon="setting">
-    23.0.2
-  </Card>
-  <Card title="pnpm" icon="rocket">
-    10.33.0
-  </Card>
-  <Card title="OS" icon="linux">
-    linux-x64
-  </Card>
-</CardGrid>
+<BentoShell id="insights" eyebrow="Workspace" heading="Report insights">
+	<AstroNxReport />
+</BentoShell>
 
-<AstroNxReport />
+<BentoProse id="raw" heading="Raw output">
 
-### Raw output
-
-<Tabs>
-  <TabItem label="NX Report">
+### NX Report
 
 ```
 The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite for details.
@@ -93,10 +140,10 @@ Community plugins:
 ---------------------------------------
 Cache Usage: 0.00 B / 14.43 GB
 
+
 ```
 
-  </TabItem>
-  <TabItem label="LOC Statistics">
+### LOC Statistics
 
 ```
 ───────────────────────────────────────────────────────────────────────────────
@@ -155,8 +202,7 @@ Processed 95471345 bytes, 95.471 megabytes (SI)
 ───────────────────────────────────────────────────────────────────────────────
 ```
 
-  </TabItem>
-  <TabItem label="Coverage">
+### Coverage
 
 ```
 
@@ -717,14 +763,18 @@ All files          |   75.46 |    57.22 |   75.07 |   76.66 |
 
 
  NX   Successfully ran target coverage for 4 projects
-
-
-
 ```
 
-  </TabItem>
-</Tabs>
+</BentoProse>
+
+<BentoProse id="about">
 
 ---
 
-*Auto-generated by [ci-dashboard.yml](https://github.com/KBVE/kbve/actions/workflows/ci-dashboard.yml)*
+*Auto-generated by [ci-daily-content.yml](https://github.com/KBVE/kbve/actions/workflows/ci-daily-content.yml)*
+
+</BentoProse>
+
+</div>
+
+<style is:global>{`.nx-report{--bento-accent:#10b981;--bento-accent-2:#38bdf8}`}</style>

--- a/packages/python/kbve/kbve/nx/render.py
+++ b/packages/python/kbve/kbve/nx/render.py
@@ -14,6 +14,7 @@ JSX-runtime-free.
 from __future__ import annotations
 
 import json
+import re
 from typing import TextIO
 
 from ..mdx.escape import escape_mdx
@@ -673,6 +674,188 @@ def render_graph_mdx(graph: GraphData, timestamp: str) -> str:
     out.write("</div>\n\n")
     out.write(
         "<style is:global>{`.graph-report{--bento-accent:#a78bfa;"
+        "--bento-accent-2:#38bdf8}`}</style>\n"
+    )
+
+    return out.getvalue()
+
+
+# ── Report ───────────────────────────────────────────────────────────
+
+REPORT_ENV_SVG = {
+    "node": (
+        "M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2"
+        " 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96"
+        " 12 12.01l8.73-5.05M12 22.08V12"
+    ),
+    "nx": "M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z",
+    "pnpm": "M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+    "os": "M2 3h20v14H2zM8 21h8M12 17v4",
+}
+
+
+def parse_report(raw: str) -> dict:
+    """Extract ``{node, nx, pnpm, os}`` from raw ``pnpm nx report`` text.
+
+    Mirrors the ``ci-dashboard`` bash: node/os/pnpm are the value after the
+    first ``:`` on their labelled line; nx is the last whitespace token on the
+    ``nx `` line. Missing fields degrade to the empty string.
+    """
+    env = {"node": "", "nx": "", "pnpm": "", "os": ""}
+    for line in raw.splitlines():
+        if line.startswith("Node") and not env["node"]:
+            env["node"] = line.split(":", 1)[1].strip() if ":" in line else ""
+        elif line.startswith("OS") and not env["os"]:
+            env["os"] = line.split(":", 1)[1].strip() if ":" in line else ""
+        elif line.startswith("pnpm") and not env["pnpm"]:
+            env["pnpm"] = line.split(":", 1)[1].strip() if ":" in line else ""
+        elif line.startswith("nx ") and not env["nx"]:
+            env["nx"] = line.split()[-1].strip()
+    return env
+
+
+def render_report_json(data: dict) -> str:
+    """Serialize the frozen NX report payload to JSON."""
+    return json.dumps(data, indent=2)
+
+
+def render_report_mdx(data: dict, timestamp: str) -> str:
+    """Render the Bento-native MDX NX workspace report."""
+    from io import StringIO
+
+    env = data.get("environment", {})
+    node = env.get("node", "")
+    nx = env.get("nx", "")
+    pnpm = env.get("pnpm", "")
+    os_info = env.get("os", "")
+    out = StringIO()
+
+    out.write(
+        "---\n"
+        "title: NX Workspace Report\n"
+        "description: |\n"
+        "    Daily auto-generated NX workspace report"
+        " for the KBVE monorepo.\n"
+        "template: splash\n"
+        "tableOfContents: false\n"
+        "editUrl: false\n"
+        "lastUpdated: false\n"
+        "next: false\n"
+        "prev: false\n"
+        "sidebar:\n"
+        "    label: Report\n"
+        "    order: 100\n"
+        "---\n\n"
+    )
+    out.write(
+        "import BentoShell from '@/components/hero/BentoShell.astro';\n"
+        "import BentoProse from '@/components/hero/BentoProse.astro';\n"
+        "import AstroNxReport from"
+        " '@/components/dashboard/AstroNxReport.astro';\n\n"
+    )
+
+    lede = (
+        f"Node <strong>{node}</strong> · Nx <strong>{nx}</strong>"
+        f" · pnpm <strong>{pnpm}</strong> on <strong>{os_info}</strong>."
+    )
+
+    out.write('<div class="nx-report" data-dash-report>\n\n')
+
+    out.write(
+        '<section class="bento-hero bento-section not-content"'
+        ' aria-label="NX workspace report">\n'
+        '\t<div class="bento-hero__bg" aria-hidden="true"></div>\n'
+        '\t<div class="bento-hero__frame bento-frame">\n'
+        '\t\t<div class="bento-board bento-board--hero">\n'
+        '\t\t\t<div class="bento-cell bento-hero-copy bento-card'
+        ' bento-card--glass">\n'
+        '\t\t\t\t<span class="bento-badge bento-chip">\n'
+        '\t\t\t\t\t<svg viewBox="0 0 24 24" width="14" height="14"'
+        ' fill="none" stroke="currentColor" stroke-width="1.75"'
+        ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<path d="M12 2 2 7l10 5 10-5zM2 17l10 5 10-5M2 12l10 5 10-5"'
+        ' /></svg>\n'
+        '\t\t\t\t\t<span>auto-generated · daily</span>\n'
+        '\t\t\t\t</span>\n'
+        '\t\t\t\t<h1 class="bento-title">\n'
+        '\t\t\t\t\tNX workspace\n'
+        '\t\t\t\t\t<span class="bento-title__accent">report.</span>\n'
+        '\t\t\t\t</h1>\n'
+        f'\t\t\t\t<p class="bento-lede">{lede}</p>\n'
+        f'\t\t\t\t<p class="bento-lede">Last generated'
+        f' <strong>{timestamp}</strong>.</p>\n'
+        '\t\t\t\t<div class="bento-cta">\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--primary" href="#insights">\n'
+        '\t\t\t\t\t\tView insights\n'
+        '\t\t\t\t\t\t<svg viewBox="0 0 24 24" fill="none"'
+        ' stroke="currentColor" aria-hidden="true"><path'
+        ' stroke-linecap="round" stroke-linejoin="round" stroke-width="2"'
+        ' d="M5 12h14M13 6l6 6-6 6" /></svg>\n'
+        '\t\t\t\t\t</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="#raw">Raw output</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="/dashboard/">Dashboard home</a>\n'
+        '\t\t\t\t</div>\n'
+        '\t\t\t</div>\n\n'
+    )
+
+    _stat_tile(out, REPORT_ENV_SVG["node"], node, "Node")
+    _stat_tile(out, REPORT_ENV_SVG["nx"], nx, "Nx")
+    _stat_tile(out, REPORT_ENV_SVG["pnpm"], pnpm, "pnpm")
+    _stat_tile(out, REPORT_ENV_SVG["os"], os_info, "OS")
+
+    out.write(
+        '\t\t</div>\n'
+        '\t\t<nav class="bento-jump" aria-label="On this page">\n'
+        '\t\t\t<a class="bento-chip" href="#insights">Insights</a>\n'
+        '\t\t\t<a class="bento-chip" href="#raw">Raw output</a>\n'
+        '\t\t</nav>\n'
+        '\t</div>\n'
+        '</section>\n\n'
+    )
+
+    out.write(
+        '<BentoShell id="insights" eyebrow="Workspace"'
+        ' heading="Report insights">\n'
+        '\t<AstroNxReport />\n'
+        '</BentoShell>\n\n'
+    )
+
+    out.write('<BentoProse id="raw" heading="Raw output">\n\n')
+
+    out.write("### NX Report\n\n")
+    out.write("```\n")
+    out.write(data.get("nx_report", ""))
+    out.write("\n```\n\n")
+
+    out.write("### LOC Statistics\n\n")
+    out.write("```\n")
+    out.write(data.get("loc_stats", ""))
+    out.write("\n```\n\n")
+
+    coverage = data.get("coverage")
+    if coverage:
+        out.write("### Coverage\n\n")
+        out.write("```\n")
+        out.write(re.sub(r"<([/a-zA-Z])", r"&lt;\1", coverage))
+        out.write("\n```\n\n")
+
+    out.write("</BentoProse>\n\n")
+
+    out.write('<BentoProse id="about">\n\n')
+    out.write("---\n\n")
+    out.write(
+        "*Auto-generated by "
+        "[ci-daily-content.yml]"
+        "(https://github.com/KBVE/kbve/actions/"
+        "workflows/ci-daily-content.yml)*\n\n"
+    )
+    out.write("</BentoProse>\n\n")
+
+    out.write("</div>\n\n")
+    out.write(
+        "<style is:global>{`.nx-report{--bento-accent:#10b981;"
         "--bento-accent-2:#38bdf8}`}</style>\n"
     )
 

--- a/packages/python/kbve/kbve/nx/routes/__init__.py
+++ b/packages/python/kbve/kbve/nx/routes/__init__.py
@@ -4,3 +4,4 @@ from . import journal  # noqa: F401
 from . import graph  # noqa: F401
 from . import security  # noqa: F401
 from . import proto  # noqa: F401
+from . import report  # noqa: F401

--- a/packages/python/kbve/kbve/nx/routes/report.py
+++ b/packages/python/kbve/kbve/nx/routes/report.py
@@ -1,0 +1,160 @@
+"""The ``report`` route — Nx workspace report dashboard (MDX + raw JSON).
+
+Mirrors the ``ci-dashboard`` report job: acquire ``pnpm nx report`` (versions),
+``scc``/``cloc`` LOC statistics, and per-package coverage as raw text, then
+render the Bento MDX + the frozen ``nx-report.json`` contract consumed by
+``AstroNxReport``. Each feed is tolerant — a single failure degrades to empty
+rather than hard-failing the whole route.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from ..builder import BuildContext, BuildResult, PlanResult, repo_root_for
+from ..render import parse_report, render_report_json, render_report_mdx
+from ..router import route
+
+_NX_REPORT_TIMEOUT = 120
+_LOC_TIMEOUT = 600
+_COVERAGE_TIMEOUT = 1800
+_SCC_EXCLUDES = "node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres"
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _warn(msg: str) -> None:
+    print("::warning::report route: %s" % msg, file=sys.stderr)
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _acquire_nx_report(repo_root: Path) -> str:
+    try:
+        proc = subprocess.run(
+            ["pnpm", "nx", "report"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=_NX_REPORT_TIMEOUT,
+        )
+        return _strip_ansi(proc.stdout + proc.stderr)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _warn("nx report failed (%s)" % exc)
+        return ""
+
+
+def _acquire_loc(repo_root: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [
+                "scc", ".",
+                "--exclude-dir=%s" % _SCC_EXCLUDES,
+                "--no-cocomo",
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=_LOC_TIMEOUT,
+        )
+        text = _strip_ansi(proc.stdout + proc.stderr)
+        if text.strip():
+            return text
+    except FileNotFoundError:
+        _warn("scc not found — falling back to cloc")
+    except (OSError, subprocess.SubprocessError) as exc:
+        _warn("scc failed (%s) — falling back to cloc" % exc)
+
+    try:
+        proc = subprocess.run(
+            [
+                "npx", "--yes", "cloc", ".",
+                "--exclude-dir=%s" % _SCC_EXCLUDES,
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=_LOC_TIMEOUT,
+        )
+        return _strip_ansi(proc.stdout + proc.stderr)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _warn("cloc failed (%s) — LOC stats empty" % exc)
+        return ""
+
+
+def _acquire_coverage(repo_root: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [
+                "pnpm", "nx", "run-many", "-t", "coverage",
+                "--projects=droid,devops,khashvault,laser",
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=_COVERAGE_TIMEOUT,
+        )
+        return _strip_ansi(proc.stdout + proc.stderr)
+    except subprocess.TimeoutExpired:
+        _warn("coverage timed out — coverage empty")
+        return ""
+    except (OSError, subprocess.SubprocessError) as exc:
+        _warn("coverage failed (%s) — coverage empty" % exc)
+        return ""
+
+
+def _acquire(ctx: BuildContext) -> dict:
+    repo_root = repo_root_for(ctx.content_root)
+    raw = _acquire_nx_report(repo_root)
+    if not raw.strip():
+        return {}
+    loc_text = _acquire_loc(repo_root)
+    cov_text = _acquire_coverage(repo_root)
+    return {
+        "generated_at": ctx.timestamp,
+        "environment": parse_report(raw),
+        "nx_report": raw,
+        "loc_stats": loc_text,
+        "coverage": cov_text or None,
+    }
+
+
+@route("report", "daily", needs=("node",))
+class ReportRoute:
+    def plan(self, ctx: BuildContext) -> PlanResult:
+        return PlanResult(
+            "report", True, "regenerate (git-diff guard drops no-ops)", []
+        )
+
+    def build(self, ctx: BuildContext) -> BuildResult:
+        data = ctx.inputs.get("report_data")
+        if not isinstance(data, dict):
+            data = _acquire(ctx)
+        if not data:
+            _warn("nx report empty — skipping report regeneration")
+            return BuildResult("report", [], True, "acquire failed")
+
+        public_dir = Path(ctx.public_dir)
+        content_root = Path(ctx.content_root)
+        json_out = public_dir / "nx-report.json"
+        mdx_out = content_root / "dashboard" / "report.mdx"
+
+        if not ctx.dry_run:
+            public_dir.mkdir(parents=True, exist_ok=True)
+            mdx_out.parent.mkdir(parents=True, exist_ok=True)
+            with open(json_out, "w") as f:
+                f.write(render_report_json(data))
+            with open(mdx_out, "w") as f:
+                f.write(render_report_mdx(data, ctx.timestamp))
+
+        repo_root = repo_root_for(content_root)
+        changed = [
+            os.path.relpath(mdx_out, repo_root),
+            os.path.relpath(json_out, repo_root),
+        ]
+        return BuildResult("report", changed, False, "generated")

--- a/packages/python/kbve/tests/test_nx_report_route.py
+++ b/packages/python/kbve/tests/test_nx_report_route.py
@@ -1,0 +1,140 @@
+"""Tests for the ``report`` route (acquisition bypassed via ``inputs``)."""
+
+from __future__ import annotations
+
+import json
+
+from kbve.nx.builder import BuildContext
+from kbve.nx.render import parse_report
+from kbve.nx.router import get
+
+_SAMPLE_NX_REPORT = """
+ NX   Report complete - copy this into the issue template
+
+Node           : 24.18.0
+OS             : linux-x64
+Native Target  : x86_64-linux
+pnpm           : 10.33.0
+daemon         : Disabled
+
+nx                     : 23.0.2
+@nx/js                 : 23.0.2
+typescript             : 5.9.3
+---------------------------------------
+Community plugins:
+@monodon/rust          : 3.0.0
+---------------------------------------
+Cache Usage: 0.00 B / 14.43 GB
+"""
+
+
+def _report_fixture() -> dict:
+    return {
+        "generated_at": "2026-07-18T00:00:00Z",
+        "environment": {
+            "node": "24.18.0",
+            "nx": "23.0.2",
+            "pnpm": "10.33.0",
+            "os": "linux-x64",
+        },
+        "nx_report": _SAMPLE_NX_REPORT,
+        "loc_stats": (
+            "Language   Files  Lines  Code\n"
+            "TypeScript   10    500   400\n"
+        ),
+        "coverage": (
+            "::group::✅ > nx run laser:coverage\n"
+            "All files | 75.46 | 57.22 | 75.07 | 76.66 |\n"
+            "new Promise (<anonymous>)\n"
+            "::endgroup::\n"
+        ),
+    }
+
+
+def _ctx(tmp_path, inputs):
+    content_root = tmp_path / "content" / "docs"
+    public_dir = tmp_path / "public" / "data" / "nx"
+    content_root.mkdir(parents=True)
+    return BuildContext(
+        content_root=content_root,
+        public_dir=public_dir,
+        timestamp="2026-07-18T00:00:00Z",
+        inputs=inputs,
+    )
+
+
+def test_report_needs_tags():
+    assert get("report").needs == ("node",)
+
+
+def test_report_plan_needs_work(tmp_path):
+    plan = get("report").plan(_ctx(tmp_path, {}))
+    assert plan.needs_work is True
+
+
+def test_report_build_writes_mdx_and_json(tmp_path):
+    ctx = _ctx(tmp_path, {"report_data": _report_fixture()})
+    result = get("report").build(ctx)
+
+    assert result.skipped is False
+    assert result.route == "report"
+
+    mdx = ctx.content_root / "dashboard" / "report.mdx"
+    js = ctx.public_dir / "nx-report.json"
+    assert mdx.exists()
+    assert js.exists()
+
+    text = mdx.read_text()
+    assert text.startswith("---\n")
+    assert "title: NX Workspace Report" in text
+    assert "template: splash" in text
+    assert "import BentoShell" in text
+    assert "import AstroNxReport" in text
+    assert "<AstroNxReport />" in text
+    assert "bento-stat" in text
+    assert "<BentoProse" in text
+    assert "<CardGrid>" not in text
+    assert "24.18.0" in text
+    assert "23.0.2" in text
+    assert "10.33.0" in text
+    assert "linux-x64" in text
+    assert "&lt;anonymous>" in text
+
+
+def test_report_build_json_matches_frozen_contract(tmp_path):
+    ctx = _ctx(tmp_path, {"report_data": _report_fixture()})
+    get("report").build(ctx)
+
+    payload = json.loads((ctx.public_dir / "nx-report.json").read_text())
+    assert set(payload) == {
+        "generated_at",
+        "environment",
+        "nx_report",
+        "loc_stats",
+        "coverage",
+    }
+    assert set(payload["environment"]) == {"node", "nx", "pnpm", "os"}
+    fixture = _report_fixture()
+    assert payload["nx_report"] == fixture["nx_report"]
+    assert payload["loc_stats"] == fixture["loc_stats"]
+    assert payload["coverage"] == fixture["coverage"]
+
+
+def test_report_build_coverage_none_when_empty(tmp_path):
+    data = _report_fixture()
+    data["coverage"] = None
+    ctx = _ctx(tmp_path, {"report_data": data})
+    get("report").build(ctx)
+
+    payload = json.loads((ctx.public_dir / "nx-report.json").read_text())
+    assert payload["coverage"] is None
+    text = (ctx.content_root / "dashboard" / "report.mdx").read_text()
+    assert "### Coverage" not in text
+
+
+def test_parse_report_extracts_environment():
+    env = parse_report(_SAMPLE_NX_REPORT)
+    assert env["node"] == "24.18.0"
+    assert env["os"] == "linux-x64"
+    assert env["nx"] == "23.0.2"
+    assert env["pnpm"] == "10.33.0"


### PR DESCRIPTION
Stage 2 of 3 finishing the ci-dashboard → router/builder migration (proto ✅ → **report** → kanban). Converts the **NX workspace report** generator, Bento-styled.

## Changes
- **`render.py`** — `parse_report` (extracts node/nx/pnpm/os from `nx report` text) + `render_report_json` + `render_report_mdx`. MDX matches the security/graph Bento skeleton (`template: splash`, `BentoShell`/`BentoProse`, env stat tiles) and **keeps `<AstroNxReport />`** for the rich LOC/coverage/plugins viz.
- **Frozen JSON contract** — `nx-report.json` keeps `generated_at` / `environment{node,nx,pnpm,os}` / `nx_report` / `loc_stats` / `coverage` as raw text, byte-compatible so `AstroNxReport` + `nxReportParse.ts` keep working unchanged.
- **`routes/report.py`** — `@route('report','daily',needs=('node',))`. Acquires `nx report` + scc (cloc fallback) + coverage (`droid,devops,khashvault,laser`), tolerant (`::warning::` + graceful skip). `ctx.inputs['report_data']` test seam.
- **`ci-daily-content.yml` builder** — `timeout-minutes: 120` (the coverage run is the slow part, per the chosen "keep coverage" option).
- **`ci-dashboard.yml`** — remove the `report` job, `track-report`, and its `commit` `needs`/copy-map/stage/PR-body refs. **Only `kanban` remains** (stage 3 fully retires ci-dashboard).

## Verification
- **337 python tests** pass (report route + `parse_report` unit tests; frozen-contract + coverage-None cases).
- `report.mdx` **regenerated from real `nx-report.json`** (fixed ts) — hero shows Node 24.18.0 / Nx 23.0.2 / pnpm 10.33.0; zero `CardGrid`; `<AstroNxReport />` intact; BentoShell/BentoProse balanced.
- Both workflows YAML-valid + **actionlint `-S error` clean**; ci-dashboard down to guard/kanban/commit/track-kanban.

## Note
Report now runs in the nightly `ci-daily-content` matrix (`needs: node`). The `nx-report.json` contract is unchanged so the existing `AstroNxReport` island + recharts viz render exactly as before, just inside a Bento page now.