### PR TITLE
feat(embeddb): v5 parallel reads + batch/stream + live read + derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6909,10 +6909,20 @@ name = "embeddb"
 version = "0.0.1"
 dependencies = [
  "duckdb",
+ "embeddb-derive",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "turso",
+]
+
+[[package]]
+name = "embeddb-derive"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,6 +5713,7 @@ dependencies = [
  "once_cell",
  "oorandom",
  "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -6908,6 +6909,7 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 name = "embeddb"
 version = "0.0.1"
 dependencies = [
+ "criterion",
  "duckdb",
  "embeddb-derive",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = '2'
 members = [
 	'packages/rust/embeddb',
+	'packages/rust/embeddb-derive',
 	'packages/rust/kbve',
 	'packages/rust/erust',
 	'packages/rust/holy',

--- a/docs/superpowers/plans/2026-07-19-embeddb-v5.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb-v5.md
@@ -1,0 +1,997 @@
+# embeddb v5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a parallel DuckDB reader pool, batch/streaming APIs, a research-gated live-read path, and a `#[derive(FromEmbedRow)]` proc-macro crate to `packages/rust/embeddb`.
+
+**Architecture:** Five ordered commits on one branch. Phase 1 replaces the single `Arc<Mutex<duckdb::Connection>>` reader with a `ReaderPool` (Mutex<Vec<Connection>> + Condvar, RAII checkout). Phase 2 layers streaming reads + batched writes on it. Phase 3 runs a WAL-visibility spike and ships a non-blocking `checkpoint_passive`. Phase 4 adds a sibling proc-macro crate + a `FromEmbedValue` conversion trait. Phase 5 adds benches + README.
+
+**Tech Stack:** Rust 2021, turso 0.7 (async write), duckdb 1.x bundled (sync read, in `spawn_blocking`), tokio, thiserror, syn 2 / quote / proc-macro2 (derive crate), criterion (benches).
+
+## Global Constraints
+
+- **Turso (write) + DuckDB (read) only.** No third backend, no rusqlite fallback.
+- Both crates `version = "0.0.1"` (publish sentinel — never hand-bump).
+- **No comments in any code** (user standing rule: drop ALL comments, inline and block).
+- DuckDB attaches strictly `READ_ONLY`; freshness preserved by the existing `attach_fresh` (`USE memory; DETACH src; ATTACH … READ_ONLY; USE src;`) on every read, regardless of which pooled connection serves it.
+- Keep ALL v1–v4 tests green (currently 41).
+- `duckdb::Connection` is `Send`, not `Sync` — never alias one; move it into/out of the pool.
+- Analytics runs only inside `tokio::task::spawn_blocking`; never hold a pool checkout across an `.await`.
+- `derive` cargo feature is **on by default**; the ergonomic path is the default build.
+
+---
+
+### Task 1: Reader pool (Phase 1 — parallel reads)
+
+**Files:**
+- Create: `packages/rust/embeddb/src/pool.rs`
+- Modify: `packages/rust/embeddb/src/lib.rs` (add `mod pool;`)
+- Modify: `packages/rust/embeddb/src/config.rs` (add `reader_pool_size`)
+- Modify: `packages/rust/embeddb/src/db.rs` (field type, `open_with`, 5 analytics wrappers, fix `open_with_custom_config` test literal)
+
+**Interfaces:**
+- Consumes: `crate::analytics::open_reader(ext_dir) -> Result<duckdb::Connection>`, the analytics free fns `scalar_i64/scalar_f64/scalar_string/query/rows(conn: &duckdb::Connection, path, sql)`.
+- Produces: `pool::ReaderPool` (pub(crate)) with `build(size: usize, ext_dir: Option<&Path>) -> Result<Self>` and `checkout(&self) -> ReaderGuard<'_>`; `ReaderGuard` derefs to `duckdb::Connection`. `EmbedConfig.reader_pool_size: usize`.
+
+- [ ] **Step 1: Write `pool.rs`**
+
+Create `packages/rust/embeddb/src/pool.rs`:
+
+```rust
+use std::path::Path;
+use std::sync::{Condvar, Mutex};
+use crate::Result;
+
+pub(crate) struct ReaderPool {
+    idle: Mutex<Vec<duckdb::Connection>>,
+    available: Condvar,
+}
+
+impl ReaderPool {
+    pub(crate) fn build(size: usize, ext_dir: Option<&Path>) -> Result<Self> {
+        if size == 0 {
+            return Err(crate::EmbedError::Other("reader_pool_size must be >= 1".into()));
+        }
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(crate::analytics::open_reader(ext_dir)?);
+        }
+        Ok(ReaderPool { idle: Mutex::new(conns), available: Condvar::new() })
+    }
+
+    pub(crate) fn checkout(&self) -> ReaderGuard<'_> {
+        let mut idle = self.idle.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if let Some(conn) = idle.pop() {
+                return ReaderGuard { pool: self, conn: Some(conn) };
+            }
+            idle = self.available.wait(idle).unwrap_or_else(|e| e.into_inner());
+        }
+    }
+
+    fn checkin(&self, conn: duckdb::Connection) {
+        let mut idle = self.idle.lock().unwrap_or_else(|e| e.into_inner());
+        idle.push(conn);
+        drop(idle);
+        self.available.notify_one();
+    }
+}
+
+pub(crate) struct ReaderGuard<'a> {
+    pool: &'a ReaderPool,
+    conn: Option<duckdb::Connection>,
+}
+
+impl std::ops::Deref for ReaderGuard<'_> {
+    type Target = duckdb::Connection;
+    fn deref(&self) -> &duckdb::Connection {
+        self.conn.as_ref().expect("reader guard holds a connection until drop")
+    }
+}
+
+impl Drop for ReaderGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            self.pool.checkin(conn);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_zero_errors() {
+        let err = ReaderPool::build(0, None).unwrap_err();
+        assert!(matches!(err, crate::EmbedError::Other(_)));
+    }
+
+    #[test]
+    fn checkout_returns_to_pool_on_drop() {
+        let pool = ReaderPool::build(1, None).unwrap();
+        {
+            let _g = pool.checkout();
+        }
+        let _g2 = pool.checkout();
+    }
+}
+```
+
+- [ ] **Step 2: Wire module + config**
+
+In `packages/rust/embeddb/src/lib.rs` add after `mod query;`:
+
+```rust
+mod pool;
+```
+
+In `packages/rust/embeddb/src/config.rs` add the field and default:
+
+```rust
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    pub journal_mode: String,
+    pub duckdb_extension_dir: Option<PathBuf>,
+    pub checkpoint_max_retries: u32,
+    pub reader_pool_size: usize,
+}
+
+impl Default for EmbedConfig {
+    fn default() -> Self {
+        EmbedConfig {
+            journal_mode: "WAL".to_string(),
+            duckdb_extension_dir: None,
+            checkpoint_max_retries: 5,
+            reader_pool_size: 4,
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Swap the reader field in `db.rs`**
+
+Change the top of `packages/rust/embeddb/src/db.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use crate::Result;
+
+pub struct EmbedDb {
+    path: PathBuf,
+    conn: turso::Connection,
+    config: crate::EmbedConfig,
+    reader: Arc<crate::pool::ReaderPool>,
+}
+```
+
+In `open_with`, replace the reader construction:
+
+```rust
+        let reader = crate::pool::ReaderPool::build(
+            config.reader_pool_size,
+            config.duckdb_extension_dir.as_deref(),
+        )?;
+        Ok(EmbedDb { path, conn, config, reader: Arc::new(reader) })
+```
+
+- [ ] **Step 4: Port the 5 analytics wrappers to `checkout()`**
+
+Rewrite each of `analytics_scalar_i64`, `analytics_scalar_f64`, `analytics_rows`, `analytics_query`, `analytics_scalar_string` to use the pool. Pattern (shown for `analytics_scalar_i64`; apply the same shape to all five, calling the matching `crate::analytics::*` fn):
+
+```rust
+    pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        let pool = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.checkout();
+            crate::analytics::scalar_i64(&guard, &path, &sql)
+        })
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+```
+
+`analytics_one` and `analytics_query_as` are unchanged (they delegate to `analytics_query`).
+
+- [ ] **Step 5: Fix the config literal in the existing test**
+
+In `db.rs` test `open_with_custom_config`, the `EmbedConfig { … }` literal now needs the new field:
+
+```rust
+        let cfg = crate::EmbedConfig { journal_mode: "WAL".into(), duckdb_extension_dir: None, checkpoint_max_retries: 1, reader_pool_size: 2 };
+```
+
+- [ ] **Step 6: Add pool integration tests in `db.rs`**
+
+Append to `db.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn pool_concurrent_reads_all_correct() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("pool.db")).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        for i in 1..=10 {
+            db.execute(&format!("INSERT INTO t VALUES ({i})"), ()).await.unwrap();
+        }
+        db.checkpoint().await.unwrap();
+        let mut handles = Vec::new();
+        for _ in 0..12 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap()
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 10);
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_exhaustion_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = crate::EmbedConfig { reader_pool_size: 2, ..Default::default() };
+        let db = std::sync::Arc::new(EmbedDb::open_with(dir.path().join("ex.db"), cfg).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap()
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_cross_connection_freshness() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = crate::EmbedConfig { reader_pool_size: 3, ..Default::default() };
+        let db = EmbedDb::open_with(dir.path().join("cf.db"), cfg).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        for _ in 0..5 {
+            assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+        }
+        db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        for _ in 0..5 {
+            assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
+        }
+    }
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p embeddb`
+Expected: PASS (44 tests: 41 prior − none removed + 3 db pool tests + 2 pool.rs unit tests; count is approximate — all must pass).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/rust/embeddb/src/pool.rs packages/rust/embeddb/src/lib.rs packages/rust/embeddb/src/config.rs packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): reader pool for parallel analytics (v5 phase 1)"
+```
+
+---
+
+### Task 2: Batch & streaming (Phase 2)
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/analytics.rs` (add `for_each` free fn)
+- Modify: `packages/rust/embeddb/src/db.rs` (add `analytics_for_each`, `execute_batch`)
+
+**Interfaces:**
+- Consumes: `crate::pool::ReaderPool::checkout`, `value_from_ref`, `attach_fresh`, `EmbedTx` (`begin/execute/commit`).
+- Produces: `EmbedDb::analytics_for_each<F: FnMut(&EmbedRow) + Send + 'static>(sql) -> Result<u64>`; `EmbedDb::execute_batch<I: IntoIterator<Item = P>, P: turso::IntoParams>(sql, params) -> Result<u64>`; `analytics::for_each(conn, path, sql, f: &mut dyn FnMut(&EmbedRow)) -> Result<u64>`.
+
+- [ ] **Step 1: Add `for_each` to `analytics.rs`**
+
+Append to `packages/rust/embeddb/src/analytics.rs` (after `rows`):
+
+```rust
+pub fn for_each(
+    conn: &duckdb::Connection,
+    path: &Path,
+    sql: &str,
+    f: &mut dyn FnMut(&crate::EmbedRow),
+) -> Result<u64> {
+    attach_fresh(conn, path)?;
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query([])?;
+    let ncols = rows.as_ref().map(|s| s.column_names().len()).unwrap_or_default();
+    let mut count = 0_u64;
+    while let Some(row) = rows.next()? {
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(value_from_ref(row.get_ref(i)?)?);
+        }
+        let er = crate::EmbedRow(vals);
+        f(&er);
+        count += 1;
+    }
+    Ok(count)
+}
+```
+
+- [ ] **Step 2: Add `analytics_for_each` + `execute_batch` to `db.rs`**
+
+Add inside `impl EmbedDb` (near the other analytics methods):
+
+```rust
+    pub async fn analytics_for_each<F>(&self, sql: &str, mut f: F) -> Result<u64>
+    where
+        F: FnMut(&crate::EmbedRow) + Send + 'static,
+    {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        let pool = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.checkout();
+            crate::analytics::for_each(&guard, &path, &sql, &mut f)
+        })
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
+    pub async fn execute_batch<I, P>(&self, sql: &str, params: I) -> Result<u64>
+    where
+        I: IntoIterator<Item = P>,
+        P: turso::IntoParams,
+    {
+        let tx = self.begin().await?;
+        let mut total = 0_u64;
+        for p in params {
+            total += tx.execute(sql, p).await?;
+        }
+        tx.commit().await?;
+        Ok(total)
+    }
+```
+
+- [ ] **Step 3: Add tests to `db.rs`**
+
+Append to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn for_each_visits_all_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("fe.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2), (3), (4)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let sum = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let s2 = sum.clone();
+        let n = db.analytics_for_each("SELECT v FROM t ORDER BY v", move |row| {
+            s2.fetch_add(row.as_i64(0).unwrap(), std::sync::atomic::Ordering::SeqCst);
+        }).await.unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(sum.load(std::sync::atomic::Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test]
+    async fn for_each_empty_calls_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("fee.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let c2 = calls.clone();
+        let n = db.analytics_for_each("SELECT v FROM t", move |_| {
+            c2.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }).await.unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_inserts_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("eb.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        let params: Vec<(i64,)> = (1..=5).map(|i| (i,)).collect();
+        let n = db.execute_batch("INSERT INTO t VALUES (?)", params).await.unwrap();
+        assert_eq!(n, 5);
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_rolls_back_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("ebr.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ()).await.unwrap();
+        let params: Vec<(i64,)> = vec![(1,), (2,), (2,), (3,)];
+        let res = db.execute_batch("INSERT INTO t VALUES (?)", params).await;
+        assert!(res.is_err());
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p embeddb`
+Expected: PASS (4 new tests green; if `execute_batch_rolls_back_atomically` shows a nonzero count, the deferred-rollback did not fire before the count read — add an explicit `drop`/no-op write is NOT allowed; instead confirm the failed `tx` was dropped before `checkpoint`. The tx is dropped at the `?` early-return inside `execute_batch`, so a fresh `checkpoint()` + read must see 0. If turso commits partial rows, that is a real finding — report it, do not paper over it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/analytics.rs packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): streaming analytics_for_each + batched execute_batch (v5 phase 2)"
+```
+
+---
+
+### Task 3: Live-read spike + passive checkpoint (Phase 3 — research-gated)
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/db.rs` (add `checkpoint_passive`, spike tests)
+
+**Interfaces:**
+- Consumes: `self.conn` (turso), `analytics_query`, `checkpoint`.
+- Produces: `EmbedDb::checkpoint_passive(&self) -> Result<()>`.
+
+**Note to implementer:** Phase 3 is a research gate. The spike test below records what DuckDB observes when reading a Turso file with uncheckpointed WAL frames. **Assert only invariants that hold regardless of the outcome** (consistency, no error, no torn value). In your report, state explicitly which value DuckDB returned (N or N+M) — that empirical result drives documentation, not code branching. Do not add a "live read" API that skips checkpointing; `checkpoint_passive` is the only new surface.
+
+- [ ] **Step 1: Add `checkpoint_passive` to `db.rs`**
+
+Add inside `impl EmbedDb` (after `checkpoint`):
+
+```rust
+    pub async fn checkpoint_passive(&self) -> Result<()> {
+        let mut rows = self.conn.query("PRAGMA wal_checkpoint(PASSIVE)", ()).await?;
+        while rows.next().await?.is_some() {}
+        Ok(())
+    }
+```
+
+- [ ] **Step 2: Add the passive-checkpoint test**
+
+Append to `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn checkpoint_passive_makes_writes_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("cpp.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2)", ()).await.unwrap();
+        db.checkpoint_passive().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+    }
+```
+
+- [ ] **Step 3: Add the WAL-visibility spike (permanent regression test)**
+
+Append to `mod tests`. This asserts consistency invariants only; record the observed count in the report:
+
+```rust
+    #[tokio::test]
+    async fn wal_visibility_uncheckpointed_is_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("wal.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2), (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.execute("INSERT INTO t VALUES (4), (5)", ()).await.unwrap();
+        let seen = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+        assert!(seen == 3 || seen == 5, "expected consistent snapshot (3 or 5), got {seen}");
+    }
+
+    #[tokio::test]
+    async fn concurrent_writer_reader_never_torn() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("conc.db")).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let writer = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                for i in 0..50_i64 {
+                    db.execute("INSERT INTO t VALUES (?)", (i,)).await.unwrap();
+                    if i % 10 == 0 {
+                        db.checkpoint_passive().await.unwrap();
+                    }
+                }
+                db.checkpoint().await.unwrap();
+            })
+        };
+        let reader = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                let mut last = 0_i64;
+                for _ in 0..20 {
+                    let n = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+                    assert!(n >= last, "count went backwards: {last} -> {n}");
+                    assert!((0..=50).contains(&n), "count out of range: {n}");
+                    last = n;
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        writer.await.unwrap();
+        reader.await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 50);
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p embeddb`
+Expected: PASS. If `concurrent_writer_reader_never_torn` fails with a backwards/torn count or a duckdb error, that is the FAIL branch of the gate — report the exact failure; do NOT relax the assertion. If it passes, report the observed value of `seen` from `wal_visibility_uncheckpointed_is_consistent` (3 = main-file-only, 5 = WAL replayed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): checkpoint_passive + WAL-visibility spike tests (v5 phase 3)"
+```
+
+---
+
+### Task 4: `embeddb-derive` proc-macro crate + `FromEmbedValue` (Phase 4a)
+
+**Files:**
+- Create: `packages/rust/embeddb-derive/Cargo.toml`
+- Create: `packages/rust/embeddb-derive/src/lib.rs`
+- Create: `packages/rust/embeddb-derive/project.json`
+- Create: `packages/rust/embeddb/src/convert.rs`
+- Modify: `packages/rust/embeddb/src/lib.rs` (add `mod convert;`, re-export trait + derive)
+- Modify: `packages/rust/embeddb/Cargo.toml` (optional dep + `derive` feature)
+- Modify: `Cargo.toml` (root workspace `members`)
+
+**Interfaces:**
+- Consumes: `EmbedValue`, `EmbedRow::get`, `EmbedError`, `Result`, `FromEmbedRow`.
+- Produces: `pub trait FromEmbedValue: Sized { fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self>; }` with impls for `i64/f64/String/bool/i128/Vec<u8>/Option<T>`; `#[derive(FromEmbedRow)]` from `embeddb_derive`, re-exported as `embeddb::FromEmbedRow` under feature `derive`.
+
+- [ ] **Step 1: Create the derive crate manifest**
+
+Create `packages/rust/embeddb-derive/Cargo.toml`:
+
+```toml
+[package]
+name = "embeddb-derive"
+version = "0.0.1"
+edition = "2021"
+description = "derive macro for embeddb FromEmbedRow"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
+```
+
+- [ ] **Step 2: Write the derive macro**
+
+Create `packages/rust/embeddb-derive/src/lib.rs`:
+
+```rust
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(FromEmbedRow)]
+pub fn derive_from_embed_row(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return syn::Error::new_spanned(name, "FromEmbedRow requires named fields")
+                    .to_compile_error()
+                    .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(name, "FromEmbedRow can only be derived for structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let inits = fields.iter().map(|field| {
+        let ident = field.ident.as_ref().unwrap();
+        let col = ident.to_string();
+        let ty = &field.ty;
+        quote! {
+            #ident: {
+                let __idx = __columns.iter().position(|c| c == #col);
+                let __v = __idx.and_then(|i| __row.get(i));
+                <#ty as ::embeddb::FromEmbedValue>::from_embed_value(__v)
+                    .map_err(|e| ::embeddb::EmbedError::Other(
+                        format!("column '{}': {}", #col, e)))?
+            }
+        }
+    });
+
+    let expanded = quote! {
+        impl ::embeddb::FromEmbedRow for #name {
+            fn from_row(__row: &::embeddb::EmbedRow, __columns: &[String]) -> ::embeddb::Result<Self> {
+                Ok(#name {
+                    #(#inits),*
+                })
+            }
+        }
+    };
+    expanded.into()
+}
+```
+
+- [ ] **Step 3: Create the derive crate `project.json`**
+
+Create `packages/rust/embeddb-derive/project.json` (mirrors `packages/rust/embeddb/project.json`, `target-dir` swapped):
+
+```json
+{
+	"name": "embeddb-derive",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/rust/embeddb-derive/src",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" },
+			"configurations": { "production": { "release": true } }
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" },
+			"configurations": { "production": { "release": true } }
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": { "commands": ["nx test embeddb-derive"], "parallel": false }
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" }
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Write `FromEmbedValue` conversion trait**
+
+Create `packages/rust/embeddb/src/convert.rs`:
+
+```rust
+use crate::{EmbedError, EmbedValue, Result};
+
+pub trait FromEmbedValue: Sized {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self>;
+}
+
+fn absent(expected: &str) -> EmbedError {
+    EmbedError::Other(format!("expected {expected}, column absent"))
+}
+
+fn mismatch(expected: &str, got: &EmbedValue) -> EmbedError {
+    EmbedError::Other(format!("expected {expected}, got {got:?}"))
+}
+
+impl FromEmbedValue for i64 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Int(n)) => Ok(*n),
+            Some(other) => Err(mismatch("i64", other)),
+            None => Err(absent("i64")),
+        }
+    }
+}
+
+impl FromEmbedValue for f64 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Float(n)) => Ok(*n),
+            Some(other) => Err(mismatch("f64", other)),
+            None => Err(absent("f64")),
+        }
+    }
+}
+
+impl FromEmbedValue for String {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Text(s)) => Ok(s.clone()),
+            Some(other) => Err(mismatch("String", other)),
+            None => Err(absent("String")),
+        }
+    }
+}
+
+impl FromEmbedValue for bool {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Bool(b)) => Ok(*b),
+            Some(other) => Err(mismatch("bool", other)),
+            None => Err(absent("bool")),
+        }
+    }
+}
+
+impl FromEmbedValue for i128 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::HugeInt(n)) => Ok(*n),
+            Some(EmbedValue::Int(n)) => Ok(*n as i128),
+            Some(other) => Err(mismatch("i128", other)),
+            None => Err(absent("i128")),
+        }
+    }
+}
+
+impl FromEmbedValue for Vec<u8> {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Blob(b)) => Ok(b.clone()),
+            Some(other) => Err(mismatch("Vec<u8>", other)),
+            None => Err(absent("Vec<u8>")),
+        }
+    }
+}
+
+impl<T: FromEmbedValue> FromEmbedValue for Option<T> {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            None | Some(EmbedValue::Null) => Ok(None),
+            some => Ok(Some(T::from_embed_value(some)?)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_conversions() {
+        assert_eq!(i64::from_embed_value(Some(&EmbedValue::Int(5))).unwrap(), 5);
+        assert_eq!(String::from_embed_value(Some(&EmbedValue::Text("x".into()))).unwrap(), "x");
+        assert!(bool::from_embed_value(Some(&EmbedValue::Int(1))).is_err());
+    }
+
+    #[test]
+    fn option_handles_null_and_absent() {
+        assert_eq!(Option::<i64>::from_embed_value(None).unwrap(), None);
+        assert_eq!(Option::<i64>::from_embed_value(Some(&EmbedValue::Null)).unwrap(), None);
+        assert_eq!(Option::<i64>::from_embed_value(Some(&EmbedValue::Int(7))).unwrap(), Some(7));
+    }
+
+    #[test]
+    fn missing_non_option_errors() {
+        assert!(i64::from_embed_value(None).is_err());
+    }
+}
+```
+
+- [ ] **Step 5: Wire the embeddb crate — feature + re-exports**
+
+In `packages/rust/embeddb/Cargo.toml`:
+
+```toml
+[dependencies]
+turso = "0.7"
+duckdb = { version = "1", features = ["bundled"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+thiserror = "1"
+embeddb-derive = { version = "0.0.1", path = "../embeddb-derive", optional = true }
+
+[features]
+default = ["derive"]
+derive = ["dep:embeddb-derive"]
+```
+
+In `packages/rust/embeddb/src/lib.rs`, add `mod convert;`, export the trait, and re-export the derive under the feature:
+
+```rust
+mod convert;
+```
+```rust
+pub use convert::FromEmbedValue;
+
+#[cfg(feature = "derive")]
+pub use embeddb_derive::FromEmbedRow;
+```
+
+Note: the trait `FromEmbedRow` (from `query.rs`) and the derive macro `FromEmbedRow` (from `embeddb_derive`) share a name in the same namespace — this is legal in Rust (a type and a derive macro coexist, as `serde::Serialize` does). Keep both `pub use`s.
+
+- [ ] **Step 6: Add the crate to the workspace**
+
+In the root `Cargo.toml`, add to `members` right after `'packages/rust/embeddb',`:
+
+```toml
+	'packages/rust/embeddb-derive',
+```
+
+- [ ] **Step 7: Add a derive round-trip test in `embeddb`**
+
+Append to `packages/rust/embeddb/src/db.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn derive_from_embed_row_round_trips() {
+        #[derive(Debug, PartialEq, crate::FromEmbedRow)]
+        struct Rec {
+            id: i64,
+            name: String,
+            note: Option<String>,
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("derive.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT, note TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'a', NULL), (2, 'b', 'hi')", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let got: Vec<Rec> = db.analytics_query_as("SELECT id, name, note FROM t ORDER BY id").await.unwrap();
+        assert_eq!(got, vec![
+            Rec { id: 1, name: "a".into(), note: None },
+            Rec { id: 2, name: "b".into(), note: Some("hi".into()) },
+        ]);
+    }
+
+    #[tokio::test]
+    async fn derive_missing_column_errors() {
+        #[derive(Debug, crate::FromEmbedRow)]
+        struct Rec { id: i64, missing: i64 }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("derive_err.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let res: Result<Vec<Rec>> = db.analytics_query_as("SELECT id FROM t").await;
+        assert!(res.is_err());
+        assert!(format!("{}", res.unwrap_err()).contains("missing"));
+    }
+```
+
+- [ ] **Step 8: Run tests (both crates)**
+
+Run: `cargo test -p embeddb-derive && cargo test -p embeddb`
+Expected: PASS. (`embeddb-derive` has no runtime tests beyond compile; its behavior is exercised by the embeddb derive tests. `cargo test -p embeddb-derive` must at least compile clean.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/rust/embeddb-derive Cargo.toml packages/rust/embeddb/Cargo.toml packages/rust/embeddb/src/lib.rs packages/rust/embeddb/src/convert.rs packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): FromEmbedRow derive macro crate + FromEmbedValue (v5 phase 4)"
+```
+
+---
+
+### Task 5: Benchmarks + README (Phase 4b/5)
+
+**Files:**
+- Create: `packages/rust/embeddb/benches/embeddb_bench.rs`
+- Modify: `packages/rust/embeddb/Cargo.toml` (criterion dev-dep + `[[bench]]`)
+- Modify: `packages/rust/embeddb/README.md` (append v5 surface)
+
+**Interfaces:**
+- Consumes: full `EmbedDb` public surface.
+- Produces: a criterion bench binary (not a test).
+
+- [ ] **Step 1: Add criterion + bench target to Cargo.toml**
+
+In `packages/rust/embeddb/Cargo.toml` `[dev-dependencies]` add criterion, and append a bench section:
+
+```toml
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+criterion = "0.5"
+
+[[bench]]
+name = "embeddb_bench"
+harness = false
+```
+
+- [ ] **Step 2: Write the benchmark**
+
+Create `packages/rust/embeddb/benches/embeddb_bench.rs`:
+
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+use embeddb::{EmbedConfig, EmbedDb};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap()
+}
+
+async fn seeded(path: std::path::PathBuf, pool: usize, rows: i64) -> EmbedDb {
+    let cfg = EmbedConfig { reader_pool_size: pool, ..Default::default() };
+    let db = EmbedDb::open_with(path, cfg).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
+    let params: Vec<(i64, f64)> = (0..rows).map(|i| (i, i as f64)).collect();
+    db.execute_batch("INSERT INTO t VALUES (?, ?)", params).await.unwrap();
+    db.checkpoint().await.unwrap();
+    db
+}
+
+fn bench_writes(c: &mut Criterion) {
+    let rt = rt();
+    let dir = tempfile::tempdir().unwrap();
+    c.bench_function("execute_batch_1000", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let db = EmbedDb::open(dir.path().join("bw.db")).await.unwrap();
+                db.execute("DROP TABLE IF EXISTS t", ()).await.unwrap();
+                db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+                let params: Vec<(i64,)> = (0..1000).map(|i| (i,)).collect();
+                db.execute_batch("INSERT INTO t VALUES (?)", params).await.unwrap();
+            })
+        })
+    });
+}
+
+fn bench_reads(c: &mut Criterion) {
+    let rt = rt();
+    let dir = tempfile::tempdir().unwrap();
+    for pool in [1usize, 4usize] {
+        let db = rt.block_on(seeded(dir.path().join(format!("br{pool}.db")), pool, 10_000));
+        let db = std::sync::Arc::new(db);
+        c.bench_function(&format!("parallel_reads_pool_{pool}"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut handles = Vec::new();
+                    for _ in 0..8 {
+                        let db = db.clone();
+                        handles.push(tokio::spawn(async move {
+                            db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap()
+                        }));
+                    }
+                    for h in handles { h.await.unwrap(); }
+                })
+            })
+        });
+    }
+}
+
+criterion_group!(benches, bench_writes, bench_reads);
+criterion_main!(benches);
+```
+
+- [ ] **Step 3: Verify the bench compiles**
+
+Run: `cargo build -p embeddb --benches`
+Expected: builds clean (do NOT run `cargo bench` in the review loop — compilation is the gate).
+
+- [ ] **Step 4: Append v5 surface to README**
+
+Add a `## v5` section to `packages/rust/embeddb/README.md` documenting: `reader_pool_size` (default 4, parallel analytics), `analytics_for_each` (streaming row callback), `execute_batch` (one-transaction batched writes, atomic rollback), `#[derive(FromEmbedRow)]` + `FromEmbedValue` + the `derive` default feature, `checkpoint_passive` (non-blocking WAL checkpoint), and the WAL-visibility freshness contract as observed by the Task 3 spike (state whether uncheckpointed writes are visible). Keep prior sections intact.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/embeddb/Cargo.toml packages/rust/embeddb/benches packages/rust/embeddb/README.md
+git commit -m "bench+docs(embeddb): criterion benches + v5 README (v5 phase 5)"
+```
+
+---
+
+## Final verification
+
+- `cargo test -p embeddb && cargo test -p embeddb-derive` — all green.
+- `cargo build -p embeddb --benches` — clean.
+- `cargo build -p embeddb --no-default-features` — clean (derive-off build compiles; `FromEmbedRow` derive unavailable but the trait + all other APIs work).
+- `project.json` files valid JSON; note nx targets can't run in the node_modules-less worktree (validate shape only, per v4).

--- a/docs/superpowers/specs/2026-07-19-embeddb-v5-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-v5-design.md
@@ -1,0 +1,286 @@
+# embeddb v5 — Parallel Reads + Batch/Streaming + Live Read + Consumability Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+Builds on: `packages/rust/embeddb` (v1 #14292, v2 #14313, v3 #14321, v4 #14332 merged)
+
+## Purpose
+
+Four improvement tracks, landed as ordered commits on one branch. Stays
+**Turso (write) + DuckDB (read) only**.
+
+1. Parallel reads — replace the single mutex-guarded DuckDB reader with a pool
+   so analytics calls run concurrently (reverses v4's documented serialize
+   trade-off).
+2. Batch / streaming — a row-callback read API that does not materialize every
+   row into a `Vec`, plus a batched multi-row write.
+3. Live concurrent read — **research-gated**: prove DuckDB can read the file
+   while Turso is actively writing; ship live reads only if the spike passes,
+   else fall back to the current checkpoint-then-read model.
+4. Consumability — a `#[derive(FromEmbedRow)]` proc-macro crate, criterion
+   benchmarks, richer README.
+
+## Current surface (v4)
+
+`EmbedDb { path, conn: turso::Connection, config: EmbedConfig,
+reader: Arc<Mutex<duckdb::Connection>> }`. Every analytics call locks the one
+reader inside `spawn_blocking`, `USE memory; DETACH src;` then re-`ATTACH` the
+file `READ_ONLY`, runs the query. Reads **serialize** on the mutex. Reads
+`analytics_scalar_i64/f64/string`, `analytics_rows`, `analytics_query` →
+`QueryResult`, `analytics_one`, `analytics_query_as::<T: FromEmbedRow>`.
+`EmbedValue { Null, Int, Float, Text, Blob, Bool, HugeInt, Timestamp, Date,
+Time }`. Writes: `execute(sql, params)`, `begin() -> EmbedTx`. `checkpoint()`
+busy-retries. `EmbedConfig { journal_mode, duckdb_extension_dir,
+checkpoint_max_retries }`.
+
+---
+
+## Phase 1 — Parallel reads (reader pool)
+
+Replace `reader: Arc<Mutex<duckdb::Connection>>` with `reader: Arc<ReaderPool>`.
+
+New module `pool.rs`:
+
+```rust
+pub(crate) struct ReaderPool {
+    idle: std::sync::Mutex<Vec<duckdb::Connection>>,
+    available: std::sync::Condvar,
+    size: usize,
+}
+
+impl ReaderPool {
+    // Build `size` DuckDB connections, each with sqlite_scanner loaded once
+    // (prepare_sqlite_scanner). Returns Err if any connection fails to build.
+    pub(crate) fn build(size: usize, ext_dir: Option<&std::path::Path>) -> crate::Result<Self>;
+
+    // Pop an idle connection (blocking on the Condvar if none idle),
+    // returning an RAII guard that pushes the connection back on drop.
+    pub(crate) fn checkout(&self) -> ReaderGuard<'_>;
+}
+
+pub(crate) struct ReaderGuard<'a> {
+    pool: &'a ReaderPool,
+    conn: Option<duckdb::Connection>, // Option so Drop can move it back
+}
+// Deref/DerefMut to duckdb::Connection; Drop pushes conn back + notify_one.
+```
+
+Design notes:
+- `duckdb::Connection` is `Send`, not `Sync`. A `Connection` is *moved* out of
+  the pool on checkout and *moved* back on guard drop — never aliased. The
+  `Mutex<Vec<Connection>>` is the only shared state; it is held only for the
+  pop/push, never across a query.
+- `build` loads the sqlite extension `size` times up front (paid once), never
+  per call — the whole point of the v4 shared reader, now multiplied for
+  concurrency.
+- Each analytics call, inside `spawn_blocking`: `let guard = pool.checkout();`
+  then `attach_fresh(&guard, path)?` → query → return. The existing
+  `attach_fresh` (`USE memory; DETACH src; ATTACH … READ_ONLY; USE src;`)
+  keeps every read fresh regardless of which pooled connection serves it.
+- Guard drop returns the connection even on query error / panic-unwind so the
+  pool never leaks a slot. (`Drop` runs on unwind; the pushed connection is
+  fine to reuse — a failed `ATTACH`/query leaves the connection usable, and
+  the next `attach_fresh` starts with `DETACH`.)
+
+Config: add `reader_pool_size: usize` to `EmbedConfig`, default `4`. `open`
+uses the default; `open_with` honors the config. `build(0, …)` is rejected →
+`EmbedError::Other("reader_pool_size must be >= 1")` (a zero pool would
+deadlock on first checkout).
+
+`db.rs` changes: all five analytics wrappers move from
+`reader.lock().unwrap_or_else(|e| e.into_inner())` to `pool.checkout()`. The
+`Arc<Mutex<…>>` self-heal-from-poison logic is removed (no shared mutex across
+the query anymore; the pool's internal mutex is held only for the microscopic
+pop/push and never runs user code under lock, so poisoning is not a practical
+concern — but still use `lock().unwrap_or_else(|e| e.into_inner())` on the
+internal mutex for robustness).
+
+`Debug` for `EmbedDb`: unchanged approach — print `path` + `config` only, not
+the pool.
+
+**Tests (P1):**
+- Existing analytics tests stay green (pool of 1 behaves like the old reader).
+- Concurrent correctness: spawn `pool_size * 3` analytics tasks via
+  `tokio::spawn` against one `EmbedDb`, each asserting the correct aggregate;
+  all must succeed (proves checkout/return has no aliasing/deadlock and the
+  pool recycles connections).
+- Pool exhaustion + recovery: with `reader_pool_size = 2`, run 6 concurrent
+  reads; all complete (checkout blocks then proceeds as guards drop).
+- Freshness across pooled connections: write N → checkpoint → read (some
+  connection); write M → checkpoint → read again; sees N+M (the v4 freshness
+  guarantee holds no matter which connection serves the second read).
+
+## Phase 2 — Batch / streaming
+
+**Streaming read** — avoid materializing all rows:
+
+```rust
+impl EmbedDb {
+    /// Run `sql`, invoking `f` once per row. Returns the row count.
+    /// `f` runs inside spawn_blocking, so it must be Send.
+    pub async fn analytics_for_each<F>(&self, sql: &str, f: F) -> Result<u64>
+    where F: FnMut(&EmbedRow) + Send + 'static;
+}
+```
+
+Implementation: inside `spawn_blocking`, checkout a reader, `attach_fresh`,
+prepare + `query([])`, iterate rows mapping each via `value_from_ref` into an
+`EmbedRow`, call `f(&row)`, increment count. Never builds a `Vec<EmbedRow>`.
+The closure is moved into the blocking task; the count is returned. (Column
+names are not surfaced here — the row-callback path is for volume; use
+`analytics_query` when you need columns.)
+
+**Batched write** — one prepared statement, one transaction, many param sets:
+
+```rust
+impl EmbedDb {
+    /// Execute `sql` once per parameter set inside a single transaction.
+    /// Returns total rows affected. Rolls back on any error.
+    pub async fn execute_batch<I, P>(&self, sql: &str, params: I) -> Result<u64>
+    where I: IntoIterator<Item = P> + Send + 'static,
+          P: turso::IntoParams + Send + 'static;
+}
+```
+
+Implementation: `self.begin()` (EmbedTx), loop the param sets calling
+`tx.execute(sql, p)` accumulating affected counts, `tx.commit()`. On any
+`Err`, drop the tx (deferred-rollback fires on next conn op — already
+documented v2 behavior) and return the error. Reuses the existing tx handle;
+turso re-parses per `execute` (turso manages its own statement cache — we do
+not add a prepared-statement cache, out of scope per v4).
+
+**Tests (P2):**
+- `analytics_for_each` visits every row in order, returns correct count,
+  values match (assert accumulated sum equals a known total).
+- `analytics_for_each` on empty result → count 0, closure never called.
+- `execute_batch` inserts K rows in one call; a following count read = K.
+- `execute_batch` rolls back atomically: a param set that violates a
+  constraint (e.g. duplicate PRIMARY KEY mid-batch) → `Err`, and a subsequent
+  count read shows **zero** rows committed from that batch.
+
+## Phase 3 — Live concurrent read (research-gated)
+
+**Step 0 — go/no-go spike (like v1's DuckDB-reads-Turso gate).** Before any API
+change, write a `#[test]` that:
+1. Opens an `EmbedDb`, creates a table, inserts N rows, `checkpoint()`.
+2. Inserts M MORE rows **without** checkpointing.
+3. Reads via DuckDB (current `analytics_query`, no checkpoint between write and
+   read).
+4. Records what DuckDB sees: N (only checkpointed main-file) or N+M (replays
+   WAL).
+
+Also a concurrent variant: a `tokio::spawn` write loop (insert + periodic
+checkpoint) running while a read loop issues `analytics_query`; assert reads
+always return a **consistent** count (never a torn/garbage value; monotonic
+non-decreasing across the checkpointed boundary), and no error/corruption.
+
+**Decision on the spike result:**
+
+- **PASS (reads are consistent while a writer is active, corruption-free):**
+  - Document the freshness contract explicitly: analytics reflects data **up to
+    the most recent checkpoint** (DuckDB sqlite_scanner reads the main file; it
+    is not guaranteed to replay uncheckpointed WAL frames — the spike records
+    which).
+  - Add `EmbedDb::checkpoint_passive(&self) -> Result<()>` running
+    `PRAGMA wal_checkpoint(PASSIVE)` — advances the main file **without
+    blocking** the writer (PASSIVE checkpoints as many frames as it can without
+    waiting on locks; never errors busy). Callers who want fresher live reads
+    call `checkpoint_passive()` then read, no writer stall.
+  - Document: live concurrent read is safe; freshness = last (passive or full)
+    checkpoint. The existing `checkpoint()` (which busy-retries toward a fuller
+    checkpoint) stays for callers who need the tightest freshness.
+
+- **FAIL (torn reads, errors, or corruption under a live writer):**
+  - Do **not** ship a live-read API. Keep checkpoint-then-read.
+  - Document the empirical WAL-visibility limit found (this is itself a
+    valuable, non-obvious result worth recording in memory).
+  - `checkpoint_passive` may still ship if it independently proves useful
+    (non-blocking partial checkpoint) — decide at implementation time from the
+    spike data.
+
+Either branch is corruption-safe: DuckDB attaches strictly `READ_ONLY`.
+
+**Tests (P3):** the spike tests above become permanent regression tests
+(asserting whichever behavior was observed, so a future turso/duckdb bump that
+changes WAL visibility is caught). If PASS, add a `checkpoint_passive` test
+(passive checkpoint advances visible count without a full `checkpoint()`).
+
+## Phase 4 — Consumability
+
+**Derive macro — new crate `packages/rust/embeddb-derive`:**
+- proc-macro crate (`proc-macro = true`), deps `syn = "2"`, `quote = "1"`,
+  `proc-macro2 = "1"`. Workspace member. `version = "0.0.1"` (publish
+  sentinel, same lane as embeddb).
+- Emits `#[derive(FromEmbedRow)]` for structs with named fields, generating
+  `impl FromEmbedRow` that reads each field **by column name** (via
+  `columns` + `EmbedRow::get`), converting through the matching accessor. Field
+  type → accessor mapping: `i64`→`as_i64`, `f64`→`as_f64`, `String`→`as_str`
+  (owned), `bool`→`as_bool`, `i128`→`as_i128`, `Vec<u8>`→blob accessor;
+  `Option<T>` → `None` when the value is `Null` or the column is absent, else
+  `Some`. A missing column or type mismatch on a non-`Option` field →
+  `Err(EmbedError::Other("column '<name>': <reason>"))`.
+- `embeddb` re-exports the derive so consumers write
+  `use embeddb::FromEmbedRow;` and `#[derive(FromEmbedRow)]` from one crate:
+  add `embeddb-derive` as a dependency of `embeddb` with a
+  `#[cfg(feature = "derive")]`-gated `pub use embeddb_derive::FromEmbedRow;`.
+  Feature `derive` is **on by default** (`default = ["derive"]`) so the ergonomic
+  path is the default; consumers who want a proc-macro-free build disable it.
+- Reconcile the exact re-export mechanics (name collision between the trait
+  `FromEmbedRow` and the derive macro `FromEmbedRow` is fine — Rust allows a
+  trait and a derive macro to share a name in the same namespace import, as
+  `serde` does).
+
+**Benchmarks — `packages/rust/embeddb/benches/` (criterion, dev-dep):**
+- `write_throughput`: N single `execute` inserts vs one `execute_batch` of N.
+- `analytics_latency`: repeated `analytics_query` on a fixed dataset.
+- `parallel_reads`: K concurrent `analytics_query` at `reader_pool_size` 1 vs
+  4 (demonstrates Phase 1's win).
+- criterion `[[bench]]` harness = false. Not run in the node_modules-less
+  worktree / not a test; `cargo bench -p embeddb` locally is the check.
+
+**README + docs:**
+- Document `reader_pool_size`, `analytics_for_each`, `execute_batch`,
+  `#[derive(FromEmbedRow)]`, `checkpoint_passive` (if shipped), the live-read
+  freshness contract (from the P3 result), and the benchmarks.
+- Note the derive crate + `derive` default feature.
+
+## Phase order & rationale
+
+1 (pool) → 2 (batch/stream, uses the pool for reads) → 3 (live read, layered on
+the pool + documents freshness) → 4 (consumability, wraps the finished
+surface). Pool must precede live-read because both touch the reader; landing
+live-read on the old single mutex then re-porting to the pool would be wasted
+work.
+
+## Testing (woven per phase + a coverage pass)
+
+- Keep ALL v1–v4 tests green.
+- P1: concurrent correctness, pool exhaustion/recovery, cross-connection
+  freshness (above).
+- P2: for_each order/count/empty, execute_batch commit + atomic rollback.
+- P3: spike regression tests (whichever behavior observed) + checkpoint_passive
+  if shipped.
+- P4: derive macro round-trips a struct (named fields, `Option`, missing-column
+  error); `project.json`/benches compile (`cargo bench --no-run` /
+  `cargo build --benches`). Derive crate has its own unit test.
+
+## Nx / project.json
+
+- `embeddb` `project.json` already exists (v4). Add `packages/rust/embeddb-derive/project.json`
+  mirroring the sibling rust libs (`@monodon/rust` build/test/lint,
+  `target-dir: dist/target/embeddb-derive`).
+- Add both new crates' membership to the root workspace `Cargo.toml`
+  (`embeddb-derive`); `embeddb` already a member.
+- `nx test embeddb` still cannot run inside the worktree (no node_modules) —
+  validate JSON shape only; `cargo test -p embeddb`, `cargo test -p embeddb-derive`,
+  `cargo build -p embeddb --benches` are the local gates.
+
+## Deferred (updated)
+
+WASM target, write-path prepared-statement cache (turso owns statement
+handling), backend-swap trait (rejected — Turso+DuckDB only). Reader pool now
+BUILT (was deferred). Live concurrent read resolved by the P3 spike either way.
+
+## README note
+
+Keep existing sections intact; append the v5 surface.

--- a/packages/rust/embeddb-derive/Cargo.toml
+++ b/packages/rust/embeddb-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "embeddb-derive"
+version = "0.0.1"
+edition = "2021"
+description = "derive macro for embeddb FromEmbedRow"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/packages/rust/embeddb-derive/project.json
+++ b/packages/rust/embeddb-derive/project.json
@@ -1,0 +1,30 @@
+{
+	"name": "embeddb-derive",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/rust/embeddb-derive/src",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" },
+			"configurations": { "production": { "release": true } }
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" },
+			"configurations": { "production": { "release": true } }
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": { "commands": ["nx test embeddb-derive"], "parallel": false }
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": { "target-dir": "dist/target/embeddb-derive" }
+		}
+	}
+}

--- a/packages/rust/embeddb-derive/src/lib.rs
+++ b/packages/rust/embeddb-derive/src/lib.rs
@@ -1,0 +1,51 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(FromEmbedRow)]
+pub fn derive_from_embed_row(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return syn::Error::new_spanned(name, "FromEmbedRow requires named fields")
+                    .to_compile_error()
+                    .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(name, "FromEmbedRow can only be derived for structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let inits = fields.iter().map(|field| {
+        let ident = field.ident.as_ref().unwrap();
+        let col = ident.to_string();
+        let ty = &field.ty;
+        quote! {
+            #ident: {
+                let __idx = __columns.iter().position(|c| c == #col);
+                let __v = __idx.and_then(|i| __row.get(i));
+                <#ty as ::embeddb::FromEmbedValue>::from_embed_value(__v)
+                    .map_err(|e| ::embeddb::EmbedError::Other(
+                        format!("column '{}': {}", #col, e)))?
+            }
+        }
+    });
+
+    let expanded = quote! {
+        impl ::embeddb::FromEmbedRow for #name {
+            fn from_row(__row: &::embeddb::EmbedRow, __columns: &[String]) -> ::embeddb::Result<Self> {
+                Ok(#name {
+                    #(#inits),*
+                })
+            }
+        }
+    };
+    expanded.into()
+}

--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -19,3 +19,8 @@ derive = ["dep:embeddb-derive"]
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+criterion = "0.5"
+
+[[bench]]
+name = "embeddb_bench"
+harness = false

--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -10,6 +10,11 @@ turso = "0.7"
 duckdb = { version = "1", features = ["bundled"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 thiserror = "1"
+embeddb-derive = { version = "0.0.1", path = "../embeddb-derive", optional = true }
+
+[features]
+default = ["derive"]
+derive = ["dep:embeddb-derive"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -19,7 +19,9 @@ The Turso write path is pure Rust and statically linked — no shared library to
 
 ## Checkpoint-then-read model
 
-Turso writes to the file's WAL. DuckDB's SQLite reader sees the main database file, not the WAL, so a checkpoint must run before DuckDB can observe recent writes. Call `EmbedDb::checkpoint` (which issues `PRAGMA wal_checkpoint(TRUNCATE)`) after writes and before running analytics queries — skipping this step means DuckDB may read stale or incomplete data.
+Turso writes to the file's WAL. DuckDB's `sqlite_scanner` replays uncheckpointed WAL frames when attached read-only, so analytics reads reflect all committed writes regardless of checkpoint status — a checkpoint is **not** required for DuckDB to observe recent writes. See "WAL-visibility freshness contract" under "v5" below for the authoritative statement and the measurements behind it.
+
+`EmbedDb::checkpoint` (which issues `PRAGMA wal_checkpoint(TRUNCATE)`) and `checkpoint_passive` (`PRAGMA wal_checkpoint(PASSIVE)`, see "v5" below) exist for WAL truncation and file-size compaction, not for read visibility. Call `checkpoint` when you want to bound WAL growth or reclaim disk space, not merely to make recent writes visible to analytics queries.
 
 `checkpoint` inspects the `(busy, log, checkpointed)` row that `PRAGMA wal_checkpoint(TRUNCATE)` returns. If it comes back busy (another reader holding the WAL), `checkpoint` retries (yielding between attempts) up to `EmbedConfig::checkpoint_max_retries` times. If it is still busy after retries, `checkpoint` returns `EmbedError::CheckpointBusy` instead of silently returning `Ok` over a possibly-incomplete flush.
 

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -224,3 +224,85 @@ db.migrate(&migrations).await?;
 `migrate` is append-only and idempotent: calling it again with the same slice is a no-op, and calling it with the same prefix plus new entries appended applies only the new entries. Each migration runs in its own transaction; if a migration fails, that transaction is rolled back and the error is returned, leaving previously-applied migrations intact and no partial record for the failed one — so migrating with the same (or a fixed) slice afterward will retry it.
 
 Each migration string is executed as a single statement via `tx.execute`. A string containing multiple statements (e.g. `"CREATE TABLE x (id INTEGER); CREATE INDEX idx_x ON x (id)"`) will only apply the first statement, yet the whole string is still recorded as applied — so the remaining statements silently never run. Callers must split multi-statement migrations into one array entry per statement.
+
+## v5
+
+### Reader pool: `EmbedConfig::reader_pool_size`
+
+v4's "Reader reuse" section above describes a single shared DuckDB reader connection behind a `Mutex`, which serializes all concurrent `analytics_*` calls. v5 replaces that single connection with a pool of DuckDB reader connections sized by `EmbedConfig::reader_pool_size` (default `4`). Concurrent `analytics_*` calls now check out a connection from the pool and run in parallel instead of queuing behind one lock:
+
+```rust
+use embeddb::{EmbedConfig, EmbedDb};
+
+let cfg = EmbedConfig { reader_pool_size: 8, ..Default::default() };
+let db = EmbedDb::open_with("data.db", cfg).await?;
+```
+
+### Streaming rows: `analytics_for_each`
+
+`analytics_query` and `analytics_rows` materialize the full result set into a `Vec` before returning. `analytics_for_each` instead streams each row through a callback and never builds that intermediate `Vec`, returning the number of rows visited:
+
+```rust
+let mut total = 0_i64;
+let n = db.analytics_for_each("SELECT v FROM t ORDER BY v", |row| {
+    total += row.as_i64(0).unwrap_or(0);
+}).await?;
+```
+
+### Batched writes: `execute_batch`
+
+`execute_batch` runs many parameter sets for the same SQL statement inside a single transaction, committing once at the end. If any one execution fails, the whole batch rolls back atomically instead of leaving a partially-applied set of rows:
+
+```rust
+let params: Vec<(i64, f64)> = (0..1000).map(|i| (i, i as f64)).collect();
+let n = db.execute_batch("INSERT INTO t VALUES (?, ?)", params).await?;
+```
+
+### Non-blocking checkpoint: `checkpoint_passive`
+
+`EmbedDb::checkpoint` issues `PRAGMA wal_checkpoint(TRUNCATE)`, which blocks new writers until it completes and truncates the WAL file. `checkpoint_passive` issues `PRAGMA wal_checkpoint(PASSIVE)` instead: it checkpoints as many WAL frames as it can without blocking writers or readers, and simply checkpoints fewer frames (or none) if the WAL is busy, rather than retrying or erroring:
+
+```rust
+db.checkpoint_passive().await?;
+```
+
+### Typed rows: `#[derive(FromEmbedRow)]` and `FromEmbedValue`
+
+The `embeddb-derive` crate provides a `#[derive(FromEmbedRow)]` proc macro that generates a `FromEmbedRow` impl for a plain struct with named fields, mapping each field to the same-named result column via that field's `FromEmbedValue` implementation:
+
+```rust
+use embeddb::FromEmbedRow;
+
+#[derive(Debug, PartialEq, FromEmbedRow)]
+struct Rec {
+    id: i64,
+    name: String,
+    note: Option<String>,
+}
+
+let rows: Vec<Rec> = db.analytics_query_as("SELECT id, name, note FROM t ORDER BY id").await?;
+```
+
+`FromEmbedValue` is implemented for `i64`, `f64`, `String`, `bool`, `i128`, `Vec<u8>`, and `Option<T>` for any `T: FromEmbedValue` (mapping SQL `NULL` to `None`). A field whose column is missing from the query's result set, or whose value doesn't convert to the field's type, makes the derived `from_row` return an error rather than panicking.
+
+The `derive` Cargo feature is on by default and pulls in `embeddb-derive`. Building with `--no-default-features` drops the proc-macro dependency: `FromEmbedRow` and `FromEmbedValue` (and all other APIs) remain available, but the `#[derive(FromEmbedRow)]` macro itself is not — implement `FromEmbedRow` by hand in that configuration.
+
+### WAL-visibility freshness contract
+
+A Task 3 spike measured what DuckDB's `sqlite_scanner` actually sees when attached read-only to a file Turso is concurrently writing. Contrary to the "checkpoint before every read" framing in "Checkpoint-then-read model" above, the scanner replays uncheckpointed WAL frames directly: a read performed after 3 checkpointed inserts plus 2 further, uncheckpointed inserts returned all 5 rows, not just the 3 checkpointed ones. A concurrent writer/reader test over the same file showed row counts observed by the reader are monotonic and non-decreasing, and never torn (no partial row ever seen) — DuckDB attaches `READ_ONLY`, so it observes a consistent view of the file even mid-write.
+
+The freshness contract this crate now documents: **analytics reads reflect all committed writes, including writes not yet checkpointed.** A live concurrent reader alongside an active writer is safe. `checkpoint` and `checkpoint_passive` still matter for WAL truncation and file-size compaction — an unbounded WAL grows without a checkpoint — but they are not required for read visibility, and callers that only need "see the latest committed data" no longer need to checkpoint before every analytics call.
+
+### Benchmarks
+
+`benches/embeddb_bench.rs` is a `criterion` benchmark binary (`harness = false`) covering `execute_batch` write throughput and parallel `analytics_scalar_f64` reads across `reader_pool_size` values of 1 and 4. Build it with:
+
+```bash
+cargo build -p embeddb --benches
+```
+
+Run it (slow — not part of the normal test loop) with:
+
+```bash
+cargo bench -p embeddb
+```

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -251,6 +251,8 @@ let n = db.analytics_for_each("SELECT v FROM t ORDER BY v", |row| {
 }).await?;
 ```
 
+The callback must be `FnMut + Send + 'static` and runs on a blocking thread, so accumulate results via `Arc`/atomics or a channel rather than capturing non-`Send` state; there is also no early-stop, so use `analytics_query` when you need column names or must be able to stop iterating early.
+
 ### Batched writes: `execute_batch`
 
 `execute_batch` runs many parameter sets for the same SQL statement inside a single transaction, committing once at the end. If any one execution fails, the whole batch rolls back atomically instead of leaving a partially-applied set of rows:

--- a/packages/rust/embeddb/benches/embeddb_bench.rs
+++ b/packages/rust/embeddb/benches/embeddb_bench.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use embeddb::{EmbedConfig, EmbedDb};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap()
+}
+
+async fn seeded(path: std::path::PathBuf, pool: usize, rows: i64) -> EmbedDb {
+    let cfg = EmbedConfig { reader_pool_size: pool, ..Default::default() };
+    let db = EmbedDb::open_with(path, cfg).await.unwrap();
+    db.execute("CREATE TABLE t (id INTEGER, v REAL)", ()).await.unwrap();
+    let params: Vec<(i64, f64)> = (0..rows).map(|i| (i, i as f64)).collect();
+    db.execute_batch("INSERT INTO t VALUES (?, ?)", params).await.unwrap();
+    db.checkpoint().await.unwrap();
+    db
+}
+
+fn bench_writes(c: &mut Criterion) {
+    let rt = rt();
+    let dir = tempfile::tempdir().unwrap();
+    c.bench_function("execute_batch_1000", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let db = EmbedDb::open(dir.path().join("bw.db")).await.unwrap();
+                db.execute("DROP TABLE IF EXISTS t", ()).await.unwrap();
+                db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+                let params: Vec<(i64,)> = (0..1000).map(|i| (i,)).collect();
+                db.execute_batch("INSERT INTO t VALUES (?)", params).await.unwrap();
+            })
+        })
+    });
+}
+
+fn bench_reads(c: &mut Criterion) {
+    let rt = rt();
+    let dir = tempfile::tempdir().unwrap();
+    for pool in [1usize, 4usize] {
+        let db = rt.block_on(seeded(dir.path().join(format!("br{pool}.db")), pool, 10_000));
+        let db = std::sync::Arc::new(db);
+        c.bench_function(&format!("parallel_reads_pool_{pool}"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut handles = Vec::new();
+                    for _ in 0..8 {
+                        let db = db.clone();
+                        handles.push(tokio::spawn(async move {
+                            db.analytics_scalar_f64("SELECT avg(v) FROM t").await.unwrap()
+                        }));
+                    }
+                    for h in handles { h.await.unwrap(); }
+                })
+            })
+        });
+    }
+}
+
+criterion_group!(benches, bench_writes, bench_reads);
+criterion_main!(benches);

--- a/packages/rust/embeddb/src/analytics.rs
+++ b/packages/rust/embeddb/src/analytics.rs
@@ -46,6 +46,29 @@ pub fn rows(conn: &duckdb::Connection, path: &Path, sql: &str) -> Result<Vec<cra
     Ok(query(conn, path, sql)?.rows)
 }
 
+pub fn for_each(
+    conn: &duckdb::Connection,
+    path: &Path,
+    sql: &str,
+    f: &mut dyn FnMut(&crate::EmbedRow),
+) -> Result<u64> {
+    attach_fresh(conn, path)?;
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query([])?;
+    let ncols = rows.as_ref().map(|s| s.column_names().len()).unwrap_or_default();
+    let mut count = 0_u64;
+    while let Some(row) = rows.next()? {
+        let mut vals = Vec::with_capacity(ncols);
+        for i in 0..ncols {
+            vals.push(value_from_ref(row.get_ref(i)?)?);
+        }
+        let er = crate::EmbedRow(vals);
+        f(&er);
+        count += 1;
+    }
+    Ok(count)
+}
+
 fn value_from_ref(v: duckdb::types::ValueRef<'_>) -> Result<crate::EmbedValue> {
     use duckdb::types::ValueRef as V;
     Ok(match v {

--- a/packages/rust/embeddb/src/config.rs
+++ b/packages/rust/embeddb/src/config.rs
@@ -5,10 +5,16 @@ pub struct EmbedConfig {
     pub journal_mode: String,
     pub duckdb_extension_dir: Option<PathBuf>,
     pub checkpoint_max_retries: u32,
+    pub reader_pool_size: usize,
 }
 
 impl Default for EmbedConfig {
     fn default() -> Self {
-        EmbedConfig { journal_mode: "WAL".to_string(), duckdb_extension_dir: None, checkpoint_max_retries: 5 }
+        EmbedConfig {
+            journal_mode: "WAL".to_string(),
+            duckdb_extension_dir: None,
+            checkpoint_max_retries: 5,
+            reader_pool_size: 4,
+        }
     }
 }

--- a/packages/rust/embeddb/src/convert.rs
+++ b/packages/rust/embeddb/src/convert.rs
@@ -1,0 +1,107 @@
+use crate::{EmbedError, EmbedValue, Result};
+
+pub trait FromEmbedValue: Sized {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self>;
+}
+
+fn absent(expected: &str) -> EmbedError {
+    EmbedError::Other(format!("expected {expected}, column absent"))
+}
+
+fn mismatch(expected: &str, got: &EmbedValue) -> EmbedError {
+    EmbedError::Other(format!("expected {expected}, got {got:?}"))
+}
+
+impl FromEmbedValue for i64 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Int(n)) => Ok(*n),
+            Some(other) => Err(mismatch("i64", other)),
+            None => Err(absent("i64")),
+        }
+    }
+}
+
+impl FromEmbedValue for f64 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Float(n)) => Ok(*n),
+            Some(other) => Err(mismatch("f64", other)),
+            None => Err(absent("f64")),
+        }
+    }
+}
+
+impl FromEmbedValue for String {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Text(s)) => Ok(s.clone()),
+            Some(other) => Err(mismatch("String", other)),
+            None => Err(absent("String")),
+        }
+    }
+}
+
+impl FromEmbedValue for bool {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Bool(b)) => Ok(*b),
+            Some(other) => Err(mismatch("bool", other)),
+            None => Err(absent("bool")),
+        }
+    }
+}
+
+impl FromEmbedValue for i128 {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::HugeInt(n)) => Ok(*n),
+            Some(EmbedValue::Int(n)) => Ok(*n as i128),
+            Some(other) => Err(mismatch("i128", other)),
+            None => Err(absent("i128")),
+        }
+    }
+}
+
+impl FromEmbedValue for Vec<u8> {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            Some(EmbedValue::Blob(b)) => Ok(b.clone()),
+            Some(other) => Err(mismatch("Vec<u8>", other)),
+            None => Err(absent("Vec<u8>")),
+        }
+    }
+}
+
+impl<T: FromEmbedValue> FromEmbedValue for Option<T> {
+    fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
+        match v {
+            None | Some(EmbedValue::Null) => Ok(None),
+            some => Ok(Some(T::from_embed_value(some)?)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_conversions() {
+        assert_eq!(i64::from_embed_value(Some(&EmbedValue::Int(5))).unwrap(), 5);
+        assert_eq!(String::from_embed_value(Some(&EmbedValue::Text("x".into()))).unwrap(), "x");
+        assert!(bool::from_embed_value(Some(&EmbedValue::Int(1))).is_err());
+    }
+
+    #[test]
+    fn option_handles_null_and_absent() {
+        assert_eq!(Option::<i64>::from_embed_value(None).unwrap(), None);
+        assert_eq!(Option::<i64>::from_embed_value(Some(&EmbedValue::Null)).unwrap(), None);
+        assert_eq!(Option::<i64>::from_embed_value(Some(&EmbedValue::Int(7))).unwrap(), Some(7));
+    }
+
+    #[test]
+    fn missing_non_option_errors() {
+        assert!(i64::from_embed_value(None).is_err());
+    }
+}

--- a/packages/rust/embeddb/src/convert.rs
+++ b/packages/rust/embeddb/src/convert.rs
@@ -26,6 +26,7 @@ impl FromEmbedValue for f64 {
     fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
         match v {
             Some(EmbedValue::Float(n)) => Ok(*n),
+            Some(EmbedValue::Int(n)) => Ok(*n as f64),
             Some(other) => Err(mismatch("f64", other)),
             None => Err(absent("f64")),
         }
@@ -103,5 +104,11 @@ mod tests {
     #[test]
     fn missing_non_option_errors() {
         assert!(i64::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn f64_accepts_int_and_float() {
+        assert_eq!(f64::from_embed_value(Some(&EmbedValue::Int(4))).unwrap(), 4.0);
+        assert_eq!(f64::from_embed_value(Some(&EmbedValue::Float(2.5))).unwrap(), 2.5);
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use crate::Result;
 
 pub struct EmbedDb {
     path: PathBuf,
     conn: turso::Connection,
     config: crate::EmbedConfig,
-    reader: Arc<Mutex<duckdb::Connection>>,
+    reader: Arc<crate::pool::ReaderPool>,
 }
 
 impl std::fmt::Debug for EmbedDb {
@@ -35,8 +35,11 @@ impl EmbedDb {
         let conn = db.connect()?;
         let pragma = format!("PRAGMA journal_mode={}", config.journal_mode);
         conn.execute(&pragma, ()).await.ok();
-        let reader = crate::analytics::open_reader(config.duckdb_extension_dir.as_deref())?;
-        Ok(EmbedDb { path, conn, config, reader: Arc::new(Mutex::new(reader)) })
+        let reader = crate::pool::ReaderPool::build(
+            config.reader_pool_size,
+            config.duckdb_extension_dir.as_deref(),
+        )?;
+        Ok(EmbedDb { path, conn, config, reader: Arc::new(reader) })
     }
 
     pub fn path(&self) -> &Path {
@@ -67,10 +70,10 @@ impl EmbedDb {
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let reader = self.reader.clone();
+        let pool = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
-            crate::analytics::scalar_i64(&conn, &path, &sql)
+            let guard = pool.checkout();
+            crate::analytics::scalar_i64(&guard, &path, &sql)
         })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
@@ -79,10 +82,10 @@ impl EmbedDb {
     pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let reader = self.reader.clone();
+        let pool = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
-            crate::analytics::scalar_f64(&conn, &path, &sql)
+            let guard = pool.checkout();
+            crate::analytics::scalar_f64(&guard, &path, &sql)
         })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
@@ -91,10 +94,10 @@ impl EmbedDb {
     pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let reader = self.reader.clone();
+        let pool = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
-            crate::analytics::rows(&conn, &path, &sql)
+            let guard = pool.checkout();
+            crate::analytics::rows(&guard, &path, &sql)
         })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
@@ -103,10 +106,10 @@ impl EmbedDb {
     pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let reader = self.reader.clone();
+        let pool = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
-            crate::analytics::query(&conn, &path, &sql)
+            let guard = pool.checkout();
+            crate::analytics::query(&guard, &path, &sql)
         })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
@@ -119,10 +122,10 @@ impl EmbedDb {
     pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let reader = self.reader.clone();
+        let pool = self.reader.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = reader.lock().unwrap_or_else(|e| e.into_inner());
-            crate::analytics::scalar_string(&conn, &path, &sql)
+            let guard = pool.checkout();
+            crate::analytics::scalar_string(&guard, &path, &sql)
         })
             .await
             .map_err(|e| crate::EmbedError::Other(e.to_string()))?
@@ -344,7 +347,7 @@ mod tests {
     #[tokio::test]
     async fn open_with_custom_config() {
         let dir = tempfile::tempdir().unwrap();
-        let cfg = crate::EmbedConfig { journal_mode: "WAL".into(), duckdb_extension_dir: None, checkpoint_max_retries: 1 };
+        let cfg = crate::EmbedConfig { journal_mode: "WAL".into(), duckdb_extension_dir: None, checkpoint_max_retries: 1, reader_pool_size: 2 };
         let db = EmbedDb::open_with(dir.path().join("cfg.db"), cfg).await.unwrap();
         db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
         db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
@@ -642,5 +645,65 @@ mod tests {
         db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn pool_concurrent_reads_all_correct() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("pool.db")).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        for i in 1..=10 {
+            db.execute(&format!("INSERT INTO t VALUES ({i})"), ()).await.unwrap();
+        }
+        db.checkpoint().await.unwrap();
+        let mut handles = Vec::new();
+        for _ in 0..12 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap()
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 10);
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_exhaustion_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = crate::EmbedConfig { reader_pool_size: 2, ..Default::default() };
+        let db = std::sync::Arc::new(EmbedDb::open_with(dir.path().join("ex.db"), cfg).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap()
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_cross_connection_freshness() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = crate::EmbedConfig { reader_pool_size: 3, ..Default::default() };
+        let db = EmbedDb::open_with(dir.path().join("cf.db"), cfg).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        for _ in 0..5 {
+            assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 1);
+        }
+        db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        for _ in 0..5 {
+            assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
+        }
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -820,6 +820,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn uncheckpointed_writes_are_visible_to_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("walvis.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2), (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.execute("INSERT INTO t VALUES (4), (5)", ()).await.unwrap();
+        let seen = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+        assert_eq!(seen, 5, "DuckDB must reflect committed-but-uncheckpointed writes (v5 freshness contract)");
+    }
+
+    #[tokio::test]
     async fn concurrent_writer_reader_never_torn() {
         let dir = tempfile::tempdir().unwrap();
         let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("conc.db")).await.unwrap());

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -854,4 +854,38 @@ mod tests {
         reader.await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 50);
     }
+
+    #[tokio::test]
+    async fn derive_from_embed_row_round_trips() {
+        #[derive(Debug, PartialEq, crate::FromEmbedRow)]
+        struct Rec {
+            id: i64,
+            name: String,
+            note: Option<String>,
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("derive.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT, note TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'a', NULL), (2, 'b', 'hi')", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let got: Vec<Rec> = db.analytics_query_as("SELECT id, name, note FROM t ORDER BY id").await.unwrap();
+        assert_eq!(got, vec![
+            Rec { id: 1, name: "a".into(), note: None },
+            Rec { id: 2, name: "b".into(), note: Some("hi".into()) },
+        ]);
+    }
+
+    #[tokio::test]
+    async fn derive_missing_column_errors() {
+        #[derive(Debug, crate::FromEmbedRow)]
+        struct Rec { id: i64, missing: i64 }
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("derive_err.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let res: Result<Vec<Rec>> = db.analytics_query_as("SELECT id FROM t").await;
+        assert!(res.is_err());
+        assert!(format!("{}", res.unwrap_err()).contains("missing"));
+    }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -67,6 +67,12 @@ impl EmbedDb {
         Err(crate::EmbedError::CheckpointBusy)
     }
 
+    pub async fn checkpoint_passive(&self) -> Result<()> {
+        let mut rows = self.conn.query("PRAGMA wal_checkpoint(PASSIVE)", ()).await?;
+        while rows.next().await?.is_some() {}
+        Ok(())
+    }
+
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
         let path = self.path.clone();
         let sql = sql.to_string();
@@ -789,5 +795,63 @@ mod tests {
         assert!(res.is_err());
         db.checkpoint().await.unwrap();
         assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_passive_makes_writes_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("cpp.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2)", ()).await.unwrap();
+        db.checkpoint_passive().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn wal_visibility_uncheckpointed_is_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("wal.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2), (3)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.execute("INSERT INTO t VALUES (4), (5)", ()).await.unwrap();
+        let seen = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+        assert!(seen == 3 || seen == 5, "expected consistent snapshot (3 or 5), got {seen}");
+    }
+
+    #[tokio::test]
+    async fn concurrent_writer_reader_never_torn() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("conc.db")).await.unwrap());
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let writer = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                for i in 0..50_i64 {
+                    db.execute("INSERT INTO t VALUES (?)", (i,)).await.unwrap();
+                    if i % 10 == 0 {
+                        db.checkpoint_passive().await.unwrap();
+                    }
+                }
+                db.checkpoint().await.unwrap();
+            })
+        };
+        let reader = {
+            let db = db.clone();
+            tokio::spawn(async move {
+                let mut last = 0_i64;
+                for _ in 0..20 {
+                    let n = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+                    assert!(n >= last, "count went backwards: {last} -> {n}");
+                    assert!((0..=50).contains(&n), "count out of range: {n}");
+                    last = n;
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        writer.await.unwrap();
+        reader.await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 50);
     }
 }

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -140,6 +140,35 @@ impl EmbedDb {
         Ok(out)
     }
 
+    pub async fn analytics_for_each<F>(&self, sql: &str, mut f: F) -> Result<u64>
+    where
+        F: FnMut(&crate::EmbedRow) + Send + 'static,
+    {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        let pool = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.checkout();
+            crate::analytics::for_each(&guard, &path, &sql, &mut f)
+        })
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+
+    pub async fn execute_batch<I, P>(&self, sql: &str, params: I) -> Result<u64>
+    where
+        I: IntoIterator<Item = P>,
+        P: turso::IntoParams,
+    {
+        let tx = self.begin().await?;
+        let mut total = 0_u64;
+        for p in params {
+            total += tx.execute(sql, p).await?;
+        }
+        tx.commit().await?;
+        Ok(total)
+    }
+
     pub async fn begin(&self) -> Result<crate::EmbedTx<'_>> {
         let tx = self.conn.unchecked_transaction().await?;
         Ok(crate::EmbedTx::new(tx))
@@ -705,5 +734,60 @@ mod tests {
         for _ in 0..5 {
             assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 3);
         }
+    }
+
+    #[tokio::test]
+    async fn for_each_visits_all_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("fe.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2), (3), (4)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let sum = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let s2 = sum.clone();
+        let n = db.analytics_for_each("SELECT v FROM t ORDER BY v", move |row| {
+            s2.fetch_add(row.as_i64(0).unwrap(), std::sync::atomic::Ordering::SeqCst);
+        }).await.unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(sum.load(std::sync::atomic::Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test]
+    async fn for_each_empty_calls_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("fee.db")).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let c2 = calls.clone();
+        let n = db.analytics_for_each("SELECT v FROM t", move |_| {
+            c2.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }).await.unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_inserts_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("eb.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        let params: Vec<(i64,)> = (1..=5).map(|i| (i,)).collect();
+        let n = db.execute_batch("INSERT INTO t VALUES (?)", params).await.unwrap();
+        assert_eq!(n, 5);
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_rolls_back_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("ebr.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", ()).await.unwrap();
+        let params: Vec<(i64,)> = vec![(1,), (2,), (2,), (3,)];
+        let res = db.execute_batch("INSERT INTO t VALUES (?)", params).await;
+        assert!(res.is_err());
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 0);
     }
 }

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -6,6 +6,7 @@ mod value;
 mod config;
 mod migrate;
 mod query;
+mod pool;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate self as embeddb;
+
 mod error;
 mod db;
 mod analytics;
@@ -7,6 +9,7 @@ mod config;
 mod migrate;
 mod query;
 mod pool;
+mod convert;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
@@ -16,3 +19,7 @@ pub use turso::IntoParams;
 pub use config::EmbedConfig;
 pub use query::QueryResult;
 pub use query::FromEmbedRow;
+pub use convert::FromEmbedValue;
+
+#[cfg(feature = "derive")]
+pub use embeddb_derive::FromEmbedRow;

--- a/packages/rust/embeddb/src/pool.rs
+++ b/packages/rust/embeddb/src/pool.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+use std::sync::{Condvar, Mutex};
+use crate::Result;
+
+#[derive(Debug)]
+pub(crate) struct ReaderPool {
+    idle: Mutex<Vec<duckdb::Connection>>,
+    available: Condvar,
+}
+
+impl ReaderPool {
+    pub(crate) fn build(size: usize, ext_dir: Option<&Path>) -> Result<Self> {
+        if size == 0 {
+            return Err(crate::EmbedError::Other("reader_pool_size must be >= 1".into()));
+        }
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(crate::analytics::open_reader(ext_dir)?);
+        }
+        Ok(ReaderPool { idle: Mutex::new(conns), available: Condvar::new() })
+    }
+
+    pub(crate) fn checkout(&self) -> ReaderGuard<'_> {
+        let mut idle = self.idle.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if let Some(conn) = idle.pop() {
+                return ReaderGuard { pool: self, conn: Some(conn) };
+            }
+            idle = self.available.wait(idle).unwrap_or_else(|e| e.into_inner());
+        }
+    }
+
+    fn checkin(&self, conn: duckdb::Connection) {
+        let mut idle = self.idle.lock().unwrap_or_else(|e| e.into_inner());
+        idle.push(conn);
+        drop(idle);
+        self.available.notify_one();
+    }
+}
+
+pub(crate) struct ReaderGuard<'a> {
+    pool: &'a ReaderPool,
+    conn: Option<duckdb::Connection>,
+}
+
+impl std::ops::Deref for ReaderGuard<'_> {
+    type Target = duckdb::Connection;
+    fn deref(&self) -> &duckdb::Connection {
+        self.conn.as_ref().expect("reader guard holds a connection until drop")
+    }
+}
+
+impl Drop for ReaderGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            self.pool.checkin(conn);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_zero_errors() {
+        let err = ReaderPool::build(0, None).unwrap_err();
+        assert!(matches!(err, crate::EmbedError::Other(_)));
+    }
+
+    #[test]
+    fn checkout_returns_to_pool_on_drop() {
+        let pool = ReaderPool::build(1, None).unwrap();
+        {
+            let _g = pool.checkout();
+        }
+        let _g2 = pool.checkout();
+    }
+}


### PR DESCRIPTION
## embeddb v5 — parallel reads, batch/stream, live read, derive macro

Fifth iteration of `packages/rust/embeddb` (Turso write + DuckDB read, single file). Five ordered phases on one branch. Builds on v1 #14292 / v2 #14313 / v3 #14321 / v4 #14332.

### Phases
1. **Parallel reads** — replaced the single `Arc<Mutex<duckdb::Connection>>` with a `ReaderPool` (`Mutex<Vec<Connection>>` + `Condvar` free-list, RAII checkout). `EmbedConfig.reader_pool_size` (default 4). Reverses v4's read-serialization trade-off; extension loaded once per pooled connection.
2. **Batch / streaming** — `analytics_for_each(sql, |row| …)` streams rows through a callback (no `Vec` materialization); `execute_batch(sql, params_iter)` runs many param sets in one transaction with atomic rollback.
3. **Live concurrent read** — `checkpoint_passive()` (non-blocking `PRAGMA wal_checkpoint(PASSIVE)`). **Spike finding:** DuckDB's sqlite_scanner *replays uncheckpointed Turso WAL frames* — analytics reads reflect committed writes even before a checkpoint, and a concurrent writer+reader stays monotonic and never-torn (READ_ONLY attach = corruption-safe). Freshness contract locked by a regression test.
4. **Derive** — new proc-macro crate `packages/rust/embeddb-derive` (`#[derive(FromEmbedRow)]`) + `FromEmbedValue` conversion trait. `derive` cargo feature on by default; `--no-default-features` still builds.
5. **Benches + README** — criterion benches (write throughput, parallel reads pool 1 vs 4); v5 README section.

### Tests
60 passing in `embeddb` (was 41 at v4); `embeddb-derive` compiles; `cargo build -p embeddb --benches` and `--no-default-features` both clean.

### Stays Turso + DuckDB only
No third backend. Both crates at `0.0.1` publish sentinel.

Reviewed subagent-driven per task + a final whole-branch review (READY TO MERGE); the WAL-visibility contract test, an `f64`-accepts-int conversion, and a `for_each` doc caveat were added from that review. Spec + plan under `docs/superpowers/`.
