### PR TITLE
fix(deps): declare d3-shape — unblocks prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
 		"cross-fetch": "^4.0.0",
 		"d3-force": "^3.0.0",
 		"d3-geo": "^3.1.1",
+		"d3-shape": "^3.2.0",
 		"date-fns": "^4.1.0",
 		"dexie": "^4.4.2",
 		"dexie-react-hooks": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       d3-geo:
         specifier: ^3.1.1
         version: 3.1.1
+      d3-shape:
+        specifier: ^3.2.0
+        version: 3.2.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
`ReactKanbanDonut` and `ReactKanbanAssignees` import `{ arc, pie } from 'd3-shape'`, but **d3-shape was never a declared dependency** (only present transitively + via `@types/d3-shape`).

Vite dev resolved it via hoisting, but the **rolldown production build fails strictly**:
```
[vite]: Rolldown failed to resolve import "d3-shape" from ".../ReactKanbanDonut.tsx".
```

Declares `d3-shape@^3.2.0` (matching the d3 v3 module family already in use, e.g. d3-force@3). Found while verifying an unrelated dashboard island build; the astro-kbve prod build can't complete without it.