### PR TITLE
feat(reel): HLS delivery routing — play every file type (Phase 3A)

### DIFF
--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{engine, state, transcode};
+use crate::{engine, hls, state, transcode};
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
@@ -12,6 +12,8 @@ pub struct AppState {
     pub token: Option<String>,
     pub transcoder: transcode::Transcoder,
     pub stream_enabled: bool,
+    pub hls: hls::HlsManager,
+    pub ffprobe_bin: String,
 }
 
 #[derive(Clone)]
@@ -221,6 +223,126 @@ async fn stream_file(
     }
 }
 
+async fn manifest(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if !st.hls.enabled() {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let _ = st.store.touch(&id, now_secs());
+
+    let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
+        Ok(p) => p,
+        Err(_) => return StatusCode::CONFLICT.into_response(),
+    };
+    let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
+        Ok(p) => p,
+        Err(_) => return StatusCode::CONFLICT.into_response(),
+    };
+    let delivery = transcode::decide_delivery(&probe);
+    if delivery == transcode::Delivery::RawProgressive {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"delivery": "raw_progressive"})),
+        )
+            .into_response();
+    }
+    if meta.state != state::TorrentState::Seeding {
+        return StatusCode::TOO_EARLY.into_response();
+    }
+
+    match st.hls.request(&id, delivery).await {
+        hls::StartOutcome::Ready(dir) => serve_manifest_file(&dir).await,
+        hls::StartOutcome::InProgress(status) => {
+            if matches!(status, state::HlsStatus::Ready | state::HlsStatus::Live) {
+                if let Some(dir) = st.store.get(&id).and_then(|m| m.hls_dir) {
+                    return serve_manifest_file(&dir).await;
+                }
+            }
+            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{status:?}")}))).into_response()
+        }
+        hls::StartOutcome::Started => {
+            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": "started"}))).into_response()
+        }
+        hls::StartOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
+        hls::StartOutcome::NotCompleted => StatusCode::TOO_EARLY.into_response(),
+        hls::StartOutcome::RawProgressive => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"delivery": "raw_progressive"})),
+        )
+            .into_response(),
+        hls::StartOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+async fn serve_manifest_file(dir: &str) -> axum::response::Response {
+    let path = std::path::Path::new(dir).join("index.m3u8");
+    let file = match tokio::fs::File::open(&path).await {
+        Ok(f) => f,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let total = match file.metadata().await {
+        Ok(m) => m.len(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    crate::stream::serve_range(file, total, None, "application/vnd.apple.mpegurl", false).await
+}
+
+async fn hls_segment(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path((id, segment)): Path<(String, String)>,
+    method: axum::http::Method,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if !hls::valid_segment_name(&segment) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let dir = match meta.hls_dir {
+        Some(d) => d,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let path = std::path::Path::new(&dir).join(&segment);
+    let head_only = method == axum::http::Method::HEAD;
+    let range = headers.get("range").and_then(|h| h.to_str().ok());
+    let ct = if segment.ends_with(".ts") {
+        "video/mp2t"
+    } else {
+        "application/vnd.apple.mpegurl"
+    };
+    if head_only {
+        let total = match tokio::fs::metadata(&path).await {
+            Ok(m) => m.len(),
+            Err(_) => return StatusCode::NOT_FOUND.into_response(),
+        };
+        return crate::stream::head_response(total, range, ct);
+    }
+    let file = match tokio::fs::File::open(&path).await {
+        Ok(f) => f,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let total = match file.metadata().await {
+        Ok(m) => m.len(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    crate::stream::serve_range(file, total, range, ct, head_only).await
+}
+
 fn store_scoped_router(state: AppStateStub) -> Router {
     Router::new()
         .route("/torrents", get(list))
@@ -236,6 +358,8 @@ pub fn router(state: AppState) -> Router {
         .route("/torrents/{id}", axum::routing::delete(remove))
         .route("/torrents/{id}/transcode", post(transcode_start))
         .route("/torrents/{id}/stream", get(stream_file).head(stream_file))
+        .route("/torrents/{id}/manifest.m3u8", get(manifest))
+        .route("/torrents/{id}/hls/{segment}", get(hls_segment).head(hls_segment))
         .with_state(state);
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -314,6 +438,71 @@ fn stream_router(store: state::StateStore, token: Option<String>, stream_enabled
     Router::new()
         .route("/torrents/{id}/stream", get(handler).head(handler))
         .with_state(StreamState { store, token, stream_enabled })
+}
+
+#[cfg(test)]
+fn hls_manifest_router(store: state::StateStore, token: Option<String>, hls: hls::HlsManager) -> Router {
+    #[derive(Clone)]
+    struct ManifestState {
+        store: state::StateStore,
+        token: Option<String>,
+        hls: hls::HlsManager,
+    }
+
+    async fn handler(
+        State(st): State<ManifestState>,
+        headers: HeaderMap,
+        Path(id): Path<String>,
+    ) -> impl IntoResponse {
+        if !check_auth(&headers, &st.token) {
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        if !st.hls.enabled() {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+        match st.store.get(&id) {
+            Some(_) => StatusCode::OK.into_response(),
+            None => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+
+    Router::new()
+        .route("/torrents/{id}/manifest.m3u8", get(handler))
+        .with_state(ManifestState { store, token, hls })
+}
+
+#[cfg(test)]
+fn hls_segment_router(store: state::StateStore, token: Option<String>) -> Router {
+    #[derive(Clone)]
+    struct SegmentState {
+        store: state::StateStore,
+        token: Option<String>,
+    }
+
+    async fn handler(
+        State(st): State<SegmentState>,
+        headers: HeaderMap,
+        Path((id, segment)): Path<(String, String)>,
+    ) -> impl IntoResponse {
+        if !check_auth(&headers, &st.token) {
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        if !hls::valid_segment_name(&segment) {
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+        let meta = match st.store.get(&id) {
+            Some(m) => m,
+            None => return StatusCode::NOT_FOUND.into_response(),
+        };
+        match meta.hls_dir {
+            Some(_) => StatusCode::OK.into_response(),
+            None => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+
+    Router::new()
+        .route("/torrents/{id}/hls/{segment}", get(handler))
+        .with_state(SegmentState { store, token })
 }
 
 #[cfg(test)]
@@ -471,5 +660,51 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn hls_manager_with(store: StateStore, enabled: bool) -> crate::hls::HlsManager {
+        crate::hls::HlsManager::new(store, 1, "ffmpeg".into(), 4, enabled)
+    }
+
+    #[tokio::test]
+    async fn manifest_missing_id_is_404() {
+        let store = store_with_one();
+        let app = hls_manifest_router(store.clone(), None, hls_manager_with(store, true));
+        let res = app
+            .oneshot(Request::get("/torrents/999/manifest.m3u8").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn manifest_hls_disabled_is_503() {
+        let store = store_with_one();
+        let app = hls_manifest_router(store.clone(), None, hls_manager_with(store, false));
+        let res = app
+            .oneshot(Request::get("/torrents/1/manifest.m3u8").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn hls_segment_rejects_bad_name_is_400() {
+        let app = hls_segment_router(store_with_one(), None);
+        let res = app
+            .oneshot(Request::get("/torrents/1/hls/seg.ts").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn hls_segment_missing_dir_is_404() {
+        let app = hls_segment_router(store_with_one(), None);
+        let res = app
+            .oneshot(Request::get("/torrents/1/hls/seg00001.ts").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -24,7 +24,10 @@ pub struct AppStateStub {
 
 impl From<&AppState> for AppStateStub {
     fn from(s: &AppState) -> Self {
-        Self { store: s.store.clone(), token: s.token.clone() }
+        Self {
+            store: s.store.clone(),
+            token: s.token.clone(),
+        }
     }
 }
 
@@ -110,6 +113,7 @@ async fn remove(
     if !check_auth(&headers, &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
+    st.hls.abort(&id).await;
     match st.engine.delete(&id).await {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => StatusCode::NOT_FOUND.into_response(),
@@ -126,15 +130,21 @@ async fn transcode_start(
         return StatusCode::UNAUTHORIZED.into_response();
     }
     match st.transcoder.request(&id).await {
-        transcode::RequestOutcome::Ready(p) => {
-            (StatusCode::OK, Json(serde_json::json!({"status":"ready","path":p}))).into_response()
-        }
-        transcode::RequestOutcome::Started => {
-            (StatusCode::ACCEPTED, Json(serde_json::json!({"status":"pending"}))).into_response()
-        }
-        transcode::RequestOutcome::InProgress(s) => {
-            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{s:?}")}))).into_response()
-        }
+        transcode::RequestOutcome::Ready(p) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"status":"ready","path":p})),
+        )
+            .into_response(),
+        transcode::RequestOutcome::Started => (
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({"status":"pending"})),
+        )
+            .into_response(),
+        transcode::RequestOutcome::InProgress(s) => (
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({"status": format!("{s:?}")})),
+        )
+            .into_response(),
         transcode::RequestOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
         transcode::RequestOutcome::NotCompleted => StatusCode::CONFLICT.into_response(),
         transcode::RequestOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
@@ -208,7 +218,11 @@ async fn stream_file(
                 .find(|f| f.index == idx)
                 .map(|f| f.name.clone())
                 .unwrap_or_default();
-            let total = files.iter().find(|f| f.index == idx).map(|f| f.len).unwrap_or(0);
+            let total = files
+                .iter()
+                .find(|f| f.index == idx)
+                .map(|f| f.len)
+                .unwrap_or(0);
             let ct = crate::stream::content_type_for(&name);
             if head_only {
                 return crate::stream::head_response(total, range, ct);
@@ -269,11 +283,17 @@ async fn manifest(
                     return serve_manifest_file(&dir).await;
                 }
             }
-            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{status:?}")}))).into_response()
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": format!("{status:?}")})),
+            )
+                .into_response()
         }
-        hls::StartOutcome::Started => {
-            (StatusCode::ACCEPTED, Json(serde_json::json!({"status": "started"}))).into_response()
-        }
+        hls::StartOutcome::Started => (
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({"status": "started"})),
+        )
+            .into_response(),
         hls::StartOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
         hls::StartOutcome::NotCompleted => StatusCode::TOO_EARLY.into_response(),
         hls::StartOutcome::RawProgressive => (
@@ -360,7 +380,10 @@ pub fn router(state: AppState) -> Router {
         .route("/torrents/{id}/transcode", post(transcode_start))
         .route("/torrents/{id}/stream", get(stream_file).head(stream_file))
         .route("/torrents/{id}/manifest.m3u8", get(manifest))
-        .route("/torrents/{id}/hls/{segment}", get(hls_segment).head(hls_segment))
+        .route(
+            "/torrents/{id}/hls/{segment}",
+            get(hls_segment).head(hls_segment),
+        )
         .with_state(state);
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -390,15 +413,21 @@ fn transcode_router(transcoder: transcode::Transcoder, token: Option<String>) ->
             return StatusCode::UNAUTHORIZED.into_response();
         }
         match st.transcoder.request(&id).await {
-            transcode::RequestOutcome::Ready(p) => {
-                (StatusCode::OK, Json(serde_json::json!({"status":"ready","path":p}))).into_response()
-            }
-            transcode::RequestOutcome::Started => {
-                (StatusCode::ACCEPTED, Json(serde_json::json!({"status":"pending"}))).into_response()
-            }
-            transcode::RequestOutcome::InProgress(s) => {
-                (StatusCode::ACCEPTED, Json(serde_json::json!({"status": format!("{s:?}")}))).into_response()
-            }
+            transcode::RequestOutcome::Ready(p) => (
+                StatusCode::OK,
+                Json(serde_json::json!({"status":"ready","path":p})),
+            )
+                .into_response(),
+            transcode::RequestOutcome::Started => (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status":"pending"})),
+            )
+                .into_response(),
+            transcode::RequestOutcome::InProgress(s) => (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": format!("{s:?}")})),
+            )
+                .into_response(),
             transcode::RequestOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
             transcode::RequestOutcome::NotCompleted => StatusCode::CONFLICT.into_response(),
             transcode::RequestOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
@@ -438,11 +467,19 @@ fn stream_router(store: state::StateStore, token: Option<String>, stream_enabled
 
     Router::new()
         .route("/torrents/{id}/stream", get(handler).head(handler))
-        .with_state(StreamState { store, token, stream_enabled })
+        .with_state(StreamState {
+            store,
+            token,
+            stream_enabled,
+        })
 }
 
 #[cfg(test)]
-fn hls_manifest_router(store: state::StateStore, token: Option<String>, hls: hls::HlsManager) -> Router {
+fn hls_manifest_router(
+    store: state::StateStore,
+    token: Option<String>,
+    hls: hls::HlsManager,
+) -> Router {
     #[derive(Clone)]
     struct ManifestState {
         store: state::StateStore,
@@ -640,7 +677,11 @@ mod tests {
     async fn stream_disabled_is_503() {
         let app = stream_router(store_with_one(), None, false);
         let res = app
-            .oneshot(Request::get("/torrents/1/stream").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -650,7 +691,11 @@ mod tests {
     async fn stream_missing_id_is_404() {
         let app = stream_router(store_with_one(), None, true);
         let res = app
-            .oneshot(Request::get("/torrents/999/stream").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/999/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -660,7 +705,11 @@ mod tests {
     async fn stream_requires_auth_when_token_set() {
         let app = stream_router(store_with_one(), Some("secret".into()), true);
         let res = app
-            .oneshot(Request::get("/torrents/1/stream").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
@@ -675,7 +724,11 @@ mod tests {
         let store = store_with_one();
         let app = hls_manifest_router(store.clone(), None, hls_manager_with(store, true));
         let res = app
-            .oneshot(Request::get("/torrents/999/manifest.m3u8").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/999/manifest.m3u8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -686,7 +739,11 @@ mod tests {
         let store = store_with_one();
         let app = hls_manifest_router(store.clone(), None, hls_manager_with(store, false));
         let res = app
-            .oneshot(Request::get("/torrents/1/manifest.m3u8").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/manifest.m3u8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -715,7 +772,11 @@ mod tests {
         .unwrap();
         let app = hls_manifest_router(s.clone(), None, hls_manager_with(s, true));
         let res = app
-            .oneshot(Request::get("/torrents/1/manifest.m3u8").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/manifest.m3u8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::TOO_EARLY);
@@ -725,7 +786,11 @@ mod tests {
     async fn hls_segment_rejects_bad_name_is_400() {
         let app = hls_segment_router(store_with_one(), None);
         let res = app
-            .oneshot(Request::get("/torrents/1/hls/seg.ts").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/hls/seg.ts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -735,7 +800,11 @@ mod tests {
     async fn hls_segment_missing_dir_is_404() {
         let app = hls_segment_router(store_with_one(), None);
         let res = app
-            .oneshot(Request::get("/torrents/1/hls/seg00001.ts").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/torrents/1/hls/seg00001.ts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -254,19 +254,41 @@ async fn manifest(
     };
     let _ = st.store.touch(&id, now_secs());
 
+    match meta.hls {
+        state::HlsStatus::Live | state::HlsStatus::Ready => match meta.hls_dir {
+            Some(dir) => return serve_manifest_file(&dir).await,
+            None => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        },
+        state::HlsStatus::Starting => {
+            return (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": "starting"})),
+            )
+                .into_response();
+        }
+        state::HlsStatus::None | state::HlsStatus::Failed => {}
+    }
+
     if meta.state != state::TorrentState::Seeding {
         return StatusCode::TOO_EARLY.into_response();
     }
 
-    let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
-        Ok(p) => p,
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    let delivery = match st.hls.cached_delivery(&id) {
+        Some(d) => d,
+        None => {
+            let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
+                Ok(p) => p,
+                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            };
+            let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
+                Ok(p) => p,
+                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            };
+            let d = transcode::decide_delivery(&probe);
+            st.hls.cache_delivery(&id, d);
+            d
+        }
     };
-    let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
-        Ok(p) => p,
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    };
-    let delivery = transcode::decide_delivery(&probe);
     if delivery == transcode::Delivery::RawProgressive {
         return (
             StatusCode::CONFLICT,
@@ -498,13 +520,28 @@ fn hls_manifest_router(
         if !st.hls.enabled() {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
-        match st.store.get(&id) {
-            Some(m) if m.state != state::TorrentState::Seeding => {
-                StatusCode::TOO_EARLY.into_response()
+        let meta = match st.store.get(&id) {
+            Some(m) => m,
+            None => return StatusCode::NOT_FOUND.into_response(),
+        };
+        match meta.hls {
+            state::HlsStatus::Live | state::HlsStatus::Ready => match meta.hls_dir {
+                Some(dir) => return serve_manifest_file(&dir).await,
+                None => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            },
+            state::HlsStatus::Starting => {
+                return (
+                    StatusCode::ACCEPTED,
+                    Json(serde_json::json!({"status": "starting"})),
+                )
+                    .into_response();
             }
-            Some(_) => StatusCode::OK.into_response(),
-            None => StatusCode::NOT_FOUND.into_response(),
+            state::HlsStatus::None | state::HlsStatus::Failed => {}
         }
+        if meta.state != state::TorrentState::Seeding {
+            return StatusCode::TOO_EARLY.into_response();
+        }
+        StatusCode::OK.into_response()
     }
 
     Router::new()
@@ -780,6 +817,46 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::TOO_EARLY);
+    }
+
+    #[tokio::test]
+    async fn manifest_live_with_hls_dir_serves_200() {
+        let dir = tempdir().unwrap();
+        let hls_dir = dir.path().join("hls");
+        std::fs::create_dir_all(&hls_dir).unwrap();
+        std::fs::write(hls_dir.join("index.m3u8"), b"#EXTM3U\n").unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: "/lib/movie.mp4".into(),
+            size: 5,
+            completed_at: Some(10),
+            last_access: 10,
+            state: TorrentState::Seeding,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::Live,
+            hls_dir: Some(hls_dir.display().to_string()),
+            hls_error: None,
+        })
+        .unwrap();
+        std::mem::forget(dir);
+        let app = hls_manifest_router(s.clone(), None, hls_manager_with(s, true));
+        let res = app
+            .oneshot(
+                Request::get("/torrents/1/manifest.m3u8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get("content-type").unwrap(),
+            "application/vnd.apple.mpegurl"
+        );
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -319,7 +319,7 @@ fn stream_router(store: state::StateStore, token: Option<String>, stream_enabled
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Metadata, StateStore, TorrentState, TranscodeStatus};
+    use crate::state::{HlsStatus, Metadata, StateStore, TorrentState, TranscodeStatus};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -341,6 +341,9 @@ mod tests {
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
         })
         .unwrap();
         s
@@ -388,6 +391,9 @@ mod tests {
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
         })
         .unwrap();
         let app = transcode_router(transcoder_with(s), None);

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -240,13 +240,17 @@ async fn manifest(
     };
     let _ = st.store.touch(&id, now_secs());
 
+    if meta.state != state::TorrentState::Seeding {
+        return StatusCode::TOO_EARLY.into_response();
+    }
+
     let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
         Ok(p) => p,
-        Err(_) => return StatusCode::CONFLICT.into_response(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
     let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
         Ok(p) => p,
-        Err(_) => return StatusCode::CONFLICT.into_response(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
     let delivery = transcode::decide_delivery(&probe);
     if delivery == transcode::Delivery::RawProgressive {
@@ -255,9 +259,6 @@ async fn manifest(
             Json(serde_json::json!({"delivery": "raw_progressive"})),
         )
             .into_response();
-    }
-    if meta.state != state::TorrentState::Seeding {
-        return StatusCode::TOO_EARLY.into_response();
     }
 
     match st.hls.request(&id, delivery).await {
@@ -461,6 +462,9 @@ fn hls_manifest_router(store: state::StateStore, token: Option<String>, hls: hls
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
         match st.store.get(&id) {
+            Some(m) if m.state != state::TorrentState::Seeding => {
+                StatusCode::TOO_EARLY.into_response()
+            }
             Some(_) => StatusCode::OK.into_response(),
             None => StatusCode::NOT_FOUND.into_response(),
         }
@@ -686,6 +690,35 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn manifest_leeching_is_425() {
+        let dir = tempdir().unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        std::mem::forget(dir);
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: "/lib/movie.mp4".into(),
+            size: 5,
+            completed_at: None,
+            last_access: 10,
+            state: TorrentState::Leeching,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
+        })
+        .unwrap();
+        let app = hls_manifest_router(s.clone(), None, hls_manager_with(s, true));
+        let res = app
+            .oneshot(Request::get("/torrents/1/manifest.m3u8").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::TOO_EARLY);
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub ffmpeg_bin: String,
     pub ffprobe_bin: String,
     pub stream_enabled: bool,
+    pub hls_enabled: bool,
+    pub hls_segment_secs: u64,
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -51,6 +53,8 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         ffmpeg_bin: env_or("REEL_FFMPEG_BIN", "ffmpeg"),
         ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
         stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
+        hls_enabled: env_bool("REEL_HLS_ENABLED", true),
+        hls_segment_secs: env_u64("REEL_HLS_SEGMENT_SECS", 4)?,
     })
 }
 
@@ -64,7 +68,8 @@ mod tests {
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
                   "REEL_VPN_CHECK_URL","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
-                  "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED"] {
+                  "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
+                  "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS"] {
             std::env::remove_var(k);
         }
     }
@@ -119,6 +124,21 @@ mod tests {
         std::env::set_var("REEL_STREAM_ENABLED", "false");
         let c2 = load_from_env().unwrap();
         assert!(!c2.stream_enabled);
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn hls_defaults_and_overrides() {
+        clear();
+        let c = load_from_env().unwrap();
+        assert!(c.hls_enabled);
+        assert_eq!(c.hls_segment_secs, 4);
+        std::env::set_var("REEL_HLS_ENABLED", "false");
+        std::env::set_var("REEL_HLS_SEGMENT_SECS", "8");
+        let c2 = load_from_env().unwrap();
+        assert!(!c2.hls_enabled);
+        assert_eq!(c2.hls_segment_secs, 8);
         clear();
     }
 }

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -103,6 +103,9 @@ impl Engine {
             transcode: state::TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
+            hls: state::HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
         })?;
 
         let store = self.store.clone();
@@ -127,6 +130,9 @@ impl Engine {
                         transcode: state::TranscodeStatus::None,
                         transcode_path: None,
                         transcode_error: None,
+                        hls: state::HlsStatus::None,
+                        hls_dir: None,
+                        hls_error: None,
                     });
                     tracing::info!(id = %id_task, "moved to library");
                 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -1,0 +1,28 @@
+pub fn valid_segment_name(name: &str) -> bool {
+    if name == "index.m3u8" {
+        return true;
+    }
+    let stem = match name.strip_suffix(".ts") {
+        Some(s) => s,
+        None => return false,
+    };
+    stem.strip_prefix("seg")
+        .map(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn accepts_segment_and_manifest() {
+        assert!(valid_segment_name("seg00001.ts"));
+        assert!(valid_segment_name("index.m3u8"));
+    }
+    #[test]
+    fn rejects_traversal() {
+        for n in ["../x", ".../x", "a/b", "/etc/passwd", "seg.ts", "index.m3u", "seg01.ts.."] {
+            assert!(!valid_segment_name(n), "{n}");
+        }
+    }
+}

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -81,6 +81,7 @@ pub struct HlsManager {
     segment_secs: u32,
     enabled: bool,
     children: Arc<Mutex<HashMap<String, Child>>>,
+    delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
 }
 
 impl HlsManager {
@@ -98,7 +99,18 @@ impl HlsManager {
             segment_secs,
             enabled,
             children: Arc::new(Mutex::new(HashMap::new())),
+            delivery_cache: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    pub fn cached_delivery(&self, id: &str) -> Option<Delivery> {
+        let g = self.delivery_cache.lock().unwrap();
+        g.get(id).copied()
+    }
+
+    pub fn cache_delivery(&self, id: &str, d: Delivery) {
+        let mut g = self.delivery_cache.lock().unwrap();
+        g.insert(id.to_string(), d);
     }
 
     pub fn enabled(&self) -> bool {
@@ -174,7 +186,15 @@ impl HlsManager {
         let src_dir = PathBuf::from(&meta.path);
         let primary = pick_primary_file(&src_dir)?;
         let hls_dir = src_dir.join("hls");
+        if hls_dir.exists() {
+            let _ = std::fs::remove_dir_all(&hls_dir);
+        }
         std::fs::create_dir_all(&hls_dir)?;
+        let hls_dir_str = hls_dir.display().to_string();
+        let _ = self.store.update(id, |m| {
+            m.hls_dir = Some(hls_dir_str.clone());
+            ((), true)
+        });
 
         let mut args: Vec<String> = vec![
             "-y".into(),
@@ -229,13 +249,11 @@ impl HlsManager {
         let this = self.clone();
         let id = id.to_string();
         let index_path = hls_dir.join("index.m3u8");
-        let hls_dir_str = hls_dir.display().to_string();
         tokio::spawn(async move {
             for _ in 0..100 {
                 if index_path.exists() {
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Live;
-                        m.hls_dir = Some(hls_dir_str.clone());
                         ((), true)
                     });
                     break;
@@ -339,5 +357,15 @@ mod mgr_tests {
         let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true);
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
+    }
+
+    #[test]
+    fn cached_delivery_none_then_some() {
+        let dir = std::env::temp_dir().join(format!("reel-hls-test-cache-{}", std::process::id()));
+        let store = StateStore::load(dir.join("state.json")).unwrap();
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true);
+        assert_eq!(mgr.cached_delivery("1"), None);
+        mgr.cache_delivery("1", Delivery::RemuxHls);
+        assert_eq!(mgr.cached_delivery("1"), Some(Delivery::RemuxHls));
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -1,3 +1,11 @@
+use crate::state::{HlsStatus, Metadata, StateStore, TorrentState};
+use crate::transcode::{pick_primary_file, Delivery};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::process::{Child, Command};
+use tokio::sync::Semaphore;
+
 pub fn valid_segment_name(name: &str) -> bool {
     if name == "index.m3u8" {
         return true;
@@ -24,5 +32,285 @@ mod tests {
         for n in ["../x", ".../x", "a/b", "/etc/passwd", "seg.ts", "index.m3u", "seg01.ts.."] {
             assert!(!valid_segment_name(n), "{n}");
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StartOutcome {
+    Started,
+    InProgress(HlsStatus),
+    Ready(String),
+    NotFound,
+    NotCompleted,
+    RawProgressive,
+    Disabled,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum HlsDecision {
+    Reject(StartOutcome),
+    Start,
+}
+
+pub fn next_hls(current: &HlsStatus, state: &TorrentState, enabled: bool) -> HlsDecision {
+    if !enabled {
+        return HlsDecision::Reject(StartOutcome::Disabled);
+    }
+    if *state != TorrentState::Seeding {
+        return HlsDecision::Reject(StartOutcome::NotCompleted);
+    }
+    match current {
+        HlsStatus::None | HlsStatus::Failed => HlsDecision::Start,
+        other => HlsDecision::Reject(StartOutcome::InProgress(other.clone())),
+    }
+}
+
+#[derive(Clone)]
+pub struct HlsManager {
+    store: StateStore,
+    encode_sem: Arc<Semaphore>,
+    ffmpeg_bin: String,
+    segment_secs: u32,
+    enabled: bool,
+    children: Arc<Mutex<HashMap<String, Child>>>,
+}
+
+impl HlsManager {
+    pub fn new(
+        store: StateStore,
+        encode_conc: usize,
+        ffmpeg_bin: String,
+        segment_secs: u32,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            store,
+            encode_sem: Arc::new(Semaphore::new(encode_conc.max(1))),
+            ffmpeg_bin,
+            segment_secs,
+            enabled,
+            children: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn request(&self, id: &str, delivery: Delivery) -> StartOutcome {
+        if delivery == Delivery::RawProgressive {
+            return StartOutcome::RawProgressive;
+        }
+        let result = self.store.update(id, |m| {
+            match next_hls(&m.hls, &m.state, self.enabled) {
+                HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Ready)) => {
+                    let outcome = match &m.hls_dir {
+                        Some(dir) => StartOutcome::Ready(dir.clone()),
+                        None => StartOutcome::InProgress(HlsStatus::Ready),
+                    };
+                    (outcome, false)
+                }
+                HlsDecision::Reject(outcome) => (outcome, false),
+                HlsDecision::Start => {
+                    m.hls = HlsStatus::Starting;
+                    m.hls_error = None;
+                    (StartOutcome::Started, true)
+                }
+            }
+        });
+        match result {
+            Ok(Some(StartOutcome::Started)) => {
+                if let Some(meta) = self.store.get(id) {
+                    self.spawn_job(id.to_string(), meta, delivery);
+                }
+                StartOutcome::Started
+            }
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => StartOutcome::NotFound,
+            Err(_) => StartOutcome::NotFound,
+        }
+    }
+
+    pub async fn abort(&self, id: &str) {
+        let child = self.take_child(id);
+        if let Some(mut child) = child {
+            let _ = child.kill().await;
+        }
+    }
+
+    fn take_child(&self, id: &str) -> Option<Child> {
+        let mut g = self.children.lock().unwrap();
+        g.remove(id)
+    }
+
+    fn poll_child(&self, id: &str) -> Option<std::io::Result<Option<std::process::ExitStatus>>> {
+        let mut g = self.children.lock().unwrap();
+        g.get_mut(id).map(|child| child.try_wait())
+    }
+
+    fn spawn_job(&self, id: String, meta: Metadata, delivery: Delivery) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.run_hls(&id, &meta, delivery).await {
+                tracing::error!(id = %id, error = %e, "hls start failed");
+                let _ = this.store.update(&id, |m| {
+                    m.hls = HlsStatus::Failed;
+                    m.hls_error = Some(e.to_string());
+                    ((), true)
+                });
+            }
+        });
+    }
+
+    async fn run_hls(&self, id: &str, meta: &Metadata, delivery: Delivery) -> anyhow::Result<()> {
+        let src_dir = PathBuf::from(&meta.path);
+        let primary = pick_primary_file(&src_dir)?;
+        let hls_dir = src_dir.join("hls");
+        std::fs::create_dir_all(&hls_dir)?;
+
+        let mut args: Vec<String> = vec![
+            "-y".into(),
+            "-nostats".into(),
+            "-loglevel".into(),
+            "error".into(),
+            "-i".into(),
+            primary.display().to_string(),
+        ];
+        match delivery {
+            Delivery::RemuxHls => {
+                args.push("-c".into());
+                args.push("copy".into());
+            }
+            Delivery::TranscodeHls => {
+                args.push("-c:v".into());
+                args.push("libx264".into());
+                args.push("-preset".into());
+                args.push("veryfast".into());
+                args.push("-c:a".into());
+                args.push("aac".into());
+            }
+            Delivery::RawProgressive => unreachable!("filtered out in request"),
+        }
+        args.push("-f".into());
+        args.push("hls".into());
+        args.push("-hls_time".into());
+        args.push(self.segment_secs.to_string());
+        args.push("-hls_playlist_type".into());
+        args.push("event".into());
+        args.push("-hls_flags".into());
+        args.push("append_list".into());
+        args.push("-hls_segment_filename".into());
+        args.push(hls_dir.join("seg%05d.ts").display().to_string());
+        args.push(hls_dir.join("index.m3u8").display().to_string());
+
+        let permit = if delivery == Delivery::TranscodeHls {
+            Some(self.encode_sem.clone().acquire_owned().await?)
+        } else {
+            None
+        };
+
+        let mut cmd = Command::new(&self.ffmpeg_bin);
+        cmd.args(&args);
+        let child = cmd.spawn()?;
+
+        {
+            let mut g = self.children.lock().unwrap();
+            g.insert(id.to_string(), child);
+        }
+
+        let this = self.clone();
+        let id = id.to_string();
+        let index_path = hls_dir.join("index.m3u8");
+        let hls_dir_str = hls_dir.display().to_string();
+        tokio::spawn(async move {
+            for _ in 0..100 {
+                if index_path.exists() {
+                    let _ = this.store.update(&id, |m| {
+                        m.hls = HlsStatus::Live;
+                        m.hls_dir = Some(hls_dir_str.clone());
+                        ((), true)
+                    });
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+
+            let exit_result = loop {
+                match this.poll_child(&id) {
+                    Some(Ok(Some(status))) => break Some(Ok(status)),
+                    Some(Ok(None)) => {}
+                    Some(Err(e)) => break Some(Err(e)),
+                    None => break None,
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            };
+
+            this.take_child(&id);
+
+            match exit_result {
+                Some(Ok(status)) if status.success() => {
+                    let _ = this.store.update(&id, |m| {
+                        m.hls = HlsStatus::Ready;
+                        m.hls_error = None;
+                        ((), true)
+                    });
+                }
+                Some(Ok(status)) => {
+                    let _ = this.store.update(&id, |m| {
+                        m.hls = HlsStatus::Failed;
+                        m.hls_error = Some(format!("ffmpeg exited: {status}"));
+                        ((), true)
+                    });
+                }
+                Some(Err(e)) => {
+                    let _ = this.store.update(&id, |m| {
+                        m.hls = HlsStatus::Failed;
+                        m.hls_error = Some(e.to_string());
+                        ((), true)
+                    });
+                }
+                None => {
+                    let _ = this.store.update(&id, |m| {
+                        m.hls = HlsStatus::Failed;
+                        m.hls_error = Some("aborted".into());
+                        ((), true)
+                    });
+                }
+            }
+            drop(permit);
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod mgr_tests {
+    use super::*;
+    use crate::state::{HlsStatus, TorrentState};
+    #[test]
+    fn disabled_rejects() {
+        assert_eq!(
+            next_hls(&HlsStatus::None, &TorrentState::Seeding, false),
+            HlsDecision::Reject(StartOutcome::Disabled)
+        );
+    }
+    #[test]
+    fn not_seeding_rejected() {
+        assert_eq!(
+            next_hls(&HlsStatus::None, &TorrentState::Leeching, true),
+            HlsDecision::Reject(StartOutcome::NotCompleted)
+        );
+    }
+    #[test]
+    fn none_starts() {
+        assert_eq!(next_hls(&HlsStatus::None, &TorrentState::Seeding, true), HlsDecision::Start);
+    }
+    #[test]
+    fn failed_restarts() {
+        assert_eq!(next_hls(&HlsStatus::Failed, &TorrentState::Seeding, true), HlsDecision::Start);
+    }
+    #[test]
+    fn live_in_progress() {
+        assert_eq!(
+            next_hls(&HlsStatus::Live, &TorrentState::Seeding, true),
+            HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Live))
+        );
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -1,5 +1,5 @@
 use crate::state::{HlsStatus, Metadata, StateStore, TorrentState};
-use crate::transcode::{pick_primary_file, Delivery};
+use crate::transcode::{Delivery, pick_primary_file};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -29,7 +29,15 @@ mod tests {
     }
     #[test]
     fn rejects_traversal() {
-        for n in ["../x", ".../x", "a/b", "/etc/passwd", "seg.ts", "index.m3u", "seg01.ts.."] {
+        for n in [
+            "../x",
+            ".../x",
+            "a/b",
+            "/etc/passwd",
+            "seg.ts",
+            "index.m3u",
+            "seg01.ts..",
+        ] {
             assert!(!valid_segment_name(n), "{n}");
         }
     }
@@ -101,8 +109,9 @@ impl HlsManager {
         if delivery == Delivery::RawProgressive {
             return StartOutcome::RawProgressive;
         }
-        let result = self.store.update(id, |m| {
-            match next_hls(&m.hls, &m.state, self.enabled) {
+        let result = self
+            .store
+            .update(id, |m| match next_hls(&m.hls, &m.state, self.enabled) {
                 HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Ready)) => {
                     let outcome = match &m.hls_dir {
                         Some(dir) => StartOutcome::Ready(dir.clone()),
@@ -116,8 +125,7 @@ impl HlsManager {
                     m.hls_error = None;
                     (StartOutcome::Started, true)
                 }
-            }
-        });
+            });
         match result {
             Ok(Some(StartOutcome::Started)) => {
                 if let Some(meta) = self.store.get(id) {
@@ -304,11 +312,17 @@ mod mgr_tests {
     }
     #[test]
     fn none_starts() {
-        assert_eq!(next_hls(&HlsStatus::None, &TorrentState::Seeding, true), HlsDecision::Start);
+        assert_eq!(
+            next_hls(&HlsStatus::None, &TorrentState::Seeding, true),
+            HlsDecision::Start
+        );
     }
     #[test]
     fn failed_restarts() {
-        assert_eq!(next_hls(&HlsStatus::Failed, &TorrentState::Seeding, true), HlsDecision::Start);
+        assert_eq!(
+            next_hls(&HlsStatus::Failed, &TorrentState::Seeding, true),
+            HlsDecision::Start
+        );
     }
     #[test]
     fn live_in_progress() {
@@ -316,5 +330,14 @@ mod mgr_tests {
             next_hls(&HlsStatus::Live, &TorrentState::Seeding, true),
             HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Live))
         );
+    }
+
+    #[tokio::test]
+    async fn abort_unknown_is_noop() {
+        let dir = std::env::temp_dir().join(format!("reel-hls-test-{}", std::process::id()));
+        let store = StateStore::load(dir.join("state.json")).unwrap();
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true);
+        mgr.abort("unknown-id").await;
+        assert!(mgr.take_child("unknown-id").is_none());
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -93,6 +93,10 @@ impl HlsManager {
         }
     }
 
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
     pub async fn request(&self, id: &str, delivery: Delivery) -> StartOutcome {
         if delivery == Delivery::RawProgressive {
             return StartOutcome::RawProgressive;

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod config;
 pub mod engine;
+pub mod hls;
 pub mod mover;
 pub mod reaper;
 pub mod state;

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -18,12 +18,6 @@ async fn main() -> anyhow::Result<()> {
         cfg.transcode_enabled,
     );
 
-    tokio::spawn(reaper::reap_loop(
-        eng.clone(),
-        cfg.ttl_secs,
-        cfg.reap_interval_secs,
-    ));
-
     let hls = reel::hls::HlsManager::new(
         store.clone(),
         cfg.encode_concurrency,
@@ -31,6 +25,13 @@ async fn main() -> anyhow::Result<()> {
         cfg.hls_segment_secs as u32,
         cfg.hls_enabled,
     );
+
+    tokio::spawn(reaper::reap_loop(
+        eng.clone(),
+        hls.clone(),
+        cfg.ttl_secs,
+        cfg.reap_interval_secs,
+    ));
 
     let app = api::router(api::AppState {
         engine: eng,

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -24,12 +24,22 @@ async fn main() -> anyhow::Result<()> {
         cfg.reap_interval_secs,
     ));
 
+    let hls = reel::hls::HlsManager::new(
+        store.clone(),
+        cfg.encode_concurrency,
+        cfg.ffmpeg_bin.clone(),
+        cfg.hls_segment_secs as u32,
+        cfg.hls_enabled,
+    );
+
     let app = api::router(api::AppState {
         engine: eng,
         store,
         token: cfg.api_token.clone(),
         transcoder,
         stream_enabled: cfg.stream_enabled,
+        hls,
+        ffprobe_bin: cfg.ffprobe_bin.clone(),
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -27,7 +27,7 @@ pub async fn reap_loop(engine: crate::engine::Engine, ttl_secs: u64, interval_se
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Metadata, TorrentState, TranscodeStatus};
+    use crate::state::{HlsStatus, Metadata, TorrentState, TranscodeStatus};
 
     fn meta(id: &str, last_access: u64) -> Metadata {
         Metadata {
@@ -35,6 +35,7 @@ mod tests {
             size: 1, completed_at: Some(last_access), last_access,
             state: TorrentState::Seeding,
             transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
+            hls: HlsStatus::None, hls_dir: None, hls_error: None,
         }
     }
 

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -1,7 +1,8 @@
 use crate::state;
 
 pub fn select_expired(items: &[state::Metadata], ttl_secs: u64, now: u64) -> Vec<String> {
-    items.iter()
+    items
+        .iter()
         .filter(|m| now.saturating_sub(m.last_access) > ttl_secs)
         .map(|m| m.id.clone())
         .collect()
@@ -14,12 +15,22 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-pub async fn reap_loop(engine: crate::engine::Engine, ttl_secs: u64, interval_secs: u64) {
+pub async fn reap_loop(
+    engine: crate::engine::Engine,
+    hls: crate::hls::HlsManager,
+    ttl_secs: u64,
+    interval_secs: u64,
+) {
     let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
     loop {
         ticker.tick().await;
-        if let Err(e) = engine.reap_expired(ttl_secs, now_secs()).await {
-            tracing::error!(error = %e, "reap cycle failed");
+        match engine.reap_expired(ttl_secs, now_secs()).await {
+            Ok(reaped) => {
+                for id in reaped {
+                    hls.abort(&id).await;
+                }
+            }
+            Err(e) => tracing::error!(error = %e, "reap cycle failed"),
         }
     }
 }
@@ -31,11 +42,19 @@ mod tests {
 
     fn meta(id: &str, last_access: u64) -> Metadata {
         Metadata {
-            id: id.into(), name: id.into(), path: format!("/lib/{id}"),
-            size: 1, completed_at: Some(last_access), last_access,
+            id: id.into(),
+            name: id.into(),
+            path: format!("/lib/{id}"),
+            size: 1,
+            completed_at: Some(last_access),
+            last_access,
             state: TorrentState::Seeding,
-            transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
-            hls: HlsStatus::None, hls_dir: None, hls_error: None,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
         }
     }
 

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -8,6 +8,9 @@ pub enum TorrentState { Queued, Leeching, Seeding, Reaped }
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub enum TranscodeStatus { #[default] None, Pending, Remuxing, Encoding, Ready, Failed }
 
+#[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub enum HlsStatus { #[default] None, Starting, Live, Ready, Failed }
+
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Metadata {
     pub id: String,
@@ -23,6 +26,12 @@ pub struct Metadata {
     pub transcode_path: Option<String>,
     #[serde(default)]
     pub transcode_error: Option<String>,
+    #[serde(default)]
+    pub hls: HlsStatus,
+    #[serde(default)]
+    pub hls_dir: Option<String>,
+    #[serde(default)]
+    pub hls_error: Option<String>,
 }
 
 #[derive(Clone)]
@@ -109,6 +118,7 @@ mod tests {
             size: 10, completed_at: Some(last_access), last_access,
             state: TorrentState::Seeding,
             transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
+            hls: HlsStatus::None, hls_dir: None, hls_error: None,
         }
     }
 
@@ -192,5 +202,18 @@ mod tests {
         assert_eq!(m.transcode, TranscodeStatus::None);
         assert!(m.transcode_path.is_none());
         assert!(m.transcode_error.is_none());
+    }
+
+    #[test]
+    fn old_json_without_hls_fields_loads_with_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        let legacy = r#"{"1":{"id":"1","name":"m","path":"/lib/m","size":3,"completed_at":10,"last_access":10,"state":"Seeding"}}"#;
+        std::fs::write(&p, legacy).unwrap();
+        let s = StateStore::load(p).unwrap();
+        let m = s.get("1").unwrap();
+        assert_eq!(m.hls, HlsStatus::None);
+        assert!(m.hls_dir.is_none());
+        assert!(m.hls_error.is_none());
     }
 }

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -369,7 +369,7 @@ mod tests {
 #[cfg(test)]
 mod transcoder_tests {
     use super::*;
-    use crate::state::{Metadata, StateStore, TorrentState, TranscodeStatus};
+    use crate::state::{HlsStatus, Metadata, StateStore, TorrentState, TranscodeStatus};
 
     fn meta(id: &str, transcode: TranscodeStatus) -> Metadata {
         Metadata {
@@ -383,6 +383,9 @@ mod transcoder_tests {
             transcode,
             transcode_path: None,
             transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
         }
     }
 

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -8,6 +8,7 @@ use tokio::sync::Semaphore;
 pub struct ProbeResult {
     pub video_codec: Option<String>,
     pub audio_codec: Option<String>,
+    pub container: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16,11 +17,31 @@ pub enum Route {
     Encode,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Delivery {
+    RawProgressive,
+    RemuxHls,
+    TranscodeHls,
+}
+
 pub fn decide_route(p: &ProbeResult) -> Route {
     if p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac") {
         Route::Remux
     } else {
         Route::Encode
+    }
+}
+
+pub fn decide_delivery(p: &ProbeResult) -> Delivery {
+    let compat_codecs = p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac");
+    if !compat_codecs {
+        return Delivery::TranscodeHls;
+    }
+    let is_mp4 = p.container.as_deref().map(|c| c.contains("mp4")).unwrap_or(false);
+    if is_mp4 {
+        Delivery::RawProgressive
+    } else {
+        Delivery::RemuxHls
     }
 }
 
@@ -58,7 +79,7 @@ pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
 
 pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult> {
     let out = Command::new(ffprobe_bin)
-        .args(["-v", "quiet", "-print_format", "json", "-show_streams"])
+        .args(["-v", "quiet", "-print_format", "json", "-show_streams", "-show_format"])
         .arg(path)
         .output()
         .await?;
@@ -79,7 +100,12 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
             }
         }
     }
-    Ok(ProbeResult { video_codec: video, audio_codec: audio })
+    let container = json
+        .get("format")
+        .and_then(|f| f.get("format_name"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    Ok(ProbeResult { video_codec: video, audio_codec: audio, container })
 }
 
 async fn run_ffmpeg(ffmpeg_bin: &str, args: &[&str], src: &Path, dest: &Path) -> anyhow::Result<()> {
@@ -273,24 +299,56 @@ impl Transcoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn pr(v: Option<&str>, a: Option<&str>) -> ProbeResult {
-        ProbeResult { video_codec: v.map(String::from), audio_codec: a.map(String::from) }
+    fn pr(v: Option<&str>, a: Option<&str>, c: Option<&str>) -> ProbeResult {
+        ProbeResult { video_codec: v.map(String::from), audio_codec: a.map(String::from), container: c.map(String::from) }
     }
     #[test]
     fn h264_aac_remuxes() {
-        assert_eq!(decide_route(&pr(Some("h264"), Some("aac"))), Route::Remux);
+        assert_eq!(decide_route(&pr(Some("h264"), Some("aac"), None)), Route::Remux);
     }
     #[test]
     fn hevc_encodes() {
-        assert_eq!(decide_route(&pr(Some("hevc"), Some("aac"))), Route::Encode);
+        assert_eq!(decide_route(&pr(Some("hevc"), Some("aac"), None)), Route::Encode);
     }
     #[test]
     fn non_aac_audio_encodes() {
-        assert_eq!(decide_route(&pr(Some("h264"), Some("ac3"))), Route::Encode);
+        assert_eq!(decide_route(&pr(Some("h264"), Some("ac3"), None)), Route::Encode);
     }
     #[test]
     fn missing_codecs_encode() {
-        assert_eq!(decide_route(&pr(None, None)), Route::Encode);
+        assert_eq!(decide_route(&pr(None, None, None)), Route::Encode);
+    }
+    #[test]
+    fn mp4_h264_aac_is_raw() {
+        assert_eq!(
+            decide_delivery(&pr(Some("h264"), Some("aac"), Some("mov,mp4,m4a,3gp,3g2,mj2"))),
+            Delivery::RawProgressive
+        );
+    }
+    #[test]
+    fn mkv_h264_aac_is_remux_hls() {
+        assert_eq!(
+            decide_delivery(&pr(Some("h264"), Some("aac"), Some("matroska,webm"))),
+            Delivery::RemuxHls
+        );
+    }
+    #[test]
+    fn hevc_is_transcode_hls() {
+        assert_eq!(
+            decide_delivery(&pr(Some("hevc"), Some("aac"), Some("matroska,webm"))),
+            Delivery::TranscodeHls
+        );
+    }
+    #[test]
+    fn non_aac_is_transcode_hls() {
+        assert_eq!(
+            decide_delivery(&pr(Some("h264"), Some("ac3"), Some("mov,mp4,m4a"))),
+            Delivery::TranscodeHls
+        );
+    }
+    #[test]
+    fn missing_is_transcode_hls() {
+        assert_eq!(decide_delivery(&pr(None, None, None)), Delivery::TranscodeHls);
     }
     #[test]
     fn picks_largest_file() {

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -33,11 +33,16 @@ pub fn decide_route(p: &ProbeResult) -> Route {
 }
 
 pub fn decide_delivery(p: &ProbeResult) -> Delivery {
-    let compat_codecs = p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac");
+    let compat_codecs =
+        p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac");
     if !compat_codecs {
         return Delivery::TranscodeHls;
     }
-    let is_mp4 = p.container.as_deref().map(|c| c.contains("mp4")).unwrap_or(false);
+    let is_mp4 = p
+        .container
+        .as_deref()
+        .map(|c| c.contains("mp4"))
+        .unwrap_or(false);
     if is_mp4 {
         Delivery::RawProgressive
     } else {
@@ -56,6 +61,14 @@ pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
             let entry = entry?;
             let path = entry.path();
             if path.is_dir() {
+                let is_hls_dir = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n == "hls")
+                    .unwrap_or(false);
+                if is_hls_dir {
+                    continue;
+                }
                 stack.push(path);
             } else {
                 let is_reel_output = path
@@ -79,7 +92,14 @@ pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
 
 pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult> {
     let out = Command::new(ffprobe_bin)
-        .args(["-v", "quiet", "-print_format", "json", "-show_streams", "-show_format"])
+        .args([
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_streams",
+            "-show_format",
+        ])
         .arg(path)
         .output()
         .await?;
@@ -92,7 +112,10 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
     if let Some(streams) = json.get("streams").and_then(|s| s.as_array()) {
         for s in streams {
             let kind = s.get("codec_type").and_then(|v| v.as_str());
-            let codec = s.get("codec_name").and_then(|v| v.as_str()).map(String::from);
+            let codec = s
+                .get("codec_name")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             match kind {
                 Some("video") if video.is_none() => video = codec,
                 Some("audio") if audio.is_none() => audio = codec,
@@ -105,10 +128,19 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
         .and_then(|f| f.get("format_name"))
         .and_then(|v| v.as_str())
         .map(String::from);
-    Ok(ProbeResult { video_codec: video, audio_codec: audio, container })
+    Ok(ProbeResult {
+        video_codec: video,
+        audio_codec: audio,
+        container,
+    })
 }
 
-async fn run_ffmpeg(ffmpeg_bin: &str, args: &[&str], src: &Path, dest: &Path) -> anyhow::Result<()> {
+async fn run_ffmpeg(
+    ffmpeg_bin: &str,
+    args: &[&str],
+    src: &Path,
+    dest: &Path,
+) -> anyhow::Result<()> {
     let mut cmd = Command::new(ffmpeg_bin);
     cmd.arg("-y")
         .arg("-nostats")
@@ -126,7 +158,13 @@ async fn run_ffmpeg(ffmpeg_bin: &str, args: &[&str], src: &Path, dest: &Path) ->
 }
 
 pub async fn remux(ffmpeg_bin: &str, src: &Path, dest: &Path) -> anyhow::Result<()> {
-    run_ffmpeg(ffmpeg_bin, &["-c", "copy", "-movflags", "+faststart"], src, dest).await
+    run_ffmpeg(
+        ffmpeg_bin,
+        &["-c", "copy", "-movflags", "+faststart"],
+        src,
+        dest,
+    )
+    .await
 }
 
 pub async fn encode(ffmpeg_bin: &str, src: &Path, dest: &Path) -> anyhow::Result<()> {
@@ -300,19 +338,32 @@ impl Transcoder {
 mod tests {
     use super::*;
     fn pr(v: Option<&str>, a: Option<&str>, c: Option<&str>) -> ProbeResult {
-        ProbeResult { video_codec: v.map(String::from), audio_codec: a.map(String::from), container: c.map(String::from) }
+        ProbeResult {
+            video_codec: v.map(String::from),
+            audio_codec: a.map(String::from),
+            container: c.map(String::from),
+        }
     }
     #[test]
     fn h264_aac_remuxes() {
-        assert_eq!(decide_route(&pr(Some("h264"), Some("aac"), None)), Route::Remux);
+        assert_eq!(
+            decide_route(&pr(Some("h264"), Some("aac"), None)),
+            Route::Remux
+        );
     }
     #[test]
     fn hevc_encodes() {
-        assert_eq!(decide_route(&pr(Some("hevc"), Some("aac"), None)), Route::Encode);
+        assert_eq!(
+            decide_route(&pr(Some("hevc"), Some("aac"), None)),
+            Route::Encode
+        );
     }
     #[test]
     fn non_aac_audio_encodes() {
-        assert_eq!(decide_route(&pr(Some("h264"), Some("ac3"), None)), Route::Encode);
+        assert_eq!(
+            decide_route(&pr(Some("h264"), Some("ac3"), None)),
+            Route::Encode
+        );
     }
     #[test]
     fn missing_codecs_encode() {
@@ -321,7 +372,11 @@ mod tests {
     #[test]
     fn mp4_h264_aac_is_raw() {
         assert_eq!(
-            decide_delivery(&pr(Some("h264"), Some("aac"), Some("mov,mp4,m4a,3gp,3g2,mj2"))),
+            decide_delivery(&pr(
+                Some("h264"),
+                Some("aac"),
+                Some("mov,mp4,m4a,3gp,3g2,mj2")
+            )),
             Delivery::RawProgressive
         );
     }
@@ -348,21 +403,30 @@ mod tests {
     }
     #[test]
     fn missing_is_transcode_hls() {
-        assert_eq!(decide_delivery(&pr(None, None, None)), Delivery::TranscodeHls);
+        assert_eq!(
+            decide_delivery(&pr(None, None, None)),
+            Delivery::TranscodeHls
+        );
     }
     #[test]
     fn picks_largest_file() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("small.mkv"), b"aa").unwrap();
         std::fs::write(dir.path().join("big.mkv"), b"aaaaaaaa").unwrap();
-        assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("big.mkv"));
+        assert_eq!(
+            pick_primary_file(dir.path()).unwrap(),
+            dir.path().join("big.mkv")
+        );
     }
     #[test]
     fn excludes_stale_reel_output() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("big.reel.mp4"), b"aaaaaaaa").unwrap();
         std::fs::write(dir.path().join("movie.mkv"), b"aa").unwrap();
-        assert_eq!(pick_primary_file(dir.path()).unwrap(), dir.path().join("movie.mkv"));
+        assert_eq!(
+            pick_primary_file(dir.path()).unwrap(),
+            dir.path().join("movie.mkv")
+        );
     }
 }
 
@@ -436,29 +500,36 @@ mod transcoder_tests {
     async fn new_resets_in_flight_to_failed() {
         let dir = tempfile::tempdir().unwrap();
         let store = StateStore::load(dir.path().join("state.json")).unwrap();
-        store.upsert(meta("pending", TranscodeStatus::Pending)).unwrap();
-        store.upsert(meta("encoding", TranscodeStatus::Encoding)).unwrap();
+        store
+            .upsert(meta("pending", TranscodeStatus::Pending))
+            .unwrap();
+        store
+            .upsert(meta("encoding", TranscodeStatus::Encoding))
+            .unwrap();
         store.upsert(meta("ready", TranscodeStatus::Ready)).unwrap();
         store.upsert(meta("none", TranscodeStatus::None)).unwrap();
 
-        let _transcoder = Transcoder::new(
-            store.clone(),
-            1,
-            1,
-            "ffmpeg".into(),
-            "ffprobe".into(),
-            true,
-        );
+        let _transcoder =
+            Transcoder::new(store.clone(), 1, 1, "ffmpeg".into(), "ffprobe".into(), true);
 
         let pending = store.get("pending").unwrap();
         assert_eq!(pending.transcode, TranscodeStatus::Failed);
-        assert_eq!(pending.transcode_error.as_deref(), Some("interrupted by restart"));
+        assert_eq!(
+            pending.transcode_error.as_deref(),
+            Some("interrupted by restart")
+        );
 
         let encoding = store.get("encoding").unwrap();
         assert_eq!(encoding.transcode, TranscodeStatus::Failed);
-        assert_eq!(encoding.transcode_error.as_deref(), Some("interrupted by restart"));
+        assert_eq!(
+            encoding.transcode_error.as_deref(),
+            Some("interrupted by restart")
+        );
 
-        assert_eq!(store.get("ready").unwrap().transcode, TranscodeStatus::Ready);
+        assert_eq!(
+            store.get("ready").unwrap().transcode,
+            TranscodeStatus::Ready
+        );
         assert_eq!(store.get("none").unwrap().transcode, TranscodeStatus::None);
     }
 }

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -1,0 +1,88 @@
+#[tokio::test]
+#[ignore = "requires ffmpeg"]
+async fn hls_transcode_integration() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("clip.mkv");
+
+    let status = std::process::Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=duration=1:size=128x128:rate=15",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-c:v",
+            "libx265",
+            "-c:a",
+            "aac",
+            "-shortest",
+        ])
+        .arg(&src)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let state_file = dir.path().join("state.json");
+    let store = reel::state::StateStore::load(state_file).unwrap();
+
+    let entry = reel::state::Metadata {
+        id: "test-hls".to_string(),
+        name: "test-clip".to_string(),
+        path: dir.path().display().to_string(),
+        size: 1024,
+        completed_at: Some(0),
+        last_access: 0,
+        state: reel::state::TorrentState::Seeding,
+        transcode: reel::state::TranscodeStatus::None,
+        transcode_path: None,
+        transcode_error: None,
+        hls: reel::state::HlsStatus::None,
+        hls_dir: None,
+        hls_error: None,
+    };
+    store.upsert(entry).unwrap();
+
+    let mgr = reel::hls::HlsManager::new(store.clone(), 1, "ffmpeg".into(), 4, true);
+    let outcome = mgr
+        .request("test-hls", reel::transcode::Delivery::TranscodeHls)
+        .await;
+    assert_eq!(outcome, reel::hls::StartOutcome::Started);
+
+    let hls_dir = dir.path().join("hls");
+    let index = hls_dir.join("index.m3u8");
+
+    for _ in 0..120 {
+        if index.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    assert!(index.exists(), "index.m3u8 not found");
+
+    let segments: Vec<_> = std::fs::read_dir(&hls_dir)
+        .unwrap()
+        .filter_map(|e| {
+            e.ok().and_then(|ent| {
+                let name = ent.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with("seg") && name_str.ends_with(".ts") {
+                    Some(ent.path())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    assert!(!segments.is_empty(), "no segment files found");
+
+    let manifest = std::fs::read_to_string(&index).unwrap();
+    assert!(
+        manifest.contains(".ts"),
+        "manifest does not reference .ts segments"
+    );
+}


### PR DESCRIPTION
## reel Phase 3A — HLS Delivery Routing

Builds on Phase 1 + 2A + 2B (merged). Makes reel play **every** file type in a browser by routing each source to the cheapest correct delivery, adding live HLS for what raw progressive streaming can't cover.

### Delivery routing (ffprobe → `decide_delivery`)
| Source | Delivery | Mechanism |
|---|---|---|
| H.264 + AAC in mp4 | `RawProgressive` | 2B `/stream` |
| H.264 + AAC, other container (mkv…) | `RemuxHls` | ffmpeg `-c copy -f hls` (no re-encode) |
| HEVC / AV1 / VP9 / non-AAC / unknown | `TranscodeHls` | ffmpeg libx264/aac `-f hls` |

### What's added
- **Container-aware probe** (`-show_format`) + pure 3-way `decide_delivery`.
- **`HlsManager`** — spawns ONE live ffmpeg (`-f hls`, event playlist) into `<library>/<id>/hls/`, idempotent per id (atomic `StateStore::update` — concurrent polls can't double-spawn), encode-semaphore-bounded, and **abortable** (killed on manual delete AND reap so no orphan ffmpeg writes into a deleted dir).
- **Endpoints**: `GET /torrents/{id}/manifest.m3u8` (starts session; 202 while starting, serves `index.m3u8` when Live/Ready; 409 raw / 425 not-complete / 503 disabled) and `GET /torrents/{id}/hls/{segment}` (strict path-traversal allowlist before any fs access, `serve_range`).
- `hls` status on `Metadata` (serde-default, back-compat); HLS output inside `m.path` → reaped with the entry.

### Robustness (review-driven)
- `hls_dir` set at directory creation (not in a timing-sensitive poll) — a slow first segment can't strand a completed stream on 202.
- Manifest checks `hls` status first + caches delivery → ffprobe runs **at most once per id**, never on repeat player polls.
- Retry clears stale `hls/`; `pick_primary_file` skips the `hls/` dir; ffmpeg `-nostats -loglevel error`.

### Testing
83 unit tests (delivery routing, segment-name guard, HLS idempotency/transitions, manifest status codes incl. engine-free 425/503/404/live-serve, delivery cache). 4 `#[ignore]` integration (Phase 1/2A/2B + new real-ffmpeg HEVC→HLS). 0 warnings.

### Process
Subagent-driven, TDD per task, per-task + opus whole-branch review. Fixes: manifest 425-before-probe, hls_dir stranding (Critical), per-poll re-probe (Important), retry/pick hardening.

### Deferred (documented)
- `delivery` not on the detail route — the 3B player routes off the manifest endpoint (409 raw / 202→200 hls).
- Progressive HLS mid-download for incompatible codecs (non-seekable growing input); available once complete.
- Separate encode semaphore (2× 2A bound), reap abort-after-delete ordering, segment `last_access` — minor/self-limiting.
- **Docker/k8s not validated in worktree** — CI/cluster.

### Next
**Phase 3B:** astro-kbve player UI (hls.js), reads the manifest endpoint to pick `<video src=/stream>` (raw) vs HLS.
