### PR TITLE
fix(herbmail-game): mask OPEN bit in mirror-gate door assertions

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/dungeon/doors.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/doors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { genSectorDesc, SECTOR_TILES } from './generate';
-import { DOORWAY } from '../geometry/grid';
+import { DOORWAY, OPEN } from '../geometry/grid';
 import { WALL, ARCH } from '../geometry/grid';
 
 const SEED = 1337;
@@ -57,7 +57,8 @@ describe('door generation', () => {
 		for (let sy = -2; sy <= 2; sy++)
 			for (let sx = -2; sx <= 2; sx++) {
 				const d = genSectorDesc(SEED, sx, sy);
-				const tile = (c: number, r: number) => d.tiles[r * d.cols + c];
+				const tile = (c: number, r: number) =>
+					d.tiles[r * d.cols + c] & ~OPEN;
 
 				const north = genSectorDesc(SEED, sx, sy - 1);
 				for (const w of north.doorways.filter((x) => x.lr === edge)) {


### PR DESCRIPTION
## Problem

`Validate Dev→Main PR` fails at `herbmail-game:test`:

```
FAIL src/game/dungeon/doors.test.ts > door generation > mirror gate narrows when the owner sector doors a border connector
AssertionError: expected 36 to be 4 // Object.is equality
```

`36 = OPEN(32) | DOORWAY(4)`.

## Cause

The open-sky oasis feature (#14139) ORs `OPEN` across a room's **entire footprint** — boundary walls included — so sky light reaches the walls (`generate.ts:465`). A mirrored border-gate `ARCH`/`WALL` tile that falls inside an oasis footprint therefore carries `OPEN` on top of its structural bits.

The mirror-gate narrowing test compared exact tile values (`.toBe(ARCH)` / `.toBe(WALL)`). The grid is an explicitly composable bitfield (`grid.ts:1-9`) where membership is a `&` test, not `===`, so exact equality was never guaranteed.

## Fix

Strip `OPEN` before comparing in the mirror-gate assertions. The narrowing invariant is about `ARCH`-vs-`WALL` structure, which is preserved; the sky flag is orthogonal.

`pnpm nx test herbmail-game` → 79 passed.