### PR TITLE
chore(firecracker-ctl): bump 0.1.42 — republish image w/ Firecracker v1.16.1

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.41"
+version: "0.1.42"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml


### PR DESCRIPTION
## Summary
Version bump `firecracker-ctl` `0.1.41` → `0.1.42` to trigger manifest dispatch, rebuilding + publishing the `kbve/firecracker-ctl` image with the Firecracker **v1.16.1** binary + 6.1 kernel fetch changes from #14482.

Follow-up to #14482, which changed the Dockerfile/kernel script but not the version, so the image had not republished.

MDX is source of truth; `version.toml` + `Cargo.toml` sync downstream via the pipeline.

## Follow-up before rollout
- Upload the new `6.1.155` vmlinux to the `firecracker-rootfs` PVC.
- Retest microVM boot timing + networking on 6.1.