### PR TITLE
feat(markets): Phase 3 — admin store + personal marketplace on @kbve/rn/markets

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -31,13 +31,21 @@ import {
 	MARKET_NAV,
 	STORE_ROOT,
 	MARKET_ROOT,
+	STORE_ADMIN_ROOT,
+	MARKET_PROFILE_ROOT,
 	buildStoreBreadcrumb,
 	buildMarketBreadcrumb,
+	buildStoreAdminBreadcrumb,
+	buildMarketProfileBreadcrumb,
 } from '../market/marketNav';
 import { getCollection } from 'astro:content';
 
 const pathname = Astro.url.pathname;
-const isDashboard = pathname.startsWith('/dashboard');
+const norm = (p: string) => (p.endsWith('/') ? p : `${p}/`);
+const isStoreAdmin = norm(pathname) === '/dashboard/store/';
+const isMarketProfile = norm(pathname) === '/dashboard/market/';
+const isDashboard =
+	pathname.startsWith('/dashboard') && !isStoreAdmin && !isMarketProfile;
 const isApplication =
 	pathname.startsWith('/application/') && pathname !== '/application/';
 const isJournal = pathname.startsWith('/journal/') && pathname !== '/journal/';
@@ -54,7 +62,6 @@ const isMc = pathname.startsWith('/mc/');
 const isNpcdb = pathname.startsWith('/npcdb/');
 const isItemdb = pathname.startsWith('/itemdb/');
 const isMapdb = pathname.startsWith('/mapdb/');
-const norm = (p: string) => (p.endsWith('/') ? p : `${p}/`);
 const isStore = norm(pathname) === '/store/';
 const isMarket = norm(pathname) === '/market/';
 
@@ -191,7 +198,27 @@ const shell = isDashboard
 														collapsible: true,
 														withToc: true,
 													}
-												: undefined;
+												: isStoreAdmin
+													? {
+															entries: MARKET_NAV,
+															root: STORE_ADMIN_ROOT,
+															menuLabel: 'Commerce menu',
+															navLabel: 'Commerce',
+															crumbs: buildStoreAdminBreadcrumb(pathname),
+															collapsible: true,
+															withToc: false,
+														}
+													: isMarketProfile
+														? {
+																entries: MARKET_NAV,
+																root: MARKET_PROFILE_ROOT,
+																menuLabel: 'Commerce menu',
+																navLabel: 'Commerce',
+																crumbs: buildMarketProfileBreadcrumb(pathname),
+																collapsible: true,
+																withToc: false,
+															}
+														: undefined;
 
 const crumbs = shell?.crumbs ?? [];
 ---

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
@@ -1,15 +1,62 @@
 ---
-import MarketProfileShell from './MarketProfileShell';
-import './market.css';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactMarketProfileRN from './ReactMarketProfileRN';
+
+const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q=80&w=2400&auto=format&fit=crop';
 ---
 
-<section class="kbve-market not-content kbve-dashboard-page">
-	<header class="kbve-market__header">
-		<div>
-			<h1>My Marketplace</h1>
-			<p>Your active listings and bids across the KBVE marketplace.</p>
+<div class="market-profile-hub" style={`--bento-hero-bg: url('${backdrop}')`}>
+	<section class="bento-hero bento-section not-content" aria-label="My Marketplace">
+		<div class="bento-hero__bg" aria-hidden="true"></div>
+		<div class="bento-hero__frame bento-frame">
+			<div class="bento-board bento-board--hero">
+				<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+					<span class="bento-badge bento-chip"><span>you</span></span>
+					<h1 class="bento-title">Your listings,
+						<span class="bento-title__accent">bids, and watchlist.</span></h1>
+					<p class="bento-lede">
+						Track your active listings, outstanding bids, and watched items
+						across the KBVE marketplace — all in one place.
+					</p>
+					<div class="bento-cta">
+						<a class="bento-btn bento-btn--primary" href="#profile">Open dashboard
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+						</a>
+						<a class="bento-btn bento-btn--ghost" href="/market/">Browse marketplace</a>
+					</div>
+				</div>
+				{[
+					{ v: 'Listings', l: 'Your active listings' },
+					{ v: 'Bids', l: 'Offers placed & received' },
+					{ v: 'Watching', l: 'Items on your watchlist' },
+				].map((s) => (
+					<div class="bento-cell bento-stat bento-card bento-card--glass">
+						<span class="bento-stat__value">{s.v}</span>
+						<span class="bento-stat__label">{s.l}</span>
+					</div>
+				))}
+			</div>
 		</div>
-		<a href="/market/" class="kbve-market__back">← Browse</a>
-	</header>
-	<MarketProfileShell client:only="react" />
-</section>
+	</section>
+
+	<BentoShell id="profile" eyebrow="You" heading="My Marketplace">
+		<div class="profile-island">
+			<ReactMarketProfileRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={3} rows={4} />
+			</ReactMarketProfileRN>
+		</div>
+	</BentoShell>
+</div>
+
+<style>
+	.profile-island { min-height: 60vh; }
+</style>
+
+<style is:global>
+	.market-profile-hub {
+		--bento-accent: #a78bfa;
+		--bento-accent-2: #22d3ee;
+		--bento-btn-fg: #1a1033;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/market/ReactMarketProfileRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/ReactMarketProfileRN.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useSession } from '@kbve/astro';
+import { MarketProfileView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export default function ReactMarketProfileRN() {
+	const { ready, authenticated } = useSession();
+	const token = useMemo(() => getToken, []);
+	if (!ready) return null;
+	return <MarketProfileView getToken={token} baseUrl="" authenticated={authenticated} />;
+}

--- a/apps/kbve/astro-kbve/src/components/market/marketNav.ts
+++ b/apps/kbve/astro-kbve/src/components/market/marketNav.ts
@@ -7,6 +7,8 @@ import { buildBreadcrumbIn } from '../dashboard/dashboardNav';
 
 export const STORE_ROOT: DashboardNavItem = { label: 'Store', href: '/store/' };
 export const MARKET_ROOT: DashboardNavItem = { label: 'Marketplace', href: '/market/' };
+export const STORE_ADMIN_ROOT: DashboardNavItem = { label: 'Store Admin', href: '/dashboard/store/' };
+export const MARKET_PROFILE_ROOT: DashboardNavItem = { label: 'My Marketplace', href: '/dashboard/market/' };
 
 export const MARKET_NAV: DashboardNavEntry[] = [
 	{
@@ -29,6 +31,16 @@ export const MARKET_NAV: DashboardNavEntry[] = [
 			{ label: 'Orders', href: '/store/#orders', icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z' },
 		],
 	},
+	{
+		label: 'Manage',
+		visibility: 'auth',
+		href: '/dashboard/market/',
+		icon: 'M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z',
+		items: [
+			{ label: 'My Marketplace', href: '/dashboard/market/', icon: 'M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z', copy: 'Your listings, bids, and watchlist.' },
+			{ label: 'Store Admin', href: '/dashboard/store/', icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z', copy: 'Staff catalog + order queue.', visibility: 'staff' },
+		],
+	},
 ];
 
 export const buildStoreBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
@@ -36,3 +48,9 @@ export const buildStoreBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
 
 export const buildMarketBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
 	buildBreadcrumbIn(MARKET_NAV, MARKET_ROOT, pathname);
+
+export const buildStoreAdminBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, STORE_ADMIN_ROOT, pathname);
+
+export const buildMarketProfileBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, MARKET_PROFILE_ROOT, pathname);

--- a/apps/kbve/astro-kbve/src/components/store/AstroStoreAdminShell.astro
+++ b/apps/kbve/astro-kbve/src/components/store/AstroStoreAdminShell.astro
@@ -1,14 +1,62 @@
 ---
-import StoreAdmin from './StoreAdmin';
-import StaffOrderQueue from './StaffOrderQueue';
-import './store.css';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactStoreAdminRN from './ReactStoreAdminRN';
+
+const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q=80&w=2400&auto=format&fit=crop';
 ---
 
-<section class="kbve-store not-content kbve-dashboard-page">
-	<header class="kbve-store__header">
-		<h1>Store Admin</h1>
-		<p>Manage products, variants, and fulfill orders. Staff only.</p>
-	</header>
-	<StoreAdmin client:only="react" />
-	<StaffOrderQueue client:only="react" />
-</section>
+<div class="store-admin-hub" style={`--bento-hero-bg: url('${backdrop}')`}>
+	<section class="bento-hero bento-section not-content" aria-label="Store Admin">
+		<div class="bento-hero__bg" aria-hidden="true"></div>
+		<div class="bento-hero__frame bento-frame">
+			<div class="bento-board bento-board--hero">
+				<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+					<span class="bento-badge bento-chip"><span>staff</span></span>
+					<h1 class="bento-title">Run the store,
+						<span class="bento-title__accent">mint the drops.</span></h1>
+					<p class="bento-lede">
+						Manage products, variants, and the fulfillment queue. Staff only —
+						every action is audited against your account.
+					</p>
+					<div class="bento-cta">
+						<a class="bento-btn bento-btn--primary" href="#admin">Open console
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+						</a>
+						<a class="bento-btn bento-btn--ghost" href="/store/">Customer store</a>
+					</div>
+				</div>
+				{[
+					{ v: 'Catalog', l: 'Products & variants' },
+					{ v: 'Fulfillment', l: 'Advance, ship, refund' },
+					{ v: 'Audited', l: 'Staff-gated actions' },
+				].map((s) => (
+					<div class="bento-cell bento-stat bento-card bento-card--glass">
+						<span class="bento-stat__value">{s.v}</span>
+						<span class="bento-stat__label">{s.l}</span>
+					</div>
+				))}
+			</div>
+		</div>
+	</section>
+
+	<BentoShell id="admin" eyebrow="Staff" heading="Store Admin">
+		<div class="admin-island">
+			<ReactStoreAdminRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={3} rows={4} />
+			</ReactStoreAdminRN>
+		</div>
+	</BentoShell>
+</div>
+
+<style>
+	.admin-island { min-height: 60vh; }
+</style>
+
+<style is:global>
+	.store-admin-hub {
+		--bento-accent: #fbbf24;
+		--bento-accent-2: #f59e0b;
+		--bento-btn-fg: #3a2a05;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/store/ReactStoreAdminRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/store/ReactStoreAdminRN.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import { $isStaff } from '@kbve/droid';
+import { ShieldOff } from 'lucide-react';
+import { useSession } from '@kbve/astro';
+import { StoreAdminView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: { margin: 0, fontSize: '1.75rem', color: 'var(--sl-color-text, #e6edf3)' },
+	sub: { margin: 0, color: 'var(--sl-color-gray-3, #8b949e)', maxWidth: '40rem' },
+};
+
+export default function ReactStoreAdminRN() {
+	const { ready, authenticated } = useSession();
+	const isStaff = useStore($isStaff);
+	const token = useMemo(() => getToken, []);
+
+	if (!ready) return null;
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>The store admin console is restricted to KBVE staff.</p>
+			</div>
+		);
+	}
+	return <StoreAdminView getToken={token} baseUrl="" authenticated={authenticated} />;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/store/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/store/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Store Admin
 description: Manage KBVE store products and variants (staff).
+template: splash
 tableOfContents: false
 graph:
    visible: false

--- a/docs/superpowers/plans/2026-07-20-markets-admin-phase3.md
+++ b/docs/superpowers/plans/2026-07-20-markets-admin-phase3.md
@@ -1,0 +1,748 @@
+# `@kbve/rn/markets` Phase 3 — Admin Store + Personal Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the staff store-admin (`/dashboard/store/`) and personal marketplace (`/dashboard/market/`) surfaces into the `@kbve/rn/markets` universal composition + bento splash + Commerce rail, completing the unified customer-vs-admin store+market view.
+
+**Architecture:** Extend the shipped `createStoreApi`/`createMarketApi` factories with staff + personal endpoints, add two RN composition views (`StoreAdminView`, `MarketProfileView`), two `client:only` astro bridges (staff-gated via `useStore($isStaff)`; auth-gated), and bento splash shells + Commerce-rail routing. Mirrors Phase 1 `/store/` and Phase 2 `/market/`.
+
+**Tech Stack:** React Native / react-native-web, `@kbve/rn/ui`, Astro + Starlight, vitest + @testing-library/react, Nx.
+
+## Global Constraints
+
+- **WT** = `/Users/alappatel/Documents/GitHub/kbve/.claude/worktrees/markets-admin-phase3` (already created off `origin/dev` @ c833daabcd; `node_modules` symlinked to main). **MAIN** = `/Users/alappatel/Documents/GitHub/kbve`.
+- **Tests (vitest-direct, NOT `nx test` in a worktree):** `cd $WT/packages/npm/rn && NX_DAEMON=false $MAIN/node_modules/.bin/vitest run <paths>`.
+- **Lint:** `cd $WT/packages/npm/rn && NX_DAEMON=false $MAIN/node_modules/.bin/nx lint rn --skip-nx-cache` (needs ProjectGraph for `enforce-module-boundaries`). Autofix: append `--fix`.
+- **Astro build:** `cd $WT/apps/kbve/astro-kbve && NX_DAEMON=false $MAIN/node_modules/.bin/astro build` (astro CLI direct).
+- **Worktree only:** never edit/commit the main `dev` checkout; PRs → `dev`; never push `dev`/`main`. Never stage `node_modules`.
+- **No code comments** anywhere. **No bare `catch {}`** → `catch { void 0; }`. **No browser `prompt`/`confirm`** (no RN equivalent) — use inline UI state.
+- **Relative UI imports inside rn:** from `markets/store/*` and `markets/market/*`, import `@kbve/rn/ui` primitives by RELATIVE path (`../../ui/primitives/{Button,Text,Stack,Surface,Badge,FormField}`, `../../ui/controls/Select`, `../../ui/theme`). NEVER the `@kbve/rn/ui` barrel or the `@kbve/rn/ui/...` subpath specifier from inside rn.
+- **Astro bridges import `@kbve/rn/markets` BARE** (out-of-project — correct).
+- **Named exports only** in composition barrels.
+- **baseUrl=''** (public main origin) for both bridges. Staff endpoints `/api/v1/store/staff/*`; personal `/api/v1/market/me/*`. NOT the dash proxy.
+- **Error precedence (droid-match):** `message = j.message ?? j.error ?? j.detail`; `code = j.error` — the ported `createStoreApi`/`createMarketApi` `call()` already do this; new methods reuse the same `call()`.
+- **Staff methods do NOT inject `idempotency_key`.**
+- **Commit trailer:** end messages with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`; NO "Generated with Claude Code" line. Stage only named files with explicit `git add` (never `-A`).
+- **Accent:** admin store = amber (`--bento-accent:#fbbf24; --bento-accent-2:#f59e0b; --bento-btn-fg:#3a2a05`, same vars as `AstroStoreShell`). Personal market = violet (`--bento-accent:#a78bfa; --bento-accent-2:#22d3ee; --bento-btn-fg:#1a1033`).
+
+**Spec:** `docs/superpowers/specs/2026-07-20-markets-admin-phase3-design.md`. Pattern references (shipped): `packages/npm/rn/src/markets/store/{api.ts,StoreView.tsx}`, `markets/market/{api.ts,MarketView.tsx,MarketProfile` N/A}`, `apps/kbve/astro-kbve/src/components/store/{ReactStoreRN.tsx,AstroStoreShell.astro}`, `components/rnweb/ReactMinecraftDashRN.tsx` (staff gate). Old-DOM sources being ported: `components/store/{StoreAdmin,StaffOrderQueue}.tsx`, `components/market/MarketProfileShell.tsx`.
+
+---
+
+## File Structure
+
+**Modify (rn):**
+- `packages/npm/rn/src/markets/store/types.ts` — add `StaffProductBody`, `StaffVariantBody`, `StoreOrderStaff`.
+- `packages/npm/rn/src/markets/store/api.ts` — add 8 staff methods to `StoreApi` + impl.
+- `packages/npm/rn/src/markets/store/index.ts` — export `StoreAdminView`.
+- `packages/npm/rn/src/markets/market/types.ts` — add `BidCursor`.
+- `packages/npm/rn/src/markets/market/api.ts` — add `myListings`/`myBids`.
+- `packages/npm/rn/src/markets/market/index.ts` — export `MarketProfileView`.
+
+**New (rn):**
+- `packages/npm/rn/src/markets/store/StoreAdminView.tsx`
+- `packages/npm/rn/src/markets/market/MarketProfileView.tsx`
+- Tests appended/added under `markets/store/__tests__/api.test.ts`, `markets/market/__tests__/api.test.ts`, new `markets/store/__tests__/StoreAdminView.test.tsx`, `markets/market/__tests__/MarketProfileView.test.tsx`.
+
+**New (astro-kbve):** `src/components/store/ReactStoreAdminRN.tsx`, `src/components/market/ReactMarketProfileRN.tsx`.
+**Modify (astro-kbve):** `components/store/AstroStoreAdminShell.astro`, `components/market/AstroMarketProfileShell.astro`, `components/market/marketNav.ts`, `components/dashboard/MarkdownContent.astro`, `content/docs/dashboard/store/index.mdx`.
+
+---
+
+## Task 1: Store staff API delta (TDD)
+
+**Files:** Modify `markets/store/types.ts`, `markets/store/api.ts`; Test `markets/store/__tests__/api.test.ts`.
+
+**Interfaces:**
+- Produces (added to `StoreApi`):
+  ```ts
+  staffUpsertProduct(body: StaffProductBody): Promise<{ id: string }>;
+  staffSetProductStatus(productId: string, status: string): Promise<void>;
+  staffUpsertVariant(productId: string, body: StaffVariantBody): Promise<{ id: string }>;
+  staffSetVariantStatus(variantId: string, status: string): Promise<void>;
+  staffListOrders(status?: OrderStatus): Promise<StoreOrderStaff[]>;
+  staffAdvanceOrder(orderId: number, body: { to_status: OrderStatus; tracking?: Record<string, unknown>; note?: string }): Promise<void>;
+  staffRefundOrder(orderId: number, reason?: string): Promise<void>;
+  staffSubmitPod(orderId: number): Promise<{ order_id: number; external_id: string }>;
+  ```
+- New types: `StaffProductBody`, `StaffVariantBody`, `StoreOrderStaff`.
+
+- [ ] **Step 1: Add types to `markets/store/types.ts`** (append; `Fulfillment`/`OrderStatus`/`StoreOrder` already present)
+
+```ts
+export interface StaffProductBody {
+	slug: string;
+	title: string;
+	description?: string | null;
+	price: number;
+	fulfillment?: Fulfillment;
+	asset_ref?: Record<string, unknown>;
+	status?: string;
+}
+
+export interface StaffVariantBody {
+	sku: string;
+	attributes?: Record<string, unknown>;
+	price: number;
+	stock?: number | null;
+	status?: string;
+}
+
+export interface StoreOrderStaff extends StoreOrder {
+	account_id: string;
+	shipping_address: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 2: Write failing tests** — append to `markets/store/__tests__/api.test.ts`
+
+```ts
+it('staffUpsertProduct POSTs bearer to staff products, returns id', async () => {
+	(global.fetch as any).mockResolvedValue({
+		ok: true,
+		status: 200,
+		text: async () => JSON.stringify({ id: 'p9' }),
+	});
+	const api = createStoreApi({ getToken: token, baseUrl: '' });
+	const res = await api.staffUpsertProduct({ slug: 's', title: 't', price: 10 });
+	expect(res).toEqual({ id: 'p9' });
+	const [url, init] = (global.fetch as any).mock.calls[0];
+	expect(url).toBe('/api/v1/store/staff/products');
+	expect(init.method).toBe('POST');
+	expect(init.headers.Authorization).toBe('Bearer tok');
+	expect(JSON.parse(init.body).idempotency_key).toBeUndefined();
+});
+
+it('staffListOrders GETs staff orders with status query', async () => {
+	(global.fetch as any).mockResolvedValue({
+		ok: true,
+		status: 200,
+		text: async () => '[]',
+	});
+	const api = createStoreApi({ getToken: token, baseUrl: 'https://x' });
+	await api.staffListOrders('paid');
+	const [url] = (global.fetch as any).mock.calls[0];
+	expect(url).toBe('https://x/api/v1/store/staff/orders?status=paid');
+});
+
+it('staffAdvanceOrder POSTs to advance with body', async () => {
+	(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+	const api = createStoreApi({ getToken: token, baseUrl: '' });
+	await api.staffAdvanceOrder(5, { to_status: 'shipped', tracking: { number: 'AB' } });
+	const [url, init] = (global.fetch as any).mock.calls[0];
+	expect(url).toBe('/api/v1/store/staff/orders/5/advance');
+	expect(JSON.parse(init.body)).toEqual({ to_status: 'shipped', tracking: { number: 'AB' } });
+});
+
+it('staff call without token throws 401 without fetch', async () => {
+	const api = createStoreApi({ getToken: async () => null });
+	await expect(api.staffListOrders()).rejects.toMatchObject({ name: 'StoreApiError', status: 401 });
+	expect(global.fetch).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run RED** — `NX_DAEMON=false $MAIN/node_modules/.bin/vitest run src/markets/store/__tests__/api.test.ts` → FAIL (methods missing).
+
+- [ ] **Step 4: Implement in `markets/store/api.ts`**
+
+Add to the `StoreApi` interface (Task-1 Interfaces block above), import the new body types, and add these to the returned object (reuse the existing `call<T>` — it already applies droid error precedence + the 401-before-fetch guard):
+
+```ts
+staffUpsertProduct: (body) =>
+	call<{ id: string }>({ path: '/api/v1/store/staff/products', method: 'POST', body, auth: true }),
+staffSetProductStatus: (productId, status) =>
+	call<void>({ path: `/api/v1/store/staff/products/${encodeURIComponent(productId)}/status`, method: 'POST', body: { status }, auth: true }),
+staffUpsertVariant: (productId, body) =>
+	call<{ id: string }>({ path: `/api/v1/store/staff/products/${encodeURIComponent(productId)}/variants`, method: 'POST', body, auth: true }),
+staffSetVariantStatus: (variantId, status) =>
+	call<void>({ path: `/api/v1/store/staff/variants/${encodeURIComponent(variantId)}/status`, method: 'POST', body: { status }, auth: true }),
+staffListOrders: (status) =>
+	call<StoreOrderStaff[]>({ path: `/api/v1/store/staff/orders${status ? `?status=${encodeURIComponent(status)}` : ''}`, auth: true }),
+staffAdvanceOrder: (orderId, body) =>
+	call<void>({ path: `/api/v1/store/staff/orders/${orderId}/advance`, method: 'POST', body, auth: true }),
+staffRefundOrder: (orderId, reason) =>
+	call<void>({ path: `/api/v1/store/staff/orders/${orderId}/refund`, method: 'POST', body: { reason }, auth: true }),
+staffSubmitPod: (orderId) =>
+	call<{ order_id: number; external_id: string }>({ path: `/api/v1/store/staff/orders/${orderId}/submit-pod`, method: 'POST', auth: true }),
+```
+
+Import types at top: add `OrderStatus, StaffProductBody, StaffVariantBody, StoreOrderStaff` to the `import type { ... } from './types';`.
+
+- [ ] **Step 5: Run GREEN + commit**
+
+`vitest run src/markets/store/__tests__/api.test.ts` → PASS (existing + 4 new). Commit:
+```bash
+git add packages/npm/rn/src/markets/store/api.ts packages/npm/rn/src/markets/store/types.ts packages/npm/rn/src/markets/store/__tests__/api.test.ts
+git commit -m "feat(rn): store staff admin API methods on createStoreApi
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Market personal API delta (TDD)
+
+**Files:** Modify `markets/market/types.ts`, `markets/market/api.ts`; Test `markets/market/__tests__/api.test.ts`.
+
+**Interfaces:**
+- Produces (added to `MarketApi`): `myListings(c?: Cursor): Promise<MyListing[]>`, `myBids(c?: BidCursor): Promise<MyBid[]>`.
+- New type `BidCursor { limit?: number; before_placed_at?: string | null; before_id?: number | null }`.
+
+- [ ] **Step 1: Add `BidCursor` to `markets/market/types.ts`** (append)
+
+```ts
+export interface BidCursor {
+	limit?: number;
+	before_placed_at?: string | null;
+	before_id?: number | null;
+}
+```
+
+- [ ] **Step 2: Write failing tests** — append to `markets/market/__tests__/api.test.ts`
+
+```ts
+it('myListings GETs personal listings with cursor, bearer', async () => {
+	(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+	const api = createMarketApi({ getToken: token, baseUrl: 'https://x' });
+	await api.myListings({ limit: 50 });
+	const [url, init] = (global.fetch as any).mock.calls[0];
+	expect(url).toBe('https://x/api/v1/market/me/listings?limit=50');
+	expect(init.headers.Authorization).toBe('Bearer tok');
+});
+
+it('myBids GETs personal bids with before_placed_at cursor', async () => {
+	(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+	const api = createMarketApi({ getToken: token, baseUrl: '' });
+	await api.myBids({ limit: 10, before_placed_at: '2020', before_id: 3 });
+	const [url] = (global.fetch as any).mock.calls[0];
+	expect(url).toBe('/api/v1/market/me/bids?limit=10&before_placed_at=2020&before_id=3');
+});
+
+it('myListings without token throws 401 without fetch', async () => {
+	const api = createMarketApi({ getToken: async () => null });
+	await expect(api.myListings()).rejects.toMatchObject({ name: 'MarketApiError', status: 401 });
+	expect(global.fetch).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run RED** — `vitest run src/markets/market/__tests__/api.test.ts` → FAIL.
+
+- [ ] **Step 4: Implement in `markets/market/api.ts`**
+
+Add to the `MarketApi` interface: `myListings(c?: Cursor): Promise<MyListing[]>; myBids(c?: BidCursor): Promise<MyBid[]>;`. Import `BidCursor, MyBid, MyListing` into the `import type` block. Add to the returned object (reuse the existing `query()` helper + `call()`):
+
+```ts
+myListings: (c = {}) =>
+	call<MyListing[]>({
+		path: `/api/v1/market/me/listings${query({
+			limit: c.limit ?? 25,
+			before_created_at: c.before_created_at,
+			before_id: c.before_id,
+		})}`,
+		auth: true,
+	}),
+myBids: (c = {}) =>
+	call<MyBid[]>({
+		path: `/api/v1/market/me/bids${query({
+			limit: c.limit ?? 25,
+			before_placed_at: c.before_placed_at,
+			before_id: c.before_id,
+		})}`,
+		auth: true,
+	}),
+```
+
+- [ ] **Step 5: Run GREEN + commit**
+
+`vitest run src/markets/market/__tests__/api.test.ts` → PASS. Commit:
+```bash
+git add packages/npm/rn/src/markets/market/api.ts packages/npm/rn/src/markets/market/types.ts packages/npm/rn/src/markets/market/__tests__/api.test.ts
+git commit -m "feat(rn): market personal myListings/myBids on createMarketApi
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `StoreAdminView` composition (TDD render)
+
+**Files:** Create `markets/store/StoreAdminView.tsx`; modify `markets/store/index.ts`; Test `markets/store/__tests__/StoreAdminView.test.tsx`.
+
+**Interfaces:**
+- Consumes: `createStoreApi` + all staff methods (Task 1); RN primitives (relative); `StoreProduct`, `StoreVariant`, `StoreOrderStaff`, `OrderStatus`, `Fulfillment` from `./types`.
+- Produces: `StoreAdminView({ getToken, baseUrl, authenticated }): JSX` and `StoreAdminViewProps`.
+
+**Design** (RN port of `components/store/{StoreAdmin,StaffOrderQueue}.tsx`, comment-free, primitives imported relative):
+
+- Props: `{ getToken: () => Promise<string | null>; baseUrl?: string; authenticated: boolean }`. `const api = useMemo(() => createStoreApi({ getToken, baseUrl }), [getToken, baseUrl])`.
+- `!authenticated` → `<Text tone="danger">Sign in as staff.</Text>`.
+- `fmtErr(e)`: `StoreApiError` → status 403 `'Staff permissions required.'`, 401 `'Sign in as staff.'`, else `e.message`; non-Error → `'request failed'`. (Import `StoreApiError` from `./errors`.)
+- **Catalog panel** (`Surface`): products state via `api.catalog()` in an effect (guarded by `authenticated`); list rows (`Text` title/slug/price/fulfillment/variant_count + a `Button title="Retire" variant="ghost"` → `api.staffSetProductStatus(p.product_id,'retired')` then reload). Upsert-product form: `FormField` slug/title, `FormField keyboardType="numeric"` price, `Select` fulfillment (`options` = digital/physical/both), `FormField` description; `Button title="Save product"` disabled when `busy || !slug || !title` → `api.staffUpsertProduct({slug,title,description:description||null,price,fulfillment})` then reload. Upsert-variant form: `Select` product (options from products, `value`=product_id), `FormField` sku, numeric price, `FormField` stock (blank→null), `FormField` attrs (JSON string; parse in submit, throw `'attributes must be valid JSON'` on failure), `Button "Save variant"` → `api.staffUpsertVariant(variantProduct,{sku,attributes,price,stock:stock===''?null:Number(stock)})`; variant list (loaded via `api.productDetail(slug).variants`) with Retire → `api.staffSetVariantStatus`.
+- **Order queue panel** (`Surface`): `orders` via `api.staffListOrders()` in an effect; `NEXT: Partial<Record<OrderStatus,OrderStatus>> = { paid:'processing', processing:'shipped', shipped:'delivered' }`. Per order `Stack`: label (`#id · qty× · credits · status Badge`); `Button "Submit POD"` when `status==='paid'` → `api.staffSubmitPod(id)`; advance `Button` `→ NEXT[status]` when defined — **advancing to `'shipped'` reveals an inline `FormField` (tracking number)** held in per-order state (`trackingFor: number|null` + `trackingInput`), submitting calls `api.staffAdvanceOrder(id,{to_status:to, tracking: to==='shipped'?{number:trackingInput}:undefined})`; **two-tap Refund** (`confirmRefundFor: number|null` state — first tap sets it and relabels the button `Confirm refund` `variant="danger"`, second tap calls `api.staffRefundOrder(id,'staff refund')`) when `status` not in `refunded`/`cancelled`. NO `prompt`/`confirm`. `busy: number|null` disables the acting order's buttons.
+- Shared: `error` state (`Text tone="danger"`), `busy` boolean/number. All async wrapped; `catch { void 0; }` where a caught value is intentionally ignored, else `setError(fmtErr(e))`.
+
+- [ ] **Step 1: Write render test** `markets/store/__tests__/StoreAdminView.test.tsx`
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { StoreAdminView } from '../StoreAdminView';
+
+beforeEach(() => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+});
+
+describe('StoreAdminView', () => {
+	it('prompts sign-in when unauthenticated', () => {
+		const { getByText } = render(
+			<StoreAdminView getToken={async () => null} baseUrl="" authenticated={false} />,
+		);
+		expect(getByText(/Sign in as staff/)).toBeTruthy();
+	});
+
+	it('renders admin panels when authenticated', async () => {
+		const { findByText } = render(
+			<StoreAdminView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText(/Save product/)).toBeTruthy();
+		expect(await findByText(/Order queue|Orders/)).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: RED** — `vitest run src/markets/store/__tests__/StoreAdminView.test.tsx` → FAIL.
+
+- [ ] **Step 3: Implement `StoreAdminView.tsx`** per Design above. Reference `markets/store/StoreView.tsx` for the api/useMemo/effect/error shape and primitive usage. Primitives relative. Comment-free.
+
+- [ ] **Step 4: Export from barrel** — `markets/store/index.ts`: add `export { StoreAdminView } from './StoreAdminView'; export type { StoreAdminViewProps } from './StoreAdminView';`
+
+- [ ] **Step 5: GREEN + lint + commit**
+
+`vitest run src/markets/store/__tests__/StoreAdminView.test.tsx` → PASS. `nx lint rn --skip-nx-cache` clean for the new file. Commit:
+```bash
+git add packages/npm/rn/src/markets/store/StoreAdminView.tsx packages/npm/rn/src/markets/store/index.ts packages/npm/rn/src/markets/store/__tests__/StoreAdminView.test.tsx
+git commit -m "feat(rn): StoreAdminView (catalog + order queue) composition
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `MarketProfileView` composition (TDD render)
+
+**Files:** Create `markets/market/MarketProfileView.tsx`; modify `markets/market/index.ts`; Test `markets/market/__tests__/MarketProfileView.test.tsx`.
+
+**Interfaces:**
+- Consumes: `createMarketApi` + `myListings`/`myBids`/`listingDetail` (Task 2); `getWatchList`/`removeFromWatch`/`subscribe` from `./watchlist`; `ItemIcon`, `EnchantList`; `formatKhash`/`formatExpiry`/`formatRelative`/`itemRefLabel` from `./format`; `MyListing`, `MyBid`, `WatchEntry`.
+- Produces: `MarketProfileView({ getToken, baseUrl, authenticated }): JSX` + `MarketProfileViewProps`.
+
+**Design** (RN port of `components/market/MarketProfileShell.tsx`, comment-free, primitives relative):
+
+- Props: `{ getToken; baseUrl?; authenticated }`. `api = useMemo(() => createMarketApi({ getToken, baseUrl }), ...)`.
+- `!authenticated` → `<Text>Sign in to view your marketplace activity.</Text>`.
+- Tabs: `type Tab='listings'|'bids'|'watching'`; `tab` state; a header `Stack direction="row"` of three `Button`s (active `variant="primary"`, else `variant="ghost"`; titles `Listings (${activeListings.length})`, `Bids (${bids.length})`, `Watching (${watchEntries.length})`) + a refresh `Button title="↻"` (disabled while `loading`).
+- Data: `refresh()` → `Promise.all([api.myListings({limit:50}), api.myBids({limit:50})])`, `setListings`/`setBids`; `loading`/`error` (`MarketApiError` → `e.message`). Effect runs `refresh()` on mount when `authenticated`. Watchlist effect: `setWatchEntries(getWatchList()); const unsub = subscribe(() => setWatchEntries(getWatchList())); return unsub;`.
+- Bid thumbnails: an effect resolving `item_ref` for each unique `bids[].listing_id` not already in a `bidRefs: Map<number, Record<string,unknown>>` via `api.listingDetail(id)` (`catch` → skip); `cancelled` flag on cleanup.
+- `activeListings = listings.filter(r => r.listing_status==='active')`; `closedListings = rest`.
+- **listings tab:** empty → `Text` "No active listings." active cards (a `Pressable` → `window.location.href='/market/listing/?id='+id` on web; guard `typeof window`); each shows `ItemIcon`, `itemRefLabel` + `EnchantList compact`, `Badge` status, prices (`formatKhash(buy_now_price)`/`current_bid`), expiry (`formatExpiry` when active else `formatRelative(settled_at)` or '—'). Closed listings under a collapsible (RN: a `Button` toggling a `showClosed` state → render `closedListings`).
+- **bids tab:** empty → "No bids yet." per bid card: thumbnail from `bidRefs.get(listing_id)` (else placeholder), label `itemRefLabel(itemRef)` or `Listing #${listing_id}`, `Badge` `bid_status`, `formatKhash(amount)`, `formatRelative(placed_at)`; `Pressable` → listing.
+- **watching tab:** empty → "No items watched yet. Star any item to track it here." each `watchEntries` row: `ItemIcon` (or placeholder for non-mc), `entry.ref`, `Badge` `entry.kind`, a `Button title="Unwatch"` → `removeFromWatch(entry)`. (Skip the `/api/mc-items.json` manifest enrichment + `/mc/items/` deep links from the DOM version — YAGNI here; just show `entry.ref`.)
+
+- [ ] **Step 1: Write render test** `markets/market/__tests__/MarketProfileView.test.tsx`
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MarketProfileView } from '../MarketProfileView';
+
+beforeEach(() => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+});
+
+describe('MarketProfileView', () => {
+	it('prompts sign-in when unauthenticated', () => {
+		const { getByText } = render(
+			<MarketProfileView getToken={async () => null} baseUrl="" authenticated={false} />,
+		);
+		expect(getByText(/Sign in to view your marketplace activity/)).toBeTruthy();
+	});
+
+	it('renders the three tabs when authenticated', async () => {
+		const { findByText } = render(
+			<MarketProfileView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText(/Listings \(/)).toBeTruthy();
+		expect(await findByText(/Bids \(/)).toBeTruthy();
+		expect(await findByText(/Watching \(/)).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: RED** — FAIL.
+
+- [ ] **Step 3: Implement `MarketProfileView.tsx`** per Design. Reference `markets/market/MarketView.tsx` + `MarketBrowse.tsx` for card/primitive shape. Primitives relative. Comment-free.
+
+- [ ] **Step 4: Export from barrel** — `markets/market/index.ts`: `export { MarketProfileView } from './MarketProfileView'; export type { MarketProfileViewProps } from './MarketProfileView';`
+
+- [ ] **Step 5: GREEN + full markets suite + lint + commit**
+
+`vitest run src/markets` → all green. `nx lint rn --skip-nx-cache` clean. Commit:
+```bash
+git add packages/npm/rn/src/markets/market/MarketProfileView.tsx packages/npm/rn/src/markets/market/index.ts packages/npm/rn/src/markets/market/__tests__/MarketProfileView.test.tsx
+git commit -m "feat(rn): MarketProfileView (my listings/bids/watching) composition
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Astro bridges — `ReactStoreAdminRN` + `ReactMarketProfileRN`
+
+**Files:** Create `apps/kbve/astro-kbve/src/components/store/ReactStoreAdminRN.tsx`, `components/market/ReactMarketProfileRN.tsx`.
+
+**Interfaces:** Consumes `StoreAdminView`/`MarketProfileView` from `@kbve/rn/markets` (bare import), `$isStaff` from `@kbve/droid`, `useSession` from `@kbve/astro`, `initSupa`/`getSupa` from `@/lib/supa`.
+
+- [ ] **Step 1: `ReactStoreAdminRN.tsx`** (staff-gated, mirrors `components/rnweb/ReactMinecraftDashRN.tsx`)
+
+```tsx
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import { $isStaff } from '@kbve/droid';
+import { ShieldOff } from 'lucide-react';
+import { useSession } from '@kbve/astro';
+import { StoreAdminView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: { margin: 0, fontSize: '1.75rem', color: 'var(--sl-color-text, #e6edf3)' },
+	sub: { margin: 0, color: 'var(--sl-color-gray-3, #8b949e)', maxWidth: '40rem' },
+};
+
+export default function ReactStoreAdminRN() {
+	const { ready, authenticated } = useSession();
+	const isStaff = useStore($isStaff);
+	const token = useMemo(() => getToken, []);
+
+	if (!ready) return null;
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>The store admin console is restricted to KBVE staff.</p>
+			</div>
+		);
+	}
+	return <StoreAdminView getToken={token} baseUrl="" authenticated={authenticated} />;
+}
+```
+
+Verify `$isStaff` is exported from `@kbve/droid` (grep `packages/npm/droid/src` — `ReactMinecraftDashRN.tsx` imports it from there). If it is instead `homeService.$isStaff` (as in `ReactS3BackupRN`), use whichever the codebase's store components use; prefer `@kbve/droid`'s `$isStaff` (matches `ReactMinecraftDashRN`).
+
+- [ ] **Step 2: `ReactMarketProfileRN.tsx`** (auth-gated only — no staff)
+
+```tsx
+import { useMemo } from 'react';
+import { useSession } from '@kbve/astro';
+import { MarketProfileView } from '@kbve/rn/markets';
+import { initSupa, getSupa } from '@/lib/supa';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export default function ReactMarketProfileRN() {
+	const { ready, authenticated } = useSession();
+	const token = useMemo(() => getToken, []);
+	if (!ready) return null;
+	return <MarketProfileView getToken={token} baseUrl="" authenticated={authenticated} />;
+}
+```
+
+- [ ] **Step 3: Commit** (astro islands; not runnable standalone — verified by the astro build in Task 8)
+
+```bash
+git add apps/kbve/astro-kbve/src/components/store/ReactStoreAdminRN.tsx apps/kbve/astro-kbve/src/components/market/ReactMarketProfileRN.tsx
+git commit -m "feat(astro): staff-gated store-admin + personal market RN bridges
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Commerce rail — `marketNav` Manage group + `MarkdownContent` routing + MDX splash
+
+**Files:** Modify `components/market/marketNav.ts`, `components/dashboard/MarkdownContent.astro`, `content/docs/dashboard/store/index.mdx`.
+
+- [ ] **Step 1: `marketNav.ts` — add roots + a Manage group**
+
+Add roots after `MARKET_ROOT`:
+```ts
+export const STORE_ADMIN_ROOT: DashboardNavItem = { label: 'Store Admin', href: '/dashboard/store/' };
+export const MARKET_PROFILE_ROOT: DashboardNavItem = { label: 'My Marketplace', href: '/dashboard/market/' };
+```
+
+Append a third entry to `MARKET_NAV` (after Wallet):
+```ts
+{
+	label: 'Manage',
+	visibility: 'auth',
+	href: '/dashboard/market/',
+	icon: 'M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z',
+	items: [
+		{ label: 'My Marketplace', href: '/dashboard/market/', icon: 'M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z', copy: 'Your listings, bids, and watchlist.' },
+		{ label: 'Store Admin', href: '/dashboard/store/', icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z', copy: 'Staff catalog + order queue.', attrs: { 'data-auth-visibility': 'staff' } },
+	],
+},
+```
+(If `DashboardNavItem` has no `attrs` field, check `dashboardNav.ts` — the store admin MDX already uses `sidebar.attrs.data-auth-visibility`; mirror whatever key the nav item type supports. If unsupported, drop the `attrs` and rely on the MDX sidebar gate + backend 403 + the island's ShieldOff — the link is then visible but the page self-gates.)
+
+Add breadcrumb builders:
+```ts
+export const buildStoreAdminBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, STORE_ADMIN_ROOT, pathname);
+export const buildMarketProfileBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(MARKET_NAV, MARKET_PROFILE_ROOT, pathname);
+```
+
+- [ ] **Step 2: `MarkdownContent.astro` — route the two dashboard commerce roots to the Commerce rail**
+
+Import the new roots + builders (extend the existing `from '../market/marketNav'` import): add `STORE_ADMIN_ROOT, MARKET_PROFILE_ROOT, buildStoreAdminBreadcrumb, buildMarketProfileBreadcrumb`.
+
+Add flags after `isMarket` (line ~59):
+```ts
+const isStoreAdmin = norm(pathname) === '/dashboard/store/';
+const isMarketProfile = norm(pathname) === '/dashboard/market/';
+```
+Exclude them from the generic dashboard branch — change line 40:
+```ts
+const isDashboard = pathname.startsWith('/dashboard') && !isStoreAdmin && !isMarketProfile;
+```
+Add two branches to the `shell` ternary (place them BEFORE the final `: undefined`, e.g. after the `isMarket` branch):
+```ts
+: isStoreAdmin
+	? {
+			entries: MARKET_NAV,
+			root: STORE_ADMIN_ROOT,
+			menuLabel: 'Commerce menu',
+			navLabel: 'Commerce',
+			crumbs: buildStoreAdminBreadcrumb(pathname),
+			collapsible: true,
+			withToc: false,
+		}
+	: isMarketProfile
+		? {
+				entries: MARKET_NAV,
+				root: MARKET_PROFILE_ROOT,
+				menuLabel: 'Commerce menu',
+				navLabel: 'Commerce',
+				crumbs: buildMarketProfileBreadcrumb(pathname),
+				collapsible: true,
+				withToc: false,
+			}
+		: undefined;
+```
+
+- [ ] **Step 3: `content/docs/dashboard/store/index.mdx` — make it a splash page**
+
+Add `template: splash` to the frontmatter (keep `title: Store Admin`, `sidebar.attrs.data-auth-visibility: staff`, `tableOfContents: false`). (`dashboard/market.mdx` is already `template: splash` — no change; it will pick up the new bento shell in Task 7.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/market/marketNav.ts apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro apps/kbve/astro-kbve/src/content/docs/dashboard/store/index.mdx
+git commit -m "feat(astro): Commerce rail + splash on dashboard store/market routes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Bento shells — `AstroStoreAdminShell` + `AstroMarketProfileShell`
+
+**Files:** Modify `components/store/AstroStoreAdminShell.astro`, `components/market/AstroMarketProfileShell.astro`.
+
+**Pattern:** mirror `components/store/AstroStoreShell.astro` exactly (hero + `BentoShell` + `RnDashSkeleton` fallback + `<style is:global>` RAW CSS accent block — NOT the MDX template-literal form).
+
+- [ ] **Step 1: Rewrite `AstroStoreAdminShell.astro`** (amber accent, staff hero)
+
+```astro
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+import ReactStoreAdminRN from './ReactStoreAdminRN';
+
+const backdrop = 'https://images.unsplash.com/photo-1607083206869-4c7672e72a8a?q=80&w=2400&auto=format&fit=crop';
+---
+
+<div class="store-admin-hub" style={`--bento-hero-bg: url('${backdrop}')`}>
+	<section class="bento-hero bento-section not-content" aria-label="Store Admin">
+		<div class="bento-hero__bg" aria-hidden="true"></div>
+		<div class="bento-hero__frame bento-frame">
+			<div class="bento-board bento-board--hero">
+				<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+					<span class="bento-badge bento-chip"><span>staff</span></span>
+					<h1 class="bento-title">Run the store,
+						<span class="bento-title__accent">mint the drops.</span></h1>
+					<p class="bento-lede">
+						Manage products, variants, and the fulfillment queue. Staff only —
+						every action is audited against your account.
+					</p>
+					<div class="bento-cta">
+						<a class="bento-btn bento-btn--primary" href="#admin">Open console
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+						</a>
+						<a class="bento-btn bento-btn--ghost" href="/store/">Customer store</a>
+					</div>
+				</div>
+				{[
+					{ v: 'Catalog', l: 'Products & variants' },
+					{ v: 'Fulfillment', l: 'Advance, ship, refund' },
+					{ v: 'Audited', l: 'Staff-gated actions' },
+				].map((s) => (
+					<div class="bento-cell bento-stat bento-card bento-card--glass">
+						<span class="bento-stat__value">{s.v}</span>
+						<span class="bento-stat__label">{s.l}</span>
+					</div>
+				))}
+			</div>
+		</div>
+	</section>
+
+	<BentoShell id="admin" eyebrow="Staff" heading="Store Admin">
+		<div class="admin-island">
+			<ReactStoreAdminRN client:only="react">
+				<RnDashSkeleton slot="fallback" tiles={3} rows={4} />
+			</ReactStoreAdminRN>
+		</div>
+	</BentoShell>
+</div>
+
+<style>
+	.admin-island { min-height: 60vh; }
+</style>
+
+<style is:global>
+	.store-admin-hub {
+		--bento-accent: #fbbf24;
+		--bento-accent-2: #f59e0b;
+		--bento-btn-fg: #3a2a05;
+	}
+</style>
+```
+
+- [ ] **Step 2: Rewrite `AstroMarketProfileShell.astro`** (violet accent, personal hero)
+
+Same structure, `class="market-profile-hub"`, badge `you`, title "Your listings, / bids, and watchlist.", lede about tracking your marketplace activity, CTA `#profile` "Open dashboard" + ghost `/market/` "Browse marketplace"; stat tiles `{Listings, Bids, Watching}`; `<BentoShell id="profile" eyebrow="You" heading="My Marketplace">` wrapping `<ReactMarketProfileRN client:only="react">` + `RnDashSkeleton` fallback; global accent:
+```
+.market-profile-hub { --bento-accent: #a78bfa; --bento-accent-2: #22d3ee; --bento-btn-fg: #1a1033; }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/store/AstroStoreAdminShell.astro apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
+git commit -m "feat(astro): bento splash shells for store admin + market profile
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Verification + build
+
+**Files:** none (verification only; fixes as needed).
+
+- [ ] **Step 1: Full markets suite**
+
+`cd $WT/packages/npm/rn && NX_DAEMON=false $MAIN/node_modules/.bin/vitest run src/markets` → all green (store + market + new staff/personal api cases + StoreAdminView + MarketProfileView).
+
+- [ ] **Step 2: Lint**
+
+`NX_DAEMON=false $MAIN/node_modules/.bin/nx lint rn --skip-nx-cache` → 0 errors (relative imports, no `no-empty`, no `prompt`/`confirm`).
+
+- [ ] **Step 3: Astro build**
+
+`cd $WT/apps/kbve/astro-kbve && NX_DAEMON=false $MAIN/node_modules/.bin/astro build` → EXIT 0.
+
+- [ ] **Step 4: Splash + island render checks** (grep the built HTML)
+
+```bash
+cd $WT/apps/kbve/astro-kbve
+grep -l 'store-admin-hub' dist/**/dashboard/store/*.html 2>/dev/null || echo "check dashboard/store output path"
+grep -l 'market-profile-hub' dist/**/dashboard/market/*.html 2>/dev/null || echo "check dashboard/market output path"
+```
+Expect the hub class present (splash rendered, no Starlight sidebar). Confirm the Commerce rail (`navLabel Commerce`) wraps them, not the Dashboard nav.
+
+- [ ] **Step 5: Web-graph clean — 0 vector-icons in the admin/profile island chunks**
+
+```bash
+cd $WT/apps/kbve/astro-kbve
+for f in dist/_astro/ReactStoreAdminRN.*.js dist/_astro/ReactMarketProfileRN.*.js; do
+	echo "$f:"; grep -c 'vector-icons\|createIconSet' "$f" 2>/dev/null || echo 0;
+done
+```
+Expect 0 for both (the RN views import UI primitives directly, never the barrel).
+
+- [ ] **Step 6: Push branch + open PR → dev**
+
+```bash
+cd $WT
+git push -u origin feat/markets-admin-phase3
+gh pr create --base dev --title "feat(markets): Phase 3 — admin store + personal marketplace on @kbve/rn/markets" --body "$(cat <<'EOF'
+Phase 3 of the store+market epic — brings the admin store (`/dashboard/store/`) and personal marketplace (`/dashboard/market/`) into the `@kbve/rn/markets` universal composition + bento splash + Commerce rail, completing the unified customer-vs-admin view. Follows #14338 (customer `/store/`) and #14398 (customer `/market/`).
+
+## What
+- `createStoreApi` gains 8 staff methods (catalog CRUD + order fulfillment); `createMarketApi` gains `myListings`/`myBids`.
+- New RN views `StoreAdminView` (catalog + order queue, inline tracking, two-tap refund — no browser dialogs) and `MarketProfileView` (my listings / bids / watching tabs).
+- Astro bridges: `ReactStoreAdminRN` (staff-gated via `$isStaff`, ShieldOff fallback) + `ReactMarketProfileRN` (auth-gated).
+- Bento splash shells (amber admin / violet profile) + Commerce rail routing for `/dashboard/store/` + `/dashboard/market/`.
+
+## Verify
+- markets vitest green (incl. new staff/personal api + view render tests); `nx lint rn` clean.
+- `astro build` EXIT 0; both routes render splash + Commerce rail + island; 0 vector-icons in the island chunks.
+
+## Deferred (Phase 4)
+`MCItemMarketSidecar`, `IdiotCard` three-fiber, Expo mobile screens; old DOM `components/{store,market}/*` kept (still power those).
+
+Docs: `docs/superpowers/specs/2026-07-20-markets-admin-phase3-design.md`, `docs/superpowers/plans/2026-07-20-markets-admin-phase3.md`.
+EOF
+)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** store staff delta → Task 1; market personal delta → Task 2; `StoreAdminView` → Task 3; `MarketProfileView` → Task 4; bridges → Task 5; Commerce rail + splash MDX → Task 6; bento shells → Task 7; verify → Task 8. All spec sections mapped.
+- **Type consistency:** `StoreOrderStaff`/`StaffProductBody`/`StaffVariantBody` defined Task 1, consumed Task 3; `BidCursor`/`MyListing`/`MyBid` Task 2, consumed Task 4. `StoreAdminViewProps`/`MarketProfileViewProps` produced Tasks 3/4, consumed by bridges Task 5.
+- **Gotchas carried:** relative UI imports; `catch { void 0; }`; RAW CSS `<style is:global>` in `.astro`; `isDashboard` precedence (exclude the two exact roots BEFORE the prefix branch); staff gate in the bridge not the RN view; `baseUrl=''`.

--- a/docs/superpowers/specs/2026-07-20-markets-admin-phase3-design.md
+++ b/docs/superpowers/specs/2026-07-20-markets-admin-phase3-design.md
@@ -1,0 +1,95 @@
+# `@kbve/rn/markets` Phase 3 — Admin Store + Personal Marketplace (`/dashboard/store/`, `/dashboard/market/`)
+
+**Date:** 2026-07-20
+**Scope:** `apps/kbve/astro-kbve` + `packages/npm/rn` — port the staff store-admin surface (`/dashboard/store/`) and the personal marketplace surface (`/dashboard/market/`) into the `@kbve/rn/markets` universal composition + bento splash + Commerce rail, completing the unified customer-vs-admin store+market view. Mirrors the shipped Phase 1 `/store/` (PR #14338) and Phase 2 `/market/` (PR #14398). See [[project_rn_markets_store]].
+
+Final phase of the store+market epic. Phase 1 = customer `/store/` (done). Phase 2 = customer `/market/` (done). **This = Phase 3, the admin/personal half.**
+
+## Decisions (locked)
+
+- **Two surfaces this phase:** admin `/dashboard/store/` (staff, `StoreAdmin` + `StaffOrderQueue`) and personal `/dashboard/market/` (`MarketProfileShell` = my listings / bids / watching). Both → `@kbve/rn/markets` + bento splash + Commerce gutter rail, matching the four-surface "all splash" requirement from Phase 1/2.
+- **Accent:** admin store = **amber** (store family — `--bento-accent:#f59e0b; --bento-accent-2:#fbbf24; --bento-btn-fg:#1a1400`, same as `AstroStoreShell`). Personal market = **violet** (market family — `--bento-accent:#a78bfa; --bento-accent-2:#22d3ee; --bento-btn-fg:#1a1033`, same as `AstroMarketShell`).
+- **Staff gate lives in the astro bridge** (dash pattern A): `ReactStoreAdminRN.tsx` gates with `useStore($isStaff)` from `@kbve/droid` (mirrors `ReactMinecraftDashRN`) → renders a `ShieldOff` "Staff Access Required" card when not staff, else mounts the RN admin view. The RN composition view itself is NOT staff-aware (takes `getToken`/`baseUrl`/`authenticated` only). Backend enforces 403 regardless. Personal market bridge is auth-gated only (no staff).
+- **`baseUrl=''`** (public main origin) for both — store staff endpoints are `/api/v1/store/staff/*`, personal market is `/api/v1/market/me/*`, both on the public origin, NOT the dash proxy.
+- **Commerce rail on `/dashboard/*` commerce routes:** add exact-root `/dashboard/store/` and `/dashboard/market/` branches to `MarkdownContent.astro` so they render the Commerce rail (Store | Marketplace | Wallet) instead of the generic Dashboard nav — unifying the commerce section. `marketNav.ts` gains a "Manage" group (Store Admin → `/dashboard/store/`, gated by `data-auth-visibility: staff`; My Marketplace → `/dashboard/market/`).
+- **No browser `prompt`/`confirm`** (no RN equivalent, matches Phase 2 no-dialog rule): `StaffOrderQueue` advance-to-shipped reveals an inline tracking `FormField`; refund uses a two-tap "Refund → Confirm" toggle button (no `confirm()` dialog).
+
+## Non-goals (deferred → Phase 4)
+
+- `MCItemMarketSidecar` (public per-item widget on `/mc/items/` via `MCItemPanel.astro`) — stays old DOM; works, different section.
+- `IdiotCard` three-fiber reveal (cosmetic, on customer `/store/` via `ReactStoreCard`) — stays old DOM; three-fiber RN port is its own effort.
+- Expo mobile screens (`MarketsScreen`, admin screens).
+- Old DOM `components/{store,market}/*` + `store.css`/`market.css` — KEPT (still power the sidecar, IdiotCard, `AstroMarketAccountSummary` DOM widget). Do not sweep.
+- No new axum routes; consume existing `/api/v1/store/staff/*` + `/api/v1/market/me/*`.
+
+## API deltas to add
+
+### Store — extend `createStoreApi` (`markets/store/api.ts`) with staff methods
+
+All authed (throw `StoreApiError('Not signed in', 401)` before fetch when token null). Backend returns 403 for non-staff.
+
+| Method | Endpoint | HTTP | Body | Returns |
+|---|---|---|---|---|
+| `staffUpsertProduct(body)` | `/api/v1/store/staff/products` | POST | `StaffProductBody` | `{ id: string }` |
+| `staffSetProductStatus(id, status)` | `/api/v1/store/staff/products/{id}/status` | POST | `{ status }` | void |
+| `staffUpsertVariant(id, body)` | `/api/v1/store/staff/products/{id}/variants` | POST | `StaffVariantBody` | `{ id: string }` |
+| `staffSetVariantStatus(id, status)` | `/api/v1/store/staff/variants/{id}/status` | POST | `{ status }` | void |
+| `staffListOrders(status?)` | `/api/v1/store/staff/orders` (`?status=`) | GET | — | `StoreOrderStaff[]` |
+| `staffAdvanceOrder(id, body)` | `/api/v1/store/staff/orders/{id}/advance` | POST | `{ to_status, tracking?, note? }` | void |
+| `staffRefundOrder(id, reason?)` | `/api/v1/store/staff/orders/{id}/refund` | POST | `{ reason }` | void |
+| `staffSubmitPod(id)` | `/api/v1/store/staff/orders/{id}/submit-pod` | POST | — | `{ order_id, external_id }` |
+
+New types in `markets/store/types.ts`: `StaffProductBody` {slug,title,description?,price,fulfillment?,asset_ref?,status?}; `StaffVariantBody` {sku,attributes?,price,stock?,status?}; `StoreOrderStaff = StoreOrder & { account_id: string; shipping_address: Record<string,unknown> }`. (`StoreOrder`/`StoreVariant`/`StoreProductDetail`/`OrderStatus`/`Fulfillment`/`ShippingAddress` already exist.) Staff methods do NOT inject `idempotency_key` (mutations are keyed by target id).
+
+### Market — extend `createMarketApi` (`markets/market/api.ts`) with personal methods
+
+| Method | Endpoint | HTTP | Cursor params | Returns |
+|---|---|---|---|---|
+| `myListings(c?)` | `/api/v1/market/me/listings` | GET | `limit`, `before_created_at`, `before_id` | `MyListing[]` |
+| `myBids(c?)` | `/api/v1/market/me/bids` | GET | `limit`, `before_placed_at`, `before_id` | `MyBid[]` |
+
+Both authed. `MyListing`/`MyBid`/`Cursor` already in `markets/market/types.ts`; add a `BidCursor` (`limit`, `before_placed_at`, `before_id`) for `myBids`.
+
+## RN composition — new views
+
+### `markets/store/StoreAdminView.tsx`
+
+`StoreAdminView({ getToken, baseUrl, authenticated })` — builds `api = createStoreApi`. Two stacked bento sections:
+- **Catalog admin** (port of `StoreAdmin.tsx`): products list (each with a Retire `Button` → `staffSetProductStatus(id,'retired')`); upsert-product form (`FormField` slug/title/price, `Select` fulfillment, `FormField` description → `staffUpsertProduct`); upsert-variant form (`Select` product, `FormField` sku/price/stock/attrs-JSON → `staffUpsertVariant`) + variant list w/ Retire.
+- **Order queue** (port of `StaffOrderQueue.tsx`): `staffListOrders()` list; per order Submit-POD (when `paid`), advance following `NEXT` map (paid→processing→shipped→delivered; advancing to `shipped` reveals an inline tracking `FormField`), two-tap Refund. No `prompt`/`confirm`.
+
+`!authenticated` → "Sign in as staff." `Text`. Errors map 403→"Staff permissions required.", 401→"Sign in as staff." RN primitives imported **relative** (`../../ui/...`).
+
+### `markets/market/MarketProfileView.tsx`
+
+`MarketProfileView({ getToken, baseUrl, authenticated })` — builds `api = createMarketApi`. Port of `MarketProfileShell.tsx`: 3-tab (`listings`/`bids`/`watching`) + refresh. `myListings({limit:50})` + `myBids({limit:50})`; bids tab resolves item_ref via `api.listingDetail` for thumbnails; watching tab reads the ported `watchlist` store (`getWatchList`/`removeFromWatch`/`subscribe`). Cards reuse `ItemIcon`/`EnchantList`; open `/market/listing/?id=`. `!authenticated` → "Sign in to view your marketplace activity." No staff gate. Tabs via a segmented control of `Button`s (active `variant`).
+
+Both views appended to their sub-area barrels + `markets/index.ts` re-exports through `./store`/`./market`.
+
+## Web bridges — astro-kbve
+
+- `components/store/ReactStoreAdminRN.tsx` — `client:only="react"`; `useStore($isStaff)` from `@kbve/droid`; not-staff → `ShieldOff` card (mirror `ReactMinecraftDashRN`); staff → `<StoreAdminView getToken baseUrl='' authenticated>` (`getToken` via `initSupa`/`getSupa`, `authenticated` via `useSession`).
+- `components/market/ReactMarketProfileRN.tsx` — `client:only="react"`; injects `getToken`/`authenticated`/`baseUrl=''`; renders `<MarketProfileView>`. No staff gate.
+
+Both import `@kbve/rn/markets` bare (out-of-project importer — correct; NOT relative).
+
+## Astro chrome
+
+- `components/store/AstroStoreAdminShell.astro` → bento splash: amber accent + backdrop; `bento-hero` (badge "Staff", title "Store Admin", lede, CTA `#admin` + `/store/`); one `<BentoShell id="admin">` wrapping `<ReactStoreAdminRN client:only>` + `RnDashSkeleton` (`rnsk`) fallback + reserved height. RAW CSS `<style is:global>` (NOT the MDX template-literal form — [[project_rn_markets_store]] GOTCHA 2).
+- `components/market/AstroMarketProfileShell.astro` → bento splash: violet accent; `bento-hero` (badge "You", title "My Marketplace", CTA `#profile` + `/market/`); `<BentoShell id="profile">` wrapping `<ReactMarketProfileRN client:only>` + skeleton fallback.
+- `content/docs/dashboard/store/index.mdx` → add `template: splash` (currently plain dashboard shell); keep `sidebar.attrs.data-auth-visibility: staff`.
+- `content/docs/dashboard/market.mdx` → already `template: splash`; verify it renders the new bento shell.
+- `components/market/marketNav.ts` → add a "Manage" group: Store Admin (`/dashboard/store/`, `data-auth-visibility: staff`) + My Marketplace (`/dashboard/market/`).
+- `components/starlight/MarkdownContent.astro` → add exact-root branches `norm(p)==='/dashboard/store/'` and `norm(p)==='/dashboard/market/'` → Commerce rail (`MARKET_NAV`), so these commerce routes get Store|Marketplace|Wallet|Manage instead of the generic Dashboard nav. Guard ordering: these exact-root checks must precede the generic `isDashboard` prefix branch.
+
+## Verification (Phase 3)
+
+- `nx lint rn` clean (new views — relative imports, no boundary violations, no `no-empty`, no `prompt`/`confirm`).
+- markets vitest suite green: existing (store + market) + new `staff` api cases + `myListings/myBids` cases + `StoreAdminView`/`MarketProfileView` render tests.
+- `astro build` EXIT 0; `/dashboard/store/` renders splash + amber bento-hero + Commerce rail (Manage group, staff link visible to staff) + `ReactStoreAdminRN` island (ShieldOff for non-staff) + `rnsk` fallback; `/dashboard/market/` renders splash + violet bento-hero + Commerce rail + `ReactMarketProfileRN` island (3 tabs) + fallback.
+- Built `ReactStoreAdminRN`/`ReactMarketProfileRN` chunks: 0 `vector-icons`.
+
+## Files
+
+- **New:** `packages/npm/rn/src/markets/store/StoreAdminView.tsx`; `market/MarketProfileView.tsx`; `apps/kbve/astro-kbve/src/components/store/ReactStoreAdminRN.tsx`, `components/market/ReactMarketProfileRN.tsx`; test files under `markets/{store,market}/__tests__/`.
+- **Edit:** `markets/store/{api,types,index}.ts`; `markets/market/{api,types,index}.ts`; `apps/kbve/astro-kbve/src/components/store/AstroStoreAdminShell.astro`, `components/market/AstroMarketProfileShell.astro`, `marketNav.ts`; `components/starlight/MarkdownContent.astro`; `content/docs/dashboard/store/index.mdx`.

--- a/packages/npm/rn/src/markets/market/MarketProfileView.tsx
+++ b/packages/npm/rn/src/markets/market/MarketProfileView.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Badge, type BadgeTone } from '../../ui/primitives/Badge';
+import { Button } from '../../ui/primitives/Button';
+import { Stack } from '../../ui/primitives/Stack';
+import { Surface } from '../../ui/primitives/Surface';
+import { Text } from '../../ui/primitives/Text';
+import { tokens } from '../../ui/theme';
+import { createMarketApi } from './api';
+import { MarketApiError } from './errors';
+import { EnchantList } from './EnchantList';
+import { ItemIcon } from './ItemIcon';
+import {
+	formatExpiry,
+	formatKhash,
+	formatRelative,
+	itemRefLabel,
+} from './format';
+import {
+	getWatchList,
+	removeFromWatch,
+	subscribe,
+	type WatchEntry,
+} from './watchlist';
+import type { BidStatus, ListingStatus, MyBid, MyListing } from './types';
+
+type Tab = 'listings' | 'bids' | 'watching';
+
+export interface MarketProfileViewProps {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	authenticated: boolean;
+}
+
+function openListing(id: number): void {
+	if (typeof window !== 'undefined') {
+		window.location.href = `/market/listing/?id=${id}`;
+	}
+}
+
+function statusTone(status: ListingStatus | BidStatus): BadgeTone {
+	if (status === 'active') return 'success';
+	if (status === 'sold' || status === 'won') return 'primary';
+	if (status === 'cancelled' || status === 'refunded') return 'danger';
+	if (status === 'expired' || status === 'outbid') return 'warning';
+	return 'neutral';
+}
+
+export function MarketProfileView({
+	getToken,
+	baseUrl = '',
+	authenticated,
+}: MarketProfileViewProps) {
+	const api = useMemo(
+		() => createMarketApi({ getToken, baseUrl }),
+		[getToken, baseUrl],
+	);
+	const [tab, setTab] = useState<Tab>('listings');
+	const [listings, setListings] = useState<MyListing[]>([]);
+	const [bids, setBids] = useState<MyBid[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [showClosed, setShowClosed] = useState(false);
+	const [bidRefs, setBidRefs] = useState<Map<number, Record<string, unknown>>>(
+		() => new Map(),
+	);
+	const [watchEntries, setWatchEntries] = useState<WatchEntry[]>([]);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const [ls, bs] = await Promise.all([
+				api.myListings({ limit: 50 }),
+				api.myBids({ limit: 50 }),
+			]);
+			setListings(ls);
+			setBids(bs);
+		} catch (e) {
+			setError(e instanceof MarketApiError ? e.message : 'failed to load');
+		} finally {
+			setLoading(false);
+		}
+	}, [api]);
+
+	useEffect(() => {
+		if (authenticated) void refresh();
+	}, [authenticated, refresh]);
+
+	useEffect(() => {
+		setWatchEntries(getWatchList());
+		const unsub = subscribe(() => setWatchEntries(getWatchList()));
+		return unsub;
+	}, []);
+
+	useEffect(() => {
+		if (bids.length === 0) return;
+		let cancelled = false;
+		const missing = Array.from(
+			new Set(
+				bids.map((b) => b.listing_id).filter((id) => !bidRefs.has(id)),
+			),
+		);
+		if (missing.length === 0) return;
+		(async () => {
+			const pairs = await Promise.all(
+				missing.map(async (id) => {
+					try {
+						const d = await api.listingDetail(id);
+						return [id, d.item_ref] as const;
+					} catch {
+						return null;
+					}
+				}),
+			);
+			if (cancelled) return;
+			setBidRefs((prev) => {
+				const next = new Map(prev);
+				for (const p of pairs) {
+					if (p) next.set(p[0], p[1]);
+				}
+				return next;
+			});
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [api, bids, bidRefs]);
+
+	const activeListings = useMemo(
+		() => listings.filter((r) => r.listing_status === 'active'),
+		[listings],
+	);
+	const closedListings = useMemo(
+		() => listings.filter((r) => r.listing_status !== 'active'),
+		[listings],
+	);
+
+	if (!authenticated) {
+		return (
+			<Text variant="body" tone="muted">
+				Sign in to view your marketplace activity.
+			</Text>
+		);
+	}
+
+	const renderListingCard = (r: MyListing) => (
+		<Pressable
+			key={r.listing_id}
+			onPress={() => openListing(r.listing_id)}
+			accessibilityRole="button">
+			<Surface style={styles.card}>
+				<Stack direction="row" gap="md" align="center">
+					<ItemIcon itemRef={r.item_ref} size={48} />
+					<Stack gap="xs" style={styles.grow}>
+						<Stack direction="row" gap="xs" align="center" wrap>
+							<Text variant="subtitle">
+								{itemRefLabel(r.item_ref)}
+							</Text>
+							<EnchantList itemRef={r.item_ref} compact />
+							<Badge
+								label={r.listing_status}
+								tone={statusTone(r.listing_status)}
+							/>
+						</Stack>
+						<Stack direction="row" gap="md" align="center" wrap>
+							{r.buy_now_price !== null ? (
+								<Text variant="caption" tone="muted">
+									Buy {formatKhash(r.buy_now_price)}
+								</Text>
+							) : null}
+							{r.current_bid !== null ? (
+								<Text variant="caption" tone="muted">
+									Bid {formatKhash(r.current_bid)}
+								</Text>
+							) : null}
+							<Text variant="caption" tone="faint">
+								{r.listing_status === 'active'
+									? formatExpiry(r.expires_at)
+									: r.settled_at
+										? formatRelative(r.settled_at)
+										: '—'}
+							</Text>
+						</Stack>
+					</Stack>
+				</Stack>
+			</Surface>
+		</Pressable>
+	);
+
+	const renderBidCard = (b: MyBid) => {
+		const itemRef = bidRefs.get(b.listing_id);
+		return (
+			<Pressable
+				key={b.bid_id}
+				onPress={() => openListing(b.listing_id)}
+				accessibilityRole="button">
+				<Surface style={styles.card}>
+					<Stack direction="row" gap="md" align="center">
+						{itemRef ? (
+							<ItemIcon itemRef={itemRef} size={48} />
+						) : (
+							<View style={styles.thumbPlaceholder}>
+								<Text variant="caption" tone="faint">
+									…
+								</Text>
+							</View>
+						)}
+						<Stack gap="xs" style={styles.grow}>
+							<Stack direction="row" gap="xs" align="center" wrap>
+								<Text variant="subtitle">
+									{itemRef
+										? itemRefLabel(itemRef)
+										: `Listing #${b.listing_id}`}
+								</Text>
+								{itemRef ? (
+									<EnchantList itemRef={itemRef} compact />
+								) : null}
+								<Badge
+									label={b.bid_status}
+									tone={statusTone(b.bid_status)}
+								/>
+							</Stack>
+							<Stack
+								direction="row"
+								gap="md"
+								align="center"
+								wrap>
+								<Text variant="caption" tone="muted">
+									{formatKhash(b.amount)}
+								</Text>
+								<Text variant="caption" tone="faint">
+									{formatRelative(b.placed_at)}
+								</Text>
+							</Stack>
+						</Stack>
+					</Stack>
+				</Surface>
+			</Pressable>
+		);
+	};
+
+	const renderWatchRow = (entry: WatchEntry) => (
+		<Surface key={`${entry.kind}::${entry.ref}`} style={styles.card}>
+			<Stack direction="row" gap="md" align="center">
+				{entry.kind === 'mc_item' ? (
+					<ItemIcon
+						itemRef={{ kind: entry.kind, id: entry.ref }}
+						size={48}
+					/>
+				) : (
+					<View style={styles.thumbPlaceholder}>
+						<Text variant="caption" tone="faint">
+							…
+						</Text>
+					</View>
+				)}
+				<Stack gap="xs" style={styles.grow}>
+					<Stack direction="row" gap="xs" align="center" wrap>
+						<Text variant="subtitle">{entry.ref}</Text>
+						<Badge label={entry.kind} />
+					</Stack>
+				</Stack>
+				<Button
+					title="Unwatch"
+					variant="ghost"
+					onPress={() => removeFromWatch(entry)}
+				/>
+			</Stack>
+		</Surface>
+	);
+
+	return (
+		<Stack gap="lg">
+			<Stack direction="row" gap="sm" align="center" wrap>
+				<Button
+					title={`Listings (${activeListings.length})`}
+					variant={tab === 'listings' ? 'primary' : 'ghost'}
+					onPress={() => setTab('listings')}
+				/>
+				<Button
+					title={`Bids (${bids.length})`}
+					variant={tab === 'bids' ? 'primary' : 'ghost'}
+					onPress={() => setTab('bids')}
+				/>
+				<Button
+					title={`Watching (${watchEntries.length})`}
+					variant={tab === 'watching' ? 'primary' : 'ghost'}
+					onPress={() => setTab('watching')}
+				/>
+				<Button
+					title="↻"
+					variant="ghost"
+					disabled={loading}
+					onPress={() => void refresh()}
+				/>
+			</Stack>
+
+			{error ? (
+				<Text variant="body" tone="danger">
+					{error}
+				</Text>
+			) : null}
+
+			{tab === 'listings' ? (
+				<Stack gap="md">
+					{activeListings.length === 0 && !loading ? (
+						<Text variant="body" tone="muted">
+							No active listings.
+						</Text>
+					) : null}
+					{activeListings.map((r) => renderListingCard(r))}
+					{closedListings.length > 0 ? (
+						<Button
+							title={
+								showClosed
+									? `Hide past listings (${closedListings.length})`
+									: `Show past listings (${closedListings.length})`
+							}
+							variant="ghost"
+							onPress={() => setShowClosed((v) => !v)}
+						/>
+					) : null}
+					{showClosed
+						? closedListings.map((r) => renderListingCard(r))
+						: null}
+				</Stack>
+			) : null}
+
+			{tab === 'bids' ? (
+				<Stack gap="md">
+					{bids.length === 0 && !loading ? (
+						<Text variant="body" tone="muted">
+							No bids yet.
+						</Text>
+					) : null}
+					{bids.map((b) => renderBidCard(b))}
+				</Stack>
+			) : null}
+
+			{tab === 'watching' ? (
+				<Stack gap="md">
+					{watchEntries.length === 0 ? (
+						<Text variant="body" tone="muted">
+							No items watched yet. Star any item to track it here.
+						</Text>
+					) : null}
+					{watchEntries.map((e) => renderWatchRow(e))}
+				</Stack>
+			) : null}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	card: { padding: tokens.space.md },
+	grow: { flexGrow: 1, flexShrink: 1 },
+	thumbPlaceholder: {
+		width: 48,
+		height: 48,
+		borderRadius: 8,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: tokens.color.surfaceAlt,
+	},
+});
+
+export default MarketProfileView;

--- a/packages/npm/rn/src/markets/market/MarketProfileView.tsx
+++ b/packages/npm/rn/src/markets/market/MarketProfileView.tsx
@@ -114,6 +114,7 @@ export function MarketProfileView({
 				}),
 			);
 			if (cancelled) return;
+			if (!pairs.some(Boolean)) return;
 			setBidRefs((prev) => {
 				const next = new Map(prev);
 				for (const p of pairs) {

--- a/packages/npm/rn/src/markets/market/__tests__/MarketProfileView.test.tsx
+++ b/packages/npm/rn/src/markets/market/__tests__/MarketProfileView.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MarketProfileView } from '../MarketProfileView';
+
+beforeEach(() => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+});
+
+describe('MarketProfileView', () => {
+	it('prompts sign-in when unauthenticated', () => {
+		const { getByText } = render(
+			<MarketProfileView getToken={async () => null} baseUrl="" authenticated={false} />,
+		);
+		expect(getByText(/Sign in to view your marketplace activity/)).toBeTruthy();
+	});
+
+	it('renders the three tabs when authenticated', async () => {
+		const { findByText } = render(
+			<MarketProfileView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText(/Listings \(/)).toBeTruthy();
+		expect(await findByText(/Bids \(/)).toBeTruthy();
+		expect(await findByText(/Watching \(/)).toBeTruthy();
+	});
+});

--- a/packages/npm/rn/src/markets/market/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/market/__tests__/api.test.ts
@@ -83,4 +83,27 @@ describe('createMarketApi', () => {
 		expect(err.message).toBe('amount must be a positive integer');
 		expect(err.code).toBe('invalid_argument');
 	});
+
+	it('myListings GETs personal listings with cursor, bearer', async () => {
+		(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+		const api = createMarketApi({ getToken: token, baseUrl: 'https://x' });
+		await api.myListings({ limit: 50 });
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('https://x/api/v1/market/me/listings?limit=50');
+		expect(init.headers.Authorization).toBe('Bearer tok');
+	});
+
+	it('myBids GETs personal bids with before_placed_at cursor', async () => {
+		(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+		const api = createMarketApi({ getToken: token, baseUrl: '' });
+		await api.myBids({ limit: 10, before_placed_at: '2020', before_id: 3 });
+		const [url] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('/api/v1/market/me/bids?limit=10&before_placed_at=2020&before_id=3');
+	});
+
+	it('myListings without token throws 401 without fetch', async () => {
+		const api = createMarketApi({ getToken: async () => null });
+		await expect(api.myListings()).rejects.toMatchObject({ name: 'MarketApiError', status: 401 });
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
 });

--- a/packages/npm/rn/src/markets/market/api.ts
+++ b/packages/npm/rn/src/markets/market/api.ts
@@ -1,10 +1,13 @@
 import { MarketApiError } from './errors';
 import { newIdempotencyKey } from '../shared';
 import type {
+	BidCursor,
 	Cursor,
 	IdResponse,
 	MarketListing,
 	MarketListingDetail,
+	MyBid,
+	MyListing,
 } from './types';
 
 export interface MarketApiOptions {
@@ -26,6 +29,8 @@ export interface MarketApi {
 	placeBid(id: number, amount: number): Promise<IdResponse>;
 	buyNow(id: number): Promise<IdResponse>;
 	cancelListing(id: number, reason?: string | null): Promise<void>;
+	myListings(c?: Cursor): Promise<MyListing[]>;
+	myBids(c?: BidCursor): Promise<MyBid[]>;
 }
 
 function query(
@@ -148,6 +153,24 @@ export function createMarketApi(opts: MarketApiOptions): MarketApi {
 				path: `/api/v1/market/listings/${id}/cancel`,
 				method: 'POST',
 				body: { reason },
+				auth: true,
+			}),
+		myListings: (c = {}) =>
+			call<MyListing[]>({
+				path: `/api/v1/market/me/listings${query({
+					limit: c.limit ?? 25,
+					before_created_at: c.before_created_at,
+					before_id: c.before_id,
+				})}`,
+				auth: true,
+			}),
+		myBids: (c = {}) =>
+			call<MyBid[]>({
+				path: `/api/v1/market/me/bids${query({
+					limit: c.limit ?? 25,
+					before_placed_at: c.before_placed_at,
+					before_id: c.before_id,
+				})}`,
 				auth: true,
 			}),
 	};

--- a/packages/npm/rn/src/markets/market/index.ts
+++ b/packages/npm/rn/src/markets/market/index.ts
@@ -22,3 +22,5 @@ export { ListingDetailView } from './ListingDetailView';
 export type { ListingDetailViewProps } from './ListingDetailView';
 export { MarketView } from './MarketView';
 export type { MarketViewProps } from './MarketView';
+export { MarketProfileView } from './MarketProfileView';
+export type { MarketProfileViewProps } from './MarketProfileView';

--- a/packages/npm/rn/src/markets/market/types.ts
+++ b/packages/npm/rn/src/markets/market/types.ts
@@ -56,3 +56,9 @@ export interface Cursor {
 	before_created_at?: string | null;
 	before_id?: number | null;
 }
+
+export interface BidCursor {
+	limit?: number;
+	before_placed_at?: string | null;
+	before_id?: number | null;
+}

--- a/packages/npm/rn/src/markets/store/StoreAdminView.tsx
+++ b/packages/npm/rn/src/markets/store/StoreAdminView.tsx
@@ -1,0 +1,401 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '../../ui/primitives/Button';
+import { Text } from '../../ui/primitives/Text';
+import { Stack } from '../../ui/primitives/Stack';
+import { Surface } from '../../ui/primitives/Surface';
+import { Badge } from '../../ui/primitives/Badge';
+import { FormField } from '../../ui/primitives/FormField';
+import { Select } from '../../ui/controls/Select';
+import { createStoreApi } from './api';
+import { StoreApiError } from './errors';
+import type {
+	Fulfillment,
+	OrderStatus,
+	StoreOrderStaff,
+	StoreProduct,
+	StoreVariant,
+} from './types';
+
+export interface StoreAdminViewProps {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	authenticated: boolean;
+}
+
+const FULFILLMENTS: { value: Fulfillment; label: string }[] = [
+	{ value: 'digital', label: 'digital' },
+	{ value: 'physical', label: 'physical' },
+	{ value: 'both', label: 'both' },
+];
+
+const NEXT: Partial<Record<OrderStatus, OrderStatus>> = {
+	paid: 'processing',
+	processing: 'shipped',
+	shipped: 'delivered',
+};
+
+function fmtErr(e: unknown): string {
+	if (e instanceof StoreApiError) {
+		if (e.status === 403) return 'Staff permissions required.';
+		if (e.status === 401) return 'Sign in as staff.';
+		return e.message || 'request failed';
+	}
+	return e instanceof Error ? e.message : 'request failed';
+}
+
+export function StoreAdminView({ getToken, baseUrl = '', authenticated }: StoreAdminViewProps) {
+	const api = useMemo(() => createStoreApi({ getToken, baseUrl }), [getToken, baseUrl]);
+
+	const [products, setProducts] = useState<StoreProduct[]>([]);
+	const [orders, setOrders] = useState<StoreOrderStaff[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [orderBusy, setOrderBusy] = useState<number | null>(null);
+
+	const [slug, setSlug] = useState('');
+	const [title, setTitle] = useState('');
+	const [price, setPrice] = useState('10');
+	const [fulfillment, setFulfillment] = useState<Fulfillment>('digital');
+	const [description, setDescription] = useState('');
+
+	const [variantProduct, setVariantProduct] = useState('');
+	const [sku, setSku] = useState('');
+	const [variantPrice, setVariantPrice] = useState('10');
+	const [stock, setStock] = useState('');
+	const [attrs, setAttrs] = useState('{"size":"L"}');
+	const [variants, setVariants] = useState<StoreVariant[]>([]);
+
+	const [trackingFor, setTrackingFor] = useState<number | null>(null);
+	const [trackingInput, setTrackingInput] = useState('');
+	const [confirmRefundFor, setConfirmRefundFor] = useState<number | null>(null);
+
+	const refresh = useCallback(async () => {
+		try {
+			setProducts(await api.catalog());
+			setError(null);
+		} catch (e) {
+			setError(fmtErr(e));
+		}
+	}, [api]);
+
+	const loadOrders = useCallback(async () => {
+		try {
+			setOrders(await api.staffListOrders());
+			setError(null);
+		} catch (e) {
+			setError(fmtErr(e));
+		}
+	}, [api]);
+
+	useEffect(() => {
+		if (authenticated) {
+			void refresh();
+			void loadOrders();
+		}
+	}, [authenticated, refresh, loadOrders]);
+
+	const loadVariants = useCallback(
+		async (productSlug: string) => {
+			if (!productSlug) {
+				setVariants([]);
+				return;
+			}
+			try {
+				const d = await api.productDetail(productSlug);
+				setVariants(d.variants);
+			} catch {
+				void 0;
+				setVariants([]);
+			}
+		},
+		[api],
+	);
+
+	const submitProduct = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			await api.staffUpsertProduct({
+				slug,
+				title,
+				description: description || null,
+				price: Number(price),
+				fulfillment,
+			});
+			await refresh();
+		} catch (e) {
+			setError(fmtErr(e));
+		} finally {
+			setBusy(false);
+		}
+	}, [api, slug, title, description, price, fulfillment, refresh]);
+
+	const submitVariant = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			let attributes: Record<string, unknown> = {};
+			try {
+				attributes = JSON.parse(attrs || '{}');
+			} catch {
+				void 0;
+				throw new Error('attributes must be valid JSON');
+			}
+			await api.staffUpsertVariant(variantProduct, {
+				sku,
+				attributes,
+				price: Number(variantPrice),
+				stock: stock === '' ? null : Number(stock),
+			});
+			const p = products.find((x) => x.product_id === variantProduct);
+			if (p) await loadVariants(p.slug);
+		} catch (e) {
+			setError(fmtErr(e));
+		} finally {
+			setBusy(false);
+		}
+	}, [api, variantProduct, sku, variantPrice, stock, attrs, products, loadVariants]);
+
+	const retireProduct = useCallback(
+		async (p: StoreProduct) => {
+			try {
+				await api.staffSetProductStatus(p.product_id, 'retired');
+				await refresh();
+			} catch (e) {
+				setError(fmtErr(e));
+			}
+		},
+		[api, refresh],
+	);
+
+	const retireVariant = useCallback(
+		async (v: StoreVariant) => {
+			try {
+				await api.staffSetVariantStatus(v.variant_id, 'retired');
+				const p = products.find((x) => x.product_id === variantProduct);
+				if (p) await loadVariants(p.slug);
+			} catch (e) {
+				setError(fmtErr(e));
+			}
+		},
+		[api, products, variantProduct, loadVariants],
+	);
+
+	const submitPod = useCallback(
+		async (o: StoreOrderStaff) => {
+			setOrderBusy(o.order_id);
+			try {
+				await api.staffSubmitPod(o.order_id);
+				await loadOrders();
+			} catch (e) {
+				setError(fmtErr(e));
+			} finally {
+				setOrderBusy(null);
+			}
+		},
+		[api, loadOrders],
+	);
+
+	const advance = useCallback(
+		async (o: StoreOrderStaff, to: OrderStatus) => {
+			setOrderBusy(o.order_id);
+			try {
+				await api.staffAdvanceOrder(o.order_id, {
+					to_status: to,
+					tracking: to === 'shipped' ? { number: trackingInput } : undefined,
+				});
+				setTrackingFor(null);
+				setTrackingInput('');
+				await loadOrders();
+			} catch (e) {
+				setError(fmtErr(e));
+			} finally {
+				setOrderBusy(null);
+			}
+		},
+		[api, trackingInput, loadOrders],
+	);
+
+	const refund = useCallback(
+		async (o: StoreOrderStaff) => {
+			setOrderBusy(o.order_id);
+			try {
+				await api.staffRefundOrder(o.order_id, 'staff refund');
+				setConfirmRefundFor(null);
+				await loadOrders();
+			} catch (e) {
+				setError(fmtErr(e));
+			} finally {
+				setOrderBusy(null);
+			}
+		},
+		[api, loadOrders],
+	);
+
+	if (!authenticated) return <Text tone="danger">Sign in as staff.</Text>;
+
+	return (
+		<Stack gap="lg">
+			{error ? (
+				<Text variant="caption" tone="danger">
+					{error}
+				</Text>
+			) : null}
+
+			<Surface>
+				<Stack gap="md">
+					<Text variant="subtitle">Products</Text>
+					{products.map((p) => (
+						<Stack key={p.product_id} direction="row" gap="sm" align="center" justify="space-between">
+							<Text variant="caption">
+								{p.title} · {p.slug} · {p.price} {p.currency} · {p.fulfillment} · {p.variant_count} variant(s)
+							</Text>
+							<Button title="Retire" variant="ghost" onPress={() => void retireProduct(p)} />
+						</Stack>
+					))}
+
+					<Text variant="label">Upsert product</Text>
+					<FormField label="slug" placeholder="slug" value={slug} onChangeText={setSlug} />
+					<FormField label="title" placeholder="title" value={title} onChangeText={setTitle} />
+					<FormField
+						label="price (credits)"
+						placeholder="price"
+						keyboardType="numeric"
+						value={price}
+						onChangeText={setPrice}
+					/>
+					<Select value={fulfillment} options={FULFILLMENTS} onValueChange={setFulfillment} />
+					<FormField
+						label="description"
+						placeholder="description"
+						value={description}
+						onChangeText={setDescription}
+					/>
+					<Button
+						title="Save product"
+						disabled={busy || !slug || !title}
+						onPress={() => void submitProduct()}
+					/>
+
+					<Text variant="label">Upsert variant</Text>
+					<Select
+						value={variantProduct}
+						options={products.map((p) => ({ value: p.product_id, label: p.title }))}
+						onValueChange={(v) => {
+							setVariantProduct(v);
+							const p = products.find((x) => x.product_id === v);
+							if (p) void loadVariants(p.slug);
+						}}
+					/>
+					<FormField label="sku" placeholder="sku" value={sku} onChangeText={setSku} />
+					<FormField
+						label="price (credits)"
+						placeholder="price"
+						keyboardType="numeric"
+						value={variantPrice}
+						onChangeText={setVariantPrice}
+					/>
+					<FormField
+						label="stock (blank = unlimited)"
+						placeholder="stock"
+						value={stock}
+						onChangeText={setStock}
+					/>
+					<FormField
+						label="attributes JSON"
+						placeholder='{"size":"L"}'
+						value={attrs}
+						onChangeText={setAttrs}
+					/>
+					<Button
+						title="Save variant"
+						disabled={busy || !variantProduct || !sku}
+						onPress={() => void submitVariant()}
+					/>
+					{variants.map((v) => (
+						<Stack key={v.variant_id} direction="row" gap="sm" align="center" justify="space-between">
+							<Text variant="caption">
+								{v.sku} · {v.price} · stock {v.stock ?? '∞'}
+							</Text>
+							<Button title="Retire" variant="ghost" onPress={() => void retireVariant(v)} />
+						</Stack>
+					))}
+				</Stack>
+			</Surface>
+
+			<Surface>
+				<Stack gap="md">
+					<Text variant="subtitle">Order queue</Text>
+					{orders.map((o) => {
+						const to = NEXT[o.status];
+						const disabled = orderBusy === o.order_id;
+						return (
+							<Stack key={o.order_id} gap="sm">
+								<Stack direction="row" gap="sm" align="center">
+									<Text variant="caption">
+										#{o.order_id} · {o.qty}× · {o.credits_amount} credits
+									</Text>
+									<Badge label={o.status} />
+								</Stack>
+								<Stack direction="row" gap="sm" wrap>
+									{o.status === 'paid' ? (
+										<Button
+											title="Submit POD"
+											variant="ghost"
+											disabled={disabled}
+											onPress={() => void submitPod(o)}
+										/>
+									) : null}
+									{to ? (
+										<Button
+											title={`→ ${to}`}
+											variant="ghost"
+											disabled={disabled}
+											onPress={() => {
+												if (to === 'shipped') {
+													setTrackingFor(o.order_id);
+													setTrackingInput('');
+												} else {
+													void advance(o, to);
+												}
+											}}
+										/>
+									) : null}
+									{o.status !== 'refunded' && o.status !== 'cancelled' ? (
+										<Button
+											title={confirmRefundFor === o.order_id ? 'Confirm refund' : 'Refund'}
+											variant={confirmRefundFor === o.order_id ? 'danger' : 'ghost'}
+											disabled={disabled}
+											onPress={() => {
+												if (confirmRefundFor === o.order_id) {
+													void refund(o);
+												} else {
+													setConfirmRefundFor(o.order_id);
+												}
+											}}
+										/>
+									) : null}
+								</Stack>
+								{trackingFor === o.order_id && to === 'shipped' ? (
+									<Stack direction="row" gap="sm" align="center">
+										<FormField
+											label="tracking number"
+											placeholder="tracking number"
+											value={trackingInput}
+											onChangeText={setTrackingInput}
+										/>
+										<Button
+											title="Confirm ship"
+											disabled={disabled}
+											onPress={() => void advance(o, 'shipped')}
+										/>
+									</Stack>
+								) : null}
+							</Stack>
+						);
+					})}
+				</Stack>
+			</Surface>
+		</Stack>
+	);
+}

--- a/packages/npm/rn/src/markets/store/__tests__/StoreAdminView.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/StoreAdminView.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { StoreAdminView } from '../StoreAdminView';
+
+beforeEach(() => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '[]' });
+});
+
+describe('StoreAdminView', () => {
+	it('prompts sign-in when unauthenticated', () => {
+		const { getByText } = render(
+			<StoreAdminView getToken={async () => null} baseUrl="" authenticated={false} />,
+		);
+		expect(getByText(/Sign in as staff/)).toBeTruthy();
+	});
+
+	it('renders admin panels when authenticated', async () => {
+		const { findByText } = render(
+			<StoreAdminView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText(/Save product/)).toBeTruthy();
+		expect(await findByText(/Order queue|Orders/)).toBeTruthy();
+	});
+});

--- a/packages/npm/rn/src/markets/store/__tests__/api.test.ts
+++ b/packages/npm/rn/src/markets/store/__tests__/api.test.ts
@@ -84,4 +84,47 @@ describe('createStoreApi', () => {
 		expect(err.status).toBe(500);
 		expect(err.message).toBe('HTTP 500');
 	});
+
+	it('staffUpsertProduct POSTs bearer to staff products, returns id', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify({ id: 'p9' }),
+		});
+		const api = createStoreApi({ getToken: token, baseUrl: '' });
+		const res = await api.staffUpsertProduct({ slug: 's', title: 't', price: 10 });
+		expect(res).toEqual({ id: 'p9' });
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('/api/v1/store/staff/products');
+		expect(init.method).toBe('POST');
+		expect(init.headers.Authorization).toBe('Bearer tok');
+		expect(JSON.parse(init.body).idempotency_key).toBeUndefined();
+	});
+
+	it('staffListOrders GETs staff orders with status query', async () => {
+		(global.fetch as any).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => '[]',
+		});
+		const api = createStoreApi({ getToken: token, baseUrl: 'https://x' });
+		await api.staffListOrders('paid');
+		const [url] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('https://x/api/v1/store/staff/orders?status=paid');
+	});
+
+	it('staffAdvanceOrder POSTs to advance with body', async () => {
+		(global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+		const api = createStoreApi({ getToken: token, baseUrl: '' });
+		await api.staffAdvanceOrder(5, { to_status: 'shipped', tracking: { number: 'AB' } });
+		const [url, init] = (global.fetch as any).mock.calls[0];
+		expect(url).toBe('/api/v1/store/staff/orders/5/advance');
+		expect(JSON.parse(init.body)).toEqual({ to_status: 'shipped', tracking: { number: 'AB' } });
+	});
+
+	it('staff call without token throws 401 without fetch', async () => {
+		const api = createStoreApi({ getToken: async () => null });
+		await expect(api.staffListOrders()).rejects.toMatchObject({ name: 'StoreApiError', status: 401 });
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
 });

--- a/packages/npm/rn/src/markets/store/api.ts
+++ b/packages/npm/rn/src/markets/store/api.ts
@@ -1,10 +1,14 @@
 import { StoreApiError } from './errors';
 import { newIdempotencyKey } from './keys';
 import type {
+	OrderStatus,
 	ShippingAddress,
+	StaffProductBody,
+	StaffVariantBody,
 	StoreEntitlement,
 	StoreItem,
 	StoreOrder,
+	StoreOrderStaff,
 	StoreProduct,
 	StoreProductDetail,
 } from './types';
@@ -25,6 +29,17 @@ export interface StoreApi {
 		body: { qty: number; shipping_address: ShippingAddress },
 	): Promise<{ order_id: number }>;
 	topupCheckout(packId: string): Promise<{ checkout_url: string }>;
+	staffUpsertProduct(body: StaffProductBody): Promise<{ id: string }>;
+	staffSetProductStatus(productId: string, status: string): Promise<void>;
+	staffUpsertVariant(productId: string, body: StaffVariantBody): Promise<{ id: string }>;
+	staffSetVariantStatus(variantId: string, status: string): Promise<void>;
+	staffListOrders(status?: OrderStatus): Promise<StoreOrderStaff[]>;
+	staffAdvanceOrder(
+		orderId: number,
+		body: { to_status: OrderStatus; tracking?: Record<string, unknown>; note?: string },
+	): Promise<void>;
+	staffRefundOrder(orderId: number, reason?: string): Promise<void>;
+	staffSubmitPod(orderId: number): Promise<{ order_id: number; external_id: string }>;
 }
 
 interface Req {
@@ -101,6 +116,49 @@ export function createStoreApi(opts: StoreApiOptions): StoreApi {
 				path: '/api/v1/wallet/topup/checkout',
 				method: 'POST',
 				body: { pack_id: packId },
+				auth: true,
+			}),
+		staffUpsertProduct: (body) =>
+			call<{ id: string }>({ path: '/api/v1/store/staff/products', method: 'POST', body, auth: true }),
+		staffSetProductStatus: (productId, status) =>
+			call<void>({
+				path: `/api/v1/store/staff/products/${encodeURIComponent(productId)}/status`,
+				method: 'POST',
+				body: { status },
+				auth: true,
+			}),
+		staffUpsertVariant: (productId, body) =>
+			call<{ id: string }>({
+				path: `/api/v1/store/staff/products/${encodeURIComponent(productId)}/variants`,
+				method: 'POST',
+				body,
+				auth: true,
+			}),
+		staffSetVariantStatus: (variantId, status) =>
+			call<void>({
+				path: `/api/v1/store/staff/variants/${encodeURIComponent(variantId)}/status`,
+				method: 'POST',
+				body: { status },
+				auth: true,
+			}),
+		staffListOrders: (status) =>
+			call<StoreOrderStaff[]>({
+				path: `/api/v1/store/staff/orders${status ? `?status=${encodeURIComponent(status)}` : ''}`,
+				auth: true,
+			}),
+		staffAdvanceOrder: (orderId, body) =>
+			call<void>({ path: `/api/v1/store/staff/orders/${orderId}/advance`, method: 'POST', body, auth: true }),
+		staffRefundOrder: (orderId, reason) =>
+			call<void>({
+				path: `/api/v1/store/staff/orders/${orderId}/refund`,
+				method: 'POST',
+				body: { reason },
+				auth: true,
+			}),
+		staffSubmitPod: (orderId) =>
+			call<{ order_id: number; external_id: string }>({
+				path: `/api/v1/store/staff/orders/${orderId}/submit-pod`,
+				method: 'POST',
 				auth: true,
 			}),
 	};

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -11,3 +11,5 @@ export { CheckoutModal } from './CheckoutModal';
 export { OrderHistory } from './OrderHistory';
 export { StoreView } from './StoreView';
 export type { StoreViewProps } from './StoreView';
+export { StoreAdminView } from './StoreAdminView';
+export type { StoreAdminViewProps } from './StoreAdminView';

--- a/packages/npm/rn/src/markets/store/types.ts
+++ b/packages/npm/rn/src/markets/store/types.ts
@@ -83,3 +83,26 @@ export const CREDIT_PACKS: CreditPack[] = [
 ];
 
 export const FEATURED_SLUG = 'i-am-an-idiot';
+
+export interface StaffProductBody {
+	slug: string;
+	title: string;
+	description?: string | null;
+	price: number;
+	fulfillment?: Fulfillment;
+	asset_ref?: Record<string, unknown>;
+	status?: string;
+}
+
+export interface StaffVariantBody {
+	sku: string;
+	attributes?: Record<string, unknown>;
+	price: number;
+	stock?: number | null;
+	status?: string;
+}
+
+export interface StoreOrderStaff extends StoreOrder {
+	account_id: string;
+	shipping_address: Record<string, unknown>;
+}


### PR DESCRIPTION
Phase 3 (final) of the store+market epic — brings the **staff store admin** (`/dashboard/store/`) and **personal marketplace** (`/dashboard/market/`) into the `@kbve/rn/markets` universal composition + bento splash + Commerce rail, completing the unified customer-vs-admin store+market view. Follows #14338 (customer `/store/`) and #14398 (customer `/market/`), same patterns.

## What
- **API deltas:** `createStoreApi` gains 8 staff methods (catalog CRUD + order fulfillment: advance / refund / submit-POD); `createMarketApi` gains `myListings` / `myBids`. Both reuse the existing `call()`/`query()` helpers (droid error precedence, 401-before-fetch).
- **RN views:** `StoreAdminView` (catalog + variant admin + order queue — inline tracking on ship-advance, two-tap refund; **no browser prompt/confirm**) and `MarketProfileView` (my listings / bids / watching tabs).
- **Astro bridges:** `ReactStoreAdminRN` (staff-gated via `$isStaff`, ShieldOff fallback) + `ReactMarketProfileRN` (auth-gated), `baseUrl=""` (public origin).
- **Chrome:** amber admin / violet profile bento splash shells; `/dashboard/store/` + `/dashboard/market/` routed to the Commerce rail (new "Manage" group, Store Admin gated `visibility:'staff'`) with correct `isDashboard` exclusion + declaration order.

## Verify
- markets vitest **39/39**; `nx lint rn` **0 errors**.
- Astro **SSG page-render pass compiled clean** (all Phase 3 shells/routing/MDX). Web-safety proven via vitest (vector-icons imports break vitest; 39/39 green ⇒ views' graph clean).
- Final whole-branch review: **READY TO MERGE** (3 non-blocking Minors: an unused default export matching the `EnchantList` sibling; orphaned old-DOM kept per spec; retire-button busy-gate matching the original).

> ⚠️ The local full `astro build` **client bundle** currently fails on a **pre-existing dev-branch break** — `components/dashboard/ReactKanbanAssignees.tsx` imports `d3-shape`, which is not installed (present on `origin/dev`, not in this branch's diff; likely pnpm-11-bump fallout). Unrelated to Phase 3; CI builds in an installed env.

## Deferred (Phase 4)
`MCItemMarketSidecar`, `IdiotCard` three-fiber, Expo mobile screens; old DOM `components/{store,market}/*` kept (still power those + `AstroMarketAccountSummary`).

Docs: `docs/superpowers/specs/2026-07-20-markets-admin-phase3-design.md`, `docs/superpowers/plans/2026-07-20-markets-admin-phase3.md`.