### PR TITLE
feat(dashboard): Cube dashboard polish — range control, ranked breakdowns, federated MC, derived stats

### DIFF
--- a/packages/npm/rn/src/dash/__tests__/cube-adapters.test.ts
+++ b/packages/npm/rn/src/dash/__tests__/cube-adapters.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+	topServicesToRows,
+	topNamespacesToRows,
+	mcPlayersToRows,
+	buildCubeStats,
+} from '../adapters/cube';
+import {
+	fmtPct,
+	rangeToDateRange,
+	rangeToGranularity,
+} from '../cube/cubeApi';
+import type { CubeRow } from '../cube/cubeApi';
+
+describe('topServicesToRows', () => {
+	it('sums by service, sorts desc, coerces, drops null/empty', () => {
+		const rows: CubeRow[] = [
+			{ 'ch_logs.service': 'api', 'ch_logs.count': '3' },
+			{ 'ch_logs.service': 'api', 'ch_logs.count': 2 },
+			{ 'ch_logs.service': 'worker', 'ch_logs.count': 10 },
+			{ 'ch_logs.service': null, 'ch_logs.count': 99 },
+			{ 'ch_logs.service': '', 'ch_logs.count': 99 },
+			{ 'ch_logs.service': 'gw', 'ch_logs.count': 'nan' },
+		];
+		const out = topServicesToRows(rows);
+		expect(out.map((r) => [r.label, r.value])).toEqual([
+			['worker', 10],
+			['api', 5],
+			['gw', 0],
+		]);
+	});
+});
+
+describe('topNamespacesToRows', () => {
+	it('groups by pod_namespace', () => {
+		const rows: CubeRow[] = [
+			{ 'ch_logs.pod_namespace': 'cube', 'ch_logs.count': 4 },
+			{ 'ch_logs.pod_namespace': 'kbve', 'ch_logs.count': 7 },
+		];
+		expect(topNamespacesToRows(rows).map((r) => r.label)).toEqual([
+			'kbve',
+			'cube',
+		]);
+	});
+});
+
+describe('mcPlayersToRows', () => {
+	it('maps federated player_name + snapshot count keys', () => {
+		const rows: CubeRow[] = [
+			{ 'pg_mc_player.player_name': 'steve', 'ch_mc_snapshots.count': 5 },
+			{ 'pg_mc_player.player_name': 'alex', 'ch_mc_snapshots.count': 12 },
+		];
+		const out = mcPlayersToRows(rows);
+		expect(out[0]).toMatchObject({ label: 'alex', value: 12 });
+		expect(out[1]).toMatchObject({ label: 'steve', value: 5 });
+	});
+});
+
+describe('buildCubeStats', () => {
+	it('computes error rate and signup month delta', () => {
+		const logs: CubeRow[] = [
+			{ 'ch_logs.level': 'info', 'ch_logs.count': 75 },
+			{ 'ch_logs.level': 'error', 'ch_logs.count': 25 },
+		];
+		const signups: CubeRow[] = [
+			{ 'pg_users.created_at.month': '2026-05-01T00:00:00.000', 'pg_users.count': 10 },
+			{ 'pg_users.created_at.month': '2026-06-01T00:00:00.000', 'pg_users.count': 18 },
+		];
+		const stats = buildCubeStats(logs, signups);
+		const by = Object.fromEntries(stats.map((s) => [s.id, s]));
+		expect(by.errorRate.value).toBe('25.0%');
+		expect(by.signupDelta.value).toBe('+8');
+		expect(by.signupDelta.tone).toBe('success');
+		expect(by.users.value).toBe('28');
+	});
+
+	it('error rate is 0% when no logs (divide by zero)', () => {
+		const stats = buildCubeStats([], []);
+		const by = Object.fromEntries(stats.map((s) => [s.id, s]));
+		expect(by.errorRate.value).toBe('0.0%');
+		expect(by.signupDelta.value).toBe('+0');
+		expect(by.signupDelta.tone).toBe('neutral');
+	});
+
+	it('negative signup delta is danger toned', () => {
+		const signups: CubeRow[] = [
+			{ 'pg_users.created_at.month': '2026-05-01T00:00:00.000', 'pg_users.count': 20 },
+			{ 'pg_users.created_at.month': '2026-06-01T00:00:00.000', 'pg_users.count': 5 },
+		];
+		const by = Object.fromEntries(
+			buildCubeStats([], signups).map((s) => [s.id, s]),
+		);
+		expect(by.signupDelta.value).toBe('-15');
+		expect(by.signupDelta.tone).toBe('danger');
+	});
+});
+
+describe('range mapping', () => {
+	it('rangeToDateRange table', () => {
+		expect(rangeToDateRange('24h')).toBe('last 24 hours');
+		expect(rangeToDateRange('7d')).toBe('last 7 days');
+		expect(rangeToDateRange('30d')).toBe('last 30 days');
+		expect(rangeToDateRange('all')).toBeUndefined();
+	});
+
+	it('rangeToGranularity uses hour for 24h else base', () => {
+		expect(rangeToGranularity('24h', 'day')).toBe('hour');
+		expect(rangeToGranularity('7d', 'day')).toBe('day');
+		expect(rangeToGranularity('all', 'month')).toBe('month');
+	});
+
+	it('fmtPct guards non-finite', () => {
+		expect(fmtPct(12.34)).toBe('12.3%');
+		expect(fmtPct(Number.NaN)).toBe('0.0%');
+	});
+});

--- a/packages/npm/rn/src/dash/adapters/cube.tsx
+++ b/packages/npm/rn/src/dash/adapters/cube.tsx
@@ -6,7 +6,14 @@ import { tokens } from '../_ui';
 import type { TrendSeries } from '../TrendChart';
 import type { StatModel } from '../types';
 import type { CubeRow } from '../cube/cubeApi';
-import { fmtInt } from '../cube/cubeApi';
+import { fmtInt, fmtPct } from '../cube/cubeApi';
+
+export interface RankedRow {
+	key: string;
+	label: string;
+	value: number;
+	badge?: string;
+}
 
 const num = (v: unknown): number => {
 	const n = Number(v ?? 0);
@@ -60,6 +67,39 @@ export function signupsToSeries(rows: CubeRow[]): TrendSeries[] {
 		: [];
 }
 
+function topByDimension(
+	rows: CubeRow[],
+	dimKey: string,
+	measureKey: string,
+): RankedRow[] {
+	const byDim = new Map<string, number>();
+	for (const r of rows) {
+		const raw = r[dimKey];
+		if (raw == null || raw === '') continue;
+		const label = String(raw);
+		byDim.set(label, (byDim.get(label) ?? 0) + num(r[measureKey]));
+	}
+	return [...byDim.entries()]
+		.map(([label, value]) => ({ key: label, label, value }))
+		.sort((a, b) => b.value - a.value);
+}
+
+export function topServicesToRows(rows: CubeRow[]): RankedRow[] {
+	return topByDimension(rows, 'ch_logs.service', 'ch_logs.count');
+}
+
+export function topNamespacesToRows(rows: CubeRow[]): RankedRow[] {
+	return topByDimension(rows, 'ch_logs.pod_namespace', 'ch_logs.count');
+}
+
+export function mcPlayersToRows(rows: CubeRow[]): RankedRow[] {
+	return topByDimension(
+		rows,
+		'pg_mc_player.player_name',
+		'ch_mc_snapshots.count',
+	);
+}
+
 /** Flat stat tiles: total logs, error logs, total users. */
 export function buildCubeStats(logs: CubeRow[], signups: CubeRow[]): StatModel[] {
 	let total = 0;
@@ -72,9 +112,36 @@ export function buildCubeStats(logs: CubeRow[], signups: CubeRow[]): StatModel[]
 		}
 	}
 	const users = signups.reduce((a, r) => a + num(r['pg_users.count']), 0);
+	const errorRate = total > 0 ? (errors / total) * 100 : 0;
+
+	const signupPoints = signups
+		.map((r) => ({
+			t: ms(r['pg_users.created_at.month'] ?? r['pg_users.created_at']),
+			v: num(r['pg_users.count']),
+		}))
+		.filter((p) => p.t)
+		.sort((a, b) => a.t - b.t);
+	const last = signupPoints.at(-1)?.v ?? 0;
+	const prev = signupPoints.at(-2)?.v ?? 0;
+	const delta = last - prev;
+	const deltaTone: StatModel['tone'] =
+		delta > 0 ? 'success' : delta < 0 ? 'danger' : 'neutral';
+
 	return [
 		{ id: 'logs', label: 'Total logs', value: fmtInt(total), tone: 'primary' },
 		{ id: 'errors', label: 'Errors', value: fmtInt(errors), tone: 'danger' },
+		{
+			id: 'errorRate',
+			label: 'Error rate',
+			value: fmtPct(errorRate),
+			tone: 'danger',
+		},
 		{ id: 'users', label: 'Users', value: fmtInt(users), tone: 'success' },
+		{
+			id: 'signupDelta',
+			label: 'Signups Δ (mo)',
+			value: `${delta >= 0 ? '+' : ''}${fmtInt(delta)}`,
+			tone: deltaTone,
+		},
 	];
 }

--- a/packages/npm/rn/src/dash/cube/CubeView.tsx
+++ b/packages/npm/rn/src/dash/cube/CubeView.tsx
@@ -1,29 +1,68 @@
-// Cube semantic-layer dashboard: live log-volume + signup trends over the
-// Cube REST API, rendered with the shared TrendChart + StatGrid primitives.
-// Polls on an interval (default 30s) so the graphs update with live data.
+// Cube semantic-layer dashboard: live log-volume + signup trends, top services /
+// namespaces, and federated Minecraft player activity over the Cube REST API.
+// Polls on an interval (default 30s) so the graphs update with live data. A local
+// range control drives the time window on every time-scoped query.
 
 import { useEffect, useMemo, useState } from 'react';
 import { Stack, Text } from '../_ui';
 import { TrendChart } from '../TrendChart';
 import { StatGrid } from '../StatGrid';
-import { cubeLoad, fmtInt } from './cubeApi';
+import { RangeControl } from './RangeControl';
+import { RankedRows } from './RankedRows';
+import {
+	cubeLoad,
+	fmtInt,
+	rangeToDateRange,
+	rangeToGranularity,
+} from './cubeApi';
+import type {
+	CubeRow,
+	CubeQuery,
+	CubeTimeDimension,
+	RangeKey,
+} from './cubeApi';
 import {
 	buildCubeStats,
 	logsByDayToSeries,
 	signupsToSeries,
+	topServicesToRows,
+	topNamespacesToRows,
+	mcPlayersToRows,
 } from '../adapters/cube';
-import type { CubeRow } from './cubeApi';
 
 export interface CubeViewProps {
 	getToken: () => Promise<string | null>;
 	baseUrl?: string;
 	/** Poll interval in ms. Defaults to 30s. */
 	pollMs?: number;
+	/** Initial time window. Defaults to 7d. */
+	initialRange?: RangeKey;
 }
 
-export function CubeView({ getToken, baseUrl = '', pollMs = 30_000 }: CubeViewProps) {
-	const [logs, setLogs] = useState<CubeRow[]>([]);
-	const [signups, setSignups] = useState<CubeRow[]>([]);
+interface Snapshot {
+	logs: CubeRow[];
+	signups: CubeRow[];
+	services: CubeRow[];
+	namespaces: CubeRow[];
+	players: CubeRow[];
+}
+
+const EMPTY: Snapshot = {
+	logs: [],
+	signups: [],
+	services: [],
+	namespaces: [],
+	players: [],
+};
+
+export function CubeView({
+	getToken,
+	baseUrl = '',
+	pollMs = 30_000,
+	initialRange = '7d',
+}: CubeViewProps) {
+	const [range, setRange] = useState<RangeKey>(initialRange);
+	const [data, setData] = useState<Snapshot>(EMPTY);
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(true);
 
@@ -32,39 +71,64 @@ export function CubeView({ getToken, baseUrl = '', pollMs = 30_000 }: CubeViewPr
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const ctrl = new AbortController();
 
+		const dateRange = rangeToDateRange(range);
+		const logTime: CubeTimeDimension = {
+			dimension: 'ch_logs.timestamp',
+			...(dateRange ? { dateRange } : {}),
+		};
+
 		async function tick() {
 			try {
 				const token = await getToken();
-				const [l, s] = await Promise.all([
-					cubeLoad(
-						baseUrl,
-						token,
-						{
+				const load = (query: CubeQuery) =>
+					cubeLoad(baseUrl, token, query, ctrl.signal);
+				const [logs, signups, services, namespaces, players] =
+					await Promise.all([
+						load({
 							measures: ['ch_logs.count'],
 							dimensions: ['ch_logs.level'],
 							timeDimensions: [
-								{ dimension: 'ch_logs.timestamp', granularity: 'day' },
+								{
+									...logTime,
+									granularity: rangeToGranularity(range, 'day'),
+								},
 							],
 							order: { 'ch_logs.timestamp': 'asc' },
-						},
-						ctrl.signal,
-					),
-					cubeLoad(
-						baseUrl,
-						token,
-						{
+						}),
+						load({
 							measures: ['pg_users.count'],
 							timeDimensions: [
-								{ dimension: 'pg_users.created_at', granularity: 'month' },
+								{
+									dimension: 'pg_users.created_at',
+									granularity: rangeToGranularity(range, 'month'),
+									...(dateRange ? { dateRange } : {}),
+								},
 							],
 							order: { 'pg_users.created_at': 'asc' },
-						},
-						ctrl.signal,
-					),
-				]);
+						}),
+						load({
+							measures: ['ch_logs.count'],
+							dimensions: ['ch_logs.service'],
+							timeDimensions: [logTime],
+							order: { 'ch_logs.count': 'desc' },
+							limit: 8,
+						}),
+						load({
+							measures: ['ch_logs.count'],
+							dimensions: ['ch_logs.pod_namespace'],
+							timeDimensions: [logTime],
+							order: { 'ch_logs.count': 'desc' },
+							limit: 8,
+						}),
+						load({
+							measures: ['ch_mc_snapshots.count'],
+							dimensions: ['pg_mc_player.player_name'],
+							order: { 'ch_mc_snapshots.count': 'desc' },
+							limit: 8,
+						}),
+					]);
 				if (!active) return;
-				setLogs(l);
-				setSignups(s);
+				setData({ logs, signups, services, namespaces, players });
 				setError(null);
 				setLoading(false);
 			} catch (e) {
@@ -82,14 +146,33 @@ export function CubeView({ getToken, baseUrl = '', pollMs = 30_000 }: CubeViewPr
 			ctrl.abort();
 			if (timer) clearTimeout(timer);
 		};
-	}, [getToken, baseUrl, pollMs]);
+	}, [getToken, baseUrl, pollMs, range]);
 
-	const logSeries = useMemo(() => logsByDayToSeries(logs), [logs]);
-	const signupSeries = useMemo(() => signupsToSeries(signups), [signups]);
-	const stats = useMemo(() => buildCubeStats(logs, signups), [logs, signups]);
+	const logSeries = useMemo(() => logsByDayToSeries(data.logs), [data.logs]);
+	const signupSeries = useMemo(
+		() => signupsToSeries(data.signups),
+		[data.signups],
+	);
+	const stats = useMemo(
+		() => buildCubeStats(data.logs, data.signups),
+		[data.logs, data.signups],
+	);
+	const serviceRows = useMemo(
+		() => topServicesToRows(data.services),
+		[data.services],
+	);
+	const namespaceRows = useMemo(
+		() => topNamespacesToRows(data.namespaces),
+		[data.namespaces],
+	);
+	const playerRows = useMemo(
+		() => mcPlayersToRows(data.players),
+		[data.players],
+	);
 
 	return (
 		<Stack gap="md">
+			<RangeControl value={range} onChange={setRange} />
 			{error ? (
 				<Text tone="muted">Cube error: {error}</Text>
 			) : loading ? (
@@ -97,18 +180,33 @@ export function CubeView({ getToken, baseUrl = '', pollMs = 30_000 }: CubeViewPr
 			) : null}
 			<StatGrid stats={stats} />
 			<TrendChart
-				title="Log volume by level · per day"
+				title="Log volume by level"
 				series={logSeries}
 				format={fmtInt}
 				zeroFloor
 				height={200}
 			/>
 			<TrendChart
-				title="User signups · per month"
+				title="User signups"
 				series={signupSeries}
 				format={fmtInt}
 				zeroFloor
 				height={180}
+			/>
+			<RankedRows
+				title="Top services · by log volume"
+				rows={serviceRows}
+				format={fmtInt}
+			/>
+			<RankedRows
+				title="Top namespaces · by log volume"
+				rows={namespaceRows}
+				format={fmtInt}
+			/>
+			<RankedRows
+				title="Minecraft players · by snapshots"
+				rows={playerRows}
+				format={fmtInt}
 			/>
 		</Stack>
 	);

--- a/packages/npm/rn/src/dash/cube/RangeControl.tsx
+++ b/packages/npm/rn/src/dash/cube/RangeControl.tsx
@@ -1,0 +1,56 @@
+import { Pressable, StyleSheet } from 'react-native';
+import { Stack, Text, tokens } from '../_ui';
+import type { RangeKey } from './cubeApi';
+
+export interface RangeControlProps {
+	value: RangeKey;
+	onChange: (k: RangeKey) => void;
+}
+
+const OPTIONS: { key: RangeKey; label: string }[] = [
+	{ key: '24h', label: '24h' },
+	{ key: '7d', label: '7d' },
+	{ key: '30d', label: '30d' },
+	{ key: 'all', label: 'All' },
+];
+
+export function RangeControl({ value, onChange }: RangeControlProps) {
+	return (
+		<Stack direction="row" gap="xs">
+			{OPTIONS.map((o) => {
+				const on = o.key === value;
+				return (
+					<Pressable
+						key={o.key}
+						onPress={() => onChange(o.key)}
+						style={[styles.seg, on ? styles.segOn : null]}>
+						<Text
+							variant="caption"
+							weight={on ? 'medium' : undefined}
+							style={{
+								color: on
+									? tokens.color.onPrimary
+									: tokens.color.textMuted,
+							}}>
+							{o.label}
+						</Text>
+					</Pressable>
+				);
+			})}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	seg: {
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 4,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	segOn: {
+		backgroundColor: tokens.color.primary,
+		borderColor: tokens.color.primary,
+	},
+});

--- a/packages/npm/rn/src/dash/cube/RankedRows.tsx
+++ b/packages/npm/rn/src/dash/cube/RankedRows.tsx
@@ -1,0 +1,45 @@
+import { StyleSheet } from 'react-native';
+import { Surface, Stack, Text, Badge, tokens } from '../_ui';
+import type { RankedRow } from '../adapters/cube';
+
+export interface RankedRowsProps {
+	title: string;
+	rows: RankedRow[];
+	format?: (v: number) => string;
+}
+
+export function RankedRows({ title, rows, format }: RankedRowsProps) {
+	if (!rows.length) return null;
+	const fmt = format ?? ((v: number) => String(v));
+	return (
+		<Stack gap="xs">
+			<Text variant="caption" tone="muted">
+				{title}
+			</Text>
+			{rows.map((r) => (
+				<Surface key={r.key} style={styles.row}>
+					<Text variant="caption" style={styles.label} numberOfLines={1}>
+						{r.label}
+					</Text>
+					{r.badge ? <Badge label={r.badge} tone="danger" /> : null}
+					<Text variant="caption" tone="muted">
+						{fmt(r.value)}
+					</Text>
+				</Surface>
+			))}
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+		padding: tokens.space.sm,
+	},
+	label: {
+		flexGrow: 1,
+		flexShrink: 1,
+	},
+});

--- a/packages/npm/rn/src/dash/cube/cubeApi.ts
+++ b/packages/npm/rn/src/dash/cube/cubeApi.ts
@@ -46,3 +46,31 @@ export function fmtInt(v: number): string {
 	if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
 	return String(Math.round(v));
 }
+
+export function fmtPct(v: number): string {
+	if (!Number.isFinite(v)) return '0.0%';
+	return `${v.toFixed(1)}%`;
+}
+
+export type RangeKey = '24h' | '7d' | '30d' | 'all';
+
+export function rangeToDateRange(k: RangeKey): string | undefined {
+	switch (k) {
+		case '24h':
+			return 'last 24 hours';
+		case '7d':
+			return 'last 7 days';
+		case '30d':
+			return 'last 30 days';
+		case 'all':
+			return undefined;
+	}
+}
+
+export function rangeToGranularity(
+	k: RangeKey,
+	base: 'day' | 'month',
+): CubeTimeDimension['granularity'] {
+	if (k === '24h') return 'hour';
+	return base;
+}

--- a/packages/npm/rn/src/dash/cube/index.ts
+++ b/packages/npm/rn/src/dash/cube/index.ts
@@ -1,4 +1,19 @@
 export { CubeView } from './CubeView';
 export type { CubeViewProps } from './CubeView';
-export { cubeLoad, fmtInt } from './cubeApi';
-export type { CubeQuery, CubeRow, CubeTimeDimension } from './cubeApi';
+export { RangeControl } from './RangeControl';
+export type { RangeControlProps } from './RangeControl';
+export { RankedRows } from './RankedRows';
+export type { RankedRowsProps } from './RankedRows';
+export {
+	cubeLoad,
+	fmtInt,
+	fmtPct,
+	rangeToDateRange,
+	rangeToGranularity,
+} from './cubeApi';
+export type {
+	CubeQuery,
+	CubeRow,
+	CubeTimeDimension,
+	RangeKey,
+} from './cubeApi';


### PR DESCRIPTION
Implements epic #14459.

## What
Polish pass on the Cube analytics dashboard (`@kbve/rn/dash/cube`). Adds interactivity + surfaces data already in the Cube models. **No Cube model, proxy, or RBAC change.**

- **Date-range control** — segmented `24h / 7d / 30d / All`, drives `dateRange` + granularity on every time-scoped query (`RangeControl`).
- **Top services / namespaces** — ranked log-volume lists by `ch_logs.service` / `ch_logs.pod_namespace` (`RankedRows` + adapters).
- **Federated MC player activity** — `ch_mc_snapshots.count` by `pg_mc_player.player_name` via the `snapshots_by_player` rollup_join (proves PG⋈CH in the UI).
- **Derived stat tiles** — error-rate %, signup month-over-month delta.

## Design
CubeView keeps its local-state polling model (no StreamStore adoption). Range control is local; value threads into all queries via a single `Promise.all`.

## Files
- `cube/RangeControl.tsx`, `cube/RankedRows.tsx` (new)
- `cube/cubeApi.ts` — `fmtPct`, `rangeToDateRange`, `rangeToGranularity`, `RangeKey`
- `adapters/cube.tsx` — `topServicesToRows`, `topNamespacesToRows`, `mcPlayersToRows`, `RankedRow`, extended `buildCubeStats`
- `cube/CubeView.tsx` — range state + 3 new queries + render wiring
- `cube/index.ts` — new exports
- `__tests__/cube-adapters.test.ts` — adapter + range-mapping unit tests

Astro island (`ReactCubeDashRN`) unchanged; new props optional, UI appears automatically.

## Verification
Worktree has no node_modules — CI typechecks TS + runs vitest.

Closes #14459