### PR TITLE
fix(kong): preserve_host on studio dashboard route

### DIFF
--- a/apps/kube/kong/manifests/kong-config.yaml
+++ b/apps/kube/kong/manifests/kong-config.yaml
@@ -84,4 +84,4 @@ data:
         \          allow:\n            - admin\n\n  ## Protected Dashboard - catch all\
         \ remaining routes\n  - name: dashboard\n    _comment: 'Studio: /* -> studio-gate (kbve-gate JWT is_staff) -> http://studio:3000/*'\n\
         \    url: http://studio-gate:5678/\n    routes:\n      - name: dashboard-all\n    \
-        \    strip_path: true\n        paths:\n          - /\n"
+        \    strip_path: true\n        preserve_host: true\n        paths:\n          - /\n"


### PR DESCRIPTION
Fixes the redirect loop on https://supabase.kbve.com login.

## Problem
Visiting supabase.kbve.com Studio bounces to kbve.com/login with `redirect_to=http%3A%2F%2Fstudio-gate%3A5678%2F`. After sign-in the browser lands on kbve.com instead of back on supabase.kbve.com.

## Root cause
The kbve-gate fronting Studio is inserted **inside** Kong on the `dashboard` catch-all route (path `/`), unlike n8n/grafana which own their own hostname. With Kong default `preserve_host: false`, Kong rewrites the `Host` header to the upstream (`studio-gate:5678`) before the request hits the gate.

The gate builds its login `redirect_to` from the incoming `Host` header (`external_url()` in `packages/rust/kbve/src/gate/proxy.rs`), so it minted `redirect_to=http://studio-gate:5678/` — an internal cluster name the browser can never return to. Hence the fall-through to kbve.com.

## Fix
Add `preserve_host: true` to the `dashboard-all` route so Kong forwards the original `Host` (`supabase.kbve.com`), making the gate mint `redirect_to=https://supabase.kbve.com/`.

## Validation
- Outer ConfigMap + embedded `kong.yml` both parse clean (one bad char = whole supabase host down).
- Route now: `{name: dashboard-all, strip_path: True, preserve_host: True, paths: [/]}`.

Reaches cluster after dev→main release sync.