### PR TITLE
fix(python): route introspection for starlette 1.x _IncludedRouter

### DIFF
--- a/packages/python/kbve/tests/test_app_server.py
+++ b/packages/python/kbve/tests/test_app_server.py
@@ -44,7 +44,7 @@ def test_app_server_no_defaults():
 def test_app_server_health_endpoint():
     """Test that /health HTTP endpoint is registered."""
     server = AppServer()
-    routes = [r.path for r in server.http.app.routes]
+    routes = list(server.http.app.openapi()["paths"].keys())
     assert "/health" in routes
 
 

--- a/packages/python/kbve/tests/test_app_server_integration.py
+++ b/packages/python/kbve/tests/test_app_server_integration.py
@@ -76,6 +76,6 @@ def test_app_server_no_defaults():
 
 def test_app_server_default_health_endpoint():
     server = AppServer()
-    routes = [r.path for r in server.http.app.routes]
+    routes = list(server.http.app.openapi()["paths"].keys())
     assert "/health" in routes
     assert "/health/live" in routes


### PR DESCRIPTION
## Why
`test_app_server_health_endpoint` + `test_app_server_default_health_endpoint` fail:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

**starlette 1.x** (pulled in via a transitive bump) changed `include_router` to keep an `_IncludedRouter` wrapper object in `app.routes` instead of flattening the included `APIRoute`s. So `[r.path for r in app.routes]` hits the wrapper, which has no `.path`. The `/health` endpoint is still registered and works at runtime — only the test's route introspection broke.

## Fix
Read registered paths from `app.openapi()["paths"]` instead of walking `app.routes`. That flattens included routers and is stable across FastAPI/starlette versions.

## Verify
Both files pass; full `python-kbve` suite → **367 passed**.