### PR TITLE
docs(embeddb): crate homepage/repository links + rust.mdx section

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/rust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/rust.mdx
@@ -1111,6 +1111,28 @@ Askama uses Jinja2-style syntax. Here are the most common patterns used in Astro
 
 </BentoProse>
 
+<BentoProse id="embeddb" eyebrow="In-house crate" heading="EmbedDB">
+
+EmbedDB is a single-file embedded database that pairs two Rust engines over one SQLite-format file: **Turso** (a pure-Rust async rewrite of SQLite) drives the write path, and **DuckDB** (bundled) drives the analytics read path. One file gives you both transactional writes and columnar analytics — no server, no separate storage.
+
+It is published on crates.io as [`embeddb`](https://crates.io/crates/embeddb) and complements the heavier data stack (Postgres, ClickHouse, Cube) rather than replacing it: reach for it when you want an embedded, in-process store with real analytics, such as a Windmill worker or a distroless service.
+
+**Why the split.** The write path is truly static — Turso is pure Rust, so no C toolchain and clean in a distroless image. DuckDB reads the Turso-written file directly through its `sqlite_scanner` extension (`ATTACH ... TYPE sqlite, READ_ONLY`), giving fast columnar queries over the same bytes. The DuckDB reader is **lazy**: it only builds on the first analytics call, so a write-only consumer never touches the extension.
+
+**What it provides.**
+
+- Parameterized writes and handle-style transactions (`begin` / `commit` / `rollback`), plus batched writes in a single atomic transaction.
+- A typed `EmbedValue` model (int, float, text, blob, bool, hugeint, temporal) with `EmbedRow` / `QueryResult` accessors.
+- Analytics reads: scalar, row vectors, streaming (`analytics_for_each`), and typed mapping via `analytics_query_as::<T>`.
+- A parallel **reader pool** so analytics queries run concurrently, each connection loading `sqlite_scanner` once.
+- **Live concurrent reads are safe** — DuckDB replays uncheckpointed Turso WAL frames, so reads reflect all committed writes (checkpoint or not) and are never torn.
+
+### embeddb-derive
+
+[`embeddb-derive`](https://crates.io/crates/embeddb-derive) is the companion proc-macro crate providing `#[derive(FromEmbedRow)]`. It maps a DuckDB analytics row into a struct by matching each field to a column **by name**, converting through the `FromEmbedValue` trait. It ships behind the default `derive` feature; building `--no-default-features` drops the macro and nothing else.
+
+</BentoProse>
+
 <BentoProse id="ci" eyebrow="Build pipelines" heading="CI">
 
 For continuous integration, we recommend checking out our [git](/application/git/) section for more information.

--- a/packages/rust/embeddb-derive/Cargo.toml
+++ b/packages/rust/embeddb-derive/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "derive macro for embeddb FromEmbedRow"
 license = "MIT"
+homepage = "https://kbve.com/application/rust/#embeddb-derive"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb-derive"
 
 [lib]
 proc-macro = true

--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "Single-file embedded DB: Turso write path + DuckDB analytics read path"
 license = "MIT"
+homepage = "https://kbve.com/application/rust/#embeddb"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb"
 
 [dependencies]
 turso = "0.7"


### PR DESCRIPTION
## What
- **Cargo.toml** (`embeddb`, `embeddb-derive`): add `homepage` + `repository` metadata. homepage points at `https://kbve.com/application/rust/#embeddb` (and `#embeddb-derive`), matching the jedi convention.
- **rust.mdx**: new in-house `<BentoProse id="embeddb">` section (→ `#embeddb` anchor) covering the Turso write + DuckDB read split, lazy reader, reader pool, live-read safety, and a `### embeddb-derive` subsection (→ `#embeddb-derive`).

## Why
`embeddb 0.1.0` and `embeddb-derive 0.1.0` are live on crates.io. The Cargo.toml links give crates.io a homepage/repo; they ride the **next** version publish (no republish now — MDX version unchanged). The rust.mdx anchor is the target those homepage links resolve to.

## Scope
Docs + metadata only. No version bump, no manifest change.