### PR TITLE
chore(embeddb): flip publish=true (derive live, unblock embeddb 0.1.0)

### DIFF
--- a/packages/rust/embeddb/version.toml
+++ b/packages/rust/embeddb/version.toml
@@ -1,2 +1,2 @@
 version = "0.0.1"
-publish = false
+publish = true


### PR DESCRIPTION
## What
Flip `packages/rust/embeddb/version.toml` `publish = false → true`.

## Why
`embeddb-derive 0.1.0` is now live on crates.io (published via #14360 → main). embeddb's `embeddb-derive = { version = "0.1.0", path = ... }` dep now resolves from the registry, so `cargo publish` of embeddb no longer fails on the path-only rejection.

Held on purpose until derive was live; this is the follow-up flip noted in the v6 scaffold.

## Effect
Once merged dev → main, `ci-main` gate passes for embeddb (MDX `0.1.0` > version.toml published `0.0.1`, publish=true) → dispatches `embeddb 0.1.0` publish; version.toml self-heals to 0.1.0 back on dev.

## Scope
One line. No code change.