### PR TITLE
fix(astro): mc dashboard staff gate reads droid $isStaff

### DIFF
--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactMinecraftDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactMinecraftDashRN.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import { ShieldOff } from 'lucide-react';
 import { McView } from '@kbve/rn/dash';
-import { homeService } from '@/components/dashboard/homeService';
+import { $isStaff } from '@kbve/droid';
 import { initSupa, getSupa } from '@/lib/supa';
 import { DASH_PROXY_BASE } from './dashProxyBase';
 
@@ -41,7 +41,7 @@ const styles = {
 };
 
 export default function ReactMinecraftDashRN() {
-	const isStaff = useStore(homeService.$isStaff);
+	const isStaff = useStore($isStaff);
 	const token = useMemo(() => getToken, []);
 
 	if (!isStaff) {


### PR DESCRIPTION
## Problem

`/dashboard/gameops/mc/` shows **Staff Access Required** even for staff, while `/dashboard/vm/` and `/dashboard/argo/` work.

## Root cause — drift

- **vm / argo**: no client-side staff gate. Access is token-only (bearer to dash proxy).
- **mc**: adds a client gate reading `homeService.$isStaff` — a HomeService-local nanostore atom that defaults to `false` and is only flipped inside HomeService's auth init routine. The standalone mc component (`ReactMinecraftDashRN`) never runs that init, so the atom stays `false` and blocks all staff.

## Fix

Point the gate at droid's reactive computed `$isStaff` (`packages/npm/droid/src/lib/state/auth.ts:137`) — the authoritative staff flag used site-wide, derived from `$auth`. As a computed store it also re-renders when the `staff_permissions` RPC resolves late, closing the cold-cache race.

2-line change in `ReactMinecraftDashRN.tsx`.