### PR TITLE
feat(graphify): weekly tiered-graph freshness pipeline

### DIFF
--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -3,6 +3,7 @@ name: Daily Content
 on:
     schedule:
         - cron: '0 1 * * *'
+        - cron: '0 2 * * 1'
     workflow_dispatch:
         inputs:
             route:
@@ -56,9 +57,13 @@ jobs:
             - name: Plan routes
               id: plan
               working-directory: packages/python/kbve
+              env:
+                  SCHEDULE: ${{ github.event.schedule }}
               run: |
                   if [ -n "${{ github.event.inputs.route }}" ]; then
                     uv run kbve-nx-router --route "${{ github.event.inputs.route }}" --json
+                  elif [ "$SCHEDULE" = "0 2 * * 1" ]; then
+                    uv run kbve-nx-router --cadence weekly --json
                   else
                     uv run kbve-nx-router --cadence "${{ github.event.inputs.cadence || 'daily' }}" --json
                   fi
@@ -144,6 +149,14 @@ jobs:
                   pip install pip-audit
                   echo "pip-audit installed: $(pip-audit --version)"
 
+            - name: Install graphify CLI
+              if: contains(matrix.needs, 'graphify')
+              run: |
+                  set -euo pipefail
+                  uv tool install 'graphifyy<1.0'
+                  echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+                  graphify --version
+
             - name: Install protoc
               if: contains(matrix.needs, 'protoc')
               run: |
@@ -173,7 +186,7 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-                  git add apps/kbve/astro-kbve/src/content/docs apps/kbve/astro-kbve/public/data/nx apps/kbve/astro-kbve/src/data
+                  git add apps/kbve/astro-kbve/src/content/docs apps/kbve/astro-kbve/public/data/nx apps/kbve/astro-kbve/src/data apps/kbve/astro-kbve/public/graphify
                   if git diff --cached --quiet; then
                     echo "::notice::No pending changes for route ${{ matrix.route }} — nothing to commit."
                     exit 0

--- a/packages/data/graphify/scripts/build-tiered-graph.sh
+++ b/packages/data/graphify/scripts/build-tiered-graph.sh
@@ -28,7 +28,10 @@ graphify cluster-only "$ROOT" --no-viz --no-label
 
 echo "📐 [3/3] precomputing tiered LOD layout…"
 rm -rf "$OUT"
-uv run --with networkx --with numpy --with scipy python \
+# Pin the scientific stack: the force layout (spring/forceatlas2, seed 1337) is
+# only reproducible for a fixed networkx/numpy/scipy — floating them churns node
+# coordinates on every rebuild and buries real code changes in layout noise.
+uv run --with 'networkx==3.4.2' --with 'numpy==2.2.6' --with 'scipy==1.15.3' python \
 	"$SCRIPT_DIR/graphify_tiered.py" "$GRAPH" "$OUT"
 
 echo "✅ wrote $OUT"

--- a/packages/python/graphify-wrapper/project.json
+++ b/packages/python/graphify-wrapper/project.json
@@ -79,6 +79,17 @@
 			},
 			"description": "Build knowledge graph for specific app (use --app=<name>)"
 		},
+		"build-tiered": {
+			"executor": "@nxlv/python:run-commands",
+			"outputs": [
+				"{workspaceRoot}/apps/kbve/astro-kbve/public/graphify"
+			],
+			"options": {
+				"command": "bash ../../data/graphify/scripts/build-tiered-graph.sh",
+				"cwd": "packages/python/graphify-wrapper"
+			},
+			"description": "Rebuild tiered LOD graph consumed by the dashboard Graph Explorer"
+		},
 		"query": {
 			"executor": "@nxlv/python:run-commands",
 			"options": {

--- a/packages/python/kbve/kbve/nx/routes/__init__.py
+++ b/packages/python/kbve/kbve/nx/routes/__init__.py
@@ -10,3 +10,4 @@ from . import ci_health  # noqa: F401
 from . import deps  # noqa: F401
 from . import activity  # noqa: F401
 from . import releases  # noqa: F401
+from . import graphify  # noqa: F401

--- a/packages/python/kbve/kbve/nx/routes/graphify.py
+++ b/packages/python/kbve/kbve/nx/routes/graphify.py
@@ -1,0 +1,68 @@
+"""The ``graphify`` route — rebuild the tiered semantic knowledge graph.
+
+Re-extracts code symbols and precomputes the directory→file→symbol LOD chunks
+consumed by the dashboard Graph Explorer (and derived by the
+``/api/graphify/monorepo.json`` endpoint). Delegates to the
+``graphify-wrapper:build-tiered`` nx target, which pins networkx/numpy/scipy so
+the force layout is deterministic — the graph moves only when code changes, not
+when a dependency floats.
+
+Registered on the ``weekly`` cadence: a monorepo-wide symbol re-extraction is
+too heavy for nightly, and the layout changes slowly. The first weekly run may
+emit a one-time coordinate-shift PR if today's committed graph was generated
+with different networkx/numpy/scipy versions than the pinned set; it is stable
+after that.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ..builder import BuildContext, BuildResult, PlanResult, repo_root_for
+from ..router import route
+
+_BUILD_TIMEOUT = 1800
+
+_DEFAULT_CMD = ["pnpm", "nx", "run", "graphify-wrapper:build-tiered"]
+
+
+def _warn(msg: str) -> None:
+    print("::warning::graphify route: %s" % msg, file=sys.stderr)
+
+
+@route("graphify", "weekly", needs=("node", "graphify"))
+class GraphifyRoute:
+    def plan(self, ctx: BuildContext) -> PlanResult:
+        return PlanResult(
+            "graphify",
+            True,
+            "rebuild tiered graph (git-diff guard drops no-ops)",
+            [],
+        )
+
+    def build(self, ctx: BuildContext) -> BuildResult:
+        repo_root = repo_root_for(ctx.content_root)
+        out_dir = repo_root / "apps" / "kbve" / "astro-kbve" / "public" / "graphify"
+        cmd = ctx.inputs.get("build_cmd") or _DEFAULT_CMD
+
+        if not ctx.dry_run:
+            try:
+                subprocess.run(
+                    cmd,
+                    cwd=str(repo_root),
+                    check=True,
+                    timeout=_BUILD_TIMEOUT,
+                )
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                OSError,
+            ) as exc:
+                _warn("tiered rebuild failed (%s) — skipping" % exc)
+                return BuildResult("graphify", [], True, "build failed: %s" % exc)
+
+        changed = [os.path.relpath(out_dir, repo_root)]
+        return BuildResult("graphify", changed, False, "rebuilt tiered graph")

--- a/packages/python/kbve/tests/test_nx_graphify_route.py
+++ b/packages/python/kbve/tests/test_nx_graphify_route.py
@@ -1,0 +1,72 @@
+"""Tests for the ``graphify`` route (tiered-graph rebuild).
+
+The rebuild subprocess is bypassed via ``inputs["build_cmd"]`` so the test
+never needs the ``graphify`` CLI or the pnpm/nx toolchain.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kbve.nx.builder import BuildContext, repo_root_for
+from kbve.nx.router import get
+
+
+def _ctx(tmp_path, inputs):
+    content_root = tmp_path / "content" / "docs"
+    content_root.mkdir(parents=True)
+    return BuildContext(
+        content_root=content_root,
+        timestamp="2026-07-22T00:00:00Z",
+        inputs=inputs,
+    )
+
+
+def _out_dir(ctx) -> Path:
+    repo_root = repo_root_for(ctx.content_root)
+    return repo_root / "apps" / "kbve" / "astro-kbve" / "public" / "graphify"
+
+
+def test_graphify_needs_tags():
+    assert get("graphify").needs == ("node", "graphify")
+
+
+def test_graphify_plan_needs_work(tmp_path):
+    plan = get("graphify").plan(_ctx(tmp_path, {}))
+    assert plan.needs_work is True
+
+
+def test_graphify_build_reports_output_on_success(tmp_path):
+    ctx = _ctx(tmp_path, {})
+    out_dir = _out_dir(ctx)
+    ctx.inputs["build_cmd"] = [
+        "bash",
+        "-c",
+        'mkdir -p "%s" && printf "{}" > "%s/overview.json"'
+        % (out_dir, out_dir),
+    ]
+
+    result = get("graphify").build(ctx)
+
+    assert result.skipped is False
+    assert result.route == "graphify"
+    assert (out_dir / "overview.json").exists()
+    assert any("public/graphify" in c for c in result.changed)
+
+
+def test_graphify_build_skips_gracefully_on_failure(tmp_path):
+    ctx = _ctx(tmp_path, {"build_cmd": ["false"]})
+
+    result = get("graphify").build(ctx)
+
+    assert result.skipped is True
+    assert result.changed == []
+
+
+def test_graphify_build_dry_run_does_not_invoke(tmp_path):
+    ctx = _ctx(tmp_path, {"build_cmd": ["false"]})
+    ctx.dry_run = True
+
+    result = get("graphify").build(ctx)
+
+    assert result.skipped is False


### PR DESCRIPTION
## What

Long-term freshness system for the monorepo semantic knowledge graph consumed by the dashboard **Graph Explorer** and derived by `/api/graphify/monorepo.json`.

## Changes

| Area | Change |
|------|--------|
| Determinism | Pin `networkx==3.4.2` / `numpy==2.2.6` / `scipy==1.15.3` in `build-tiered-graph.sh` so the seeded (1337) force layout is reproducible — node coords move on **code** changes, not dependency drift |
| Nx | New `graphify-wrapper:build-tiered` target (`outputs: [public/graphify]`) wrapping the tiered rebuild script |
| Router | New **weekly** `graphify` route (`needs: node, graphify`); rebuilds tiered LOD data, reports changes, and catches subprocess failure so a missing CLI **no-ops** instead of crashing CI |
| CI | Folded into `ci-daily-content`: weekly cron `0 2 * * 1`, `schedule`→cadence map, graphify CLI install step, and `public/graphify` staged in the sync PR |

## Notes

- **ETag was intentionally not added** — the endpoint prerenders to a static file under `output: 'static'`; the static host already emits a content-hash ETag + 304. Handler ETag code would be dead. Explicit `immutable`/long-max-age is a CDN concern, not app code.
- **First weekly run** may emit a one-time coordinate-shift PR if today's committed `overview.json` was generated with different lib versions than the pins; stable after (documented in the route docstring).

## Tests

`nx run kbve:test` — 372 pass, incl. 5 new `test_nx_graphify_route.py` covering needs tags, plan, success/failure/dry-run build paths. YAML validated; `weekly` cadence resolves to `['graphify']`.