### PR TITLE
feat(dashboard): add Cube card to portal grid

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/portal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/portal.mdx
@@ -49,6 +49,7 @@ export const internal = [
 	{ href: '/dashboard/grafana/', title: 'Grafana', copy: 'Proxied cluster monitoring.', icon: 'M3 3v18h18M7 15l4-4 3 3 5-6' },
 	{ href: '/dashboard/argo/', title: 'ArgoCD', copy: 'Proxied deployment status.', icon: 'M6 3v12M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 12a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 9v3a6 6 0 0 1-6 6H6' },
 	{ href: '/dashboard/clickhouse/', title: 'ClickHouse', copy: 'Log aggregation and analytics.', icon: 'M4 7c0-1.66 3.58-3 8-3s8 1.34 8 3-3.58 3-8 3-8-1.34-8-3zM4 7v10c0 1.66 3.58 3 8 3s8-1.34 8-3V7' },
+	{ href: '/dashboard/cube/', title: 'Cube', copy: 'Semantic-layer metrics over Postgres + ClickHouse.', icon: 'M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96 12 12.01l8.73-5.05M12 22.08V12' },
 	{ href: '/dashboard/edge/', title: 'Edge', copy: 'Edge function health.', icon: 'M13 2 3 14h8l-1 8 10-12h-8z' },
 	{ href: '/dashboard/forgejo/', title: 'Forgejo', copy: 'Git hosting dashboard.', icon: 'M6 3v12M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 6v2a4 4 0 0 1-4 4H6' },
 	{ href: '/dashboard/vm/', title: 'Virtual Machines', copy: 'KubeVirt VM management.', icon: 'M2 5h20v11H2zM8 20h8M12 16v4' },


### PR DESCRIPTION
Adds the Cube analytics dashboard to the portal landing grid (was reachable only via sidebar). Follow-up to #14330.

- Card links `/dashboard/cube/` after ClickHouse
- Copy: semantic-layer metrics over Postgres + ClickHouse

🤖 Generated with [KBVE](https://kbve.com/)