### PR TITLE
feat(reel): transcode to faststart MP4 (Phase 2A)

### DIFF
--- a/apps/media/reel/Dockerfile
+++ b/apps/media/reel/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo build --release -p reel --target-dir /app/target
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/target/release/reel /usr/local/bin/reel
 VOLUME ["/data"]

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -141,7 +141,7 @@ fn store_router(store: state::StateStore, token: Option<String>) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Metadata, StateStore, TorrentState};
+    use crate::state::{Metadata, StateStore, TorrentState, TranscodeStatus};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -160,6 +160,9 @@ mod tests {
             completed_at: Some(10),
             last_access: 10,
             state: TorrentState::Seeding,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
         })
         .unwrap();
         s

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{engine, state};
+use crate::{engine, state, transcode};
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
@@ -10,6 +10,7 @@ pub struct AppState {
     pub engine: engine::Engine,
     pub store: state::StateStore,
     pub token: Option<String>,
+    pub transcoder: transcode::Transcoder,
 }
 
 #[derive(Clone)]
@@ -113,6 +114,30 @@ async fn remove(
     }
 }
 
+async fn transcode_start(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    match st.transcoder.request(&id).await {
+        transcode::RequestOutcome::Ready(p) => {
+            (StatusCode::OK, Json(serde_json::json!({"status":"ready","path":p}))).into_response()
+        }
+        transcode::RequestOutcome::Started => {
+            (StatusCode::ACCEPTED, Json(serde_json::json!({"status":"pending"}))).into_response()
+        }
+        transcode::RequestOutcome::InProgress(s) => {
+            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{s:?}")}))).into_response()
+        }
+        transcode::RequestOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
+        transcode::RequestOutcome::NotCompleted => StatusCode::CONFLICT.into_response(),
+        transcode::RequestOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
 fn store_scoped_router(state: AppStateStub) -> Router {
     Router::new()
         .route("/torrents", get(list))
@@ -126,6 +151,7 @@ pub fn router(state: AppState) -> Router {
     let engine_router = Router::new()
         .route("/torrents", post(add))
         .route("/torrents/{id}", axum::routing::delete(remove))
+        .route("/torrents/{id}/transcode", post(transcode_start))
         .with_state(state);
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -136,6 +162,43 @@ pub fn router(state: AppState) -> Router {
 #[cfg(test)]
 fn store_router(store: state::StateStore, token: Option<String>) -> Router {
     store_scoped_router(AppStateStub { store, token })
+}
+
+#[cfg(test)]
+fn transcode_router(transcoder: transcode::Transcoder, token: Option<String>) -> Router {
+    #[derive(Clone)]
+    struct TranscodeState {
+        transcoder: transcode::Transcoder,
+        token: Option<String>,
+    }
+
+    async fn handler(
+        State(st): State<TranscodeState>,
+        headers: HeaderMap,
+        Path(id): Path<String>,
+    ) -> impl IntoResponse {
+        if !check_auth(&headers, &st.token) {
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        match st.transcoder.request(&id).await {
+            transcode::RequestOutcome::Ready(p) => {
+                (StatusCode::OK, Json(serde_json::json!({"status":"ready","path":p}))).into_response()
+            }
+            transcode::RequestOutcome::Started => {
+                (StatusCode::ACCEPTED, Json(serde_json::json!({"status":"pending"}))).into_response()
+            }
+            transcode::RequestOutcome::InProgress(s) => {
+                (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{s:?}")}))).into_response()
+            }
+            transcode::RequestOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
+            transcode::RequestOutcome::NotCompleted => StatusCode::CONFLICT.into_response(),
+            transcode::RequestOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        }
+    }
+
+    Router::new()
+        .route("/torrents/{id}/transcode", post(handler))
+        .with_state(TranscodeState { transcoder, token })
 }
 
 #[cfg(test)]
@@ -185,6 +248,54 @@ mod tests {
         let app = store_router(store_with_one(), None);
         let res = app
             .oneshot(Request::get("/torrents/999").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    fn transcoder_with(store: StateStore) -> transcode::Transcoder {
+        transcode::Transcoder::new(store, 1, 1, "ffmpeg".into(), "ffprobe".into(), true)
+    }
+
+    #[tokio::test]
+    async fn transcode_not_completed_is_409() {
+        let dir = tempdir().unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        std::mem::forget(dir);
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: "/lib/movie.mp4".into(),
+            size: 5,
+            completed_at: None,
+            last_access: 10,
+            state: TorrentState::Leeching,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+        })
+        .unwrap();
+        let app = transcode_router(transcoder_with(s), None);
+        let res = app
+            .oneshot(
+                Request::post("/torrents/1/transcode")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn transcode_missing_id_is_404() {
+        let app = transcode_router(transcoder_with(store_with_one()), None);
+        let res = app
+            .oneshot(
+                Request::post("/torrents/999/transcode")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -9,6 +9,11 @@ pub struct Config {
     pub api_addr: String,
     pub vpn_check_url: String,
     pub api_token: Option<String>,
+    pub transcode_enabled: bool,
+    pub remux_concurrency: usize,
+    pub encode_concurrency: usize,
+    pub ffmpeg_bin: String,
+    pub ffprobe_bin: String,
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -22,6 +27,13 @@ fn env_u64(key: &str, default: u64) -> anyhow::Result<u64> {
     }
 }
 
+fn env_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(v) => !(v.eq_ignore_ascii_case("false") || v == "0"),
+        Err(_) => default,
+    }
+}
+
 pub fn load_from_env() -> anyhow::Result<Config> {
     Ok(Config {
         ttl_secs: env_u64("REEL_TTL_SECS", 21600)?,
@@ -32,6 +44,11 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         api_addr: env_or("REEL_API_ADDR", "0.0.0.0:8080"),
         vpn_check_url: env_or("REEL_VPN_CHECK_URL", "https://api.ipify.org"),
         api_token: std::env::var("REEL_API_TOKEN").ok(),
+        transcode_enabled: env_bool("REEL_TRANSCODE_ENABLED", true),
+        remux_concurrency: env_u64("REEL_REMUX_CONCURRENCY", 3)? as usize,
+        encode_concurrency: env_u64("REEL_ENCODE_CONCURRENCY", 1)? as usize,
+        ffmpeg_bin: env_or("REEL_FFMPEG_BIN", "ffmpeg"),
+        ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
     })
 }
 
@@ -43,7 +60,9 @@ mod tests {
     fn clear() {
         for k in ["REEL_TTL_SECS","REEL_REAP_INTERVAL_SECS","REEL_ACTIVE_DIR",
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
-                  "REEL_VPN_CHECK_URL","REEL_API_TOKEN"] {
+                  "REEL_VPN_CHECK_URL","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
+                  "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
+                  "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN"] {
             std::env::remove_var(k);
         }
     }
@@ -69,6 +88,23 @@ mod tests {
         let c = load_from_env().unwrap();
         assert_eq!(c.ttl_secs, 60);
         assert_eq!(c.api_token.as_deref(), Some("secret"));
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn transcode_defaults_and_overrides() {
+        clear();
+        let c = load_from_env().unwrap();
+        assert!(c.transcode_enabled);
+        assert_eq!(c.remux_concurrency, 3);
+        assert_eq!(c.encode_concurrency, 1);
+        assert_eq!(c.ffmpeg_bin, "ffmpeg");
+        std::env::set_var("REEL_TRANSCODE_ENABLED", "false");
+        std::env::set_var("REEL_ENCODE_CONCURRENCY", "2");
+        let c2 = load_from_env().unwrap();
+        assert!(!c2.transcode_enabled);
+        assert_eq!(c2.encode_concurrency, 2);
         clear();
     }
 }

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -99,6 +99,9 @@ impl Engine {
             completed_at: None,
             last_access: now_secs(),
             state: state::TorrentState::Leeching,
+            transcode: state::TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
         })?;
 
         let store = self.store.clone();
@@ -120,6 +123,9 @@ impl Engine {
                         completed_at: Some(now),
                         last_access: now,
                         state: state::TorrentState::Seeding,
+                        transcode: state::TranscodeStatus::None,
+                        transcode_path: None,
+                        transcode_error: None,
                     });
                     tracing::info!(id = %id_task, "moved to library");
                 }

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -141,12 +141,7 @@ impl Engine {
             let _ = self.session.delete(TorrentIdOrHash::Id(tid), true).await;
         }
         if let Some(m) = &removed {
-            let p = std::path::Path::new(&m.path);
-            if p.is_dir() {
-                let _ = std::fs::remove_dir_all(p);
-            } else if p.exists() {
-                let _ = std::fs::remove_file(p);
-            }
+            remove_entry_files(&m.path, m.transcode_path.as_deref());
         }
         Ok(removed.is_some())
     }
@@ -173,10 +168,34 @@ impl Engine {
     }
 }
 
+pub fn remove_entry_files(path: &str, transcode_path: Option<&str>) {
+    for p in std::iter::once(path).chain(transcode_path) {
+        let pb = std::path::Path::new(p);
+        if pb.is_dir() {
+            let _ = std::fs::remove_dir_all(pb);
+        } else if pb.exists() {
+            let _ = std::fs::remove_file(pb);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::net::IpAddr;
+
+    #[test]
+    fn remove_entry_files_deletes_source_and_transcode() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("srcdir");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.mkv"), b"x").unwrap();
+        let tc = dir.path().join("out.reel.mp4");
+        std::fs::write(&tc, b"y").unwrap();
+        remove_entry_files(&src.display().to_string(), Some(&tc.display().to_string()));
+        assert!(!src.exists());
+        assert!(!tc.exists());
+    }
 
     #[test]
     fn private_and_loopback_are_not_vpn() {

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -4,3 +4,4 @@ pub mod engine;
 pub mod mover;
 pub mod reaper;
 pub mod state;
+pub mod transcode;

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -9,6 +9,14 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::load_from_env()?;
     let store = state::StateStore::load(cfg.state_file.clone())?;
     let eng = engine::Engine::start(&cfg, store.clone()).await?;
+    let transcoder = reel::transcode::Transcoder::new(
+        store.clone(),
+        cfg.remux_concurrency,
+        cfg.encode_concurrency,
+        cfg.ffmpeg_bin.clone(),
+        cfg.ffprobe_bin.clone(),
+        cfg.transcode_enabled,
+    );
 
     tokio::spawn(reaper::reap_loop(
         eng.clone(),
@@ -20,6 +28,7 @@ async fn main() -> anyhow::Result<()> {
         engine: eng,
         store,
         token: cfg.api_token.clone(),
+        transcoder,
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -27,13 +27,14 @@ pub async fn reap_loop(engine: crate::engine::Engine, ttl_secs: u64, interval_se
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Metadata, TorrentState};
+    use crate::state::{Metadata, TorrentState, TranscodeStatus};
 
     fn meta(id: &str, last_access: u64) -> Metadata {
         Metadata {
             id: id.into(), name: id.into(), path: format!("/lib/{id}"),
             size: 1, completed_at: Some(last_access), last_access,
             state: TorrentState::Seeding,
+            transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
         }
     }
 

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -5,6 +5,9 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TorrentState { Queued, Leeching, Seeding, Reaped }
 
+#[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub enum TranscodeStatus { #[default] None, Pending, Remuxing, Encoding, Ready, Failed }
+
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Metadata {
     pub id: String,
@@ -14,6 +17,12 @@ pub struct Metadata {
     pub completed_at: Option<u64>,
     pub last_access: u64,
     pub state: TorrentState,
+    #[serde(default)]
+    pub transcode: TranscodeStatus,
+    #[serde(default)]
+    pub transcode_path: Option<String>,
+    #[serde(default)]
+    pub transcode_error: Option<String>,
 }
 
 #[derive(Clone)]
@@ -80,6 +89,7 @@ mod tests {
             id: id.into(), name: format!("t-{id}"), path: format!("/lib/{id}"),
             size: 10, completed_at: Some(last_access), last_access,
             state: TorrentState::Seeding,
+            transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
         }
     }
 
@@ -120,5 +130,18 @@ mod tests {
         s.upsert(meta("a", 100)).unwrap();
         assert_eq!(s.remove("a").unwrap().unwrap().id, "a");
         assert!(s.get("a").is_none());
+    }
+
+    #[test]
+    fn old_json_without_transcode_fields_loads_with_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        let legacy = r#"{"1":{"id":"1","name":"m","path":"/lib/m","size":3,"completed_at":10,"last_access":10,"state":"Seeding"}}"#;
+        std::fs::write(&p, legacy).unwrap();
+        let s = StateStore::load(p).unwrap();
+        let m = s.get("1").unwrap();
+        assert_eq!(m.transcode, TranscodeStatus::None);
+        assert!(m.transcode_path.is_none());
+        assert!(m.transcode_error.is_none());
     }
 }

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -77,6 +77,21 @@ impl StateStore {
         self.persist(&g)?;
         Ok(removed)
     }
+
+    pub fn update<F, R>(&self, id: &str, f: F) -> anyhow::Result<Option<R>>
+    where
+        F: FnOnce(&mut Metadata) -> R,
+    {
+        let mut g = self.inner.lock().unwrap();
+        match g.get_mut(id) {
+            Some(m) => {
+                let r = f(m);
+                self.persist(&g)?;
+                Ok(Some(r))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -130,6 +145,24 @@ mod tests {
         s.upsert(meta("a", 100)).unwrap();
         assert_eq!(s.remove("a").unwrap().unwrap().id, "a");
         assert!(s.get("a").is_none());
+    }
+
+    #[test]
+    fn update_mutates_in_place_and_preserves_other_fields() {
+        let dir = tempdir().unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        s.upsert(meta("a", 100)).unwrap();
+        let got = s
+            .update("a", |m| {
+                m.transcode = TranscodeStatus::Pending;
+                m.last_access
+            })
+            .unwrap();
+        assert_eq!(got, Some(100));
+        let m = s.get("a").unwrap();
+        assert_eq!(m.transcode, TranscodeStatus::Pending);
+        assert_eq!(m.last_access, 100);
+        assert!(s.update("missing", |_m| ()).unwrap().is_none());
     }
 
     #[test]

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -80,13 +80,17 @@ impl StateStore {
 
     pub fn update<F, R>(&self, id: &str, f: F) -> anyhow::Result<Option<R>>
     where
-        F: FnOnce(&mut Metadata) -> R,
+        F: FnOnce(&mut Metadata) -> (R, bool),
     {
         let mut g = self.inner.lock().unwrap();
         match g.get_mut(id) {
             Some(m) => {
-                let r = f(m);
-                self.persist(&g)?;
+                let (r, dirty) = f(m);
+                if dirty {
+                    let snap = g.clone();
+                    drop(g);
+                    self.persist(&snap)?;
+                }
                 Ok(Some(r))
             }
             None => Ok(None),
@@ -155,14 +159,26 @@ mod tests {
         let got = s
             .update("a", |m| {
                 m.transcode = TranscodeStatus::Pending;
-                m.last_access
+                (m.last_access, true)
             })
             .unwrap();
         assert_eq!(got, Some(100));
         let m = s.get("a").unwrap();
         assert_eq!(m.transcode, TranscodeStatus::Pending);
         assert_eq!(m.last_access, 100);
-        assert!(s.update("missing", |_m| ()).unwrap().is_none());
+        assert!(s.update("missing", |_m| ((), true)).unwrap().is_none());
+    }
+
+    #[test]
+    fn update_without_dirty_flag_does_not_change_persisted_state() {
+        let dir = tempdir().unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        s.upsert(meta("a", 100)).unwrap();
+        let got = s.update("a", |m| (m.last_access, false)).unwrap();
+        assert_eq!(got, Some(100));
+        let m = s.get("a").unwrap();
+        assert_eq!(m.last_access, 100);
+        assert_eq!(m.transcode, TranscodeStatus::None);
     }
 
     #[test]

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -157,26 +157,32 @@ impl Transcoder {
     }
 
     pub async fn request(&self, id: &str) -> RequestOutcome {
-        let meta = match self.store.get(id) {
-            Some(m) => m,
-            None => return RequestOutcome::NotFound,
-        };
-        match next_status(&meta.transcode, &meta.state, self.enabled) {
-            Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Ready)) => {
-                match meta.transcode_path {
-                    Some(p) => RequestOutcome::Ready(p),
-                    None => RequestOutcome::InProgress(TranscodeStatus::Ready),
+        let result = self.store.update(id, |m| {
+            match next_status(&m.transcode, &m.state, self.enabled) {
+                Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Ready)) => {
+                    match &m.transcode_path {
+                        Some(p) => RequestOutcome::Ready(p.clone()),
+                        None => RequestOutcome::InProgress(TranscodeStatus::Ready),
+                    }
+                }
+                Decision::Reject(outcome) => outcome,
+                Decision::Enqueue => {
+                    m.transcode = TranscodeStatus::Pending;
+                    m.transcode_error = None;
+                    RequestOutcome::Started
                 }
             }
-            Decision::Reject(outcome) => outcome,
-            Decision::Enqueue => {
-                let mut m = meta.clone();
-                m.transcode = TranscodeStatus::Pending;
-                m.transcode_error = None;
-                let _ = self.store.upsert(m);
-                self.spawn_job(id.to_string(), meta);
+        });
+        match result {
+            Ok(Some(RequestOutcome::Started)) => {
+                if let Some(meta) = self.store.get(id) {
+                    self.spawn_job(id.to_string(), meta);
+                }
                 RequestOutcome::Started
             }
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => RequestOutcome::NotFound,
+            Err(_) => RequestOutcome::NotFound,
         }
     }
 
@@ -185,11 +191,10 @@ impl Transcoder {
         tokio::spawn(async move {
             if let Err(e) = this.run_job(&id, &meta).await {
                 tracing::error!(id = %id, error = %e, "transcode failed");
-                if let Some(mut m) = this.store.get(&id) {
+                let _ = this.store.update(&id, |m| {
                     m.transcode = TranscodeStatus::Failed;
                     m.transcode_error = Some(e.to_string());
-                    let _ = this.store.upsert(m);
-                }
+                });
             }
         });
     }
@@ -205,13 +210,12 @@ impl Transcoder {
             .unwrap_or_else(|| "media".into());
         let dest = src_dir.join(format!("{stem}.reel.mp4"));
 
-        if let Some(mut m) = self.store.get(id) {
+        let _ = self.store.update(id, |m| {
             m.transcode = match route {
                 Route::Remux => TranscodeStatus::Remuxing,
                 Route::Encode => TranscodeStatus::Encoding,
             };
-            let _ = self.store.upsert(m);
-        }
+        });
 
         match route {
             Route::Remux => {
@@ -224,12 +228,11 @@ impl Transcoder {
             }
         }
 
-        if let Some(mut m) = self.store.get(id) {
+        let _ = self.store.update(id, |m| {
             m.transcode = TranscodeStatus::Ready;
             m.transcode_path = Some(dest.display().to_string());
             m.transcode_error = None;
-            let _ = self.store.upsert(m);
-        }
+        });
         Ok(())
     }
 }

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -37,6 +37,14 @@ pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
             if path.is_dir() {
                 stack.push(path);
             } else {
+                let is_reel_output = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.ends_with(".reel.mp4"))
+                    .unwrap_or(false);
+                if is_reel_output {
+                    continue;
+                }
                 let len = entry.metadata()?.len();
                 if best.as_ref().map(|(b, _)| len > *b).unwrap_or(true) {
                     best = Some((len, path));
@@ -76,7 +84,14 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
 
 async fn run_ffmpeg(ffmpeg_bin: &str, args: &[&str], src: &Path, dest: &Path) -> anyhow::Result<()> {
     let mut cmd = Command::new(ffmpeg_bin);
-    cmd.arg("-y").arg("-i").arg(src).args(args).arg(dest);
+    cmd.arg("-y")
+        .arg("-nostats")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-i")
+        .arg(src)
+        .args(args)
+        .arg(dest);
     let out = cmd.output().await?;
     if !out.status.success() {
         anyhow::bail!("ffmpeg failed: {}", String::from_utf8_lossy(&out.stderr));
@@ -146,30 +161,45 @@ impl Transcoder {
         ffprobe_bin: String,
         enabled: bool,
     ) -> Self {
-        Self {
+        let this = Self {
             store,
             remux_sem: Arc::new(Semaphore::new(remux_conc.max(1))),
             encode_sem: Arc::new(Semaphore::new(encode_conc.max(1))),
             ffmpeg_bin,
             ffprobe_bin,
             enabled,
+        };
+        for m in this.store.list() {
+            let in_flight = matches!(
+                m.transcode,
+                TranscodeStatus::Pending | TranscodeStatus::Remuxing | TranscodeStatus::Encoding
+            );
+            if in_flight {
+                let _ = this.store.update(&m.id, |m| {
+                    m.transcode = TranscodeStatus::Failed;
+                    m.transcode_error = Some("interrupted by restart".into());
+                    ((), true)
+                });
+            }
         }
+        this
     }
 
     pub async fn request(&self, id: &str) -> RequestOutcome {
         let result = self.store.update(id, |m| {
             match next_status(&m.transcode, &m.state, self.enabled) {
                 Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Ready)) => {
-                    match &m.transcode_path {
+                    let outcome = match &m.transcode_path {
                         Some(p) => RequestOutcome::Ready(p.clone()),
                         None => RequestOutcome::InProgress(TranscodeStatus::Ready),
-                    }
+                    };
+                    (outcome, false)
                 }
-                Decision::Reject(outcome) => outcome,
+                Decision::Reject(outcome) => (outcome, false),
                 Decision::Enqueue => {
                     m.transcode = TranscodeStatus::Pending;
                     m.transcode_error = None;
-                    RequestOutcome::Started
+                    (RequestOutcome::Started, true)
                 }
             }
         });
@@ -194,6 +224,7 @@ impl Transcoder {
                 let _ = this.store.update(&id, |m| {
                     m.transcode = TranscodeStatus::Failed;
                     m.transcode_error = Some(e.to_string());
+                    ((), true)
                 });
             }
         });
@@ -215,6 +246,7 @@ impl Transcoder {
                 Route::Remux => TranscodeStatus::Remuxing,
                 Route::Encode => TranscodeStatus::Encoding,
             };
+            ((), true)
         });
 
         match route {
@@ -232,6 +264,7 @@ impl Transcoder {
             m.transcode = TranscodeStatus::Ready;
             m.transcode_path = Some(dest.display().to_string());
             m.transcode_error = None;
+            ((), true)
         });
         Ok(())
     }
@@ -266,12 +299,34 @@ mod tests {
         std::fs::write(dir.path().join("big.mkv"), b"aaaaaaaa").unwrap();
         assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("big.mkv"));
     }
+    #[test]
+    fn excludes_stale_reel_output() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("big.reel.mp4"), b"aaaaaaaa").unwrap();
+        std::fs::write(dir.path().join("movie.mkv"), b"aa").unwrap();
+        assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("movie.mkv"));
+    }
 }
 
 #[cfg(test)]
 mod transcoder_tests {
     use super::*;
-    use crate::state::{TorrentState, TranscodeStatus};
+    use crate::state::{Metadata, StateStore, TorrentState, TranscodeStatus};
+
+    fn meta(id: &str, transcode: TranscodeStatus) -> Metadata {
+        Metadata {
+            id: id.into(),
+            name: format!("t-{id}"),
+            path: format!("/lib/{id}"),
+            size: 10,
+            completed_at: Some(1),
+            last_access: 1,
+            state: TorrentState::Seeding,
+            transcode,
+            transcode_path: None,
+            transcode_error: None,
+        }
+    }
 
     #[test]
     fn disabled_rejects() {
@@ -314,5 +369,35 @@ mod transcoder_tests {
             next_status(&TranscodeStatus::Failed, &TorrentState::Seeding, true),
             Decision::Enqueue
         );
+    }
+
+    #[tokio::test]
+    async fn new_resets_in_flight_to_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::load(dir.path().join("state.json")).unwrap();
+        store.upsert(meta("pending", TranscodeStatus::Pending)).unwrap();
+        store.upsert(meta("encoding", TranscodeStatus::Encoding)).unwrap();
+        store.upsert(meta("ready", TranscodeStatus::Ready)).unwrap();
+        store.upsert(meta("none", TranscodeStatus::None)).unwrap();
+
+        let _transcoder = Transcoder::new(
+            store.clone(),
+            1,
+            1,
+            "ffmpeg".into(),
+            "ffprobe".into(),
+            true,
+        );
+
+        let pending = store.get("pending").unwrap();
+        assert_eq!(pending.transcode, TranscodeStatus::Failed);
+        assert_eq!(pending.transcode_error.as_deref(), Some("interrupted by restart"));
+
+        let encoding = store.get("encoding").unwrap();
+        assert_eq!(encoding.transcode, TranscodeStatus::Failed);
+        assert_eq!(encoding.transcode_error.as_deref(), Some("interrupted by restart"));
+
+        assert_eq!(store.get("ready").unwrap().transcode, TranscodeStatus::Ready);
+        assert_eq!(store.get("none").unwrap().transcode, TranscodeStatus::None);
     }
 }

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -1,5 +1,8 @@
+use crate::state::{StateStore, TorrentState, TranscodeStatus};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::process::Command;
+use tokio::sync::Semaphore;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProbeResult {
@@ -95,6 +98,142 @@ pub async fn encode(ffmpeg_bin: &str, src: &Path, dest: &Path) -> anyhow::Result
     .await
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum RequestOutcome {
+    Ready(String),
+    InProgress(TranscodeStatus),
+    Started,
+    NotFound,
+    NotCompleted,
+    Disabled,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Decision {
+    Reject(RequestOutcome),
+    Enqueue,
+}
+
+pub fn next_status(current: &TranscodeStatus, state: &TorrentState, enabled: bool) -> Decision {
+    if !enabled {
+        return Decision::Reject(RequestOutcome::Disabled);
+    }
+    if *state != TorrentState::Seeding {
+        return Decision::Reject(RequestOutcome::NotCompleted);
+    }
+    match current {
+        TranscodeStatus::None | TranscodeStatus::Failed => Decision::Enqueue,
+        other => Decision::Reject(RequestOutcome::InProgress(other.clone())),
+    }
+}
+
+#[derive(Clone)]
+pub struct Transcoder {
+    store: StateStore,
+    remux_sem: Arc<Semaphore>,
+    encode_sem: Arc<Semaphore>,
+    ffmpeg_bin: String,
+    ffprobe_bin: String,
+    enabled: bool,
+}
+
+impl Transcoder {
+    pub fn new(
+        store: StateStore,
+        remux_conc: usize,
+        encode_conc: usize,
+        ffmpeg_bin: String,
+        ffprobe_bin: String,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            store,
+            remux_sem: Arc::new(Semaphore::new(remux_conc.max(1))),
+            encode_sem: Arc::new(Semaphore::new(encode_conc.max(1))),
+            ffmpeg_bin,
+            ffprobe_bin,
+            enabled,
+        }
+    }
+
+    pub async fn request(&self, id: &str) -> RequestOutcome {
+        let meta = match self.store.get(id) {
+            Some(m) => m,
+            None => return RequestOutcome::NotFound,
+        };
+        match next_status(&meta.transcode, &meta.state, self.enabled) {
+            Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Ready)) => {
+                match meta.transcode_path {
+                    Some(p) => RequestOutcome::Ready(p),
+                    None => RequestOutcome::InProgress(TranscodeStatus::Ready),
+                }
+            }
+            Decision::Reject(outcome) => outcome,
+            Decision::Enqueue => {
+                let mut m = meta.clone();
+                m.transcode = TranscodeStatus::Pending;
+                m.transcode_error = None;
+                let _ = self.store.upsert(m);
+                self.spawn_job(id.to_string(), meta);
+                RequestOutcome::Started
+            }
+        }
+    }
+
+    fn spawn_job(&self, id: String, meta: crate::state::Metadata) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.run_job(&id, &meta).await {
+                tracing::error!(id = %id, error = %e, "transcode failed");
+                if let Some(mut m) = this.store.get(&id) {
+                    m.transcode = TranscodeStatus::Failed;
+                    m.transcode_error = Some(e.to_string());
+                    let _ = this.store.upsert(m);
+                }
+            }
+        });
+    }
+
+    async fn run_job(&self, id: &str, meta: &crate::state::Metadata) -> anyhow::Result<()> {
+        let src_dir = std::path::PathBuf::from(&meta.path);
+        let primary = pick_primary_file(&src_dir)?;
+        let probe = probe(&self.ffprobe_bin, &primary).await?;
+        let route = decide_route(&probe);
+        let stem = primary
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "media".into());
+        let dest = src_dir.join(format!("{stem}.reel.mp4"));
+
+        if let Some(mut m) = self.store.get(id) {
+            m.transcode = match route {
+                Route::Remux => TranscodeStatus::Remuxing,
+                Route::Encode => TranscodeStatus::Encoding,
+            };
+            let _ = self.store.upsert(m);
+        }
+
+        match route {
+            Route::Remux => {
+                let _permit = self.remux_sem.acquire().await?;
+                remux(&self.ffmpeg_bin, &primary, &dest).await?;
+            }
+            Route::Encode => {
+                let _permit = self.encode_sem.acquire().await?;
+                encode(&self.ffmpeg_bin, &primary, &dest).await?;
+            }
+        }
+
+        if let Some(mut m) = self.store.get(id) {
+            m.transcode = TranscodeStatus::Ready;
+            m.transcode_path = Some(dest.display().to_string());
+            m.transcode_error = None;
+            let _ = self.store.upsert(m);
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,5 +262,54 @@ mod tests {
         std::fs::write(dir.path().join("small.mkv"), b"aa").unwrap();
         std::fs::write(dir.path().join("big.mkv"), b"aaaaaaaa").unwrap();
         assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("big.mkv"));
+    }
+}
+
+#[cfg(test)]
+mod transcoder_tests {
+    use super::*;
+    use crate::state::{TorrentState, TranscodeStatus};
+
+    #[test]
+    fn disabled_rejects() {
+        assert_eq!(
+            next_status(&TranscodeStatus::None, &TorrentState::Seeding, false),
+            Decision::Reject(RequestOutcome::Disabled)
+        );
+    }
+    #[test]
+    fn not_seeding_rejected() {
+        assert_eq!(
+            next_status(&TranscodeStatus::None, &TorrentState::Leeching, true),
+            Decision::Reject(RequestOutcome::NotCompleted)
+        );
+    }
+    #[test]
+    fn ready_is_idempotent() {
+        assert_eq!(
+            next_status(&TranscodeStatus::Ready, &TorrentState::Seeding, true),
+            Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Ready))
+        );
+    }
+    #[test]
+    fn in_flight_not_requeued() {
+        assert_eq!(
+            next_status(&TranscodeStatus::Encoding, &TorrentState::Seeding, true),
+            Decision::Reject(RequestOutcome::InProgress(TranscodeStatus::Encoding))
+        );
+    }
+    #[test]
+    fn none_enqueues() {
+        assert_eq!(
+            next_status(&TranscodeStatus::None, &TorrentState::Seeding, true),
+            Decision::Enqueue
+        );
+    }
+    #[test]
+    fn failed_re_enqueues() {
+        assert_eq!(
+            next_status(&TranscodeStatus::Failed, &TorrentState::Seeding, true),
+            Decision::Enqueue
+        );
     }
 }

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -1,0 +1,127 @@
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProbeResult {
+    pub video_codec: Option<String>,
+    pub audio_codec: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Route {
+    Remux,
+    Encode,
+}
+
+pub fn decide_route(p: &ProbeResult) -> Route {
+    if p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac") {
+        Route::Remux
+    } else {
+        Route::Encode
+    }
+}
+
+pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
+    if dir.is_file() {
+        return Ok(dir.to_path_buf());
+    }
+    let mut best: Option<(u64, PathBuf)> = None;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                let len = entry.metadata()?.len();
+                if best.as_ref().map(|(b, _)| len > *b).unwrap_or(true) {
+                    best = Some((len, path));
+                }
+            }
+        }
+    }
+    best.map(|(_, p)| p)
+        .ok_or_else(|| anyhow::anyhow!("no media file under {}", dir.display()))
+}
+
+pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult> {
+    let out = Command::new(ffprobe_bin)
+        .args(["-v", "quiet", "-print_format", "json", "-show_streams"])
+        .arg(path)
+        .output()
+        .await?;
+    if !out.status.success() {
+        anyhow::bail!("ffprobe failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout)?;
+    let mut video = None;
+    let mut audio = None;
+    if let Some(streams) = json.get("streams").and_then(|s| s.as_array()) {
+        for s in streams {
+            let kind = s.get("codec_type").and_then(|v| v.as_str());
+            let codec = s.get("codec_name").and_then(|v| v.as_str()).map(String::from);
+            match kind {
+                Some("video") if video.is_none() => video = codec,
+                Some("audio") if audio.is_none() => audio = codec,
+                _ => {}
+            }
+        }
+    }
+    Ok(ProbeResult { video_codec: video, audio_codec: audio })
+}
+
+async fn run_ffmpeg(ffmpeg_bin: &str, args: &[&str], src: &Path, dest: &Path) -> anyhow::Result<()> {
+    let mut cmd = Command::new(ffmpeg_bin);
+    cmd.arg("-y").arg("-i").arg(src).args(args).arg(dest);
+    let out = cmd.output().await?;
+    if !out.status.success() {
+        anyhow::bail!("ffmpeg failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    Ok(())
+}
+
+pub async fn remux(ffmpeg_bin: &str, src: &Path, dest: &Path) -> anyhow::Result<()> {
+    run_ffmpeg(ffmpeg_bin, &["-c", "copy", "-movflags", "+faststart"], src, dest).await
+}
+
+pub async fn encode(ffmpeg_bin: &str, src: &Path, dest: &Path) -> anyhow::Result<()> {
+    run_ffmpeg(
+        ffmpeg_bin,
+        &["-c:v", "libx264", "-c:a", "aac", "-movflags", "+faststart"],
+        src,
+        dest,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn pr(v: Option<&str>, a: Option<&str>) -> ProbeResult {
+        ProbeResult { video_codec: v.map(String::from), audio_codec: a.map(String::from) }
+    }
+    #[test]
+    fn h264_aac_remuxes() {
+        assert_eq!(decide_route(&pr(Some("h264"), Some("aac"))), Route::Remux);
+    }
+    #[test]
+    fn hevc_encodes() {
+        assert_eq!(decide_route(&pr(Some("hevc"), Some("aac"))), Route::Encode);
+    }
+    #[test]
+    fn non_aac_audio_encodes() {
+        assert_eq!(decide_route(&pr(Some("h264"), Some("ac3"))), Route::Encode);
+    }
+    #[test]
+    fn missing_codecs_encode() {
+        assert_eq!(decide_route(&pr(None, None)), Route::Encode);
+    }
+    #[test]
+    fn picks_largest_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("small.mkv"), b"aa").unwrap();
+        std::fs::write(dir.path().join("big.mkv"), b"aaaaaaaa").unwrap();
+        assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("big.mkv"));
+    }
+}

--- a/apps/media/reel/tests/transcode_integration.rs
+++ b/apps/media/reel/tests/transcode_integration.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+fn moov_before_mdat(path: &Path) -> bool {
+    let bytes = std::fs::read(path).unwrap();
+    let find = |needle: &[u8]| bytes.windows(4).position(|w| w == needle);
+    match (find(b"moov"), find(b"mdat")) {
+        (Some(m), Some(d)) => m < d,
+        _ => false,
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires ffmpeg/ffprobe"]
+async fn remux_and_encode_produce_faststart_mp4() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src.mp4");
+    let status = std::process::Command::new("ffmpeg")
+        .args(["-y", "-f", "lavfi", "-i", "testsrc=duration=1:size=128x128:rate=15",
+               "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+               "-c:v", "libx264", "-c:a", "aac", "-shortest"])
+        .arg(&src)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let probe = reel::transcode::probe("ffprobe", &src).await.unwrap();
+    assert_eq!(reel::transcode::decide_route(&probe), reel::transcode::Route::Remux);
+
+    let remuxed = dir.path().join("out.remux.mp4");
+    reel::transcode::remux("ffmpeg", &src, &remuxed).await.unwrap();
+    assert!(remuxed.exists() && std::fs::metadata(&remuxed).unwrap().len() > 0);
+    assert!(moov_before_mdat(&remuxed));
+
+    let encoded = dir.path().join("out.encode.mp4");
+    reel::transcode::encode("ffmpeg", &src, &encoded).await.unwrap();
+    assert!(encoded.exists() && std::fs::metadata(&encoded).unwrap().len() > 0);
+    assert!(moov_before_mdat(&encoded));
+}


### PR DESCRIPTION
## reel Phase 2A — Transcode (completed file)

Builds on Phase 1 (merged). Adds a `transcode` module to reel: on demand, turn a completed library entry into a browser-streamable **faststart MP4**, probing codecs to route between a cheap remux and a full re-encode. In-binary, tokio subprocess, concurrency-isolated so transcode can't starve the torrent engine.

### Flow
`POST /torrents/{id}/transcode` → ffprobe the primary media file → route:
- **remux** (video H.264 + audio AAC already) → `-c copy -movflags +faststart` (seconds, no re-encode)
- **encode** (HEVC/AV1/VP9/non-AAC/etc.) → libx264/aac faststart

Hybrid trigger: manual endpoint now; Phase 3 streaming will call the same `Transcoder::request` lazily on first stream.

### Design
- **State:** `TranscodeStatus` (None/Pending/Remuxing/Encoding/Ready/Failed) + `transcode_path`/`transcode_error` on `Metadata`, all `#[serde(default)]` (pre-2A state loads clean).
- **Idempotent:** concurrent double-POST safe — check-then-set is one atomic `StateStore::update` under a single lock; no duplicate jobs.
- **Concurrency isolation:** separate semaphores for remux (IO-bound, default 3) vs encode (CPU-heavy, default 1).
- **No disk leak:** reap/delete frees both source and transcode output (`remove_entry_files`).
- **Restart-safe:** in-flight transcode status reset to Failed (retryable) on startup.
- **Config:** `REEL_TRANSCODE_ENABLED`, `REEL_REMUX_CONCURRENCY`, `REEL_ENCODE_CONCURRENCY`, `REEL_FFMPEG_BIN`, `REEL_FFPROBE_BIN`.
- **Status codes:** Ready→200, Started/InProgress→202, NotFound→404, NotCompleted→409, Disabled→503; Bearer-auth on the route.

### Testing
- 39 unit tests (route decision, config, serde back-compat, atomic update, idempotency truth-table, delete cleanup, API route). 2 `#[ignore]` integration tests (Phase 1 leech + real-ffmpeg remux/encode faststart via `moov`-before-`mdat` check). 0 warnings.
- ffmpeg added to the Docker image. **Docker build + k8s apply not validated in the worktree** — deferred to CI/cluster.

### Process
Subagent-driven, TDD per task, spec+quality review each task + opus whole-branch review. Review-driven fixes: a TOCTOU double-enqueue race (→ atomic `StateStore::update`), the last_access clobber, restart-stranding, and unconditional-persist write amplification.

### Deferred (follow-ups)
- kill_on_drop / abort a running ffmpeg when its entry is reaped mid-transcode.
- Bound concurrent ffprobe.
- **Phase 2B — progressive:** confirm librqbit streaming reader, head/tail piece prioritization, stream-while-downloading.
- **Phase 3 — streaming endpoint** (axum-kbve range/HLS) + astro-kbve player.
