### PR TITLE
fix(discordsh): /wm embeds — footer string not {text} (bot dumped JSON)

### DIFF
--- a/apps/windmill/f/discordsh/poem2.ts
+++ b/apps/windmill/f/discordsh/poem2.ts
@@ -83,7 +83,7 @@ export async function main(args: string[] = [], discord: Discord = {}) {
       description,
       color: 0x8b5cf6,
       author: by ? { name: by } : undefined,
-      footer: { text: `${COST} credits · requested by ${discord.username ?? "you"}` },
+      footer: `${COST} credits · requested by ${discord.username ?? "you"}`,
     },
   };
 }

--- a/apps/windmill/f/discordsh/store.ts
+++ b/apps/windmill/f/discordsh/store.ts
@@ -61,9 +61,7 @@ function catalogEmbed(discord: Discord) {
         `or browse at [kbve.com/store](${STORE_URL}) — sign in with Discord.`,
       color: BRAND,
       fields,
-      footer: {
-        text: `${STORE_URL.replace(/^https?:\/\//, "")} · requested by ${discord.username ?? "you"}`,
-      },
+      footer: `${STORE_URL.replace(/^https?:\/\//, "")} · requested by ${discord.username ?? "you"}`,
     },
   };
 }
@@ -129,9 +127,7 @@ async function buy(rest: string[], discord: Discord) {
       description:
         `It's yours. Reveal your card at [kbve.com/store](${STORE_URL}) — sign in with Discord and it'll be waiting in your collection.`,
       color: OK,
-      footer: {
-        text: `${product.price} · ${discord.username ?? "you"}`,
-      },
+      footer: `${product.price} · ${discord.username ?? "you"}`,
     },
   };
 }
@@ -178,9 +174,7 @@ async function balance(discord: Discord) {
         `**${credits} credits**\n\n` +
         `Spend them with \`/wm store buy\`, or browse at [kbve.com/store](${STORE_URL}).`,
       color: BRAND,
-      footer: {
-        text: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
-      },
+      footer: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
     },
   };
 }
@@ -230,9 +224,7 @@ async function inventory(discord: Discord) {
           `Nothing here yet. Unlock your first collectible with \`/wm store buy\` — ` +
           `browse at [kbve.com/store](${STORE_URL}).`,
         color: BRAND,
-        footer: {
-          text: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
-        },
+        footer: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
       },
     };
   }
@@ -244,9 +236,7 @@ async function inventory(discord: Discord) {
       url: STORE_URL,
       description: `${lines.join("\n")}\n\nReveal them at [kbve.com/store](${STORE_URL}).`,
       color: OK,
-      footer: {
-        text: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
-      },
+      footer: `${STORE_URL.replace(/^https?:\/\//, "")} · ${discord.username ?? "you"}`,
     },
   };
 }


### PR DESCRIPTION
## Symptom
`/wm store` (and every store subcommand) returned raw JSON instead of a rendered embed.

## Root cause
The bot's embed contract (`windmill_embed.rs`) types `WmEmbed.footer` as `Option<String>`. `store.ts` and `poem2.ts` sent Discord's native `footer: { text: ... }` **object**, so `serde_json::from_value::<WmEmbed>` failed → `embed_from_value` returned `None` → the bot fell back to the raw-JSON path.

Confirmed: every working command (poem, joke, advice, npm, ud, help) already sends `footer: <string>`. Only `store.ts` (added this week) and `poem2.ts` used the object form — both were silently falling to JSON.

## Fix
Align both scripts with the contract: `footer: <string>`. store.ts = 5 embeds (catalog/buy/balance/inventory empty+list), poem2.ts = 1.

## Deploy
Script-only — **no bot redeploy**. Goes live via windmill-sync on merge to main.

## Verify
`bun build` clean for both scripts.