### PR TITLE
feat(discordsh): /wm — single free-text field (first token = script)

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/windmill.rs
@@ -15,8 +15,8 @@ const WM_INDEX_PATH: &str = "help";
 #[poise::command(slash_command, rename = "wm")]
 pub async fn wm(
     ctx: Context<'_>,
-    #[description = "Script name (e.g. poem) → f/discordsh/; blank lists every command"] wm_path: Option<String>,
-    #[description = "Space-separated args"] args: Option<String>,
+    #[description = "Command + args (e.g. poem Emily Dickinson); blank lists every command"]
+    args: Option<String>,
 ) -> Result<(), Error> {
     let Some(cfg) = ctx.data().app.windmill.clone() else {
         ctx.send(
@@ -28,11 +28,13 @@ pub async fn wm(
         return Ok(());
     };
 
-    let wm_path = wm_path
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| WM_INDEX_PATH.to_owned());
-    let args = args.map(|s| split_args(&s)).unwrap_or_default();
+    let mut tokens = args.map(|s| split_args(&s)).unwrap_or_default();
+    let wm_path = if tokens.is_empty() {
+        WM_INDEX_PATH.to_owned()
+    } else {
+        tokens.remove(0)
+    };
+    let args = tokens;
     let path_for_log = wm_path.clone();
     let arg_count = args.len();
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## Change
Collapses the `/wm` slash command's two options (`wm_path` + `args`) into **one** free-text `args` field. First whitespace token = script name, remainder = its args. Blank field still lists every command.

## Why it's safe
The split happens at the input surface only. `build_wm_action_row` (reroll button), `windmill_embed`, and `cfg.run` all still take the `(path, args)` pair — derived from the single field. So every existing usage resolves identically:
- `/wm poem Emily Dickinson` → path `poem`, args `[Emily, Dickinson]`
- `/wm store buy i-am-an-idiot` → path `store`, args `[buy, i-am-an-idiot]`

Matches how the help menu already documents usage, so no script or embed copy changes needed.

## Version / deploy
- Bumps `discordsh-bot` 0.1.27 → 0.1.28 via MDX (CI syncs Cargo.toml + version.toml on publish)
- **Bot redeploy required** — the slash command schema changed (2 options → 1)

## Verify
`cargo check -p discordsh-bot` 0 errors; `cargo test -p discordsh-bot windmill` 49 passed.