### PR TITLE
fix(git): untrack husky bootstrap hooks (recurring phantom diffs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,13 @@ apps/**/unreal-*/DerivedDataCache/
 
 # Per-machine UE plugin settings overrides (gitignored AnonKey, etc).
 apps/**/unreal-*/Config/Local*.ini
+
+# Husky-managed hook bootstrap dir. Regenerated on every install by `prepare`;
+# git-lfs also rewrites these, causing phantom diffs. Never track.
+.husky/_/
+.husky/_/post-checkout
+.husky/_/post-commit
+.husky/_/post-merge
+.husky/_/pre-push
+.husky/_/pre-commit
+.husky/_/pre-rebase

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"


### PR DESCRIPTION
## Problem
`.husky/_/{post-checkout,post-commit,post-merge,pre-push}` are tracked on `main` with git-lfs hook content. Husky's `prepare` step and git-lfs both regenerate these on every install → recurring phantom diffs. This has resurfaced 4×: removing them only on `dev` doesn't stick because every branch/merge off `main` reintroduces the tracked versions. `.husky/_/.gitignore` (`*`) can't help once files are already tracked.

## Fix
- `git rm --cached` the 4 bootstrap files (removes from index; files stay on disk, husky regenerates them locally)
- Add explicit `.husky/_/` entries to root `.gitignore` as a second layer

Once merged to `main`, all future branches/worktrees stay clean.