### PR TITLE
chore(firecracker): bump microVM kernel to 6.1.155

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v11
+    name: firecracker-rootfs-init-v16
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -29,9 +29,9 @@ spec:
                       - /bin/sh
                       - -c
                   args:
-                      - "set -eu\nOUTPUT=\"/rootfs\"\nKERNEL_URL=\"https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.11/x86_64/vmlinux-5.10.225\"\
+                      - "set -eu\nOUTPUT=\"/rootfs\"\nKERNEL_URL=\"https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/x86_64/vmlinux-6.1.155\"\
                         \n\necho \"=== Firecracker rootfs init ===\"\n\napk add --no-cache curl\
-                        \ e2fsprogs\n\n# --- vmlinux kernel ---\nif [ ! -f \"${OUTPUT}/vmlinux\"\
+                        \ e2fsprogs\n\n# --- vmlinux kernel ---\nrm -f \"${OUTPUT}/vmlinux\"\nif [ ! -f \"${OUTPUT}/vmlinux\"\
                         \ ]; then\n    echo \"[1/4] Downloading vmlinux kernel...\"\n    curl -fSL\
                         \ \"${KERNEL_URL}\" -o \"${OUTPUT}/vmlinux\"\n    chmod 644 \"${OUTPUT}/vmlinux\"\
                         \n    echo \"  Kernel: $(wc -c < ${OUTPUT}/vmlinux) bytes\"\nelse\n    echo\


### PR DESCRIPTION
## Summary
Roll the Firecracker microVM guest kernel from **5.10.225** to **6.1.155** in the prod rootfs-init job. Completes the Firecracker v1.16.1 upgrade — the binary already ships in image `0.1.42` (#14482, #14484); this moves the kernel to match.

The deployed kernel is sourced by `firecracker-rootfs-init.yaml`, **not** by `download-kernel.sh` (that's a dev helper, already on 6.1.155).

## Changes (`apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml`)
- `KERNEL_URL`: `firecracker-ci/v1.11/.../vmlinux-5.10.225` → `firecracker-ci/v1.15/.../vmlinux-6.1.155` (v1.16 CI kernel bucket not published on S3; v1.15 is latest, FC-version backward-compatible).
- Job name `-v11` → `-v16`.
- Added `rm -f "${OUTPUT}/vmlinux"` before the download guard — matches the pip/npm-cache force-refresh convention so the new kernel **overwrites** the 5.10 one already staged on the `firecracker-rootfs` PVC (the `if [ ! -f vmlinux ]` guard would otherwise skip it).

## Verification
- YAML parses; decoded script confirmed (job `-v16`, correct URL, `rm -f` before guard). ✅
- `https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/x86_64/vmlinux-6.1.155` → 200, 42.2 MB valid ELF. ✅

## Rollout / risk
- ArgoCD PostSync re-runs the init job → wipes old kernel, stages 6.1.155; `wait-rootfs` unblocks the deployment.
- **5.10 → 6.1 is a guest boot-surface change** — retest microVM boot timing + TAP networking after sync.

Docs: [firecracker-ctl.mdx](apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx)