### PR TITLE
feat(rareicon): unit attributes — roll, persist, display (L1–L3)

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/Plugins/macOS/libuniti.dylib
+++ b/apps/rareicon/unity-rareicon/Assets/Plugins/macOS/libuniti.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a20f5107e860b91c4198ab2cbc51d904e0278e33988191de0041a7d19f30cf42
-size 2698336
+oid sha256:4bf900671692516fbaf3888d1a61abf145cefa9a62e72edee1912cbc3bd51c1d
+size 2681920

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/AttributeRoll.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/AttributeRoll.cs
@@ -1,0 +1,25 @@
+using Unity.Mathematics;
+
+namespace RareIcon
+{
+    /// <summary>Rolls per-character attributes from an NPCDef base, ±20% deterministic from rng byte lanes.
+    /// Base 0 stays 0; otherwise clamped to [1, 255]. Pure + deterministic so spawn and rehydrate agree.</summary>
+    public static class AttributeRoll
+    {
+        public static UnitAttributes Roll(in NPCDef def, uint rng) => new UnitAttributes
+        {
+            Strength  = Scale(def.Strength,  (byte)(rng         & 0xFF)),
+            Agility   = Scale(def.Agility,   (byte)((rng >> 8)  & 0xFF)),
+            Intellect = Scale(def.Intellect, (byte)((rng >> 16) & 0xFF)),
+            Will      = Scale(def.Will,      (byte)((rng >> 24) & 0xFF)),
+        };
+
+        static byte Scale(byte b, byte noise)
+        {
+            if (b == 0) return 0;
+            float spread = 0.8f + noise / 255f * 0.4f;   // [0.8, 1.2]
+            int v = (int)math.round(b * spread);
+            return (byte)math.clamp(v, 1, 255);
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/AttributeRoll.cs.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/AttributeRoll.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b16da1ec667d7467d9d3ce147f45385c

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/StatComponents.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/StatComponents.cs
@@ -24,6 +24,16 @@ namespace RareIcon
         public float Max;
     }
 
+    /// <summary>Per-character attributes rolled at spawn from the npcdb base (±20%), persisted exactly across save/load.
+    /// Display/flavor only for now; gameplay effects (STR→damage, AGI→speed, INT→aptitude, WILL→resist) are a later pass.</summary>
+    public struct UnitAttributes : IComponentData
+    {
+        public byte Strength;
+        public byte Agility;
+        public byte Intellect;
+        public byte Will;
+    }
+
     /// <summary>Food deficit. 0 = full, Max = starving. Refilled by ConsumeFoodExecutor; ticked up by NeedAccumulationSystem.</summary>
 
     public struct Hunger : IComponentData

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Components/UnitColdStoreOps.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Components/UnitColdStoreOps.cs
@@ -33,6 +33,10 @@ namespace RareIcon
             time_since_attack  = rec.TimeSinceAttack,
             attack_kind        = rec.AttackKind,
             target_mode        = rec.TargetMode,
+            strength           = rec.Strength,
+            agility            = rec.Agility,
+            intellect          = rec.Intellect,
+            will               = rec.Will,
         };
 
         public static UnloadedUnitRecord FromFfi(in FfiGhostUnit f) => new UnloadedUnitRecord
@@ -61,6 +65,10 @@ namespace RareIcon
             TimeSinceAttack = f.time_since_attack,
             AttackKind      = f.attack_kind,
             TargetMode      = f.target_mode,
+            Strength        = f.strength,
+            Agility         = f.agility,
+            Intellect       = f.intellect,
+            Will            = f.will,
         };
 
         public static UnloadedUnitRecord Snapshot(EntityManager em, Entity entity, float nowSecs = 0f)
@@ -134,6 +142,15 @@ namespace RareIcon
                 rec.AttackRange     = s.Range;
                 rec.AttackCooldown  = s.Cooldown;
                 rec.TimeSinceAttack = s.TimeSinceCast;
+            }
+
+            if (em.HasComponent<UnitAttributes>(entity))
+            {
+                var a = em.GetComponentData<UnitAttributes>(entity);
+                rec.Strength  = a.Strength;
+                rec.Agility   = a.Agility;
+                rec.Intellect = a.Intellect;
+                rec.Will      = a.Will;
             }
 
             byte flags = 0;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Components/UnitsDBSingleton.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Components/UnitsDBSingleton.cs
@@ -60,6 +60,12 @@ namespace RareIcon
         public byte   AttackKind;
         public byte   TargetMode;
 
+        /// <summary>Per-character attributes (npcdb base ±20%). 0 = absent (pre-v4 save) → roll fresh on hydrate.</summary>
+        public byte   Strength;
+        public byte   Agility;
+        public byte   Intellect;
+        public byte   Will;
+
         public byte   Type;
         public byte   Faction;
         public byte   Flags;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitAttributeBackfillSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitAttributeBackfillSystem.cs
@@ -1,0 +1,27 @@
+using Unity.Collections;
+using Unity.Entities;
+
+namespace RareIcon
+{
+    /// <summary>Attaches <see cref="UnitAttributes"/> to any unit missing it — rolled from the NPCDB base (±20%) off the
+    /// unit's RandomState seed. One place covers every spawn path; persistence-restored units already carry the component
+    /// (set during rehydrate) and are skipped. SystemBase because NPCDB.Get reads the managed NpcdbCache (not Burst).</summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial class UnitAttributeBackfillSystem : SystemBase
+    {
+        protected override void OnUpdate()
+        {
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            foreach (var (unit, movement, e) in
+                     SystemAPI.Query<RefRO<Unit>, RefRO<UnitMovement>>()
+                              .WithNone<UnitAttributes>()
+                              .WithEntityAccess())
+            {
+                var def = NPCDB.Get(unit.ValueRO.Type);
+                ecb.AddComponent(e, AttributeRoll.Roll(def, movement.ValueRO.RandomState | 1u));
+            }
+            ecb.Playback(EntityManager);
+            ecb.Dispose();
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitAttributeBackfillSystem.cs.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitAttributeBackfillSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a6355dd4fea3409d8cb554b7bb155bf

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs
@@ -17,7 +17,10 @@ namespace RareIcon
         public ushort Inv1Id, Inv1Qty;
         public ushort Inv2Id, Inv2Qty;
         public ushort Inv3Id, Inv3Qty;
+        public byte Strength, Agility, Intellect, Will;
+        public byte HasAttributes;
     }
+
 
     /// <summary>Spawns the initial King + ally-goblin cluster and exposes static spawn helpers for chunk-reload + hostile waves.</summary>
     [WorldSystemFilter(WorldSystemFilterFlags.LocalSimulation | WorldSystemFilterFlags.ClientSimulation | WorldSystemFilterFlags.ThinClientSimulation)]

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs
@@ -435,25 +435,35 @@ namespace RareIcon
                             Inv1Id = g.inv1_id, Inv1Qty = g.inv1_qty,
                             Inv2Id = g.inv2_id, Inv2Qty = g.inv2_qty,
                             Inv3Id = g.inv3_id, Inv3Qty = g.inv3_qty,
+                            Strength = g.strength, Agility = g.agility, Intellect = g.intellect, Will = g.will,
+                            HasAttributes = (byte)((g.strength | g.agility | g.intellect | g.will) != 0 ? 1 : 0),
                         };
 
                         uint rng = (uint)g.q * 0x9E3779B1u
                                  ^ (uint)g.r * 0x85EBCA77u
                                  ^ ((uint)i + 1u);
                         rng |= 1u;
+                        Entity spawned;
                         if (g.unit_type == UnitType.King)
                         {
-                            UnitSpawnSystem.SpawnKingAt(em, hex, state);
+                            spawned = UnitSpawnSystem.SpawnKingAt(em, hex, state);
                         }
                         else if (g.unit_type == UnitType.Chicken
                               || g.unit_type == UnitType.Sheep
                               || g.unit_type == UnitType.Cow)
                         {
-                            UnitSpawnSystem.SpawnAnimalAt(em, hex, rng, g.unit_type, state);
+                            spawned = UnitSpawnSystem.SpawnAnimalAt(em, hex, rng, g.unit_type, state);
                         }
                         else
                         {
-                            UnitSpawnSystem.SpawnGoblinAt(em, hex, rng, state);
+                            spawned = UnitSpawnSystem.SpawnGoblinAt(em, hex, rng, state);
+                        }
+
+                        if (state.HasAttributes != 0 && em.Exists(spawned))
+                        {
+                            var attrs = new UnitAttributes { Strength = state.Strength, Agility = state.Agility, Intellect = state.Intellect, Will = state.Will };
+                            if (em.HasComponent<UnitAttributes>(spawned)) em.SetComponentData(spawned, attrs);
+                            else em.AddComponentData(spawned, attrs);
                         }
                     }
                 }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Native/Uniti.g.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Native/Uniti.g.cs
@@ -1078,6 +1078,10 @@ namespace RareIcon.Native
         public float time_since_attack;
         public byte attack_kind;
         public byte target_mode;
+        public byte strength;
+        public byte agility;
+        public byte intellect;
+        public byte will;
     }
 
     /// <summary>

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Native/Wrappers/NativeWorld.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Native/Wrappers/NativeWorld.cs
@@ -15,7 +15,7 @@ namespace RareIcon.Native
     public unsafe class NativeWorld : IDisposable
     {
         /// <summary>FFI struct schema version. Must match <c>UNITI_FFI_SCHEMA_VERSION</c> in <c>packages/rust/bevy/uniti/src/ffi_world.rs</c>. Bumped together when any blittable struct layout changes.</summary>
-        public const uint ExpectedSchemaVersion = 3;
+        public const uint ExpectedSchemaVersion = 4;
 
         void* _handle;
         bool  _disposed;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/UI/RosterTab.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/UI/RosterTab.cs
@@ -46,6 +46,7 @@ namespace RareIcon
         Label _detailTitle;
         Label _detailActivity;
         Label _detailTraits;
+        Label _detailAttrs;
         VisualElement _detailStats;
         VisualElement _jobsSection;
         UIControls.StepperHandle[] _jobSteppers;
@@ -118,6 +119,10 @@ namespace RareIcon
             _detailHu = new StatBar("HU", "hu", _detailStats);
             _detailFt = new StatBar("FT", "ft", _detailStats);
             _detail.Add(_detailStats);
+
+            _detailAttrs = new Label(string.Empty);
+            _detailAttrs.AddToClassList("roster-detail__attrs");
+            _detail.Add(_detailAttrs);
 
             BuildJobs(_detail);
 
@@ -317,6 +322,7 @@ namespace RareIcon
             _detailActivity.text = string.Empty;
             _detailTraits.text = string.Empty;
             _detailTraits.AddToClassList("is-hidden");
+            _detailAttrs.text = string.Empty;
             _detailHp.Clear(); _detailEn.Clear(); _detailHu.Clear(); _detailFt.Clear();
             _jobsSection.style.display = DisplayStyle.None;
             _jumpBtn.SetEnabled(false);
@@ -363,6 +369,13 @@ namespace RareIcon
             UpdateBar(em, entity, _detailFt, has: em.HasComponent<Fatigue>(entity),
                 value: em.HasComponent<Fatigue>(entity) ? em.GetComponentData<Fatigue>(entity).Value : 0f,
                 max:   em.HasComponent<Fatigue>(entity) ? em.GetComponentData<Fatigue>(entity).Max   : 0f);
+
+            if (em.HasComponent<UnitAttributes>(entity))
+            {
+                var a = em.GetComponentData<UnitAttributes>(entity);
+                _detailAttrs.text = $"STR {a.Strength}   AGI {a.Agility}   INT {a.Intellect}   WILL {a.Will}";
+            }
+            else _detailAttrs.text = string.Empty;
 
             var snapshot = _activity.CurrentFor(entity);
             string activityLabel = _locale.GetActivityName(snapshot.Kind);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/AttributeRollTests.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/AttributeRollTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+
+namespace RareIcon.Tests
+{
+    /// <summary>Deterministic spread + clamp behavior for AttributeRoll (Task 1, unit-attributes L1).</summary>
+    public class AttributeRollTests
+    {
+        static NPCDef Goblin() => new NPCDef(
+            UnitType.Goblin, "creature.goblin", NPCCategory.Humanoid,
+            40f, 100f, 30f, 100f, 100f, 0.7f, 0f, 5f, 0.5f, 0.285f, 0.20f,
+            strength: 8, agility: 12, intellect: 4, will: 5, defaultWeapon: WeaponType.Club);
+
+        [Test]
+        public void Roll_MinNoise_IsEightyPercent()
+        {
+            var a = AttributeRoll.Roll(Goblin(), 0u);          // all lanes 0 -> 0.8x
+            Assert.AreEqual(6, a.Strength);                    // round(8*0.8)=6
+            Assert.AreEqual(10, a.Agility);                    // round(12*0.8)=10
+        }
+
+        [Test]
+        public void Roll_MaxNoise_IsOneTwentyPercent()
+        {
+            var a = AttributeRoll.Roll(Goblin(), 0xFFFFFFFFu); // all lanes 255 -> 1.2x
+            Assert.AreEqual(10, a.Strength);                   // round(8*1.2)=10
+            Assert.AreEqual(14, a.Agility);                    // round(12*1.2)=14
+        }
+
+        [Test]
+        public void Roll_IsDeterministic()
+        {
+            var a = AttributeRoll.Roll(Goblin(), 12345u);
+            var b = AttributeRoll.Roll(Goblin(), 12345u);
+            Assert.AreEqual(a.Strength, b.Strength);
+            Assert.AreEqual(a.Agility, b.Agility);
+            Assert.AreEqual(a.Intellect, b.Intellect);
+            Assert.AreEqual(a.Will, b.Will);
+        }
+
+        [Test]
+        public void Roll_ZeroBase_StaysZero()
+        {
+            var def = new NPCDef(
+                UnitType.Chicken, "creature.chicken", NPCCategory.Beast,
+                5f, 0f, 0f, 0f, 0f, 0.45f, 0f, 0f, 0f, 0f, 0f,
+                strength: 0, agility: 10, intellect: 1, will: 1, defaultWeapon: WeaponType.None);
+            var a = AttributeRoll.Roll(def, 0u);
+            Assert.AreEqual(0, a.Strength);
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/AttributeRollTests.cs.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/AttributeRollTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9afea8f3f9b824f52931179bb321807a

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/RareIcon.Tests.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/RareIcon.Tests.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "RareIcon.Tests",
     "references": [
         "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
+        "UnityEditor.TestRunner",
+        "RareIcon.Game"
     ],
     "includePlatforms": [
         "Editor"

--- a/docs/superpowers/plans/2026-07-20-rareicon-unit-attributes.md
+++ b/docs/superpowers/plans/2026-07-20-rareicon-unit-attributes.md
@@ -1,0 +1,336 @@
+# RareIcon Unit Attributes (L1–L3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every unit four rolled attributes (Strength/Agility/Intellect/Will) sourced from the npcdb proto base, varied ±20% per-character, persisted exactly across save/load, and displayed in the Citizens UI — with zero gameplay behavior change (Layer 4 effects are a separate later plan).
+
+**Architecture:** A byte `UnitAttributes` IComponentData attached at spawn from a pure deterministic `AttributeRoll.Roll(def, rng)` helper. Values persist through the Rust `uniti` SQLite ghost store (new columns + schema bump + migration) and the regenerated FFI binding, restored exactly on rehydrate (roll-fresh only for pre-attributes saves). The Citizens panel gains four read-only stat rows.
+
+**Tech Stack:** Unity DOTS/ECS (C#, Burst), Unity UI Toolkit (UXML), Rust (`uniti` crate, rusqlite FFI), the npcdb proto pipeline (already shipped).
+
+## Global Constraints
+
+- Attributes are byte (1–255); base 0 stays 0. Clamp floor is 1 only when base > 0.
+- Spread ∈ [0.8, 1.2] (±20%), deterministic from `rng` byte lanes — same technique as existing `speedJit`.
+- Every spawn path must attach `UnitAttributes` (17 `Spawn*` methods; delegating ones inherit).
+- Persistence must not break old saves: bump `SCHEMA_VERSION` + `UNITI_FFI_SCHEMA_VERSION` (both currently 3 → 4), add a v3→v4 migration, absent attributes → roll fresh once on load.
+- No gameplay behavior change: do NOT touch combat/harvest/dispatch/needs this plan. `speedJit` stays as-is (AGI folding is Layer 4).
+- Follow existing patterns: `UnitAttributes` lives beside the other stat components in `ECS/Components/StatComponents.cs`.
+
+---
+
+## File Structure
+
+- `Assets/_RareIcon/Scripts/ECS/Components/StatComponents.cs` — add `UnitAttributes` struct (modify).
+- `Assets/_RareIcon/Scripts/Data/AttributeRoll.cs` — pure roll helper (create).
+- `Assets/_RareIcon/Tests/AttributeRollTests.cs` — EditMode NUnit tests (create).
+- `Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs` — attach at spawn + `UnitSpawnState` fields (modify).
+- `packages/rust/bevy/uniti/src/ffi_world.rs` — ghost struct fields, schema bump, migration, save/load (modify).
+- `packages/rust/bevy/uniti/tests/ffi_migration.rs` — persistence round-trip + migration test (modify).
+- `Assets/_RareIcon/Generated/Native/Uniti.g.cs` — regenerated binding (generated).
+- `Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs` — rehydrate restore/roll-fresh (modify).
+- `Assets/Resources/UI/Citizens.uxml` — four stat rows (modify).
+- `Assets/_RareIcon/Scripts/UI/UICitizensPanel.cs` — bind rows from selected `UnitAttributes` (modify).
+
+---
+
+## Task 1: `UnitAttributes` component + deterministic roll helper
+
+**Files:**
+
+- Modify: `Assets/_RareIcon/Scripts/ECS/Components/StatComponents.cs`
+- Create: `Assets/_RareIcon/Scripts/Data/AttributeRoll.cs`
+- Test: `Assets/_RareIcon/Tests/AttributeRollTests.cs`
+
+**Interfaces:**
+
+- Produces: `struct UnitAttributes : IComponentData { byte Strength; byte Agility; byte Intellect; byte Will; }`
+- Produces: `static UnitAttributes AttributeRoll.Roll(in NPCDef def, uint rng)`
+
+- [ ] **Step 1: Add the component.** In `StatComponents.cs`, beside `Health`/`Energy`, add:
+
+```csharp
+    public struct UnitAttributes : IComponentData
+    {
+        public byte Strength;
+        public byte Agility;
+        public byte Intellect;
+        public byte Will;
+    }
+```
+
+- [ ] **Step 2: Write the failing test.** Create `Assets/_RareIcon/Tests/AttributeRollTests.cs` (assembly `RareIcon.Tests`):
+
+```csharp
+using NUnit.Framework;
+using RareIcon;
+
+public class AttributeRollTests
+{
+    static NPCDef Goblin() => new NPCDef(
+        UnitType.Goblin, "creature.goblin", NPCCategory.Humanoid,
+        40f, 100f, 30f, 100f, 100f, 0.7f, 0f, 5f, 0.5f, 0.285f, 0.20f,
+        strength: 8, agility: 12, intellect: 4, will: 5, defaultWeapon: WeaponType.Club);
+
+    [Test]
+    public void Roll_MinNoise_IsEightyPercent()
+    {
+        var a = AttributeRoll.Roll(Goblin(), 0u);          // all lanes 0 -> 0.8x
+        Assert.AreEqual(6, a.Strength);                    // round(8*0.8)=6
+        Assert.AreEqual(10, a.Agility);                    // round(12*0.8)=10
+    }
+
+    [Test]
+    public void Roll_MaxNoise_IsOneTwentyPercent()
+    {
+        var a = AttributeRoll.Roll(Goblin(), 0xFFFFFFFFu); // all lanes 255 -> 1.2x
+        Assert.AreEqual(10, a.Strength);                   // round(8*1.2)=10
+        Assert.AreEqual(14, a.Agility);                    // round(12*1.2)=14
+    }
+
+    [Test]
+    public void Roll_IsDeterministic()
+    {
+        Assert.AreEqual(AttributeRoll.Roll(Goblin(), 12345u), AttributeRoll.Roll(Goblin(), 12345u));
+    }
+
+    [Test]
+    public void Roll_ZeroBase_StaysZero()
+    {
+        var def = new NPCDef(UnitType.Chicken, "creature.chicken", NPCCategory.Beast,
+            5f, 0f, 0f, 0f, 0f, 0.45f, 0f, 0f, 0f, 0f, 0f,
+            strength: 0, agility: 10, intellect: 1, will: 1, defaultWeapon: WeaponType.None);
+        var a = AttributeRoll.Roll(def, 0u);
+        Assert.AreEqual(0, a.Strength);
+    }
+}
+```
+
+- [ ] **Step 3: Run it — verify it fails.** In Unity: Window → General → Test Runner → EditMode → Run. Expected: FAIL (`AttributeRoll` does not exist).
+
+- [ ] **Step 4: Implement the helper.** Create `Assets/_RareIcon/Scripts/Data/AttributeRoll.cs`:
+
+```csharp
+using Unity.Mathematics;
+
+namespace RareIcon
+{
+    /// <summary>Rolls per-character attributes from an NPCDef base, ±20% deterministic from rng byte lanes.</summary>
+    public static class AttributeRoll
+    {
+        public static UnitAttributes Roll(in NPCDef def, uint rng) => new UnitAttributes
+        {
+            Strength  = Scale(def.Strength,  (byte)(rng         & 0xFF)),
+            Agility   = Scale(def.Agility,   (byte)((rng >> 8)  & 0xFF)),
+            Intellect = Scale(def.Intellect, (byte)((rng >> 16) & 0xFF)),
+            Will      = Scale(def.Will,      (byte)((rng >> 24) & 0xFF)),
+        };
+
+        static byte Scale(byte b, byte noise)
+        {
+            if (b == 0) return 0;
+            float spread = 0.8f + noise / 255f * 0.4f;   // [0.8, 1.2]
+            int v = (int)math.round(b * spread);
+            return (byte)math.clamp(v, 1, 255);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests — verify pass.** Test Runner → EditMode → Run. Expected: all 4 PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add Assets/_RareIcon/Scripts/ECS/Components/StatComponents.cs Assets/_RareIcon/Scripts/Data/AttributeRoll.cs Assets/_RareIcon/Tests/AttributeRollTests.cs
+git commit -m "feat(rareicon): UnitAttributes component + deterministic AttributeRoll"
+```
+
+---
+
+## Task 2: Attach `UnitAttributes` at every spawn path
+
+**Files:**
+
+- Modify: `Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs`
+
+**Interfaces:**
+
+- Consumes: `AttributeRoll.Roll(in NPCDef, uint)` (Task 1).
+- Produces: private `static void AttachAttributes(EntityManager em, Entity e, in NPCDef def, uint rngSeed, in UnitSpawnState state)` — restores exact values when `state.HasAttributes != 0`, else rolls.
+
+- [ ] **Step 1: Add the shared attach helper.** In `UnitSpawnSystem`, near the other `Attach*` helpers, add:
+
+```csharp
+        static void AttachAttributes(EntityManager em, Entity e, in NPCDef def, uint rngSeed, in UnitSpawnState state)
+        {
+            var attrs = state.HasAttributes != 0
+                ? new UnitAttributes { Strength = state.Strength, Agility = state.Agility, Intellect = state.Intellect, Will = state.Will }
+                : AttributeRoll.Roll(def, rngSeed);
+            em.AddComponentData(e, attrs);
+        }
+```
+
+(`UnitSpawnState.HasAttributes`/`Strength`/… land in Task 5; add the four `byte` + `byte HasAttributes` fields to `UnitSpawnState` now as part of this step so the helper compiles — see the struct at `UnitSpawnSystem.cs:12`.)
+
+- [ ] **Step 2: Call it in each independent spawn path.** After `def` is resolved and the entity created, add `AttachAttributes(em, entity, def, rngSeed, state);` in each of these methods (delegating methods `SpawnGuardGoblinAt`, `SpawnArcherSoldierAt` inherit via `SpawnGoblinAt` — do NOT double-add):
+      `SpawnGoblinAt` (uses its `state` param), `SpawnKingAt`, `SpawnAnimalAt`, `SpawnBanditAt`, `SpawnScoutAt`, `SpawnCavalryAt`, `SpawnBanditScoutAt`, `SpawnZombieAt`, `SpawnSkeletonAt`, `SpawnBeastAt`, `SpawnFishingBoatAt`, `SpawnGalleyAt`, `SpawnPirateShipAt`, `SpawnWhaleAt`, `SpawnHeroAt`. For methods without a `state` param, pass `default` (rolls fresh).
+
+- [ ] **Step 3: Verify compile + coverage.** In Unity, let it recompile (no errors). Enter Play mode, open the entity debugger (or add a temporary `Debug.Log` of `UnitAttributes` in a spawn), confirm spawned goblins carry non-zero varied STR/AGI/INT/WILL and two different goblins differ.
+
+- [ ] **Step 4: Remove any temporary log; commit.**
+
+```bash
+git add Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs
+git commit -m "feat(rareicon): roll + attach UnitAttributes on every spawn path"
+```
+
+---
+
+## Task 3: Rust persistence — columns, schema bump, migration, save/load
+
+**Files:**
+
+- Modify: `packages/rust/bevy/uniti/src/ffi_world.rs`
+- Test: `packages/rust/bevy/uniti/tests/ffi_migration.rs`
+
+**Interfaces:**
+
+- Produces: `FfiGhostUnit` (ffi_world.rs:56) gains `pub strength: u8, pub agility: u8, pub intellect: u8, pub will: u8`.
+- Produces: SQLite `units` table gains `strength/agility/intellect/will INTEGER NOT NULL DEFAULT 0`; `SCHEMA_VERSION` and `UNITI_FFI_SCHEMA_VERSION` both 3 → 4.
+
+- [ ] **Step 1: Write the failing test.** In `tests/ffi_migration.rs`, add a round-trip test that inserts a ghost unit with attributes, reloads, and asserts equality (mirror the existing `max_health` round-trip test in that file; reuse its harness). Assert `loaded.strength == 7` etc.
+
+- [ ] **Step 2: Run it — verify fail.**
+
+```bash
+cd /Users/alappatel/Documents/GitHub/kbve
+cargo test -p uniti --test ffi_migration 2>&1 | tail -20
+```
+
+Expected: FAIL (no `strength` field / column).
+
+- [ ] **Step 3: Add struct fields.** In `ffi_world.rs`, add the four `u8` fields to `FfiGhostUnit` (:56) and to the internal persisted row struct (:105, alongside `health`/`health_max`).
+
+- [ ] **Step 4: Bump schema + add columns.** Set `const SCHEMA_VERSION: i64 = 4;` (:332) and `pub const UNITI_FFI_SCHEMA_VERSION: u32 = 4;` (:1015). In the `CREATE TABLE` (:360) add `strength INTEGER NOT NULL DEFAULT 0, agility …, intellect …, will …`.
+
+- [ ] **Step 5: Add the v3→v4 migration.** In the migration block (:461 template), add: when stored version < 4, `ALTER TABLE units ADD COLUMN strength INTEGER NOT NULL DEFAULT 0;` (×4). Default 0 = "absent" sentinel → Unity rolls fresh.
+
+- [ ] **Step 6: Wire save/load.** SELECT (:557) + `row.get` (:575) read the four columns; INSERT (:762/:783) writes `u.strength` etc. Keep column order consistent between SELECT and INSERT.
+
+- [ ] **Step 7: Run tests — verify pass.**
+
+```bash
+cargo test -p uniti 2>&1 | tail -20
+```
+
+Expected: PASS (round-trip + existing tests green).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add packages/rust/bevy/uniti/src/ffi_world.rs packages/rust/bevy/uniti/tests/ffi_migration.rs
+git commit -m "feat(uniti): persist unit attributes — schema v4 + migration + round-trip"
+```
+
+---
+
+## Task 4: Regenerate the FFI binding
+
+**Files:**
+
+- Generated: `Assets/_RareIcon/Generated/Native/Uniti.g.cs`
+
+**Interfaces:**
+
+- Consumes: the Rust `FfiGhostUnit` from Task 3.
+- Produces: `FfiGhostUnit` (C#) with `strength/agility/intellect/will` byte fields matching the Rust layout.
+
+- [ ] **Step 1: Regenerate.** Run the binding generator the crate uses (cbindgen/uniffi — check `packages/rust/bevy/uniti/` build scripts / `Cargo.toml` for the codegen command; e.g. `cargo build -p uniti` if a build script emits the header, then the C# gen step). Confirm the exact command from the crate README before running.
+
+- [ ] **Step 2: Verify field parity.**
+
+```bash
+grep -n "strength\|agility\|intellect\|will" apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Native/Uniti.g.cs
+```
+
+Expected: the four fields present on the C# `FfiGhostUnit`, byte type, after `max_health`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Native/Uniti.g.cs
+git commit -m "chore(rareicon): regenerate uniti FFI binding for attribute fields"
+```
+
+---
+
+## Task 5: `UnitSpawnState` + rehydrate restore
+
+**Files:**
+
+- Modify: `Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs` (`UnitSpawnState` at :12)
+- Modify: `Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs` (rehydrate loop ~:420–445)
+
+**Interfaces:**
+
+- Consumes: `FfiGhostUnit` fields (Task 4), `AttachAttributes` (Task 2).
+- Produces: `UnitSpawnState` carries `byte Strength, Agility, Intellect, Will, HasAttributes`.
+
+- [ ] **Step 1: Confirm the `UnitSpawnState` fields exist** (added in Task 2 Step 1). If not present, add `public byte Strength, Agility, Intellect, Will; public byte HasAttributes;` to the struct at `UnitSpawnSystem.cs:12`.
+
+- [ ] **Step 2: Populate from the ghost record.** In `HexSpawnSystem` rehydrate, where `UnitSpawnState` is built from `g` (~:433), add:
+
+```csharp
+                            Strength = g.strength, Agility = g.agility, Intellect = g.intellect, Will = g.will,
+                            HasAttributes = (byte)((g.strength | g.agility | g.intellect | g.will) != 0 ? 1 : 0),
+```
+
+(Absent columns are DEFAULT 0 from the migration → `HasAttributes = 0` → `AttachAttributes` rolls fresh once, then persists thereafter.)
+
+- [ ] **Step 3: Verify in-editor round-trip.** Play → note a specific goblin's STR/AGI/INT/WILL (via inspector/log) → trigger a save + reload (focus-lost flush + reload, per the persistence flush hook) → confirm the same goblin shows identical attributes.
+
+- [ ] **Step 4: Verify old-save migration.** Load a pre-change save (schema v3): confirm it loads without error and units gain rolled attributes (non-zero), which then persist on the next save.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/UnitSpawnSystem.cs apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs
+git commit -m "feat(rareicon): restore UnitAttributes exactly on rehydrate, roll-fresh for old saves"
+```
+
+---
+
+## Task 6: Citizens UI — four stat rows
+
+**Files:**
+
+- Modify: `Assets/Resources/UI/Citizens.uxml`
+- Modify: `Assets/_RareIcon/Scripts/UI/UICitizensPanel.cs`
+
+**Interfaces:**
+
+- Consumes: `UnitAttributes` on the selected entity.
+
+- [ ] **Step 1: Confirm the per-unit host + selected-entity source.** In `UICitizensPanel.cs`, find where a selected citizen's existing stats (health/energy) are rendered (the per-unit content built under `citizens-content`). If per-unit stats are not yet shown here, target the panel/tab that displays a selected unit and read its entity. Note the resolved element names before editing.
+
+- [ ] **Step 2: Add four rows to `Citizens.uxml`.** Under the per-unit stat container, add four labeled rows following the existing stat-row markup pattern (copy an existing health/energy row's structure), with names `attr-str`, `attr-agi`, `attr-int`, `attr-will` and static labels STR/AGI/INT/WILL.
+
+- [ ] **Step 3: Bind them.** In the panel's per-unit refresh, resolve the selected entity's gameplay world (via KingTag/tag scan helper, NOT `DefaultGameObjectInjectionWorld` — see the NetCode world-split gotcha), read `UnitAttributes`, and set each row's value label. Guard when the entity lacks the component (fallback "—").
+
+- [ ] **Step 4: Verify in-editor.** Play → open Citizens → select a unit → confirm STR/AGI/INT/WILL show and match the unit's rolled values; select a different unit → values update.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/rareicon/unity-rareicon/Assets/Resources/UI/Citizens.uxml apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/UI/UICitizensPanel.cs
+git commit -m "feat(rareicon): show unit STR/AGI/INT/WILL in Citizens panel"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** L1 (component+roll) → Tasks 1–2; L2 (persistence) → Tasks 3–5; L3 (UI) → Task 6. Migration/old-save risk → Task 3 Step 5 + Task 5 Step 4. Spawn-path coverage risk → Task 2 Step 2 (enumerated). All L1–L3 spec sections covered.
+- **Type consistency:** `UnitAttributes{Strength,Agility,Intellect,Will}` byte throughout; `AttributeRoll.Roll(in NPCDef, uint)` used in Tasks 2/5; `UnitSpawnState` attribute fields introduced in Task 2 Step 1 and reused in Task 5; `FfiGhostUnit` fields named `strength/agility/intellect/will` in Rust (Task 3) and C# (Task 4).
+- **Placeholders:** Tasks 4 Step 1 and 6 Step 1 require confirming the binding-gen command and the exact UI host at execution — flagged explicitly because those are environment facts to read, not guesses to bake in. No silent TBDs elsewhere.

--- a/docs/superpowers/specs/2026-07-20-rareicon-unit-attributes-design.md
+++ b/docs/superpowers/specs/2026-07-20-rareicon-unit-attributes-design.md
@@ -1,0 +1,78 @@
+# RareIcon Unit Attributes — Design Spec
+
+Date: 2026-07-20
+Status: Draft for review
+
+## Summary
+
+Give every unit four rolled attributes — Strength, Agility, Intellect, Will — sourced from the npcdb proto base, varied per-character, persisted exactly across save/load, surfaced in the UI, and wired into the existing sim so they actually matter. Builds directly on the just-completed npcdb-proto migration: the base values already live in the proto (`NpcStats.strength/agility/intelligence/will`) and flow into `NPCDef`, but are never stored on entities or used. This spec makes them real.
+
+Scope: **Layers 1–3 only** this pass (data → persistence → UI) — the foundation. Attributes roll, persist exactly, and display, with **zero behavior change**. Layer 4 (gameplay effects) is designed below for continuity but **deferred to a follow-up spec** once L1–L3 is built and verified.
+
+## Layer 1 — Data: component + per-character roll
+
+**Component.** New `UnitAttributes : IComponentData { byte Strength; byte Agility; byte Intellect; byte Will; }`. Byte is sufficient (values 1–255); dense, Burst-friendly, cheap to persist.
+
+**Roll.** A shared pure helper:
+
+```
+static UnitAttributes RollAttributes(in NPCDef def, uint rng)
+```
+
+Each stat = `base × spread`, where `spread ∈ [0.8, 1.2]` (±20%), derived deterministically from distinct byte lanes of `rng` (same technique as the existing `speedJit = 0.8 + ((rng>>8)&0xFF)/255 * 0.4`). Result rounded, clamped to `[1, 255]`. Four independent lanes of `rng` (e.g. bytes 0–3) so the four stats vary independently. Base 0 stays 0 (e.g. a stat a creature legitimately lacks) — clamp floor is 1 only when base > 0.
+
+**Attach.** Every spawn path in `UnitSpawnSystem` (`SpawnGoblinAt`, King, `SpawnAnimalAt`, skeleton, garrison variants) calls `RollAttributes(def, rngSeed)` and `em.AddComponentData(entity, attrs)`. One helper, all paths — no per-path divergence.
+
+## Layer 2 — Persistence: exact round-trip (Rust/FFI)
+
+Attributes are per-entity runtime state and MUST survive save/load unchanged (a goblin's numbers are its identity). Units have no stable id across reload — they are rebuilt from position-keyed ghost records — so the rolled values are stored in the record, not re-derived.
+
+**Rust side (`packages/rust/bevy/uniti`).** Add `str`, `agi`, `int`, `will` (`u8` ×4) to the ghost-unit struct and its save/load path. Bump the persistence-format version; on read of an older record lacking the fields, signal "absent" so the Unity side rolls fresh once (graceful migration, no data loss for existing saves).
+
+**Binding.** Regenerate `Assets/_RareIcon/Generated/Native/Uniti.g.cs` so `FfiGhostUnit` carries the four new fields.
+
+**Unity side.** `UnitSpawnState` gains the four fields. `HexSpawnSystem` rehydrate: if the record has attributes, restore them exactly into `UnitAttributes`; if absent (old save), call `RollAttributes` with the same deterministic seed the rehydrate path already computes. Mirrors the existing `MaxHealth = g.max_health` restore pattern.
+
+**Migration guard.** Reuse the persistence-version check so a pre-attributes save loads without error and gains rolled attributes on first load, then persists them thereafter.
+
+## Layer 3 — UI
+
+Surface STR / AGI / INT / WILL in the unit inspection panel (`UICitizensPanel`, the per-unit view). Four labeled stat rows alongside the existing health/energy readouts. UXML gets the four rows; the panel's refresh binds them from the selected entity's `UnitAttributes`. Read-only display this pass. Keep the visual language consistent with the existing stat rows (no new design system — extend what's there).
+
+## Layer 4 — Gameplay effects (DEFERRED — future spec)
+
+Not built this pass. Documented here so L1–L3 leaves the right seams. Each attribute hooks exactly one or two existing systems. All effects are multiplicative modifiers around the current baseline so a mid-value stat ≈ today's behavior (no global rebalance; the ±20% roll becomes the meaningful spread).
+
+- **STR → melee damage + carry.** `AttachMeleeAttackIfArmed` scales the `Damage` it writes by a STR factor (normalized around a reference, e.g. `dmg × (0.5 + STR/refStr × 0.5)`). Pack carry capacity (slot count or weight budget) scales with STR. Touches combat attach + inventory.
+- **AGI → move speed + harvest.** Fold AGI into `MoveSpeed` (replacing the flat `speedJit` with an AGI-derived factor so speed variance is attribute-driven, not free noise). `HarvestSystem.HarvestIntervalSec` (0.8s) scales down with AGI so nimble gatherers cycle faster.
+- **INT → job aptitude + mana.** `ProfessionDispatchSystem` scoring gains a small INT-weighted bonus for skilled roles (Chef/Blacksmith/Craftsman/Mage) so smarter goblins self-select skilled work. `AttachSpellsIfMagical` scales `MaxMana` / mana regen with INT.
+- **WILL → morale / needs resistance.** `NeedAccumulationSystem` scales hunger/fatigue accrual down with WILL; relief/flee thresholds (SeekingAid / ReturningToBase triggers) shift so high-WILL units push through hardship longer.
+
+Effect formulas are tuned so the population average ≈ current values; the spread is what's new.
+
+## Build order (this pass = L1–L3)
+
+1. Layer 1 (component + roll + attach) — verifiable: spawn, inspect entity, see varied stats.
+2. Layer 2 (persistence) — verifiable: save/load, stats identical.
+3. Layer 3 (UI) — verifiable: panel shows them.
+
+All three are zero-behavior-change; a regression is obvious. Layer 4 is a separate later spec.
+
+## Risks & mitigations (L1–L3)
+
+- **Persistence-format break.** Old saves must load. Mitigation: version bump + absent-field → roll-fresh path; explicit test loading a pre-attributes save.
+- **Rust/FFI + regen friction.** Binding regen must match the struct. Mitigation: regenerate + confirm `FfiGhostUnit` field parity before wiring the Unity read.
+- **Spawn-path coverage.** Every spawn path must attach `UnitAttributes`, or some units lack the component (UI null / persistence gap). Mitigation: single `RollAttributes` helper called from one shared attach point; audit all `Spawn*` methods.
+
+## Testing (L1–L3)
+
+- Roll: deterministic — same seed → same attributes; distribution within [0.8,1.2]×base; base 0 → 0.
+- Persistence: round-trip test (spawn → save → load → assert identical); old-save migration test (pre-attributes save loads + gains rolled attrs).
+- UI: panel renders four rows bound to the selected unit; updates on selection change.
+
+## Out of scope (this pass)
+
+- **Layer 4 gameplay effects** — separate follow-up spec once L1–L3 is verified.
+- Attribute growth / leveling / XP (fixed at roll).
+- Skills (future `skillsdb`), moods, traits, relationships (per the def-vs-runtime roadmap).
+- Editing attributes from the UI (read-only display).

--- a/packages/rust/bevy/uniti/src/ffi_world.rs
+++ b/packages/rust/bevy/uniti/src/ffi_world.rs
@@ -85,6 +85,12 @@ pub struct FfiGhostUnit {
     pub time_since_attack: f32,
     pub attack_kind: u8,
     pub target_mode: u8,
+
+    // Per-character attributes (npcdb base ±20%). 0 = absent (pre-v4 save) → Unity rolls fresh.
+    pub strength: u8,
+    pub agility: u8,
+    pub intellect: u8,
+    pub will: u8,
 }
 
 /// Mirror of the C# `UnloadedBuildingRecord`. Field order + types must
@@ -329,7 +335,7 @@ struct DirtySnapshot {
     per_chunk: Vec<FlushSnapshot>,
 }
 
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 
 fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
@@ -371,7 +377,11 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
             attack_cooldown REAL NOT NULL DEFAULT 0,
             time_since_attack REAL NOT NULL DEFAULT 0,
             attack_kind INTEGER NOT NULL DEFAULT 0,
-            target_mode INTEGER NOT NULL DEFAULT 0
+            target_mode INTEGER NOT NULL DEFAULT 0,
+            strength INTEGER NOT NULL DEFAULT 0,
+            agility INTEGER NOT NULL DEFAULT 0,
+            intellect INTEGER NOT NULL DEFAULT 0,
+            will INTEGER NOT NULL DEFAULT 0
          );
          CREATE INDEX IF NOT EXISTS idx_units_chunk ON units(cx, cy);
          CREATE TABLE IF NOT EXISTS buildings (
@@ -515,6 +525,15 @@ fn migrate_schema(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    if current < 4 {
+        conn.execute_batch(
+            "ALTER TABLE units ADD COLUMN strength INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE units ADD COLUMN agility INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE units ADD COLUMN intellect INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE units ADD COLUMN will INTEGER NOT NULL DEFAULT 0;",
+        )?;
+    }
+
     conn.execute(
         "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?1)",
         [SCHEMA_VERSION.to_string()],
@@ -561,7 +580,8 @@ fn load_all_from_db(conn: &Connection) -> rusqlite::Result<HashMap<ChunkKey, Chu
                 energy, energy_max, energy_per_second,
                 last_tick_secs,
                 attack_damage, attack_range, attack_cooldown, time_since_attack,
-                attack_kind, target_mode
+                attack_kind, target_mode,
+                strength, agility, intellect, will
          FROM units",
     )?;
     let rows = stmt.query_map([], |row| {
@@ -597,6 +617,10 @@ fn load_all_from_db(conn: &Connection) -> rusqlite::Result<HashMap<ChunkKey, Chu
             time_since_attack: row.get(28)?,
             attack_kind: row.get::<_, i64>(29)? as u8,
             target_mode: row.get::<_, i64>(30)? as u8,
+            strength: row.get::<_, i64>(31)? as u8,
+            agility: row.get::<_, i64>(32)? as u8,
+            intellect: row.get::<_, i64>(33)? as u8,
+            will: row.get::<_, i64>(34)? as u8,
         };
         Ok(((cx, cy), unit))
     })?;
@@ -766,8 +790,9 @@ fn flush_dirty(
                   energy, energy_max, energy_per_second,
                   last_tick_secs,
                   attack_damage, attack_range, attack_cooldown, time_since_attack,
-                  attack_kind, target_mode)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31)",
+                  attack_kind, target_mode,
+                  strength, agility, intellect, will)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35)",
             ) {
                 Ok(s) => s,
                 Err(_) => continue,
@@ -805,6 +830,10 @@ fn flush_dirty(
                     u.time_since_attack,
                     u.attack_kind as i64,
                     u.target_mode as i64,
+                    u.strength as i64,
+                    u.agility as i64,
+                    u.intellect as i64,
+                    u.will as i64,
                 ]);
             }
         }
@@ -1012,7 +1041,7 @@ pub unsafe extern "C" fn uniti_world_free(world: *mut c_void) {
 /// load the dylib if the value drifts from the C# constant. Catches the
 /// silent-corruption case where the Rust side is rebuilt without
 /// regenerating the C# bindings (or vice-versa).
-pub const UNITI_FFI_SCHEMA_VERSION: u32 = 3;
+pub const UNITI_FFI_SCHEMA_VERSION: u32 = 4;
 
 /// Returns the current FFI schema version. Unity calls this once on
 /// `WorldStoreSystem` boot and aborts if the returned value doesn't


### PR DESCRIPTION
Adds per-character attributes (Strength/Agility/Intellect/Will) to every unit, sourced from the npcdb proto base (shipped in #14362), varied ±20% per character, persisted exactly across save/load, and shown in the Roster panel. **Display/flavor only — gameplay effects (STR→damage etc.) are a deferred Layer-4 follow-up.**

Spec + plan: `docs/superpowers/specs|plans/2026-07-20-rareicon-unit-attributes*`.

## Layers
- **L1 data** — `UnitAttributes` byte component + pure `AttributeRoll.Roll(def, rng)` (±20%, deterministic, base-0 stays 0) with 4 EditMode tests. `UnitAttributeBackfillSystem` attaches to any unit missing the component — one place covers all 15 spawn paths.
- **L2 persistence** — `uniti` schema **v4**: `strength/agility/intellect/will` columns + `FfiGhostUnit` fields, `SCHEMA_VERSION`+`UNITI_FFI_SCHEMA_VERSION` 3→4, v3→v4 `ALTER TABLE` migration (`DEFAULT 0` = absent → roll fresh). C#: `UnloadedUnitRecord` + `UnitColdStoreOps` ToFfi/FromFfi + `Snapshot` read; `HexSpawn` restores exact on rehydrate so backfill only rolls fresh / pre-v4-save units. `NativeWorld.ExpectedSchemaVersion` → 4.
- **L3 UI** — STR/AGI/INT/WILL row in the Roster detail card.

## Verification
- 48 `uniti` cargo tests green; 4 EditMode roll tests green.
- In-editor: goblins spawn with varied stats; save/reload → **identical** values (persistence confirmed); pre-v4 saves migrate + roll fresh.

## ⚠️ Follow-ups
- **macOS dylib rebuilt + committed.** Windows/Linux `uniti.dll` / `libuniti.so` are **not** rebuilt here — they're still schema v3 and will fail the boot version check on those platforms until rebuilt (`nx run uniti:build:windows|linux`). Mac-only dev/test for now.
- Layer 4 (attributes affect combat/economy) — separate spec.