### PR TITLE
fix(deps): declare unist-util-visit for astro build under pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
 		"ts-node": "10.9.2",
 		"twin.macro": "^3.4.1",
 		"typescript": "5.9.3",
+		"unist-util-visit": "^5.1.0",
 		"verdaccio": "6.5.1",
 		"vite": "8.0.9",
 		"vite-plugin-dts": "4.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       verdaccio:
         specifier: 6.5.1
         version: 6.5.1(encoding@0.1.13)(supports-color@10.2.2)(typanion@3.14.0)
@@ -15584,9 +15587,6 @@ packages:
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
-  unist-util-is@6.0.0:
-    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
-
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -15613,9 +15613,6 @@ packages:
 
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
-
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
@@ -33975,7 +33972,7 @@ snapshots:
       hast-util-is-element: 3.0.0
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.2
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   rehype-format@5.0.1:
     dependencies:
@@ -35871,10 +35868,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
-  unist-util-is@6.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -35908,18 +35901,12 @@ snapshots:
   unist-util-visit-parents@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
-
-  unist-util-visit@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.2
 
   unist-util-visit@5.1.0:
     dependencies:


### PR DESCRIPTION
## Why
`CI - Docker / axum-kbve` e2e failed (run [29725384705](https://github.com/KBVE/kbve/actions/runs/29725384705), exit 130). The astro-kbve build inside the axum-kbve image died with:

```
Cannot find module 'unist-util-visit' imported from /app/apps/kbve/astro-kbve/src/lib/rehype-link-attrs.mjs
```

so `dist/apps/astro-kbve` was never produced and the Docker build failed at the COPY.

Same root cause as #14399 (glob / gray-matter): a bare-specifier import that was only ever satisfied by pnpm 10's transitive hoisting, which **pnpm 11 dropped** after the bump (#14394).

## Changes
- Declare `unist-util-visit@^5.1.0` in root `package.json`
- Lockfile update also dedups the duplicate `unist-util-visit@5.0.0` / `unist-util-is@6.0.0` onto `5.1.0` / `6.0.1`

## Verify
`node --import ...rehype-link-attrs.mjs` resolves cleanly (`IMPORT OK`). Scanned all astro-kbve `src/lib/*.mjs` + `scripts/*.mts` bare imports — `unist-util-visit` was the only remaining undeclared one after #14399.