### PR TITLE
chore(security): raise pnpm minimumReleaseAge to 48h

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-minimumReleaseAge: 720
+minimumReleaseAge: 2880
 overrides:
   '@novnc/novnc': 1.5.0
   '@xmldom/xmldom@<0.8.13': '>=0.8.13'


### PR DESCRIPTION
Part of #14423.

Raises pnpm `minimumReleaseAge` from `720` to `2880` (unit = **minutes**, so 12h → 48h).

Widens the quarantine window before a freshly-published npm version is installable. Most supply-chain compromises are detected and yanked within 24h; a 48h floor means the resolver falls back to the prior known-good version during that window.

Isolated from the bwrap wrapper (#14423 item 2) — that ships separately.

### Risk
Low. Only affects resolution of brand-new releases (<48h old). `--frozen-lockfile` installs are unaffected (pinned versions already resolved in the lockfile).
