### PR TITLE
feat: /market/ customer marketplace on @kbve/rn/markets (Phase 2)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
@@ -1,7 +1,27 @@
 ---
-import MarketListingDetail from './MarketListingDetail';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactMarketDetailRN from './ReactMarketDetailRN';
 ---
 
-<section class="kbve-market not-content kbve-dashboard-page">
-	<MarketListingDetail client:only="react" />
-</section>
+<div class="market-hub">
+	<BentoShell eyebrow="Marketplace" heading="Listing">
+		<div class="market-island">
+			<ReactMarketDetailRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={2} rows={3} />
+			</ReactMarketDetailRN>
+		</div>
+	</BentoShell>
+</div>
+
+<style>
+	.market-island { min-height: 60vh; }
+</style>
+
+<style is:global>
+	.market-hub {
+		--bento-accent: #a78bfa;
+		--bento-accent-2: #22d3ee;
+		--bento-btn-fg: #1a1033;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -1,50 +1,87 @@
 ---
-import MarketBrowse from './MarketBrowse';
-import MarketCreateForm from './MarketCreateForm';
-import './market.css';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactMarketRN from './ReactMarketRN';
+
+const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q=80&w=2400&auto=format&fit=crop';
 ---
 
-<section class="kbve-market not-content kbve-dashboard-page">
-	<header class="kbve-market__header">
-		<div>
-			<h1>Marketplace</h1>
-			<p>
-				Player-driven listings settled in KHash. A 1% KBVE Treasury fee
-				applies on every sale. Auction bids hold your KHash in escrow
-				until you're outbid or the listing settles.
-			</p>
+<div class="market-hub" style={`--bento-hero-bg: url('${backdrop}')`}>
+	<section class="bento-hero bento-section not-content" aria-label="KBVE Marketplace">
+		<div class="bento-hero__bg" aria-hidden="true"></div>
+		<div class="bento-hero__frame bento-frame">
+			<div class="bento-board bento-board--hero">
+				<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+					<span class="bento-badge bento-chip"><span>marketplace</span></span>
+					<h1 class="bento-title">Trade with KHash,
+						<span class="bento-title__accent">settle with escrow.</span></h1>
+					<p class="bento-lede">
+						Player-driven listings settled in KHash. A 1% KBVE Treasury fee
+						applies on every sale. Auction bids hold your KHash in escrow
+						until you're outbid or the listing settles.
+					</p>
+					<div class="bento-cta">
+						<a class="bento-btn bento-btn--primary" href="#market">Browse the market
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+						</a>
+						<a class="bento-btn bento-btn--ghost" href="/store/">Store</a>
+						<button
+							type="button"
+							class="kbve-search-trigger"
+							data-kbve-search-trigger
+							aria-label="Open universal search">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-hidden="true">
+								<circle cx="11" cy="11" r="7"></circle>
+								<path d="m20 20-3-3"></path>
+							</svg>
+							<span class="kbve-search-trigger__label">Search…</span>
+							<span class="kbve-search-trigger__keycap" data-kbve-search-keycap>
+								Ctrl+K
+							</span>
+						</button>
+					</div>
+				</div>
+				{[
+					{ v: 'Settled in KHash', l: 'Every sale clears in KHash' },
+					{ v: '1% Treasury fee', l: 'Flat fee on every sale' },
+					{ v: 'Escrow bids', l: 'Bids hold KHash until settled' },
+				].map((s) => (
+					<div class="bento-cell bento-stat bento-card bento-card--glass">
+						<span class="bento-stat__value">{s.v}</span>
+						<span class="bento-stat__label">{s.l}</span>
+					</div>
+				))}
+			</div>
 		</div>
-		<button
-			type="button"
-			class="kbve-search-trigger"
-			data-kbve-search-trigger
-			aria-label="Open universal search">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="16"
-				height="16"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				aria-hidden="true">
-				<circle cx="11" cy="11" r="7"></circle>
-				<path d="m20 20-3-3"></path>
-			</svg>
-			<span class="kbve-search-trigger__label">Search…</span>
-			<span class="kbve-search-trigger__keycap" data-kbve-search-keycap>
-				Ctrl+K
-			</span>
-		</button>
-	</header>
+	</section>
 
-	<details class="kbve-market__create">
-		<summary>Create a listing</summary>
-		<MarketCreateForm client:only="react" />
-	</details>
+	<BentoShell id="market" eyebrow="Browse" heading="Marketplace">
+		<div class="market-island">
+			<ReactMarketRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={3} rows={4} />
+			</ReactMarketRN>
+		</div>
+	</BentoShell>
+</div>
 
-	<h2 class="kbve-market__section">Active Listings</h2>
-	<MarketBrowse client:only="react" />
-</section>
+<style>
+	.market-island { min-height: 60vh; }
+</style>
+
+<style is:global>
+	.market-hub {
+		--bento-accent: #a78bfa;
+		--bento-accent-2: #22d3ee;
+		--bento-btn-fg: #1a1033;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/market/ReactMarketDetailRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/ReactMarketDetailRN.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useSession } from '@kbve/astro';
+import { ListingDetailView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function readId(): number | null {
+	if (typeof window === 'undefined') return null;
+	const raw = new URLSearchParams(window.location.search).get('id');
+	const n = Number(raw);
+	return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export default function ReactMarketDetailRN() {
+	const { ready, authenticated } = useSession();
+	const token = useMemo(() => getToken, []);
+	const id = useMemo(() => readId(), []);
+
+	if (!ready) return null;
+	if (id === null) return <div>Missing or invalid ?id= parameter.</div>;
+
+	return (
+		<ListingDetailView
+			id={id}
+			getToken={token}
+			baseUrl=""
+			authenticated={authenticated}
+		/>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/market/ReactMarketRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/ReactMarketRN.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useSession } from '@kbve/astro';
+import { MarketView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export default function ReactMarketRN() {
+	const { ready, authenticated } = useSession();
+	const token = useMemo(() => getToken, []);
+
+	if (!ready) return null;
+
+	return <MarketView getToken={token} baseUrl="" authenticated={authenticated} />;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/market/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/market/index.mdx
@@ -3,6 +3,7 @@ title: Marketplace
 description: |
     Browse active KBVE marketplace listings, place bids, and buy items
     settled in KHash. A 1% Treasury fee applies on every sale.
+template: splash
 tableOfContents: false
 graph:
    visible: false

--- a/packages/npm/rn/src/markets/index.ts
+++ b/packages/npm/rn/src/markets/index.ts
@@ -1,1 +1,2 @@
 export * from './store';
+export * from './market';

--- a/packages/npm/rn/src/markets/market/EnchantList.tsx
+++ b/packages/npm/rn/src/markets/market/EnchantList.tsx
@@ -1,0 +1,50 @@
+import { Badge } from '../../ui/primitives/Badge';
+import { Stack } from '../../ui/primitives/Stack';
+import { Text } from '../../ui/primitives/Text';
+import { enchantDef, formatEnchant, parseEnchants } from './enchants';
+
+export interface EnchantListProps {
+	itemRef: unknown;
+	compact?: boolean;
+}
+
+export function EnchantList({ itemRef, compact = false }: EnchantListProps) {
+	const enchants = parseEnchants(itemRef);
+	if (enchants.length === 0) return null;
+	if (compact) {
+		return (
+			<Text
+				variant="caption"
+				tone="muted"
+				accessibilityLabel={enchants.map(formatEnchant).join(', ')}>
+				{'✨ '}
+				{enchants.length}
+			</Text>
+		);
+	}
+	return (
+		<Stack
+			direction="row"
+			gap="xs"
+			wrap
+			accessibilityLabel="Enchantments">
+			{enchants.map((e, i) => {
+				const def = enchantDef(e.id);
+				const tone = def?.curse
+					? 'danger'
+					: def?.treasure
+						? 'warning'
+						: 'neutral';
+				return (
+					<Badge
+						key={`${e.id}-${i}`}
+						label={formatEnchant(e)}
+						tone={tone}
+					/>
+				);
+			})}
+		</Stack>
+	);
+}
+
+export default EnchantList;

--- a/packages/npm/rn/src/markets/market/ItemIcon.tsx
+++ b/packages/npm/rn/src/markets/market/ItemIcon.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { Text } from '../../ui/primitives/Text';
+
+export interface ItemIconProps {
+	itemRef: Record<string, unknown> | null | undefined;
+	size?: number;
+}
+
+function mcCandidates(id: string): string[] {
+	const clean = id.replace(/^minecraft:/, '').toLowerCase();
+	return [
+		`https://mcasset.cloud/1.21.5/assets/minecraft/textures/item/${clean}.png`,
+		`https://mcasset.cloud/1.21.5/assets/minecraft/textures/block/${clean}.png`,
+	];
+}
+
+const KIND_COLOR: Record<string, string> = {
+	mc_item: '#16a34a',
+	rareicon_item: '#a855f7',
+};
+
+function kindInitial(kind: string): string {
+	if (kind === 'mc_item') return 'M';
+	if (kind === 'rareicon_item') return 'R';
+	if (kind === 'generic') return 'G';
+	return kind ? kind[0].toUpperCase() : '?';
+}
+
+export function ItemIcon({ itemRef, size = 64 }: ItemIconProps) {
+	const meta = useMemo(() => {
+		const o = (itemRef ?? {}) as Record<string, unknown>;
+		return {
+			kind: typeof o.kind === 'string' ? o.kind : 'generic',
+			id: typeof o.id === 'string' ? o.id : '',
+		};
+	}, [itemRef]);
+	const [errIdx, setErrIdx] = useState(0);
+	const candidates =
+		meta.kind === 'mc_item' && meta.id ? mcCandidates(meta.id) : [];
+	const exhausted = errIdx >= candidates.length;
+
+	if (candidates.length > 0 && !exhausted) {
+		return (
+			<Image
+				source={{ uri: candidates[errIdx] }}
+				onError={() => setErrIdx((i) => i + 1)}
+				resizeMode="contain"
+				style={{ width: size, height: size }}
+			/>
+		);
+	}
+	return (
+		<View
+			style={[
+				styles.ph,
+				{
+					width: size,
+					height: size,
+					backgroundColor: KIND_COLOR[meta.kind] ?? '#475569',
+				},
+			]}>
+			<Text
+				variant="title"
+				style={{ fontSize: size * 0.42, color: '#fff' }}>
+				{kindInitial(meta.kind)}
+			</Text>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	ph: { alignItems: 'center', justifyContent: 'center', borderRadius: 8 },
+});

--- a/packages/npm/rn/src/markets/market/ListingCard.tsx
+++ b/packages/npm/rn/src/markets/market/ListingCard.tsx
@@ -1,0 +1,83 @@
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Stack } from '../../ui/primitives/Stack';
+import { Surface } from '../../ui/primitives/Surface';
+import { Text } from '../../ui/primitives/Text';
+import { tokens } from '../../ui/theme';
+import { useCountdown, formatCountdown } from './countdown';
+import { EnchantList } from './EnchantList';
+import { ItemIcon } from './ItemIcon';
+import { WatchToggle } from './WatchToggle';
+import { formatKhash, itemRefLabel } from './format';
+import type { MarketListing } from './types';
+
+export interface ListingCardProps {
+	row: MarketListing;
+	onOpen: (listingId: number) => void;
+}
+
+export function ListingCard({ row, onOpen }: ListingCardProps) {
+	const countdown = useCountdown(row.expires_at);
+	const urgent = countdown.totalMs < 60 * 60 * 1000;
+	const refObj = (row.item_ref ?? {}) as { kind?: unknown; id?: unknown };
+	const refKind = typeof refObj.kind === 'string' ? refObj.kind : '';
+	const refId =
+		typeof refObj.id === 'string' || typeof refObj.id === 'number'
+			? String(refObj.id)
+			: '';
+	return (
+		<View style={styles.card}>
+			<Pressable
+				onPress={() => onOpen(row.listing_id)}
+				accessibilityRole="button">
+				<Surface style={styles.surface}>
+					<View style={styles.icon}>
+						<ItemIcon itemRef={row.item_ref} size={96} />
+					</View>
+					<Stack gap="xs">
+						<Stack direction="row" gap="xs" align="center" wrap>
+							<Text variant="subtitle">{itemRefLabel(row.item_ref)}</Text>
+							<EnchantList itemRef={row.item_ref} compact />
+						</Stack>
+						<Stack direction="row" gap="md">
+							{row.buy_now_price !== null ? (
+								<Stack gap="xs">
+									<Text variant="caption" tone="muted">
+										Buy
+									</Text>
+									<Text variant="body" weight="medium">
+										{formatKhash(row.buy_now_price)}
+									</Text>
+								</Stack>
+							) : null}
+							{row.current_bid !== null || row.min_bid !== null ? (
+								<Stack gap="xs">
+									<Text variant="caption" tone="muted">
+										{row.current_bid !== null ? 'Bid' : 'Min'}
+									</Text>
+									<Text variant="body" weight="medium">
+										{formatKhash(row.current_bid ?? row.min_bid)}
+									</Text>
+								</Stack>
+							) : null}
+						</Stack>
+						<Text variant="caption" tone={urgent ? 'danger' : 'muted'}>
+							{formatCountdown(countdown)}
+						</Text>
+					</Stack>
+				</Surface>
+			</Pressable>
+			{refKind && refId ? (
+				<View style={styles.watch}>
+					<WatchToggle kind={refKind} itemRef={refId} size="sm" />
+				</View>
+			) : null}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	card: { flexGrow: 1, flexBasis: 220, maxWidth: '100%', position: 'relative' },
+	surface: { position: 'relative' },
+	watch: { position: 'absolute', top: tokens.space.sm, right: tokens.space.sm },
+	icon: { alignItems: 'center', marginBottom: tokens.space.sm },
+});

--- a/packages/npm/rn/src/markets/market/ListingDetail.tsx
+++ b/packages/npm/rn/src/markets/market/ListingDetail.tsx
@@ -243,7 +243,11 @@ export function ListingDetail({
 				) : null}
 
 				{active && !authenticated ? (
-					<Pressable accessibilityRole="button">
+					<Pressable
+						accessibilityRole="button"
+						onPress={() => {
+							window.location.href = '/login/';
+						}}>
 						<Text tone="primary">Sign in to bid or buy</Text>
 					</Pressable>
 				) : null}

--- a/packages/npm/rn/src/markets/market/ListingDetail.tsx
+++ b/packages/npm/rn/src/markets/market/ListingDetail.tsx
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Badge } from '../../ui/primitives/Badge';
+import { Button } from '../../ui/primitives/Button';
+import { FormField } from '../../ui/primitives/FormField';
+import { Stack } from '../../ui/primitives/Stack';
+import { Surface } from '../../ui/primitives/Surface';
+import { Text } from '../../ui/primitives/Text';
+import { tokens } from '../../ui/theme';
+import { notifyWalletRefresh } from '../shared';
+import type { MarketApi } from './api';
+import { MarketApiError } from './errors';
+import { useCountdown, formatCountdown } from './countdown';
+import { ItemIcon } from './ItemIcon';
+import { EnchantList } from './EnchantList';
+import { WatchToggle } from './WatchToggle';
+import { formatKhash, formatRelative, itemRefLabel } from './format';
+import type { MarketListingDetail } from './types';
+
+export interface ListingDetailProps {
+	api: MarketApi;
+	listingId: number | null;
+	authenticated: boolean;
+	myAccount: string | null;
+	onBack: () => void;
+}
+
+export function ListingDetail({
+	api,
+	listingId,
+	authenticated,
+	myAccount,
+	onBack,
+}: ListingDetailProps) {
+	const [row, setRow] = useState<MarketListingDetail | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [actionError, setActionError] = useState<string | null>(null);
+	const [actionBusy, setActionBusy] = useState<string | null>(null);
+	const [bidInput, setBidInput] = useState('');
+
+	const refresh = useCallback(async () => {
+		if (listingId == null) return;
+		setLoading(true);
+		try {
+			const d = await api.listingDetail(listingId);
+			setRow(d);
+			setError(null);
+		} catch (e) {
+			setError(
+				e instanceof MarketApiError ? e.message : 'failed to load listing',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [api, listingId]);
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+
+	const countdown = useCountdown(row?.expires_at);
+
+	const isSeller = useMemo(
+		() => Boolean(row && myAccount && row.seller_account === myAccount),
+		[row, myAccount],
+	);
+
+	const active = row?.listing_status === 'active';
+	const minNextBid = row
+		? (row.current_bid ?? ((row.min_bid ?? 1) - 1)) + 1
+		: 1;
+
+	const onBid = async () => {
+		if (!row) return;
+		const amount = Number(bidInput);
+		if (!Number.isFinite(amount) || amount <= 0) {
+			setActionError('bid must be a positive integer');
+			return;
+		}
+		setActionBusy('bid');
+		setActionError(null);
+		try {
+			await api.placeBid(row.listing_id, Math.floor(amount));
+			setBidInput('');
+			notifyWalletRefresh();
+			await refresh();
+		} catch (e) {
+			setActionError(e instanceof MarketApiError ? e.message : 'bid failed');
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	const onBuyNow = async () => {
+		if (!row) return;
+		setActionBusy('buy');
+		setActionError(null);
+		try {
+			await api.buyNow(row.listing_id);
+			notifyWalletRefresh();
+			await refresh();
+		} catch (e) {
+			setActionError(
+				e instanceof MarketApiError ? e.message : 'buy-now failed',
+			);
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	const onCancel = async () => {
+		if (!row) return;
+		setActionBusy('cancel');
+		setActionError(null);
+		try {
+			await api.cancelListing(row.listing_id);
+			await refresh();
+		} catch (e) {
+			setActionError(
+				e instanceof MarketApiError ? e.message : 'cancel failed',
+			);
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	if (listingId == null) {
+		return <Text tone="muted">Missing or invalid listing id.</Text>;
+	}
+	if (loading && !row) {
+		return <Text tone="muted">Loading listing…</Text>;
+	}
+	if (error && !row) {
+		return <Text tone="danger">{error}</Text>;
+	}
+	if (!row) return null;
+
+	const refObj = (row.item_ref ?? {}) as { kind?: unknown; id?: unknown };
+	const refKind = typeof refObj.kind === 'string' ? refObj.kind : '';
+	const refId =
+		typeof refObj.id === 'string' || typeof refObj.id === 'number'
+			? String(refObj.id)
+			: '';
+
+	return (
+		<Stack gap="lg">
+			<Pressable onPress={onBack} accessibilityRole="button">
+				<Text tone="muted">← Browse</Text>
+			</Pressable>
+
+			<Surface>
+				<Stack direction="row" gap="lg" wrap>
+					<View style={styles.icon}>
+						<ItemIcon itemRef={row.item_ref} size={128} />
+					</View>
+					<Stack gap="xs" style={styles.grow}>
+						<Stack direction="row" gap="xs" align="center" wrap>
+							<Text variant="title">{itemRefLabel(row.item_ref)}</Text>
+							<EnchantList itemRef={row.item_ref} />
+						</Stack>
+						{refKind && refId ? (
+							<WatchToggle kind={refKind} itemRef={refId} />
+						) : null}
+						<Badge label={row.listing_status} />
+						<Text variant="caption" tone="muted">
+							Seller {row.seller_account}
+						</Text>
+						<Text variant="caption" tone="muted">
+							Listed {formatRelative(row.created_at)}
+						</Text>
+						<Text tone={active && countdown.totalMs < 60_000 ? 'danger' : 'muted'}>
+							{active
+								? formatCountdown(countdown)
+								: row.settled_at
+									? formatRelative(row.settled_at)
+									: 'Closed'}
+						</Text>
+					</Stack>
+				</Stack>
+
+				<Stack direction="row" gap="lg" wrap>
+					{row.buy_now_price !== null ? (
+						<Stack gap="xs">
+							<Text variant="caption" tone="muted">
+								Buy-Now Price
+							</Text>
+							<Text variant="body" weight="medium">
+								{formatKhash(row.buy_now_price)}
+							</Text>
+						</Stack>
+					) : null}
+					<Stack gap="xs">
+						<Text variant="caption" tone="muted">
+							{row.current_bid !== null ? 'Current Bid' : 'Min Bid'}
+						</Text>
+						<Text variant="body" weight="medium">
+							{formatKhash(row.current_bid ?? row.min_bid)}
+						</Text>
+					</Stack>
+				</Stack>
+
+				{active && authenticated && !isSeller ? (
+					<Stack gap="md">
+						{row.buy_now_price !== null ? (
+							<Button
+								title={
+									actionBusy === 'buy'
+										? 'Buying…'
+										: `Buy Now · ${formatKhash(row.buy_now_price)}`
+								}
+								variant="primary"
+								disabled={actionBusy !== null}
+								onPress={() => void onBuyNow()}
+							/>
+						) : null}
+						{row.min_bid !== null ? (
+							<Stack gap="xs">
+								<FormField
+									label="Your Bid"
+									placeholder={`min ${minNextBid}`}
+									value={bidInput}
+									onChangeText={setBidInput}
+									keyboardType="number-pad"
+								/>
+								<Button
+									title={actionBusy === 'bid' ? 'Bidding…' : 'Bid'}
+									variant="secondary"
+									disabled={actionBusy !== null}
+									onPress={() => void onBid()}
+								/>
+							</Stack>
+						) : null}
+					</Stack>
+				) : null}
+
+				{active && authenticated && isSeller ? (
+					<Button
+						title={actionBusy === 'cancel' ? 'Cancelling…' : 'Cancel Listing'}
+						variant="danger"
+						disabled={actionBusy !== null}
+						onPress={() => void onCancel()}
+					/>
+				) : null}
+
+				{active && !authenticated ? (
+					<Pressable accessibilityRole="button">
+						<Text tone="primary">Sign in to bid or buy</Text>
+					</Pressable>
+				) : null}
+
+				{actionError ? <Text tone="danger">{actionError}</Text> : null}
+			</Surface>
+
+			<Stack gap="sm">
+				<Text variant="subtitle">Bid History</Text>
+				{row.bids.length > 0 ? (
+					<Stack gap="xs">
+						{row.bids.slice(0, 25).map((b, i) => {
+							const amount =
+								typeof (b as { amount?: number }).amount === 'number'
+									? (b as { amount: number }).amount
+									: null;
+							const placedAt = (b as { placed_at?: string }).placed_at;
+							const status = (b as { bid_status?: string }).bid_status;
+							return (
+								<Stack
+									key={i}
+									direction="row"
+									gap="sm"
+									align="center"
+									wrap>
+									<Text variant="body">
+										{amount !== null ? formatKhash(amount) : '—'}
+									</Text>
+									<Badge label={status ?? 'unknown'} />
+									<Text variant="caption" tone="muted">
+										{placedAt ? formatRelative(placedAt) : '—'}
+									</Text>
+								</Stack>
+							);
+						})}
+					</Stack>
+				) : (
+					<Text tone="muted">No bids yet</Text>
+				)}
+			</Stack>
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	icon: { alignItems: 'center' },
+	grow: { flexGrow: 1, flexBasis: 200 },
+});
+
+export default ListingDetail;

--- a/packages/npm/rn/src/markets/market/ListingDetail.tsx
+++ b/packages/npm/rn/src/markets/market/ListingDetail.tsx
@@ -6,7 +6,6 @@ import { FormField } from '../../ui/primitives/FormField';
 import { Stack } from '../../ui/primitives/Stack';
 import { Surface } from '../../ui/primitives/Surface';
 import { Text } from '../../ui/primitives/Text';
-import { tokens } from '../../ui/theme';
 import { notifyWalletRefresh } from '../shared';
 import type { MarketApi } from './api';
 import { MarketApiError } from './errors';

--- a/packages/npm/rn/src/markets/market/ListingDetailView.tsx
+++ b/packages/npm/rn/src/markets/market/ListingDetailView.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createMarketApi } from './api';
+import { ListingDetail } from './ListingDetail';
+
+export interface ListingDetailViewProps {
+	id: number;
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	authenticated: boolean;
+	onBack?: () => void;
+}
+
+export function ListingDetailView({
+	id,
+	getToken,
+	baseUrl = '',
+	authenticated,
+	onBack,
+}: ListingDetailViewProps) {
+	const api = useMemo(
+		() => createMarketApi({ getToken, baseUrl }),
+		[getToken, baseUrl],
+	);
+	const [myAccount, setMyAccount] = useState<string | null>(null);
+	useEffect(() => {
+		if (!authenticated) {
+			setMyAccount(null);
+			return;
+		}
+		let live = true;
+		void api.myAccountId().then((a) => {
+			if (live) setMyAccount(a);
+		});
+		return () => {
+			live = false;
+		};
+	}, [api, authenticated]);
+	return (
+		<ListingDetail
+			api={api}
+			listingId={id}
+			authenticated={authenticated}
+			myAccount={myAccount}
+			onBack={
+				onBack ??
+				(() => {
+					window.location.href = '/market/';
+				})
+			}
+		/>
+	);
+}
+
+export default ListingDetailView;

--- a/packages/npm/rn/src/markets/market/MarketBrowse.tsx
+++ b/packages/npm/rn/src/markets/market/MarketBrowse.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button } from '../../ui/primitives/Button';
+import { Stack } from '../../ui/primitives/Stack';
+import { Text } from '../../ui/primitives/Text';
+import { tokens } from '../../ui/theme';
+import { Select } from '../../ui/controls/Select';
+import type { SelectOption } from '../../ui/controls/Select.types';
+import type { MarketApi } from './api';
+import { MarketApiError } from './errors';
+import { ListingCard } from './ListingCard';
+import type { MarketListing } from './types';
+
+const PAGE_SIZE = 25;
+
+const KIND_FILTERS: SelectOption[] = [
+	{ value: 'all', label: 'All kinds' },
+	{ value: 'mc_item', label: 'Minecraft' },
+	{ value: 'rareicon_item', label: 'Rareicon' },
+	{ value: 'generic', label: 'Other' },
+];
+
+export interface MarketBrowseProps {
+	api: MarketApi;
+	onOpen: (listingId: number) => void;
+}
+
+export function MarketBrowse({ api, onOpen }: MarketBrowseProps) {
+	const [rows, setRows] = useState<MarketListing[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [hasMore, setHasMore] = useState(false);
+	const [kindFilter, setKindFilter] = useState<string>('all');
+
+	const load = useCallback(
+		async (after?: MarketListing) => {
+			setLoading(true);
+			setError(null);
+			try {
+				const page = await api.listActive({
+					limit: PAGE_SIZE,
+					before_created_at: after?.created_at ?? null,
+					before_id: after?.listing_id ?? null,
+				});
+				setRows((prev) => (after ? [...prev, ...page] : page));
+				setHasMore(page.length === PAGE_SIZE);
+			} catch (e) {
+				setError(
+					e instanceof MarketApiError
+						? e.message
+						: 'failed to load listings',
+				);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[api],
+	);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	const loadMore = () => {
+		const tail = rows[rows.length - 1];
+		if (tail) void load(tail);
+	};
+
+	const filtered = useMemo(() => {
+		if (kindFilter === 'all') return rows;
+		return rows.filter((r) => {
+			const k = (r.item_ref as { kind?: unknown })?.kind;
+			return typeof k === 'string' ? k === kindFilter : kindFilter === 'generic';
+		});
+	}, [rows, kindFilter]);
+
+	return (
+		<Stack gap="lg">
+			<Stack direction="row" align="center" gap="md" wrap>
+				<Select
+					value={kindFilter}
+					options={KIND_FILTERS}
+					onValueChange={setKindFilter}
+				/>
+				<Text variant="caption" tone="muted">
+					{filtered.length} / {rows.length} shown
+				</Text>
+				<Button
+					title={loading ? '…' : '↻ Refresh'}
+					variant="secondary"
+					disabled={loading}
+					onPress={() => void load()}
+				/>
+			</Stack>
+
+			{loading && rows.length === 0 ? (
+				<Text variant="body" tone="muted">
+					Loading listings…
+				</Text>
+			) : null}
+			{error && rows.length === 0 ? (
+				<Text variant="body" tone="danger">
+					{error}
+				</Text>
+			) : null}
+			{!loading && rows.length === 0 && !error ? (
+				<Text variant="body" tone="muted">
+					No active listings yet. Check back soon.
+				</Text>
+			) : null}
+
+			{filtered.length > 0 ? (
+				<View style={styles.grid}>
+					{filtered.map((r) => (
+						<ListingCard key={r.listing_id} row={r} onOpen={onOpen} />
+					))}
+				</View>
+			) : null}
+
+			{rows.length > 0 && filtered.length === 0 ? (
+				<Text variant="body" tone="muted">
+					No active listings match this filter.
+				</Text>
+			) : null}
+
+			{hasMore ? (
+				<Button
+					title={loading ? 'Loading…' : 'Load more'}
+					variant="outline"
+					disabled={loading}
+					onPress={loadMore}
+				/>
+			) : null}
+			{error && rows.length > 0 ? (
+				<Text variant="body" tone="danger">
+					{error}
+				</Text>
+			) : null}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	grid: { flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.md },
+});
+
+export default MarketBrowse;

--- a/packages/npm/rn/src/markets/market/MarketCreateForm.tsx
+++ b/packages/npm/rn/src/markets/market/MarketCreateForm.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { Button } from '../../ui/primitives/Button';
+import { FormField } from '../../ui/primitives/FormField';
+import { Stack } from '../../ui/primitives/Stack';
+import { Text } from '../../ui/primitives/Text';
+import { tokens } from '../../ui/theme';
+import { Select } from '../../ui/controls/Select';
+import type { SelectOption } from '../../ui/controls/Select.types';
+import type { MarketApi } from './api';
+import { MarketApiError } from './errors';
+
+const UUID_RE =
+	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+const DURATION_MS: Record<string, number> = {
+	'24h': 1000 * 60 * 60 * 24,
+	'3d': 1000 * 60 * 60 * 24 * 3,
+	'7d': 1000 * 60 * 60 * 24 * 7,
+	'14d': 1000 * 60 * 60 * 24 * 14,
+	'30d': 1000 * 60 * 60 * 24 * 30,
+};
+
+const DURATION_OPTIONS: SelectOption[] = [
+	{ value: '24h', label: '24 hours' },
+	{ value: '3d', label: '3 days' },
+	{ value: '7d', label: '7 days' },
+	{ value: '14d', label: '14 days' },
+	{ value: '30d', label: '30 days' },
+];
+
+export interface MarketCreateFormProps {
+	api: MarketApi;
+	authenticated: boolean;
+	onCreated?: (id: number) => void;
+}
+
+export function MarketCreateForm({
+	api,
+	authenticated,
+	onCreated,
+}: MarketCreateFormProps) {
+	const [srcItemId, setSrcItemId] = useState('');
+	const [qty, setQty] = useState('');
+	const [buyNow, setBuyNow] = useState('');
+	const [minBid, setMinBid] = useState('');
+	const [duration, setDuration] = useState('24h');
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<number | null>(null);
+
+	if (!authenticated) {
+		return <Text tone="muted">Sign in to list an item for sale.</Text>;
+	}
+
+	const onSubmit = async () => {
+		setError(null);
+		setSuccess(null);
+		const id = srcItemId.trim();
+		if (!UUID_RE.test(id)) {
+			setError('inventory item id must be a UUID');
+			return;
+		}
+		const bn = buyNow.trim() ? Number(buyNow) : null;
+		const mb = minBid.trim() ? Number(minBid) : null;
+		if (bn === null && mb === null) {
+			setError('set a buy-now price or a min bid');
+			return;
+		}
+		if (bn !== null && (!Number.isFinite(bn) || bn <= 0)) {
+			setError('buy-now must be a positive integer');
+			return;
+		}
+		if (mb !== null && (!Number.isFinite(mb) || mb <= 0)) {
+			setError('min bid must be a positive integer');
+			return;
+		}
+		let qtyParsed: number | null = null;
+		if (qty.trim()) {
+			const n = Number(qty);
+			if (!Number.isFinite(n) || n <= 0 || n !== Math.floor(n)) {
+				setError('qty must be a positive integer');
+				return;
+			}
+			qtyParsed = n;
+		}
+		const durationMs = DURATION_MS[duration] ?? DURATION_MS['24h'];
+		const expiresAt = new Date(Date.now() + durationMs).toISOString();
+		setBusy(true);
+		try {
+			const res = await api.createListing({
+				src_item_id: id,
+				qty: qtyParsed,
+				buy_now_price: bn !== null ? Math.floor(bn) : null,
+				min_bid: mb !== null ? Math.floor(mb) : null,
+				expires_at: expiresAt,
+			});
+			setSuccess(res.id);
+			setSrcItemId('');
+			setQty('');
+			setBuyNow('');
+			setMinBid('');
+		} catch (err) {
+			setError(
+				err instanceof MarketApiError ? err.message : 'create failed',
+			);
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<Stack gap="lg">
+			<FormField
+				label="Inventory Item ID"
+				placeholder="uuid from your KBVE inventory"
+				value={srcItemId}
+				onChangeText={setSrcItemId}
+				autoCapitalize="none"
+				autoCorrect={false}
+				hint="UUID of the item row in your KBVE inventory. The item must be in held state and owned by you."
+			/>
+			<FormField
+				label="Qty (optional)"
+				placeholder="leave blank for whole row"
+				value={qty}
+				onChangeText={setQty}
+				keyboardType="number-pad"
+				hint="Partial-stack listing. Blank = list the whole row."
+			/>
+			<Stack direction="row" gap="md" wrap>
+				<FormField
+					label="Buy Now (KHash)"
+					value={buyNow}
+					onChangeText={setBuyNow}
+					keyboardType="number-pad"
+					style={styles.half}
+				/>
+				<FormField
+					label="Min Bid (KHash)"
+					value={minBid}
+					onChangeText={setMinBid}
+					keyboardType="number-pad"
+					style={styles.half}
+				/>
+			</Stack>
+			<Stack gap="xs">
+				<Text variant="label" tone="muted">
+					Expires In
+				</Text>
+				<Select
+					value={duration}
+					options={DURATION_OPTIONS}
+					onValueChange={setDuration}
+				/>
+			</Stack>
+			<Button
+				title={busy ? 'Listing…' : 'Create Listing'}
+				variant="primary"
+				disabled={busy}
+				onPress={() => void onSubmit()}
+			/>
+			<Text variant="caption" tone="muted">
+				1% KBVE Treasury fee applies on sale. Listing duration capped at
+				30 days.
+			</Text>
+			{error ? <Text tone="danger">{error}</Text> : null}
+			{success !== null ? (
+				<Stack gap="xs">
+					<Text tone="default">Listing #{success} created</Text>
+					<Button
+						title="View listing"
+						variant="secondary"
+						onPress={() => onCreated?.(success)}
+					/>
+				</Stack>
+			) : null}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	half: { flex: 1, minWidth: 120 },
+});
+
+export default MarketCreateForm;

--- a/packages/npm/rn/src/markets/market/MarketCreateForm.tsx
+++ b/packages/npm/rn/src/markets/market/MarketCreateForm.tsx
@@ -4,7 +4,6 @@ import { Button } from '../../ui/primitives/Button';
 import { FormField } from '../../ui/primitives/FormField';
 import { Stack } from '../../ui/primitives/Stack';
 import { Text } from '../../ui/primitives/Text';
-import { tokens } from '../../ui/theme';
 import { Select } from '../../ui/controls/Select';
 import type { SelectOption } from '../../ui/controls/Select.types';
 import type { MarketApi } from './api';

--- a/packages/npm/rn/src/markets/market/MarketView.tsx
+++ b/packages/npm/rn/src/markets/market/MarketView.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { Stack } from '../../ui/primitives/Stack';
+import { Text } from '../../ui/primitives/Text';
+import { createMarketApi } from './api';
+import { MarketBrowse } from './MarketBrowse';
+import { MarketCreateForm } from './MarketCreateForm';
+
+export interface MarketViewProps {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	authenticated: boolean;
+	onOpen?: (listingId: number) => void;
+}
+
+export function MarketView({
+	getToken,
+	baseUrl = '',
+	authenticated,
+	onOpen,
+}: MarketViewProps) {
+	const api = useMemo(
+		() => createMarketApi({ getToken, baseUrl }),
+		[getToken, baseUrl],
+	);
+	const open =
+		onOpen ??
+		((id: number) => {
+			window.location.href = `/market/listing/?id=${id}`;
+		});
+	return (
+		<Stack gap="lg">
+			<Text variant="subtitle">Sell an item</Text>
+			<MarketCreateForm
+				api={api}
+				authenticated={authenticated}
+				onCreated={open}
+			/>
+			<Text variant="subtitle">Active listings</Text>
+			<MarketBrowse api={api} onOpen={open} />
+		</Stack>
+	);
+}

--- a/packages/npm/rn/src/markets/market/WatchToggle.tsx
+++ b/packages/npm/rn/src/markets/market/WatchToggle.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text } from '../../ui/primitives/Text';
+import {
+	isWatched as readIsWatched,
+	subscribe,
+	toggleWatch,
+} from './watchlist';
+
+export interface WatchToggleProps {
+	kind: string;
+	itemRef: string;
+	size?: 'sm' | 'md';
+}
+
+export function WatchToggle({ kind, itemRef, size = 'md' }: WatchToggleProps) {
+	const [watched, setWatched] = useState(false);
+	useEffect(() => {
+		const entry = { kind, ref: itemRef };
+		setWatched(readIsWatched(entry));
+		return subscribe(() => setWatched(readIsWatched(entry)));
+	}, [kind, itemRef]);
+	const onPress = useCallback(() => {
+		toggleWatch({ kind, ref: itemRef });
+	}, [kind, itemRef]);
+	return (
+		<Pressable
+			onPress={onPress}
+			accessibilityRole="button"
+			accessibilityLabel={
+				watched ? 'Remove from watch list' : 'Add to watch list'
+			}
+			style={styles.btn}>
+			<Text
+				variant={size === 'sm' ? 'caption' : 'body'}
+				tone={watched ? 'default' : 'muted'}>
+				{watched ? '★' : '☆'}
+			</Text>
+		</Pressable>
+	);
+}
+
+const styles = StyleSheet.create({ btn: { padding: 4 } });

--- a/packages/npm/rn/src/markets/market/__tests__/ListingDetail.test.tsx
+++ b/packages/npm/rn/src/markets/market/__tests__/ListingDetail.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ListingDetail } from '../ListingDetail';
+import type { MarketApi } from '../api';
+
+const DETAIL = {
+	listing_id: 7,
+	seller_account: 'seller',
+	item_ref: { kind: 'generic', id: 'x' },
+	currency: 'khash',
+	buy_now_price: 1000,
+	min_bid: 100,
+	current_bid: null,
+	current_bid_id: null,
+	listing_status: 'active',
+	expires_at: new Date(Date.now() + 86400000).toISOString(),
+	created_at: '2020',
+	updated_at: '2020',
+	settled_at: null,
+	bids: [],
+};
+
+function stubApi(over: Partial<MarketApi> = {}): MarketApi {
+	return {
+		listActive: vi.fn(),
+		listingDetail: vi.fn(async () => DETAIL as any),
+		myAccountId: vi.fn(),
+		createListing: vi.fn(),
+		placeBid: vi.fn(async () => ({ id: 1 })),
+		buyNow: vi.fn(async () => ({ id: 2 })),
+		cancelListing: vi.fn(async () => undefined),
+		...over,
+	} as MarketApi;
+}
+
+describe('ListingDetail', () => {
+	it('renders buy-now for a non-seller authenticated viewer and fires buyNow', async () => {
+		const buyNow = vi.fn(async () => ({ id: 2 }));
+		const { findByText } = render(
+			<ListingDetail
+				api={stubApi({ buyNow })}
+				listingId={7}
+				authenticated
+				myAccount="buyer"
+				onBack={vi.fn()}
+			/>,
+		);
+		const btn = await findByText(/Buy Now/);
+		fireEvent.click(btn);
+		await waitFor(() => expect(buyNow).toHaveBeenCalledWith(7));
+	});
+
+	it('shows cancel for the seller, not buy-now', async () => {
+		const { findByText, queryByText } = render(
+			<ListingDetail
+				api={stubApi()}
+				listingId={7}
+				authenticated
+				myAccount="seller"
+				onBack={vi.fn()}
+			/>,
+		);
+		expect(await findByText(/Cancel Listing/)).toBeTruthy();
+		expect(queryByText(/Buy Now/)).toBeNull();
+	});
+
+	it('signed-out viewer sees a sign-in affordance, no actions', async () => {
+		const { findByText, queryByText } = render(
+			<ListingDetail
+				api={stubApi()}
+				listingId={7}
+				authenticated={false}
+				myAccount={null}
+				onBack={vi.fn()}
+			/>,
+		);
+		expect(await findByText(/Sign in to bid or buy/)).toBeTruthy();
+		expect(queryByText(/Buy Now/)).toBeNull();
+	});
+});

--- a/packages/npm/rn/src/markets/market/__tests__/MarketBrowse.test.tsx
+++ b/packages/npm/rn/src/markets/market/__tests__/MarketBrowse.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MarketBrowse } from '../MarketBrowse';
+import type { MarketApi } from '../api';
+
+const ROWS = [
+	{
+		listing_id: 1,
+		seller_account: 's',
+		item_ref: { kind: 'mc_item', id: 'diamond' },
+		currency: 'khash',
+		buy_now_price: 500,
+		min_bid: null,
+		current_bid: null,
+		expires_at: new Date(Date.now() + 86400000).toISOString(),
+		created_at: '2020',
+	},
+];
+
+function stubApi(over: Partial<MarketApi> = {}): MarketApi {
+	return {
+		listActive: vi.fn(async () => ROWS as any),
+		listingDetail: vi.fn(),
+		myAccountId: vi.fn(),
+		createListing: vi.fn(),
+		placeBid: vi.fn(),
+		buyNow: vi.fn(),
+		cancelListing: vi.fn(),
+		...over,
+	} as MarketApi;
+}
+
+describe('MarketBrowse', () => {
+	beforeEach(() => {});
+	it('loads and renders a listing card with its buy-now price', async () => {
+		const { findByText } = render(
+			<MarketBrowse api={stubApi()} onOpen={vi.fn()} />,
+		);
+		expect(await findByText(/500 KHash/)).toBeTruthy();
+	});
+	it('shows empty state when no listings', async () => {
+		const { findByText } = render(
+			<MarketBrowse
+				api={stubApi({ listActive: vi.fn(async () => []) })}
+				onOpen={vi.fn()}
+			/>,
+		);
+		expect(await findByText(/No active listings/)).toBeTruthy();
+	});
+});

--- a/packages/npm/rn/src/markets/market/__tests__/MarketBrowse.test.tsx
+++ b/packages/npm/rn/src/markets/market/__tests__/MarketBrowse.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 import { MarketBrowse } from '../MarketBrowse';
 import type { MarketApi } from '../api';
 
@@ -31,7 +31,6 @@ function stubApi(over: Partial<MarketApi> = {}): MarketApi {
 }
 
 describe('MarketBrowse', () => {
-	beforeEach(() => {});
 	it('loads and renders a listing card with its buy-now price', async () => {
 		const { findByText } = render(
 			<MarketBrowse api={stubApi()} onOpen={vi.fn()} />,

--- a/packages/npm/rn/src/markets/market/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/market/__tests__/api.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMarketApi } from '../api';
+import { MarketApiError } from '../errors';
+
+const token = async () => 'tok';
+
+describe('createMarketApi', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn();
+	});
+
+	it('listActive builds cursor query, tokenless', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => '[]',
+		});
+		const api = createMarketApi({
+			getToken: async () => null,
+			baseUrl: 'https://x',
+		});
+		await api.listActive({
+			limit: 10,
+			before_created_at: '2020',
+			before_id: 5,
+		});
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe(
+			'https://x/api/v1/market/listings?limit=10&before_created_at=2020&before_id=5',
+		);
+		expect(init?.headers?.Authorization).toBeUndefined();
+	});
+
+	it('placeBid posts bearer + amount + idempotency_key', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify({ id: 9 }),
+		});
+		const api = createMarketApi({ getToken: token, baseUrl: '' });
+		const res = await api.placeBid(3, 250);
+		expect(res).toEqual({ id: 9 });
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('/api/v1/market/listings/3/bid');
+		expect(init.headers.Authorization).toBe('Bearer tok');
+		const body = JSON.parse(init.body);
+		expect(body.amount).toBe(250);
+		expect(typeof body.idempotency_key).toBe('string');
+	});
+
+	it('authed call without token throws 401 without fetch', async () => {
+		const api = createMarketApi({ getToken: async () => null });
+		await expect(api.buyNow(1)).rejects.toMatchObject({
+			name: 'MarketApiError',
+			status: 401,
+		});
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('myAccountId returns account_id, null on failure', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify({ account_id: 'acc-1' }),
+		});
+		const api = createMarketApi({ getToken: token });
+		expect(await api.myAccountId()).toBe('acc-1');
+		(global.fetch as any).mockRejectedValue(new Error('down'));
+		expect(await api.myAccountId()).toBeNull();
+	});
+
+	it('non-OK JSON error surfaces message + status + code', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: false,
+			status: 409,
+			text: async () => JSON.stringify({ error: 'outbid', code: 'M12' }),
+		});
+		const api = createMarketApi({ getToken: token });
+		const err = await api.placeBid(1, 5).catch((e) => e);
+		expect(err).toBeInstanceOf(MarketApiError);
+		expect(err.status).toBe(409);
+		expect(err.code).toBe('M12');
+		expect(err.message).toBe('outbid');
+	});
+});

--- a/packages/npm/rn/src/markets/market/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/market/__tests__/api.test.ts
@@ -69,17 +69,18 @@ describe('createMarketApi', () => {
 		expect(await api.myAccountId()).toBeNull();
 	});
 
-	it('non-OK JSON error surfaces message + status + code', async () => {
+	it('non-OK JSON error surfaces human message over slug; code = error slug', async () => {
 		(global.fetch as any).mockResolvedValue({
 			ok: false,
 			status: 409,
-			text: async () => JSON.stringify({ error: 'outbid', code: 'M12' }),
+			text: async () =>
+				JSON.stringify({ error: 'invalid_argument', message: 'amount must be a positive integer' }),
 		});
 		const api = createMarketApi({ getToken: token });
 		const err = await api.placeBid(1, 5).catch((e) => e);
 		expect(err).toBeInstanceOf(MarketApiError);
 		expect(err.status).toBe(409);
-		expect(err.code).toBe('M12');
-		expect(err.message).toBe('outbid');
+		expect(err.message).toBe('amount must be a positive integer');
+		expect(err.code).toBe('invalid_argument');
 	});
 });

--- a/packages/npm/rn/src/markets/market/__tests__/countdown.test.ts
+++ b/packages/npm/rn/src/markets/market/__tests__/countdown.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { formatCountdown } from '../countdown';
+
+describe('formatCountdown', () => {
+	it('expired', () => {
+		expect(
+			formatCountdown({
+				expired: true,
+				days: 0,
+				hours: 0,
+				minutes: 0,
+				seconds: 0,
+				totalMs: 0,
+			}),
+		).toBe('expired');
+	});
+	it('days/hours/minutes/seconds tiers', () => {
+		expect(
+			formatCountdown({
+				expired: false,
+				days: 2,
+				hours: 3,
+				minutes: 0,
+				seconds: 0,
+				totalMs: 1,
+			}),
+		).toBe('2d 3h');
+		expect(
+			formatCountdown({
+				expired: false,
+				days: 0,
+				hours: 5,
+				minutes: 9,
+				seconds: 0,
+				totalMs: 1,
+			}),
+		).toBe('5h 9m');
+		expect(
+			formatCountdown({
+				expired: false,
+				days: 0,
+				hours: 0,
+				minutes: 4,
+				seconds: 3,
+				totalMs: 1,
+			}),
+		).toBe('4m 03s');
+		expect(
+			formatCountdown({
+				expired: false,
+				days: 0,
+				hours: 0,
+				minutes: 0,
+				seconds: 8,
+				totalMs: 1,
+			}),
+		).toBe('8s');
+	});
+});

--- a/packages/npm/rn/src/markets/market/__tests__/format.test.ts
+++ b/packages/npm/rn/src/markets/market/__tests__/format.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { formatKhash, itemRefLabel, itemRefHasEnchants } from '../format';
+
+describe('format', () => {
+	it('formatKhash', () => {
+		expect(formatKhash(null)).toBe('—');
+		expect(formatKhash(1500)).toBe('1,500 KHash');
+	});
+	it('itemRefLabel', () => {
+		expect(itemRefLabel({ kind: 'mc_item', id: 'diamond' })).toBe(
+			'mc_item:diamond',
+		);
+		expect(itemRefLabel({ id: 'x' })).toBe('x');
+		expect(itemRefLabel(5)).toBe('Unknown item');
+	});
+	it('itemRefHasEnchants', () => {
+		expect(itemRefHasEnchants({ enchants: [{}] })).toBe(true);
+		expect(itemRefHasEnchants({ enchants: [] })).toBe(false);
+		expect(itemRefHasEnchants({})).toBe(false);
+	});
+});

--- a/packages/npm/rn/src/markets/market/api.ts
+++ b/packages/npm/rn/src/markets/market/api.ts
@@ -1,0 +1,154 @@
+import { MarketApiError } from './errors';
+import { newIdempotencyKey } from '../shared';
+import type {
+	Cursor,
+	IdResponse,
+	MarketListing,
+	MarketListingDetail,
+} from './types';
+
+export interface MarketApiOptions {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+}
+
+export interface MarketApi {
+	listActive(c?: Cursor): Promise<MarketListing[]>;
+	listingDetail(id: number): Promise<MarketListingDetail>;
+	myAccountId(): Promise<string | null>;
+	createListing(body: {
+		src_item_id: string;
+		qty: number | null;
+		buy_now_price: number | null;
+		min_bid: number | null;
+		expires_at: string;
+	}): Promise<IdResponse>;
+	placeBid(id: number, amount: number): Promise<IdResponse>;
+	buyNow(id: number): Promise<IdResponse>;
+	cancelListing(id: number, reason?: string | null): Promise<void>;
+}
+
+function query(
+	params: Record<string, string | number | null | undefined>,
+): string {
+	const usp = new URLSearchParams();
+	for (const [k, v] of Object.entries(params)) {
+		if (v === null || v === undefined || v === '') continue;
+		usp.set(k, String(v));
+	}
+	const s = usp.toString();
+	return s ? `?${s}` : '';
+}
+
+interface Req {
+	path: string;
+	method?: string;
+	body?: unknown;
+	auth?: boolean;
+}
+
+export function createMarketApi(opts: MarketApiOptions): MarketApi {
+	const { getToken, baseUrl = '' } = opts;
+
+	async function call<T>({
+		path,
+		method = 'GET',
+		body,
+		auth = false,
+	}: Req): Promise<T> {
+		const headers: Record<string, string> = {};
+		if (body !== undefined) headers['Content-Type'] = 'application/json';
+		if (auth) {
+			const token = await getToken().catch(() => null);
+			if (!token) throw new MarketApiError('Not signed in', 401);
+			headers.Authorization = `Bearer ${token}`;
+		}
+		let res: Response;
+		try {
+			res = await fetch(`${baseUrl}${path}`, {
+				method,
+				headers,
+				body: body === undefined ? undefined : JSON.stringify(body),
+			});
+		} catch (e) {
+			throw new MarketApiError(
+				e instanceof Error ? e.message : 'request failed',
+				0,
+			);
+		}
+		const text = await res.text();
+		let json: unknown;
+		try {
+			json = text ? JSON.parse(text) : undefined;
+		} catch {
+			json = undefined;
+		}
+		if (!res.ok) {
+			const j = (json ?? {}) as {
+				error?: string;
+				message?: string;
+				code?: string;
+			};
+			throw new MarketApiError(
+				j.error ?? j.message ?? (text || `HTTP ${res.status}`),
+				res.status,
+				j.code,
+			);
+		}
+		return json as T;
+	}
+
+	return {
+		listActive: (c = {}) =>
+			call<MarketListing[]>({
+				path: `/api/v1/market/listings${query({
+					limit: c.limit ?? 25,
+					before_created_at: c.before_created_at,
+					before_id: c.before_id,
+				})}`,
+			}),
+		listingDetail: (id) =>
+			call<MarketListingDetail>({
+				path: `/api/v1/market/listings/${id}`,
+			}),
+		myAccountId: async () => {
+			try {
+				const r = await call<{ account_id?: string }>({
+					path: '/api/v1/wallet/me/balance',
+					auth: true,
+				});
+				return r?.account_id ?? null;
+			} catch {
+				return null;
+			}
+		},
+		createListing: (body) =>
+			call<IdResponse>({
+				path: '/api/v1/market/listings',
+				method: 'POST',
+				body: { ...body, idempotency_key: newIdempotencyKey() },
+				auth: true,
+			}),
+		placeBid: (id, amount) =>
+			call<IdResponse>({
+				path: `/api/v1/market/listings/${id}/bid`,
+				method: 'POST',
+				body: { amount, idempotency_key: newIdempotencyKey() },
+				auth: true,
+			}),
+		buyNow: (id) =>
+			call<IdResponse>({
+				path: `/api/v1/market/listings/${id}/buy-now`,
+				method: 'POST',
+				body: { idempotency_key: newIdempotencyKey() },
+				auth: true,
+			}),
+		cancelListing: (id, reason = null) =>
+			call<void>({
+				path: `/api/v1/market/listings/${id}/cancel`,
+				method: 'POST',
+				body: { reason },
+				auth: true,
+			}),
+	};
+}

--- a/packages/npm/rn/src/markets/market/api.ts
+++ b/packages/npm/rn/src/markets/market/api.ts
@@ -87,12 +87,12 @@ export function createMarketApi(opts: MarketApiOptions): MarketApi {
 			const j = (json ?? {}) as {
 				error?: string;
 				message?: string;
-				code?: string;
+				detail?: string;
 			};
 			throw new MarketApiError(
-				j.error ?? j.message ?? (text || `HTTP ${res.status}`),
+				j.message ?? j.error ?? j.detail ?? (text || `HTTP ${res.status}`),
 				res.status,
-				j.code,
+				j.error,
 			);
 		}
 		return json as T;

--- a/packages/npm/rn/src/markets/market/countdown.ts
+++ b/packages/npm/rn/src/markets/market/countdown.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+export interface Countdown {
+	expired: boolean;
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+	totalMs: number;
+}
+
+const ZERO: Countdown = {
+	expired: true,
+	days: 0,
+	hours: 0,
+	minutes: 0,
+	seconds: 0,
+	totalMs: 0,
+};
+
+function compute(iso: string): Countdown {
+	const ms = new Date(iso).getTime() - Date.now();
+	if (ms <= 0) return ZERO;
+	const totalSec = Math.floor(ms / 1000);
+	return {
+		expired: false,
+		days: Math.floor(totalSec / 86400),
+		hours: Math.floor((totalSec % 86400) / 3600),
+		minutes: Math.floor((totalSec % 3600) / 60),
+		seconds: totalSec % 60,
+		totalMs: ms,
+	};
+}
+
+export function useCountdown(iso: string | null | undefined): Countdown {
+	const [c, setC] = useState<Countdown>(() => (iso ? compute(iso) : ZERO));
+	useEffect(() => {
+		if (!iso) return;
+		setC(compute(iso));
+		const fast = compute(iso).totalMs < 60_000;
+		const id = setInterval(() => setC(compute(iso)), fast ? 1000 : 30_000);
+		return () => clearInterval(id);
+	}, [iso]);
+	return c;
+}
+
+export function formatCountdown(c: Countdown): string {
+	if (c.expired) return 'expired';
+	if (c.days > 0) return `${c.days}d ${c.hours}h`;
+	if (c.hours > 0) return `${c.hours}h ${c.minutes}m`;
+	if (c.minutes > 0)
+		return `${c.minutes}m ${String(c.seconds).padStart(2, '0')}s`;
+	return `${c.seconds}s`;
+}

--- a/packages/npm/rn/src/markets/market/enchants.ts
+++ b/packages/npm/rn/src/markets/market/enchants.ts
@@ -1,0 +1,129 @@
+export type Enchant = {
+	id: string;
+	level: number;
+};
+
+type EnchantDef = {
+	id: string;
+	label: string;
+	maxLevel: number;
+	curse?: boolean;
+	treasure?: boolean;
+};
+
+export const VANILLA_ENCHANTS: EnchantDef[] = [
+	{ id: 'aqua_affinity', label: 'Aqua Affinity', maxLevel: 1 },
+	{ id: 'bane_of_arthropods', label: 'Bane of Arthropods', maxLevel: 5 },
+	{
+		id: 'binding_curse',
+		label: 'Curse of Binding',
+		maxLevel: 1,
+		curse: true,
+	},
+	{ id: 'blast_protection', label: 'Blast Protection', maxLevel: 4 },
+	{ id: 'breach', label: 'Breach', maxLevel: 4 },
+	{ id: 'channeling', label: 'Channeling', maxLevel: 1 },
+	{ id: 'density', label: 'Density', maxLevel: 5 },
+	{ id: 'depth_strider', label: 'Depth Strider', maxLevel: 3 },
+	{ id: 'efficiency', label: 'Efficiency', maxLevel: 5 },
+	{ id: 'feather_falling', label: 'Feather Falling', maxLevel: 4 },
+	{ id: 'fire_aspect', label: 'Fire Aspect', maxLevel: 2 },
+	{ id: 'fire_protection', label: 'Fire Protection', maxLevel: 4 },
+	{ id: 'flame', label: 'Flame', maxLevel: 1 },
+	{ id: 'fortune', label: 'Fortune', maxLevel: 3 },
+	{ id: 'frost_walker', label: 'Frost Walker', maxLevel: 2, treasure: true },
+	{ id: 'impaling', label: 'Impaling', maxLevel: 5 },
+	{ id: 'infinity', label: 'Infinity', maxLevel: 1 },
+	{ id: 'knockback', label: 'Knockback', maxLevel: 2 },
+	{ id: 'looting', label: 'Looting', maxLevel: 3 },
+	{ id: 'loyalty', label: 'Loyalty', maxLevel: 3 },
+	{ id: 'luck_of_the_sea', label: 'Luck of the Sea', maxLevel: 3 },
+	{ id: 'lure', label: 'Lure', maxLevel: 3 },
+	{ id: 'mending', label: 'Mending', maxLevel: 1, treasure: true },
+	{ id: 'multishot', label: 'Multishot', maxLevel: 1 },
+	{ id: 'piercing', label: 'Piercing', maxLevel: 4 },
+	{ id: 'power', label: 'Power', maxLevel: 5 },
+	{
+		id: 'projectile_protection',
+		label: 'Projectile Protection',
+		maxLevel: 4,
+	},
+	{ id: 'protection', label: 'Protection', maxLevel: 4 },
+	{ id: 'punch', label: 'Punch', maxLevel: 2 },
+	{ id: 'quick_charge', label: 'Quick Charge', maxLevel: 3 },
+	{ id: 'respiration', label: 'Respiration', maxLevel: 3 },
+	{ id: 'riptide', label: 'Riptide', maxLevel: 3 },
+	{ id: 'sharpness', label: 'Sharpness', maxLevel: 5 },
+	{ id: 'silk_touch', label: 'Silk Touch', maxLevel: 1 },
+	{ id: 'smite', label: 'Smite', maxLevel: 5 },
+	{ id: 'soul_speed', label: 'Soul Speed', maxLevel: 3, treasure: true },
+	{ id: 'sweeping_edge', label: 'Sweeping Edge', maxLevel: 3 },
+	{ id: 'swift_sneak', label: 'Swift Sneak', maxLevel: 3, treasure: true },
+	{ id: 'thorns', label: 'Thorns', maxLevel: 3 },
+	{ id: 'unbreaking', label: 'Unbreaking', maxLevel: 3 },
+	{
+		id: 'vanishing_curse',
+		label: 'Curse of Vanishing',
+		maxLevel: 1,
+		curse: true,
+	},
+	{ id: 'wind_burst', label: 'Wind Burst', maxLevel: 3, treasure: true },
+];
+
+const ENCHANT_INDEX: Map<string, EnchantDef> = new Map(
+	VANILLA_ENCHANTS.map((e) => [e.id, e]),
+);
+
+export function enchantLabel(id: string): string {
+	return (
+		ENCHANT_INDEX.get(id)?.label ??
+		id.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+	);
+}
+
+export function enchantDef(id: string): EnchantDef | undefined {
+	return ENCHANT_INDEX.get(id);
+}
+
+const ROMAN: Record<number, string> = {
+	1: 'I',
+	2: 'II',
+	3: 'III',
+	4: 'IV',
+	5: 'V',
+	6: 'VI',
+	7: 'VII',
+	8: 'VIII',
+	9: 'IX',
+	10: 'X',
+};
+
+export function roman(n: number): string {
+	if (n in ROMAN) return ROMAN[n];
+	return String(n);
+}
+
+export function formatEnchant(e: Enchant): string {
+	const label = enchantLabel(e.id);
+	if (e.level <= 1 && (enchantDef(e.id)?.maxLevel ?? 1) === 1) return label;
+	return `${label} ${roman(e.level)}`;
+}
+
+export function parseEnchants(itemRef: unknown): Enchant[] {
+	if (!itemRef || typeof itemRef !== 'object') return [];
+	const raw = (itemRef as { enchants?: unknown }).enchants;
+	if (!Array.isArray(raw)) return [];
+	const out: Enchant[] = [];
+	for (const e of raw) {
+		if (!e || typeof e !== 'object') continue;
+		const id = (e as { id?: unknown }).id;
+		const level = (e as { level?: unknown }).level;
+		if (typeof id !== 'string' || !id) continue;
+		const lvl =
+			typeof level === 'number' && Number.isFinite(level)
+				? Math.max(1, Math.floor(level))
+				: 1;
+		out.push({ id, level: lvl });
+	}
+	return out;
+}

--- a/packages/npm/rn/src/markets/market/errors.ts
+++ b/packages/npm/rn/src/markets/market/errors.ts
@@ -1,0 +1,10 @@
+export class MarketApiError extends Error {
+	status: number;
+	code?: string;
+	constructor(message: string, status: number, code?: string) {
+		super(message);
+		this.name = 'MarketApiError';
+		this.status = status;
+		this.code = code;
+	}
+}

--- a/packages/npm/rn/src/markets/market/format.ts
+++ b/packages/npm/rn/src/markets/market/format.ts
@@ -1,0 +1,44 @@
+export function formatKhash(n: number | null | undefined): string {
+	if (n === null || n === undefined) return '—';
+	return `${n.toLocaleString()} KHash`;
+}
+
+export function formatRelative(iso: string): string {
+	const s = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+	if (s < 60) return `${s}s ago`;
+	const m = Math.round(s / 60);
+	if (m < 60) return `${m}m ago`;
+	const h = Math.round(m / 60);
+	if (h < 48) return `${h}h ago`;
+	return `${Math.round(h / 24)}d ago`;
+}
+
+export function formatExpiry(iso: string): string {
+	const ms = new Date(iso).getTime() - Date.now();
+	if (ms <= 0) return 'expired';
+	const s = Math.round(ms / 1000);
+	if (s < 60) return `${s}s left`;
+	const m = Math.round(s / 60);
+	if (m < 60) return `${m}m left`;
+	const h = Math.round(m / 60);
+	if (h < 48) return `${h}h left`;
+	return `${Math.round(h / 24)}d left`;
+}
+
+export function itemRefLabel(itemRef: unknown): string {
+	if (itemRef && typeof itemRef === 'object') {
+		const o = itemRef as Record<string, unknown>;
+		const kind = typeof o.kind === 'string' ? o.kind : '';
+		const id = typeof o.id === 'string' ? o.id : '';
+		if (kind && id) return `${kind}:${id}`;
+		if (id) return id;
+		return JSON.stringify(itemRef).slice(0, 64);
+	}
+	return 'Unknown item';
+}
+
+export function itemRefHasEnchants(itemRef: unknown): boolean {
+	if (!itemRef || typeof itemRef !== 'object') return false;
+	const e = (itemRef as Record<string, unknown>).enchants;
+	return Array.isArray(e) && e.length > 0;
+}

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export { MarketApiError } from './errors';
+export * from './format';
+export { useCountdown, formatCountdown } from './countdown';
+export type { Countdown } from './countdown';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -8,3 +8,5 @@ export type { MarketApi, MarketApiOptions } from './api';
 export { WatchToggle } from './WatchToggle';
 export { getWatchList, isWatched, toggleWatch, subscribe } from './watchlist';
 export type { WatchEntry } from './watchlist';
+export { ItemIcon } from './ItemIcon';
+export { EnchantList } from './EnchantList';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -10,3 +10,7 @@ export { getWatchList, isWatched, toggleWatch, subscribe } from './watchlist';
 export type { WatchEntry } from './watchlist';
 export { ItemIcon } from './ItemIcon';
 export { EnchantList } from './EnchantList';
+export { ListingCard } from './ListingCard';
+export type { ListingCardProps } from './ListingCard';
+export { MarketBrowse } from './MarketBrowse';
+export type { MarketBrowseProps } from './MarketBrowse';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -20,3 +20,5 @@ export { ListingDetail } from './ListingDetail';
 export type { ListingDetailProps } from './ListingDetail';
 export { ListingDetailView } from './ListingDetailView';
 export type { ListingDetailViewProps } from './ListingDetailView';
+export { MarketView } from './MarketView';
+export type { MarketViewProps } from './MarketView';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -5,3 +5,6 @@ export { useCountdown, formatCountdown } from './countdown';
 export type { Countdown } from './countdown';
 export { createMarketApi } from './api';
 export type { MarketApi, MarketApiOptions } from './api';
+export { WatchToggle } from './WatchToggle';
+export { getWatchList, isWatched, toggleWatch, subscribe } from './watchlist';
+export type { WatchEntry } from './watchlist';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -14,3 +14,5 @@ export { ListingCard } from './ListingCard';
 export type { ListingCardProps } from './ListingCard';
 export { MarketBrowse } from './MarketBrowse';
 export type { MarketBrowseProps } from './MarketBrowse';
+export { MarketCreateForm } from './MarketCreateForm';
+export type { MarketCreateFormProps } from './MarketCreateForm';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -16,3 +16,7 @@ export { MarketBrowse } from './MarketBrowse';
 export type { MarketBrowseProps } from './MarketBrowse';
 export { MarketCreateForm } from './MarketCreateForm';
 export type { MarketCreateFormProps } from './MarketCreateForm';
+export { ListingDetail } from './ListingDetail';
+export type { ListingDetailProps } from './ListingDetail';
+export { ListingDetailView } from './ListingDetailView';
+export type { ListingDetailViewProps } from './ListingDetailView';

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -3,3 +3,5 @@ export { MarketApiError } from './errors';
 export * from './format';
 export { useCountdown, formatCountdown } from './countdown';
 export type { Countdown } from './countdown';
+export { createMarketApi } from './api';
+export type { MarketApi, MarketApiOptions } from './api';

--- a/packages/npm/rn/src/markets/market/types.ts
+++ b/packages/npm/rn/src/markets/market/types.ts
@@ -1,0 +1,58 @@
+export type ListingStatus = 'active' | 'sold' | 'cancelled' | 'expired';
+export type BidStatus = 'active' | 'outbid' | 'won' | 'refunded' | 'cancelled';
+
+export interface MarketListing {
+	listing_id: number;
+	seller_account: string;
+	item_ref: Record<string, unknown>;
+	currency: string;
+	buy_now_price: number | null;
+	min_bid: number | null;
+	current_bid: number | null;
+	expires_at: string;
+	created_at: string;
+}
+
+export interface MarketListingDetail extends MarketListing {
+	current_bid_id: number | null;
+	listing_status: ListingStatus;
+	updated_at: string;
+	settled_at: string | null;
+	bids: Array<Record<string, unknown>>;
+}
+
+export interface MyListing {
+	listing_id: number;
+	item_ref: Record<string, unknown>;
+	currency: string;
+	buy_now_price: number | null;
+	min_bid: number | null;
+	current_bid: number | null;
+	current_bid_account: string | null;
+	buyer_account: string | null;
+	listing_status: ListingStatus;
+	expires_at: string;
+	created_at: string;
+	settled_at: string | null;
+}
+
+export interface MyBid {
+	bid_id: number;
+	listing_id: number;
+	amount: number;
+	bid_status: BidStatus;
+	placed_at: string;
+	settled_at: string | null;
+	escrow_ledger_id: number;
+	refund_ledger_id: number | null;
+}
+
+export interface IdResponse {
+	id: number;
+}
+
+export interface Cursor {
+	limit?: number;
+	before_created_at?: string | null;
+	before_id?: number | null;
+}

--- a/packages/npm/rn/src/markets/market/watchlist.ts
+++ b/packages/npm/rn/src/markets/market/watchlist.ts
@@ -1,0 +1,117 @@
+export type WatchEntry = {
+	kind: string;
+	ref: string;
+};
+
+const STORAGE_KEY = 'kbve:market:watchlist:v1';
+const subscribers = new Set<() => void>();
+
+function isBrowser(): boolean {
+	return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+}
+
+function entryKey(e: WatchEntry): string {
+	return `${e.kind}::${e.ref}`;
+}
+
+function readRaw(): WatchEntry[] {
+	if (!isBrowser()) return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		const out: WatchEntry[] = [];
+		const seen = new Set<string>();
+		for (const e of parsed) {
+			if (
+				e &&
+				typeof e === 'object' &&
+				typeof e.kind === 'string' &&
+				typeof e.ref === 'string'
+			) {
+				const k = entryKey(e);
+				if (!seen.has(k)) {
+					seen.add(k);
+					out.push({ kind: e.kind, ref: e.ref });
+				}
+			}
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
+function writeRaw(entries: WatchEntry[]): void {
+	if (!isBrowser()) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+	} catch {
+		void 0;
+	}
+}
+
+function notify(): void {
+	for (const fn of subscribers) {
+		try {
+			fn();
+		} catch {
+			void 0;
+		}
+	}
+}
+
+export function getWatchList(): WatchEntry[] {
+	return readRaw();
+}
+
+export function isWatched(entry: WatchEntry): boolean {
+	const list = readRaw();
+	const k = entryKey(entry);
+	return list.some((e) => entryKey(e) === k);
+}
+
+export function addToWatch(entry: WatchEntry): void {
+	const list = readRaw();
+	const k = entryKey(entry);
+	if (list.some((e) => entryKey(e) === k)) return;
+	list.push({ kind: entry.kind, ref: entry.ref });
+	writeRaw(list);
+	notify();
+}
+
+export function removeFromWatch(entry: WatchEntry): void {
+	const list = readRaw();
+	const k = entryKey(entry);
+	const next = list.filter((e) => entryKey(e) !== k);
+	if (next.length === list.length) return;
+	writeRaw(next);
+	notify();
+}
+
+export function toggleWatch(entry: WatchEntry): boolean {
+	if (isWatched(entry)) {
+		removeFromWatch(entry);
+		return false;
+	}
+	addToWatch(entry);
+	return true;
+}
+
+export function subscribe(fn: () => void): () => void {
+	subscribers.add(fn);
+	if (isBrowser()) {
+		const onStorage = (ev: StorageEvent) => {
+			if (ev.key === STORAGE_KEY) fn();
+		};
+		window.addEventListener('storage', onStorage);
+		return () => {
+			subscribers.delete(fn);
+			window.removeEventListener('storage', onStorage);
+		};
+	}
+	return () => {
+		subscribers.delete(fn);
+	};
+}

--- a/packages/npm/rn/src/markets/shared.ts
+++ b/packages/npm/rn/src/markets/shared.ts
@@ -1,0 +1,27 @@
+export function newIdempotencyKey(): string {
+	const c = (globalThis as { crypto?: Crypto }).crypto;
+	if (c?.randomUUID) return c.randomUUID();
+	if (c?.getRandomValues) {
+		const b = c.getRandomValues(new Uint8Array(16));
+		b[6] = (b[6] & 0x0f) | 0x40;
+		b[8] = (b[8] & 0x3f) | 0x80;
+		const h = Array.from(b, (x) => x.toString(16).padStart(2, '0'));
+		return `${h[0]}${h[1]}${h[2]}${h[3]}-${h[4]}${h[5]}-${h[6]}${h[7]}-${h[8]}${h[9]}-${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}`;
+	}
+	return `k-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+}
+
+const WALLET_BROADCAST = 'kbve-wallet-sync';
+
+export function notifyWalletRefresh(): void {
+	const B = (globalThis as { BroadcastChannel?: typeof BroadcastChannel })
+		.BroadcastChannel;
+	if (!B) return;
+	try {
+		const ch = new B(WALLET_BROADCAST);
+		ch.postMessage({ type: 'refresh' });
+		ch.close();
+	} catch {
+		void 0;
+	}
+}

--- a/packages/npm/rn/src/markets/store/StoreView.tsx
+++ b/packages/npm/rn/src/markets/store/StoreView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Stack } from '../../ui/primitives/Stack';
 import { Text } from '../../ui/primitives/Text';
-import { tokens } from '@kbve/rn/ui/theme';
+import { tokens } from '../../ui/theme';
 import { createStoreApi } from './api';
 import { BuyCredits } from './BuyCredits';
 import { ProductCard } from './ProductCard';

--- a/packages/npm/rn/src/markets/store/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/store/__tests__/api.test.ts
@@ -48,18 +48,18 @@ describe('createStoreApi', () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 	});
 
-	it('non-OK JSON body surfaces error message + status + code', async () => {
+	it('non-OK JSON body surfaces human message over slug; code = error slug', async () => {
 		(global.fetch as any).mockResolvedValue({
 			ok: false,
 			status: 402,
-			text: async () => JSON.stringify({ error: 'insufficient', code: 'P1001' }),
+			text: async () => JSON.stringify({ error: 'insufficient_funds', message: 'not enough credits' }),
 		});
 		const api = createStoreApi({ getToken: token });
 		const err = await api.buyProduct('x').catch((e) => e);
 		expect(err).toBeInstanceOf(StoreApiError);
 		expect(err.status).toBe(402);
-		expect(err.code).toBe('P1001');
-		expect(err.message).toBe('insufficient');
+		expect(err.message).toBe('not enough credits');
+		expect(err.code).toBe('insufficient_funds');
 	});
 
 	it('topupCheckout returns checkout_url', async () => {

--- a/packages/npm/rn/src/markets/store/api.ts
+++ b/packages/npm/rn/src/markets/store/api.ts
@@ -63,11 +63,11 @@ export function createStoreApi(opts: StoreApiOptions): StoreApi {
 			json = undefined;
 		}
 		if (!res.ok) {
-			const j = (json ?? {}) as { error?: string; message?: string; code?: string };
+			const j = (json ?? {}) as { error?: string; message?: string; detail?: string };
 			throw new StoreApiError(
-				j.error ?? j.message ?? (text || `HTTP ${res.status}`),
+				j.message ?? j.error ?? j.detail ?? (text || `HTTP ${res.status}`),
 				res.status,
-				j.code,
+				j.error,
 			);
 		}
 		return json as T;

--- a/packages/npm/rn/src/markets/store/keys.ts
+++ b/packages/npm/rn/src/markets/store/keys.ts
@@ -1,12 +1,1 @@
-export function newIdempotencyKey(): string {
-	const c = (globalThis as { crypto?: Crypto }).crypto;
-	if (c?.randomUUID) return c.randomUUID();
-	if (c?.getRandomValues) {
-		const b = c.getRandomValues(new Uint8Array(16));
-		b[6] = (b[6] & 0x0f) | 0x40;
-		b[8] = (b[8] & 0x3f) | 0x80;
-		const h = Array.from(b, (x) => x.toString(16).padStart(2, '0'));
-		return `${h[0]}${h[1]}${h[2]}${h[3]}-${h[4]}${h[5]}-${h[6]}${h[7]}-${h[8]}${h[9]}-${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}`;
-	}
-	return `k-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-}
+export { newIdempotencyKey } from '../shared';

--- a/packages/npm/rn/src/markets/store/walletSync.ts
+++ b/packages/npm/rn/src/markets/store/walletSync.ts
@@ -1,14 +1,1 @@
-const WALLET_BROADCAST = 'kbve-wallet-sync';
-
-export function notifyWalletRefresh(): void {
-	const B = (globalThis as { BroadcastChannel?: typeof BroadcastChannel })
-		.BroadcastChannel;
-	if (!B) return;
-	try {
-		const ch = new B(WALLET_BROADCAST);
-		ch.postMessage({ type: 'refresh' });
-		ch.close();
-	} catch {
-		void 0;
-	}
-}
+export { notifyWalletRefresh } from '../shared';


### PR DESCRIPTION
Phase 2 of the store/market → `@kbve/rn/markets` epic (Phase 1 = #14338, merged). Ports the customer marketplace (`/market/` browse+sell, `/market/listing/` detail) into the universal RN composition + bento splash + Commerce rail, mirroring shipped `/store/`. Rebased onto dev (Phase 1's squash is already in dev).

## What's in
- **`@kbve/rn/markets/market`** sub-area: `createMarketApi({getToken, baseUrl})` factory; `MarketBrowse` (grid + kind filter + cursor pagination + live countdown), `MarketCreateForm` (sell — UUID field + duration Select), `ListingDetail`/`ListingDetailView` (bid / buy-now / cancel + bid history + seller/bidder/signed-out), `ListingCard`, `WatchToggle`, `ItemIcon`, `EnchantList`, `MarketView`. Universal; UI imported relative (`../../ui/primitives/*`) — web-safe (0 vector-icons in built chunks).
- **Bridges** `ReactMarketRN` + `ReactMarketDetailRN` (Supabase token, `baseUrl=''`, no staff gate; detail reads `?id=`).
- **Bento** `AstroMarketShell` + `AstroMarketDetailShell` (violet) + `template: splash` on `/market/`.
- **Store retrofit** (Phase 0): store UI imports → relative (`enforce-module-boundaries`); shared `newIdempotencyKey`/`notifyWalletRefresh` hoisted to `markets/shared.ts`.
- **Fix**: market **and** store API error precedence now matches `@kbve/droid` (human `message` over `error` slug; `code = error` slug) — verified against axum `{error, message}` shape.

## Verification
- markets vitest **28/28**; eslint markets/market **0 errors**.
- `astro build` **EXIT 0**. `/market/` = splash (no Starlight sidebar) + bento-hero + Commerce rail + `ReactMarketRN` island + `rnsk`; `/market/listing/` = `ReactMarketDetailRN` island. Built market chunks **0** `vector-icons`.
- Final opus whole-branch review: ready to merge, 0 Critical/Important.
- Not run: live Playwright hydration.

## Deferred → Phase 3
`/dashboard/store/` (staff admin), `/dashboard/market/` (personal `MarketProfileShell`), `MCItemMarketSidecar`, Expo mobile. Old DOM `components/market/*` + `market.css` kept (live via admin/profile shells). Minor a11y (`ItemIcon` label) + numeric-item-id support deferred (ids are string slugs).

No kube/infra changes.