### PR TITLE
feat(embeddb): v6 lazy reader + crate release scaffold (derive publishes 0.1.0, embeddb held)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -715,6 +715,22 @@
 			"version_target": "packages/rust/bevy/bevy_tasker/Cargo.toml"
 		},
 		{
+			"key": "embeddb_crate",
+			"package_name": "embeddb",
+			"version": "0.1.0",
+			"version_toml": "packages/rust/embeddb/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx",
+			"version_target": "packages/rust/embeddb/Cargo.toml"
+		},
+		{
+			"key": "embeddb_derive_crate",
+			"package_name": "embeddb-derive",
+			"version": "0.1.0",
+			"version_toml": "packages/rust/embeddb-derive/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx",
+			"version_target": "packages/rust/embeddb-derive/Cargo.toml"
+		},
+		{
 			"key": "erust_crate",
 			"package_name": "erust",
 			"version": "0.1.7",

--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1368,7 +1368,7 @@
 	"summary": {
 		"docker": 36,
 		"npm": 4,
-		"crates": 25,
+		"crates": 27,
 		"python": 2,
 		"unreal": 27,
 		"ue5_server": 1,
@@ -1377,6 +1377,6 @@
 		"unreal_game": 4,
 		"bevy_game": 0,
 		"vite_game": 1,
-		"total": 101
+		"total": 103
 	}
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,7 @@ dependencies = [
 
 [[package]]
 name = "embeddb-derive"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx
@@ -1,0 +1,92 @@
+---
+title: EmbedDB — Single-File Turso + DuckDB Crate
+description: embeddb is a single-file embedded database pairing Turso (async write path) with DuckDB (analytics read path) over one SQLite-format file, with a parallel reader pool, streaming reads, batched writes, and a FromEmbedRow derive.
+sem: 1
+sidebar:
+    label: EmbedDB Crate
+    order: 74
+tags:
+    - crates
+    - rust
+key: embeddb_crate
+pipeline: crates
+package_name: embeddb
+version: "0.1.0"
+source_path: packages/rust/embeddb
+version_toml: packages/rust/embeddb/version.toml
+author: h0lybyte
+license: MIT
+status: active
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+jsonld:
+    faq:
+        - question: What is the embeddb crate?
+          answer: embeddb is a foundational Rust library providing a single-file embedded database. It pairs Turso (a pure-Rust async SQLite rewrite) as the write path with DuckDB as the analytics read path over one SQLite-format file, so a single file gives both transactional writes and columnar analytics.
+        - question: What does embeddb provide?
+          answer: Parameterized writes and transactions via Turso, a DuckDB reader pool for parallel analytics, streaming row callbacks, batched writes, migrations and config, a rich EmbedValue type set, QueryResult with column names, and a FromEmbedRow derive for mapping rows into structs.
+        - question: How does concurrency and freshness work?
+          answer: Turso owns all writes; DuckDB attaches the same file read-only for analytics. DuckDB replays uncheckpointed WAL frames, so analytics reflect committed writes even before a checkpoint, and concurrent reads stay consistent. The reader pool builds lazily on the first analytics call, so write-only use never loads the analytics engine.
+bento:
+    badge: crates · rust
+    title: Single-file embedded DB for
+    accent: kbve
+    lede: >-
+        Turso (async write) paired with DuckDB (analytics read) over one
+        SQLite-format file — parallel reader pool, streaming reads, batched
+        writes, and a FromEmbedRow derive.
+    ctas:
+        - label: View source
+          href: https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb
+          primary: true
+          external: true
+        - label: Features
+          href: "#features"
+    aside:
+        icon: database
+        title: One file, two engines
+        body: >-
+            Turso writes and DuckDB analytics over a single SQLite-format file.
+            The derive macro ships in
+            <a href="/project/embeddb-derive-crate/">embeddb-derive</a>.
+        points:
+            - <strong>Write</strong> — Turso async, parameterized, transactions.
+            - <strong>Read</strong> — DuckDB pool, streaming, columnar analytics.
+    stats:
+        - { label: Package, value: embeddb, icon: package }
+        - { label: Edition, value: "2021", icon: rust }
+        - { label: Version, value: "0.1.0", icon: branch }
+        - { label: License, value: MIT, icon: license }
+    features:
+        - title: Turso write path
+          icon: database
+          body: Pure-Rust async SQLite rewrite for parameterized writes, transactions, and batched inserts.
+        - title: DuckDB analytics pool
+          icon: activity
+          body: A pooled read-only DuckDB reader for parallel columnar analytics over the same file, built lazily on first use.
+        - title: Streaming + batch
+          icon: server
+          body: analytics_for_each streams rows without materializing; execute_batch runs many writes in one transaction.
+        - title: Row mapping
+          icon: package
+          body: EmbedValue type set, QueryResult with column names, and #[derive(FromEmbedRow)] for structs.
+        - title: Live-read freshness
+          icon: shield
+          body: DuckDB replays uncheckpointed WAL, so analytics reflect committed writes without a forced checkpoint.
+    related:
+        - title: EmbedDB Derive
+          href: /project/embeddb-derive-crate/
+          copy: The FromEmbedRow procedural macro companion crate.
+          icon: package
+    features_eyebrow: What it gives you
+    features_heading: Features
+    related_heading: Related crates
+---
+
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+
+<BentoDoc data={frontmatter.bento} faq={frontmatter.jsonld?.faq} />

--- a/apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx
@@ -1,0 +1,86 @@
+---
+title: EmbedDB Derive — FromEmbedRow Macro Crate
+description: embeddb-derive provides the #[derive(FromEmbedRow)] procedural macro for the embeddb single-file embedded database — maps analytics rows into structs by column name.
+sem: 1
+sidebar:
+    label: EmbedDB Derive Crate
+    order: 73
+tags:
+    - crates
+    - rust
+key: embeddb_derive_crate
+pipeline: crates
+package_name: embeddb-derive
+version: "0.1.0"
+source_path: packages/rust/embeddb-derive
+version_toml: packages/rust/embeddb-derive/version.toml
+author: h0lybyte
+license: MIT
+status: active
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+jsonld:
+    faq:
+        - question: What is the embeddb-derive crate?
+          answer: embeddb-derive is the procedural macro crate for embeddb. It provides #[derive(FromEmbedRow)], which generates a FromEmbedRow implementation that maps a DuckDB analytics row into a struct by matching each field to a column name.
+        - question: How does it relate to embeddb?
+          answer: It is a companion crate to embeddb. The embeddb crate re-exports the derive under its default-on derive feature, so consumers write #[derive(FromEmbedRow)] and use embeddb::FromEmbedRow from a single dependency.
+        - question: What field types does the derive support?
+          answer: Fields convert through the FromEmbedValue trait — i64, f64, String, bool, i128, Vec<u8>, and Option<T> (None for a null or absent column). A missing column or type mismatch on a non-Option field returns an error naming the column.
+bento:
+    badge: crates · rust
+    title: Row-to-struct derive for
+    accent: embeddb
+    lede: >-
+        The #[derive(FromEmbedRow)] procedural macro for embeddb — maps DuckDB
+        analytics rows into your structs by column name, with Option and
+        type-checked conversions.
+    ctas:
+        - label: View source
+          href: https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb-derive
+          primary: true
+          external: true
+        - label: Features
+          href: "#features"
+    aside:
+        icon: package
+        title: Companion to embeddb
+        body: >-
+            Re-exported through <a href="/project/embeddb-crate/">embeddb</a>'s
+            default derive feature, so #[derive(FromEmbedRow)] works from a single
+            dependency.
+        points:
+            - <strong>By name</strong> — fields map to columns by identifier, not position.
+            - <strong>Typed</strong> — conversions go through FromEmbedValue with clear errors.
+    stats:
+        - { label: Package, value: embeddb-derive, icon: package }
+        - { label: Edition, value: "2021", icon: rust }
+        - { label: Version, value: "0.1.0", icon: branch }
+        - { label: License, value: MIT, icon: license }
+    features:
+        - title: FromEmbedRow derive
+          icon: package
+          body: Generates a FromEmbedRow impl mapping analytics rows into structs by column name.
+        - title: Typed conversions
+          icon: shield
+          body: Fields convert through FromEmbedValue — i64, f64, String, bool, i128, Vec<u8>, Option<T>.
+        - title: Clear errors
+          icon: key
+          body: Missing column or type mismatch on a non-Option field errors, naming the column.
+    related:
+        - title: EmbedDB
+          href: /project/embeddb-crate/
+          copy: The single-file Turso + DuckDB embedded database this derive serves.
+          icon: database
+    features_eyebrow: What it gives you
+    features_heading: Features
+    related_heading: Related crates
+---
+
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+
+<BentoDoc data={frontmatter.bento} faq={frontmatter.jsonld?.faq} />

--- a/docs/superpowers/plans/2026-07-19-embeddb-v6.md
+++ b/docs/superpowers/plans/2026-07-19-embeddb-v6.md
@@ -1,0 +1,490 @@
+# embeddb v6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the DuckDB reader pool build lazily (first analytics call, not `open()`), and scaffold both crates for crates.io release (`embeddb-derive` publishes at 0.1.0; `embeddb` held at `publish=false`).
+
+**Architecture:** Two tracks, ordered commits on one branch. Track 1 is a Rust change in `packages/rust/embeddb` (wrap `ReaderPool` in a lazy holder). Track 2 is release data/docs (version.toml, MDX, dispatch-manifest entries, dependency lockstep) — no runtime code.
+
+**Tech Stack:** Rust 2021 (turso, duckdb, tokio), Astro MDX release manifest, KBVE ci-publish pipeline.
+
+## Global Constraints
+
+- **Turso (write) + DuckDB (read) only.** No third backend.
+- **No comments in any code** (drop ALL comments, inline and block).
+- `embeddb-derive` releases at **0.1.0 with `publish = true`**; `embeddb` is **held with `publish = false`** (flipped in a later follow-up once the derive is live on crates.io).
+- **version.toml seed = `0.0.1`** for both (non-zero, below the `0.1.0` MDX target — `0.0.0` reads as "not initialized → skip"). MDX `version:` = `0.1.0` = source of truth.
+- Keep ALL v1–v5 tests green.
+- `duckdb::Connection` is `Send`, not `Sync`; the pool is unchanged — only its construction is deferred. Never hold a lock across `checkout()` or `.await`.
+
+---
+
+### Task 1: Lazy reader pool
+
+**Files:**
+- Modify: `packages/rust/embeddb/src/pool.rs` (add `LazyReaderPool`)
+- Modify: `packages/rust/embeddb/src/db.rs` (field type, `open_with`, 6 analytics wrappers, add tests)
+
+**Interfaces:**
+- Consumes: existing `pool::ReaderPool::build(size, ext_dir) -> Result<Self>`, `ReaderPool::checkout()`, `EmbedConfig.reader_pool_size`, `EmbedConfig.duckdb_extension_dir`.
+- Produces: `pool::LazyReaderPool` (pub(crate)) with `new(size: usize, ext_dir: Option<PathBuf>) -> Self` and `get(&self) -> Result<Arc<ReaderPool>>`. `EmbedDb.reader` becomes `Arc<pool::LazyReaderPool>`.
+
+- [ ] **Step 1: Add `LazyReaderPool` to `pool.rs`**
+
+Append to `packages/rust/embeddb/src/pool.rs`:
+
+```rust
+pub(crate) struct LazyReaderPool {
+    size: usize,
+    ext_dir: Option<std::path::PathBuf>,
+    inner: std::sync::Mutex<Option<std::sync::Arc<ReaderPool>>>,
+}
+
+impl LazyReaderPool {
+    pub(crate) fn new(size: usize, ext_dir: Option<std::path::PathBuf>) -> Self {
+        LazyReaderPool { size, ext_dir, inner: std::sync::Mutex::new(None) }
+    }
+
+    pub(crate) fn get(&self) -> crate::Result<std::sync::Arc<ReaderPool>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pool) = guard.as_ref() {
+            return Ok(pool.clone());
+        }
+        let pool = std::sync::Arc::new(ReaderPool::build(self.size, self.ext_dir.as_deref())?);
+        *guard = Some(pool.clone());
+        Ok(pool)
+    }
+}
+```
+
+- [ ] **Step 2: Run pool unit tests to confirm nothing broke**
+
+Run: `cargo test -p embeddb pool::`
+Expected: existing `pool::tests::*` PASS (LazyReaderPool has no test yet; compiles).
+
+- [ ] **Step 3: Swap the field + `open_with` in `db.rs`**
+
+Change the struct field (line 9) from `reader: Arc<crate::pool::ReaderPool>,` to:
+
+```rust
+    reader: Arc<crate::pool::LazyReaderPool>,
+```
+
+In `open_with`, replace the eager build (the `let reader = crate::pool::ReaderPool::build(...)?;` block and the `Ok(EmbedDb { ... reader: Arc::new(reader) })` line) with:
+
+```rust
+        let reader = crate::pool::LazyReaderPool::new(
+            config.reader_pool_size,
+            config.duckdb_extension_dir.clone(),
+        );
+        Ok(EmbedDb { path, conn, config, reader: Arc::new(reader) })
+```
+
+(Delete the two now-unused lines that called `ReaderPool::build` at open.)
+
+- [ ] **Step 4: Update the 6 analytics wrappers to lazy `get()`**
+
+In each of `analytics_scalar_i64`, `analytics_scalar_f64`, `analytics_rows`,
+`analytics_query`, `analytics_scalar_string`, `analytics_for_each`: the wrapper
+currently does `let pool = self.reader.clone();` then inside `spawn_blocking`
+`let guard = pool.checkout();`. Change to clone the lazy holder and build-or-get
+inside the closure. Concretely, rename the captured binding and add the `get()`:
+
+- Outside the closure: `let reader = self.reader.clone();` (was `let pool = self.reader.clone();`)
+- First line inside the `spawn_blocking(move || { ... })` closure, before `checkout()`:
+  ```rust
+            let pool = reader.get()?;
+            let guard = pool.checkout();
+  ```
+
+Apply to all six. `analytics_one` and `analytics_query_as` delegate and need no change. Example — `analytics_scalar_i64` becomes:
+
+```rust
+    pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
+        let path = self.path.clone();
+        let sql = sql.to_string();
+        let reader = self.reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
+            let guard = pool.checkout();
+            crate::analytics::scalar_i64(&guard, &path, &sql)
+        })
+            .await
+            .map_err(|e| crate::EmbedError::Other(e.to_string()))?
+    }
+```
+
+- [ ] **Step 5: Run the full suite to confirm the happy path still works**
+
+Run: `cargo test -p embeddb`
+Expected: all v1–v5 tests PASS (every analytics test now triggers the lazy build on first call transparently).
+
+- [ ] **Step 6: Write the laziness-proof test**
+
+Append to `db.rs` `mod tests`. The forcing function is a `duckdb_extension_dir`
+that makes `ReaderPool::build` fail. **Verify during implementation that the
+chosen path actually fails the build in this environment; if it does not, pick a
+path that does** (a path that is an existing FILE, or a non-writable/nonexistent
+directory that `SET extension_directory` + `INSTALL sqlite` rejects). The test's
+contract: open + write + checkpoint succeed, first analytics errors.
+
+```rust
+    #[tokio::test]
+    async fn reader_builds_lazily_on_first_analytics() {
+        let dir = tempfile::tempdir().unwrap();
+        let bogus = dir.path().join("not-a-real-extension-dir-file");
+        std::fs::write(&bogus, b"x").unwrap();
+        let cfg = crate::EmbedConfig {
+            duckdb_extension_dir: Some(bogus),
+            ..Default::default()
+        };
+        let db = EmbedDb::open_with(dir.path().join("lazy.db"), cfg).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let res = db.analytics_scalar_i64("SELECT count(*) FROM t").await;
+        assert!(res.is_err(), "expected lazy reader build to fail on bogus extension dir");
+    }
+```
+
+- [ ] **Step 7: Write the reuse test**
+
+Append to `db.rs` `mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn lazy_reader_reused_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("reuse.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+    }
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test -p embeddb`
+Expected: PASS, including the two new tests. If `reader_builds_lazily_on_first_analytics`
+does NOT error (the bogus dir was tolerated), the forcing function is wrong — fix
+it to a path/condition that deterministically fails `ReaderPool::build`, do not
+weaken the assertion.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/rust/embeddb/src/pool.rs packages/rust/embeddb/src/db.rs
+git commit -m "feat(embeddb): build DuckDB reader lazily on first analytics call (v6)"
+```
+
+---
+
+### Task 2: Crate release scaffold (both crates)
+
+**Files:**
+- Create: `packages/rust/embeddb-derive/version.toml`
+- Create: `packages/rust/embeddb/version.toml`
+- Create: `apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx`
+- Create: `apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx`
+- Modify: `packages/rust/embeddb/Cargo.toml` (bump the `embeddb-derive` dep to `0.1.0`)
+- Modify: `.github/ci-dispatch-manifest.json` (add two `crates` entries)
+- Modify: `packages/rust/embeddb/README.md` (append a Publishing note)
+
+**Interfaces:** none (data/docs only). No Rust API change.
+
+- [ ] **Step 1: `embeddb-derive/version.toml` (publish now)**
+
+Create `packages/rust/embeddb-derive/version.toml`:
+
+```toml
+version = "0.0.1"
+publish = true
+```
+
+- [ ] **Step 2: `embeddb/version.toml` (held)**
+
+Create `packages/rust/embeddb/version.toml`:
+
+```toml
+version = "0.0.1"
+publish = false
+```
+
+- [ ] **Step 3: Bump the dependency in `embeddb/Cargo.toml`**
+
+In `packages/rust/embeddb/Cargo.toml`, change the `embeddb-derive` line from
+`version = "0.0.1"` to `0.1.0` (keep path + optional):
+
+```toml
+embeddb-derive = { version = "0.1.0", path = "../embeddb-derive", optional = true }
+```
+
+Leave `embeddb`'s own `[package] version = "0.0.1"` unchanged (the publish sync
+patches it from the MDX at publish time; it is held anyway).
+
+- [ ] **Step 4: `embeddb-derive-crate.mdx`**
+
+Create `apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx`
+mirroring the `jedi-crate.mdx` frontmatter shape. Content:
+
+```mdx
+---
+title: EmbedDB Derive — FromEmbedRow Macro Crate
+description: embeddb-derive provides the #[derive(FromEmbedRow)] procedural macro for the embeddb single-file embedded database — maps analytics rows into structs by column name.
+sem: 1
+sidebar:
+    label: EmbedDB Derive Crate
+    order: 73
+tags:
+    - crates
+    - rust
+key: embeddb_derive_crate
+pipeline: crates
+package_name: embeddb-derive
+version: "0.1.0"
+source_path: packages/rust/embeddb-derive
+version_toml: packages/rust/embeddb-derive/version.toml
+author: h0lybyte
+license: MIT
+status: active
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+jsonld:
+    faq:
+        - question: What is the embeddb-derive crate?
+          answer: embeddb-derive is the procedural macro crate for embeddb. It provides #[derive(FromEmbedRow)], which generates a FromEmbedRow implementation that maps a DuckDB analytics row into a struct by matching each field to a column name.
+        - question: How does it relate to embeddb?
+          answer: It is a companion crate to embeddb. The embeddb crate re-exports the derive under its default-on derive feature, so consumers write #[derive(FromEmbedRow)] and use embeddb::FromEmbedRow from a single dependency.
+        - question: What field types does the derive support?
+          answer: Fields convert through the FromEmbedValue trait — i64, f64, String, bool, i128, Vec<u8>, and Option<T> (None for a null or absent column). A missing column or type mismatch on a non-Option field returns an error naming the column.
+bento:
+    badge: crates · rust
+    title: Row-to-struct derive for
+    accent: embeddb
+    lede: >-
+        The #[derive(FromEmbedRow)] procedural macro for embeddb — maps DuckDB
+        analytics rows into your structs by column name, with Option and
+        type-checked conversions.
+    ctas:
+        - label: View source
+          href: https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb-derive
+          primary: true
+          external: true
+        - label: Features
+          href: "#features"
+    aside:
+        icon: package
+        title: Companion to embeddb
+        body: >-
+            Re-exported through <a href="/project/embeddb-crate/">embeddb</a>'s
+            default derive feature, so #[derive(FromEmbedRow)] works from a single
+            dependency.
+        points:
+            - <strong>By name</strong> — fields map to columns by identifier, not position.
+            - <strong>Typed</strong> — conversions go through FromEmbedValue with clear errors.
+    stats:
+        - { label: Package, value: embeddb-derive, icon: package }
+        - { label: Edition, value: "2021", icon: rust }
+        - { label: Version, value: "0.1.0", icon: branch }
+        - { label: License, value: MIT, icon: license }
+    features:
+        - title: FromEmbedRow derive
+          icon: package
+          body: Generates a FromEmbedRow impl mapping analytics rows into structs by column name.
+        - title: Typed conversions
+          icon: shield
+          body: Fields convert through FromEmbedValue — i64, f64, String, bool, i128, Vec<u8>, Option<T>.
+        - title: Clear errors
+          icon: key
+          body: Missing column or type mismatch on a non-Option field errors, naming the column.
+    related:
+        - title: EmbedDB
+          href: /project/embeddb-crate/
+          copy: The single-file Turso + DuckDB embedded database this derive serves.
+          icon: database
+    features_eyebrow: What it gives you
+    features_heading: Features
+    related_heading: Related crates
+---
+
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+
+<BentoDoc data={frontmatter.bento} faq={frontmatter.jsonld?.faq} />
+```
+
+- [ ] **Step 5: `embeddb-crate.mdx`**
+
+Create `apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx`:
+
+```mdx
+---
+title: EmbedDB — Single-File Turso + DuckDB Crate
+description: embeddb is a single-file embedded database pairing Turso (async write path) with DuckDB (analytics read path) over one SQLite-format file, with a parallel reader pool, streaming reads, batched writes, and a FromEmbedRow derive.
+sem: 1
+sidebar:
+    label: EmbedDB Crate
+    order: 74
+tags:
+    - crates
+    - rust
+key: embeddb_crate
+pipeline: crates
+package_name: embeddb
+version: "0.1.0"
+source_path: packages/rust/embeddb
+version_toml: packages/rust/embeddb/version.toml
+author: h0lybyte
+license: MIT
+status: active
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+jsonld:
+    faq:
+        - question: What is the embeddb crate?
+          answer: embeddb is a foundational Rust library providing a single-file embedded database. It pairs Turso (a pure-Rust async SQLite rewrite) as the write path with DuckDB as the analytics read path over one SQLite-format file, so a single file gives both transactional writes and columnar analytics.
+        - question: What does embeddb provide?
+          answer: Parameterized writes and transactions via Turso, a DuckDB reader pool for parallel analytics, streaming row callbacks, batched writes, migrations and config, a rich EmbedValue type set, QueryResult with column names, and a FromEmbedRow derive for mapping rows into structs.
+        - question: How does concurrency and freshness work?
+          answer: Turso owns all writes; DuckDB attaches the same file read-only for analytics. DuckDB replays uncheckpointed WAL frames, so analytics reflect committed writes even before a checkpoint, and concurrent reads stay consistent. The reader pool builds lazily on the first analytics call, so write-only use never loads the analytics engine.
+bento:
+    badge: crates · rust
+    title: Single-file embedded DB for
+    accent: kbve
+    lede: >-
+        Turso (async write) paired with DuckDB (analytics read) over one
+        SQLite-format file — parallel reader pool, streaming reads, batched
+        writes, and a FromEmbedRow derive.
+    ctas:
+        - label: View source
+          href: https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb
+          primary: true
+          external: true
+        - label: Features
+          href: "#features"
+    aside:
+        icon: database
+        title: One file, two engines
+        body: >-
+            Turso writes and DuckDB analytics over a single SQLite-format file.
+            The derive macro ships in
+            <a href="/project/embeddb-derive-crate/">embeddb-derive</a>.
+        points:
+            - <strong>Write</strong> — Turso async, parameterized, transactions.
+            - <strong>Read</strong> — DuckDB pool, streaming, columnar analytics.
+    stats:
+        - { label: Package, value: embeddb, icon: package }
+        - { label: Edition, value: "2021", icon: rust }
+        - { label: Version, value: "0.1.0", icon: branch }
+        - { label: License, value: MIT, icon: license }
+    features:
+        - title: Turso write path
+          icon: database
+          body: Pure-Rust async SQLite rewrite for parameterized writes, transactions, and batched inserts.
+        - title: DuckDB analytics pool
+          icon: activity
+          body: A pooled read-only DuckDB reader for parallel columnar analytics over the same file, built lazily on first use.
+        - title: Streaming + batch
+          icon: server
+          body: analytics_for_each streams rows without materializing; execute_batch runs many writes in one transaction.
+        - title: Row mapping
+          icon: package
+          body: EmbedValue type set, QueryResult with column names, and #[derive(FromEmbedRow)] for structs.
+        - title: Live-read freshness
+          icon: shield
+          body: DuckDB replays uncheckpointed WAL, so analytics reflect committed writes without a forced checkpoint.
+    related:
+        - title: EmbedDB Derive
+          href: /project/embeddb-derive-crate/
+          copy: The FromEmbedRow procedural macro companion crate.
+          icon: package
+    features_eyebrow: What it gives you
+    features_heading: Features
+    related_heading: Related crates
+---
+
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+
+<BentoDoc data={frontmatter.bento} faq={frontmatter.jsonld?.faq} />
+```
+
+- [ ] **Step 6: Add two dispatch-manifest entries**
+
+In `.github/ci-dispatch-manifest.json`, add these two objects to the `crates`
+array. The array is sorted alphabetically by `key`; place both immediately
+before the `erust_crate` entry (order: `embeddb_crate`, then
+`embeddb_derive_crate`):
+
+```json
+{
+ "key": "embeddb_crate",
+ "package_name": "embeddb",
+ "version": "0.1.0",
+ "version_toml": "packages/rust/embeddb/version.toml",
+ "version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx",
+ "version_target": "packages/rust/embeddb/Cargo.toml"
+},
+{
+ "key": "embeddb_derive_crate",
+ "package_name": "embeddb-derive",
+ "version": "0.1.0",
+ "version_toml": "packages/rust/embeddb-derive/version.toml",
+ "version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx",
+ "version_target": "packages/rust/embeddb-derive/Cargo.toml"
+}
+```
+
+Match the existing entries' exact key names and field set. Confirm the file is
+still valid JSON after the edit (`python3 -m json.tool .github/ci-dispatch-manifest.json > /dev/null`).
+Note in the task report: the CI `ci-manifest-guard` regenerates the manifest from
+the MDX and will reject any drift; if the guard fails on the PR, the manifest must
+be regenerated via `npx nx run astro-kbve:gen:ci-manifest` on a node_modules-enabled
+checkout.
+
+- [ ] **Step 7: Append a Publishing note to the README**
+
+Add a short `## Publishing` section to `packages/rust/embeddb/README.md`
+documenting: MDX `version:` is the source of truth; `version.toml` carries the
+last-published marker (seed `0.0.1`) + a `publish` flag; `embeddb-derive`
+publishes first, `embeddb` is held (`publish = false`) until the derive is live on
+crates.io, then flipped. Keep all prior sections intact.
+
+- [ ] **Step 8: Validate**
+
+Run:
+- `python3 -m json.tool .github/ci-dispatch-manifest.json > /dev/null` (valid JSON)
+- `cargo build -p embeddb` (the `0.1.0` dep still resolves via the local path)
+- `cargo test -p embeddb-derive` (compiles clean)
+
+Expected: all succeed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/rust/embeddb-derive/version.toml packages/rust/embeddb/version.toml \
+  packages/rust/embeddb/Cargo.toml \
+  apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx \
+  apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx \
+  .github/ci-dispatch-manifest.json packages/rust/embeddb/README.md
+git commit -m "chore(embeddb): crate release scaffold — derive publishes 0.1.0, embeddb held (v6)"
+```
+
+---
+
+## Final verification
+
+- `cargo test -p embeddb && cargo test -p embeddb-derive` — all green.
+- `cargo build -p embeddb --no-default-features` — clean (lazy reader + held-dep both build without the derive feature).
+- `.github/ci-dispatch-manifest.json` valid JSON with both entries.
+- `version.toml`: `embeddb-derive` = `publish = true`; `embeddb` = `publish = false`; both `version = "0.0.1"`.
+- MDX `version:` = `0.1.0` for both; manifest `version` = `0.1.0` for both.
+- Note: `nx`/manifest-guard cannot run in the node_modules-less worktree — the CI guard validates the manifest on the PR.

--- a/docs/superpowers/specs/2026-07-19-embeddb-v6-design.md
+++ b/docs/superpowers/specs/2026-07-19-embeddb-v6-design.md
@@ -1,0 +1,203 @@
+# embeddb v6 — Lazy Reader + Crate Release Scaffold Design Spec
+
+Date: 2026-07-19
+Status: Approved, pre-implementation
+Builds on: `packages/rust/embeddb` + `packages/rust/embeddb-derive` (v1 #14292 … v5 #14345 merged)
+
+## Purpose
+
+Two tracks on one branch. Stays **Turso (write) + DuckDB (read) only**.
+
+1. **Lazy reader** — build the DuckDB reader pool on first analytics call instead
+   of at `open()`. A Turso-only consumer never runs `INSTALL sqlite` / touches
+   the sqlite_scanner extension, so the egress dependency only matters for code
+   that actually runs analytics. Resolves the "distroless-clean for the write
+   path" concern for the primary use.
+2. **Crate release scaffold** — prepare both crates for crates.io. `embeddb-derive`
+   publishes now (0.1.0); `embeddb` is scaffolded but held (`publish = false`)
+   until its dependency is live, then flipped in a follow-up.
+
+## Track 1 — Lazy reader
+
+### Current (v5)
+`EmbedDb { path, conn, config, reader: Arc<crate::pool::ReaderPool> }`.
+`open_with` eagerly calls `ReaderPool::build(size, ext_dir)` — which builds
+`size` DuckDB connections, each running `INSTALL sqlite; LOAD sqlite;`
+(`prepare_sqlite_scanner`). So **every `open()` pays the extension load / egress
+hit**, even a consumer that only writes via Turso and never reads analytics.
+
+### Change
+Wrap the pool in a lazy holder built in `pool.rs`:
+
+```rust
+pub(crate) struct LazyReaderPool {
+    size: usize,
+    ext_dir: Option<std::path::PathBuf>,
+    inner: std::sync::Mutex<Option<std::sync::Arc<ReaderPool>>>,
+}
+
+impl LazyReaderPool {
+    pub(crate) fn new(size: usize, ext_dir: Option<std::path::PathBuf>) -> Self {
+        LazyReaderPool { size, ext_dir, inner: std::sync::Mutex::new(None) }
+    }
+
+    pub(crate) fn get(&self) -> crate::Result<std::sync::Arc<ReaderPool>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pool) = guard.as_ref() {
+            return Ok(pool.clone());
+        }
+        let pool = std::sync::Arc::new(ReaderPool::build(self.size, self.ext_dir.as_deref())?);
+        *guard = Some(pool.clone());
+        Ok(pool)
+    }
+}
+```
+
+- `EmbedDb.reader` becomes `Arc<crate::pool::LazyReaderPool>`.
+- `open_with` constructs `Arc::new(LazyReaderPool::new(config.reader_pool_size,
+  config.duckdb_extension_dir.clone()))` — **no `ReaderPool::build` at open**.
+- Each of the six analytics wrappers (`analytics_scalar_i64/f64/string`,
+  `analytics_rows`→delegates, `analytics_query`, `analytics_for_each`), inside
+  `spawn_blocking`: `let pool = lazy.get()?;` then `let guard = pool.checkout();`
+  then the existing free-fn call. `get()` runs in the blocking context (the
+  `INSTALL sqlite` network call is sync — correct to run off the async runtime).
+- Failure of `get()` is **not cached** (only a successful build is stored under
+  the mutex), so a consumer that stages the extension after a failed first
+  analytics call can retry successfully.
+- `ReaderPool` and its `build`/`checkout`/`ReaderGuard` are unchanged. The
+  freshness `attach_fresh` per read is unchanged. Concurrency guarantees from v5
+  hold (the pool itself is identical; only its construction is deferred).
+
+### Concurrency note
+`LazyReaderPool::get` holds `inner` only for the check-or-build. Two concurrent
+first-callers serialize on the mutex: the first builds and stores, the second
+sees `Some` and clones. Build-under-lock means the second waits out the first
+build — acceptable (both need the pool before proceeding). No lock is held
+across `checkout()` or the query.
+
+### Tests (Track 1)
+- **Laziness proof (deterministic):** open a DB with a config whose
+  `duckdb_extension_dir` points at a path that makes `ReaderPool::build` FAIL,
+  then `open`, `execute`, `checkpoint` must all SUCCEED (no reader built), and a
+  subsequent `analytics_scalar_i64` must ERROR (reader built lazily, hits the bad
+  dir). The implementer must confirm the chosen forcing function actually fails
+  the build in this environment (e.g. a `duckdb_extension_dir` set to a path that
+  is a file, or a non-writable/nonexistent path that `SET extension_directory` +
+  `INSTALL sqlite` rejects); if the first choice does not fail deterministically,
+  pick one that does — the test's contract is "open succeeds, analytics fails,
+  proving the build was deferred to the analytics call."
+- **Happy path unchanged:** an existing-style test (open → write → checkpoint →
+  `analytics_scalar_i64`) still returns the correct value (lazy build succeeds on
+  first analytics call, pool then reused).
+- **Reuse across calls:** two sequential analytics calls on one `EmbedDb` both
+  succeed and return correct values (second reuses the cached pool).
+- All v1–v5 tests stay green (they call analytics, which now triggers the lazy
+  build transparently).
+
+## Track 2 — Crate release scaffold
+
+KBVE crate release mechanics (verified against `.github/workflows/ci-publish.yml`
++ `rust-publish-crate.yml` + `ci-dispatch-manifest.json`):
+- **Publish fires only when** `version.toml` `publish != false` AND the MDX/manifest
+  version (LOCAL) > `version.toml` version (PUBLISHED), both non-`0.0.0`.
+- MDX `version:` is the source of truth (patched into Cargo.toml at publish);
+  `version.toml` `version` is the "last published" marker; `0.0.0` = "not
+  initialized → skip". So a **first publish seeds `version.toml` at `0.0.1`**
+  (non-zero, below the `0.1.0` target).
+- The dispatch manifest (`.github/ci-dispatch-manifest.json`) is regenerated from
+  the project MDX by `npx nx run astro-kbve:gen:ci-manifest`; a CI guard
+  (`ci-manifest-guard.yml`) verifies it matches. The worktree has no node_modules,
+  so the manifest entries are hand-written to match the generator's shape; the CI
+  guard validates on the PR.
+
+### 2a. `embeddb-derive` — publishes now (0.1.0)
+- `packages/rust/embeddb-derive/version.toml`:
+  ```toml
+  version = "0.0.1"
+  publish = true
+  ```
+- `apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx` —
+  mirror the `jedi-crate.mdx` frontmatter shape with:
+  `pipeline: crates`, `package_name: embeddb-derive`, `version: "0.1.0"`,
+  `source_path: packages/rust/embeddb-derive`,
+  `version_toml: packages/rust/embeddb-derive/version.toml`, plus the sidebar,
+  tags, jsonld FAQ, and `bento` block (splash) describing the derive macro. A
+  `BentoDoc` body import as jedi does.
+- `packages/rust/embeddb-derive/Cargo.toml` `version` stays `0.0.1` (the sync
+  step patches it to the MDX `0.1.0` at publish time).
+
+### 2b. `embeddb` — scaffolded, held (`publish = false`)
+- `packages/rust/embeddb/version.toml`:
+  ```toml
+  version = "0.0.1"
+  publish = false
+  ```
+  (`publish = false` gates it off at `ci-publish.yml:180` regardless of version —
+  held until the derive is live on crates.io and this is flipped in a follow-up.)
+- `apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx` — same
+  frontmatter shape: `pipeline: crates`, `package_name: embeddb`,
+  `version: "0.1.0"`, `source_path: packages/rust/embeddb`,
+  `version_toml: packages/rust/embeddb/version.toml`, bento block describing the
+  Turso+DuckDB single-file DB (pool, streaming, derive, live-read).
+- **Dependency lockstep:** `packages/rust/embeddb/Cargo.toml` — change the
+  `embeddb-derive` dependency from `version = "0.0.1"` to `version = "0.1.0"`
+  (keep `path = "../embeddb-derive"`, `optional = true`). When `embeddb` is later
+  unheld, cargo resolves the published `embeddb-derive 0.1.0`. (Path + version
+  coexist; local builds use the path, crates.io publish uses the version.)
+
+### 2c. Dispatch manifest entries
+Hand-add two entries to the `crates` array of `.github/ci-dispatch-manifest.json`,
+matching the existing entry shape (e.g. `jedi_crate`), placed in the array's sort
+order (`embeddb_crate`, then `embeddb_derive_crate`, both before `erust_crate`):
+
+```json
+{
+ "key": "embeddb_crate",
+ "package_name": "embeddb",
+ "version": "0.1.0",
+ "version_toml": "packages/rust/embeddb/version.toml",
+ "version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx",
+ "version_target": "packages/rust/embeddb/Cargo.toml"
+}
+```
+```json
+{
+ "key": "embeddb_derive_crate",
+ "package_name": "embeddb-derive",
+ "version": "0.1.0",
+ "version_toml": "packages/rust/embeddb-derive/version.toml",
+ "version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx",
+ "version_target": "packages/rust/embeddb-derive/Cargo.toml"
+}
+```
+The exact key ordering / placement must match what `gen:ci-manifest` produces so
+the guard passes — reconcile against the generator's sort at implementation time
+(the existing array is alphabetical by `key`). If the CI guard rejects the
+hand-written manifest, regenerate via the nx target on a node_modules-enabled
+checkout and use that output.
+
+### Release sequence (documented, not automated here)
+On merge to dev → main, the pipeline publishes `embeddb-derive 0.1.0` (its
+`publish = true`, LOCAL 0.1.0 > version.toml 0.0.1). `embeddb` is skipped
+(`publish = false`). After `embeddb-derive 0.1.0` is live and indexed on
+crates.io, a **follow-up PR** flips `embeddb/version.toml` to `publish = true`
+(leaving version.toml `version` at `0.0.1` so 0.1.0 > 0.0.1 triggers), and the
+next run publishes `embeddb 0.1.0`.
+
+## Non-goals / deferred (unchanged)
+WASM, write-path prepared-statement cache, live Valkey/Redis-protocol
+integration (revisit later per user), backend-swap trait (rejected). The reader
+pool, streaming, derive, and live-read all shipped in v1–v5.
+
+## Testing summary
+- Track 1: laziness proof + happy-path + reuse, all v1–v5 green.
+- Track 2: `version.toml`/MDX are data — validated by `cargo build -p embeddb`
+  (dep version resolves via path locally) + JSON validity of the manifest + the
+  CI manifest-guard on the PR. No new Rust tests for Track 2.
+- Gates: `cargo test -p embeddb`, `cargo test -p embeddb-derive`,
+  `cargo build -p embeddb` (confirms the `0.1.0` dep still resolves via path).
+
+## README
+Append a short "Publishing" note to `packages/rust/embeddb/README.md`: MDX =
+version source of truth, `version.toml` seed `0.0.1` + `publish` flag, derive
+publishes first, embeddb held until the derive is live.

--- a/packages/rust/embeddb-derive/Cargo.toml
+++ b/packages/rust/embeddb-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embeddb-derive"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 description = "derive macro for embeddb FromEmbedRow"
 license = "MIT"

--- a/packages/rust/embeddb-derive/version.toml
+++ b/packages/rust/embeddb-derive/version.toml
@@ -1,0 +1,2 @@
+version = "0.0.1"
+publish = true

--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -10,7 +10,7 @@ turso = "0.7"
 duckdb = { version = "1", features = ["bundled"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 thiserror = "1"
-embeddb-derive = { version = "0.0.1", path = "../embeddb-derive", optional = true }
+embeddb-derive = { version = "0.1.0", path = "../embeddb-derive", optional = true }
 
 [features]
 default = ["derive"]

--- a/packages/rust/embeddb/README.md
+++ b/packages/rust/embeddb/README.md
@@ -310,3 +310,11 @@ Run it (slow — not part of the normal test loop) with:
 ```bash
 cargo bench -p embeddb
 ```
+
+## Publishing
+
+The MDX file at `apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx` (and, for the companion crate, `embeddb-derive-crate.mdx`) is the source of truth for the published version — its `version:` frontmatter field drives what the publish pipeline writes into `Cargo.toml` at release time.
+
+`version.toml` in each crate root carries the last-published marker (seeded at `0.0.1` for both crates) plus a `publish` flag the pipeline reads to decide whether to publish at all.
+
+`embeddb-derive` publishes first (`publish = true`, target `0.1.0`). `embeddb` itself is held (`publish = false`) until `embeddb-derive` is live on crates.io and its path dependency can be replaced with a registry dependency; once that's true, `embeddb`'s `version.toml` is flipped to `publish = true` and it publishes on the next pass.

--- a/packages/rust/embeddb/src/db.rs
+++ b/packages/rust/embeddb/src/db.rs
@@ -6,7 +6,7 @@ pub struct EmbedDb {
     path: PathBuf,
     conn: turso::Connection,
     config: crate::EmbedConfig,
-    reader: Arc<crate::pool::ReaderPool>,
+    reader: Arc<crate::pool::LazyReaderPool>,
 }
 
 impl std::fmt::Debug for EmbedDb {
@@ -35,10 +35,10 @@ impl EmbedDb {
         let conn = db.connect()?;
         let pragma = format!("PRAGMA journal_mode={}", config.journal_mode);
         conn.execute(&pragma, ()).await.ok();
-        let reader = crate::pool::ReaderPool::build(
+        let reader = crate::pool::LazyReaderPool::new(
             config.reader_pool_size,
-            config.duckdb_extension_dir.as_deref(),
-        )?;
+            config.duckdb_extension_dir.clone(),
+        );
         Ok(EmbedDb { path, conn, config, reader: Arc::new(reader) })
     }
 
@@ -76,8 +76,9 @@ impl EmbedDb {
     pub async fn analytics_scalar_i64(&self, sql: &str) -> Result<i64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::scalar_i64(&guard, &path, &sql)
         })
@@ -88,8 +89,9 @@ impl EmbedDb {
     pub async fn analytics_scalar_f64(&self, sql: &str) -> Result<f64> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::scalar_f64(&guard, &path, &sql)
         })
@@ -100,8 +102,9 @@ impl EmbedDb {
     pub async fn analytics_rows(&self, sql: &str) -> Result<Vec<crate::EmbedRow>> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::rows(&guard, &path, &sql)
         })
@@ -112,8 +115,9 @@ impl EmbedDb {
     pub async fn analytics_query(&self, sql: &str) -> Result<crate::QueryResult> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::query(&guard, &path, &sql)
         })
@@ -128,8 +132,9 @@ impl EmbedDb {
     pub async fn analytics_scalar_string(&self, sql: &str) -> Result<String> {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::scalar_string(&guard, &path, &sql)
         })
@@ -152,8 +157,9 @@ impl EmbedDb {
     {
         let path = self.path.clone();
         let sql = sql.to_string();
-        let pool = self.reader.clone();
+        let reader = self.reader.clone();
         tokio::task::spawn_blocking(move || {
+            let pool = reader.get()?;
             let guard = pool.checkout();
             crate::analytics::for_each(&guard, &path, &sql, &mut f)
         })
@@ -899,5 +905,33 @@ mod tests {
         let res: Result<Vec<Rec>> = db.analytics_query_as("SELECT id FROM t").await;
         assert!(res.is_err());
         assert!(format!("{}", res.unwrap_err()).contains("missing"));
+    }
+
+    #[tokio::test]
+    async fn reader_builds_lazily_on_first_analytics() {
+        let dir = tempfile::tempdir().unwrap();
+        let bogus = dir.path().join("not-a-real-extension-dir-file");
+        std::fs::write(&bogus, b"x").unwrap();
+        let cfg = crate::EmbedConfig {
+            duckdb_extension_dir: Some(bogus),
+            ..Default::default()
+        };
+        let db = EmbedDb::open_with(dir.path().join("lazy.db"), cfg).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        let res = db.analytics_scalar_i64("SELECT count(*) FROM t").await;
+        assert!(res.is_err(), "expected lazy reader build to fail on bogus extension dir");
+    }
+
+    #[tokio::test]
+    async fn lazy_reader_reused_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join("reuse.db")).await.unwrap();
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1), (2)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+        assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
     }
 }

--- a/packages/rust/embeddb/src/pool.rs
+++ b/packages/rust/embeddb/src/pool.rs
@@ -58,6 +58,28 @@ impl Drop for ReaderGuard<'_> {
     }
 }
 
+pub(crate) struct LazyReaderPool {
+    size: usize,
+    ext_dir: Option<std::path::PathBuf>,
+    inner: std::sync::Mutex<Option<std::sync::Arc<ReaderPool>>>,
+}
+
+impl LazyReaderPool {
+    pub(crate) fn new(size: usize, ext_dir: Option<std::path::PathBuf>) -> Self {
+        LazyReaderPool { size, ext_dir, inner: std::sync::Mutex::new(None) }
+    }
+
+    pub(crate) fn get(&self) -> crate::Result<std::sync::Arc<ReaderPool>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pool) = guard.as_ref() {
+            return Ok(pool.clone());
+        }
+        let pool = std::sync::Arc::new(ReaderPool::build(self.size, self.ext_dir.as_deref())?);
+        *guard = Some(pool.clone());
+        Ok(pool)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust/embeddb/version.toml
+++ b/packages/rust/embeddb/version.toml
@@ -1,0 +1,2 @@
+version = "0.0.1"
+publish = false


### PR DESCRIPTION
## embeddb v6 — lazy reader + crate release scaffold

Two tracks, one branch. Builds on v1–v5 (#14292…#14345, all merged).

### Track 1 — Lazy DuckDB reader
The reader pool now builds **on the first analytics call**, not at `open()`. A Turso-only consumer never runs `INSTALL sqlite` / touches the sqlite_scanner extension — so the DuckDB extension/egress dependency only matters for code that actually runs analytics. `pool.rs` gains `LazyReaderPool` (build params + `Mutex<Option<Arc<ReaderPool>>>`, failure not cached so a retry works after the extension is staged); the 6 analytics wrappers call `reader.get()?` inside `spawn_blocking` before `checkout()`. `ReaderPool` itself is unchanged — v5 concurrency guarantees hold. +2 tests (laziness proof via a bogus extension dir; reuse). 62 tests green.

### Track 2 — Crate release scaffold
Prepares both crates for crates.io via the MDX-driven publish pipeline:
- **`embeddb-derive` publishes 0.1.0** — `version.toml` `publish=true`, MDX/manifest `0.1.0`.
- **`embeddb` HELD** — `version.toml` `publish=false` (flipped to publish in a follow-up once the derive is live on crates.io, since cargo can't publish `embeddb` until its `embeddb-derive` dep is indexed).
- `embeddb-crate.mdx` + `embeddb-derive-crate.mdx` (MDX `version:` = source of truth), two `ci-dispatch-manifest.json` entries + summary counts, `embeddb`'s `embeddb-derive` dep bumped to `0.1.0`.

Both crate names verified free on crates.io.

### Verification
62 tests (embeddb) + embeddb-derive compiles; `cargo build -p embeddb` and `--no-default-features` clean; manifest valid JSON with consistent summary. Reviewed subagent-driven per task + a final whole-branch review confirming the release config produces exactly **derive-publishes-0.1.0 / embeddb-held** (the one finding — stale manifest summary counts that would fail ci-manifest-guard — is fixed). Spec + plan under `docs/superpowers/`.

**Publishes `embeddb-derive` 0.1.0 to crates.io on merge to main.** `embeddb` stays unpublished until a follow-up flips its `publish` flag.
