### PR TITLE
feat: /store/ on @kbve/rn/markets + bento Commerce rail (Phase 1)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -27,6 +27,13 @@ import {
 	buildItemBreadcrumb,
 } from '../itemdb/itemNav';
 import { MAP_ROOT, buildMapNav, buildMapBreadcrumb } from '../mapdb/mapNav';
+import {
+	MARKET_NAV,
+	STORE_ROOT,
+	MARKET_ROOT,
+	buildStoreBreadcrumb,
+	buildMarketBreadcrumb,
+} from '../market/marketNav';
 import { getCollection } from 'astro:content';
 
 const pathname = Astro.url.pathname;
@@ -47,6 +54,9 @@ const isMc = pathname.startsWith('/mc/');
 const isNpcdb = pathname.startsWith('/npcdb/');
 const isItemdb = pathname.startsWith('/itemdb/');
 const isMapdb = pathname.startsWith('/mapdb/');
+const norm = (p: string) => (p.endsWith('/') ? p : `${p}/`);
+const isStore = norm(pathname) === '/store/';
+const isMarket = norm(pathname) === '/market/';
 
 const npcNav = isNpcdb ? buildNpcNav(await getCollection('npcdb')) : [];
 const itemNav = isItemdb ? buildItemNav(await getCollection('itemdb')) : [];
@@ -161,7 +171,27 @@ const shell = isDashboard
 												collapsible: true,
 												withToc: true,
 											}
-										: undefined;
+										: isStore
+											? {
+													entries: MARKET_NAV,
+													root: STORE_ROOT,
+													menuLabel: 'Commerce menu',
+													navLabel: 'Commerce',
+													crumbs: buildStoreBreadcrumb(pathname),
+													collapsible: true,
+													withToc: true,
+												}
+											: isMarket
+												? {
+														entries: MARKET_NAV,
+														root: MARKET_ROOT,
+														menuLabel: 'Commerce menu',
+														navLabel: 'Commerce',
+														crumbs: buildMarketBreadcrumb(pathname),
+														collapsible: true,
+														withToc: true,
+													}
+												: undefined;
 
 const crumbs = shell?.crumbs ?? [];
 ---

--- a/apps/kbve/astro-kbve/src/components/market/marketNav.ts
+++ b/apps/kbve/astro-kbve/src/components/market/marketNav.ts
@@ -1,0 +1,38 @@
+import type {
+	BreadcrumbCrumb,
+	DashboardNavEntry,
+	DashboardNavItem,
+} from '../dashboard/dashboardNav';
+import { buildBreadcrumbIn } from '../dashboard/dashboardNav';
+
+export const STORE_ROOT: DashboardNavItem = { label: 'Store', href: '/store/' };
+export const MARKET_ROOT: DashboardNavItem = { label: 'Marketplace', href: '/market/' };
+
+export const MARKET_NAV: DashboardNavEntry[] = [
+	{
+		label: 'Commerce',
+		eyebrow: 'Buy & trade',
+		href: '/store/',
+		icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4zM3 6h18M16 10a4 4 0 0 1-8 0',
+		items: [
+			{ label: 'Store', href: '/store/', icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4zM3 6h18M16 10a4 4 0 0 1-8 0', copy: 'Spend credits on collectibles.' },
+			{ label: 'Marketplace', href: '/market/', icon: 'M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82zM7 7h.01', copy: 'Player listings settled in KHash.' },
+		],
+	},
+	{
+		label: 'Wallet',
+		visibility: 'auth',
+		href: '/dashboard/account/',
+		icon: 'M21 12V7H5a2 2 0 0 1 0-4h14v4M3 5v14a2 2 0 0 0 2 2h16v-5M18 12a2 2 0 0 0 0 4h4v-4z',
+		items: [
+			{ label: 'Account & Credits', href: '/dashboard/account/', icon: 'M21 12V7H5a2 2 0 0 1 0-4h14v4M3 5v14a2 2 0 0 0 2 2h16v-5M18 12a2 2 0 0 0 0 4h4v-4z' },
+			{ label: 'Orders', href: '/store/#orders', icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z' },
+		],
+	},
+];
+
+export const buildStoreBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, STORE_ROOT, pathname);
+
+export const buildMarketBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, MARKET_ROOT, pathname);

--- a/apps/kbve/astro-kbve/src/components/store/AstroStoreShell.astro
+++ b/apps/kbve/astro-kbve/src/components/store/AstroStoreShell.astro
@@ -1,28 +1,63 @@
 ---
-import ReactStoreCard from './ReactStoreCard';
-import StoreCatalog from './StoreCatalog';
-import OrderHistory from './OrderHistory';
-import BuyCredits from './BuyCredits';
-import './store.css';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactStoreRN from './ReactStoreRN';
+
+const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q=80&w=2400&auto=format&fit=crop';
 ---
 
-<section class="kbve-store not-content kbve-dashboard-page">
-	<header class="kbve-store__header">
-		<h1>Store</h1>
-		<p>
-			Spend credits to unlock collectibles and merch. Purchases mint an
-			inventory item you own — and can later list on the marketplace.
-		</p>
-	</header>
+<div class="store-hub" style={`--bento-hero-bg: url('${backdrop}')`}>
+	<section class="bento-hero bento-section not-content" aria-label="KBVE Store">
+		<div class="bento-hero__bg" aria-hidden="true"></div>
+		<div class="bento-hero__frame bento-frame">
+			<div class="bento-board bento-board--hero">
+				<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+					<span class="bento-badge bento-chip"><span>store</span></span>
+					<h1 class="bento-title">Spend credits,
+						<span class="bento-title__accent">own the drop.</span></h1>
+					<p class="bento-lede">
+						Buy collectibles and merch with credits. Every purchase mints an
+						inventory item you own — and can later list on the marketplace.
+					</p>
+					<div class="bento-cta">
+						<a class="bento-btn bento-btn--primary" href="#store">Browse the store
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+						</a>
+						<a class="bento-btn bento-btn--ghost" href="/market/">Marketplace</a>
+					</div>
+				</div>
+				{[
+					{ v: 'Own it', l: 'Purchases mint inventory items' },
+					{ v: 'Trade later', l: 'List on the marketplace' },
+					{ v: 'Credits → items', l: 'Top up with Stripe' },
+				].map((s) => (
+					<div class="bento-cell bento-stat bento-card bento-card--glass">
+						<span class="bento-stat__value">{s.v}</span>
+						<span class="bento-stat__label">{s.l}</span>
+					</div>
+				))}
+			</div>
+		</div>
+	</section>
 
-	<BuyCredits client:only="react" />
+	<BentoShell id="store" eyebrow="Browse" heading="Store">
+		<div class="store-island">
+			<ReactStoreRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={3} rows={4} />
+			</ReactStoreRN>
+		</div>
+		<div id="orders" aria-hidden="true"></div>
+	</BentoShell>
+</div>
 
-	<div class="kbve-store__grid">
-		<ReactStoreCard client:only="react" />
-	</div>
+<style>
+	.store-island { min-height: 60vh; }
+</style>
 
-	<h2>All products</h2>
-	<StoreCatalog client:only="react" />
-
-	<OrderHistory client:only="react" />
-</section>
+<style is:global>{`
+	.store-hub {
+		--bento-accent: #fbbf24;
+		--bento-accent-2: #f59e0b;
+		--bento-btn-fg: #3a2a05;
+	}
+`}</style>

--- a/apps/kbve/astro-kbve/src/components/store/AstroStoreShell.astro
+++ b/apps/kbve/astro-kbve/src/components/store/AstroStoreShell.astro
@@ -54,10 +54,10 @@ const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q
 	.store-island { min-height: 60vh; }
 </style>
 
-<style is:global>{`
+<style is:global>
 	.store-hub {
 		--bento-accent: #fbbf24;
 		--bento-accent-2: #f59e0b;
 		--bento-btn-fg: #3a2a05;
 	}
-`}</style>
+</style>

--- a/apps/kbve/astro-kbve/src/components/store/ReactStoreRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/store/ReactStoreRN.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useSession } from '@kbve/astro';
+import { StoreView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export default function ReactStoreRN() {
+	const { ready, authenticated } = useSession();
+	const token = useMemo(() => getToken, []);
+
+	if (!ready) return null;
+
+	return <StoreView getToken={token} baseUrl="" authenticated={authenticated} />;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/store/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/store/index.mdx
@@ -3,6 +3,7 @@ title: Store
 description: |
     Spend credits to unlock KBVE collectibles. Purchases mint an inventory
     item you own and can later trade on the marketplace.
+template: splash
 tableOfContents: false
 graph:
    visible: false

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -34,6 +34,9 @@
 			"@kbve/rn/ui": ["../../../packages/npm/rn/src/ui/index.web.ts"],
 			"@kbve/rn/ui/*": ["../../../packages/npm/rn/src/ui/*"],
 			"@kbve/rn/dash": ["../../../packages/npm/rn/src/dash/index.ts"],
+			"@kbve/rn/markets": [
+				"../../../packages/npm/rn/src/markets/index.ts"
+			],
 			"@kbve/rn/workflows": [
 				"../../../packages/npm/rn/src/workflows/index.ts"
 			],

--- a/docs/superpowers/plans/2026-07-19-markets-store-phase1.md
+++ b/docs/superpowers/plans/2026-07-19-markets-store-phase1.md
@@ -742,7 +742,11 @@ Expected: FAIL — `ProductCard` not found.
 - [ ] **Step 3: Write `store/ProductCard.tsx`**
 
 ```tsx
-import { Badge, Button, Stack, Surface, Text } from '@kbve/rn/ui';
+import { Badge } from '@kbve/rn/ui/primitives/Badge';
+import { Button } from '@kbve/rn/ui/primitives/Button';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
 import type { StoreProduct } from './types';
 
 export interface ProductCardProps {
@@ -803,14 +807,12 @@ export function ProductCard({
 
 ```tsx
 import { useEffect, useState } from 'react';
-import {
-	Button,
-	FormField,
-	Select,
-	Stack,
-	Surface,
-	Text,
-} from '@kbve/rn/ui';
+import { Button } from '@kbve/rn/ui/primitives/Button';
+import { FormField } from '@kbve/rn/ui/primitives/FormField';
+import { Select } from '@kbve/rn/ui/controls/Select';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
 import type { StoreApi } from './api';
 import type { ShippingAddress, StoreVariant } from './types';
 import { StoreApiError } from './errors';
@@ -1031,7 +1033,9 @@ Expected: FAIL — `StoreView` not found.
 - [ ] **Step 3: Write `store/OrderHistory.tsx`**
 
 ```tsx
-import { Stack, Surface, Text } from '@kbve/rn/ui';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
 import type { StoreOrder } from './types';
 
 export interface OrderHistoryProps {
@@ -1065,7 +1069,9 @@ export function OrderHistory({ orders }: OrderHistoryProps) {
 ```tsx
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Stack, Text, tokens } from '@kbve/rn/ui';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import { tokens } from '@kbve/rn/ui/theme';
 import { createStoreApi } from './api';
 import { BuyCredits } from './BuyCredits';
 import { ProductCard } from './ProductCard';
@@ -1373,11 +1379,27 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 **Files:**
 - Create: `apps/kbve/astro-kbve/src/components/market/marketNav.ts`
-- Modify: `apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro`, `apps/kbve/astro-kbve/src/content/docs/store/index.mdx`
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro`, `apps/kbve/astro-kbve/src/content/docs/store/index.mdx`, `tsconfig.base.json`, `apps/kbve/astro-kbve/tsconfig.json`
 
 **Interfaces:**
 - Consumes: `DashboardNavEntry`, `DashboardNavGroup`, `DashboardNavItem`, `buildBreadcrumbIn`, `isActiveIn`, `BreadcrumbCrumb` from `../dashboard/dashboardNav`.
 - Produces: `MARKET_NAV`, `STORE_ROOT`, `MARKET_ROOT`, `buildStoreBreadcrumb`, `buildMarketBreadcrumb`.
+
+- [ ] **Step 0: Add the `@kbve/rn/markets` tsconfig path aliases** (the bridge in Task 6 imports `@kbve/rn/markets`; tsconfig paths are explicit per-subpath, no `@kbve/rn/*` wildcard, so the subpath won't resolve without these).
+
+In `tsconfig.base.json`, in `compilerOptions.paths`, after the `"@kbve/rn/dash"` line, add:
+
+```json
+"@kbve/rn/markets": ["packages/npm/rn/src/markets/index.ts"],
+```
+
+In `apps/kbve/astro-kbve/tsconfig.json`, in `compilerOptions.paths`, after the `"@kbve/rn/dash"` line, add:
+
+```json
+"@kbve/rn/markets": ["../../../packages/npm/rn/src/markets/index.ts"],
+```
+
+(No `.web` variant needed — `markets/index.ts` has no native-only code; its UI resolves through the existing `@kbve/rn/ui/*` alias whose `.web` variants win under vite's web resolve extensions.)
 
 - [ ] **Step 1: Write `components/market/marketNav.ts`**
 
@@ -1496,7 +1518,7 @@ Expected: no new type errors from `marketNav.ts` / `MarkdownContent.astro`.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add apps/kbve/astro-kbve/src/components/market/marketNav.ts apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro apps/kbve/astro-kbve/src/content/docs/store/index.mdx
+git add tsconfig.base.json apps/kbve/astro-kbve/tsconfig.json apps/kbve/astro-kbve/src/components/market/marketNav.ts apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro apps/kbve/astro-kbve/src/content/docs/store/index.mdx
 git commit -m "feat(astro-kbve): Commerce gutter rail + splash for /store/
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"

--- a/packages/npm/rn/package.json
+++ b/packages/npm/rn/package.json
@@ -44,6 +44,10 @@
 			"types": "./src/store/index.ts",
 			"import": "./src/store/index.ts"
 		},
+		"./markets": {
+			"types": "./src/markets/index.ts",
+			"import": "./src/markets/index.ts"
+		},
 		"./dash": {
 			"types": "./src/dash/index.ts",
 			"import": "./src/dash/index.ts"

--- a/packages/npm/rn/package.json
+++ b/packages/npm/rn/package.json
@@ -40,6 +40,10 @@
 			"types": "./src/ui/*.tsx",
 			"import": "./src/ui/*.tsx"
 		},
+		"./ui/theme": {
+			"types": "./src/ui/theme.ts",
+			"import": "./src/ui/theme.ts"
+		},
 		"./store": {
 			"types": "./src/store/index.ts",
 			"import": "./src/store/index.ts"

--- a/packages/npm/rn/src/markets/index.ts
+++ b/packages/npm/rn/src/markets/index.ts
@@ -1,0 +1,1 @@
+export * from './store';

--- a/packages/npm/rn/src/markets/store/BuyCredits.tsx
+++ b/packages/npm/rn/src/markets/store/BuyCredits.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Button } from '@kbve/rn/ui/primitives/Button';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import type { StoreApi } from './api';
+import { CREDIT_PACKS } from './types';
+import { StoreApiError } from './errors';
+import { openCheckout } from './openCheckout';
+
+export interface BuyCreditsProps {
+	api: StoreApi;
+	authenticated: boolean;
+}
+
+export function BuyCredits({ api, authenticated }: BuyCreditsProps) {
+	const [busy, setBusy] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const buy = async (packId: string) => {
+		setBusy(packId);
+		setError(null);
+		try {
+			const { checkout_url } = await api.topupCheckout(packId);
+			openCheckout(checkout_url);
+		} catch (e) {
+			if (e instanceof StoreApiError && e.status === 503)
+				setError('Credit top-up is not available yet.');
+			else if (e instanceof StoreApiError && e.status === 401)
+				setError('Sign in to buy credits.');
+			else setError(e instanceof Error ? e.message : 'checkout failed');
+			setBusy(null);
+		}
+	};
+
+	return (
+		<Surface>
+			<Stack gap="sm">
+				<Text variant="subtitle">Buy credits</Text>
+				<Text variant="caption" tone="muted">
+					Top up with Stripe. Credits buy anything in the store.
+				</Text>
+				{error ? (
+					<Text variant="caption" tone="danger">
+						{error}
+					</Text>
+				) : null}
+				<Stack direction="row" gap="sm">
+					{CREDIT_PACKS.map((p) => (
+						<Button
+							key={p.pack_id}
+							title={busy === p.pack_id ? 'Redirecting…' : p.label}
+							variant="secondary"
+							disabled={!authenticated || busy !== null}
+							onPress={() => void buy(p.pack_id)}
+						/>
+					))}
+				</Stack>
+				{!authenticated ? (
+					<Text variant="caption" tone="muted">
+						Sign in to buy credits.
+					</Text>
+				) : null}
+			</Stack>
+		</Surface>
+	);
+}

--- a/packages/npm/rn/src/markets/store/CheckoutModal.tsx
+++ b/packages/npm/rn/src/markets/store/CheckoutModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@kbve/rn/ui/primitives/Button';
+import { FormField } from '@kbve/rn/ui/primitives/FormField';
+import { Select } from '@kbve/rn/ui/controls/Select';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import type { StoreApi } from './api';
+import type { ShippingAddress, StoreVariant } from './types';
+import { StoreApiError } from './errors';
+import { notifyWalletRefresh } from './walletSync';
+
+const EMPTY_ADDR: ShippingAddress = {
+	name: '', line1: '', line2: '', city: '', region: '', postal_code: '', country: '',
+};
+
+const ADDR_FIELDS: [keyof ShippingAddress, string][] = [
+	['name', 'Full name'],
+	['line1', 'Address line 1'],
+	['line2', 'Address line 2'],
+	['city', 'City'],
+	['region', 'State / region'],
+	['postal_code', 'Postal code'],
+	['country', 'Country'],
+];
+
+export interface CheckoutModalProps {
+	api: StoreApi;
+	slug: string;
+	onClose: () => void;
+	onPurchased?: (orderId: number) => void;
+}
+
+export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModalProps) {
+	const [variants, setVariants] = useState<StoreVariant[]>([]);
+	const [variantId, setVariantId] = useState('');
+	const [qty, setQty] = useState('1');
+	const [addr, setAddr] = useState<ShippingAddress>(EMPTY_ADDR);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [done, setDone] = useState<number | null>(null);
+
+	useEffect(() => {
+		void api
+			.productDetail(slug)
+			.then((d) => {
+				setVariants(d.variants);
+				if (d.variants[0]) setVariantId(d.variants[0].variant_id);
+			})
+			.catch((e) => setError(e instanceof Error ? e.message : 'load failed'));
+	}, [api, slug]);
+
+	const submit = async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			const res = await api.buyPhysical(variantId, {
+				qty: Math.max(1, Number(qty) || 1),
+				shipping_address: addr,
+			});
+			notifyWalletRefresh();
+			setDone(res.order_id);
+			onPurchased?.(res.order_id);
+		} catch (e) {
+			if (e instanceof StoreApiError) {
+				if (e.status === 402) setError('Not enough credits.');
+				else if (e.code === 'P1020' || e.status === 409)
+					setError('Out of stock or duplicate. Try again.');
+				else if (e.status === 401) setError('Sign in to buy.');
+				else setError(e.message || 'purchase failed');
+			} else setError(e instanceof Error ? e.message : 'purchase failed');
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const set = (k: keyof ShippingAddress) => (v: string) =>
+		setAddr((a) => ({ ...a, [k]: v }));
+
+	const invalid =
+		busy || !variantId || !addr.name || !addr.line1 || !addr.city ||
+		!addr.postal_code || !addr.country;
+
+	return (
+		<Surface>
+			<Stack gap="sm">
+				<Stack direction="row" justify="space-between" align="center">
+					<Text variant="subtitle">{done ? `Order #${done} placed` : 'Checkout'}</Text>
+					<Button title="Close" variant="ghost" onPress={onClose} accessibilityLabel="Close" />
+				</Stack>
+				{done ? (
+					<Text variant="caption" tone="muted">
+						Paid in credits. Track it in your order history.
+					</Text>
+				) : (
+					<>
+						{error ? (
+							<Text variant="caption" tone="danger">{error}</Text>
+						) : null}
+						<Select
+							value={variantId}
+							onValueChange={setVariantId}
+							options={variants.map((v) => ({
+								value: v.variant_id,
+								label: `${v.sku} · ${v.price} credits · ${v.stock === null ? 'in stock' : `${v.stock} left`}`,
+							}))}
+						/>
+						<FormField
+							label="Qty"
+							keyboardType="number-pad"
+							value={qty}
+							onChangeText={setQty}
+						/>
+						{ADDR_FIELDS.map(([k, label]) => (
+							<FormField
+								key={k}
+								label={label}
+								value={addr[k] ?? ''}
+								onChangeText={set(k)}
+							/>
+						))}
+						<Button
+							title={busy ? 'Placing…' : 'Buy with credits'}
+							variant="primary"
+							disabled={invalid}
+							onPress={() => void submit()}
+						/>
+					</>
+				)}
+			</Stack>
+		</Surface>
+	);
+}

--- a/packages/npm/rn/src/markets/store/OrderHistory.tsx
+++ b/packages/npm/rn/src/markets/store/OrderHistory.tsx
@@ -1,0 +1,29 @@
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import type { StoreOrder } from './types';
+
+export interface OrderHistoryProps {
+	orders: StoreOrder[];
+}
+
+export function OrderHistory({ orders }: OrderHistoryProps) {
+	if (orders.length === 0) return null;
+	return (
+		<Surface>
+			<Stack gap="xs">
+				<Text variant="subtitle">Your orders</Text>
+				{orders.map((o) => (
+					<Stack key={o.order_id} direction="row" justify="space-between">
+						<Text variant="caption">
+							{`#${o.order_id} · ${o.qty}× · ${o.credits_amount} credits · ${o.status}`}
+						</Text>
+						<Text variant="caption" tone="muted">
+							{new Date(o.created_at).toLocaleDateString()}
+						</Text>
+					</Stack>
+				))}
+			</Stack>
+		</Surface>
+	);
+}

--- a/packages/npm/rn/src/markets/store/ProductCard.tsx
+++ b/packages/npm/rn/src/markets/store/ProductCard.tsx
@@ -1,0 +1,59 @@
+import { Badge } from '@kbve/rn/ui/primitives/Badge';
+import { Button } from '@kbve/rn/ui/primitives/Button';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Surface } from '@kbve/rn/ui/primitives/Surface';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import type { StoreProduct } from './types';
+
+export interface ProductCardProps {
+	product: StoreProduct;
+	owned: boolean;
+	authenticated: boolean;
+	busy: boolean;
+	onBuyDigital: (slug: string) => void;
+	onBuyPhysical: (slug: string) => void;
+}
+
+export function ProductCard({
+	product,
+	owned,
+	authenticated,
+	busy,
+	onBuyDigital,
+	onBuyPhysical,
+}: ProductCardProps) {
+	const price = `${product.price.toLocaleString()} ${product.currency}`;
+	const physical = product.fulfillment !== 'digital';
+	return (
+		<Surface>
+			<Stack gap="xs">
+				<Stack direction="row" justify="space-between" align="center">
+					<Text variant="subtitle">{product.title}</Text>
+					<Badge tone="neutral" label={product.fulfillment} />
+				</Stack>
+				<Text variant="caption" tone="muted">
+					{owned ? 'Unlocked. You own this.' : (product.description ?? '')}
+				</Text>
+				<Stack direction="row" justify="space-between" align="center">
+					<Text variant="body">{price}</Text>
+					{owned ? (
+						<Badge tone="success" label="Owned" />
+					) : !authenticated ? (
+						<Text variant="caption" tone="muted">{`Sign in to buy · ${price}`}</Text>
+					) : (
+						<Button
+							title={busy ? 'Purchasing…' : `Buy · ${price}`}
+							variant="primary"
+							disabled={busy}
+							onPress={() =>
+								physical
+									? onBuyPhysical(product.slug)
+									: onBuyDigital(product.slug)
+							}
+						/>
+					)}
+				</Stack>
+			</Stack>
+		</Surface>
+	);
+}

--- a/packages/npm/rn/src/markets/store/StoreView.tsx
+++ b/packages/npm/rn/src/markets/store/StoreView.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Stack } from '@kbve/rn/ui/primitives/Stack';
+import { Text } from '@kbve/rn/ui/primitives/Text';
+import { tokens } from '@kbve/rn/ui/theme';
+import { createStoreApi } from './api';
+import { BuyCredits } from './BuyCredits';
+import { ProductCard } from './ProductCard';
+import { CheckoutModal } from './CheckoutModal';
+import { OrderHistory } from './OrderHistory';
+import { StoreApiError } from './errors';
+import { notifyWalletRefresh } from './walletSync';
+import { FEATURED_SLUG } from './types';
+import type { StoreEntitlement, StoreOrder, StoreProduct } from './types';
+
+export interface StoreViewProps {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	authenticated: boolean;
+}
+
+export function StoreView({ getToken, baseUrl = '', authenticated }: StoreViewProps) {
+	const api = useMemo(() => createStoreApi({ getToken, baseUrl }), [getToken, baseUrl]);
+	const [products, setProducts] = useState<StoreProduct[]>([]);
+	const [entitlements, setEntitlements] = useState<StoreEntitlement[]>([]);
+	const [orders, setOrders] = useState<StoreOrder[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [busySlug, setBusySlug] = useState<string | null>(null);
+	const [checkoutSlug, setCheckoutSlug] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			setProducts(await api.catalog());
+			setError(null);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'load failed');
+		}
+		if (authenticated) {
+			const [ents, ords] = await Promise.all([
+				api.myEntitlements().catch(() => [] as StoreEntitlement[]),
+				api.myOrders().catch(() => [] as StoreOrder[]),
+			]);
+			setEntitlements(ents);
+			setOrders(ords);
+		} else {
+			setEntitlements([]);
+			setOrders([]);
+		}
+	}, [api, authenticated]);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	const owns = useCallback(
+		(slug: string) => entitlements.some((e) => e.slug === slug),
+		[entitlements],
+	);
+
+	const buyDigital = useCallback(
+		async (slug: string) => {
+			setBusySlug(slug);
+			try {
+				await api.buyProduct(slug);
+				notifyWalletRefresh();
+				setEntitlements(await api.myEntitlements().catch(() => entitlements));
+			} catch (e) {
+				if (e instanceof StoreApiError && e.status === 409) {
+					notifyWalletRefresh();
+					setEntitlements(await api.myEntitlements().catch(() => entitlements));
+				} else {
+					setError(e instanceof Error ? e.message : 'purchase failed');
+				}
+			} finally {
+				setBusySlug(null);
+			}
+		},
+		[api, entitlements],
+	);
+
+	const featured = products.find((p) => p.slug === FEATURED_SLUG);
+	const rest = products.filter((p) => p.slug !== FEATURED_SLUG);
+
+	return (
+		<Stack gap="lg">
+			<BuyCredits api={api} authenticated={authenticated} />
+			{error ? (
+				<Text variant="caption" tone="danger">{error}</Text>
+			) : null}
+			{featured ? (
+				<ProductCard
+					product={featured}
+					owned={owns(featured.slug)}
+					authenticated={authenticated}
+					busy={busySlug === featured.slug}
+					onBuyDigital={(s) => void buyDigital(s)}
+					onBuyPhysical={setCheckoutSlug}
+				/>
+			) : null}
+			<Text variant="subtitle">All products</Text>
+			<View style={styles.grid}>
+				{rest.map((p) => (
+					<View key={p.product_id} style={styles.cell}>
+						<ProductCard
+							product={p}
+							owned={owns(p.slug)}
+							authenticated={authenticated}
+							busy={busySlug === p.slug}
+							onBuyDigital={(s) => void buyDigital(s)}
+							onBuyPhysical={setCheckoutSlug}
+						/>
+					</View>
+				))}
+			</View>
+			<OrderHistory orders={orders} />
+			{checkoutSlug ? (
+				<CheckoutModal
+					api={api}
+					slug={checkoutSlug}
+					onClose={() => setCheckoutSlug(null)}
+					onPurchased={() => void load()}
+				/>
+			) : null}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	grid: { flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.md },
+	cell: { flexGrow: 1, flexBasis: 300, maxWidth: '100%' },
+});

--- a/packages/npm/rn/src/markets/store/__tests__/BuyCredits.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/BuyCredits.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { BuyCredits } from '../BuyCredits';
+import type { StoreApi } from '../api';
+
+function stubApi(over: Partial<StoreApi> = {}): StoreApi {
+	return {
+		catalog: vi.fn(),
+		productDetail: vi.fn(),
+		myEntitlements: vi.fn(),
+		myOrders: vi.fn(),
+		buyProduct: vi.fn(),
+		buyPhysical: vi.fn(),
+		topupCheckout: vi.fn(async () => ({ checkout_url: 'https://pay' })),
+		...over,
+	} as StoreApi;
+}
+
+describe('BuyCredits', () => {
+	it('renders a button per credit pack', () => {
+		const { getByText } = render(<BuyCredits api={stubApi()} authenticated />);
+		expect(getByText('100 credits · $1')).toBeTruthy();
+		expect(getByText('550 credits · $5')).toBeTruthy();
+		expect(getByText('1200 credits · $10')).toBeTruthy();
+	});
+
+	it('calls topupCheckout when a pack is pressed while authenticated', async () => {
+		const topupCheckout = vi.fn(async () => ({ checkout_url: 'https://pay' }));
+		const { getByText } = render(
+			<BuyCredits api={stubApi({ topupCheckout })} authenticated />,
+		);
+		fireEvent.click(getByText('100 credits · $1'));
+		await waitFor(() => expect(topupCheckout).toHaveBeenCalledWith('small'));
+	});
+});

--- a/packages/npm/rn/src/markets/store/__tests__/ProductCard.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/ProductCard.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { ProductCard } from '../ProductCard';
+import type { StoreProduct } from '../types';
+
+const digital: StoreProduct = {
+	product_id: 'p1', slug: 'coin', title: 'Coin', description: 'shiny',
+	price: 50, currency: 'credits', fulfillment: 'digital', asset_ref: {},
+	variant_count: 0, created_at: '',
+};
+
+describe('ProductCard', () => {
+	it('shows Owned badge and no buy button when owned', () => {
+		const { getByText, queryByText } = render(
+			<ProductCard product={digital} owned authenticated busy={false}
+				onBuyDigital={vi.fn()} onBuyPhysical={vi.fn()} />,
+		);
+		expect(getByText('Owned')).toBeTruthy();
+		expect(queryByText(/Buy/)).toBeNull();
+	});
+
+	it('fires onBuyDigital for a digital product when authenticated', () => {
+		const onBuyDigital = vi.fn();
+		const { getByText } = render(
+			<ProductCard product={digital} owned={false} authenticated busy={false}
+				onBuyDigital={onBuyDigital} onBuyPhysical={vi.fn()} />,
+		);
+		fireEvent.click(getByText(/Buy/));
+		expect(onBuyDigital).toHaveBeenCalledWith('coin');
+	});
+});

--- a/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { StoreView } from '../StoreView';
+
+const PRODUCTS = [
+	{ product_id: 'p1', slug: 'i-am-an-idiot', title: 'Idiot', description: 'gag',
+		price: 100, currency: 'credits', fulfillment: 'digital', asset_ref: {},
+		variant_count: 0, created_at: '' },
+	{ product_id: 'p2', slug: 'mug', title: 'Mug', description: 'cup',
+		price: 500, currency: 'credits', fulfillment: 'physical', asset_ref: {},
+		variant_count: 1, created_at: '' },
+];
+
+describe('StoreView', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn(async (url: string) => ({
+			ok: true,
+			status: 200,
+			text: async () =>
+				url.includes('/products') ? JSON.stringify(PRODUCTS)
+					: url.includes('/entitlements') ? JSON.stringify([])
+					: JSON.stringify([]),
+		})) as any;
+	});
+
+	it('loads and renders catalog products', async () => {
+		const { findByText } = render(
+			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText('Idiot')).toBeTruthy();
+		expect(await findByText('Mug')).toBeTruthy();
+	});
+
+	it('renders the Buy credits panel', async () => {
+		const { findByText } = render(
+			<StoreView getToken={async () => null} baseUrl="" authenticated={false} />,
+		);
+		expect(await findByText('Buy credits')).toBeTruthy();
+	});
+});

--- a/packages/npm/rn/src/markets/store/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/store/__tests__/api.test.ts
@@ -71,4 +71,17 @@ describe('createStoreApi', () => {
 		const api = createStoreApi({ getToken: token });
 		expect(await api.topupCheckout('small')).toEqual({ checkout_url: 'https://pay' });
 	});
+
+	it('non-OK empty body falls back to HTTP status message', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: false,
+			status: 500,
+			text: async () => '',
+		});
+		const api = createStoreApi({ getToken: token });
+		const err = await api.buyProduct('x').catch((e) => e);
+		expect(err).toBeInstanceOf(StoreApiError);
+		expect(err.status).toBe(500);
+		expect(err.message).toBe('HTTP 500');
+	});
 });

--- a/packages/npm/rn/src/markets/store/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/store/__tests__/api.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createStoreApi } from '../api';
+import { StoreApiError } from '../errors';
+
+const token = async () => 'tok';
+
+describe('createStoreApi', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn();
+	});
+
+	it('catalog GETs products tokenless from baseUrl', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify([{ product_id: 'p1', slug: 's' }]),
+		});
+		const api = createStoreApi({ getToken: async () => null, baseUrl: 'https://x' });
+		const rows = await api.catalog();
+		expect(rows).toEqual([{ product_id: 'p1', slug: 's' }]);
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('https://x/api/v1/store/products');
+		expect(init?.headers?.Authorization).toBeUndefined();
+	});
+
+	it('buyProduct posts with bearer + injected idempotency_key', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify({ item_id: 'i1' }),
+		});
+		const api = createStoreApi({ getToken: token, baseUrl: '' });
+		const res = await api.buyProduct('i-am-an-idiot');
+		expect(res).toEqual({ item_id: 'i1' });
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('/api/v1/store/products/i-am-an-idiot/buy');
+		expect(init.method).toBe('POST');
+		expect(init.headers.Authorization).toBe('Bearer tok');
+		expect(typeof JSON.parse(init.body).idempotency_key).toBe('string');
+	});
+
+	it('authed call without token throws StoreApiError 401 and does not fetch', async () => {
+		const api = createStoreApi({ getToken: async () => null });
+		await expect(api.myOrders()).rejects.toMatchObject({
+			name: 'StoreApiError',
+			status: 401,
+		});
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('non-OK JSON body surfaces error message + status + code', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: false,
+			status: 402,
+			text: async () => JSON.stringify({ error: 'insufficient', code: 'P1001' }),
+		});
+		const api = createStoreApi({ getToken: token });
+		const err = await api.buyProduct('x').catch((e) => e);
+		expect(err).toBeInstanceOf(StoreApiError);
+		expect(err.status).toBe(402);
+		expect(err.code).toBe('P1001');
+		expect(err.message).toBe('insufficient');
+	});
+
+	it('topupCheckout returns checkout_url', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify({ checkout_url: 'https://pay' }),
+		});
+		const api = createStoreApi({ getToken: token });
+		expect(await api.topupCheckout('small')).toEqual({ checkout_url: 'https://pay' });
+	});
+});

--- a/packages/npm/rn/src/markets/store/__tests__/keys.test.ts
+++ b/packages/npm/rn/src/markets/store/__tests__/keys.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { newIdempotencyKey } from '../keys';
+
+describe('newIdempotencyKey', () => {
+	it('returns a unique non-empty string each call', () => {
+		const a = newIdempotencyKey();
+		const b = newIdempotencyKey();
+		expect(a).toBeTruthy();
+		expect(typeof a).toBe('string');
+		expect(a).not.toBe(b);
+	});
+});

--- a/packages/npm/rn/src/markets/store/api.ts
+++ b/packages/npm/rn/src/markets/store/api.ts
@@ -65,7 +65,7 @@ export function createStoreApi(opts: StoreApiOptions): StoreApi {
 		if (!res.ok) {
 			const j = (json ?? {}) as { error?: string; message?: string; code?: string };
 			throw new StoreApiError(
-				j.error ?? j.message ?? text ?? `HTTP ${res.status}`,
+				j.error ?? j.message ?? (text || `HTTP ${res.status}`),
 				res.status,
 				j.code,
 			);

--- a/packages/npm/rn/src/markets/store/api.ts
+++ b/packages/npm/rn/src/markets/store/api.ts
@@ -1,0 +1,107 @@
+import { StoreApiError } from './errors';
+import { newIdempotencyKey } from './keys';
+import type {
+	ShippingAddress,
+	StoreEntitlement,
+	StoreItem,
+	StoreOrder,
+	StoreProduct,
+	StoreProductDetail,
+} from './types';
+
+export interface StoreApiOptions {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+}
+
+export interface StoreApi {
+	catalog(): Promise<StoreProduct[]>;
+	productDetail(slug: string): Promise<StoreProductDetail>;
+	myEntitlements(): Promise<StoreEntitlement[]>;
+	myOrders(): Promise<StoreOrder[]>;
+	buyProduct(slug: string): Promise<StoreItem>;
+	buyPhysical(
+		variantId: string,
+		body: { qty: number; shipping_address: ShippingAddress },
+	): Promise<{ order_id: number }>;
+	topupCheckout(packId: string): Promise<{ checkout_url: string }>;
+}
+
+interface Req {
+	path: string;
+	method?: string;
+	body?: unknown;
+	auth?: boolean;
+}
+
+export function createStoreApi(opts: StoreApiOptions): StoreApi {
+	const { getToken, baseUrl = '' } = opts;
+
+	async function call<T>({ path, method = 'GET', body, auth = false }: Req): Promise<T> {
+		const headers: Record<string, string> = {};
+		if (body !== undefined) headers['Content-Type'] = 'application/json';
+		if (auth) {
+			const token = await getToken().catch(() => null);
+			if (!token) throw new StoreApiError('Not signed in', 401);
+			headers.Authorization = `Bearer ${token}`;
+		}
+		let res: Response;
+		try {
+			res = await fetch(`${baseUrl}${path}`, {
+				method,
+				headers,
+				body: body === undefined ? undefined : JSON.stringify(body),
+			});
+		} catch (e) {
+			throw new StoreApiError(e instanceof Error ? e.message : 'request failed', 0);
+		}
+		const text = await res.text();
+		let json: unknown;
+		try {
+			json = text ? JSON.parse(text) : undefined;
+		} catch {
+			json = undefined;
+		}
+		if (!res.ok) {
+			const j = (json ?? {}) as { error?: string; message?: string; code?: string };
+			throw new StoreApiError(
+				j.error ?? j.message ?? text ?? `HTTP ${res.status}`,
+				res.status,
+				j.code,
+			);
+		}
+		return json as T;
+	}
+
+	return {
+		catalog: () => call<StoreProduct[]>({ path: '/api/v1/store/products' }),
+		productDetail: (slug) =>
+			call<StoreProductDetail>({
+				path: `/api/v1/store/products/${encodeURIComponent(slug)}`,
+			}),
+		myEntitlements: () =>
+			call<StoreEntitlement[]>({ path: '/api/v1/store/me/entitlements', auth: true }),
+		myOrders: () => call<StoreOrder[]>({ path: '/api/v1/store/me/orders', auth: true }),
+		buyProduct: (slug) =>
+			call<StoreItem>({
+				path: `/api/v1/store/products/${encodeURIComponent(slug)}/buy`,
+				method: 'POST',
+				body: { idempotency_key: newIdempotencyKey() },
+				auth: true,
+			}),
+		buyPhysical: (variantId, body) =>
+			call<{ order_id: number }>({
+				path: `/api/v1/store/variants/${encodeURIComponent(variantId)}/buy`,
+				method: 'POST',
+				body: { ...body, idempotency_key: newIdempotencyKey() },
+				auth: true,
+			}),
+		topupCheckout: (packId) =>
+			call<{ checkout_url: string }>({
+				path: '/api/v1/wallet/topup/checkout',
+				method: 'POST',
+				body: { pack_id: packId },
+				auth: true,
+			}),
+	};
+}

--- a/packages/npm/rn/src/markets/store/errors.ts
+++ b/packages/npm/rn/src/markets/store/errors.ts
@@ -1,0 +1,10 @@
+export class StoreApiError extends Error {
+	status: number;
+	code?: string;
+	constructor(message: string, status: number, code?: string) {
+		super(message);
+		this.name = 'StoreApiError';
+		this.status = status;
+		this.code = code;
+	}
+}

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -8,3 +8,6 @@ export type { StoreApi, StoreApiOptions } from './api';
 export { BuyCredits } from './BuyCredits';
 export { ProductCard } from './ProductCard';
 export { CheckoutModal } from './CheckoutModal';
+export { OrderHistory } from './OrderHistory';
+export { StoreView } from './StoreView';
+export type { StoreViewProps } from './StoreView';

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -6,3 +6,5 @@ export { openCheckout } from './openCheckout';
 export { createStoreApi } from './api';
 export type { StoreApi, StoreApiOptions } from './api';
 export { BuyCredits } from './BuyCredits';
+export { ProductCard } from './ProductCard';
+export { CheckoutModal } from './CheckoutModal';

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export { StoreApiError } from './errors';
+export { newIdempotencyKey } from './keys';
+export { notifyWalletRefresh } from './walletSync';
+export { openCheckout } from './openCheckout';

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -5,3 +5,4 @@ export { notifyWalletRefresh } from './walletSync';
 export { openCheckout } from './openCheckout';
 export { createStoreApi } from './api';
 export type { StoreApi, StoreApiOptions } from './api';
+export { BuyCredits } from './BuyCredits';

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -3,3 +3,5 @@ export { StoreApiError } from './errors';
 export { newIdempotencyKey } from './keys';
 export { notifyWalletRefresh } from './walletSync';
 export { openCheckout } from './openCheckout';
+export { createStoreApi } from './api';
+export type { StoreApi, StoreApiOptions } from './api';

--- a/packages/npm/rn/src/markets/store/keys.ts
+++ b/packages/npm/rn/src/markets/store/keys.ts
@@ -1,0 +1,12 @@
+export function newIdempotencyKey(): string {
+	const c = (globalThis as { crypto?: Crypto }).crypto;
+	if (c?.randomUUID) return c.randomUUID();
+	if (c?.getRandomValues) {
+		const b = c.getRandomValues(new Uint8Array(16));
+		b[6] = (b[6] & 0x0f) | 0x40;
+		b[8] = (b[8] & 0x3f) | 0x80;
+		const h = Array.from(b, (x) => x.toString(16).padStart(2, '0'));
+		return `${h[0]}${h[1]}${h[2]}${h[3]}-${h[4]}${h[5]}-${h[6]}${h[7]}-${h[8]}${h[9]}-${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}`;
+	}
+	return `k-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+}

--- a/packages/npm/rn/src/markets/store/openCheckout.ts
+++ b/packages/npm/rn/src/markets/store/openCheckout.ts
@@ -1,0 +1,5 @@
+import { Linking } from 'react-native';
+
+export function openCheckout(url: string): void {
+	void Linking.openURL(url);
+}

--- a/packages/npm/rn/src/markets/store/openCheckout.web.ts
+++ b/packages/npm/rn/src/markets/store/openCheckout.web.ts
@@ -1,0 +1,3 @@
+export function openCheckout(url: string): void {
+	window.location.assign(url);
+}

--- a/packages/npm/rn/src/markets/store/types.ts
+++ b/packages/npm/rn/src/markets/store/types.ts
@@ -1,0 +1,85 @@
+export type Fulfillment = 'digital' | 'physical' | 'both';
+
+export type OrderStatus =
+	| 'paid'
+	| 'processing'
+	| 'shipped'
+	| 'delivered'
+	| 'cancelled'
+	| 'refunded';
+
+export interface StoreProduct {
+	product_id: string;
+	slug: string;
+	title: string;
+	description: string | null;
+	price: number;
+	currency: string;
+	fulfillment: Fulfillment;
+	asset_ref: Record<string, unknown>;
+	variant_count: number;
+	created_at: string;
+}
+
+export interface StoreVariant {
+	variant_id: string;
+	sku: string;
+	attributes: Record<string, unknown>;
+	price: number;
+	stock: number | null;
+}
+
+export interface StoreProductDetail {
+	product: Omit<StoreProduct, 'fulfillment' | 'variant_count'> & {
+		fulfillment?: Fulfillment;
+	};
+	variants: StoreVariant[];
+}
+
+export interface StoreEntitlement {
+	item_id: string;
+	slug: string;
+	product_id: string;
+	title: string | null;
+	granted_at: string;
+}
+
+export interface StoreItem {
+	item_id: string;
+}
+
+export interface StoreOrder {
+	order_id: number;
+	product_id: string;
+	variant_id: string | null;
+	qty: number;
+	credits_amount: number;
+	status: OrderStatus;
+	tracking: Record<string, unknown>;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ShippingAddress {
+	name: string;
+	line1: string;
+	line2?: string;
+	city: string;
+	region: string;
+	postal_code: string;
+	country: string;
+}
+
+export interface CreditPack {
+	pack_id: string;
+	credits: number;
+	label: string;
+}
+
+export const CREDIT_PACKS: CreditPack[] = [
+	{ pack_id: 'small', credits: 100, label: '100 credits · $1' },
+	{ pack_id: 'medium', credits: 550, label: '550 credits · $5' },
+	{ pack_id: 'large', credits: 1200, label: '1200 credits · $10' },
+];
+
+export const FEATURED_SLUG = 'i-am-an-idiot';

--- a/packages/npm/rn/src/markets/store/walletSync.ts
+++ b/packages/npm/rn/src/markets/store/walletSync.ts
@@ -1,0 +1,12 @@
+const WALLET_BROADCAST = 'kbve-wallet-sync';
+
+export function notifyWalletRefresh(): void {
+	const B = (globalThis as { BroadcastChannel?: typeof BroadcastChannel })
+		.BroadcastChannel;
+	if (!B) return;
+	try {
+		const ch = new B(WALLET_BROADCAST);
+		ch.postMessage({ type: 'refresh' });
+		ch.close();
+	} catch {}
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -40,6 +40,7 @@
 			"@kbve/rn/ui/*": ["packages/npm/rn/src/ui/*"],
 			"@kbve/rn/store": ["packages/npm/rn/src/store/index.ts"],
 			"@kbve/rn/dash": ["packages/npm/rn/src/dash/index.ts"],
+			"@kbve/rn/markets": ["packages/npm/rn/src/markets/index.ts"],
 			"@kbve/rn/account": ["packages/npm/rn/src/account/index.ts"],
 			"@kbve/rn/workflows": ["packages/npm/rn/src/workflows/index.ts"],
 			"@kbve/rn-astro": ["packages/npm/rn-astro/src/index.ts"],


### PR DESCRIPTION
Phase 1 of the store/market → `@kbve/rn/markets` epic. Rebuilds `/store/` as a single universal React Native island (renders on web via react-native-web, mirroring `@kbve/rn/dash/mc`), wrapped in bento splash + a Commerce gutter rail.

## What's in
- **`@kbve/rn/markets`** composition (new subpath): `createStoreApi({getToken, baseUrl})` injected factory, `BuyCredits`, `ProductCard`, `CheckoutModal`, `OrderHistory`, `StoreView`. Universal (native + web), UI via `@kbve/rn/ui/primitives/*` subpaths (web-safe — no `@expo/vector-icons` in the island graph).
- **`ReactStoreRN`** astro bridge — injects Supabase token + session, `baseUrl=''` (public origin), no staff gate.
- **`AstroStoreShell`** rewritten to bento: `bento-hero` + one `BentoShell` island + amber accent + `RnDashSkeleton` SSR fallback.
- **Commerce rail**: new `marketNav`, `MarkdownContent` exact-root branch for `/store/` + `/market/`, `template: splash`, `@kbve/rn/markets` tsconfig aliases.

## Verification
- markets vitest suite **13/13** green.
- `astro build` **EXIT 0** (7417 pages). `/store/` renders splash (no Starlight sidebar) + bento-hero + Commerce rail + `#store`/`#orders` anchors + `ReactStoreRN` island hydration + `rnsk` SSR fallback.
- Built island chunk grepped: **0** `vector-icons` (web-graph clean).
- Not run: live Playwright hydration (build-compiles-island + clean-chunk + SSR-fallback used as proxy).

## Deferred (per spec)
`IdiotCard` reveal animation (featured = plain `ProductCard`), marketplace (`/market/`), Expo mobile screens, staff admin migration. Old React-DOM store components + `store.css`/`api.ts` kept — still live via `AstroStoreAdminShell` (`/dashboard/store/`).

No kube/infra changes.

Spec: `docs/superpowers/specs/2026-07-19-store-market-bento-design.md`
Plan: `docs/superpowers/plans/2026-07-19-markets-store-phase1.md`