### PR TITLE
feat(desktop-kbve): phase B frontend — dictation settings views

### DIFF
--- a/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
@@ -156,6 +156,11 @@ fn specta_builder() -> Builder<tauri::Wry> {
         commands::transcription::set_model_unload_timeout,
         commands::transcription::get_model_load_status,
         commands::transcription::unload_model_manually,
+        // dictation: shortcuts
+        shortcut::change_binding,
+        shortcut::reset_binding,
+        shortcut::change_ptt_setting,
+        shortcut::change_paste_method_setting,
     ])
 }
 

--- a/apps/kbve/desktop-kbve/src/bindings.ts
+++ b/apps/kbve/desktop-kbve/src/bindings.ts
@@ -402,6 +402,38 @@ async unloadModelManually() : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async changeBinding(id: string, binding: string) : Promise<Result<BindingResponse, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_binding", { id, binding }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async resetBinding(id: string) : Promise<Result<BindingResponse, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reset_binding", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changePttSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_ptt_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changePasteMethodSetting(method: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_paste_method_setting", { method }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -417,6 +449,7 @@ async unloadModelManually() : Promise<Result<null, string>> {
 
 export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; filler_detection_enabled?: boolean; filler_output_mode?: FillerOutputMode; custom_filler_words?: string[]; show_filler_overlay?: boolean; active_ui_section?: string; onichan_silence_threshold?: number; enabled_agents?: string[]; sandbox_enabled?: boolean }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
+export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
 export type CustomSounds = { start: boolean; stop: boolean }
 export type EngineType = "Whisper" | "Parakeet" | "Moonshine"

--- a/apps/kbve/desktop-kbve/src/views/audio.tsx
+++ b/apps/kbve/desktop-kbve/src/views/audio.tsx
@@ -1,18 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import { SettingsCard } from '../components/SettingsCard';
+import { SettingsRow } from '../components/SettingsRow';
+import { ToggleSwitch } from '../components/ToggleSwitch';
+import { commands, type AudioDevice } from '../bindings';
+
+const DEFAULT = '__default__';
 
 export function AudioView() {
+	const [mics, setMics] = useState<AudioDevice[]>([]);
+	const [outputs, setOutputs] = useState<AudioDevice[]>([]);
+	const [selectedMic, setSelectedMic] = useState('');
+	const [selectedOut, setSelectedOut] = useState('');
+	const [alwaysOn, setAlwaysOn] = useState(false);
+	const levelRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		(async () => {
+			const m = await commands.getAvailableMicrophones();
+			if (m.status === 'ok') setMics(m.data);
+			const o = await commands.getAvailableOutputDevices();
+			if (o.status === 'ok') setOutputs(o.data);
+			const sm = await commands.getSelectedMicrophone();
+			if (sm.status === 'ok') setSelectedMic(sm.data);
+			const so = await commands.getSelectedOutputDevice();
+			if (so.status === 'ok') setSelectedOut(so.data);
+			const mode = await commands.getMicrophoneMode();
+			if (mode.status === 'ok') setAlwaysOn(mode.data);
+		})();
+	}, []);
+
+	// Live mic level meter driven by the backend "mic-level" event.
+	useEffect(() => {
+		const unlisten = listen<number[]>('mic-level', (e) => {
+			const peak = e.payload.length
+				? Math.max(...e.payload.map(Math.abs))
+				: 0;
+			if (levelRef.current) {
+				levelRef.current.style.width = `${Math.min(100, peak * 140)}%`;
+			}
+		});
+		return () => {
+			unlisten.then((f) => f());
+		};
+	}, []);
+
 	return (
 		<div className="flex max-w-2xl flex-col gap-6">
 			<SettingsCard title="Audio Devices">
-				<div className="px-4 pb-4">
-					<p
-						className="text-sm"
-						style={{ color: 'var(--color-text-muted)' }}>
-						Audio device selection and recording settings will
-						appear here.
-					</p>
-				</div>
+				<SettingsRow
+					label="Microphone"
+					description="Input device used for dictation">
+					<DeviceSelect
+						devices={mics}
+						value={selectedMic}
+						onChange={(name) => {
+							setSelectedMic(name);
+							commands.setSelectedMicrophone(name);
+						}}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label="Output device"
+					description="Device used for audio feedback sounds">
+					<DeviceSelect
+						devices={outputs}
+						value={selectedOut}
+						onChange={(name) => {
+							setSelectedOut(name);
+							commands.setSelectedOutputDevice(name);
+						}}
+					/>
+				</SettingsRow>
+			</SettingsCard>
+
+			<SettingsCard title="Recording">
+				<SettingsRow
+					label="Always-on microphone"
+					description="Keep the mic stream open for faster capture (uses more power)">
+					<ToggleSwitch
+						checked={alwaysOn}
+						onChange={(v) => {
+							setAlwaysOn(v);
+							commands.updateMicrophoneMode(v);
+						}}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label="Input level"
+					description="Live microphone level while recording">
+					<div
+						className="h-2 w-40 overflow-hidden rounded-full"
+						style={{ backgroundColor: 'var(--color-border)' }}>
+						<div
+							ref={levelRef}
+							className="h-full transition-[width] duration-75"
+							style={{
+								width: '0%',
+								backgroundColor: 'var(--color-toggle-on)',
+							}}
+						/>
+					</div>
+				</SettingsRow>
+				<SettingsRow
+					label="Test sound"
+					description="Play the recording start/stop feedback sound">
+					<button
+						onClick={() => commands.playTestSound('start')}
+						className="rounded-md border px-3 py-1.5 text-caption"
+						style={{
+							backgroundColor: 'var(--color-bg)',
+							borderColor: 'var(--color-border)',
+							color: 'var(--color-text)',
+						}}>
+						Play
+					</button>
+				</SettingsRow>
 			</SettingsCard>
 		</div>
+	);
+}
+
+function DeviceSelect({
+	devices,
+	value,
+	onChange,
+}: {
+	devices: AudioDevice[];
+	value: string;
+	onChange: (name: string) => void;
+}) {
+	return (
+		<select
+			className="max-w-xs rounded-md border px-3 py-1.5 text-body"
+			style={{
+				backgroundColor: 'var(--color-bg)',
+				borderColor: 'var(--color-border)',
+				color: 'var(--color-text)',
+			}}
+			value={value || DEFAULT}
+			onChange={(e) =>
+				onChange(e.target.value === DEFAULT ? '' : e.target.value)
+			}>
+			<option value={DEFAULT}>System default</option>
+			{devices.map((d) => (
+				<option key={d.index} value={d.name}>
+					{d.name}
+					{d.is_default ? ' (default)' : ''}
+				</option>
+			))}
+		</select>
 	);
 }

--- a/apps/kbve/desktop-kbve/src/views/models.tsx
+++ b/apps/kbve/desktop-kbve/src/views/models.tsx
@@ -1,18 +1,208 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import { SettingsCard } from '../components/SettingsCard';
+import { commands, type ModelInfo } from '../bindings';
+
+interface DownloadProgress {
+	model_id: string;
+	downloaded: number;
+	total: number;
+	percentage: number;
+}
+
+const muted = { color: 'var(--color-text-muted)' } as const;
 
 export function ModelsView() {
+	const [models, setModels] = useState<ModelInfo[]>([]);
+	const [activeId, setActiveId] = useState<string>('');
+	const [progress, setProgress] = useState<Record<string, number>>({});
+	const [busy, setBusy] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const refresh = useCallback(async () => {
+		const list = await commands.getAvailableModels();
+		if (list.status === 'ok') setModels(list.data);
+		else setError(list.error);
+		const current = await commands.getCurrentModel();
+		if (current.status === 'ok') setActiveId(current.data);
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	useEffect(() => {
+		const unlisten = listen<DownloadProgress>(
+			'model-download-progress',
+			(e) => {
+				setProgress((p) => ({
+					...p,
+					[e.payload.model_id]: e.payload.percentage,
+				}));
+			},
+		);
+		const unlistenDone = listen<string>('model-download-complete', () => {
+			setProgress({});
+			refresh();
+		});
+		return () => {
+			unlisten.then((f) => f());
+			unlistenDone.then((f) => f());
+		};
+	}, [refresh]);
+
+	const download = async (id: string) => {
+		setBusy(id);
+		setError(null);
+		const res = await commands.downloadModel(id);
+		if (res.status === 'error') setError(res.error);
+		setBusy(null);
+		refresh();
+	};
+
+	const remove = async (id: string) => {
+		setBusy(id);
+		const res = await commands.deleteModel(id);
+		if (res.status === 'error') setError(res.error);
+		setBusy(null);
+		refresh();
+	};
+
+	const activate = async (id: string) => {
+		setBusy(id);
+		const res = await commands.setActiveModel(id);
+		if (res.status === 'ok') setActiveId(id);
+		else setError(res.error);
+		setBusy(null);
+	};
+
 	return (
 		<div className="flex max-w-2xl flex-col gap-6">
-			<SettingsCard title="Model Management">
-				<div className="px-4 pb-4">
-					<p
-						className="text-sm"
-						style={{ color: 'var(--color-text-muted)' }}>
-						Speech-to-text model downloads and selection will appear
-						here.
-					</p>
+			{error && (
+				<div
+					className="rounded-md border px-4 py-2 text-caption"
+					style={{
+						borderColor: 'var(--color-border)',
+						color: 'var(--color-danger, #e5484d)',
+					}}>
+					{error}
+				</div>
+			)}
+			<SettingsCard title="Speech-to-Text Models">
+				<div className="flex flex-col">
+					{models.length === 0 && (
+						<p className="px-6 py-5 text-sm" style={muted}>
+							Loading models…
+						</p>
+					)}
+					{models.map((m) => {
+						const isActive = m.id === activeId;
+						const pct = progress[m.id];
+						const downloading = m.is_downloading || pct != null;
+						return (
+							<div
+								key={m.id}
+								className="flex items-center justify-between border-b px-6 py-5"
+								style={{ borderColor: 'var(--color-border)' }}>
+								<div className="flex flex-col gap-1.5">
+									<span className="text-body">
+										{m.name}
+										{isActive && (
+											<span
+												className="ml-2 text-caption"
+												style={{
+													color: 'var(--color-toggle-on)',
+												}}>
+												● active
+											</span>
+										)}
+									</span>
+									<span className="text-caption" style={muted}>
+										{m.engine_type} · {m.size_mb} MB ·{' '}
+										{m.description}
+									</span>
+									{downloading && pct != null && (
+										<span
+											className="text-caption"
+											style={muted}>
+											Downloading… {pct.toFixed(0)}%
+										</span>
+									)}
+								</div>
+								<div className="flex gap-2">
+									{m.is_downloaded ? (
+										<>
+											{!isActive && (
+												<Btn
+													label="Use"
+													onClick={() =>
+														activate(m.id)
+													}
+													disabled={busy === m.id}
+												/>
+											)}
+											<Btn
+												label="Delete"
+												variant="danger"
+												onClick={() => remove(m.id)}
+												disabled={
+													busy === m.id || isActive
+												}
+											/>
+										</>
+									) : downloading ? (
+										<Btn
+											label="Cancel"
+											onClick={() =>
+												commands
+													.cancelDownload(m.id)
+													.then(() => refresh())
+											}
+										/>
+									) : (
+										<Btn
+											label="Download"
+											onClick={() => download(m.id)}
+											disabled={busy === m.id}
+										/>
+									)}
+								</div>
+							</div>
+						);
+					})}
 				</div>
 			</SettingsCard>
 		</div>
+	);
+}
+
+function Btn({
+	label,
+	onClick,
+	disabled,
+	variant,
+}: {
+	label: string;
+	onClick: () => void;
+	disabled?: boolean;
+	variant?: 'danger';
+}) {
+	return (
+		<button
+			onClick={onClick}
+			disabled={disabled}
+			className="rounded-md border px-3 py-1.5 text-caption transition-colors"
+			style={{
+				backgroundColor: 'var(--color-bg)',
+				borderColor: 'var(--color-border)',
+				color:
+					variant === 'danger'
+						? 'var(--color-danger, #e5484d)'
+						: 'var(--color-text)',
+				opacity: disabled ? 0.5 : 1,
+				cursor: disabled ? 'not-allowed' : 'pointer',
+			}}>
+			{label}
+		</button>
 	);
 }

--- a/apps/kbve/desktop-kbve/src/views/shortcuts.tsx
+++ b/apps/kbve/desktop-kbve/src/views/shortcuts.tsx
@@ -1,17 +1,175 @@
+import { useEffect, useState } from 'react';
 import { SettingsCard } from '../components/SettingsCard';
+import { SettingsRow } from '../components/SettingsRow';
+import { ToggleSwitch } from '../components/ToggleSwitch';
+import {
+	commands,
+	type ShortcutBinding,
+	type PasteMethod,
+} from '../bindings';
+
+const PASTE_METHODS: { value: PasteMethod; label: string }[] = [
+	{ value: 'ctrl_v', label: 'Ctrl/Cmd + V' },
+	{ value: 'ctrl_shift_v', label: 'Ctrl/Cmd + Shift + V' },
+	{ value: 'shift_insert', label: 'Shift + Insert' },
+	{ value: 'direct', label: 'Direct typing' },
+	{ value: 'none', label: 'None (clipboard only)' },
+];
 
 export function ShortcutsView() {
+	const [bindings, setBindings] = useState<ShortcutBinding[]>([]);
+	const [pushToTalk, setPushToTalk] = useState(true);
+	const [pasteMethod, setPasteMethod] = useState<PasteMethod>('ctrl_v');
+	const [error, setError] = useState<string | null>(null);
+
+	const load = async () => {
+		const s = await commands.getAppSettings();
+		if (s.status === 'ok') {
+			setBindings(
+				Object.values(s.data.bindings).filter(
+					(b): b is ShortcutBinding => !!b,
+				),
+			);
+			setPushToTalk(s.data.push_to_talk);
+			setPasteMethod(s.data.paste_method);
+		} else setError(s.error);
+	};
+
+	useEffect(() => {
+		load();
+	}, []);
+
+	const save = async (id: string, binding: string) => {
+		const res = await commands.changeBinding(id, binding);
+		if (res.status === 'error') setError(res.error);
+		load();
+	};
+
+	const reset = async (id: string) => {
+		await commands.resetBinding(id);
+		load();
+	};
+
 	return (
 		<div className="flex max-w-2xl flex-col gap-6">
-			<SettingsCard title="Keyboard Shortcuts">
-				<div className="px-4 pb-4">
-					<p
-						className="text-sm"
-						style={{ color: 'var(--color-text-muted)' }}>
-						Global keyboard shortcut configuration will appear here.
-					</p>
+			{error && (
+				<div
+					className="rounded-md border px-4 py-2 text-caption"
+					style={{
+						borderColor: 'var(--color-border)',
+						color: 'var(--color-danger, #e5484d)',
+					}}>
+					{error}
 				</div>
+			)}
+			<SettingsCard title="Global Shortcuts">
+				{bindings.length === 0 && (
+					<p
+						className="px-6 py-5 text-sm"
+						style={{ color: 'var(--color-text-muted)' }}>
+						Loading shortcuts…
+					</p>
+				)}
+				{bindings.map((b) => (
+					<SettingsRow
+						key={b.id}
+						label={b.name}
+						description={b.description}>
+						<BindingEditor
+							binding={b}
+							onSave={(v) => save(b.id, v)}
+							onReset={() => reset(b.id)}
+						/>
+					</SettingsRow>
+				))}
 			</SettingsCard>
+
+			<SettingsCard title="Behavior">
+				<SettingsRow
+					label="Push to talk"
+					description="Hold the shortcut to record; release to transcribe. Off = toggle mode.">
+					<ToggleSwitch
+						checked={pushToTalk}
+						onChange={(v) => {
+							setPushToTalk(v);
+							commands.changePttSetting(v);
+						}}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label="Paste method"
+					description="How transcribed text is inserted into the focused app">
+					<select
+						className="rounded-md border px-3 py-1.5 text-body"
+						style={{
+							backgroundColor: 'var(--color-bg)',
+							borderColor: 'var(--color-border)',
+							color: 'var(--color-text)',
+						}}
+						value={pasteMethod}
+						onChange={(e) => {
+							const v = e.target.value as PasteMethod;
+							setPasteMethod(v);
+							commands.changePasteMethodSetting(v);
+						}}>
+						{PASTE_METHODS.map((m) => (
+							<option key={m.value} value={m.value}>
+								{m.label}
+							</option>
+						))}
+					</select>
+				</SettingsRow>
+			</SettingsCard>
+		</div>
+	);
+}
+
+function BindingEditor({
+	binding,
+	onSave,
+	onReset,
+}: {
+	binding: ShortcutBinding;
+	onSave: (value: string) => void;
+	onReset: () => void;
+}) {
+	const [value, setValue] = useState(binding.current_binding);
+	useEffect(() => setValue(binding.current_binding), [binding.current_binding]);
+	const dirty = value !== binding.current_binding;
+
+	return (
+		<div className="flex items-center gap-2">
+			<input
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				spellCheck={false}
+				className="w-40 rounded-md border px-3 py-1.5 text-body font-mono"
+				style={{
+					backgroundColor: 'var(--color-bg)',
+					borderColor: 'var(--color-border)',
+					color: 'var(--color-text)',
+				}}
+				placeholder="e.g. ctrl+space"
+			/>
+			<button
+				onClick={() => onSave(value)}
+				disabled={!dirty}
+				className="rounded-md border px-3 py-1.5 text-caption"
+				style={{
+					backgroundColor: 'var(--color-bg)',
+					borderColor: 'var(--color-border)',
+					color: 'var(--color-text)',
+					opacity: dirty ? 1 : 0.5,
+					cursor: dirty ? 'pointer' : 'not-allowed',
+				}}>
+				Save
+			</button>
+			<button
+				onClick={onReset}
+				className="text-caption"
+				style={{ color: 'var(--color-text-muted)' }}>
+				Reset
+			</button>
 		</div>
 	);
 }


### PR DESCRIPTION
Builds on the merged phase-B backend (#14489). Replaces the placeholder Audio / Models / Shortcuts stubs with working UI wired to the typed tauri-specta bindings.

### Views
- **models.tsx** — model catalog list, download with live progress (`model-download-progress` event), set-active, delete, cancel
- **audio.tsx** — microphone + output device pickers, always-on-mic toggle, live input level meter (`mic-level` event), test-sound button
- **shortcuts.tsx** — per-binding hotkey editor (change / reset), push-to-talk toggle, paste-method selector

### Backend
Exposes four shortcut settings commands through the specta `Builder`
(`change_binding`, `reset_binding`, `change_ptt_setting`,
`change_paste_method_setting`) and regenerates `src/bindings.ts`.

### Verification
`tsc --noEmit` → no errors in the new views (the lone `tsconfig` `ignoreDeprecations` error is pre-existing from the nx flat-config migration, unrelated to this change).

### Remaining (later phases)
Tray icons + recording-overlay window (needs resource assets); Onichan pillar (phase C).