### PR TITLE
feat(embeddb): v4 value completeness + ergonomic reads + nx + perf

### DIFF
--- a/docs/superpowers/plans/2026-07-19-embeddb-v4.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb-v4.md
@@ -1,0 +1,609 @@
+# embeddb v4 (value completeness + ergonomic reads + nx + perf) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the value mapping, add ergonomic read APIs, wire the crate into nx, and reuse the DuckDB reader for perf.
+
+**Architecture:** Extend `EmbedValue`/`EmbedRow` (`value.rs`) and `value_from_ref` (`analytics.rs`); add `QueryResult`/`FromEmbedRow` reads; add `project.json` + an example; store a shared `Arc<Mutex<duckdb::Connection>>` reader on `EmbedDb`.
+
+**Tech Stack:** Rust, `turso` 0.7, `duckdb` 1.x, `tokio`, `thiserror`.
+
+## Global Constraints
+
+- Work only in `packages/rust/embeddb`.
+- No inline comments in source. No panics on the library path.
+- Build/test scoped: `cargo test -p embeddb` (+ `cargo build -p embeddb --examples` where noted). Never build the whole workspace. `nx` cannot run in this node_modules-less worktree — do not attempt it.
+- Keep all existing v1–v3 tests green; update call sites when signatures change.
+- Verified API facts:
+  - duckdb `TimeUnit { Second, Millisecond, Microsecond, Nanosecond }` (in `duckdb::types`).
+  - duckdb `ValueRef` incl `Boolean(bool)`, `HugeInt(i128)`, `UBigInt(u64)`, `Decimal(Decimal)`, `Timestamp(TimeUnit, i64)`, `Date32(i32)`, `Time64(TimeUnit, i64)`, `Interval{..}`.
+  - `Statement::column_names() -> Vec<String>`, `column_count() -> usize` — both PANIC if called before the statement is executed. After `stmt.query([])?`, read names via `rows.as_ref().map(|s| s.column_names()).unwrap_or_default()` (works for zero rows too).
+  - `duckdb::Connection` is `Send` but not `Sync`; `Mutex<Connection>` is `Send + Sync`.
+- Commit after every task. No direct pushes to dev/main.
+
+---
+
+## Phase 1 — Value-type completeness
+
+### Task 1: New `EmbedValue` variants + accessors
+
+**Files:** Modify `src/value.rs`.
+
+**Interfaces:**
+- Produces: `EmbedValue` gains `Bool(bool)`, `HugeInt(i128)`, `Timestamp(i64)`, `Date(i32)`, `Time(i64)`; `EmbedRow` gains `as_bool`, `as_i128`, `as_timestamp`, `as_date`, `as_time`.
+
+- [ ] **Step 1: Failing test** — extend the `tests` mod in `src/value.rs`:
+
+```rust
+#[test]
+fn new_variant_accessors() {
+    let r = EmbedRow(vec![
+        EmbedValue::Bool(true),
+        EmbedValue::HugeInt(170141183460469231731687303715884105727),
+        EmbedValue::Timestamp(1_600_000_000_000_000),
+        EmbedValue::Date(19000),
+        EmbedValue::Time(3_600_000_000),
+    ]);
+    assert_eq!(r.as_bool(0), Some(true));
+    assert_eq!(r.as_i128(1), Some(170141183460469231731687303715884105727));
+    assert_eq!(r.as_timestamp(2), Some(1_600_000_000_000_000));
+    assert_eq!(r.as_date(3), Some(19000));
+    assert_eq!(r.as_time(4), Some(3_600_000_000));
+    assert_eq!(r.as_bool(1), None);
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`cargo test -p embeddb new_variant_accessors`).
+
+- [ ] **Step 3: Add variants + accessors.** In the `EmbedValue` enum add:
+
+```rust
+    Bool(bool),
+    HugeInt(i128),
+    Timestamp(i64),
+    Date(i32),
+    Time(i64),
+```
+
+Add to `impl EmbedRow`:
+
+```rust
+    pub fn as_bool(&self, idx: usize) -> Option<bool> {
+        match self.0.get(idx) { Some(EmbedValue::Bool(v)) => Some(*v), _ => None }
+    }
+    pub fn as_i128(&self, idx: usize) -> Option<i128> {
+        match self.0.get(idx) { Some(EmbedValue::HugeInt(v)) => Some(*v), _ => None }
+    }
+    pub fn as_timestamp(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) { Some(EmbedValue::Timestamp(v)) => Some(*v), _ => None }
+    }
+    pub fn as_date(&self, idx: usize) -> Option<i32> {
+        match self.0.get(idx) { Some(EmbedValue::Date(v)) => Some(*v), _ => None }
+    }
+    pub fn as_time(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) { Some(EmbedValue::Time(v)) => Some(*v), _ => None }
+    }
+```
+
+- [ ] **Step 4: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 5: Commit** — `feat(embeddb): EmbedValue bool/i128/temporal variants + accessors`
+
+---
+
+### Task 2: Map bool / big-int / temporal / decimal in `value_from_ref`
+
+**Files:** Modify `src/analytics.rs`.
+
+**Interfaces:** Consumes the new `EmbedValue` variants. No signature change to `value_from_ref`.
+
+- [ ] **Step 1: Failing tests** — in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn analytics_rows_maps_bool_and_types() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("v.db")).await.unwrap();
+    db.execute("CREATE TABLE t (b INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let rows = db.analytics_rows("SELECT CAST(b AS BOOLEAN) FROM t").await.unwrap();
+    assert_eq!(rows[0].as_bool(0), Some(true));
+}
+
+#[tokio::test]
+async fn analytics_rows_maps_ubigint_over_i64() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("u.db")).await.unwrap();
+    db.execute("CREATE TABLE t (x INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let rows = db.analytics_rows("SELECT 18446744073709551615::UBIGINT FROM t").await.unwrap();
+    assert_eq!(rows[0].as_i128(0), Some(18446744073709551615_i128));
+}
+
+#[tokio::test]
+async fn analytics_rows_maps_timestamp_and_date() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("ts.db")).await.unwrap();
+    db.execute("CREATE TABLE t (x INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let rows = db.analytics_rows("SELECT TIMESTAMP '2021-01-01 00:00:00', DATE '2021-01-01' FROM t").await.unwrap();
+    assert!(matches!(rows[0].get(0), Some(crate::EmbedValue::Timestamp(_))));
+    assert!(matches!(rows[0].get(1), Some(crate::EmbedValue::Date(_))));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (bool maps to Int today; ubigint over i64 errors today).
+
+- [ ] **Step 3: Update `value_from_ref`.** Replace the relevant arms:
+
+```rust
+        V::Boolean(b) => crate::EmbedValue::Bool(b),
+        // int arms unchanged for TinyInt..UInt (all fit i64)
+        V::BigInt(n) => crate::EmbedValue::Int(n),
+        V::HugeInt(n) => crate::EmbedValue::HugeInt(n),
+        V::UBigInt(n) => match i64::try_from(n) {
+            Ok(v) => crate::EmbedValue::Int(v),
+            Err(_) => crate::EmbedValue::HugeInt(n as i128),
+        },
+        V::Float(n) => crate::EmbedValue::Float(n as f64),
+        V::Double(n) => crate::EmbedValue::Double_placeholder, // see note
+```
+
+Add temporal + decimal arms (place before the catch-all):
+
+```rust
+        V::Timestamp(unit, v) => crate::EmbedValue::Timestamp(to_micros(unit, v)),
+        V::Date32(v) => crate::EmbedValue::Date(v),
+        V::Time64(unit, v) => crate::EmbedValue::Time(to_micros(unit, v)),
+        V::Decimal(d) => crate::EmbedValue::Text(d.to_string()),
+```
+
+(The `Double_placeholder` line above is a typo guard — keep the existing
+`V::Double(n) => crate::EmbedValue::Float(n)` and `V::Float(n) => Float(n as f64)`
+arms exactly as they are today; only add/replace the arms listed.)
+
+Add the normalization helper:
+
+```rust
+fn to_micros(unit: duckdb::types::TimeUnit, v: i64) -> i64 {
+    use duckdb::types::TimeUnit as U;
+    match unit {
+        U::Second => v.saturating_mul(1_000_000),
+        U::Millisecond => v.saturating_mul(1_000),
+        U::Microsecond => v,
+        U::Nanosecond => v / 1_000,
+    }
+}
+```
+
+Improve the catch-all error:
+
+```rust
+        other => return Err(crate::EmbedError::Other(format!(
+            "unmapped duckdb type {:?}; cast to VARCHAR in SQL", other))),
+```
+
+Reconcile exact `ValueRef` variant names / `Decimal::to_string` against installed duckdb 1.x.
+
+- [ ] **Step 4: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 5: Commit** — `feat(embeddb): map bool/i128/timestamp/date/time/decimal reads`
+
+---
+
+## Phase 2 — Ergonomic reads
+
+### Task 3: `QueryResult` + `analytics_query` + `analytics_one`
+
+**Files:** Create `src/query.rs`; modify `src/analytics.rs`, `src/db.rs`, `src/lib.rs`.
+
+**Interfaces:**
+- Produces: `QueryResult { columns: Vec<String>, rows: Vec<EmbedRow> }` with `column_index`, `get(row, col)`, `len`, `is_empty`; `analytics::query(path, sql, ext) -> Result<QueryResult>`; `EmbedDb::analytics_query`, `EmbedDb::analytics_one`; `analytics_rows` delegates to `analytics_query`.
+
+- [ ] **Step 1: Failing tests** — in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn analytics_query_columns_and_get() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("q.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'a')", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let q = db.analytics_query("SELECT id, name FROM t").await.unwrap();
+    assert_eq!(q.columns, vec!["id".to_string(), "name".to_string()]);
+    assert_eq!(q.column_index("name"), Some(1));
+    assert_eq!(q.get(0, "name"), Some(&crate::EmbedValue::Text("a".into())));
+    assert_eq!(q.get(0, "missing"), None);
+    assert_eq!(q.len(), 1);
+}
+
+#[tokio::test]
+async fn analytics_one_first_or_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("o.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert!(db.analytics_one("SELECT id FROM t").await.unwrap().is_none());
+    db.execute("INSERT INTO t VALUES (5)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_one("SELECT id FROM t").await.unwrap().unwrap().as_i64(0), Some(5));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Create `src/query.rs`:**
+
+```rust
+use crate::EmbedValue;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<crate::EmbedRow>,
+}
+
+impl QueryResult {
+    pub fn column_index(&self, name: &str) -> Option<usize> {
+        self.columns.iter().position(|c| c == name)
+    }
+    pub fn get(&self, row: usize, column: &str) -> Option<&EmbedValue> {
+        let idx = self.column_index(column)?;
+        self.rows.get(row)?.get(idx)
+    }
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+```
+
+Add `mod query; pub use query::QueryResult;` to `lib.rs`.
+
+- [ ] **Step 4: Implement `analytics::query`** in `src/analytics.rs`, and re-express `rows` on top of it:
+
+```rust
+pub fn query(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<crate::QueryResult> {
+    let conn = attached_conn(path, ext_dir)?;
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query([])?;
+    let columns = rows.as_ref().map(|s| s.column_names()).unwrap_or_default();
+    let ncols = columns.len();
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(value_from_ref(row.get_ref(i)?)?);
+        }
+        out.push(crate::EmbedRow(vals));
+    }
+    Ok(crate::QueryResult { columns, rows: out })
+}
+
+pub fn rows(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<Vec<crate::EmbedRow>> {
+    Ok(query(path, sql, ext_dir)?.rows)
+}
+```
+
+(If `ncols` is 0 because there were zero rows AND `rows.as_ref()` returned names, prefer `columns.len()`; if names are empty with rows present, fall back to the per-row `row.as_ref().column_count()` from v3 — reconcile so a zero-row query still yields correct `columns`.)
+
+- [ ] **Step 5: Add `EmbedDb` wrappers** in `src/db.rs` (mirror existing spawn_blocking pattern, passing `self.config.duckdb_extension_dir.as_deref()`):
+
+```rust
+pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    let ext = self.config.duckdb_extension_dir.clone();
+    tokio::task::spawn_blocking(move || crate::analytics::query(&path, &sql, ext.as_deref()))
+        .await
+        .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+
+pub async fn analytics_one(&self, sql: &str) -> Result<Option<crate::EmbedRow>> {
+    Ok(self.analytics_query(sql).await?.rows.into_iter().next())
+}
+```
+
+Ensure the existing `analytics_rows` still returns `Vec<EmbedRow>` (its free fn now delegates to `query`).
+
+- [ ] **Step 6: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 7: Commit** — `feat(embeddb): QueryResult + analytics_query + analytics_one`
+
+---
+
+### Task 4: `FromEmbedRow` + `analytics_query_as`
+
+**Files:** Modify `src/query.rs`, `src/db.rs`, `src/lib.rs`.
+
+**Interfaces:**
+- Produces: `pub trait FromEmbedRow: Sized { fn from_row(row: &EmbedRow, columns: &[String]) -> Result<Self>; }`; `EmbedDb::analytics_query_as<T: FromEmbedRow>(&self, sql) -> Result<Vec<T>>`.
+
+- [ ] **Step 1: Failing test** — in `db.rs` tests, define a local struct impl + use it:
+
+```rust
+#[tokio::test]
+async fn analytics_query_as_maps_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Rowt { id: i64, name: String }
+    impl crate::FromEmbedRow for Rowt {
+        fn from_row(row: &crate::EmbedRow, cols: &[String]) -> crate::Result<Self> {
+            let ci = |n: &str| cols.iter().position(|c| c == n)
+                .ok_or_else(|| crate::EmbedError::Other(format!("missing col {n}")));
+            let id = row.as_i64(ci("id")?).ok_or_else(|| crate::EmbedError::Other("id".into()))?;
+            let name = row.as_str(ci("name")?).ok_or_else(|| crate::EmbedError::Other("name".into()))?.to_string();
+            Ok(Rowt { id, name })
+        }
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("as.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    let got: Vec<Rowt> = db.analytics_query_as("SELECT id, name FROM t ORDER BY id").await.unwrap();
+    assert_eq!(got, vec![Rowt{id:1,name:"a".into()}, Rowt{id:2,name:"b".into()}]);
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Add the trait** in `src/query.rs`:
+
+```rust
+pub trait FromEmbedRow: Sized {
+    fn from_row(row: &crate::EmbedRow, columns: &[String]) -> crate::Result<Self>;
+}
+```
+
+Add `pub use query::FromEmbedRow;` to `lib.rs`.
+
+- [ ] **Step 4: Add the method** in `src/db.rs`:
+
+```rust
+pub async fn analytics_query_as<T: crate::FromEmbedRow>(&self, sql: &str) -> Result<Vec<T>> {
+    let q = self.analytics_query(sql).await?;
+    let mut out = Vec::with_capacity(q.rows.len());
+    for row in &q.rows {
+        out.push(T::from_row(row, &q.columns)?);
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 6: Commit** — `feat(embeddb): FromEmbedRow + analytics_query_as`
+
+---
+
+## Phase 3 — Nx + example
+
+### Task 5: `project.json` + `examples/basic.rs`
+
+**Files:** Create `packages/rust/embeddb/project.json`, `packages/rust/embeddb/examples/basic.rs`.
+
+**Interfaces:** none (build/tooling).
+
+- [ ] **Step 1: Create `project.json`** matching `packages/rust/holy/project.json` exactly in shape, substituting `embeddb`:
+
+```json
+{
+	"name": "embeddb",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/rust/embeddb/src",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb" },
+			"configurations": { "production": { "release": true } }
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb" },
+			"configurations": { "production": { "release": true } }
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": { "commands": ["nx test embeddb"], "parallel": false }
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb" }
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Create `examples/basic.rs`** exercising the real API:
+
+```rust
+use embeddb::{EmbedDb, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let dir = std::env::temp_dir().join("embeddb-example.db");
+    let db = EmbedDb::open(&dir).await?;
+    db.migrate(&["CREATE TABLE users (id INTEGER, name TEXT)"]).await?;
+
+    let tx = db.begin().await?;
+    tx.execute("INSERT INTO users VALUES (?, ?)", (1_i64, "alice")).await?;
+    tx.execute("INSERT INTO users VALUES (?, ?)", (2_i64, "bob")).await?;
+    tx.commit().await?;
+    db.checkpoint().await?;
+
+    let q = db.analytics_query("SELECT id, name FROM users ORDER BY id").await?;
+    println!("columns: {:?}", q.columns);
+    for row in &q.rows {
+        println!("{:?}", row);
+    }
+    let n = db.analytics_scalar_i64("SELECT count(*) FROM users").await?;
+    println!("count: {n}");
+    db.close().await?;
+    Ok(())
+}
+```
+
+Add `tokio` with the `macros`+`rt-multi-thread` features to `[dev-dependencies]` if the example needs `#[tokio::main]` and it is not already available for examples (examples use dev-deps; tokio is already a dev-dep — confirm the feature set covers `macros`; add if missing).
+
+- [ ] **Step 3: Verify build + tests.**
+
+Run: `cargo test -p embeddb` (all pass) and `cargo build -p embeddb --examples` (example compiles).
+Note in the report: `nx test embeddb` is NOT runnable in this worktree (no node_modules); project.json validated as JSON + shape-matched to siblings.
+
+- [ ] **Step 4: Commit** — `chore(embeddb): nx project.json + basic usage example`
+
+---
+
+## Phase 4 — Perf: reuse the DuckDB reader
+
+### Task 6: Shared `Arc<Mutex<Connection>>` reader
+
+**Files:** Modify `src/db.rs`, `src/analytics.rs`.
+
+**Interfaces:**
+- Consumes: `EmbedConfig`. Produces: `EmbedDb` holds `reader: Arc<Mutex<duckdb::Connection>>`; analytics free fns take `&duckdb::Connection` and DETACH/ATTACH per call; async wrappers lock the shared reader inside `spawn_blocking`.
+
+- [ ] **Step 1: Failing/guarding test** — the freshness gate, in `db.rs` tests:
+
+```rust
+#[tokio::test]
+async fn reused_reader_sees_fresh_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("fresh.db")).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+    db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
+}
+```
+
+(This test passes with the current fresh-conn-per-call impl too; it is the
+regression guard proving the reused reader is not serving stale data.)
+
+- [ ] **Step 2: Add the reader field + construct it** in `open_with` (`src/db.rs`):
+
+```rust
+use std::sync::{Arc, Mutex};
+
+pub struct EmbedDb {
+    path: PathBuf,
+    conn: turso::Connection,
+    config: crate::EmbedConfig,
+    reader: Arc<Mutex<duckdb::Connection>>,
+}
+```
+
+In `open_with`, after opening the turso conn:
+
+```rust
+let reader = crate::analytics::open_reader(config.duckdb_extension_dir.as_deref())?;
+Ok(EmbedDb { path, conn, config, reader: Arc::new(Mutex::new(reader)) })
+```
+
+Handle `Debug`: if `#[derive(Debug)]` on `EmbedDb` no longer compiles because
+`Mutex<duckdb::Connection>` isn't `Debug`, implement `Debug` by hand printing
+only `path` and `config` (do NOT print the reader).
+
+- [ ] **Step 3: Refactor `analytics.rs`** to a reusable reader:
+
+```rust
+pub fn open_reader(ext_dir: Option<&Path>) -> Result<duckdb::Connection> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    prepare_sqlite_scanner(&conn, ext_dir)?;
+    Ok(conn)
+}
+
+fn attach_fresh(conn: &duckdb::Connection, path: &Path) -> Result<()> {
+    let _ = conn.execute_batch("DETACH src;");
+    let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
+    conn.execute_batch(&attach)?;
+    conn.execute_batch("USE src;")?;
+    Ok(())
+}
+
+pub fn query(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<crate::QueryResult> {
+    attach_fresh(conn, path)?;
+    // ... same statement/rows/column loop as Task 3, using `conn` ...
+}
+
+pub fn scalar_i64(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<i64> {
+    attach_fresh(conn, path)?;
+    let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
+    Ok(val)
+}
+// scalar_f64, scalar_string, rows likewise take `conn: &duckdb::Connection`
+```
+
+`prepare_sqlite_scanner` keeps its `ext_dir` param (now only called from
+`open_reader`). Remove the old per-call `attached_conn`.
+
+- [ ] **Step 4: Update all `EmbedDb` analytics wrappers** to lock the shared reader inside `spawn_blocking`:
+
+```rust
+pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
+    let path = self.path.clone();
+    let sql = sql.to_string();
+    let reader = self.reader.clone();
+    tokio::task::spawn_blocking(move || {
+        let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+        crate::analytics::query(&conn, &path, &sql)
+    })
+    .await
+    .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+}
+```
+
+Apply the same shape to `analytics_rows`, `analytics_scalar_i64`, `analytics_scalar_f64`, `analytics_scalar_string`. (`analytics_one`/`analytics_query_as` build on `analytics_query`, no change.)
+
+- [ ] **Step 5: Run — expect PASS.** `cargo test -p embeddb` (freshness test + all existing analytics tests green).
+
+- [ ] **Step 6: Commit** — `perf(embeddb): reuse a shared DuckDB reader connection`
+
+---
+
+## Phase 5 — Coverage + README
+
+### Task 7: Coverage pass + README
+
+**Files:** Modify `src/db.rs` (tests), `packages/rust/embeddb/README.md`.
+
+**Interfaces:** none (tests + docs).
+
+- [ ] **Step 1: Add tests** (each asserts concrete values):
+  - `analytics_query` on an empty table returns correct `columns` (non-empty) and empty `rows`.
+  - `analytics_query_as` returning zero rows → empty Vec.
+  - Decimal column → `EmbedValue::Text` with the expected decimal string (`SELECT CAST(1.5 AS DECIMAL(4,2))`).
+  - An unmapped type (e.g. `SELECT INTERVAL '1' DAY`) returns an error whose message contains `cast to VARCHAR`.
+  - Concurrent-ish reads still correct: run two `analytics_query` awaits sequentially after separate checkpoints, assert both counts (guards the shared-reader serialization path).
+
+- [ ] **Step 2: Run — expect PASS.** `cargo test -p embeddb`
+
+- [ ] **Step 3: Update README** — new `EmbedValue` variants + accessors; `analytics_query`/`QueryResult`/`analytics_one`/`analytics_query_as`+`FromEmbedRow`; the nx targets (`nx build/test/lint embeddb`); the reader-reuse behavior (analytics reads serialize on a shared reader; every read reflects the latest checkpoint). For unmapped exotic types, note the `CAST(... AS VARCHAR)` workaround. Keep all existing sections intact.
+
+- [ ] **Step 4: Run full suite + examples build — expect PASS.** `cargo test -p embeddb && cargo build -p embeddb --examples`
+
+- [ ] **Step 5: Commit** — `test(embeddb): v4 coverage + README`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** P1 variants (T1) + mapping (T2); P2 QueryResult/query/one (T3) + FromEmbedRow (T4); P3 nx+example (T5); P4 reader reuse (T6); P5 coverage+README (T7). All spec test items mapped.
+- **Placeholder scan:** the `Double_placeholder` token in T2 Step 3 is explicitly called out as a typo-guard with instructions to keep the real `V::Double(n) => Float(n)` arm — no placeholder reaches final code.
+- **Type consistency:** `EmbedValue`/`EmbedRow` new variants+accessors, `QueryResult`, `FromEmbedRow`, `analytics::{open_reader, attach_fresh, query, rows, scalar_i64/f64/string}` (all now taking `&duckdb::Connection`), `reader: Arc<Mutex<duckdb::Connection>>`, `to_micros` used consistently across tasks.
+- **Ordering note:** T3 defines `analytics::query` taking `path` (fresh conn via `attached_conn`); T6 changes its signature to take `&duckdb::Connection`. Intentional — T6 is the perf refactor; its Step 3/4 update `query` and ALL call sites together, and the freshness test (T6 Step 1) gates it.

--- a/docs/superpowers/specs/2026-07-19-embeddb-v4-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-v4-design.md
@@ -1,0 +1,168 @@
+# embeddb v4 — Value Completeness + Ergonomic Reads + Nx + Perf Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+Builds on: `packages/rust/embeddb` (v1 #14292, v2 #14313, v3 #14321 merged)
+
+## Purpose
+
+Four improvement tracks, landed as ordered commits on one branch. Stays
+**Turso (write) + DuckDB (read) only**.
+
+1. Value-type completeness — stop erroring on bool / big ints / temporals.
+2. Ergonomic reads — column names, single-row, query-into-struct.
+3. Nx + consumability — real nx `project.json` + usage example.
+4. Perf — reuse the DuckDB reader connection instead of rebuilding per call.
+
+## Current surface (v3)
+
+`EmbedValue { Null, Int(i64), Float(f64), Text(String), Blob(Vec<u8>) }`;
+`EmbedRow(Vec<EmbedValue>)` with `get/as_i64/as_f64/as_str`. Reads:
+`analytics_scalar_i64/f64/string`, `analytics_rows -> Vec<EmbedRow>`. `analytics.rs`
+maps `duckdb::types::ValueRef` → `EmbedValue`, ERRORING on Bool→(actually maps to
+Int today), HugeInt/UBigInt out-of-range, and all temporal/decimal/interval types.
+Each read opens a fresh in-memory DuckDB conn + `INSTALL sqlite; LOAD sqlite;` +
+`ATTACH`. `EmbedConfig` carries `duckdb_extension_dir`, `checkpoint_max_retries`.
+
+---
+
+## Phase 1 — Value-type completeness
+
+Extend `EmbedValue` and the `value_from_ref` mapper.
+
+New variants:
+```rust
+pub enum EmbedValue {
+    Null, Int(i64), Float(f64), Text(String), Blob(Vec<u8>),
+    Bool(bool),
+    HugeInt(i128),
+    Timestamp(i64), // microseconds since unix epoch (normalized from TimeUnit)
+    Date(i32),      // days since unix epoch
+    Time(i64),      // microseconds since midnight (normalized from TimeUnit)
+}
+```
+
+Mapping changes in `value_from_ref`:
+- `Boolean(b)` → `Bool(b)` (was `Int(b as i64)`).
+- `HugeInt(n)` → `HugeInt(n)` (was try_from→Int or error). `UBigInt(n)` that
+  fits i64 → `Int`; if it exceeds i64 → `HugeInt(n as i128)` (no longer errors —
+  i128 holds any u64).
+- `Timestamp(unit, v)` → `Timestamp(micros)` normalizing: Second×1_000_000,
+  Millisecond×1_000, Microsecond×1, Nanosecond÷1_000.
+- `Date32(v)` → `Date(v)`.
+- `Time64(unit, v)` → `Time(micros)` (same normalization as Timestamp).
+- `Decimal(d)` → `Text(d.to_string())`.
+- Remaining exotic (Interval, Union, Struct, List, Map, Enum, etc.) → keep
+  erroring, but improve the message: name the type and suggest casting to VARCHAR
+  in SQL, e.g. `EmbedError::Other("unmapped duckdb type <X>; cast to VARCHAR in SQL")`.
+
+New `EmbedRow` accessors: `as_bool`, `as_i128`, `as_timestamp`, `as_date`, `as_time`.
+
+Reconcile the exact duckdb `TimeUnit` enum variant names against the installed
+crate during implementation.
+
+## Phase 2 — Ergonomic reads
+
+- New `QueryResult`:
+  ```rust
+  pub struct QueryResult {
+      pub columns: Vec<String>,
+      pub rows: Vec<EmbedRow>,
+  }
+  impl QueryResult {
+      pub fn column_index(&self, name: &str) -> Option<usize>;
+      pub fn get(&self, row: usize, column: &str) -> Option<&EmbedValue>;
+      pub fn len(&self) -> usize;      // row count
+      pub fn is_empty(&self) -> bool;
+  }
+  ```
+- `EmbedDb::analytics_query(&self, sql) -> Result<QueryResult>` — reads column
+  names (from the executed statement) + all rows.
+- `analytics_rows` re-expressed as `analytics_query(sql).map(|q| q.rows)` (keeps
+  the existing signature + tests green).
+- `EmbedDb::analytics_one(&self, sql) -> Result<Option<EmbedRow>>` — first row or None.
+- Query-into-struct: a trait
+  ```rust
+  pub trait FromEmbedRow: Sized {
+      fn from_row(row: &EmbedRow, columns: &[String]) -> Result<Self>;
+  }
+  ```
+  and `EmbedDb::analytics_query_as<T: FromEmbedRow>(&self, sql) -> Result<Vec<T>>`
+  that runs `analytics_query` then maps each row. Ship the trait + method + one
+  test impl in the test module (no derive macro — YAGNI).
+
+Column names: `Statement::column_count()` panics before `query()` (v3 gotcha) —
+read column names the same safe way (after the query executes, via the first
+`Row`'s statement `row.as_ref().column_names()`, or a documented equivalent).
+If there are zero rows, fall back to preparing + reading names post-execute;
+reconcile the exact duckdb API that returns names without panicking.
+
+## Phase 3 — Nx + consumability
+
+- Add `packages/rust/embeddb/project.json` mirroring the existing rust libs
+  (`packages/rust/holy/project.json` is the template): `@monodon/rust` `build`,
+  `test`, `lint` targets + an `e2e` `nx:run-commands` → `nx test embeddb`;
+  `projectType: library`, `sourceRoot: packages/rust/embeddb/src`,
+  `target-dir: dist/target/embeddb`.
+- Add a runnable example `packages/rust/embeddb/examples/basic.rs` exercising
+  open → migrate → execute (params) → transaction → checkpoint → analytics_query,
+  printing results. (Compiled by `cargo build --examples`, not a test.)
+- Note in the report: `nx test embeddb` cannot be run inside the node_modules-less
+  worktree; verification of the nx target itself is deferred to CI / main tree.
+  The `project.json` must be valid JSON matching the sibling libs' shape, and
+  `cargo test -p embeddb` + `cargo build -p embeddb --examples` must pass locally.
+
+## Phase 4 — Perf: reuse the DuckDB reader
+
+Today every `analytics_*` call: `open_in_memory` + `INSTALL sqlite; LOAD sqlite;`
++ `ATTACH`. The extension load + connection create dominate. Reuse one reader.
+
+- `EmbedDb` stores `reader: std::sync::Arc<std::sync::Mutex<duckdb::Connection>>`
+  created in `open_with`: `open_in_memory` + `prepare_sqlite_scanner` once.
+  (`duckdb::Connection` is `Send` but not `Sync`; `Mutex<Connection>` is
+  `Send + Sync`, and it is locked only inside `spawn_blocking`.)
+- Each analytics call, inside `spawn_blocking`: lock the reader, then
+  **DETACH the previous `src` if attached, ATTACH the file fresh, run the query**.
+  Re-attaching per call guarantees the reader sees post-checkpoint data (no stale
+  page/schema cache). Use `ATTACH ... AS src (TYPE sqlite, READ_ONLY)` then
+  `DETACH src` at the end (or `DETACH IF EXISTS` at the start) so the alias is
+  reusable across calls.
+- **Trade-off (documented):** a shared reader serializes analytics calls (they
+  lock the same Mutex) — analytics reads no longer run in parallel. Acceptable
+  for this single-file embedded lane; the setup cost saved dominates. If parallel
+  reads are later needed, a small reader pool is the follow-up (deferred).
+- **Critical correctness test:** write rows → checkpoint → analytics (sees N);
+  write more → checkpoint → analytics again on the SAME db (sees N+M). Proves the
+  reused reader is not serving stale data.
+- Write-path prepared-statement caching is explicitly **out of scope** (turso
+  manages its own statement handling; poor risk/reward) — noted, not built.
+
+`EmbedDb` is no longer trivially `Debug` if it holds the reader — derive `Debug`
+manually or `#[derive(Debug)]` only if all fields are Debug (Mutex<Connection>
+is Debug if Connection is Debug; reconcile — if not, implement Debug by hand
+printing just the path/config).
+
+## Testing (woven per phase + a coverage pass)
+
+- P1: bool, i128 (u64::MAX round-trips as HugeInt), timestamp/date/time columns
+  map to the right variant with correct normalized values; decimal → text;
+  interval still errors with the improved message; new accessors.
+- P2: `analytics_query` returns correct column names + rows; `get(row, "col")`;
+  `column_index`; `analytics_one` (row / None on empty); `analytics_query_as`
+  into a test struct.
+- P3: `project.json` is valid JSON; `examples/basic.rs` compiles
+  (`cargo build -p embeddb --examples`).
+- P4: reader-reuse freshness test (above); existing analytics tests still green.
+- Keep all v1–v3 tests green.
+
+## README
+
+Document the new `EmbedValue` variants + accessors, `analytics_query`/`QueryResult`/
+`analytics_one`/`analytics_query_as` + `FromEmbedRow`, the nx targets, and the
+reader-reuse behavior (analytics reads serialize; reads always reflect the last
+checkpoint). Keep existing sections intact.
+
+## Deferred (unchanged)
+
+Live concurrent write/read, WASM target, reader pool for parallel analytics,
+write-path prepared-statement cache, backend-swap trait (rejected).

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -33,6 +33,16 @@ In an offline, distroless, or egress-denied deployment — the target environmen
 
 To support that environment, pre-stage `sqlite_scanner.duckdb_extension` (matching the DuckDB version pulled in by this crate) in a directory on the target, and set the `EMBEDDB_DUCKDB_EXTENSION_DIR` environment variable to that directory before calling any `analytics_*` method. When set, `embeddb` runs `SET extension_directory = '<dir>';` on the DuckDB connection before `INSTALL sqlite`, so `INSTALL` resolves from the pre-staged directory instead of the network and becomes a no-op if the extension is already present there. When unset (the default, including in this crate's own test suite), behavior is unchanged from before this note.
 
+## Nx targets
+
+This crate is an Nx project (`packages/rust/embeddb/project.json`) with `build`, `test`, `e2e`, and `lint` targets backed by `@monodon/rust`. Run them through Nx rather than calling `cargo` directly:
+
+```bash
+pnpm nx build embeddb
+pnpm nx test embeddb
+pnpm nx lint embeddb
+```
+
 ## Usage
 
 ```rust
@@ -112,7 +122,92 @@ assert_eq!(rows[0].as_f64(1), Some(1.5));
 assert_eq!(rows[0].as_str(2), Some("a"));
 ```
 
-Each `EmbedRow` wraps a `Vec<EmbedValue>`, one per selected column. `EmbedValue` is `Null | Int(i64) | Float(f64) | Text(String) | Blob(Vec<u8>)`. Use `EmbedRow::get` for the raw `&EmbedValue`, or the typed `as_i64` / `as_f64` / `as_str` accessors, which return `None` if the column is absent or holds a different variant.
+Each `EmbedRow` wraps a `Vec<EmbedValue>`, one per selected column. `EmbedValue` is:
+
+```rust
+pub enum EmbedValue {
+    Null,
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Blob(Vec<u8>),
+    Bool(bool),
+    HugeInt(i128),
+    Timestamp(i64),
+    Date(i32),
+    Time(i64),
+}
+```
+
+`Timestamp`/`Time` are stored as microseconds (DuckDB's `SECOND`/`MILLISECOND`/`NANOSECOND` units are normalized to microseconds; `NANOSECOND` truncates, it does not round). `Date` is days since the Unix epoch (DuckDB's native `DATE` representation). `HugeInt` covers DuckDB `HUGEINT` and any `UBIGINT` value too large for `i64`, which otherwise maps to `Int`.
+
+Use `EmbedRow::get` for the raw `&EmbedValue`, or the typed accessors, which return `None` if the column is absent or holds a different variant: `as_i64`, `as_f64`, `as_str`, `as_bool`, `as_i128` (for `HugeInt`), `as_timestamp`, `as_date`, `as_time`.
+
+`DECIMAL` columns map to `EmbedValue::Text` holding DuckDB's formatted decimal string (e.g. `CAST(1.5 AS DECIMAL(4,2))` → `"1.50"`) rather than a lossy float conversion.
+
+Not every DuckDB type has a dedicated `EmbedValue` variant. An unmapped type (e.g. `INTERVAL`) returns `EmbedError::Other` with a message containing `cast to VARCHAR` — cast the column to `VARCHAR` in the SQL to read it as `EmbedValue::Text` instead:
+
+```rust
+db.analytics_rows("SELECT CAST(some_interval_col AS VARCHAR) FROM t").await?;
+```
+
+### Structured queries: `analytics_query`, `QueryResult`, `analytics_one`, `analytics_query_as`
+
+`analytics_rows` returns bare `Vec<EmbedRow>` with no column names. `analytics_query` returns a `QueryResult` that pairs the result rows with their column names:
+
+```rust
+pub struct QueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<EmbedRow>,
+}
+```
+
+`QueryResult::column_index(name)` looks up a column's position, `QueryResult::get(row, name)` fetches a value by row index and column name in one call, and `len`/`is_empty` describe the row count:
+
+```rust
+let q = db.analytics_query("SELECT id, name FROM t ORDER BY id").await?;
+assert_eq!(q.columns, vec!["id".to_string(), "name".to_string()]);
+assert_eq!(q.get(0, "name"), Some(&embeddb::EmbedValue::Text("a".into())));
+```
+
+On an empty result set, `columns` still reflects the query's projected column names — only `rows` is empty.
+
+`analytics_one` runs a query and returns just the first row (`Option<EmbedRow>`), or `None` if the query matched nothing:
+
+```rust
+let first = db.analytics_one("SELECT id FROM t").await?;
+```
+
+`analytics_query_as<T>` maps each row into a caller-defined type `T: FromEmbedRow`:
+
+```rust
+pub trait FromEmbedRow: Sized {
+    fn from_row(row: &EmbedRow, columns: &[String]) -> embeddb::Result<Self>;
+}
+
+struct User { id: i64, name: String }
+
+impl FromEmbedRow for User {
+    fn from_row(row: &EmbedRow, columns: &[String]) -> embeddb::Result<Self> {
+        let idx = |n: &str| columns.iter().position(|c| c == n)
+            .ok_or_else(|| embeddb::EmbedError::Other(format!("missing col {n}")));
+        Ok(User {
+            id: row.as_i64(idx("id")?).ok_or_else(|| embeddb::EmbedError::Other("id".into()))?,
+            name: row.as_str(idx("name")?).ok_or_else(|| embeddb::EmbedError::Other("name".into()))?.to_string(),
+        })
+    }
+}
+
+let users: Vec<User> = db.analytics_query_as("SELECT id, name FROM t ORDER BY id").await?;
+```
+
+A query matching zero rows produces an empty `Vec<T>`.
+
+### Reader reuse
+
+`EmbedDb` holds one shared, long-lived DuckDB reader connection (`Arc<Mutex<duckdb::Connection>>`) instead of opening a fresh connection per analytics call. All `analytics_*` methods (`analytics_scalar_i64`, `analytics_scalar_f64`, `analytics_scalar_string`, `analytics_rows`, `analytics_query`, `analytics_one`, `analytics_query_as`) lock that same reader, re-`ATTACH` the file, and run their query on a blocking thread via `tokio::task::spawn_blocking`.
+
+Because the reader is behind a `Mutex`, concurrent analytics calls on the same `EmbedDb` serialize rather than running in parallel — correctness is preserved, but heavy concurrent analytics load is bottlenecked on a single DuckDB connection. Each call re-attaches before querying, so every read reflects the most recent `checkpoint`, not a snapshot taken when the reader was first opened.
 
 ### Schema migrations: `migrate`
 

--- a/packages/rust/embeddb/examples/basic.rs
+++ b/packages/rust/embeddb/examples/basic.rs
@@ -1,0 +1,24 @@
+use embeddb::{EmbedDb, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let dir = std::env::temp_dir().join("embeddb-example.db");
+    let db = EmbedDb::open(&dir).await?;
+    db.migrate(&["CREATE TABLE users (id INTEGER, name TEXT)"]).await?;
+
+    let tx = db.begin().await?;
+    tx.execute("INSERT INTO users VALUES (?, ?)", (1_i64, "alice")).await?;
+    tx.execute("INSERT INTO users VALUES (?, ?)", (2_i64, "bob")).await?;
+    tx.commit().await?;
+    db.checkpoint().await?;
+
+    let q = db.analytics_query("SELECT id, name FROM users ORDER BY id").await?;
+    println!("columns: {:?}", q.columns);
+    for row in &q.rows {
+        println!("{:?}", row);
+    }
+    let n = db.analytics_scalar_i64("SELECT count(*) FROM users").await?;
+    println!("count: {n}");
+    db.close().await?;
+    Ok(())
+}

--- a/packages/rust/embeddb/project.json
+++ b/packages/rust/embeddb/project.json
@@ -1,0 +1,47 @@
+{
+	"name": "embeddb",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/rust/embeddb/src",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/embeddb"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/embeddb"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx test embeddb"],
+				"parallel": false
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/embeddb"
+			}
+		}
+	}
+}

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -19,20 +19,26 @@ pub fn scalar_string(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<S
     Ok(val)
 }
 
-pub fn rows(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<Vec<crate::EmbedRow>> {
+pub fn query(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<crate::QueryResult> {
     let conn = attached_conn(path, ext_dir)?;
     let mut stmt = conn.prepare(sql)?;
-    let mut out = Vec::new();
     let mut rows = stmt.query([])?;
+    let columns = rows.as_ref().map(|s| s.column_names()).unwrap_or_default();
+    let ncols = columns.len();
+    let mut out = Vec::new();
     while let Some(row) = rows.next()? {
-        let ncols = row.as_ref().column_count();
+        let ncols = if ncols > 0 { ncols } else { row.as_ref().column_count() };
         let mut vals = Vec::with_capacity(ncols);
         for i in 0..ncols {
             vals.push(value_from_ref(row.get_ref(i)?)?);
         }
         out.push(crate::EmbedRow(vals));
     }
-    Ok(out)
+    Ok(crate::QueryResult { columns, rows: out })
+}
+
+pub fn rows(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<Vec<crate::EmbedRow>> {
+    Ok(query(path, sql, ext_dir)?.rows)
 }
 
 fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -39,26 +39,40 @@ fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
     use duckdb::types::ValueRef as V;
     Ok(match v {
         V::Null => crate::EmbedValue::Null,
-        V::Boolean(b) => crate::EmbedValue::Int(b as i64),
+        V::Boolean(b) => crate::EmbedValue::Bool(b),
         V::TinyInt(n) => crate::EmbedValue::Int(n as i64),
         V::SmallInt(n) => crate::EmbedValue::Int(n as i64),
         V::Int(n) => crate::EmbedValue::Int(n as i64),
         V::BigInt(n) => crate::EmbedValue::Int(n),
-        V::HugeInt(n) => i64::try_from(n)
-            .map(crate::EmbedValue::Int)
-            .map_err(|_| crate::EmbedError::Other(format!("i128 value out of i64 range: {}", n)))?,
+        V::HugeInt(n) => crate::EmbedValue::HugeInt(n),
         V::UTinyInt(n) => crate::EmbedValue::Int(n as i64),
         V::USmallInt(n) => crate::EmbedValue::Int(n as i64),
         V::UInt(n) => crate::EmbedValue::Int(n as i64),
-        V::UBigInt(n) => i64::try_from(n)
-            .map(crate::EmbedValue::Int)
-            .map_err(|_| crate::EmbedError::Other(format!("u64 value out of i64 range: {}", n)))?,
+        V::UBigInt(n) => match i64::try_from(n) {
+            Ok(v) => crate::EmbedValue::Int(v),
+            Err(_) => crate::EmbedValue::HugeInt(n as i128),
+        },
         V::Float(n) => crate::EmbedValue::Float(n as f64),
         V::Double(n) => crate::EmbedValue::Float(n),
+        V::Decimal(d) => crate::EmbedValue::Text(d.to_string()),
+        V::Timestamp(unit, v) => crate::EmbedValue::Timestamp(to_micros(unit, v)),
+        V::Date32(v) => crate::EmbedValue::Date(v),
+        V::Time64(unit, v) => crate::EmbedValue::Time(to_micros(unit, v)),
         V::Text(b) => crate::EmbedValue::Text(String::from_utf8_lossy(b).into_owned()),
         V::Blob(b) => crate::EmbedValue::Blob(b.to_vec()),
-        other => return Err(crate::EmbedError::Other(format!("unmapped duckdb type: {:?}", other))),
+        other => return Err(crate::EmbedError::Other(format!(
+            "unmapped duckdb type {:?}; cast to VARCHAR in SQL", other))),
     })
+}
+
+fn to_micros(unit: duckdb::types::TimeUnit, v: i64) -> i64 {
+    use duckdb::types::TimeUnit as U;
+    match unit {
+        U::Second => v.saturating_mul(1_000_000),
+        U::Millisecond => v.saturating_mul(1_000),
+        U::Microsecond => v,
+        U::Nanosecond => v / 1_000,
+    }
 }
 
 fn attached_conn(path: &Path, ext_dir: Option<&Path>) -> Result<duckdb::Connection> {

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -1,26 +1,32 @@
 use std::path::Path;
 use crate::Result;
 
-pub fn scalar_i64(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<i64> {
-    let conn = attached_conn(path, ext_dir)?;
+pub fn open_reader(ext_dir: Option<&Path>) -> Result<duckdb::Connection> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    prepare_sqlite_scanner(&conn, ext_dir)?;
+    Ok(conn)
+}
+
+pub fn scalar_i64(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<i64> {
+    attach_fresh(conn, path)?;
     let val: i64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn scalar_f64(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<f64> {
-    let conn = attached_conn(path, ext_dir)?;
+pub fn scalar_f64(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<f64> {
+    attach_fresh(conn, path)?;
     let val: f64 = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn scalar_string(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<String> {
-    let conn = attached_conn(path, ext_dir)?;
+pub fn scalar_string(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<String> {
+    attach_fresh(conn, path)?;
     let val: String = conn.query_row(sql, [], |r| r.get(0))?;
     Ok(val)
 }
 
-pub fn query(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<crate::QueryResult> {
-    let conn = attached_conn(path, ext_dir)?;
+pub fn query(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<crate::QueryResult> {
+    attach_fresh(conn, path)?;
     let mut stmt = conn.prepare(sql)?;
     let mut rows = stmt.query([])?;
     let columns = rows.as_ref().map(|s| s.column_names()).unwrap_or_default();
@@ -36,8 +42,8 @@ pub fn query(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<crate::Qu
     Ok(crate::QueryResult { columns, rows: out })
 }
 
-pub fn rows(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<Vec<crate::EmbedRow>> {
-    Ok(query(path, sql, ext_dir)?.rows)
+pub fn rows(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<Vec<crate::EmbedRow>> {
+    Ok(query(conn, path, sql)?.rows)
 }
 
 fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
@@ -80,13 +86,12 @@ fn to_micros(unit: duckdb::types::TimeUnit, v: i64) -> i64 {
     }
 }
 
-fn attached_conn(path: &Path, ext_dir: Option<&Path>) -> Result<duckdb::Connection> {
-    let conn = duckdb::Connection::open_in_memory()?;
-    prepare_sqlite_scanner(&conn, ext_dir)?;
+fn attach_fresh(conn: &duckdb::Connection, path: &Path) -> Result<()> {
+    let _ = conn.execute_batch("USE memory; DETACH src;");
     let attach = format!("ATTACH '{}' AS src (TYPE sqlite, READ_ONLY);", sql_quote_str(crate::db::path_str(path)?));
     conn.execute_batch(&attach)?;
     conn.execute_batch("USE src;")?;
-    Ok(conn)
+    Ok(())
 }
 
 fn prepare_sqlite_scanner(conn: &duckdb::Connection, ext_dir: Option<&Path>) -> Result<()> {

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -27,7 +27,6 @@ pub fn query(path: &Path, sql: &str, ext_dir: Option<&Path>) -> Result<crate::Qu
     let ncols = columns.len();
     let mut out = Vec::new();
     while let Some(row) = rows.next()? {
-        let ncols = if ncols > 0 { ncols } else { row.as_ref().column_count() };
         let mut vals = Vec::with_capacity(ncols);
         for i in 0..ncols {
             vals.push(value_from_ref(row.get_ref(i)?)?);

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -80,6 +80,19 @@ impl EmbedDb {
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
 
+    pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        let ext_dir = self.config.duckdb_extension_dir.clone();
+        tokio::task::spawn_blocking(move || crate::analytics::query(&path, &sql, ext_dir.as_deref()))
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
+    pub async fn analytics_one(&self, sql: &str) -> Result<Option<crate::EmbedRow>> {
+        Ok(self.analytics_query(sql).await?.rows.into_iter().next())
+    }
+
     pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
         let path = self.path.clone();
         let sql = sql.to_string();
@@ -449,6 +462,33 @@ mod tests {
         let rows = db.analytics_rows("SELECT TIMESTAMP '2021-01-01 00:00:00', DATE '2021-01-01' FROM t").await.unwrap();
         assert!(matches!(rows[0].get(0), Some(crate::EmbedValue::Timestamp(_))));
         assert!(matches!(rows[0].get(1), Some(crate::EmbedValue::Date(_))));
+    }
+
+    #[tokio::test]
+    async fn analytics_query_columns_and_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("q.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'a')", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let q = db.analytics_query("SELECT id, name FROM t").await.unwrap();
+        assert_eq!(q.columns, vec!["id".to_string(), "name".to_string()]);
+        assert_eq!(q.column_index("name"), Some(1));
+        assert_eq!(q.get(0, "name"), Some(&crate::EmbedValue::Text("a".into())));
+        assert_eq!(q.get(0, "missing"), None);
+        assert_eq!(q.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn analytics_one_first_or_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("o.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert!(db.analytics_one("SELECT id FROM t").await.unwrap().is_none());
+        db.execute("INSERT INTO t VALUES (5)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_one("SELECT id FROM t").await.unwrap().unwrap().as_i64(0), Some(5));
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -69,7 +69,7 @@ impl EmbedDb {
         let sql = sql.to_string();
         let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
             crate::analytics::scalar_i64(&conn, &path, &sql)
         })
             .await
@@ -81,7 +81,7 @@ impl EmbedDb {
         let sql = sql.to_string();
         let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
             crate::analytics::scalar_f64(&conn, &path, &sql)
         })
             .await
@@ -93,7 +93,7 @@ impl EmbedDb {
         let sql = sql.to_string();
         let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
             crate::analytics::rows(&conn, &path, &sql)
         })
             .await
@@ -105,7 +105,7 @@ impl EmbedDb {
         let sql = sql.to_string();
         let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
             crate::analytics::query(&conn, &path, &sql)
         })
             .await
@@ -121,7 +121,7 @@ impl EmbedDb {
         let sql = sql.to_string();
         let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
             crate::analytics::scalar_string(&conn, &path, &sql)
         })
             .await
@@ -494,9 +494,11 @@ mod tests {
         db.execute("CREATE TABLE t (x INTEGER)", ()).await.unwrap();
         db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
-        let rows = db.analytics_rows("SELECT TIMESTAMP '2021-01-01 00:00:00', DATE '2021-01-01' FROM t").await.unwrap();
+        let rows = db.analytics_rows("SELECT TIMESTAMP '2021-01-01 00:00:00' AT TIME ZONE 'UTC', DATE '2021-01-01' FROM t").await.unwrap();
         assert!(matches!(rows[0].get(0), Some(crate::EmbedValue::Timestamp(_))));
         assert!(matches!(rows[0].get(1), Some(crate::EmbedValue::Date(_))));
+        assert_eq!(rows[0].as_timestamp(0), Some(1_609_459_200_000_000));
+        assert_eq!(rows[0].as_date(1), Some(18628));
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -102,6 +102,15 @@ impl EmbedDb {
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
 
+    pub async fn analytics_query_as<T: crate::FromEmbedRow>(&self, sql: &str) -> Result<Vec<T>> {
+        let q = self.analytics_query(sql).await?;
+        let mut out = Vec::with_capacity(q.rows.len());
+        for row in &q.rows {
+            out.push(T::from_row(row, &q.columns)?);
+        }
+        Ok(out)
+    }
+
     pub async fn begin(&self) -> Result<crate::EmbedTx<'_>> {
         let tx = self.conn.unchecked_transaction().await?;
         Ok(crate::EmbedTx::new(tx))
@@ -489,6 +498,28 @@ mod tests {
         db.execute("INSERT INTO t VALUES (5)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_one("SELECT id FROM t").await.unwrap().unwrap().as_i64(0), Some(5));
+    }
+
+    #[tokio::test]
+    async fn analytics_query_as_maps_struct() {
+        #[derive(Debug, PartialEq)]
+        struct Rowt { id: i64, name: String }
+        impl crate::FromEmbedRow for Rowt {
+            fn from_row(row: &crate::EmbedRow, cols: &[String]) -> crate::Result<Self> {
+                let ci = |n: &str| cols.iter().position(|c| c == n)
+                    .ok_or_else(|| crate::EmbedError::Other(format!("missing col {n}")));
+                let id = row.as_i64(ci("id")?).ok_or_else(|| crate::EmbedError::Other("id".into()))?;
+                let name = row.as_str(ci("name")?).ok_or_else(|| crate::EmbedError::Other("name".into()))?.to_string();
+                Ok(Rowt { id, name })
+            }
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("as.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let got: Vec<Rowt> = db.analytics_query_as("SELECT id, name FROM t ORDER BY id").await.unwrap();
+        assert_eq!(got, vec![Rowt{id:1,name:"a".into()}, Rowt{id:2,name:"b".into()}]);
     }
 
     #[tokio::test]

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -418,6 +418,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn analytics_rows_maps_bool_and_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("v.db")).await.unwrap();
+        db.execute("CREATE TABLE t (b INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT CAST(b AS BOOLEAN) FROM t").await.unwrap();
+        assert_eq!(rows[0].as_bool(0), Some(true));
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_maps_ubigint_over_i64() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("u.db")).await.unwrap();
+        db.execute("CREATE TABLE t (x INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT 18446744073709551615::UBIGINT FROM t").await.unwrap();
+        assert_eq!(rows[0].as_i128(0), Some(18446744073709551615_i128));
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_maps_timestamp_and_date() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("ts.db")).await.unwrap();
+        db.execute("CREATE TABLE t (x INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT TIMESTAMP '2021-01-01 00:00:00', DATE '2021-01-01' FROM t").await.unwrap();
+        assert!(matches!(rows[0].get(0), Some(crate::EmbedValue::Timestamp(_))));
+        assert!(matches!(rows[0].get(1), Some(crate::EmbedValue::Date(_))));
+    }
+
+    #[tokio::test]
     async fn migrate_failure_rolls_back_that_migration() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("m3.db")).await.unwrap();

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -561,6 +561,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn analytics_query_empty_table_has_columns_no_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("empty_q.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let q = db.analytics_query("SELECT id, name FROM t").await.unwrap();
+        assert_eq!(q.columns, vec!["id".to_string(), "name".to_string()]);
+        assert!(q.rows.is_empty());
+        assert_eq!(q.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn analytics_query_as_empty_returns_empty_vec() {
+        struct Rowt;
+        impl crate::FromEmbedRow for Rowt {
+            fn from_row(_row: &crate::EmbedRow, _cols: &[String]) -> crate::Result<Self> {
+                Ok(Rowt)
+            }
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("empty_as.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let got: Vec<Rowt> = db.analytics_query_as("SELECT id FROM t").await.unwrap();
+        assert_eq!(got.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_decimal_maps_to_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("decimal.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let rows = db.analytics_rows("SELECT CAST(1.5 AS DECIMAL(4,2)) FROM t").await.unwrap();
+        assert_eq!(rows[0].get(0), Some(&crate::EmbedValue::Text("1.50".to_string())));
+    }
+
+    #[tokio::test]
+    async fn analytics_rows_unmapped_type_errors_with_cast_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("interval.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let err = db.analytics_rows("SELECT INTERVAL '1' DAY FROM t").await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("cast to VARCHAR"), "unexpected error message: {msg}");
+    }
+
+    #[tokio::test]
+    async fn analytics_query_sequential_reads_reflect_checkpoints() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("seq.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let q1 = db.analytics_query("SELECT id FROM t").await.unwrap();
+        assert_eq!(q1.len(), 1);
+
+        db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let q2 = db.analytics_query("SELECT id FROM t").await.unwrap();
+        assert_eq!(q2.len(), 3);
+    }
+
+    #[tokio::test]
     async fn reused_reader_sees_fresh_data() {
         let dir = tempfile::tempdir().unwrap();
         let db = EmbedDb::open(dir.path().join("fresh.db")).await.unwrap();

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,11 +1,21 @@
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use crate::Result;
 
-#[derive(Debug)]
 pub struct EmbedDb {
     path: PathBuf,
     conn: turso::Connection,
     config: crate::EmbedConfig,
+    reader: Arc<Mutex<duckdb::Connection>>,
+}
+
+impl std::fmt::Debug for EmbedDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbedDb")
+            .field("path", &self.path)
+            .field("config", &self.config)
+            .finish()
+    }
 }
 
 pub(crate) fn path_str(path: &Path) -> Result<&str> {
@@ -25,7 +35,8 @@ impl EmbedDb {
         let conn = db.connect()?;
         let pragma = format!("PRAGMA journal_mode={}", config.journal_mode);
         conn.execute(&pragma, ()).await.ok();
-        Ok(EmbedDb { path, conn, config })
+        let reader = crate::analytics::open_reader(config.duckdb_extension_dir.as_deref())?;
+        Ok(EmbedDb { path, conn, config, reader: Arc::new(Mutex::new(reader)) })
     }
 
     pub fn path(&self) -> &Path {
@@ -56,8 +67,11 @@ impl EmbedDb {
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let ext_dir = self.config.duckdb_extension_dir.clone();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_i64(&path, &sql, ext_dir.as_deref()))
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            crate::analytics::scalar_i64(&conn, &path, &sql)
+        })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -65,8 +79,11 @@ impl EmbedDb {
     pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let ext_dir = self.config.duckdb_extension_dir.clone();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_f64(&path, &sql, ext_dir.as_deref()))
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            crate::analytics::scalar_f64(&conn, &path, &sql)
+        })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -74,8 +91,11 @@ impl EmbedDb {
     pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let ext_dir = self.config.duckdb_extension_dir.clone();
-        tokio::task::spawn_blocking(move || crate::analytics::rows(&path, &sql, ext_dir.as_deref()))
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            crate::analytics::rows(&conn, &path, &sql)
+        })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -83,8 +103,11 @@ impl EmbedDb {
     pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let ext_dir = self.config.duckdb_extension_dir.clone();
-        tokio::task::spawn_blocking(move || crate::analytics::query(&path, &sql, ext_dir.as_deref()))
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            crate::analytics::query(&conn, &path, &sql)
+        })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -96,8 +119,11 @@ impl EmbedDb {
     pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let ext_dir = self.config.duckdb_extension_dir.clone();
-        tokio::task::spawn_blocking(move || crate::analytics::scalar_string(&path, &sql, ext_dir.as_deref()))
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = reader.lock().map_err(|e| crate::EmbedError::Other(e.to_string()))?;
+            crate::analytics::scalar_string(&conn, &path, &sql)
+        })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
     }
@@ -532,5 +558,19 @@ mod tests {
         db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn reused_reader_sees_fresh_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("fresh.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+        db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
     }
 }

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -5,6 +5,7 @@ mod tx;
 mod value;
 mod config;
 mod migrate;
+mod query;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
@@ -12,3 +13,4 @@ pub use tx::EmbedTx;
 pub use value::{EmbedValue, EmbedRow};
 pub use turso::IntoParams;
 pub use config::EmbedConfig;
+pub use query::QueryResult;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -14,3 +14,4 @@ pub use value::{EmbedValue, EmbedRow};
 pub use turso::IntoParams;
 pub use config::EmbedConfig;
 pub use query::QueryResult;
+pub use query::FromEmbedRow;

--- a/packages/rust/embeddb/src/query.rs
+++ b/packages/rust/embeddb/src/query.rs
@@ -1,0 +1,26 @@
+use crate::EmbedValue;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<crate::EmbedRow>,
+}
+
+impl QueryResult {
+    pub fn column_index(&self, name: &str) -> Option<usize> {
+        self.columns.iter().position(|c| c == name)
+    }
+
+    pub fn get(&self, row: usize, column: &str) -> Option<&EmbedValue> {
+        let idx = self.column_index(column)?;
+        self.rows.get(row)?.get(idx)
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}

--- a/packages/rust/embeddb/src/query.rs
+++ b/packages/rust/embeddb/src/query.rs
@@ -24,3 +24,7 @@ impl QueryResult {
         self.rows.is_empty()
     }
 }
+
+pub trait FromEmbedRow: Sized {
+    fn from_row(row: &crate::EmbedRow, columns: &[String]) -> crate::Result<Self>;
+}

--- a/packages/rust/embeddb/src/value.rs
+++ b/packages/rust/embeddb/src/value.rs
@@ -5,6 +5,11 @@ pub enum EmbedValue {
     Float(f64),
     Text(String),
     Blob(Vec<u8>),
+    Bool(bool),
+    HugeInt(i128),
+    Timestamp(i64),
+    Date(i32),
+    Time(i64),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -32,6 +37,21 @@ impl EmbedRow {
             _ => None,
         }
     }
+    pub fn as_bool(&self, idx: usize) -> Option<bool> {
+        match self.0.get(idx) { Some(EmbedValue::Bool(v)) => Some(*v), _ => None }
+    }
+    pub fn as_i128(&self, idx: usize) -> Option<i128> {
+        match self.0.get(idx) { Some(EmbedValue::HugeInt(v)) => Some(*v), _ => None }
+    }
+    pub fn as_timestamp(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) { Some(EmbedValue::Timestamp(v)) => Some(*v), _ => None }
+    }
+    pub fn as_date(&self, idx: usize) -> Option<i32> {
+        match self.0.get(idx) { Some(EmbedValue::Date(v)) => Some(*v), _ => None }
+    }
+    pub fn as_time(&self, idx: usize) -> Option<i64> {
+        match self.0.get(idx) { Some(EmbedValue::Time(v)) => Some(*v), _ => None }
+    }
 }
 
 #[cfg(test)]
@@ -45,5 +65,22 @@ mod tests {
         assert_eq!(r.get(2), Some(&EmbedValue::Null));
         assert_eq!(r.as_i64(1), None);
         assert_eq!(r.get(9), None);
+    }
+
+    #[test]
+    fn new_variant_accessors() {
+        let r = EmbedRow(vec![
+            EmbedValue::Bool(true),
+            EmbedValue::HugeInt(170141183460469231731687303715884105727),
+            EmbedValue::Timestamp(1_600_000_000_000_000),
+            EmbedValue::Date(19000),
+            EmbedValue::Time(3_600_000_000),
+        ]);
+        assert_eq!(r.as_bool(0), Some(true));
+        assert_eq!(r.as_i128(1), Some(170141183460469231731687303715884105727));
+        assert_eq!(r.as_timestamp(2), Some(1_600_000_000_000_000));
+        assert_eq!(r.as_date(3), Some(19000));
+        assert_eq!(r.as_time(4), Some(3_600_000_000));
+        assert_eq!(r.as_bool(1), None);
     }
 }


### PR DESCRIPTION
## embeddb v4 — value completeness + ergonomic reads + nx + perf

Follow-up to v1 (#14292), v2 (#14313), v3 (#14321). Four tracks, Turso+DuckDB only.

### Phase 1 — Value-type completeness
`EmbedValue` gains `Bool`, `HugeInt(i128)`, `Timestamp(i64 µs)`, `Date(i32 days)`, `Time(i64 µs)` + accessors. `analytics_rows` now maps bool / big ints / timestamps / dates / decimals instead of erroring. UBIGINT over i64 → HugeInt (no overflow). Unmapped exotic types error with a `cast to VARCHAR` hint.

### Phase 2 — Ergonomic reads
- `QueryResult { columns, rows }` via `analytics_query(sql)` — column names + `get(row, "col")` / `column_index`.
- `analytics_one(sql) -> Option<EmbedRow>`.
- `FromEmbedRow` trait + `analytics_query_as::<T>(sql) -> Vec<T>` (query-into-struct, no macro).

### Phase 3 — Nx + consumability
`packages/rust/embeddb/project.json` (@monodon/rust build/test/lint/e2e, matching siblings) + `examples/basic.rs`.

### Phase 4 — Perf: shared DuckDB reader
Was: every analytics call opened a fresh in-memory conn + `INSTALL/LOAD sqlite` + ATTACH. Now: one `Arc<Mutex<duckdb::Connection>>` reader built once, extension loaded once; each call locks it inside `spawn_blocking` and re-`ATTACH`es for a fresh post-checkpoint view. Reader mutex self-heals from poisoning. Trade-off (documented): analytics reads serialize on the shared reader; each read still reflects the latest checkpoint.

### Phase 5 — Tests + README
41 passing (`cargo test -p embeddb`), up from 27. New coverage: bool/i128/decimal/timestamp+date (value-asserted), empty results, unmapped-type error, reader freshness across checkpoints, query-into-struct. README + example updated.

### Notable gotcha found
DuckDB `DETACH src` fails once `USE src` made it the active catalog → must `USE memory; DETACH src;` before re-attach. Caught by the reader-freshness test.

Still deferred: live concurrent read, WASM, reader pool for parallel analytics, write-path prepared-statement cache.
