### PR TITLE
feat(reel): progressive HTTP streaming endpoint (Phase 2B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15390,6 +15390,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tower 0.5.3",
  "tracing",
  "tracing-subscriber",

--- a/apps/media/reel/Cargo.toml
+++ b/apps/media/reel/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = { version = "0.8.5", features = ["macros", "json"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 librqbit = "8"
+tokio-util = { version = "0.7", features = ["io"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -173,6 +173,14 @@ async fn stream_file(
                     Err(_) => return StatusCode::CONFLICT.into_response(),
                 },
             };
+            let ct = crate::stream::content_type_for(&path.to_string_lossy());
+            if head_only {
+                let total = match tokio::fs::metadata(&path).await {
+                    Ok(m) => m.len(),
+                    Err(_) => return StatusCode::NOT_FOUND.into_response(),
+                };
+                return crate::stream::head_response(total, range, ct);
+            }
             let file = match tokio::fs::File::open(&path).await {
                 Ok(f) => f,
                 Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -181,7 +189,6 @@ async fn stream_file(
                 Ok(m) => m.len(),
                 Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             };
-            let ct = crate::stream::content_type_for(&path.to_string_lossy());
             crate::stream::serve_range(file, total, range, ct, head_only).await
         }
         state::TorrentState::Leeching => {
@@ -199,12 +206,15 @@ async fn stream_file(
                 .find(|f| f.index == idx)
                 .map(|f| f.name.clone())
                 .unwrap_or_default();
+            let total = files.iter().find(|f| f.index == idx).map(|f| f.len).unwrap_or(0);
+            let ct = crate::stream::content_type_for(&name);
+            if head_only {
+                return crate::stream::head_response(total, range, ct);
+            }
             let stream = match st.engine.open_stream(&id, idx) {
                 Ok(s) => s,
                 Err(_) => return StatusCode::TOO_EARLY.into_response(),
             };
-            let total = files.iter().find(|f| f.index == idx).map(|f| f.len).unwrap_or(0);
-            let ct = crate::stream::content_type_for(&name);
             crate::stream::serve_range(stream, total, range, ct, head_only).await
         }
         _ => StatusCode::CONFLICT.into_response(),

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -11,6 +11,7 @@ pub struct AppState {
     pub store: state::StateStore,
     pub token: Option<String>,
     pub transcoder: transcode::Transcoder,
+    pub stream_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -138,6 +139,78 @@ async fn transcode_start(
     }
 }
 
+async fn stream_file(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    method: axum::http::Method,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if !st.stream_enabled {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let head_only = method == axum::http::Method::HEAD;
+    let range = headers.get("range").and_then(|h| h.to_str().ok());
+    let _ = st.store.touch(&id, now_secs());
+
+    match meta.state {
+        state::TorrentState::Seeding => {
+            let path = if meta.transcode == state::TranscodeStatus::Ready {
+                meta.transcode_path.clone().map(std::path::PathBuf::from)
+            } else {
+                None
+            };
+            let path = match path {
+                Some(p) => p,
+                None => match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
+                    Ok(p) => p,
+                    Err(_) => return StatusCode::CONFLICT.into_response(),
+                },
+            };
+            let file = match tokio::fs::File::open(&path).await {
+                Ok(f) => f,
+                Err(_) => return StatusCode::NOT_FOUND.into_response(),
+            };
+            let total = match file.metadata().await {
+                Ok(m) => m.len(),
+                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            };
+            let ct = crate::stream::content_type_for(&path.to_string_lossy());
+            crate::stream::serve_range(file, total, range, ct, head_only).await
+        }
+        state::TorrentState::Leeching => {
+            let files = match st.engine.list_files(&id) {
+                Ok(Some(f)) => f,
+                Ok(None) => return StatusCode::TOO_EARLY.into_response(),
+                Err(_) => return StatusCode::TOO_EARLY.into_response(),
+            };
+            let idx = match engine::primary_file_index(&files) {
+                Some(i) => i,
+                None => return StatusCode::CONFLICT.into_response(),
+            };
+            let name = files
+                .iter()
+                .find(|f| f.index == idx)
+                .map(|f| f.name.clone())
+                .unwrap_or_default();
+            let stream = match st.engine.open_stream(&id, idx) {
+                Ok(s) => s,
+                Err(_) => return StatusCode::TOO_EARLY.into_response(),
+            };
+            let total = files.iter().find(|f| f.index == idx).map(|f| f.len).unwrap_or(0);
+            let ct = crate::stream::content_type_for(&name);
+            crate::stream::serve_range(stream, total, range, ct, head_only).await
+        }
+        _ => StatusCode::CONFLICT.into_response(),
+    }
+}
+
 fn store_scoped_router(state: AppStateStub) -> Router {
     Router::new()
         .route("/torrents", get(list))
@@ -152,6 +225,7 @@ pub fn router(state: AppState) -> Router {
         .route("/torrents", post(add))
         .route("/torrents/{id}", axum::routing::delete(remove))
         .route("/torrents/{id}/transcode", post(transcode_start))
+        .route("/torrents/{id}/stream", get(stream_file).head(stream_file))
         .with_state(state);
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -199,6 +273,37 @@ fn transcode_router(transcoder: transcode::Transcoder, token: Option<String>) ->
     Router::new()
         .route("/torrents/{id}/transcode", post(handler))
         .with_state(TranscodeState { transcoder, token })
+}
+
+#[cfg(test)]
+fn stream_router(store: state::StateStore, token: Option<String>, stream_enabled: bool) -> Router {
+    #[derive(Clone)]
+    struct StreamState {
+        store: state::StateStore,
+        token: Option<String>,
+        stream_enabled: bool,
+    }
+
+    async fn handler(
+        State(st): State<StreamState>,
+        headers: HeaderMap,
+        Path(id): Path<String>,
+    ) -> impl IntoResponse {
+        if !check_auth(&headers, &st.token) {
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        if !st.stream_enabled {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+        match st.store.get(&id) {
+            Some(_) => StatusCode::OK.into_response(),
+            None => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+
+    Router::new()
+        .route("/torrents/{id}/stream", get(handler).head(handler))
+        .with_state(StreamState { store, token, stream_enabled })
 }
 
 #[cfg(test)]
@@ -320,5 +425,35 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn stream_disabled_is_503() {
+        let app = stream_router(store_with_one(), None, false);
+        let res = app
+            .oneshot(Request::get("/torrents/1/stream").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn stream_missing_id_is_404() {
+        let app = stream_router(store_with_one(), None, true);
+        let res = app
+            .oneshot(Request::get("/torrents/999/stream").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn stream_requires_auth_when_token_set() {
+        let app = stream_router(store_with_one(), Some("secret".into()), true);
+        let res = app
+            .oneshot(Request::get("/torrents/1/stream").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub encode_concurrency: usize,
     pub ffmpeg_bin: String,
     pub ffprobe_bin: String,
+    pub stream_enabled: bool,
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -49,6 +50,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         encode_concurrency: env_u64("REEL_ENCODE_CONCURRENCY", 1)? as usize,
         ffmpeg_bin: env_or("REEL_FFMPEG_BIN", "ffmpeg"),
         ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
+        stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
     })
 }
 
@@ -62,7 +64,7 @@ mod tests {
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
                   "REEL_VPN_CHECK_URL","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
-                  "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN"] {
+                  "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED"] {
             std::env::remove_var(k);
         }
     }
@@ -105,6 +107,18 @@ mod tests {
         let c2 = load_from_env().unwrap();
         assert!(!c2.transcode_enabled);
         assert_eq!(c2.encode_concurrency, 2);
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn stream_defaults_and_overrides() {
+        clear();
+        let c = load_from_env().unwrap();
+        assert!(c.stream_enabled);
+        std::env::set_var("REEL_STREAM_ENABLED", "false");
+        let c2 = load_from_env().unwrap();
+        assert!(!c2.stream_enabled);
         clear();
     }
 }

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -1,12 +1,13 @@
 use crate::{config, mover, state};
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use librqbit::api::TorrentIdOrHash;
-use librqbit::{AddTorrent, AddTorrentOptions, Session};
+use librqbit::{AddTorrent, AddTorrentOptions, ManagedTorrent, Session};
+use tokio::io::{AsyncRead, AsyncSeek};
 
 pub fn is_vpn_ip(ip: IpAddr) -> bool {
     match ip {
@@ -168,6 +169,68 @@ impl Engine {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct FileEntry {
+    pub index: usize,
+    pub name: String,
+    pub len: u64,
+}
+
+fn is_media_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    [".mp4", ".mkv", ".webm", ".avi", ".mov", ".m4v", ".ts"]
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+}
+
+pub fn primary_file_index(files: &[FileEntry]) -> Option<usize> {
+    files
+        .iter()
+        .filter(|f| is_media_name(&f.name))
+        .max_by_key(|f| f.len)
+        .map(|f| f.index)
+}
+
+impl Engine {
+    fn handle(&self, id: &str) -> Option<Arc<ManagedTorrent>> {
+        let tid = id.parse::<usize>().ok()?;
+        self.session.get(TorrentIdOrHash::Id(tid))
+    }
+
+    pub fn list_files(&self, id: &str) -> anyhow::Result<Option<Vec<FileEntry>>> {
+        let handle = match self.handle(id) {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        let files = handle.with_metadata(|m| {
+            m.file_infos
+                .iter()
+                .enumerate()
+                .map(|(index, fi)| FileEntry {
+                    index,
+                    name: fi.relative_filename.to_string_lossy().into_owned(),
+                    len: fi.len,
+                })
+                .collect::<Vec<_>>()
+        });
+        match files {
+            Ok(v) => Ok(Some(v)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn open_stream(
+        &self,
+        id: &str,
+        file_id: usize,
+    ) -> anyhow::Result<impl AsyncRead + AsyncSeek + Send + 'static> {
+        let handle = self
+            .handle(id)
+            .ok_or_else(|| anyhow::anyhow!("no managed torrent for id {id}"))?;
+        handle.stream(file_id)
+    }
+}
+
 pub fn remove_entry_files(path: &str, transcode_path: Option<&str>) {
     for p in std::iter::once(path).chain(transcode_path) {
         let pb = std::path::Path::new(p);
@@ -223,5 +286,42 @@ mod tests {
     #[test]
     fn ipv6_public_is_vpn() {
         assert!(is_vpn_ip("2606:4700::1111".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn primary_file_index_picks_largest_media() {
+        let files = vec![
+            FileEntry {
+                index: 0,
+                name: "sample.nfo".into(),
+                len: 10,
+            },
+            FileEntry {
+                index: 1,
+                name: "movie.mkv".into(),
+                len: 900,
+            },
+            FileEntry {
+                index: 2,
+                name: "poster.jpg".into(),
+                len: 5000,
+            },
+            FileEntry {
+                index: 3,
+                name: "clip.mp4".into(),
+                len: 100,
+            },
+        ];
+        assert_eq!(primary_file_index(&files), Some(1));
+    }
+
+    #[test]
+    fn primary_file_index_none_when_no_media() {
+        let files = vec![FileEntry {
+            index: 0,
+            name: "readme.txt".into(),
+            len: 10,
+        }];
+        assert_eq!(primary_file_index(&files), None);
     }
 }

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -4,4 +4,5 @@ pub mod engine;
 pub mod mover;
 pub mod reaper;
 pub mod state;
+pub mod stream;
 pub mod transcode;

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -29,6 +29,7 @@ async fn main() -> anyhow::Result<()> {
         store,
         token: cfg.api_token.clone(),
         transcoder,
+        stream_enabled: cfg.stream_enabled,
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");

--- a/apps/media/reel/src/stream.rs
+++ b/apps/media/reel/src/stream.rs
@@ -1,6 +1,6 @@
 use axum::body::Body;
 use axum::http::{header, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 
@@ -64,11 +64,12 @@ where
     let spec = match parse_range(range, total) {
         Ok(s) => s,
         Err(()) => {
-            return (
-                StatusCode::RANGE_NOT_SATISFIABLE,
-                [(header::CONTENT_RANGE, format!("bytes */{total}"))],
-            )
-                .into_response();
+            return Response::builder()
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_RANGE, format!("bytes */{total}"))
+                .body(Body::empty())
+                .unwrap();
         }
     };
 
@@ -92,7 +93,13 @@ where
             let body = if head_only {
                 Body::empty()
             } else {
-                reader.seek(std::io::SeekFrom::Start(start)).await.unwrap();
+                if reader.seek(std::io::SeekFrom::Start(start)).await.is_err() {
+                    return Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .header(header::ACCEPT_RANGES, "bytes")
+                        .body(Body::empty())
+                        .unwrap();
+                }
                 Body::from_stream(ReaderStream::new(reader.take(len)))
             };
             Response::builder()
@@ -154,6 +161,15 @@ mod tests {
         let data = std::io::Cursor::new(vec![0u8; 50]);
         let resp = serve_range(data, 50, None, "video/mp4", false).await;
         assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    }
+
+    #[tokio::test]
+    async fn serve_range_416_has_accept_ranges() {
+        use axum::http::StatusCode;
+        let data = std::io::Cursor::new(vec![0u8; 100]);
+        let resp = serve_range(data, 100, Some("bytes=100-"), "video/mp4", false).await;
+        assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
         assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
     }
 }

--- a/apps/media/reel/src/stream.rs
+++ b/apps/media/reel/src/stream.rs
@@ -20,11 +20,24 @@ pub fn parse_range(header: Option<&str>, total: u64) -> Result<Option<RangeSpec>
     if total == 0 {
         return Err(());
     }
-    let start: u64 = s.trim().parse().map_err(|_| ())?;
-    let end: u64 = if e.trim().is_empty() {
+    let s = s.trim();
+    let e = e.trim();
+    if s.is_empty() {
+        if e.is_empty() {
+            return Err(());
+        }
+        let suffix_len: u64 = e.parse().map_err(|_| ())?;
+        if suffix_len == 0 {
+            return Err(());
+        }
+        let start = total.saturating_sub(suffix_len);
+        return Ok(Some(RangeSpec { start, end: total - 1 }));
+    }
+    let start: u64 = s.parse().map_err(|_| ())?;
+    let end: u64 = if e.is_empty() {
         total - 1
     } else {
-        e.trim().parse::<u64>().map_err(|_| ())?.min(total - 1)
+        e.parse::<u64>().map_err(|_| ())?.min(total - 1)
     };
     if start > end || start > total - 1 {
         return Err(());
@@ -114,6 +127,41 @@ where
     }
 }
 
+pub fn head_response(total: u64, range: Option<&str>, content_type: &str) -> Response {
+    let spec = match parse_range(range, total) {
+        Ok(s) => s,
+        Err(()) => {
+            return Response::builder()
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_RANGE, format!("bytes */{total}"))
+                .body(Body::empty())
+                .unwrap();
+        }
+    };
+
+    match spec {
+        None => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::CONTENT_LENGTH, total)
+            .header(header::CONTENT_TYPE, content_type)
+            .body(Body::empty())
+            .unwrap(),
+        Some(RangeSpec { start, end }) => {
+            let len = end - start + 1;
+            Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_RANGE, format!("bytes {start}-{end}/{total}"))
+                .header(header::CONTENT_LENGTH, len)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(Body::empty())
+                .unwrap()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,6 +185,22 @@ mod tests {
     #[test]
     fn start_past_end_is_416() {
         assert_eq!(parse_range(Some("bytes=100-"), 100), Err(()));
+    }
+    #[test]
+    fn suffix_range_larger_than_total() {
+        assert_eq!(parse_range(Some("bytes=-500"), 100), Ok(Some(RangeSpec { start: 0, end: 99 })));
+    }
+    #[test]
+    fn suffix_range_within_total() {
+        assert_eq!(parse_range(Some("bytes=-50"), 100), Ok(Some(RangeSpec { start: 50, end: 99 })));
+    }
+    #[test]
+    fn suffix_range_zero_is_416() {
+        assert_eq!(parse_range(Some("bytes=-0"), 100), Err(()));
+    }
+    #[test]
+    fn empty_range_is_416() {
+        assert_eq!(parse_range(Some("bytes=-"), 100), Err(()));
     }
     #[test]
     fn content_types() {
@@ -171,5 +235,29 @@ mod tests {
         let resp = serve_range(data, 100, Some("bytes=100-"), "video/mp4", false).await;
         assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
         assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    }
+
+    #[test]
+    fn head_response_206_has_content_range_and_empty_body() {
+        use axum::http::StatusCode;
+        let resp = head_response(100, Some("bytes=10-19"), "video/mp4");
+        assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(resp.headers().get("content-range").unwrap(), "bytes 10-19/100");
+        assert_eq!(resp.headers().get("content-length").unwrap(), "10");
+    }
+
+    #[test]
+    fn head_response_full_is_200() {
+        use axum::http::StatusCode;
+        let resp = head_response(50, None, "video/mp4");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("content-length").unwrap(), "50");
+    }
+
+    #[test]
+    fn head_response_416() {
+        use axum::http::StatusCode;
+        let resp = head_response(100, Some("bytes=100-"), "video/mp4");
+        assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
     }
 }

--- a/apps/media/reel/src/stream.rs
+++ b/apps/media/reel/src/stream.rs
@@ -1,0 +1,159 @@
+use axum::body::Body;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
+use tokio_util::io::ReaderStream;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RangeSpec {
+    pub start: u64,
+    pub end: u64,
+}
+
+pub fn parse_range(header: Option<&str>, total: u64) -> Result<Option<RangeSpec>, ()> {
+    let h = match header {
+        Some(h) => h,
+        None => return Ok(None),
+    };
+    let spec = h.strip_prefix("bytes=").ok_or(())?;
+    let (s, e) = spec.split_once('-').ok_or(())?;
+    if total == 0 {
+        return Err(());
+    }
+    let start: u64 = s.trim().parse().map_err(|_| ())?;
+    let end: u64 = if e.trim().is_empty() {
+        total - 1
+    } else {
+        e.trim().parse::<u64>().map_err(|_| ())?.min(total - 1)
+    };
+    if start > end || start > total - 1 {
+        return Err(());
+    }
+    Ok(Some(RangeSpec { start, end }))
+}
+
+pub fn content_type_for(name: &str) -> &'static str {
+    let lower = name.to_ascii_lowercase();
+    if lower.ends_with(".mp4") || lower.ends_with(".m4v") {
+        "video/mp4"
+    } else if lower.ends_with(".mkv") {
+        "video/x-matroska"
+    } else if lower.ends_with(".webm") {
+        "video/webm"
+    } else if lower.ends_with(".mov") {
+        "video/quicktime"
+    } else if lower.ends_with(".avi") {
+        "video/x-msvideo"
+    } else if lower.ends_with(".ts") {
+        "video/mp2t"
+    } else {
+        "application/octet-stream"
+    }
+}
+
+pub async fn serve_range<R>(
+    mut reader: R,
+    total: u64,
+    range: Option<&str>,
+    content_type: &str,
+    head_only: bool,
+) -> Response
+where
+    R: AsyncRead + AsyncSeek + Send + Unpin + 'static,
+{
+    let spec = match parse_range(range, total) {
+        Ok(s) => s,
+        Err(()) => {
+            return (
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                [(header::CONTENT_RANGE, format!("bytes */{total}"))],
+            )
+                .into_response();
+        }
+    };
+
+    match spec {
+        None => {
+            let body = if head_only {
+                Body::empty()
+            } else {
+                Body::from_stream(ReaderStream::new(reader))
+            };
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_LENGTH, total)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(body)
+                .unwrap()
+        }
+        Some(RangeSpec { start, end }) => {
+            let len = end - start + 1;
+            let body = if head_only {
+                Body::empty()
+            } else {
+                reader.seek(std::io::SeekFrom::Start(start)).await.unwrap();
+                Body::from_stream(ReaderStream::new(reader.take(len)))
+            };
+            Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_RANGE, format!("bytes {start}-{end}/{total}"))
+                .header(header::CONTENT_LENGTH, len)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(body)
+                .unwrap()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_header_is_full() {
+        assert_eq!(parse_range(None, 100), Ok(None));
+    }
+    #[test]
+    fn closed_range() {
+        assert_eq!(parse_range(Some("bytes=0-9"), 100), Ok(Some(RangeSpec { start: 0, end: 9 })));
+    }
+    #[test]
+    fn open_ended_range() {
+        assert_eq!(parse_range(Some("bytes=90-"), 100), Ok(Some(RangeSpec { start: 90, end: 99 })));
+    }
+    #[test]
+    fn end_clamped_to_total() {
+        assert_eq!(parse_range(Some("bytes=0-999"), 100), Ok(Some(RangeSpec { start: 0, end: 99 })));
+    }
+    #[test]
+    fn start_past_end_is_416() {
+        assert_eq!(parse_range(Some("bytes=100-"), 100), Err(()));
+    }
+    #[test]
+    fn content_types() {
+        assert_eq!(content_type_for("a.mp4"), "video/mp4");
+        assert_eq!(content_type_for("a.mkv"), "video/x-matroska");
+        assert_eq!(content_type_for("a.unknown"), "application/octet-stream");
+    }
+
+    #[tokio::test]
+    async fn serve_range_206_has_content_range() {
+        use axum::http::StatusCode;
+        let data = std::io::Cursor::new((0u8..100).collect::<Vec<u8>>());
+        let resp = serve_range(data, 100, Some("bytes=10-19"), "video/mp4", false).await;
+        assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(resp.headers().get("content-range").unwrap(), "bytes 10-19/100");
+        assert_eq!(resp.headers().get("content-length").unwrap(), "10");
+    }
+
+    #[tokio::test]
+    async fn serve_range_full_is_200() {
+        use axum::http::StatusCode;
+        let data = std::io::Cursor::new(vec![0u8; 50]);
+        let resp = serve_range(data, 50, None, "video/mp4", false).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    }
+}

--- a/apps/media/reel/tests/stream_integration.rs
+++ b/apps/media/reel/tests/stream_integration.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+
+#[tokio::test]
+#[ignore = "network + vpn required; run manually with a legal torrent"]
+async fn progressive_stream_reads_head_before_complete() {
+    let magnet = std::env::var("REEL_TEST_MAGNET").expect("set REEL_TEST_MAGNET");
+    let tmp = tempfile::tempdir().unwrap();
+    std::env::set_var("REEL_ACTIVE_DIR", tmp.path().join("active"));
+    std::env::set_var("REEL_LIBRARY_DIR", tmp.path().join("library"));
+    std::env::set_var("REEL_STATE_FILE", tmp.path().join("state.json"));
+    let cfg = reel::config::load_from_env().unwrap();
+    let store = reel::state::StateStore::load(cfg.state_file.clone()).unwrap();
+    let eng = reel::engine::Engine::start(&cfg, store.clone()).await.unwrap();
+    let id = eng.add(&magnet).await.unwrap();
+
+    let mut files = None;
+    for _ in 0..120 {
+        if let Ok(Some(f)) = eng.list_files(&id) { files = Some(f); break; }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    let files = files.expect("metadata resolved");
+    let idx = reel::engine::primary_file_index(&files).expect("a media file");
+    let mut stream = eng.open_stream(&id, idx).unwrap();
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = stream.read(&mut buf).await.unwrap();
+    assert!(n > 0, "progressive read returned bytes before completion");
+}


### PR DESCRIPTION
## reel Phase 2B — Progressive Streaming

Builds on Phase 1 + 2A (merged). Adds `GET`/`HEAD /torrents/{id}/stream` — serve a torrent's primary media file over HTTP byte-range, **while it's still downloading**.

### How
- **Leeching** (in progress): serve librqbit's `FileStream` — a read blocks until the covering piece downloads AND prioritizes the pieces the reader needs (splices ahead of normal download order). This is the "request → prioritize the front → play ASAP" behavior, and librqbit's own first-piece/last-piece ordering handles moov-at-tail for free.
- **Seeding** (completed, moved to `library/`): serve the filesystem file (transcode output if `transcode == Ready`, else the primary media file) — a `FileStream` reopen would miss the renamed path.
- Both sources flow through one async `serve_range` helper: 200 full / 206 range (seek + `take`, inclusive end) / 416 / HEAD. `Accept-Ranges: bytes` everywhere. Suffix ranges (`bytes=-N`) supported. HEAD returns headers without opening the stream (doesn't perturb librqbit's piece priority).
- Auth (Bearer) → `stream_enabled`(503) → not-found(404) checked before any engine call; `last_access` touched on open → feeds the reaper (delivers the "real last_access" the earlier phases stubbed).

### Notes
- librqbit's `FileStream` type isn't re-exported (private module) → `open_stream` returns `impl AsyncRead + AsyncSeek + Send` (confirmed `Unpin`); byte length sourced from `FileEntry.len`.
- Browser-incompatible codecs (HEVC/MKV) stream raw; playability is the caller's concern — codec info is exposed (2A) so a player routes stream-vs-`POST /transcode`.
- **Known limitation** (documented): a stream started while Leeching can short-read if the torrent completes mid-stream (mover renames files before flipping state to Seeding). Inherent to the active→library move; a follow-up can flip state before the rename.

### Testing
61 unit tests (range parsing incl. suffix/416/clamp, content-type, `serve_range`/`head_response` parity, `primary_file_index`, stream route auth/503/404). 3 `#[ignore]` integration tests (Phase 1 leech, 2A transcode, 2B progressive read-before-complete). 0 warnings.

### Process
Subagent-driven, TDD per task, per-task + opus whole-branch review. Review-driven fixes: 416 `Accept-Ranges`, graceful 500 on seek error, suffix ranges, HEAD-without-open.

### Next
- **Phase 3:** astro-kbve player UI; transcode-during-stream (pipe `FileStream` → ffmpeg → HLS) for incompatible codecs; adaptive/HLS.
