### PR TITLE
fix(dashboard): kanban page on splash template for fullscreen gsap snap

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -791,21 +791,30 @@ const sectionNames = [
 <style>
 	/* ── Snap container ── */
 	.kb-snap-container {
-		position: relative;
-		height: 100vh;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		position: fixed;
+		inset: var(--sl-nav-height, 3.5rem) 0 0
+			var(--sl-content-inline-start, 0);
 		overflow: hidden;
 		background: var(--sl-color-bg, #0a0a0a);
+		z-index: 1;
 	}
 
 	/* ── Sections ── */
 	.kb-section {
-		width: 100%;
-		top: calc(var(--sl-nav-height, 3.5rem) + 3.5rem);
-		height: calc(100vh - var(--sl-nav-height, 3.5rem) - 3.5rem);
-		position: fixed;
+		position: absolute;
+		top: 3.5rem;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: auto;
+		height: auto;
 		visibility: hidden;
+	}
+	/* Progressive enhancement: the first section is visible without JS so a
+	   failed GSAP init (or blocked import) shows the Summary instead of a
+	   blank board. GSAP takes over visibility once it hydrates. */
+	.kb-section[data-section='0'] {
+		visibility: visible;
 	}
 	.kb-section-outer,
 	.kb-section-inner {

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/kanban.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/kanban.mdx
@@ -2,11 +2,15 @@
 title: Project Kanban
 description: |
     Daily auto-generated snapshot of the KBVE project board.
+template: splash
 sidebar:
     label: Kanban
     order: 110
 editUrl: false
 tableOfContents: false
+lastUpdated: false
+next: false
+prev: false
 ---
 
 import AstroKanbanDashboard from '@/components/dashboard/AstroKanbanDashboard.astro';


### PR DESCRIPTION
## What

Switch `/dashboard/kanban/` to `template: splash`.

## Why

The interactive kanban island (`AstroKanbanDashboard.astro`) uses a `position:fixed` fullscreen GSAP snap container anchored to `--sl-content-inline-start`. On the default docs template the left sidebar + right TOC squeezed the container and clipped the right edge (last column + dot-nav). Splash drops both → the var falls back to `0` → board fills the viewport. Fixed dot-nav / section-label now hit the true viewport edge with no TOC overlap.

## Safety

Python `kanban` route (`packages/python/kbve/kbve/nx/routes/kanban.py`) writes **only** `kanban-data.mdx` + `nx-kanban.json` — never `kanban.mdx`. So this frontmatter is safe from daily regeneration. (`render_kanban_mdx` already emits `template: splash` for the data page too.)

## Verify

Load `/dashboard/kanban/`: fullscreen scroll-snap, no right clip, `client:only="react"` charts size on scroll (lazy-init off `data-active-section`).