### PR TITLE
chore(python-kbve): bump 1.0.13 → 1.0.14 (republish w/ starlette route fix)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx
@@ -12,7 +12,7 @@ key: py_lib_kbve
 pipeline: python
 package_name: python-kbve
 pypi_name: kbve
-version: "1.0.13"
+version: "1.0.14"
 source_path: packages/python/kbve
 version_toml: packages/python/kbve/version.toml
 author: h0lybyte


### PR DESCRIPTION
Bumps python-kbve MDX manifest version `1.0.13 → 1.0.14` to trigger a republish.

## Why
CI Publish for python-kbve failed (#14397, run 29731347225) on:
```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```
Starlette 1.x route introspection regression. Fix already merged to main in `e98bf608df` (#14413) — tests now use `app.openapi()["paths"]`. Both failing runs predate that commit.

## What
- MDX `manifest_version` is the publish source of truth; CI patches pyproject + gates MDX vs version.toml. Bumping the MDX is the only lever needed.
- version.toml (1.0.13, last-published marker) left untouched — the gate will update it post-publish.

Closes #14397 once republished.