### PR TITLE
chore(firecracker-ctl): upgrade Firecracker to v1.16.1

### DIFF
--- a/apps/vm/firecracker-ctl/Dockerfile
+++ b/apps/vm/firecracker-ctl/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-ARG FC_VERSION=1.15.1
+ARG FC_VERSION=1.16.1
 RUN curl -fSL "https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/firecracker-v${FC_VERSION}-x86_64.tgz" \
     -o /tmp/fc.tgz && \
     tar -xzf /tmp/fc.tgz -C /tmp && \

--- a/apps/vm/firecracker-ctl/rootfs/download-kernel.sh
+++ b/apps/vm/firecracker-ctl/rootfs/download-kernel.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-# Download a pre-built Firecracker-compatible Linux kernel.
+# Download a pre-built Firecracker-compatible Linux kernel from the CI bucket.
 #
-# Firecracker maintains pre-built vmlinux binaries on their GitHub releases.
-# These kernels are minimal (no modules, no initrd needed) and boot in ~125ms.
+# Firecracker publishes minimal vmlinux binaries (no modules/initrd) under
+# s3.amazonaws.com/spec.ccfc.min/firecracker-ci/<ci>/<arch>/vmlinux-<kernel>.
+# Release-asset kernels were removed; only firecracker/jailer tgz ship there.
 #
 # Usage:
 #   ./download-kernel.sh [output_dir]
@@ -12,15 +13,15 @@
 
 set -eu
 
-FC_KERNEL_VERSION="${FC_KERNEL_VERSION:-5.10}"
-FC_VERSION="${FC_VERSION:-1.15.1}"
+FC_CI_VERSION="${FC_CI_VERSION:-v1.15}"
+FC_KERNEL_VERSION="${FC_KERNEL_VERSION:-6.1.155}"
 OUTPUT_DIR="${1:-.}"
 ARCH="x86_64"
 
-KERNEL_URL="https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/vmlinux-${FC_KERNEL_VERSION}.bin"
+KERNEL_URL="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${FC_CI_VERSION}/${ARCH}/vmlinux-${FC_KERNEL_VERSION}"
 OUTPUT_FILE="${OUTPUT_DIR}/vmlinux"
 
-echo "Downloading Firecracker kernel ${FC_KERNEL_VERSION} (Firecracker v${FC_VERSION})..."
+echo "Downloading Firecracker kernel ${FC_KERNEL_VERSION} (CI ${FC_CI_VERSION}, ${ARCH})..."
 echo "  URL: ${KERNEL_URL}"
 echo "  Output: ${OUTPUT_FILE}"
 


### PR DESCRIPTION
## Summary
Upgrade `apps/vm/firecracker-ctl` to Firecracker **v1.16.1**.

- **Dockerfile**: `FC_VERSION` `1.15.1` → `1.16.1`. Verified the v1.16.1 x86_64 tgz contains `firecracker-v1.16.1-x86_64` + `jailer-v1.16.1-x86_64`, matching the existing `mv` paths.
- **download-kernel.sh**: rewritten. The old GitHub release-asset kernel URL (`.../releases/download/v${FC_VERSION}/vmlinux-5.10.bin`) **404s on both 1.15.1 and 1.16.1** — Firecracker no longer ships kernels as release assets. Now fetches from the S3 CI bucket: `firecracker-ci/<ci>/<arch>/vmlinux-<kernel>`. New vars `FC_CI_VERSION=v1.15`, `FC_KERNEL_VERSION=6.1.155`.

## Notes
- **Kernel bumped 5.10 → 6.1.155** (6.1 LTS line).
- Firecracker **v1.16 CI kernel bucket is not published on S3 yet** — pinned to the latest available (`v1.15`, kernels are FC-version backward-compatible). Bump `FC_CI_VERSION` when v1.16 lands.
- `src/main.rs` needs no change — references `/vmlinux` by path; kernel is loaded from the `firecracker-rootfs` PVC at runtime.

## Verification
- Ran `download-kernel.sh` → fetched 42.2 MB valid ELF vmlinux (`.ELF` magic). ✅
- Confirmed FC v1.16.1 tgz downloads + binary layout matches Dockerfile. ✅

## Follow-up before rollout
- Re-upload the new `6.1.155` vmlinux to the `firecracker-rootfs` PVC.
- Retest microVM boot timing + networking on 6.1.