### PR TITLE
feat(kbve-nx): ci-health route (bento) — GitHub Actions run health

### DIFF
--- a/packages/python/kbve/kbve/nx/ci_health.py
+++ b/packages/python/kbve/kbve/nx/ci_health.py
@@ -1,0 +1,183 @@
+"""Fetch and aggregate GitHub Actions run health for KBVE/kbve.
+
+Pages the Actions ``runs`` REST endpoint over a trailing window (default 7
+days) and rolls the runs up into per-workflow health: success rate, average
+duration, and flaky count (a run that only went green on a re-run). The fetch
+uses ``GITHUB_TOKEN``; the pure :func:`aggregate` is unit-tested via the
+route's ``inputs`` seam.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+OWNER = "KBVE"
+REPO = "kbve"
+API_BASE = "https://api.github.com"
+API_VERSION = "2022-11-28"
+USER_AGENT = "kbve-ci-daily-content-fetch/1.0"
+
+_TERMINAL = {"success", "failure", "cancelled", "skipped", "timed_out",
+             "action_required", "neutral", "stale"}
+
+
+def _next_link(header: str) -> str | None:
+    for part in header.split(","):
+        segs = [s.strip() for s in part.split(";")]
+        if len(segs) >= 2 and 'rel="next"' in segs[1:]:
+            url = segs[0].strip()
+            if url.startswith("<") and url.endswith(">"):
+                return url[1:-1]
+    return None
+
+
+def fetch_runs(token: str, since_date: str, per_page: int = 100,
+               timeout: float = 30.0, max_pages: int = 40) -> list[dict]:
+    """Page ``/actions/runs?created=>=<since_date>`` into one list."""
+    url = (f"{API_BASE}/repos/{OWNER}/{REPO}/actions/runs"
+           f"?per_page={per_page}&created=%3E%3D{since_date}")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    runs: list[dict] = []
+    pages = 0
+    while url and pages < max_pages:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.load(resp)
+            runs.extend(payload.get("workflow_runs", []))
+            url = _next_link(resp.headers.get("Link") or "")
+        pages += 1
+    return runs
+
+
+def _duration_s(run: dict) -> float | None:
+    start = run.get("run_started_at")
+    end = run.get("updated_at")
+    if not start or not end:
+        return None
+    try:
+        s = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    d = (e - s).total_seconds()
+    return d if d >= 0 else None
+
+
+def _blank() -> dict:
+    return {"runs": 0, "success": 0, "failure": 0, "cancelled": 0,
+            "skipped": 0, "other": 0, "flaky": 0, "_dur": []}
+
+
+def _bucket_conclusion(acc: dict, concl: str | None) -> None:
+    if concl == "success":
+        acc["success"] += 1
+    elif concl == "failure":
+        acc["failure"] += 1
+    elif concl == "cancelled":
+        acc["cancelled"] += 1
+    elif concl == "skipped":
+        acc["skipped"] += 1
+    else:
+        acc["other"] += 1
+
+
+def _rate(success: int, failure: int) -> float:
+    denom = success + failure
+    return round(success / denom * 100, 1) if denom else 0.0
+
+
+def _finalize(acc: dict) -> dict:
+    durs = acc.pop("_dur")
+    avg = round(sum(durs) / len(durs)) if durs else 0
+    acc["success_rate"] = _rate(acc["success"], acc["failure"])
+    acc["avg_duration_s"] = avg
+    return acc
+
+
+def aggregate(runs: list[dict], since_iso: str, now_iso: str,
+              days: int = 7) -> dict:
+    """Roll raw runs into totals + per-workflow health + recent failures."""
+    try:
+        now = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    except ValueError:
+        now = datetime.now(timezone.utc)
+    day_ago = now - timedelta(days=1)
+
+    totals = _blank()
+    per_wf: dict[str, dict] = {}
+    t24 = {"runs": 0, "success": 0, "failure": 0}
+    failures: list[dict] = []
+
+    for run in runs:
+        concl = run.get("conclusion")
+        name = run.get("name") or "(unnamed)"
+        attempt = run.get("run_attempt") or 1
+        dur = _duration_s(run)
+
+        totals["runs"] += 1
+        _bucket_conclusion(totals, concl)
+        if dur is not None:
+            totals["_dur"].append(dur)
+
+        wf = per_wf.setdefault(name, _blank())
+        wf["runs"] += 1
+        _bucket_conclusion(wf, concl)
+        if dur is not None:
+            wf["_dur"].append(dur)
+
+        if concl == "success" and attempt > 1:
+            totals["flaky"] += 1
+            wf["flaky"] += 1
+
+        started = run.get("run_started_at")
+        if started:
+            try:
+                ts = datetime.fromisoformat(started.replace("Z", "+00:00"))
+            except ValueError:
+                ts = None
+            if ts and ts >= day_ago:
+                t24["runs"] += 1
+                if concl == "success":
+                    t24["success"] += 1
+                elif concl == "failure":
+                    t24["failure"] += 1
+
+        if concl == "failure":
+            failures.append({
+                "name": name,
+                "branch": run.get("head_branch"),
+                "event": run.get("event"),
+                "url": run.get("html_url"),
+                "finished_at": run.get("updated_at"),
+            })
+
+    workflows = [{"name": n, **_finalize(a)} for n, a in per_wf.items()]
+    workflows.sort(key=lambda w: (-w["runs"], w["name"]))
+
+    failures.sort(key=lambda f: f.get("finished_at") or "", reverse=True)
+
+    return {
+        "window": {"days": days, "since": since_iso},
+        "totals": _finalize(totals),
+        "totals_24h": {**t24, "success_rate": _rate(
+            t24["success"], t24["failure"])},
+        "workflows": workflows,
+        "recent_failures": failures[:15],
+    }
+
+
+def since_date(now_iso: str, days: int = 7) -> str:
+    """``YYYY-MM-DD`` for ``days`` before ``now_iso`` (for the created filter)."""
+    try:
+        now = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    except ValueError:
+        now = datetime.now(timezone.utc)
+    return (now - timedelta(days=days)).strftime("%Y-%m-%d")

--- a/packages/python/kbve/kbve/nx/render.py
+++ b/packages/python/kbve/kbve/nx/render.py
@@ -1186,3 +1186,257 @@ def _write_kanban_tables(out: TextIO, columns: dict, summary: dict) -> None:
                 f"| {ref} | {title} | {priority} | {assignees} | {labels} |\n"
             )
         out.write("\n")
+
+
+# ── CI Health ────────────────────────────────────────────────────────
+
+CI_HEALTH_SVG = {
+    "runs": "M22 12h-4l-3 9L9 3l-3 9H2",
+    "rate": "M22 11.1V12a10 10 0 1 1-5.9-9.1M22 4 12 14.01l-3-3",
+    "duration": "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 6v6l4 2",
+    "failures": "M7.9 2h8.2L22 7.9v8.2L16.1 22H7.9L2 16.1V7.9zM15 9l-6 6M9 9l6 6",
+    "flaky": "M13 2 3 14h7l-1 8 10-12h-7z",
+    "workflow": ("M6 3v12M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 21a3 3 0 1 0"
+                 " 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9"),
+}
+
+
+def build_ci_health_payload(agg: dict, timestamp: str) -> dict:
+    """Prepend ``generated_at`` to the aggregated CI-health rollup."""
+    return {"generated_at": timestamp, **agg}
+
+
+def render_ci_health_json(payload: dict) -> str:
+    """Serialize the CI-health payload to JSON."""
+    return json.dumps(payload, indent=2)
+
+
+def _fmt_duration(seconds: int | float) -> str:
+    s = int(round(seconds or 0))
+    if s <= 0:
+        return "—"
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m"
+    if m:
+        return f"{m}m {sec}s"
+    return f"{sec}s"
+
+
+def render_ci_health_mdx(payload: dict, timestamp: str) -> str:
+    """Render the Bento-native MDX CI-health report."""
+    from io import StringIO
+
+    totals = payload["totals"]
+    t24 = payload["totals_24h"]
+    workflows = payload["workflows"]
+    failures = payload["recent_failures"]
+    days = payload["window"]["days"]
+    rate = totals["success_rate"]
+    fails = totals["failure"]
+    flaky = totals["flaky"]
+    out = StringIO()
+
+    out.write(
+        "---\n"
+        "title: CI Health Report\n"
+        "description: |\n"
+        "    Daily auto-generated GitHub Actions health for the KBVE monorepo.\n"
+        "template: splash\n"
+        "tableOfContents: false\n"
+        "editUrl: false\n"
+        "lastUpdated: false\n"
+        "next: false\n"
+        "prev: false\n"
+        "sidebar:\n"
+        "    label: CI Health\n"
+        "    order: 103\n"
+        "---\n\n"
+    )
+    out.write(
+        "import BentoShell from '@/components/hero/BentoShell.astro';\n"
+        "import BentoProse from '@/components/hero/BentoProse.astro';\n\n"
+    )
+
+    if totals["runs"] == 0:
+        lede = f"No workflow runs recorded in the last {days} days."
+    elif fails > 0:
+        lede = (
+            f"<strong>{rate}%</strong> success across"
+            f" <strong>{totals['runs']}</strong> runs"
+            f" ({days}d) — <strong>{fails}</strong> failure"
+            f"{'s' if fails != 1 else ''}, <strong>{flaky}</strong> flaky."
+        )
+    else:
+        lede = (
+            f"<strong>{rate}%</strong> success across"
+            f" <strong>{totals['runs']}</strong> runs"
+            f" ({days}d) — all green."
+        )
+
+    out.write('<div class="ci-health-report" data-dash-report>\n\n')
+
+    out.write(
+        '<section class="bento-hero bento-section not-content"'
+        ' aria-label="CI health">\n'
+        '\t<div class="bento-hero__bg" aria-hidden="true"></div>\n'
+        '\t<div class="bento-hero__frame bento-frame">\n'
+        '\t\t<div class="bento-board bento-board--hero">\n'
+        '\t\t\t<div class="bento-cell bento-hero-copy bento-card'
+        ' bento-card--glass">\n'
+        '\t\t\t\t<span class="bento-badge bento-chip">\n'
+        '\t\t\t\t\t<svg viewBox="0 0 24 24" width="14" height="14"'
+        ' fill="none" stroke="currentColor" stroke-width="1.75"'
+        ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>\n'
+        '\t\t\t\t\t<span>auto-generated · daily</span>\n'
+        '\t\t\t\t</span>\n'
+        '\t\t\t\t<h1 class="bento-title">\n'
+        '\t\t\t\t\tPipeline health\n'
+        '\t\t\t\t\t<span class="bento-title__accent">every workflow,'
+        ' every day.</span>\n'
+        '\t\t\t\t</h1>\n'
+        f'\t\t\t\t<p class="bento-lede">{lede}</p>\n'
+        f'\t\t\t\t<p class="bento-lede">Last generated'
+        f' <strong>{timestamp}</strong>.</p>\n'
+        '\t\t\t\t<div class="bento-cta">\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--primary"'
+        ' href="#workflows">\n'
+        '\t\t\t\t\t\tView workflows\n'
+        '\t\t\t\t\t\t<svg viewBox="0 0 24 24" fill="none"'
+        ' stroke="currentColor" aria-hidden="true"><path'
+        ' stroke-linecap="round" stroke-linejoin="round" stroke-width="2"'
+        ' d="M5 12h14M13 6l6 6-6 6" /></svg>\n'
+        '\t\t\t\t\t</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="#failures">Failures</a>\n'
+        '\t\t\t\t\t<a class="bento-btn bento-btn--ghost"'
+        ' href="/dashboard/">Dashboard home</a>\n'
+        '\t\t\t\t</div>\n'
+        '\t\t\t</div>\n\n'
+    )
+
+    _stat_tile(out, CI_HEALTH_SVG["runs"], totals["runs"], f"Runs ({days}d)")
+    _stat_tile(out, CI_HEALTH_SVG["rate"], f"{rate}%", "Success rate")
+    _stat_tile(out, CI_HEALTH_SVG["duration"],
+               _fmt_duration(totals["avg_duration_s"]), "Avg duration")
+    _stat_tile(out, CI_HEALTH_SVG["failures"], fails, "Failures")
+    _stat_tile(out, CI_HEALTH_SVG["flaky"], flaky, "Flaky")
+
+    out.write(
+        '\t\t</div>\n'
+        '\t\t<nav class="bento-jump" aria-label="On this page">\n'
+        '\t\t\t<a class="bento-chip" href="#workflows">Workflows</a>\n'
+        '\t\t\t<a class="bento-chip" href="#trends">Trends</a>\n'
+        '\t\t\t<a class="bento-chip" href="#failures">Failures</a>\n'
+        '\t\t</nav>\n'
+        '\t</div>\n'
+        '</section>\n\n'
+    )
+
+    out.write(
+        '<BentoShell id="workflows" eyebrow="Volume"'
+        ' heading="Busiest workflows">\n'
+        '\t<div class="bento-board bento-board--cols-3">\n'
+    )
+    for wf in workflows[:9]:
+        copy = f"{wf['runs']} runs · {wf['success_rate']}% ok"
+        _linkcard(out, CI_HEALTH_SVG["workflow"], escape_mdx(wf["name"]),
+                  copy, href="#health-table")
+    out.write("\t</div>\n</BentoShell>\n\n")
+
+    out.write('<BentoProse id="trends" heading="Trends">\n\n')
+
+    concl = {
+        "Success": totals["success"], "Failure": totals["failure"],
+        "Cancelled": totals["cancelled"], "Skipped": totals["skipped"],
+        "Other": totals["other"],
+    }
+    if any(v > 0 for v in concl.values()):
+        out.write("### Outcome distribution\n\n")
+        out.write("```mermaid\npie showData\n    title Runs by Outcome\n")
+        for label, val in concl.items():
+            if val > 0:
+                out.write(f'    "{label}" : {val}\n')
+        out.write("```\n\n")
+
+    top = [w for w in workflows[:8] if w["runs"] > 0]
+    if top:
+        out.write("### Volume by workflow\n\n")
+        out.write("```mermaid\npie showData\n    title Runs by Workflow"
+                  " (top 8)\n")
+        for wf in top:
+            out.write(f'    "{_mermaid_label(wf["name"])}" : {wf["runs"]}\n')
+        out.write("```\n\n")
+
+    out.write(f"### Last 24 hours\n\n")
+    out.write(
+        f"**{t24['runs']}** runs · **{t24['success']}** ok ·"
+        f" **{t24['failure']}** failed · **{t24['success_rate']}%** success"
+        f" rate.\n\n"
+    )
+
+    out.write('<span id="health-table"></span>\n\n')
+    out.write("### Per-workflow health\n\n")
+    if workflows:
+        out.write(
+            "| Workflow | Runs | OK | Fail | Success | Avg | Flaky |\n"
+            "|----------|:----:|:--:|:----:|:-------:|:---:|:-----:|\n"
+        )
+        for wf in workflows:
+            out.write(
+                f"| {escape_mdx(wf['name'])} | {wf['runs']} |"
+                f" {wf['success']} | {wf['failure']} |"
+                f" {wf['success_rate']}% |"
+                f" {_fmt_duration(wf['avg_duration_s'])} |"
+                f" {wf['flaky']} |\n"
+            )
+        out.write("\n")
+    else:
+        out.write(":::tip[Idle]\nNo workflow runs in the window.\n:::\n\n")
+
+    out.write("</BentoProse>\n\n")
+
+    out.write('<BentoProse id="failures" heading="Recent failures">\n\n')
+    if failures:
+        out.write(
+            "| Workflow | Branch | Event | Finished | Link |\n"
+            "|----------|--------|-------|----------|------|\n"
+        )
+        for f in failures:
+            name = escape_mdx(f.get("name") or "")
+            branch = escape_mdx(f.get("branch") or "—")
+            event = f.get("event") or "—"
+            fin = (f.get("finished_at") or "—")[:16].replace("T", " ")
+            url = f.get("url")
+            link = f"[run]({url})" if url else "—"
+            out.write(
+                f"| {name} | {branch} | {event} | {fin} | {link} |\n")
+        out.write("\n")
+    else:
+        out.write(
+            ":::tip[All Clear]\nNo failed runs in the window.\n:::\n\n")
+    out.write("</BentoProse>\n\n")
+
+    out.write('<BentoProse id="about">\n\n')
+    out.write("---\n\n")
+    out.write(
+        "*Auto-generated by "
+        "[ci-daily-content.yml]"
+        "(https://github.com/KBVE/kbve/actions/"
+        "workflows/ci-daily-content.yml)*\n\n"
+    )
+    out.write("</BentoProse>\n\n")
+
+    out.write("</div>\n\n")
+    out.write(
+        "<style is:global>{`.ci-health-report{--bento-accent:#06b6d4;"
+        "--bento-accent-2:#f43f5e}`}</style>\n"
+    )
+
+    return out.getvalue()
+
+
+def _mermaid_label(name: str) -> str:
+    return name.replace('"', "'").replace("\n", " ")[:40]

--- a/packages/python/kbve/kbve/nx/routes/__init__.py
+++ b/packages/python/kbve/kbve/nx/routes/__init__.py
@@ -6,3 +6,4 @@ from . import security  # noqa: F401
 from . import proto  # noqa: F401
 from . import report  # noqa: F401
 from . import kanban  # noqa: F401
+from . import ci_health  # noqa: F401

--- a/packages/python/kbve/kbve/nx/routes/ci_health.py
+++ b/packages/python/kbve/kbve/nx/routes/ci_health.py
@@ -1,0 +1,82 @@
+"""The ``ci_health`` route — GitHub Actions run health (MDX + raw JSON).
+
+Pages the Actions ``runs`` REST endpoint over a trailing 7-day window
+(``GITHUB_TOKEN``) and rolls it into per-workflow health — success rate,
+average duration, flaky count — then renders the Bento MDX + companion JSON.
+A missing token or a fetch error degrades to a graceful skip.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from ..builder import BuildContext, BuildResult, PlanResult, repo_root_for
+from ..ci_health import aggregate, fetch_runs, since_date
+from ..render import (
+    build_ci_health_payload,
+    render_ci_health_json,
+    render_ci_health_mdx,
+)
+from ..router import route
+
+_WINDOW_DAYS = 7
+_FETCH_TIMEOUT = 30.0
+
+
+def _warn(msg: str) -> None:
+    print("::warning::ci_health route: %s" % msg, file=sys.stderr)
+
+
+def _acquire(ctx: BuildContext) -> dict | None:
+    since = since_date(ctx.timestamp, _WINDOW_DAYS)
+    seam = ctx.inputs.get("ci_runs")
+    if isinstance(seam, list):
+        runs = seam
+    else:
+        token = os.environ.get("GITHUB_TOKEN", "").strip()
+        if not token:
+            _warn("GITHUB_TOKEN not set — skipping CI health sync")
+            return None
+        try:
+            runs = fetch_runs(token, since, timeout=_FETCH_TIMEOUT)
+        except Exception as exc:  # noqa: BLE001 — degrade, never hard-fail
+            _warn("runs fetch failed (%s)" % exc)
+            return None
+
+    agg = aggregate(runs, since, ctx.timestamp, days=_WINDOW_DAYS)
+    return build_ci_health_payload(agg, ctx.timestamp)
+
+
+@route("ci-health", "daily", needs=("token",))
+class CiHealthRoute:
+    def plan(self, ctx: BuildContext) -> PlanResult:
+        return PlanResult(
+            "ci-health", True, "regenerate (git-diff guard drops no-ops)", []
+        )
+
+    def build(self, ctx: BuildContext) -> BuildResult:
+        payload = _acquire(ctx)
+        if payload is None:
+            return BuildResult("ci-health", [], True, "acquire failed")
+
+        content_root = Path(ctx.content_root)
+        public_dir = Path(ctx.public_dir)
+        json_out = public_dir / "nx-ci-health.json"
+        mdx_out = content_root / "dashboard" / "ci-health.mdx"
+
+        if not ctx.dry_run:
+            public_dir.mkdir(parents=True, exist_ok=True)
+            mdx_out.parent.mkdir(parents=True, exist_ok=True)
+            with open(json_out, "w") as f:
+                f.write(render_ci_health_json(payload))
+            with open(mdx_out, "w") as f:
+                f.write(render_ci_health_mdx(payload, ctx.timestamp))
+
+        repo_root = repo_root_for(content_root)
+        changed = [
+            os.path.relpath(mdx_out, repo_root),
+            os.path.relpath(json_out, repo_root),
+        ]
+        return BuildResult("ci-health", changed, False, "generated")

--- a/packages/python/kbve/tests/test_nx_ci_health_route.py
+++ b/packages/python/kbve/tests/test_nx_ci_health_route.py
@@ -1,0 +1,110 @@
+"""Tests for the ``ci-health`` route (Actions fetch bypassed via inputs)."""
+
+from __future__ import annotations
+
+import json
+
+from kbve.nx.builder import BuildContext
+from kbve.nx.ci_health import aggregate, since_date
+from kbve.nx.router import get
+
+
+def _ctx(tmp_path, inputs):
+    content_root = tmp_path / "apps/kbve/astro-kbve/src/content/docs"
+    public_dir = tmp_path / "apps/kbve/astro-kbve/public/data/nx"
+    content_root.mkdir(parents=True)
+    (tmp_path / "nx.json").write_text("{}")
+    return BuildContext(
+        content_root=content_root,
+        public_dir=public_dir,
+        timestamp="2026-07-19T12:00:00Z",
+        inputs=inputs,
+    )
+
+
+def _run(name, concl, start, end, attempt=1, branch="dev", event="push"):
+    return {
+        "name": name,
+        "conclusion": concl,
+        "run_attempt": attempt,
+        "run_started_at": start,
+        "updated_at": end,
+        "head_branch": branch,
+        "event": event,
+        "html_url": f"https://github.com/KBVE/kbve/actions/runs/1",
+    }
+
+
+def test_ci_health_needs_tags():
+    assert get("ci-health").needs == ("token",)
+
+
+def test_ci_health_plan_needs_work(tmp_path):
+    assert get("ci-health").plan(_ctx(tmp_path, {})).needs_work is True
+
+
+def test_ci_health_skips_without_token(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    result = get("ci-health").build(_ctx(tmp_path, {}))
+    assert result.skipped is True
+
+
+def test_since_date_offsets_window():
+    assert since_date("2026-07-19T12:00:00Z", 7) == "2026-07-12"
+
+
+def test_aggregate_rates_and_flaky():
+    runs = [
+        _run("CI", "success", "2026-07-19T10:00:00Z", "2026-07-19T10:05:00Z"),
+        _run("CI", "failure", "2026-07-19T09:00:00Z", "2026-07-19T09:04:00Z"),
+        _run("CI", "success", "2026-07-18T09:00:00Z", "2026-07-18T09:02:00Z",
+             attempt=2),
+        _run("Deploy", "cancelled", "2026-07-15T09:00:00Z",
+             "2026-07-15T09:01:00Z"),
+    ]
+    agg = aggregate(runs, "2026-07-12", "2026-07-19T12:00:00Z", days=7)
+    assert agg["totals"]["runs"] == 4
+    assert agg["totals"]["success"] == 2
+    assert agg["totals"]["failure"] == 1
+    assert agg["totals"]["success_rate"] == 66.7
+    assert agg["totals"]["flaky"] == 1
+    # 24h window: only the two 07-19 runs
+    assert agg["totals_24h"]["runs"] == 2
+    assert agg["totals_24h"]["failure"] == 1
+    ci = next(w for w in agg["workflows"] if w["name"] == "CI")
+    assert ci["runs"] == 3 and ci["flaky"] == 1
+    assert len(agg["recent_failures"]) == 1
+
+
+def test_ci_health_build_writes_json_and_mdx(tmp_path):
+    runs = [
+        _run("CI", "success", "2026-07-19T10:00:00Z", "2026-07-19T10:05:00Z"),
+        _run("CI", "failure", "2026-07-19T09:00:00Z", "2026-07-19T09:04:00Z"),
+    ]
+    ctx = _ctx(tmp_path, {"ci_runs": runs})
+    result = get("ci-health").build(ctx)
+    assert result.skipped is False
+    assert len(result.changed) == 2
+
+    json_out = ctx.public_dir / "nx-ci-health.json"
+    mdx = ctx.content_root / "dashboard" / "ci-health.mdx"
+    assert json_out.exists() and mdx.exists()
+
+    data = json.loads(json_out.read_text())
+    assert data["generated_at"] == "2026-07-19T12:00:00Z"
+    assert data["totals"]["runs"] == 2
+    assert list(data.keys())[0] == "generated_at"
+
+    body = mdx.read_text()
+    assert "template: splash" in body
+    assert "import BentoShell" in body
+    assert "CardGrid" not in body
+    assert body.count("<BentoProse") == body.count("</BentoProse>")
+    assert "```mermaid" in body
+
+
+def test_aggregate_empty():
+    agg = aggregate([], "2026-07-12", "2026-07-19T12:00:00Z")
+    assert agg["totals"]["runs"] == 0
+    assert agg["totals"]["success_rate"] == 0.0
+    assert agg["recent_failures"] == []


### PR DESCRIPTION
Stage 4 — first **net-new** daily route beyond the ci-dashboard migration. Rolls up GitHub Actions runs over a trailing 7-day window into per-workflow health. Ties into the ci-failure-tracker.

## What
- **`ci_health.py`** — paginated fetch of `/repos/KBVE/kbve/actions/runs?created=>=<since>` (Link-header pagination) + pure `aggregate()`:
  - totals: runs, success/failure/cancelled/skipped/other, **success rate**, **avg duration**, **flaky** (a run that only went green on a re-run, `run_attempt>1 && conclusion=success`)
  - 24h subset, per-workflow rollup (sorted by volume), recent failures (last 15)
- **`render.py`** — `build_ci_health_payload` + `render_ci_health_json` + `render_ci_health_mdx`: Bento shell, hero stat tiles (runs / success-rate / avg-duration / failures / flaky), outcome + volume pies, per-workflow health table, recent-failures table. Cyan/rose accent.
- **`routes/ci_health.py`** — `needs=('token',)`; reads `GITHUB_TOKEN` from env, **graceful skip** when unset; writes `public/data/nx/nx-ci-health.json` + `dashboard/ci-health.mdx`.

## Zero workflow edits
The router/builder scaled with **no `.yml` changes**: `GITHUB_TOKEN` is already in the builder env, and the output paths already sit under the auto-merge allowlist. Route name is hyphenated (`ci-health`) to satisfy the `daily <route> scaffold` title regex.

## Validation
- 7 new tests (needs-tag, skip-without-token, since-date window, aggregate rates+flaky+24h, JSON+MDX write, empty-window). Route suite green.
- Router lists `ci-health` in daily cadence; `--route ci-health` → `needs: token`.
- Sample render verified: flaky detection, per-workflow table, failures table all correct.

Note: two pre-existing `test_nx_journal.py` failures are date-driven (fixed 2026-07-19 == today → plan sees no work) and unrelated to this route.

First daily run (or `workflow_dispatch route: ci-health`) generates the page and auto-merges to dev.