### PR TITLE
feat(discordsh): thread-aware /github close & reopen with attribution

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
@@ -1143,114 +1143,281 @@ async fn create(
     }
 }
 
-// ── /github close ───────────────────────────────────────────────────
+// ── /github close + reopen ──────────────────────────────────────────
 
-/// Close an issue or pull request.
-#[poise::command(slash_command)]
-async fn close(
+const REVERSE_DIRECTION: &str = "discord_to_github";
+
+/// Gate for Discord-driven GitHub state changes: the invoker must hold
+/// MANAGE_THREADS (administrators bypass). Sends an ephemeral notice + returns
+/// `false` when denied. Missing member context (DM) falls through to `true`; the
+/// command still requires a guild for token resolution.
+async fn require_manage_threads(ctx: Context<'_>) -> Result<bool, Error> {
+    if let Some(member) = ctx.author_member().await {
+        let perms = member
+            .permissions
+            .unwrap_or_else(poise::serenity_prelude::Permissions::empty);
+        if !perms.administrator() && !perms.manage_threads() {
+            send_error(
+                ctx,
+                "You need the **Manage Threads** permission to close or reopen issues.",
+            )
+            .await?;
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn neutralize_at(s: &str) -> String {
+    s.replace('@', "@\u{200b}")
+}
+
+/// GitHub attribution comment for a Discord-driven state change. Mentions are
+/// neutralized so nothing pings a GitHub user once mirrored.
+fn state_change_comment(author: &str, reopen: bool, is_pull_request: bool) -> String {
+    let who = neutralize_at(author.trim());
+    let action = if reopen { "reopened" } else { "closed" };
+    let kind = if is_pull_request { "pull request" } else { "issue" };
+    if who.is_empty() {
+        format!("_(via Discord)_ {action} this {kind}.")
+    } else {
+        format!("**{who}** _(via Discord)_ {action} this {kind}.")
+    }
+}
+
+/// Only GitHub's two `state_reason` values are accepted; anything else rejects.
+fn validate_close_reason(reason: &Option<String>) -> Result<Option<String>, String> {
+    match reason.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some("completed") => Ok(Some("completed".to_owned())),
+        Some("not_planned") => Ok(Some("not_planned".to_owned())),
+        Some(other) => Err(format!(
+            "Invalid reason `{other}`. Use `completed` or `not_planned`."
+        )),
+    }
+}
+
+struct StateTarget {
+    owner: String,
+    repo: String,
+    number: u64,
+    is_pull_request: bool,
+    current_state: Option<String>,
+}
+
+/// Resolve the issue/PR to act on: an explicit number (with optional repo), or
+/// the issue mirrored to the current forum thread when no number is given.
+async fn resolve_state_target(
     ctx: Context<'_>,
-    #[description = "Issue or PR number"] number: u64,
-    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+    number: Option<u64>,
+    repo: &Option<String>,
+) -> Result<StateTarget, String> {
+    let store = &ctx.data().app.github_store;
+    if let Some(number) = number {
+        let (owner, repo_name) = parse_repo(repo, &ctx.data().app.default_repo);
+        let cached = if store.is_enabled() {
+            store
+                .get_issue(&owner, &repo_name, number as u32)
+                .await
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+        return Ok(StateTarget {
+            is_pull_request: cached.as_ref().map(|c| c.is_pull_request).unwrap_or(false),
+            current_state: cached.map(|c| c.state),
+            owner,
+            repo: repo_name,
+            number,
+        });
+    }
+
+    if !store.is_enabled() {
+        return Err("Provide an issue number — thread lookup is unavailable.".to_owned());
+    }
+    let thread_id = ctx.channel_id().get() as i64;
+    let issue = store
+        .get_issue_by_thread_id(thread_id)
+        .await
+        .map_err(|e| format!("Thread lookup failed: {e}"))?
+        .ok_or_else(|| {
+            "This channel isn't a linked GitHub thread. Run this inside a synced issue/PR thread, or pass a number.".to_owned()
+        })?;
+    Ok(StateTarget {
+        owner: issue.owner,
+        repo: issue.repo,
+        number: issue.number as u64,
+        is_pull_request: issue.is_pull_request,
+        current_state: Some(issue.state),
+    })
+}
+
+/// Post the attribution comment and record a mirror row keyed on the interaction
+/// snowflake so the forward `commented` webhook echo-skips it (no dup in-thread).
+/// Best-effort: a failure here never blocks the state change.
+async fn post_state_attribution(
+    ctx: Context<'_>,
+    gh: &GitHubClient,
+    target: &StateTarget,
+    reopen: bool,
+) {
+    let store = &ctx.data().app.github_store;
+    if !store.is_enabled() {
+        return;
+    }
+    let author = ctx
+        .author()
+        .global_name
+        .clone()
+        .unwrap_or_else(|| ctx.author().name.clone());
+    let body = state_change_comment(&author, reopen, target.is_pull_request);
+    let interaction_id = ctx.id() as i64;
+    let channel_id = ctx.channel_id().get() as i64;
+
+    match store
+        .claim_comment_mirror(
+            interaction_id,
+            channel_id,
+            &target.owner,
+            &target.repo,
+            target.number as u32,
+            REVERSE_DIRECTION,
+            Some(&author),
+        )
+        .await
+    {
+        Ok(false) => return,
+        Ok(true) => {}
+        Err(e) => {
+            warn!(error = %e, number = target.number, "gh state: mirror claim failed; posting without echo-guard");
+        }
+    }
+
+    match gh
+        .create_comment(&target.owner, &target.repo, target.number, &body)
+        .await
+    {
+        Ok(c) => {
+            if let Err(e) = store.set_comment_mirror_github_id(interaction_id, c.id as i64).await {
+                warn!(error = %e, comment_id = c.id, "gh state: finalize mirror failed; forward echo-guard may miss");
+            }
+        }
+        Err(e) => warn!(error = %e, number = target.number, "gh state: attribution comment failed"),
+    }
+}
+
+/// Shared driver for `/github close` and `/github reopen`. GitHub stays the
+/// source of truth; the resulting `closed`/`reopened` webhook flows forward to
+/// archive/unarchive the thread — this command never touches thread state.
+async fn run_state_change(
+    ctx: Context<'_>,
+    number: Option<u64>,
+    repo: Option<String>,
+    reopen: bool,
+    reason: Option<String>,
 ) -> Result<(), Error> {
-    if !check_tier(ctx, CommandTier::Admin).await? {
+    if !require_manage_threads(ctx).await? {
         return Ok(());
     }
+    let reason = if reopen {
+        None
+    } else {
+        match validate_close_reason(&reason) {
+            Ok(r) => r,
+            Err(msg) => return send_error(ctx, &msg).await,
+        }
+    };
     ctx.defer().await?;
 
-    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+    let outcome = tokio::time::timeout(COMMAND_TIMEOUT, async {
         let gh = get_github_client(ctx).await?;
-        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
-        let full_name = format!("{}/{}", owner, repo_name);
+        let target = resolve_state_target(ctx, number, &repo).await?;
+        let full_name = format!("{}/{}", target.owner, target.repo);
+        let desired = if reopen { "open" } else { "closed" };
+
+        if target.current_state.as_deref() == Some(desired) {
+            return Err(format!("#{} is already {desired}.", target.number));
+        }
+
+        post_state_attribution(ctx, &gh, &target, reopen).await;
 
         let req = UpdateIssueRequest {
-            state: Some("closed".to_owned()),
+            state: Some(desired.to_owned()),
+            state_reason: reason.clone(),
             ..Default::default()
         };
+        gh.update_issue(&target.owner, &target.repo, target.number, &req)
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to {} #{}: {e}",
+                    if reopen { "reopen" } else { "close" },
+                    target.number
+                )
+            })?;
 
-        match gh.update_issue(&owner, &repo_name, number, &req).await {
-            Ok(_) => {
-                ctx.data()
-                    .app
-                    .github_cache
-                    .invalidate_issue(&owner, &repo_name, number);
-                info!(user = %ctx.author().name, issue = number, "Issue closed via Discord");
-
-                let embed = poise::serenity_prelude::CreateEmbed::new()
-                    .title(format!("Closed #{number}"))
-                    .description(format!("Issue closed in `{full_name}`"))
-                    .color(branding::GH_GRAY)
-                    .author(branding::embed_author())
-                    .footer(branding::embed_footer(None));
-
-                ctx.send(poise::CreateReply::default().embed(embed))
-                    .await
-                    .map_err(|e| e.to_string())?;
-                Ok(())
-            }
-            Err(e) => Err(format!("Failed to close #{number}: {e}")),
-        }
+        ctx.data()
+            .app
+            .github_cache
+            .invalidate_issue(&target.owner, &target.repo, target.number);
+        ctx.data()
+            .app
+            .github_store
+            .invalidate(&target.owner, &target.repo, target.number as u32);
+        info!(user = %ctx.author().name, issue = target.number, reopen, "Issue state changed via Discord");
+        Ok((target.number, full_name))
     })
-    .await
-    {
-        Ok(Ok(())) => Ok(()),
+    .await;
+
+    match outcome {
+        Ok(Ok((number, full_name))) => {
+            let (title, desc, color) = if reopen {
+                (
+                    format!("Reopened #{number}"),
+                    format!("Issue reopened in `{full_name}`"),
+                    branding::GH_GREEN,
+                )
+            } else {
+                (
+                    format!("Closed #{number}"),
+                    format!("Issue closed in `{full_name}`"),
+                    branding::GH_GRAY,
+                )
+            };
+            let embed = poise::serenity_prelude::CreateEmbed::new()
+                .title(title)
+                .description(desc)
+                .color(color)
+                .author(branding::embed_author())
+                .footer(branding::embed_footer(None));
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
+            Ok(())
+        }
         Ok(Err(msg)) => send_error(ctx, &msg).await,
         Err(_) => send_error(ctx, "The request timed out — please try again.").await,
     }
 }
 
-// ── /github reopen ──────────────────────────────────────────────────
+/// Close an issue or pull request. Run inside a linked thread to omit the number.
+#[poise::command(slash_command)]
+async fn close(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number (optional inside a linked thread)"] number: Option<u64>,
+    #[description = "Close reason: completed or not_planned"] reason: Option<String>,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    run_state_change(ctx, number, repo, false, reason).await
+}
 
-/// Reopen a closed issue or pull request.
+/// Reopen a closed issue or pull request. Run inside a linked thread to omit the number.
 #[poise::command(slash_command)]
 async fn reopen(
     ctx: Context<'_>,
-    #[description = "Issue or PR number"] number: u64,
+    #[description = "Issue or PR number (optional inside a linked thread)"] number: Option<u64>,
     #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
 ) -> Result<(), Error> {
-    if !check_tier(ctx, CommandTier::Admin).await? {
-        return Ok(());
-    }
-    ctx.defer().await?;
-
-    match tokio::time::timeout(COMMAND_TIMEOUT, async {
-        let gh = get_github_client(ctx).await?;
-        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
-        let full_name = format!("{}/{}", owner, repo_name);
-
-        let req = UpdateIssueRequest {
-            state: Some("open".to_owned()),
-            ..Default::default()
-        };
-
-        match gh.update_issue(&owner, &repo_name, number, &req).await {
-            Ok(_) => {
-                ctx.data()
-                    .app
-                    .github_cache
-                    .invalidate_issue(&owner, &repo_name, number);
-                info!(user = %ctx.author().name, issue = number, "Issue reopened via Discord");
-
-                let embed = poise::serenity_prelude::CreateEmbed::new()
-                    .title(format!("Reopened #{number}"))
-                    .description(format!("Issue reopened in `{full_name}`"))
-                    .color(branding::GH_GREEN)
-                    .author(branding::embed_author())
-                    .footer(branding::embed_footer(None));
-
-                ctx.send(poise::CreateReply::default().embed(embed))
-                    .await
-                    .map_err(|e| e.to_string())?;
-                Ok(())
-            }
-            Err(e) => Err(format!("Failed to reopen #{number}: {e}")),
-        }
-    })
-    .await
-    {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(msg)) => send_error(ctx, &msg).await,
-        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
-    }
+    run_state_change(ctx, number, repo, true, None).await
 }
 
 // ── /github comment ─────────────────────────────────────────────────
@@ -1877,5 +2044,58 @@ async fn merge(
         Ok(Ok(())) => Ok(()),
         Ok(Err(msg)) => send_error(ctx, &msg).await,
         Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_comment_close_issue() {
+        let body = state_change_comment("h0lyMac", false, false);
+        assert_eq!(body, "**h0lyMac** _(via Discord)_ closed this issue.");
+    }
+
+    #[test]
+    fn state_comment_reopen_pull_request() {
+        let body = state_change_comment("mod", true, true);
+        assert_eq!(body, "**mod** _(via Discord)_ reopened this pull request.");
+    }
+
+    #[test]
+    fn state_comment_neutralizes_mentions() {
+        let body = state_change_comment("@everyone", false, false);
+        assert!(!body.contains("@everyone"));
+        assert!(body.contains("@\u{200b}everyone"));
+    }
+
+    #[test]
+    fn state_comment_blank_author_omits_prefix() {
+        let body = state_change_comment("   ", false, false);
+        assert_eq!(body, "_(via Discord)_ closed this issue.");
+    }
+
+    #[test]
+    fn reason_none_and_empty_are_none() {
+        assert_eq!(validate_close_reason(&None), Ok(None));
+        assert_eq!(validate_close_reason(&Some("  ".to_owned())), Ok(None));
+    }
+
+    #[test]
+    fn reason_accepts_github_values() {
+        assert_eq!(
+            validate_close_reason(&Some("completed".to_owned())),
+            Ok(Some("completed".to_owned()))
+        );
+        assert_eq!(
+            validate_close_reason(&Some(" not_planned ".to_owned())),
+            Ok(Some("not_planned".to_owned()))
+        );
+    }
+
+    #[test]
+    fn reason_rejects_unknown() {
+        assert!(validate_close_reason(&Some("wontfix".to_owned())).is_err());
     }
 }

--- a/apps/discordsh/discordsh-bot/src/discord/github_permissions.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/github_permissions.rs
@@ -189,6 +189,7 @@ fn parse_permissions(s: &str) -> serenity::Permissions {
             "MANAGE_GUILD" => serenity::Permissions::MANAGE_GUILD,
             "MANAGE_MESSAGES" => serenity::Permissions::MANAGE_MESSAGES,
             "MANAGE_CHANNELS" => serenity::Permissions::MANAGE_CHANNELS,
+            "MANAGE_THREADS" => serenity::Permissions::MANAGE_THREADS,
             "MANAGE_ROLES" => serenity::Permissions::MANAGE_ROLES,
             "SEND_MESSAGES" => serenity::Permissions::SEND_MESSAGES,
             "VIEW_CHANNEL" => serenity::Permissions::VIEW_CHANNEL,
@@ -284,6 +285,12 @@ mod tests {
         let perms = parse_permissions("ADMINISTRATOR,MANAGE_MESSAGES");
         assert!(perms.contains(serenity::Permissions::ADMINISTRATOR));
         assert!(perms.contains(serenity::Permissions::MANAGE_MESSAGES));
+    }
+
+    #[test]
+    fn parse_permissions_manage_threads() {
+        let perms = parse_permissions("MANAGE_THREADS");
+        assert!(perms.contains(serenity::Permissions::MANAGE_THREADS));
     }
 
     #[test]

--- a/packages/rust/jedi/src/entity/github/types.rs
+++ b/packages/rust/jedi/src/entity/github/types.rs
@@ -183,6 +183,8 @@ pub struct UpdateIssueRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignees: Option<Vec<String>>,
@@ -282,4 +284,30 @@ pub struct GitHubRateLimit {
     pub remaining: u32,
     pub limit: u32,
     pub reset: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_issue_omits_none_state_reason() {
+        let req = UpdateIssueRequest {
+            state: Some("closed".to_owned()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, r#"{"state":"closed"}"#);
+    }
+
+    #[test]
+    fn update_issue_serializes_state_reason() {
+        let req = UpdateIssueRequest {
+            state: Some("closed".to_owned()),
+            state_reason: Some("not_planned".to_owned()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""state_reason":"not_planned""#));
+    }
 }


### PR DESCRIPTION
Closes #14342.

## What

Upgrades the existing (number-driven, admin-gated) `/github close` and `/github reopen` into thread-aware, attributed lifecycle commands. GitHub stays the source of truth — the command drives GitHub, and the resulting `closed`/`reopened` webhook flows **forward** through `gh_sync` to archive/unarchive the thread. The command never touches Discord thread state, so there is no loop and no reverse authority (this is why the naive Discord→GitHub state mirror was rejected during design).

Reconciliation note: `/github close|reopen` already existed, so this **enhances** them rather than adding a duplicate `/gh close`.

## Changes

- **Optional number** — omit it inside a mirrored forum thread and the target issue/PR resolves via `get_issue_by_thread_id`; pass a number to act anywhere.
- **Attribution comment** — posts `**user** _(via Discord)_ closed this issue.` with neutralized mentions, recorded in `gh.comment_mirror` keyed on the interaction snowflake so the forward `commented` webhook echo-skips it (no duplicate post back into the thread). Best-effort: never blocks the state change.
- **Close reason** — optional `completed | not_planned` → GitHub `state_reason`. Added `state_reason` to `UpdateIssueRequest` (serialize-skips `None`).
- **Gate** — MANAGE_THREADS (administrators bypass), dedicated so the shared `Admin` tier (merge/dispatch) stays ADMINISTRATOR-only. Added MANAGE_THREADS to the permission parser.
- **No-op** when the issue is already in the target state.

## Testing

- Unit: attribution builder (close/reopen, issue/PR, mention-neutralize, blank author), reason validation (accept/reject/trim), MANAGE_THREADS parse, `state_reason` serialize-skip.
- `cargo check` + `cargo test` (bot 792 pass, jedi github 38 pass) + `cargo clippy` clean (no new lints).
- End-to-end Discord/GitHub driving not run locally (needs live bot + guild PAT); validate on the bot image rollout.

## Ship

No DB migration, no new required env. Bot version bump + image rollout (CI publish on main + ArgoCD). Optional: gate is MANAGE_THREADS by default now; no env change needed.

Docs: https://kbve.com/