### PR TITLE
fix(dashboard): kanban board blank state + right-edge clipping

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -791,21 +791,30 @@ const sectionNames = [
 <style>
 	/* ── Snap container ── */
 	.kb-snap-container {
-		position: relative;
-		height: 100vh;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		position: fixed;
+		inset: var(--sl-nav-height, 3.5rem) 0 0
+			var(--sl-content-inline-start, 0);
 		overflow: hidden;
 		background: var(--sl-color-bg, #0a0a0a);
+		z-index: 1;
 	}
 
 	/* ── Sections ── */
 	.kb-section {
-		width: 100%;
-		top: calc(var(--sl-nav-height, 3.5rem) + 3.5rem);
-		height: calc(100vh - var(--sl-nav-height, 3.5rem) - 3.5rem);
-		position: fixed;
+		position: absolute;
+		top: 3.5rem;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: auto;
+		height: auto;
 		visibility: hidden;
+	}
+	/* Progressive enhancement: the first section is visible without JS so a
+	   failed GSAP init (or blocked import) shows the Summary instead of a
+	   blank board. GSAP takes over visibility once it hydrates. */
+	.kb-section[data-section='0'] {
+		visibility: visible;
 	}
 	.kb-section-outer,
 	.kb-section-inner {


### PR DESCRIPTION
Fixes two layout bugs in the interactive kanban board (`/dashboard/kanban/`), found + verified with local Playwright screenshots at desktop (1440) and mobile (700).

## Bugs
1. **Blank-on-load** — all 10 `.kb-section` slides are `visibility:hidden`, revealed only by GSAP `gotoSection(0)` on `astro:page-load`. If that init fails or the `gsap` import is blocked, the **entire board renders blank** with no fallback (reproduced on dev via the Vite dep-optimize 504, and live-as-guest).
2. **Right-edge clipping** — `.kb-snap-container` full-bleeds via `margin-left: calc(-50vw + 50%)`, which mis-centers under Starlight's left sidebar; the `position:fixed; width:100vw` sections overflowed ~270px past the viewport, clipping the last column + dot-nav.

## Fix (CSS only — GSAP JS untouched)
- **Progressive enhancement**: `.kb-section[data-section='0']` is visible by default → a failed/blocked GSAP init shows the Summary instead of a blank page. GSAP still owns transitions once hydrated (inline `autoAlpha` overrides the default).
- **Sidebar-aware layout**: the container is now a fixed box anchored to the content area — `inset: var(--sl-nav-height) 0 0 var(--sl-content-inline-start)` — with sections `position:absolute` inside it. Fills the content column exactly on desktop (x=300, w=1140, no overflow) and full width on mobile (x=0), sidebar stays visible + usable.

## Verification
| | before | after |
|---|---|---|
| JS-fails load | blank board | Summary visible |
| desktop width | overflows +270px, clips last column | fits content area, no overflow |
| mobile | clipped | full width, clean |

The GSAP scroll/dot nav is unchanged; couldn't exercise it live in dev because the `gsap` chunk 504s on every reload (pre-existing Vite dep-optimize flake, not introduced here), but the JS is byte-identical so production nav is unaffected.