### PR TITLE
feat(kbve): global user tooltip on forum author cards

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -1,5 +1,6 @@
 ---
 import AstroDroidFooter from './AstroDroidFooter.astro';
+import AstroUserTooltip from '@/components/tooltip/AstroUserTooltip.astro';
 import ReactNavBarStrip from '@/components/rnweb/ReactNavBarStrip.tsx';
 import SocialTooltip from '@kbve/astro/components/tooltip/social/SocialTooltip.astro';
 import SocialIcon from '@kbve/astro/components/social/icons/SocialIcon.astro';
@@ -226,6 +227,8 @@ const currentYear = new Date().getFullYear();
 
 	<AstroDroidFooter />
 </footer>
+
+<AstroUserTooltip />
 
 {/* <AstroYukiDock /> */}
 

--- a/apps/kbve/astro-kbve/src/components/tooltip/AstroUserTooltip.astro
+++ b/apps/kbve/astro-kbve/src/components/tooltip/AstroUserTooltip.astro
@@ -1,0 +1,128 @@
+---
+/**
+ * Global user tooltip singleton. Mount once (via AstroFooter) so every page
+ * shares a single hover profile card. Author links (`<a href="/@name">`)
+ * across the site trigger it through delegated listeners — no per-link markup.
+ */
+---
+
+<div id="kbve-user-tooltip" class="kut not-content" role="tooltip" hidden></div>
+
+<script>
+	import { initUserTooltip } from './userTooltipService';
+
+	const start = () => initUserTooltip();
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', start, { once: true });
+	} else {
+		start();
+	}
+	// Astro view transitions re-run scripts; init is idempotent per document.
+	document.addEventListener('astro:page-load', start);
+</script>
+
+<style is:global>
+	.kut {
+		position: fixed;
+		z-index: 9999;
+		max-width: 18rem;
+		padding: 0.75rem 0.85rem;
+		border-radius: 0.75rem;
+		background: var(--sl-color-bg-nav, #10131a);
+		color: var(--sl-color-white, #f5f7fa);
+		border: 1px solid var(--sl-color-hairline, rgba(255, 255, 255, 0.12));
+		box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+		font-size: 0.85rem;
+		line-height: 1.35;
+		pointer-events: none;
+		opacity: 0;
+		transform: translateY(4px);
+		transition:
+			opacity 0.12s ease,
+			transform 0.12s ease;
+	}
+	.kut[data-open='true'] {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	.kut__head {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+	.kut__avatar {
+		flex: 0 0 auto;
+		width: 40px;
+		height: 40px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0.6rem;
+		overflow: hidden;
+		background: var(--sl-color-accent-low, rgba(120, 130, 255, 0.25));
+		font-weight: 700;
+		text-transform: uppercase;
+	}
+	.kut__avatar-img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.kut__names {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+	.kut__display {
+		font-weight: 600;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.kut__handle {
+		color: var(--sl-color-text-accent, #9aa7ff);
+		text-decoration: none;
+		font-size: 0.8rem;
+	}
+	.kut__badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		margin-top: 0.55rem;
+	}
+	.kut__badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.1rem 0.45rem;
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 600;
+		background: var(--sl-color-gray-6, rgba(255, 255, 255, 0.08));
+		color: var(--sl-color-gray-1, #cbd2e0);
+	}
+	.kut__badge--discord {
+		color: #c7ceff;
+	}
+	.kut__badge--github {
+		color: #e6e6e6;
+	}
+	.kut__badge--twitch {
+		color: #d6b8ff;
+	}
+	.kut__badge--guild {
+		color: #9ff5c4;
+	}
+	.kut__live {
+		color: #ff5c5c;
+		font-weight: 700;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.kut {
+			transition: none;
+			transform: none;
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/tooltip/userTooltipService.test.ts
+++ b/apps/kbve/astro-kbve/src/components/tooltip/userTooltipService.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import {
+	parseUsernameFromHref,
+	pickAvatar,
+	pickDisplayName,
+	connectedProviders,
+	buildTooltipHtml,
+	type UserProfileResponse,
+} from './userTooltipService';
+
+describe('parseUsernameFromHref', () => {
+	it('parses relative profile links', () => {
+		expect(parseUsernameFromHref('/@h0lybyte')).toBe('h0lybyte');
+	});
+
+	it('stops at path/query/fragment boundaries', () => {
+		expect(parseUsernameFromHref('/@h0lybyte/threads')).toBe('h0lybyte');
+		expect(parseUsernameFromHref('/@h0lybyte?tab=1')).toBe('h0lybyte');
+		expect(parseUsernameFromHref('/@h0lybyte#top')).toBe('h0lybyte');
+	});
+
+	it('parses absolute profile links', () => {
+		expect(parseUsernameFromHref('https://kbve.com/@al_1')).toBe('al_1');
+	});
+
+	it('rejects non-profile hrefs', () => {
+		expect(parseUsernameFromHref('/forum/t/hello')).toBeNull();
+		expect(parseUsernameFromHref('/docs')).toBeNull();
+		expect(parseUsernameFromHref('')).toBeNull();
+		expect(parseUsernameFromHref(null)).toBeNull();
+		expect(parseUsernameFromHref(undefined)).toBeNull();
+	});
+
+	it('rejects empty or oversized usernames', () => {
+		expect(parseUsernameFromHref('/@')).toBeNull();
+		expect(parseUsernameFromHref('/@' + 'a'.repeat(65))).toBeNull();
+	});
+
+	it('rejects disallowed characters', () => {
+		expect(parseUsernameFromHref('/@bad name')).toBeNull();
+		expect(parseUsernameFromHref('/@bad.name')).toBeNull();
+	});
+
+	it('round-trips any valid username', () => {
+		fc.assert(
+			fc.property(
+				fc
+					.stringMatching(/^[A-Za-z0-9_-]{1,64}$/)
+					.filter((s) => s.length >= 1),
+				(name) => {
+					expect(parseUsernameFromHref(`/@${name}`)).toBe(name);
+					expect(parseUsernameFromHref(`/@${name}/x`)).toBe(name);
+				},
+			),
+		);
+	});
+});
+
+describe('pickAvatar / pickDisplayName / connectedProviders', () => {
+	it('prefers discord, then github, then twitch avatar', () => {
+		expect(
+			pickAvatar({
+				username: 'a',
+				discord: { avatar_url: 'd' },
+				github: { avatar_url: 'g' },
+			}),
+		).toBe('d');
+		expect(
+			pickAvatar({ username: 'a', github: { avatar_url: 'g' } }),
+		).toBe('g');
+		expect(
+			pickAvatar({ username: 'a', twitch: { avatar_url: 't' } }),
+		).toBe('t');
+		expect(pickAvatar({ username: 'a' })).toBeNull();
+	});
+
+	it('falls back to @username for display name', () => {
+		expect(pickDisplayName({ username: 'a' })).toBe('@a');
+		expect(
+			pickDisplayName({ username: 'a', github: { username: 'Gh' } }),
+		).toBe('Gh');
+	});
+
+	it('derives providers when list absent', () => {
+		expect(
+			connectedProviders({ username: 'a', discord: {}, twitch: {} }),
+		).toEqual(['discord', 'twitch']);
+	});
+
+	it('honors explicit connected_providers list', () => {
+		expect(
+			connectedProviders({
+				username: 'a',
+				connected_providers: ['github'],
+			}),
+		).toEqual(['github']);
+	});
+});
+
+describe('buildTooltipHtml', () => {
+	const base: UserProfileResponse = {
+		username: 'h0lybyte',
+		discord: { username: 'Al', avatar_url: 'https://cdn/a.png' },
+		connected_providers: ['discord'],
+	};
+
+	it('renders avatar image and display name', () => {
+		const html = buildTooltipHtml(base);
+		expect(html).toContain('https://cdn/a.png');
+		expect(html).toContain('Al');
+		expect(html).toContain('@h0lybyte');
+		expect(html).toContain('kut__badge--discord');
+	});
+
+	it('renders initial-letter fallback with no avatar', () => {
+		const html = buildTooltipHtml({ username: 'zed' });
+		expect(html).not.toContain('<img');
+		expect(html).toContain('Z');
+	});
+
+	it('shows twitch live marker', () => {
+		const html = buildTooltipHtml({
+			username: 'a',
+			twitch: { username: 't', is_live: true },
+			connected_providers: ['twitch'],
+		});
+		expect(html).toContain('kut__live');
+		expect(html).toContain('Live');
+	});
+
+	it('shows guild member badge', () => {
+		const html = buildTooltipHtml({
+			username: 'a',
+			discord: { username: 'd', is_guild_member: true },
+			connected_providers: ['discord'],
+		});
+		expect(html).toContain('kut__badge--guild');
+	});
+
+	it('escapes hostile provider values', () => {
+		const html = buildTooltipHtml({
+			username: 'a',
+			github: { username: '<script>x</script>', avatar_url: '"onerror="y' },
+			connected_providers: ['github'],
+		});
+		expect(html).not.toContain('<script>x</script>');
+		expect(html).toContain('&lt;script&gt;');
+		expect(html).not.toContain('"onerror="y"');
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/tooltip/userTooltipService.ts
+++ b/apps/kbve/astro-kbve/src/components/tooltip/userTooltipService.ts
@@ -1,0 +1,325 @@
+/**
+ * User Tooltip Service — shared logic for the global hover profile card.
+ *
+ * A single tooltip node lives in the DOM (mounted once via AstroUserTooltip).
+ * `initUserTooltip` wires delegated hover/focus listeners on the document so
+ * any author link (`<a href="/@username">`) across the site re-uses the same
+ * tooltip: on hover it fetches `/api/v1/profile/{username}`, builds a mini
+ * profile card, positions it near the trigger, and fades it in.
+ *
+ * The pure helpers (parse/pick/build) are unit-tested; `initUserTooltip`
+ * owns the DOM wiring.
+ */
+
+export interface ProfileProvider {
+	username?: string | null;
+	avatar_url?: string | null;
+}
+
+export interface DiscordProvider extends ProfileProvider {
+	is_guild_member?: boolean | null;
+	is_boosting?: boolean | null;
+	role_names?: string[] | null;
+}
+
+export interface TwitchProvider extends ProfileProvider {
+	is_live?: boolean | null;
+}
+
+export interface UserProfileResponse {
+	username: string;
+	user_id?: string;
+	discord?: DiscordProvider | null;
+	github?: ProfileProvider | null;
+	twitch?: TwitchProvider | null;
+	connected_providers?: string[];
+}
+
+/**
+ * Extract the username from a profile href. Handles relative (`/@name`) and
+ * absolute (`https://kbve.com/@name/tab?x`) forms. Returns null when the href
+ * is not a profile link or the username fails the `[A-Za-z0-9_-]` charset.
+ */
+export function parseUsernameFromHref(
+	href: string | null | undefined,
+): string | null {
+	if (!href) return null;
+	const marker = href.indexOf('/@');
+	if (marker === -1) return null;
+	const rest = href.slice(marker + 2);
+	// Username ends at the next path/query/fragment boundary.
+	const raw = rest.split(/[/?#]/, 1)[0] ?? '';
+	if (!/^[A-Za-z0-9_-]{1,64}$/.test(raw)) return null;
+	return raw;
+}
+
+/** Preferred display avatar: Discord → GitHub → Twitch. */
+export function pickAvatar(p: UserProfileResponse): string | null {
+	return (
+		p.discord?.avatar_url ||
+		p.github?.avatar_url ||
+		p.twitch?.avatar_url ||
+		null
+	);
+}
+
+/** Preferred display name: provider handle, falling back to `@username`. */
+export function pickDisplayName(p: UserProfileResponse): string {
+	return (
+		p.discord?.username ||
+		p.github?.username ||
+		p.twitch?.username ||
+		`@${p.username}`
+	);
+}
+
+/** Ordered list of connected providers for the badge row. */
+export function connectedProviders(p: UserProfileResponse): string[] {
+	if (Array.isArray(p.connected_providers)) return p.connected_providers;
+	const out: string[] = [];
+	if (p.discord) out.push('discord');
+	if (p.github) out.push('github');
+	if (p.twitch) out.push('twitch');
+	return out;
+}
+
+function esc(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+	discord: 'Discord',
+	github: 'GitHub',
+	twitch: 'Twitch',
+	rentearth: 'RentEarth',
+};
+
+/** Build the inner HTML of the tooltip card for a resolved profile. */
+export function buildTooltipHtml(p: UserProfileResponse): string {
+	const avatar = pickAvatar(p);
+	const name = pickDisplayName(p);
+	const letter = (p.username || '?').charAt(0).toUpperCase();
+
+	const avatarHtml = avatar
+		? `<img class="kut__avatar-img" src="${esc(avatar)}" alt="" width="40" height="40" loading="lazy" />`
+		: esc(letter);
+
+	const badges = connectedProviders(p)
+		.map((prov) => {
+			const label = PROVIDER_LABELS[prov] ?? prov;
+			const live =
+				prov === 'twitch' && p.twitch?.is_live
+					? ' <span class="kut__live" aria-label="Live">● Live</span>'
+					: '';
+			return `<span class="kut__badge kut__badge--${esc(prov)}">${esc(label)}${live}</span>`;
+		})
+		.join('');
+
+	const guild = p.discord?.is_guild_member
+		? `<span class="kut__badge kut__badge--guild">✓ Member</span>`
+		: '';
+
+	const badgeRow =
+		badges || guild
+			? `<div class="kut__badges">${badges}${guild}</div>`
+			: '';
+
+	return `
+		<div class="kut__head">
+			<span class="kut__avatar">${avatarHtml}</span>
+			<span class="kut__names">
+				<span class="kut__display">${esc(name)}</span>
+				<a class="kut__handle" href="/@${esc(p.username)}">@${esc(p.username)}</a>
+			</span>
+		</div>
+		${badgeRow}
+	`;
+}
+
+export interface InitOptions {
+	/** Base URL for the profile API. Defaults to same-origin. */
+	apiBase?: string;
+	/** id of the singleton tooltip node. */
+	nodeId?: string;
+	/** Hover intent delay before showing (ms). */
+	openDelay?: number;
+	/** Grace delay before hiding (ms). */
+	closeDelay?: number;
+}
+
+const DEFAULT_NODE_ID = 'kbve-user-tooltip';
+
+/**
+ * Wire the global user tooltip. Idempotent per document — a second call is a
+ * no-op once the listeners are installed.
+ */
+export function initUserTooltip(opts: InitOptions = {}): void {
+	if (typeof document === 'undefined') return;
+
+	const doc = document as Document & { __kbveUserTooltip?: boolean };
+	if (doc.__kbveUserTooltip) return;
+	doc.__kbveUserTooltip = true;
+
+	const nodeId = opts.nodeId ?? DEFAULT_NODE_ID;
+	const apiBase = opts.apiBase ?? '';
+	const openDelay = opts.openDelay ?? 150;
+	const closeDelay = opts.closeDelay ?? 120;
+
+	let node = document.getElementById(nodeId);
+	if (!node) {
+		node = document.createElement('div');
+		node.id = nodeId;
+		node.className = 'kut not-content';
+		node.setAttribute('role', 'tooltip');
+		node.hidden = true;
+		document.body.appendChild(node);
+	}
+	const tip = node;
+
+	const cache = new Map<string, Promise<UserProfileResponse | null>>();
+	let openTimer: number | undefined;
+	let closeTimer: number | undefined;
+	let activeTrigger: HTMLElement | null = null;
+
+	async function loadProfile(
+		username: string,
+	): Promise<UserProfileResponse | null> {
+		const key = username.toLowerCase();
+		const cached = cache.get(key);
+		if (cached) return cached;
+		const promise = (async () => {
+			try {
+				const res = await fetch(
+					`${apiBase}/api/v1/profile/${encodeURIComponent(username)}`,
+					{ headers: { Accept: 'application/json' } },
+				);
+				if (res.status === 404) {
+					return { username, connected_providers: [] };
+				}
+				if (!res.ok) return null;
+				return (await res.json()) as UserProfileResponse;
+			} catch {
+				return null;
+			}
+		})();
+		cache.set(key, promise);
+		return promise;
+	}
+
+	function position(trigger: HTMLElement) {
+		const margin = 8;
+		const r = trigger.getBoundingClientRect();
+		tip.style.visibility = 'hidden';
+		tip.hidden = false;
+		const tw = tip.offsetWidth;
+		const th = tip.offsetHeight;
+
+		let top = r.bottom + margin;
+		if (top + th > window.innerHeight - margin && r.top - margin - th > 0) {
+			top = r.top - margin - th;
+		}
+		let left = r.left;
+		if (left + tw > window.innerWidth - margin) {
+			left = window.innerWidth - margin - tw;
+		}
+		if (left < margin) left = margin;
+
+		tip.style.top = `${Math.round(top)}px`;
+		tip.style.left = `${Math.round(left)}px`;
+		tip.style.visibility = '';
+	}
+
+	function hydrateAvatarFallback() {
+		const el = tip.querySelector<HTMLElement>('.kut__avatar');
+		if (el && !el.querySelector('img') && !el.textContent?.trim()) {
+			el.textContent = '?';
+		}
+	}
+
+	async function show(trigger: HTMLElement, username: string) {
+		const profile = await loadProfile(username);
+		if (activeTrigger !== trigger) return;
+		if (!profile) return;
+		tip.innerHTML = buildTooltipHtml(profile);
+		hydrateAvatarFallback();
+		tip.dataset.open = 'true';
+		position(trigger);
+	}
+
+	function scheduleShow(trigger: HTMLElement, username: string) {
+		window.clearTimeout(closeTimer);
+		window.clearTimeout(openTimer);
+		activeTrigger = trigger;
+		openTimer = window.setTimeout(() => {
+			void show(trigger, username);
+		}, openDelay);
+	}
+
+	function hide() {
+		window.clearTimeout(openTimer);
+		activeTrigger = null;
+		tip.hidden = true;
+		delete tip.dataset.open;
+	}
+
+	function scheduleHide() {
+		window.clearTimeout(openTimer);
+		window.clearTimeout(closeTimer);
+		closeTimer = window.setTimeout(hide, closeDelay);
+	}
+
+	function triggerFrom(target: EventTarget | null): {
+		el: HTMLElement;
+		username: string;
+	} | null {
+		if (!(target instanceof Element)) return null;
+		const anchor = target.closest<HTMLAnchorElement>('a[href]');
+		if (!anchor) return null;
+		if (anchor.hasAttribute('data-no-user-tooltip')) return null;
+		const username = parseUsernameFromHref(anchor.getAttribute('href'));
+		if (!username) return null;
+		return { el: anchor, username };
+	}
+
+	document.addEventListener('mouseover', (e) => {
+		const hit = triggerFrom(e.target);
+		if (!hit) return;
+		scheduleShow(hit.el, hit.username);
+	});
+
+	document.addEventListener('mouseout', (e) => {
+		const hit = triggerFrom(e.target);
+		if (!hit) return;
+		const related = e.relatedTarget;
+		if (related instanceof Node && hit.el.contains(related)) return;
+		scheduleHide();
+	});
+
+	document.addEventListener(
+		'focusin',
+		(e) => {
+			const hit = triggerFrom(e.target);
+			if (hit) scheduleShow(hit.el, hit.username);
+		},
+		true,
+	);
+
+	document.addEventListener(
+		'focusout',
+		(e) => {
+			const hit = triggerFrom(e.target);
+			if (hit) scheduleHide();
+		},
+		true,
+	);
+
+	window.addEventListener('scroll', hide, true);
+	window.addEventListener('resize', hide);
+	document.addEventListener('keydown', (e) => {
+		if (e.key === 'Escape') hide();
+	});
+}


### PR DESCRIPTION
## What

One shared hover tooltip re-used across **every** author reference on the site. Delegated `mouseover`/`focusin` listeners match author links (`a[href^="/@username"]`) so forum feed items, the thread card, and comments all trigger the same tooltip — zero per-card markup.

On hover it fetches the existing `/api/v1/profile/{username}` endpoint (backend untouched, 60s SWR cached) and renders a mini profile: avatar, display name, and connected-provider badges (Discord/GitHub/Twitch, Twitch live dot, guild-member check).

## How

- `userTooltipService.ts` — pure helpers (`parseUsernameFromHref`, `pickAvatar`, `pickDisplayName`, `buildTooltipHtml`) + `initUserTooltip` (fetch + in-memory cache, hover-intent delay, viewport flip/clamp, hide on scroll/blur/Esc, HTML-escaped output).
- `AstroUserTooltip.astro` — singleton node + styles + idempotent init (Astro view-transition safe).
- Mounted once in `AstroFooter.astro` (global Starlight `Footer` override → present on every page, incl. splash forum pages).

## Verify

- `astro build` green (7416 pages); tooltip node + inlined init script + CSS confirmed on forum thread/feed askama footers and normal pages.
- 16 vitest cases pass (parse boundaries, provider precedence, live/guild badges, XSS escaping, fast-check username round-trip).
- `tsc --noEmit --strict` clean.

Follow-up: browser drive-through needs the axum backend + live profiles (not feasible in the build worktree).