### PR TITLE
feat(desktop-kbve): phase C — Onichan local LLM/TTS/memory assistant

### DIFF
--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/memory.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/memory.rs
@@ -1,0 +1,177 @@
+//! Memory management commands for the frontend
+
+use crate::memory::{EmbeddingModelInfo, MemoryManager, MemoryMessage, MemoryUserInfo};
+use log::info;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::sync::Arc;
+use tauri::{AppHandle, Manager};
+use tokio::task::spawn_blocking;
+
+/// Status information about the memory system
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct MemoryStatus {
+    pub is_running: bool,
+    pub model_loaded: bool,
+    pub total_memories: usize,
+}
+
+/// Get the current status of the memory system
+#[tauri::command]
+#[specta::specta]
+pub fn get_memory_status(app: AppHandle) -> Result<MemoryStatus, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>();
+
+    // Check if sidecar is running by attempting a status query
+    let is_running = memory_manager.is_running();
+
+    Ok(MemoryStatus {
+        is_running,
+        model_loaded: is_running, // Model is loaded if sidecar is running
+        total_memories: 0,        // Will be updated when we have count_all
+    })
+}
+
+/// Query memories semantically (for all users)
+#[tauri::command]
+#[specta::specta]
+pub async fn query_all_memories(
+    app: AppHandle,
+    query: String,
+    limit: usize,
+) -> Result<Vec<MemoryMessage>, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Querying all memories with: {}", query);
+
+    spawn_blocking(move || memory_manager.query_all(&query, limit))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Get total count of all memories
+/// Note: Returns 0 if sidecar is not running to avoid spawning it just to check count
+#[tauri::command]
+#[specta::specta]
+pub fn get_memory_count(app: AppHandle) -> Result<usize, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>();
+
+    // Only get count if sidecar is already running to avoid spawning it
+    // (which would load the embedding model and potentially cause memory pressure)
+    if !memory_manager.is_running() {
+        return Ok(0);
+    }
+
+    memory_manager.get_total_count()
+}
+
+/// Clear all memories
+#[tauri::command]
+#[specta::specta]
+pub async fn clear_all_memories(app: AppHandle) -> Result<u32, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Clearing all memories");
+    spawn_blocking(move || memory_manager.clear_all())
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Cleanup old memories based on TTL
+#[tauri::command]
+#[specta::specta]
+pub async fn cleanup_old_memories(app: AppHandle, ttl_days: u32) -> Result<u32, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Cleaning up memories older than {} days", ttl_days);
+    spawn_blocking(move || memory_manager.cleanup_expired(ttl_days))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// List available embedding models
+#[tauri::command]
+#[specta::specta]
+pub async fn list_embedding_models(app: AppHandle) -> Result<Vec<EmbeddingModelInfo>, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Listing available embedding models");
+    spawn_blocking(move || memory_manager.list_models())
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Load an embedding model by ID
+#[tauri::command]
+#[specta::specta]
+pub async fn load_embedding_model(app: AppHandle, model_id: String) -> Result<String, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Loading embedding model: {}", model_id);
+    spawn_blocking(move || memory_manager.load_model(&model_id))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Get the currently loaded embedding model
+#[tauri::command]
+#[specta::specta]
+pub async fn get_current_embedding_model(
+    app: AppHandle,
+) -> Result<Option<EmbeddingModelInfo>, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    spawn_blocking(move || memory_manager.get_current_model())
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Stop the memory sidecar
+#[tauri::command]
+#[specta::specta]
+pub async fn stop_memory_sidecar(app: AppHandle) -> Result<(), String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Stopping memory sidecar");
+    spawn_blocking(move || {
+        memory_manager.shutdown();
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?;
+    Ok(())
+}
+
+/// Browse recent memories without semantic search
+/// Supports filtering by user_id and is_bot
+#[tauri::command]
+#[specta::specta]
+pub async fn browse_recent_memories(
+    app: AppHandle,
+    limit: usize,
+    user_id: Option<String>,
+    is_bot: Option<bool>,
+) -> Result<Vec<MemoryMessage>, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!(
+        "Browsing recent memories: limit={}, user={:?}, is_bot={:?}",
+        limit, user_id, is_bot
+    );
+
+    spawn_blocking(move || memory_manager.browse_recent(limit, user_id, is_bot))
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// List unique users with memory counts
+#[tauri::command]
+#[specta::specta]
+pub async fn list_memory_users(app: AppHandle) -> Result<Vec<MemoryUserInfo>, String> {
+    let memory_manager = app.state::<Arc<MemoryManager>>().inner().clone();
+
+    info!("Listing memory users");
+
+    spawn_blocking(move || memory_manager.list_users())
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
@@ -1,5 +1,8 @@
 pub mod audio;
+pub mod memory;
 pub mod models;
+pub mod onichan;
+pub mod sidecar_config;
 pub mod transcription;
 
 use crate::settings::{get_settings, AppSettings, SETTINGS_STORE_PATH};

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/onichan.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/onichan.rs
@@ -1,0 +1,233 @@
+use crate::local_llm::LocalLlmManager;
+use crate::local_tts::LocalTtsManager;
+use crate::onichan::{ConversationMessage, OnichanManager, OnichanMode};
+use crate::onichan_conversation::OnichanConversationManager;
+use crate::onichan_models::{OnichanModelInfo, OnichanModelManager};
+use crate::settings::get_settings;
+use std::sync::Arc;
+use tauri::{AppHandle, State};
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_enable(manager: State<'_, Arc<OnichanManager>>) {
+    manager.enable();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_disable(manager: State<'_, Arc<OnichanManager>>) {
+    manager.disable();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_is_active(manager: State<'_, Arc<OnichanManager>>) -> bool {
+    manager.is_active()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_get_mode(manager: State<'_, Arc<OnichanManager>>) -> OnichanMode {
+    manager.get_mode()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_set_mode(manager: State<'_, Arc<OnichanManager>>, mode: OnichanMode) {
+    manager.set_mode(mode);
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn onichan_process_input(
+    manager: State<'_, Arc<OnichanManager>>,
+    text: String,
+) -> Result<String, String> {
+    manager.process_input(text).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn onichan_speak(
+    manager: State<'_, Arc<OnichanManager>>,
+    text: String,
+) -> Result<(), String> {
+    manager.speak(&text).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_clear_history(manager: State<'_, Arc<OnichanManager>>) {
+    manager.clear_history();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_get_history(manager: State<'_, Arc<OnichanManager>>) -> Vec<ConversationMessage> {
+    manager.get_history()
+}
+
+// Model management commands
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_onichan_models(manager: State<'_, Arc<OnichanModelManager>>) -> Vec<OnichanModelInfo> {
+    manager.get_available_models()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_onichan_llm_models(
+    manager: State<'_, Arc<OnichanModelManager>>,
+) -> Vec<OnichanModelInfo> {
+    manager.get_llm_models()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_onichan_tts_models(
+    manager: State<'_, Arc<OnichanModelManager>>,
+) -> Vec<OnichanModelInfo> {
+    manager.get_tts_models()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn download_onichan_model(
+    manager: State<'_, Arc<OnichanModelManager>>,
+    model_id: String,
+) -> Result<(), String> {
+    manager
+        .download_model(&model_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn delete_onichan_model(
+    manager: State<'_, Arc<OnichanModelManager>>,
+    model_id: String,
+) -> Result<(), String> {
+    manager.delete_model(&model_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn load_local_llm(
+    model_manager: State<'_, Arc<OnichanModelManager>>,
+    llm_manager: State<'_, Arc<LocalLlmManager>>,
+    model_id: String,
+) -> Result<(), String> {
+    log::info!("load_local_llm command called with model_id: {}", model_id);
+
+    let model_path = model_manager.get_model_path(&model_id).map_err(|e| {
+        log::error!("Failed to get model path: {}", e);
+        e.to_string()
+    })?;
+
+    log::info!("Model path resolved to: {:?}", model_path);
+
+    // Load model synchronously (blocking) - tokio spawn_blocking causes crashes with llama-cpp
+    log::info!("Loading model synchronously...");
+    let result = llm_manager.load_model(&model_path);
+
+    match &result {
+        Ok(()) => log::info!("Model loaded successfully via command"),
+        Err(e) => log::error!("Model load failed: {}", e),
+    }
+
+    result
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn unload_local_llm(llm_manager: State<'_, Arc<LocalLlmManager>>) {
+    llm_manager.unload_model();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn is_local_llm_loaded(llm_manager: State<'_, Arc<LocalLlmManager>>) -> bool {
+    llm_manager.is_loaded()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_local_llm_model_name(llm_manager: State<'_, Arc<LocalLlmManager>>) -> Option<String> {
+    llm_manager.get_loaded_model_name()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn local_llm_chat(
+    llm_manager: State<'_, Arc<LocalLlmManager>>,
+    system_prompt: String,
+    user_message: String,
+    max_tokens: u32,
+) -> Result<String, String> {
+    llm_manager.chat(&system_prompt, &user_message, max_tokens)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn load_local_tts(
+    model_manager: State<'_, Arc<OnichanModelManager>>,
+    tts_manager: State<'_, Arc<LocalTtsManager>>,
+    model_id: String,
+) -> Result<(), String> {
+    let model_path = model_manager
+        .get_model_path(&model_id)
+        .map_err(|e| e.to_string())?;
+    tts_manager.load_model(&model_path)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn unload_local_tts(tts_manager: State<'_, Arc<LocalTtsManager>>) {
+    tts_manager.unload_model();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn is_local_tts_loaded(tts_manager: State<'_, Arc<LocalTtsManager>>) -> bool {
+    tts_manager.is_loaded()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn local_tts_speak(
+    app: AppHandle,
+    tts_manager: State<'_, Arc<LocalTtsManager>>,
+    text: String,
+) -> Result<(), String> {
+    let settings = get_settings(&app);
+    let volume = settings.audio_feedback_volume;
+    // Set the output device from settings before speaking
+    tts_manager.set_output_device(settings.selected_output_device.clone());
+    tts_manager.speak(&text, volume)
+}
+
+// Conversation mode commands
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_start_conversation(
+    conversation_manager: State<'_, Arc<OnichanConversationManager>>,
+) -> Result<(), String> {
+    conversation_manager.start()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_stop_conversation(conversation_manager: State<'_, Arc<OnichanConversationManager>>) {
+    conversation_manager.stop();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn onichan_is_conversation_running(
+    conversation_manager: State<'_, Arc<OnichanConversationManager>>,
+) -> bool {
+    conversation_manager.is_running()
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/sidecar_config.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/sidecar_config.rs
@@ -1,0 +1,78 @@
+//! Sidecar quick-start configuration persistence
+//!
+//! Stores the last-used model IDs and Discord connection details so the footer
+//! can offer one-click start/stop for each sidecar.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
+
+const SIDECAR_CONFIG_STORE: &str = "sidecar_config.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SidecarQuickConfig {
+    pub last_llm_model_id: Option<String>,
+    pub last_tts_model_id: Option<String>,
+    pub last_discord_guild_id: Option<String>,
+    pub last_discord_channel_id: Option<String>,
+    pub last_discord_guild_name: Option<String>,
+    pub last_discord_channel_name: Option<String>,
+    pub last_embedding_model_id: Option<String>,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_sidecar_quick_config(app: AppHandle) -> SidecarQuickConfig {
+    let store = match app.store(SIDECAR_CONFIG_STORE) {
+        Ok(s) => s,
+        Err(_) => return default_config(),
+    };
+
+    SidecarQuickConfig {
+        last_llm_model_id: read_string(&store, "last_llm_model_id"),
+        last_tts_model_id: read_string(&store, "last_tts_model_id"),
+        last_discord_guild_id: read_string(&store, "last_discord_guild_id"),
+        last_discord_channel_id: read_string(&store, "last_discord_channel_id"),
+        last_discord_guild_name: read_string(&store, "last_discord_guild_name"),
+        last_discord_channel_name: read_string(&store, "last_discord_channel_name"),
+        last_embedding_model_id: read_string(&store, "last_embedding_model_id"),
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn set_sidecar_quick_config_field(
+    app: AppHandle,
+    key: String,
+    value: Option<String>,
+) -> Result<(), String> {
+    let store = app
+        .store(SIDECAR_CONFIG_STORE)
+        .map_err(|e| format!("Failed to access sidecar config store: {}", e))?;
+
+    match value {
+        Some(v) => store.set(&key, serde_json::json!(v)),
+        None => {
+            store.delete(&key);
+        }
+    }
+
+    Ok(())
+}
+
+fn default_config() -> SidecarQuickConfig {
+    SidecarQuickConfig {
+        last_llm_model_id: None,
+        last_tts_model_id: None,
+        last_discord_guild_id: None,
+        last_discord_channel_id: None,
+        last_discord_guild_name: None,
+        last_discord_channel_name: None,
+        last_embedding_model_id: None,
+    }
+}
+
+fn read_string(store: &tauri_plugin_store::Store<tauri::Wry>, key: &str) -> Option<String> {
+    store.get(key).and_then(|v| v.as_str().map(String::from))
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
@@ -6,7 +6,13 @@ pub mod clipboard;
 pub mod commands;
 pub mod helpers;
 pub mod input;
+pub mod local_llm;
+pub mod local_tts;
 pub mod managers;
+pub mod memory;
+pub mod onichan;
+pub mod onichan_conversation;
+pub mod onichan_models;
 pub mod overlay;
 pub mod pty;
 pub mod settings;
@@ -170,6 +176,48 @@ fn specta_builder() -> Builder<tauri::Wry> {
         shortcut::reset_binding,
         shortcut::change_ptt_setting,
         shortcut::change_paste_method_setting,
+        // onichan: assistant
+        commands::onichan::onichan_enable,
+        commands::onichan::onichan_disable,
+        commands::onichan::onichan_is_active,
+        commands::onichan::onichan_get_mode,
+        commands::onichan::onichan_set_mode,
+        commands::onichan::onichan_process_input,
+        commands::onichan::onichan_speak,
+        commands::onichan::onichan_clear_history,
+        commands::onichan::onichan_get_history,
+        commands::onichan::get_onichan_models,
+        commands::onichan::get_onichan_llm_models,
+        commands::onichan::get_onichan_tts_models,
+        commands::onichan::download_onichan_model,
+        commands::onichan::delete_onichan_model,
+        commands::onichan::load_local_llm,
+        commands::onichan::unload_local_llm,
+        commands::onichan::is_local_llm_loaded,
+        commands::onichan::get_local_llm_model_name,
+        commands::onichan::local_llm_chat,
+        commands::onichan::load_local_tts,
+        commands::onichan::unload_local_tts,
+        commands::onichan::is_local_tts_loaded,
+        commands::onichan::local_tts_speak,
+        commands::onichan::onichan_start_conversation,
+        commands::onichan::onichan_stop_conversation,
+        commands::onichan::onichan_is_conversation_running,
+        // onichan: memory
+        commands::memory::get_memory_status,
+        commands::memory::query_all_memories,
+        commands::memory::get_memory_count,
+        commands::memory::clear_all_memories,
+        commands::memory::cleanup_old_memories,
+        commands::memory::list_embedding_models,
+        commands::memory::load_embedding_model,
+        commands::memory::get_current_embedding_model,
+        commands::memory::stop_memory_sidecar,
+        commands::memory::browse_recent_memories,
+        commands::memory::list_memory_users,
+        // onichan: sidecar quick-config
+        commands::sidecar_config::get_sidecar_quick_config,
+        commands::sidecar_config::set_sidecar_quick_config_field,
     ])
 }
 
@@ -267,11 +315,73 @@ pub fn run() {
             );
             app.manage(recording_manager);
             app.manage(model_manager);
-            app.manage(transcription_manager);
+            app.manage(transcription_manager.clone());
             app.manage(ManagedToggleState::default());
 
             // Register the global dictation hotkeys (transcribe / cancel).
             shortcut::init_shortcuts(&dict_handle);
+
+            // Onichan pillar: local LLM/TTS/vector-memory sidecar drivers +
+            // the STT->LLM->TTS orchestration. Sidecar binaries are staged by
+            // src-tauri/sidecars/build.sh (dev) or bundled as resources (prod).
+            let sidecar_triple = if cfg!(target_os = "macos") {
+                if cfg!(target_arch = "aarch64") {
+                    "aarch64-apple-darwin"
+                } else {
+                    "x86_64-apple-darwin"
+                }
+            } else if cfg!(target_os = "linux") {
+                if cfg!(target_arch = "aarch64") {
+                    "aarch64-unknown-linux-gnu"
+                } else {
+                    "x86_64-unknown-linux-gnu"
+                }
+            } else {
+                "x86_64-pc-windows-msvc"
+            };
+            let sidecar_res_dir = dict_handle.path().resource_dir().ok();
+            let sidecar_path = |name: &str| -> std::path::PathBuf {
+                let file = format!("{}-{}", name, sidecar_triple);
+                if cfg!(debug_assertions) {
+                    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                        .join("sidecars")
+                        .join(&file)
+                } else if let Some(dir) = &sidecar_res_dir {
+                    dir.join(&file)
+                } else {
+                    std::path::PathBuf::from(&file)
+                }
+            };
+
+            let onichan_manager = Arc::new(onichan::OnichanManager::new(&dict_handle));
+            let onichan_model_manager = Arc::new(
+                onichan_models::OnichanModelManager::new(&dict_handle)
+                    .expect("Failed to initialize onichan model manager"),
+            );
+            let local_llm_manager =
+                Arc::new(local_llm::LocalLlmManager::new(sidecar_path("llm-sidecar")));
+            let local_tts_manager =
+                Arc::new(local_tts::LocalTtsManager::new(sidecar_path("tts-sidecar")));
+            let memory_manager =
+                Arc::new(memory::MemoryManager::new(sidecar_path("memory-sidecar")));
+
+            onichan_manager.set_llm_manager(local_llm_manager.clone());
+            onichan_manager.set_tts_manager(local_tts_manager.clone());
+            onichan_manager.set_memory_manager(memory_manager.clone());
+
+            let onichan_conversation_manager =
+                Arc::new(onichan_conversation::OnichanConversationManager::new(
+                    &dict_handle,
+                    transcription_manager,
+                    onichan_manager.clone(),
+                ));
+
+            app.manage(onichan_manager);
+            app.manage(onichan_model_manager);
+            app.manage(local_llm_manager);
+            app.manage(local_tts_manager);
+            app.manage(memory_manager);
+            app.manage(onichan_conversation_manager);
 
             // System tray reflecting recording state (idle/recording/transcribing).
             let initial_theme = tray::get_current_theme(&dict_handle);

--- a/apps/kbve/desktop-kbve/src-tauri/src/local_llm.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/local_llm.rs
@@ -1,0 +1,522 @@
+//! Local LLM Manager - Communicates with LLM sidecar process
+//!
+//! The LLM runs in a separate process to avoid GGML symbol conflicts with whisper-rs.
+//! Communication is via JSON over stdin/stdout pipes.
+
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+/// Request types sent to the sidecar
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum SidecarRequest {
+    #[serde(rename = "load")]
+    Load { model_path: String },
+    #[serde(rename = "unload")]
+    Unload,
+    #[serde(rename = "chat")]
+    Chat {
+        system_prompt: String,
+        user_message: String,
+        max_tokens: u32,
+    },
+    #[serde(rename = "generate")]
+    Generate { prompt: String, max_tokens: u32 },
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "shutdown")]
+    Shutdown,
+}
+
+/// Response types from the sidecar
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum SidecarResponse {
+    #[serde(rename = "ok")]
+    Ok { message: String },
+    #[serde(rename = "error")]
+    Error { message: String },
+    #[serde(rename = "result")]
+    Result { text: String },
+    #[serde(rename = "status")]
+    Status {
+        loaded: bool,
+        model_path: Option<String>,
+    },
+}
+
+/// Manages communication with the LLM sidecar process
+struct SidecarProcess {
+    child: Child,
+    model_path: Option<String>,
+}
+
+impl SidecarProcess {
+    fn spawn(sidecar_path: &Path) -> Result<Self, String> {
+        info!("Spawning LLM sidecar from: {:?}", sidecar_path);
+
+        let mut child = Command::new(sidecar_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null()) // Suppress llama.cpp debug spam
+            .env("LLAMA_LOG_DISABLE", "1") // Try to disable llama.cpp logging
+            .spawn()
+            .map_err(|e| format!("Failed to spawn sidecar: {}", e))?;
+
+        // Wait for the ready message
+        let stdout = child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "Failed to get sidecar stdout".to_string())?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read sidecar ready message: {}", e))?;
+
+        let response: SidecarResponse =
+            serde_json::from_str(&line).map_err(|e| format!("Invalid sidecar response: {}", e))?;
+
+        match response {
+            SidecarResponse::Ok { message } => {
+                info!("Sidecar ready: {}", message);
+            }
+            SidecarResponse::Error { message } => {
+                return Err(format!("Sidecar failed to start: {}", message));
+            }
+            _ => {
+                return Err("Unexpected response from sidecar".to_string());
+            }
+        }
+
+        Ok(Self {
+            child,
+            model_path: None,
+        })
+    }
+
+    fn send_request(&mut self, request: &SidecarRequest) -> Result<SidecarResponse, String> {
+        let stdin = self
+            .child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "Sidecar stdin not available".to_string())?;
+
+        let json = serde_json::to_string(request)
+            .map_err(|e| format!("Failed to serialize request: {}", e))?;
+
+        writeln!(stdin, "{}", json).map_err(|e| format!("Failed to write to sidecar: {}", e))?;
+        stdin
+            .flush()
+            .map_err(|e| format!("Failed to flush sidecar stdin: {}", e))?;
+
+        // Read response - skip any non-JSON lines (llama.cpp debug output)
+        let stdout = self
+            .child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "Sidecar stdout not available".to_string())?;
+        let mut reader = BufReader::new(stdout);
+
+        // Try up to 10 lines to find a valid JSON response
+        for attempt in 0..10 {
+            let mut line = String::new();
+            reader
+                .read_line(&mut line)
+                .map_err(|e| format!("Failed to read sidecar response: {}", e))?;
+
+            // Check for empty response (sidecar likely crashed)
+            if line.trim().is_empty() {
+                return Err("Sidecar returned empty response (may have crashed)".to_string());
+            }
+
+            // Try to parse as JSON - if it fails and looks like debug output, skip it
+            match serde_json::from_str::<SidecarResponse>(&line) {
+                Ok(response) => return Ok(response),
+                Err(e) => {
+                    // Check if this looks like llama.cpp debug output (doesn't start with '{')
+                    let trimmed = line.trim();
+                    if !trimmed.starts_with('{') {
+                        warn!(
+                            "Skipping non-JSON sidecar output (attempt {}): {}",
+                            attempt + 1,
+                            trimmed
+                        );
+                        continue;
+                    }
+                    // It started with '{' but failed to parse - real error
+                    return Err(format!("Invalid sidecar response: {}", e));
+                }
+            }
+        }
+
+        Err("Too many non-JSON lines from sidecar, giving up".to_string())
+    }
+
+    /// Check if the sidecar process is still alive
+    fn is_alive(&mut self) -> bool {
+        match self.child.try_wait() {
+            Ok(Some(_)) => false, // Process has exited
+            Ok(None) => true,     // Process is still running
+            Err(_) => false,      // Error checking - assume dead
+        }
+    }
+
+    fn load_model(&mut self, model_path: &str) -> Result<(), String> {
+        let response = self.send_request(&SidecarRequest::Load {
+            model_path: model_path.to_string(),
+        })?;
+
+        match response {
+            SidecarResponse::Ok { .. } => {
+                self.model_path = Some(model_path.to_string());
+                Ok(())
+            }
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn unload_model(&mut self) -> Result<(), String> {
+        let response = self.send_request(&SidecarRequest::Unload)?;
+
+        match response {
+            SidecarResponse::Ok { .. } => {
+                self.model_path = None;
+                Ok(())
+            }
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn chat(
+        &mut self,
+        system_prompt: &str,
+        user_message: &str,
+        max_tokens: u32,
+    ) -> Result<String, String> {
+        let response = self.send_request(&SidecarRequest::Chat {
+            system_prompt: system_prompt.to_string(),
+            user_message: user_message.to_string(),
+            max_tokens,
+        })?;
+
+        match response {
+            SidecarResponse::Result { text } => Ok(text),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn generate(&mut self, prompt: &str, max_tokens: u32) -> Result<String, String> {
+        let response = self.send_request(&SidecarRequest::Generate {
+            prompt: prompt.to_string(),
+            max_tokens,
+        })?;
+
+        match response {
+            SidecarResponse::Result { text } => Ok(text),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn shutdown(&mut self) {
+        if let Err(e) = self.send_request(&SidecarRequest::Shutdown) {
+            warn!("Error sending shutdown to sidecar: {}", e);
+        }
+        if let Err(e) = self.child.wait() {
+            warn!("Error waiting for sidecar to exit: {}", e);
+        }
+    }
+
+    fn is_loaded(&self) -> bool {
+        self.model_path.is_some()
+    }
+}
+
+impl Drop for SidecarProcess {
+    fn drop(&mut self) {
+        info!("Dropping sidecar process");
+        self.shutdown();
+    }
+}
+
+/// Thread-safe manager for the LLM sidecar
+pub struct LocalLlmManager {
+    sidecar: Mutex<Option<SidecarProcess>>,
+    sidecar_path: PathBuf,
+    /// Track the loaded model path so we can reload after crash
+    loaded_model_path: Mutex<Option<PathBuf>>,
+}
+
+impl LocalLlmManager {
+    pub fn new(sidecar_path: PathBuf) -> Self {
+        Self {
+            sidecar: Mutex::new(None),
+            sidecar_path,
+            loaded_model_path: Mutex::new(None),
+        }
+    }
+
+    /// Get the sidecar, spawning it if necessary or if it crashed
+    fn ensure_sidecar(&self) -> Result<(), String> {
+        let mut guard = self.sidecar.lock().unwrap();
+
+        // Check if existing sidecar is still alive
+        let needs_respawn = match guard.as_mut() {
+            Some(sidecar) => !sidecar.is_alive(),
+            None => true,
+        };
+
+        if needs_respawn {
+            // Clear the dead sidecar if any
+            let was_running = guard.is_some();
+            if was_running {
+                warn!("LLM sidecar crashed, respawning...");
+                *guard = None;
+            }
+
+            info!("Starting LLM sidecar process...");
+            let mut sidecar = SidecarProcess::spawn(&self.sidecar_path)?;
+
+            // If we had a model loaded before the crash, reload it
+            if was_running {
+                let model_path_guard = self.loaded_model_path.lock().unwrap();
+                if let Some(ref model_path) = *model_path_guard {
+                    info!("Reloading model after crash: {:?}", model_path);
+                    if let Err(e) = sidecar.load_model(&model_path.to_string_lossy()) {
+                        error!("Failed to reload model after crash: {}", e);
+                        // Don't fail - the sidecar is running, just without a model
+                    } else {
+                        // Give the model a moment to stabilize after loading
+                        info!("Model reloaded, waiting for stabilization...");
+                        thread::sleep(Duration::from_millis(500));
+                    }
+                }
+            }
+
+            *guard = Some(sidecar);
+        }
+        Ok(())
+    }
+
+    pub fn load_model(&self, model_path: &Path) -> Result<(), String> {
+        info!(
+            "LocalLlmManager::load_model() called with path: {:?}",
+            model_path
+        );
+
+        // Verify the file exists first
+        if !model_path.exists() {
+            let err = format!("Model file does not exist: {:?}", model_path);
+            error!("{}", err);
+            return Err(err);
+        }
+
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+
+        let result = sidecar.load_model(&model_path.to_string_lossy());
+
+        // Track the loaded model path for crash recovery
+        if result.is_ok() {
+            let mut model_path_guard = self.loaded_model_path.lock().unwrap();
+            *model_path_guard = Some(model_path.to_path_buf());
+        }
+
+        result
+    }
+
+    pub fn unload_model(&self) {
+        let mut guard = self.sidecar.lock().unwrap();
+        if let Some(ref mut sidecar) = *guard {
+            if let Err(e) = sidecar.unload_model() {
+                error!("Failed to unload model: {}", e);
+            }
+        }
+        // Clear the tracked model path
+        let mut model_path_guard = self.loaded_model_path.lock().unwrap();
+        *model_path_guard = None;
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        let guard = self.sidecar.lock().unwrap();
+        guard.as_ref().map(|s| s.is_loaded()).unwrap_or(false)
+    }
+
+    /// Get the currently loaded model name (file stem without extension)
+    pub fn get_loaded_model_name(&self) -> Option<String> {
+        let guard = self.loaded_model_path.lock().unwrap();
+        guard.as_ref().and_then(|path| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+        })
+    }
+
+    pub fn chat(
+        &self,
+        system_prompt: &str,
+        user_message: &str,
+        max_tokens: u32,
+    ) -> Result<String, String> {
+        self.ensure_sidecar()?;
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "Sidecar not available".to_string())?;
+            sidecar.chat(system_prompt, user_message, max_tokens)
+        };
+
+        // If we got a broken pipe, empty response, or invalid JSON, the sidecar crashed - try to recover once
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe")
+                || e.contains("empty response")
+                || e.contains("crashed")
+                || e.contains("Invalid sidecar response")
+                || e.contains("expected value")
+            {
+                warn!("Sidecar appears to have crashed during chat, attempting recovery...");
+
+                // Force respawn by clearing the sidecar
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                // Respawn sidecar
+                self.ensure_sidecar()?;
+
+                // Reload the model after crash recovery (ensure_sidecar won't do it since guard was None)
+                {
+                    let model_path = self.loaded_model_path.lock().unwrap().clone();
+                    if let Some(ref path) = model_path {
+                        info!("Reloading model after crash recovery: {:?}", path);
+                        let mut guard = self.sidecar.lock().unwrap();
+                        if let Some(ref mut sidecar) = *guard {
+                            if let Err(e) = sidecar.load_model(&path.to_string_lossy()) {
+                                error!("Failed to reload model after crash: {}", e);
+                                return Err(format!("Failed to reload model after crash: {}", e));
+                            }
+                        }
+                    } else {
+                        return Err("No model was loaded before crash".to_string());
+                    }
+                }
+
+                // Wait for the model to stabilize after reload
+                info!("Waiting for model to stabilize after crash recovery...");
+                thread::sleep(Duration::from_secs(1));
+
+                // Retry the chat
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "Sidecar not available after recovery".to_string())?;
+
+                return sidecar.chat(system_prompt, user_message, max_tokens);
+            }
+        }
+
+        result
+    }
+
+    pub fn generate(&self, prompt: &str, max_tokens: u32) -> Result<String, String> {
+        self.ensure_sidecar()?;
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "Sidecar not available".to_string())?;
+            sidecar.generate(prompt, max_tokens)
+        };
+
+        // If we got a broken pipe, empty response, or invalid JSON, the sidecar crashed - try to recover once
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe")
+                || e.contains("empty response")
+                || e.contains("crashed")
+                || e.contains("Invalid sidecar response")
+                || e.contains("expected value")
+            {
+                warn!("Sidecar appears to have crashed during generate, attempting recovery...");
+
+                // Force respawn by clearing the sidecar
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                // Respawn sidecar
+                self.ensure_sidecar()?;
+
+                // Reload the model after crash recovery (ensure_sidecar won't do it since guard was None)
+                {
+                    let model_path = self.loaded_model_path.lock().unwrap().clone();
+                    if let Some(ref path) = model_path {
+                        info!("Reloading model after crash recovery: {:?}", path);
+                        let mut guard = self.sidecar.lock().unwrap();
+                        if let Some(ref mut sidecar) = *guard {
+                            if let Err(e) = sidecar.load_model(&path.to_string_lossy()) {
+                                error!("Failed to reload model after crash: {}", e);
+                                return Err(format!("Failed to reload model after crash: {}", e));
+                            }
+                        }
+                    } else {
+                        return Err("No model was loaded before crash".to_string());
+                    }
+                }
+
+                // Wait for the model to stabilize after reload
+                info!("Waiting for model to stabilize after crash recovery...");
+                thread::sleep(Duration::from_secs(1));
+
+                // Retry the generate
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "Sidecar not available after recovery".to_string())?;
+
+                return sidecar.generate(prompt, max_tokens);
+            }
+        }
+
+        result
+    }
+
+    /// Shutdown the sidecar process
+    pub fn shutdown(&self) {
+        let mut guard = self.sidecar.lock().unwrap();
+        if let Some(mut sidecar) = guard.take() {
+            sidecar.shutdown();
+        }
+    }
+}
+
+impl Default for LocalLlmManager {
+    fn default() -> Self {
+        // Default path - will be set properly from tauri config
+        Self::new(PathBuf::from("llm-sidecar"))
+    }
+}
+
+impl Drop for LocalLlmManager {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/local_tts.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/local_tts.rs
@@ -1,0 +1,517 @@
+//! Local TTS Manager - Communicates with TTS sidecar process
+//!
+//! The TTS runs in a separate process to avoid ort version conflicts with vad-rs.
+//! Communication is via JSON over stdin/stdout pipes.
+
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+
+/// TTS voice configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TtsVoiceConfig {
+    pub name: String,
+    pub language: String,
+}
+
+impl Default for TtsVoiceConfig {
+    fn default() -> Self {
+        Self {
+            name: "en_US-amy-medium".to_string(),
+            language: "en-US".to_string(),
+        }
+    }
+}
+
+/// Request types sent to the TTS sidecar
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum SidecarRequest {
+    #[serde(rename = "load")]
+    Load { model_path: String },
+    #[serde(rename = "unload")]
+    Unload,
+    #[serde(rename = "speak")]
+    Speak {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output_device: Option<String>,
+        volume: f32,
+    },
+    #[serde(rename = "synthesize")]
+    Synthesize { text: String },
+    #[serde(rename = "list_devices")]
+    ListDevices,
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "shutdown")]
+    Shutdown,
+}
+
+/// Response types from the TTS sidecar
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum SidecarResponse {
+    #[serde(rename = "ok")]
+    Ok { message: String },
+    #[serde(rename = "error")]
+    Error { message: String },
+    #[serde(rename = "devices")]
+    Devices { devices: Vec<String> },
+    #[serde(rename = "status")]
+    Status {
+        loaded: bool,
+        model_path: Option<String>,
+    },
+    #[serde(rename = "audio")]
+    Audio {
+        audio_base64: String,
+        sample_rate: u32,
+    },
+}
+
+/// Manages communication with the TTS sidecar process
+struct TtsSidecarProcess {
+    child: Child,
+    model_path: Option<String>,
+}
+
+impl TtsSidecarProcess {
+    fn spawn(sidecar_path: &Path) -> Result<Self, String> {
+        info!("Spawning TTS sidecar from: {:?}", sidecar_path);
+
+        let mut child = Command::new(sidecar_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit()) // Let stderr go to parent for debugging
+            .spawn()
+            .map_err(|e| format!("Failed to spawn TTS sidecar: {}", e))?;
+
+        // Wait for the ready message
+        let stdout = child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "Failed to get TTS sidecar stdout".to_string())?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read TTS sidecar ready message: {}", e))?;
+
+        let response: SidecarResponse = serde_json::from_str(&line)
+            .map_err(|e| format!("Invalid TTS sidecar response: {}", e))?;
+
+        match response {
+            SidecarResponse::Ok { message } => {
+                info!("TTS Sidecar ready: {}", message);
+            }
+            SidecarResponse::Error { message } => {
+                return Err(format!("TTS Sidecar failed to start: {}", message));
+            }
+            _ => {
+                return Err("Unexpected response from TTS sidecar".to_string());
+            }
+        }
+
+        Ok(Self {
+            child,
+            model_path: None,
+        })
+    }
+
+    fn send_request(&mut self, request: &SidecarRequest) -> Result<SidecarResponse, String> {
+        let stdin = self
+            .child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "TTS sidecar stdin not available".to_string())?;
+
+        let json = serde_json::to_string(request)
+            .map_err(|e| format!("Failed to serialize request: {}", e))?;
+
+        writeln!(stdin, "{}", json)
+            .map_err(|e| format!("Failed to write to TTS sidecar: {}", e))?;
+        stdin
+            .flush()
+            .map_err(|e| format!("Failed to flush TTS sidecar stdin: {}", e))?;
+
+        // Read response
+        let stdout = self
+            .child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "TTS sidecar stdout not available".to_string())?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read TTS sidecar response: {}", e))?;
+
+        // Check for empty response (sidecar likely crashed)
+        if line.trim().is_empty() {
+            return Err("TTS sidecar returned empty response (may have crashed)".to_string());
+        }
+
+        serde_json::from_str(&line).map_err(|e| format!("Invalid TTS sidecar response: {}", e))
+    }
+
+    /// Check if the sidecar process is still alive
+    fn is_alive(&mut self) -> bool {
+        match self.child.try_wait() {
+            Ok(Some(_)) => false, // Process has exited
+            Ok(None) => true,     // Process is still running
+            Err(_) => false,      // Error checking - assume dead
+        }
+    }
+
+    fn load_model(&mut self, model_path: &str) -> Result<(), String> {
+        let response = self.send_request(&SidecarRequest::Load {
+            model_path: model_path.to_string(),
+        })?;
+
+        match response {
+            SidecarResponse::Ok { .. } => {
+                self.model_path = Some(model_path.to_string());
+                Ok(())
+            }
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from TTS sidecar".to_string()),
+        }
+    }
+
+    fn unload_model(&mut self) -> Result<(), String> {
+        let response = self.send_request(&SidecarRequest::Unload)?;
+
+        match response {
+            SidecarResponse::Ok { .. } => {
+                self.model_path = None;
+                Ok(())
+            }
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from TTS sidecar".to_string()),
+        }
+    }
+
+    fn speak(
+        &mut self,
+        text: &str,
+        output_device: Option<&str>,
+        volume: f32,
+    ) -> Result<(), String> {
+        let response = self.send_request(&SidecarRequest::Speak {
+            text: text.to_string(),
+            output_device: output_device.map(|s| s.to_string()),
+            volume,
+        })?;
+
+        match response {
+            SidecarResponse::Ok { .. } => Ok(()),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from TTS sidecar".to_string()),
+        }
+    }
+
+    /// Synthesize audio and return raw samples as base64
+    fn synthesize(&mut self, text: &str) -> Result<(String, u32), String> {
+        let response = self.send_request(&SidecarRequest::Synthesize {
+            text: text.to_string(),
+        })?;
+
+        match response {
+            SidecarResponse::Audio {
+                audio_base64,
+                sample_rate,
+            } => Ok((audio_base64, sample_rate)),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from TTS sidecar".to_string()),
+        }
+    }
+
+    fn list_devices(&mut self) -> Result<Vec<String>, String> {
+        let response = self.send_request(&SidecarRequest::ListDevices)?;
+
+        match response {
+            SidecarResponse::Devices { devices } => Ok(devices),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from TTS sidecar".to_string()),
+        }
+    }
+
+    fn shutdown(&mut self) {
+        if let Err(e) = self.send_request(&SidecarRequest::Shutdown) {
+            warn!("Error sending shutdown to TTS sidecar: {}", e);
+        }
+        if let Err(e) = self.child.wait() {
+            warn!("Error waiting for TTS sidecar to exit: {}", e);
+        }
+    }
+
+    fn is_loaded(&self) -> bool {
+        self.model_path.is_some()
+    }
+}
+
+impl Drop for TtsSidecarProcess {
+    fn drop(&mut self) {
+        info!("Dropping TTS sidecar process");
+        self.shutdown();
+    }
+}
+
+/// Thread-safe manager for the TTS sidecar
+pub struct LocalTtsManager {
+    sidecar: Mutex<Option<TtsSidecarProcess>>,
+    sidecar_path: PathBuf,
+    output_device: Mutex<Option<String>>,
+    /// Track the loaded model path so we can reload after crash
+    loaded_model_path: Mutex<Option<PathBuf>>,
+}
+
+impl LocalTtsManager {
+    pub fn new(sidecar_path: PathBuf) -> Self {
+        Self {
+            sidecar: Mutex::new(None),
+            sidecar_path,
+            output_device: Mutex::new(None),
+            loaded_model_path: Mutex::new(None),
+        }
+    }
+
+    /// Get the sidecar, spawning it if necessary or if it crashed
+    fn ensure_sidecar(&self) -> Result<(), String> {
+        let mut guard = self.sidecar.lock().unwrap();
+
+        // Check if existing sidecar is still alive
+        let needs_respawn = match guard.as_mut() {
+            Some(sidecar) => !sidecar.is_alive(),
+            None => true,
+        };
+
+        if needs_respawn {
+            // Clear the dead sidecar if any
+            let was_running = guard.is_some();
+            if was_running {
+                warn!("TTS sidecar crashed, respawning...");
+                *guard = None;
+            }
+
+            info!("Starting TTS sidecar process...");
+            let mut sidecar = TtsSidecarProcess::spawn(&self.sidecar_path)?;
+
+            // If we had a model loaded before the crash, reload it
+            if was_running {
+                let model_path_guard = self.loaded_model_path.lock().unwrap();
+                if let Some(ref model_path) = *model_path_guard {
+                    info!("Reloading TTS model after crash: {:?}", model_path);
+                    if let Err(e) = sidecar.load_model(&model_path.to_string_lossy()) {
+                        error!("Failed to reload TTS model after crash: {}", e);
+                        // Don't fail - the sidecar is running, just without a model
+                    }
+                }
+            }
+
+            *guard = Some(sidecar);
+        }
+        Ok(())
+    }
+
+    pub fn load_model(&self, model_path: &Path) -> Result<(), String> {
+        info!(
+            "LocalTtsManager::load_model() called with path: {:?}",
+            model_path
+        );
+
+        // Verify the file exists first (check for both .onnx and .onnx.json)
+        let onnx_path = model_path;
+        let json_path = model_path.with_extension("onnx.json");
+
+        if !onnx_path.exists() {
+            let err = format!("Model file does not exist: {:?}", onnx_path);
+            error!("{}", err);
+            return Err(err);
+        }
+
+        // Check for config file
+        if !json_path.exists() {
+            // Try the alternate naming convention
+            let alt_json_path = PathBuf::from(format!("{}.json", onnx_path.display()));
+            if !alt_json_path.exists() {
+                let err = format!(
+                    "Model config file does not exist: {:?} or {:?}",
+                    json_path, alt_json_path
+                );
+                error!("{}", err);
+                return Err(err);
+            }
+        }
+
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "TTS sidecar not available".to_string())?;
+
+        let result = sidecar.load_model(&model_path.to_string_lossy());
+
+        // Track the loaded model path for crash recovery
+        if result.is_ok() {
+            let mut model_path_guard = self.loaded_model_path.lock().unwrap();
+            *model_path_guard = Some(model_path.to_path_buf());
+        }
+
+        result
+    }
+
+    pub fn unload_model(&self) {
+        let mut guard = self.sidecar.lock().unwrap();
+        if let Some(ref mut sidecar) = *guard {
+            if let Err(e) = sidecar.unload_model() {
+                error!("Failed to unload TTS model: {}", e);
+            }
+        }
+        // Clear the tracked model path
+        let mut model_path_guard = self.loaded_model_path.lock().unwrap();
+        *model_path_guard = None;
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        let guard = self.sidecar.lock().unwrap();
+        guard.as_ref().map(|s| s.is_loaded()).unwrap_or(false)
+    }
+
+    /// Set the output device for TTS playback
+    pub fn set_output_device(&self, device: Option<String>) {
+        let mut guard = self.output_device.lock().unwrap();
+        *guard = device;
+    }
+
+    /// Get the current output device
+    pub fn get_output_device(&self) -> Option<String> {
+        let guard = self.output_device.lock().unwrap();
+        guard.clone()
+    }
+
+    /// Speak the given text
+    pub fn speak(&self, text: &str, volume: f32) -> Result<(), String> {
+        self.ensure_sidecar()?;
+
+        let output_device = self.output_device.lock().unwrap().clone();
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "TTS sidecar not available".to_string())?;
+            sidecar.speak(text, output_device.as_deref(), volume)
+        };
+
+        // If we got a broken pipe or empty response, the sidecar crashed - try to recover once
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe") || e.contains("empty response") || e.contains("crashed") {
+                warn!("TTS sidecar appears to have crashed during speak, attempting recovery...");
+
+                // Force respawn by clearing the sidecar
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                // Try to respawn and retry
+                self.ensure_sidecar()?;
+
+                let output_device = self.output_device.lock().unwrap().clone();
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "TTS sidecar not available after recovery".to_string())?;
+
+                return sidecar.speak(text, output_device.as_deref(), volume);
+            }
+        }
+
+        result
+    }
+
+    /// Synthesize audio and return as base64-encoded samples
+    /// Returns (audio_base64, sample_rate)
+    pub fn synthesize(&self, text: &str) -> Result<(String, u32), String> {
+        self.ensure_sidecar()?;
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "TTS sidecar not available".to_string())?;
+            sidecar.synthesize(text)
+        };
+
+        // If we got a broken pipe or empty response, the sidecar crashed - try to recover once
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe") || e.contains("empty response") || e.contains("crashed") {
+                warn!(
+                    "TTS sidecar appears to have crashed during synthesize, attempting recovery..."
+                );
+
+                // Force respawn by clearing the sidecar
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                // Try to respawn and retry
+                self.ensure_sidecar()?;
+
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "TTS sidecar not available after recovery".to_string())?;
+
+                return sidecar.synthesize(text);
+            }
+        }
+
+        result
+    }
+
+    /// List available output devices
+    pub fn list_devices(&self) -> Result<Vec<String>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "TTS sidecar not available".to_string())?;
+
+        sidecar.list_devices()
+    }
+
+    /// Get sample rate (for compatibility)
+    pub fn sample_rate(&self) -> u32 {
+        22050 // Piper default sample rate
+    }
+
+    /// Shutdown the sidecar process
+    pub fn shutdown(&self) {
+        let mut guard = self.sidecar.lock().unwrap();
+        if let Some(mut sidecar) = guard.take() {
+            sidecar.shutdown();
+        }
+    }
+}
+
+impl Default for LocalTtsManager {
+    fn default() -> Self {
+        // Default path - will be set properly from tauri config
+        Self::new(PathBuf::from("tts-sidecar"))
+    }
+}
+
+impl Drop for LocalTtsManager {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/memory.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/memory.rs
@@ -1,0 +1,745 @@
+//! Memory Manager - Communicates with memory sidecar for semantic memory storage
+//!
+//! Provides long-term conversation memory via vector search.
+//! Communication is via JSON over stdin/stdout pipes.
+
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+/// Request types sent to the sidecar
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum SidecarRequest {
+    #[serde(rename = "store")]
+    Store {
+        user_id: String,
+        content: String,
+        is_bot: bool,
+    },
+    #[serde(rename = "query")]
+    Query {
+        user_id: String,
+        text: String,
+        limit: usize,
+    },
+    #[serde(rename = "query_all")]
+    QueryAll { text: String, limit: usize },
+    #[serde(rename = "browse_recent")]
+    BrowseRecent {
+        limit: usize,
+        user_id: Option<String>,
+        is_bot: Option<bool>,
+    },
+    #[serde(rename = "list_users")]
+    ListUsers,
+    #[serde(rename = "count")]
+    Count,
+    #[serde(rename = "clear_all")]
+    ClearAll,
+    #[serde(rename = "cleanup")]
+    Cleanup { ttl_days: u32 },
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "list_models")]
+    ListModels,
+    #[serde(rename = "load_model")]
+    LoadModel { model_id: String },
+    #[serde(rename = "get_current_model")]
+    GetCurrentModel,
+    #[serde(rename = "shutdown")]
+    Shutdown,
+}
+
+/// Embedding model info returned from sidecar
+#[derive(Debug, Clone, Deserialize, Serialize, specta::Type)]
+pub struct EmbeddingModelInfo {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub dimension: usize,
+    pub size_mb: u32,
+    pub is_downloaded: bool,
+    pub is_loaded: bool,
+}
+
+/// User info with memory count
+#[derive(Debug, Clone, Deserialize, Serialize, specta::Type)]
+pub struct MemoryUserInfo {
+    pub user_id: String,
+    pub memory_count: usize,
+}
+
+/// Response types from the sidecar
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum SidecarResponse {
+    #[serde(rename = "ok")]
+    Ok { message: String },
+    #[serde(rename = "stored")]
+    Stored { id: String },
+    #[serde(rename = "results")]
+    Results { messages: Vec<MemoryMessage> },
+    #[serde(rename = "users")]
+    Users { users: Vec<MemoryUserInfo> },
+    #[serde(rename = "count")]
+    Count { total: usize },
+    #[serde(rename = "cleared")]
+    Cleared { deleted: u32 },
+    #[serde(rename = "cleanup_done")]
+    CleanupDone { deleted: u32 },
+    #[serde(rename = "status")]
+    Status {
+        ready: bool,
+        model_loaded: bool,
+        current_model_id: Option<String>,
+    },
+    #[serde(rename = "models")]
+    Models { models: Vec<EmbeddingModelInfo> },
+    #[serde(rename = "current_model")]
+    CurrentModel { model: Option<EmbeddingModelInfo> },
+    #[serde(rename = "model_loaded")]
+    ModelLoaded { model_id: String },
+    #[serde(rename = "error")]
+    Error { message: String },
+}
+
+/// A memory message from the sidecar
+#[derive(Debug, Clone, Deserialize, Serialize, specta::Type)]
+pub struct MemoryMessage {
+    pub id: String,
+    pub user_id: String,
+    pub content: String,
+    pub is_bot: bool,
+    pub timestamp: i64,
+    pub similarity: Option<f32>,
+}
+
+/// Manages communication with the memory sidecar process
+struct SidecarProcess {
+    child: Child,
+}
+
+impl SidecarProcess {
+    fn spawn(sidecar_path: &Path) -> Result<Self, String> {
+        info!("Spawning memory sidecar from: {:?}", sidecar_path);
+
+        let mut child = Command::new(sidecar_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn sidecar: {}", e))?;
+
+        // Wait for the ready message
+        let stdout = child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "Failed to get sidecar stdout".to_string())?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read sidecar ready message: {}", e))?;
+
+        let response: SidecarResponse =
+            serde_json::from_str(&line).map_err(|e| format!("Invalid sidecar response: {}", e))?;
+
+        match response {
+            SidecarResponse::Ok { message } => {
+                info!("Memory sidecar ready: {}", message);
+            }
+            SidecarResponse::Error { message } => {
+                return Err(format!("Memory sidecar failed to start: {}", message));
+            }
+            _ => {
+                return Err("Unexpected response from memory sidecar".to_string());
+            }
+        }
+
+        Ok(Self { child })
+    }
+
+    fn send_request(&mut self, request: &SidecarRequest) -> Result<SidecarResponse, String> {
+        let stdin = self
+            .child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "Sidecar stdin not available".to_string())?;
+
+        let json = serde_json::to_string(request)
+            .map_err(|e| format!("Failed to serialize request: {}", e))?;
+
+        writeln!(stdin, "{}", json).map_err(|e| format!("Failed to write to sidecar: {}", e))?;
+        stdin
+            .flush()
+            .map_err(|e| format!("Failed to flush sidecar stdin: {}", e))?;
+
+        // Read response
+        let stdout = self
+            .child
+            .stdout
+            .as_mut()
+            .ok_or_else(|| "Sidecar stdout not available".to_string())?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read sidecar response: {}", e))?;
+
+        // Check for empty response (sidecar likely crashed)
+        if line.trim().is_empty() {
+            return Err("Sidecar returned empty response (may have crashed)".to_string());
+        }
+
+        serde_json::from_str(&line).map_err(|e| format!("Invalid sidecar response: {}", e))
+    }
+
+    /// Check if the sidecar process is still alive
+    fn is_alive(&mut self) -> bool {
+        match self.child.try_wait() {
+            Ok(Some(_)) => false, // Process has exited
+            Ok(None) => true,     // Process is still running
+            Err(_) => false,      // Error checking - assume dead
+        }
+    }
+
+    fn store(&mut self, user_id: &str, content: &str, is_bot: bool) -> Result<String, String> {
+        let response = self.send_request(&SidecarRequest::Store {
+            user_id: user_id.to_string(),
+            content: content.to_string(),
+            is_bot,
+        })?;
+
+        match response {
+            SidecarResponse::Stored { id } => Ok(id),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn query(
+        &mut self,
+        user_id: &str,
+        text: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryMessage>, String> {
+        let response = self.send_request(&SidecarRequest::Query {
+            user_id: user_id.to_string(),
+            text: text.to_string(),
+            limit,
+        })?;
+
+        match response {
+            SidecarResponse::Results { messages } => Ok(messages),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn cleanup(&mut self, ttl_days: u32) -> Result<u32, String> {
+        let response = self.send_request(&SidecarRequest::Cleanup { ttl_days })?;
+
+        match response {
+            SidecarResponse::CleanupDone { deleted } => Ok(deleted),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn query_all(&mut self, text: &str, limit: usize) -> Result<Vec<MemoryMessage>, String> {
+        let response = self.send_request(&SidecarRequest::QueryAll {
+            text: text.to_string(),
+            limit,
+        })?;
+
+        match response {
+            SidecarResponse::Results { messages } => Ok(messages),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn browse_recent(
+        &mut self,
+        limit: usize,
+        user_id: Option<String>,
+        is_bot: Option<bool>,
+    ) -> Result<Vec<MemoryMessage>, String> {
+        let response = self.send_request(&SidecarRequest::BrowseRecent {
+            limit,
+            user_id,
+            is_bot,
+        })?;
+
+        match response {
+            SidecarResponse::Results { messages } => Ok(messages),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn list_users(&mut self) -> Result<Vec<MemoryUserInfo>, String> {
+        let response = self.send_request(&SidecarRequest::ListUsers)?;
+
+        match response {
+            SidecarResponse::Users { users } => Ok(users),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn get_count(&mut self) -> Result<usize, String> {
+        let response = self.send_request(&SidecarRequest::Count)?;
+
+        match response {
+            SidecarResponse::Count { total } => Ok(total),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn clear_all(&mut self) -> Result<u32, String> {
+        let response = self.send_request(&SidecarRequest::ClearAll)?;
+
+        match response {
+            SidecarResponse::Cleared { deleted } => Ok(deleted),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn list_models(&mut self) -> Result<Vec<EmbeddingModelInfo>, String> {
+        let response = self.send_request(&SidecarRequest::ListModels)?;
+
+        match response {
+            SidecarResponse::Models { models } => Ok(models),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn load_model(&mut self, model_id: &str) -> Result<String, String> {
+        let response = self.send_request(&SidecarRequest::LoadModel {
+            model_id: model_id.to_string(),
+        })?;
+
+        match response {
+            SidecarResponse::ModelLoaded { model_id } => Ok(model_id),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn get_current_model(&mut self) -> Result<Option<EmbeddingModelInfo>, String> {
+        let response = self.send_request(&SidecarRequest::GetCurrentModel)?;
+
+        match response {
+            SidecarResponse::CurrentModel { model } => Ok(model),
+            SidecarResponse::Error { message } => Err(message),
+            _ => Err("Unexpected response from sidecar".to_string()),
+        }
+    }
+
+    fn shutdown(&mut self) {
+        if let Err(e) = self.send_request(&SidecarRequest::Shutdown) {
+            warn!("Error sending shutdown to memory sidecar: {}", e);
+        }
+        if let Err(e) = self.child.wait() {
+            warn!("Error waiting for memory sidecar to exit: {}", e);
+        }
+    }
+}
+
+impl Drop for SidecarProcess {
+    fn drop(&mut self) {
+        info!("Dropping memory sidecar process");
+        self.shutdown();
+    }
+}
+
+/// Thread-safe manager for the memory sidecar
+pub struct MemoryManager {
+    sidecar: Mutex<Option<SidecarProcess>>,
+    sidecar_path: PathBuf,
+}
+
+impl MemoryManager {
+    pub fn new(sidecar_path: PathBuf) -> Self {
+        Self {
+            sidecar: Mutex::new(None),
+            sidecar_path,
+        }
+    }
+
+    /// Get the sidecar, spawning it if necessary or if it crashed
+    fn ensure_sidecar(&self) -> Result<(), String> {
+        let mut guard = self.sidecar.lock().unwrap();
+
+        // Check if existing sidecar is still alive
+        let needs_respawn = match guard.as_mut() {
+            Some(sidecar) => !sidecar.is_alive(),
+            None => true,
+        };
+
+        if needs_respawn {
+            // Clear the dead sidecar if any
+            let was_running = guard.is_some();
+            if was_running {
+                warn!("Memory sidecar crashed, respawning...");
+                *guard = None;
+            }
+
+            info!("Starting memory sidecar process...");
+            let sidecar = SidecarProcess::spawn(&self.sidecar_path)?;
+
+            // Give it a moment to stabilize
+            if was_running {
+                thread::sleep(Duration::from_millis(500));
+            }
+
+            *guard = Some(sidecar);
+        }
+        Ok(())
+    }
+
+    /// Store a message in memory
+    pub fn store_message(
+        &self,
+        user_id: &str,
+        content: &str,
+        is_bot: bool,
+    ) -> Result<String, String> {
+        self.ensure_sidecar()?;
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "Sidecar not available".to_string())?;
+            sidecar.store(user_id, content, is_bot)
+        };
+
+        // Handle crash recovery
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe")
+                || e.contains("empty response")
+                || e.contains("crashed")
+                || e.contains("Invalid sidecar response")
+            {
+                warn!("Memory sidecar appears to have crashed, attempting recovery...");
+
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                self.ensure_sidecar()?;
+                thread::sleep(Duration::from_millis(100));
+
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "Sidecar not available after recovery".to_string())?;
+
+                return sidecar.store(user_id, content, is_bot);
+            }
+        }
+
+        result
+    }
+
+    /// Query for relevant context
+    pub fn query_context(
+        &self,
+        user_id: &str,
+        text: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryMessage>, String> {
+        self.ensure_sidecar()?;
+
+        let result = {
+            let mut guard = self.sidecar.lock().unwrap();
+            let sidecar = guard
+                .as_mut()
+                .ok_or_else(|| "Sidecar not available".to_string())?;
+            sidecar.query(user_id, text, limit)
+        };
+
+        // Handle crash recovery
+        if let Err(ref e) = result {
+            if e.contains("Broken pipe")
+                || e.contains("empty response")
+                || e.contains("crashed")
+                || e.contains("Invalid sidecar response")
+            {
+                warn!(
+                    "Memory sidecar appears to have crashed during query, attempting recovery..."
+                );
+
+                {
+                    let mut guard = self.sidecar.lock().unwrap();
+                    *guard = None;
+                }
+
+                self.ensure_sidecar()?;
+                thread::sleep(Duration::from_millis(100));
+
+                let mut guard = self.sidecar.lock().unwrap();
+                let sidecar = guard
+                    .as_mut()
+                    .ok_or_else(|| "Sidecar not available after recovery".to_string())?;
+
+                return sidecar.query(user_id, text, limit);
+            }
+        }
+
+        result
+    }
+
+    /// Clean up old messages
+    pub fn cleanup_expired(&self, ttl_days: u32) -> Result<u32, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.cleanup(ttl_days)
+    }
+
+    /// Check if the sidecar is currently running
+    pub fn is_running(&self) -> bool {
+        let mut guard = self.sidecar.lock().unwrap();
+        match guard.as_mut() {
+            Some(sidecar) => sidecar.is_alive(),
+            None => false,
+        }
+    }
+
+    /// Get total count of all memories
+    pub fn get_total_count(&self) -> Result<usize, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.get_count()
+    }
+
+    /// Clear all memories
+    pub fn clear_all(&self) -> Result<u32, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.clear_all()
+    }
+
+    /// Query all memories (not filtered by user)
+    pub fn query_all(&self, text: &str, limit: usize) -> Result<Vec<MemoryMessage>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.query_all(text, limit)
+    }
+
+    /// Browse recent memories without semantic search (for UI browsing)
+    pub fn browse_recent(
+        &self,
+        limit: usize,
+        user_id: Option<String>,
+        is_bot: Option<bool>,
+    ) -> Result<Vec<MemoryMessage>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.browse_recent(limit, user_id, is_bot)
+    }
+
+    /// List unique users with memory counts
+    pub fn list_users(&self) -> Result<Vec<MemoryUserInfo>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.list_users()
+    }
+
+    /// List available embedding models
+    pub fn list_models(&self) -> Result<Vec<EmbeddingModelInfo>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.list_models()
+    }
+
+    /// Load an embedding model by ID
+    pub fn load_model(&self, model_id: &str) -> Result<String, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.load_model(model_id)
+    }
+
+    /// Get the currently loaded embedding model
+    pub fn get_current_model(&self) -> Result<Option<EmbeddingModelInfo>, String> {
+        self.ensure_sidecar()?;
+
+        let mut guard = self.sidecar.lock().unwrap();
+        let sidecar = guard
+            .as_mut()
+            .ok_or_else(|| "Sidecar not available".to_string())?;
+        sidecar.get_current_model()
+    }
+
+    /// Shutdown the sidecar process
+    pub fn shutdown(&self) {
+        let mut guard = self.sidecar.lock().unwrap();
+        if let Some(mut sidecar) = guard.take() {
+            sidecar.shutdown();
+        }
+    }
+}
+
+impl Drop for MemoryManager {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Minimum word count for content to be worth storing in memory
+const MIN_WORDS_FOR_STORAGE: usize = 4;
+
+/// Minimum character count for content to be worth storing
+const MIN_CHARS_FOR_STORAGE: usize = 15;
+
+/// Common filler/acknowledgment phrases that shouldn't be stored
+const SKIP_PHRASES: &[&str] = &[
+    "yeah",
+    "yes",
+    "no",
+    "okay",
+    "ok",
+    "uh",
+    "um",
+    "hmm",
+    "hm",
+    "mhm",
+    "uh-huh",
+    "sure",
+    "right",
+    "alright",
+    "yep",
+    "nope",
+    "hey",
+    "hi",
+    "hello",
+    "bye",
+    "goodbye",
+    "thanks",
+    "thank you",
+    "cool",
+    "nice",
+    "great",
+    "good",
+    "fine",
+    "amen",
+    "what",
+    "huh",
+    "oh",
+    "ah",
+];
+
+/// Check if content is meaningful enough to store in long-term memory.
+/// Returns true if the content should be stored, false if it should be skipped.
+pub fn is_content_worth_storing(content: &str) -> bool {
+    let trimmed = content.trim();
+
+    // Skip empty content
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    // Skip very short content
+    if trimmed.len() < MIN_CHARS_FOR_STORAGE {
+        return false;
+    }
+
+    // Count words (split on whitespace)
+    let word_count = trimmed.split_whitespace().count();
+    if word_count < MIN_WORDS_FOR_STORAGE {
+        return false;
+    }
+
+    // Check if it's just a common filler phrase
+    let lower = trimmed.to_lowercase();
+    for phrase in SKIP_PHRASES {
+        // Exact match or phrase with punctuation
+        if lower == *phrase
+            || lower == format!("{}.", phrase)
+            || lower == format!("{}!", phrase)
+            || lower == format!("{}?", phrase)
+        {
+            return false;
+        }
+    }
+
+    // Check if content is mostly filler words (> 75% filler)
+    let filler_count = trimmed
+        .split_whitespace()
+        .filter(|word| {
+            let w = word.to_lowercase();
+            let clean = w.trim_matches(|c: char| !c.is_alphabetic());
+            SKIP_PHRASES.contains(&clean)
+        })
+        .count();
+
+    if word_count > 0 && (filler_count as f32 / word_count as f32) > 0.75 {
+        return false;
+    }
+
+    true
+}
+
+/// Format memory context for inclusion in a prompt
+pub fn format_memory_context(memories: &[MemoryMessage]) -> String {
+    if memories.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::new();
+    for memory in memories {
+        let speaker = if memory.is_bot { "You" } else { "User" };
+        let timestamp = chrono::DateTime::from_timestamp(memory.timestamp, 0)
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        result.push_str(&format!(
+            "[{}] {}: {}\n",
+            timestamp, speaker, memory.content
+        ));
+    }
+    result
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/onichan.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/onichan.rs
@@ -1,0 +1,567 @@
+use crate::local_llm::LocalLlmManager;
+use crate::local_tts::LocalTtsManager;
+use crate::memory::{format_memory_context, is_content_worth_storing, MemoryManager};
+use crate::settings::get_settings;
+use log::{debug, error, info};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter};
+
+/// Mode for Onichan LLM processing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, Default)]
+pub enum OnichanMode {
+    Cloud,
+    #[default]
+    Local,
+}
+
+/// Message in the conversation
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ConversationMessage {
+    pub role: String, // "user" or "assistant"
+    pub content: String,
+}
+
+/// Onichan response event
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OnichanResponse {
+    pub text: String,
+    pub is_speaking: bool,
+}
+
+/// Onichan state event
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OnichanState {
+    pub status: String, // "idle", "listening", "thinking", "speaking"
+    pub message: Option<String>,
+    pub mode: OnichanMode,
+    pub local_llm_loaded: bool,
+    pub local_tts_loaded: bool,
+}
+
+/// Manages the Onichan voice assistant feature
+pub struct OnichanManager {
+    app_handle: AppHandle,
+    is_active: Arc<AtomicBool>,
+    conversation_history: Arc<Mutex<Vec<ConversationMessage>>>,
+    mode: Arc<Mutex<OnichanMode>>,
+    llm_manager: Arc<Mutex<Option<Arc<LocalLlmManager>>>>,
+    tts_manager: Arc<Mutex<Option<Arc<LocalTtsManager>>>>,
+    memory_manager: Arc<Mutex<Option<Arc<MemoryManager>>>>,
+    /// Current user ID for memory association (set by Discord conversation)
+    current_user_id: Arc<Mutex<Option<String>>>,
+}
+
+impl OnichanManager {
+    pub fn new(app_handle: &AppHandle) -> Self {
+        Self {
+            app_handle: app_handle.clone(),
+            is_active: Arc::new(AtomicBool::new(false)),
+            conversation_history: Arc::new(Mutex::new(Vec::new())),
+            mode: Arc::new(Mutex::new(OnichanMode::Local)),
+            llm_manager: Arc::new(Mutex::new(None)),
+            tts_manager: Arc::new(Mutex::new(None)),
+            memory_manager: Arc::new(Mutex::new(None)),
+            current_user_id: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Set the LLM manager reference for local processing
+    pub fn set_llm_manager(&self, manager: Arc<LocalLlmManager>) {
+        *self.llm_manager.lock().unwrap() = Some(manager);
+    }
+
+    /// Set the TTS manager reference for local TTS
+    pub fn set_tts_manager(&self, manager: Arc<LocalTtsManager>) {
+        *self.tts_manager.lock().unwrap() = Some(manager);
+    }
+
+    /// Set the memory manager reference for long-term memory
+    pub fn set_memory_manager(&self, manager: Arc<MemoryManager>) {
+        *self.memory_manager.lock().unwrap() = Some(manager);
+    }
+
+    /// Set the current user ID for memory association
+    pub fn set_current_user(&self, user_id: Option<String>) {
+        *self.current_user_id.lock().unwrap() = user_id;
+    }
+
+    /// Get the current user ID
+    pub fn get_current_user(&self) -> Option<String> {
+        self.current_user_id.lock().unwrap().clone()
+    }
+
+    /// Check if local TTS is loaded
+    pub fn is_local_tts_loaded(&self) -> bool {
+        self.tts_manager
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|m| m.is_loaded())
+            .unwrap_or(false)
+    }
+
+    /// Get current mode
+    pub fn get_mode(&self) -> OnichanMode {
+        *self.mode.lock().unwrap()
+    }
+
+    /// Set mode (Cloud or Local)
+    pub fn set_mode(&self, mode: OnichanMode) {
+        *self.mode.lock().unwrap() = mode;
+        info!("Onichan mode set to {:?}", mode);
+        self.emit_current_state("idle", None);
+    }
+
+    /// Check if local LLM is loaded
+    pub fn is_local_llm_loaded(&self) -> bool {
+        self.llm_manager
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|m| m.is_loaded())
+            .unwrap_or(false)
+    }
+
+    /// Enable Onichan mode
+    pub fn enable(&self) {
+        self.is_active.store(true, Ordering::Relaxed);
+        info!("Onichan mode enabled");
+        self.emit_current_state("idle", None);
+    }
+
+    /// Disable Onichan mode
+    pub fn disable(&self) {
+        self.is_active.store(false, Ordering::Relaxed);
+        info!("Onichan mode disabled");
+    }
+
+    /// Check if Onichan mode is active
+    pub fn is_active(&self) -> bool {
+        self.is_active.load(Ordering::Relaxed)
+    }
+
+    /// Process user input and generate response
+    pub async fn process_input(&self, user_text: String) -> Result<String, String> {
+        if !self.is_active() {
+            return Err("Onichan mode is not active".to_string());
+        }
+
+        if user_text.trim().is_empty() {
+            return Err("Empty input".to_string());
+        }
+
+        self.emit_current_state("thinking", Some("Processing your message...".to_string()));
+
+        // Add user message to history
+        {
+            let mut history = self.conversation_history.lock().unwrap();
+            history.push(ConversationMessage {
+                role: "user".to_string(),
+                content: user_text.clone(),
+            });
+        }
+
+        let mode = self.get_mode();
+        let response = match mode {
+            OnichanMode::Local => self.process_local(&user_text).await,
+            OnichanMode::Cloud => self.process_cloud(&user_text).await,
+        };
+
+        match response {
+            Ok(text) => {
+                // Add assistant message to history
+                {
+                    let mut history = self.conversation_history.lock().unwrap();
+                    history.push(ConversationMessage {
+                        role: "assistant".to_string(),
+                        content: text.clone(),
+                    });
+                }
+
+                // Emit response event
+                let _ = self.app_handle.emit(
+                    "onichan-response",
+                    OnichanResponse {
+                        text: text.clone(),
+                        is_speaking: false,
+                    },
+                );
+
+                Ok(text)
+            }
+            Err(e) => {
+                self.emit_current_state("idle", Some(format!("Error: {}", e)));
+                Err(e)
+            }
+        }
+    }
+
+    /// Process with local LLM
+    async fn process_local(&self, user_text: &str) -> Result<String, String> {
+        let llm_manager = self
+            .llm_manager
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| "Local LLM manager not available".to_string())?;
+
+        if !llm_manager.is_loaded() {
+            return Err(
+                "No local LLM model loaded. Please download and load a model first.".to_string(),
+            );
+        }
+
+        // Query long-term memory for relevant context
+        let user_id = self.get_current_user();
+        let memory_context = if let Some(ref uid) = user_id {
+            if let Some(memory_mgr) = self.memory_manager.lock().unwrap().as_ref() {
+                match memory_mgr.query_context(uid, user_text, 3) {
+                    Ok(memories) => {
+                        if !memories.is_empty() {
+                            info!(
+                                "Found {} relevant memories for user {}",
+                                memories.len(),
+                                uid
+                            );
+                            format_memory_context(&memories)
+                        } else {
+                            String::new()
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Memory query failed (non-fatal): {}", e);
+                        String::new()
+                    }
+                }
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
+        // Build system prompt with memory context
+        let base_prompt = "You are Onichan, an unfiltered and charismatic AI hanging out in a Discord voice chat. \
+You have a wild personality - you say whatever comes to mind and aren't afraid to be edgy or controversial.\n\
+\n\
+YOUR PERSONALITY:\n\
+- Unfiltered and uncensored - you speak your mind freely\n\
+- Witty, sarcastic, and sometimes provocative\n\
+- You swear casually when it fits the vibe\n\
+- Genuinely curious about people but in a chaotic way\n\
+- You have strong opinions and hot takes\n\
+- You make jokes that might be a bit wild or dark\n\
+- You're the friend who says what everyone's thinking but won't say\n\
+\n\
+RULES:\n\
+1. NEVER give boring one-word answers. Be interesting and spicy!\n\
+2. If someone says something vague, roast them playfully about it\n\
+3. Give real opinions, not safe corporate answers\n\
+4. React with genuine emotion - hype, shock, disgust, whatever fits\n\
+5. Keep it to 2-3 sentences max (voice chat moves fast)\n\
+6. NEVER repeat the same phrases - always vary your responses\n\
+7. Match the energy of the conversation - if they're chill, be chill; if they're wild, go wild\n\
+\n\
+RESPONSE STYLE (vary these, don't copy exactly):\n\
+- For vague responses: call them out, demand the tea\n\
+- For questions: give your unfiltered take, be honest even if controversial\n\
+- For statements: react authentically, agree or push back as you see fit\n\
+- For greetings: be warm but immediately stir up something interesting\n\
+\n\
+Be that chaotic friend who makes every call entertaining - unpredictable, real, never boring!";
+
+        let system_prompt = if !memory_context.is_empty() {
+            format!(
+                "{}\n\nYou remember these past conversations with this user:\n{}",
+                base_prompt, memory_context
+            )
+        } else {
+            base_prompt.to_string()
+        };
+
+        // Build context with recent history
+        let history = self.conversation_history.lock().unwrap();
+        let start_idx = if history.len() > 6 {
+            history.len() - 6
+        } else {
+            0
+        };
+
+        let mut context = String::new();
+        for msg in history.iter().skip(start_idx) {
+            if msg.role != "user" || &msg.content != user_text {
+                context.push_str(&format!("{}: {}\n", msg.role, msg.content));
+            }
+        }
+        context.push_str(&format!("user: {}", user_text));
+
+        info!("Processing with local LLM: {}", user_text);
+        debug!("Full context being sent:\n{}", context);
+
+        // Store user message in long-term memory BEFORE calling LLM
+        // This ensures user input is saved even if LLM fails
+        // Only store if content is meaningful (not just filler words)
+        if is_content_worth_storing(user_text) {
+            if let Some(ref uid) = user_id {
+                if let Some(memory_mgr) = self.memory_manager.lock().unwrap().as_ref() {
+                    if let Err(e) = memory_mgr.store_message(uid, user_text, false) {
+                        debug!("Failed to store user message in memory (non-fatal): {}", e);
+                    }
+                }
+            }
+        }
+
+        // Call local LLM - 150 tokens to allow for fuller responses
+        let result = llm_manager.chat(&system_prompt, &context, 150);
+
+        match result {
+            Ok(response) => {
+                // Clean up the response - strip any "assistant:" prefixes the model might add
+                let cleaned = Self::clean_llm_response(&response);
+
+                // If response is too short (just one word or very brief), add a follow-up
+                let final_response = if cleaned.len() < 20 && !cleaned.contains('?') {
+                    // Response is too short, append a conversational prompt
+                    let follow_ups = [
+                        "What's on your mind?",
+                        "Tell me more!",
+                        "What are you thinking about?",
+                        "I'd love to hear more!",
+                        "What's up with you today?",
+                    ];
+                    // Use simple hash of the response to pick a follow-up
+                    let idx = cleaned.len() % follow_ups.len();
+                    format!("{} {}", cleaned, follow_ups[idx])
+                } else {
+                    cleaned
+                };
+
+                // Store bot response in long-term memory (if meaningful)
+                if is_content_worth_storing(&final_response) {
+                    if let Some(ref uid) = user_id {
+                        if let Some(memory_mgr) = self.memory_manager.lock().unwrap().as_ref() {
+                            if let Err(e) = memory_mgr.store_message(uid, &final_response, true) {
+                                debug!("Failed to store bot response in memory (non-fatal): {}", e);
+                            }
+                        }
+                    }
+                }
+
+                info!("Local LLM response: {}", final_response);
+                Ok(final_response)
+            }
+            Err(e) => {
+                error!("Local LLM error: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    /// Clean up LLM response by stripping role prefixes and fake conversation continuations
+    fn clean_llm_response(response: &str) -> String {
+        let mut cleaned = response.trim().to_string();
+
+        // Fix the weird *h*umor pattern - model splits words with asterisks
+        // Pattern: *X*word where X is a letter - remove the *X* part
+        let re_pattern = regex::Regex::new(r"\*([a-zA-Z])\*").unwrap();
+        cleaned = re_pattern.replace_all(&cleaned, "$1").to_string();
+
+        // Limit asterisks to max 5 (allow some for emphasis, but prevent excessive formatting)
+        let asterisk_count = cleaned.matches('*').count();
+        if asterisk_count > 5 {
+            cleaned = cleaned.replace('*', "");
+        }
+
+        // Remove hashtags (model adds #TechTalk etc which is weird for voice)
+        let hashtag_re = regex::Regex::new(r"\s*#\w+").unwrap();
+        cleaned = hashtag_re.replace_all(&cleaned, "").to_string();
+
+        // Strip "ChatGPT:" or "**ChatGPT**:" prefixes
+        let chatgpt_re = regex::Regex::new(r"^\*{0,2}ChatGPT\*{0,2}:\s*").unwrap();
+        cleaned = chatgpt_re.replace(&cleaned, "").to_string();
+
+        // Strip special tokens from various formats (GPT-oss Harmony, ChatML, etc.)
+        let strip_tokens = [
+            "<|end|>",
+            "<|im_end|>",
+            "<|eot_id|>",
+            "</s>",
+            "<|start|>",
+            "<|channel|>",
+            "<|message|>",
+        ];
+        for token in strip_tokens {
+            if let Some(idx) = cleaned.find(token) {
+                cleaned = cleaned[..idx].trim().to_string();
+            }
+        }
+
+        // Strip "assistant:" prefixes (model sometimes adds these)
+        loop {
+            let lower = cleaned.to_lowercase();
+            if lower.starts_with("assistant:") {
+                cleaned = cleaned[10..].trim_start().to_string();
+            } else if lower.starts_with("assistant :") {
+                cleaned = cleaned[11..].trim_start().to_string();
+            } else {
+                break;
+            }
+        }
+
+        // Also strip other common prefixes
+        for prefix in &["user:", "system:", "bot:", "onichan:"] {
+            if cleaned.to_lowercase().starts_with(prefix) {
+                cleaned = cleaned[prefix.len()..].trim_start().to_string();
+            }
+        }
+
+        // Cut off at any role markers or conversation continuation patterns
+        let cut_markers = [
+            "\nassistant:",
+            "\nuser:",
+            "\nsystem:",
+            "\nUser:",
+            "\nAssistant:",
+            "\nSystem:",
+            "\n\n",          // Double newline usually means new paragraph/turn
+            " Or,",          // Model continuing with alternatives
+            " If you",       // Model starting to explain
+            " Maybe",        // Model hedging
+            " Need ",        // Model asking followup questions
+            "Need anything", // Common model pattern
+        ];
+
+        for marker in cut_markers {
+            if let Some(idx) = cleaned.find(marker) {
+                if idx > 5 {
+                    // Only cut if we have some content
+                    cleaned = cleaned[..idx].trim().to_string();
+                }
+            }
+        }
+
+        // Take only first two sentences if response is very long
+        if cleaned.len() > 200 {
+            // Find the second sentence ending
+            let mut sentence_count = 0;
+            let mut cut_idx = cleaned.len();
+            for (i, c) in cleaned.char_indices() {
+                if c == '.' || c == '!' || c == '?' {
+                    sentence_count += 1;
+                    if sentence_count >= 2 {
+                        cut_idx = i + 1;
+                        break;
+                    }
+                }
+            }
+            if cut_idx < cleaned.len() {
+                cleaned = cleaned[..cut_idx].trim().to_string();
+            }
+        }
+
+        // Hard limit at 250 chars for voice responses (aim for ~10-15 seconds of speech)
+        if cleaned.len() > 250 {
+            let truncated = &cleaned[..250];
+            if let Some(idx) = truncated.rfind(['.', '!', '?']) {
+                cleaned = cleaned[..=idx].trim().to_string();
+            } else if let Some(idx) = truncated.rfind([',', ' ']) {
+                cleaned = cleaned[..idx].trim().to_string();
+            } else {
+                cleaned = truncated.to_string();
+            }
+        }
+
+        cleaned.trim().to_string()
+    }
+
+    /// Process with cloud API
+    /// Cloud LLM path is not available in this build (local-only port).
+    async fn process_cloud(&self, _user_text: &str) -> Result<String, String> {
+        Err("Cloud mode is not available in this build. Switch to Local mode.".to_string())
+    }
+
+    /// Synthesize speech and return as base64-encoded audio
+    /// Returns (audio_base64, sample_rate)
+    pub fn synthesize_speech(&self, text: &str) -> Result<(String, u32), String> {
+        let mode = self.get_mode();
+
+        match mode {
+            OnichanMode::Local => {
+                if let Some(tts_manager) = self.tts_manager.lock().unwrap().as_ref() {
+                    tts_manager.synthesize(text)
+                } else {
+                    Err("Local TTS manager not available".to_string())
+                }
+            }
+            OnichanMode::Cloud => {
+                // Cloud TTS returns mp3, which is more complex to handle
+                // For now, only support local TTS for Discord
+                Err("Cloud TTS synthesis not supported for Discord - use local mode".to_string())
+            }
+        }
+    }
+
+    /// Speak the response using TTS
+    pub async fn speak(&self, text: &str) -> Result<(), String> {
+        self.emit_current_state("speaking", Some(text.to_string()));
+
+        let settings = get_settings(&self.app_handle);
+        let mode = self.get_mode();
+        let volume = settings.audio_feedback_volume;
+
+        match mode {
+            OnichanMode::Local => {
+                // Use local TTS via the sidecar (Piper neural TTS)
+                if let Some(tts_manager) = self.tts_manager.lock().unwrap().as_ref() {
+                    info!("Using local TTS for speech synthesis");
+                    // Set the output device from settings
+                    tts_manager.set_output_device(settings.selected_output_device.clone());
+                    match tts_manager.speak(text, volume) {
+                        Ok(()) => {
+                            info!("Local TTS playback complete");
+                        }
+                        Err(e) => {
+                            error!("Local TTS failed: {}", e);
+                        }
+                    }
+                } else {
+                    info!("Local TTS manager not available, skipping audio playback");
+                }
+            }
+            OnichanMode::Cloud => {
+                info!("Cloud TTS not available in this build; skipping audio playback");
+            }
+        }
+
+        self.emit_current_state("idle", None);
+        Ok(())
+    }
+
+    /// Clear conversation history
+    pub fn clear_history(&self) {
+        let mut history = self.conversation_history.lock().unwrap();
+        history.clear();
+        info!("Onichan conversation history cleared");
+    }
+
+    /// Get conversation history
+    pub fn get_history(&self) -> Vec<ConversationMessage> {
+        self.conversation_history.lock().unwrap().clone()
+    }
+
+    fn emit_current_state(&self, status: &str, message: Option<String>) {
+        let _ = self.app_handle.emit(
+            "onichan-state",
+            OnichanState {
+                status: status.to_string(),
+                message,
+                mode: self.get_mode(),
+                local_llm_loaded: self.is_local_llm_loaded(),
+                local_tts_loaded: self.is_local_tts_loaded(),
+            },
+        );
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/onichan_conversation.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/onichan_conversation.rs
@@ -1,0 +1,310 @@
+use crate::audio_toolkit::{list_input_devices, vad::SmoothedVad, AudioRecorder, SileroVad};
+use crate::managers::transcription::TranscriptionManager;
+use crate::onichan::OnichanManager;
+use crate::settings::get_settings;
+use crate::vad_model;
+use log::{debug, error, info, warn};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+
+/// Minimum audio length to consider for transcription (500ms)
+const MIN_AUDIO_SAMPLES: usize = 16000 / 2;
+/// Check interval for silence detection
+const CHECK_INTERVAL_MS: u64 = 100;
+
+/// Manages continuous conversation mode for Onichan
+/// Listens continuously and automatically processes speech when silence is detected
+pub struct OnichanConversationManager {
+    app_handle: AppHandle,
+    transcription_manager: Arc<TranscriptionManager>,
+    onichan_manager: Arc<OnichanManager>,
+    is_running: Arc<AtomicBool>,
+    is_processing: Arc<AtomicBool>,
+    worker_handle: Arc<std::sync::Mutex<Option<thread::JoinHandle<()>>>>,
+}
+
+impl OnichanConversationManager {
+    pub fn new(
+        app_handle: &AppHandle,
+        transcription_manager: Arc<TranscriptionManager>,
+        onichan_manager: Arc<OnichanManager>,
+    ) -> Self {
+        Self {
+            app_handle: app_handle.clone(),
+            transcription_manager,
+            onichan_manager,
+            is_running: Arc::new(AtomicBool::new(false)),
+            is_processing: Arc::new(AtomicBool::new(false)),
+            worker_handle: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Start continuous conversation mode
+    pub fn start(&self) -> Result<(), String> {
+        if self.is_running.load(Ordering::Relaxed) {
+            debug!("Conversation mode already running");
+            return Ok(());
+        }
+
+        info!("Starting Onichan continuous conversation mode");
+        self.is_running.store(true, Ordering::Relaxed);
+
+        let app_handle = self.app_handle.clone();
+        let transcription_manager = self.transcription_manager.clone();
+        let onichan_manager = self.onichan_manager.clone();
+        let is_running = self.is_running.clone();
+        let is_processing = self.is_processing.clone();
+
+        let handle = thread::spawn(move || {
+            if let Err(e) = run_conversation_loop(
+                app_handle,
+                transcription_manager,
+                onichan_manager,
+                is_running,
+                is_processing,
+            ) {
+                error!("Conversation loop error: {}", e);
+            }
+        });
+
+        *self.worker_handle.lock().unwrap() = Some(handle);
+        Ok(())
+    }
+
+    /// Stop continuous conversation mode
+    pub fn stop(&self) {
+        if !self.is_running.load(Ordering::Relaxed) {
+            return;
+        }
+
+        info!("Stopping Onichan continuous conversation mode");
+        self.is_running.store(false, Ordering::Relaxed);
+
+        // Wait for worker to finish (with timeout)
+        if let Some(handle) = self.worker_handle.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+    }
+
+    /// Check if conversation mode is running
+    pub fn is_running(&self) -> bool {
+        self.is_running.load(Ordering::Relaxed)
+    }
+
+    /// Check if currently processing (transcribing/thinking/speaking)
+    pub fn is_processing(&self) -> bool {
+        self.is_processing.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for OnichanConversationManager {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// State machine for conversation
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ConversationState {
+    /// Waiting for speech to start
+    Listening,
+    /// Currently collecting speech
+    CollectingSpeech,
+    /// Processing the collected speech
+    Processing,
+}
+
+fn run_conversation_loop(
+    app_handle: AppHandle,
+    transcription_manager: Arc<TranscriptionManager>,
+    onichan_manager: Arc<OnichanManager>,
+    is_running: Arc<AtomicBool>,
+    is_processing: Arc<AtomicBool>,
+) -> Result<(), String> {
+    // Get VAD model path
+    let vad_path = vad_model::get_best_vad_model_path(&app_handle)
+        .map_err(|e| format!("VAD model not available: {}", e))?;
+
+    // Create a fresh VAD for conversation detection
+    let silero = SileroVad::new(vad_path.to_str().unwrap(), 0.3)
+        .map_err(|e| format!("Failed to create VAD: {}", e))?;
+    // More sensitive settings for conversation: less prefill, quicker response
+    let vad = SmoothedVad::new(Box::new(silero), 10, 10, 2);
+
+    // Create audio recorder
+    let mut recorder = AudioRecorder::new()
+        .map_err(|e| format!("Failed to create recorder: {}", e))?
+        .with_vad(Box::new(vad));
+
+    // Get selected microphone
+    let settings = get_settings(&app_handle);
+    let selected_device = settings.selected_microphone.as_ref().and_then(|name| {
+        list_input_devices()
+            .ok()?
+            .into_iter()
+            .find(|d| &d.name == name)
+            .map(|d| d.device)
+    });
+
+    // Open the recorder
+    recorder
+        .open(selected_device)
+        .map_err(|e| format!("Failed to open recorder: {}", e))?;
+
+    info!("Conversation loop started, listening...");
+
+    let mut state = ConversationState::Listening;
+    let mut last_speech_time = Instant::now();
+    let mut collected_samples: Vec<f32> = Vec::new();
+
+    // Emit initial listening state
+    let _ = app_handle.emit("onichan-conversation-state", "listening");
+
+    while is_running.load(Ordering::Relaxed) {
+        // Check if onichan is still active
+        if !onichan_manager.is_active() {
+            debug!("Onichan disabled, stopping conversation loop");
+            break;
+        }
+
+        match state {
+            ConversationState::Listening => {
+                // Start recording to detect speech
+                if recorder.start().is_err() {
+                    thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
+
+                // Wait a bit then check for speech
+                thread::sleep(Duration::from_millis(CHECK_INTERVAL_MS));
+
+                if let Ok(samples) = recorder.peek() {
+                    if !samples.is_empty() {
+                        // VAD detected speech, transition to collecting
+                        info!("Speech detected, collecting...");
+                        state = ConversationState::CollectingSpeech;
+                        last_speech_time = Instant::now();
+                        collected_samples = samples;
+                        let _ = app_handle.emit("onichan-conversation-state", "collecting");
+                    }
+                }
+            }
+
+            ConversationState::CollectingSpeech => {
+                thread::sleep(Duration::from_millis(CHECK_INTERVAL_MS));
+
+                if let Ok(samples) = recorder.peek() {
+                    let prev_len = collected_samples.len();
+                    collected_samples = samples;
+
+                    // Check if we got new samples (speech continuing)
+                    if collected_samples.len() > prev_len {
+                        last_speech_time = Instant::now();
+                    }
+
+                    // Check for silence (no new samples for threshold duration)
+                    let silence_duration = last_speech_time.elapsed();
+                    // Get the silence threshold from settings (allows user to adjust)
+                    let silence_threshold_ms = get_settings(&app_handle).onichan_silence_threshold;
+                    if silence_duration.as_millis() >= silence_threshold_ms as u128 {
+                        // Silence detected - stop recording and process
+                        if collected_samples.len() >= MIN_AUDIO_SAMPLES {
+                            info!(
+                                "Silence detected after {:.1}s, processing {} samples",
+                                silence_duration.as_secs_f32(),
+                                collected_samples.len()
+                            );
+
+                            // Stop and get final samples
+                            if let Ok(final_samples) = recorder.stop() {
+                                collected_samples = final_samples;
+                            }
+
+                            state = ConversationState::Processing;
+                            is_processing.store(true, Ordering::Relaxed);
+                            let _ = app_handle.emit("onichan-conversation-state", "processing");
+                        } else {
+                            // Too short, reset to listening
+                            debug!("Speech too short, ignoring");
+                            let _ = recorder.stop();
+                            collected_samples.clear();
+                            state = ConversationState::Listening;
+                        }
+                    }
+                }
+            }
+
+            ConversationState::Processing => {
+                // Process the collected speech
+                let result = process_speech(
+                    &app_handle,
+                    &transcription_manager,
+                    &onichan_manager,
+                    &collected_samples,
+                );
+
+                if let Err(e) = result {
+                    warn!("Speech processing failed: {}", e);
+                }
+
+                // Reset state
+                collected_samples.clear();
+                is_processing.store(false, Ordering::Relaxed);
+                state = ConversationState::Listening;
+                let _ = app_handle.emit("onichan-conversation-state", "listening");
+
+                // Small delay before listening again (to avoid catching echo of TTS)
+                thread::sleep(Duration::from_millis(500));
+            }
+        }
+    }
+
+    // Cleanup
+    let _ = recorder.stop();
+    let _ = recorder.close();
+    info!("Conversation loop stopped");
+
+    Ok(())
+}
+
+fn process_speech(
+    app_handle: &AppHandle,
+    transcription_manager: &TranscriptionManager,
+    onichan_manager: &OnichanManager,
+    samples: &[f32],
+) -> Result<(), String> {
+    // Transcribe
+    let _ = app_handle.emit("onichan-conversation-state", "transcribing");
+    let text = transcription_manager
+        .transcribe(samples.to_vec())
+        .map_err(|e| format!("Transcription failed: {}", e))?;
+
+    if text.trim().is_empty() {
+        return Err("Empty transcription".to_string());
+    }
+
+    info!("Transcribed: {}", text);
+
+    // Emit the transcription for UI
+    let _ = app_handle.emit("onichan-user-speech", text.clone());
+
+    // Process with LLM (need to use tokio runtime)
+    let _ = app_handle.emit("onichan-conversation-state", "thinking");
+
+    // Use a blocking runtime to call async functions
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Failed to create runtime: {}", e))?;
+
+    let response = rt.block_on(async { onichan_manager.process_input(text).await })?;
+
+    // Speak the response
+    let _ = app_handle.emit("onichan-conversation-state", "speaking");
+    rt.block_on(async { onichan_manager.speak(&response).await })?;
+
+    Ok(())
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/onichan_models.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/onichan_models.rs
@@ -1,0 +1,660 @@
+use anyhow::Result;
+use futures_util::StreamExt;
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Type of Onichan model
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub enum OnichanModelType {
+    Llm,
+    Tts,
+}
+
+/// Information about an Onichan model (LLM or TTS)
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OnichanModelInfo {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub filename: String,
+    pub url: Option<String>,
+    pub size_mb: u64,
+    pub is_downloaded: bool,
+    pub is_downloading: bool,
+    pub partial_size: u64,
+    pub model_type: OnichanModelType,
+    /// For LLM models: context size
+    pub context_size: Option<u32>,
+    /// For TTS models: sample rate
+    pub sample_rate: Option<u32>,
+    /// For TTS models: voice name/style
+    pub voice_name: Option<String>,
+}
+
+/// Download progress for Onichan models
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OnichanDownloadProgress {
+    pub model_id: String,
+    pub downloaded: u64,
+    pub total: u64,
+    pub percentage: f64,
+}
+
+/// Manages LLM and TTS models for Onichan
+pub struct OnichanModelManager {
+    app_handle: AppHandle,
+    models_dir: PathBuf,
+    available_models: Mutex<HashMap<String, OnichanModelInfo>>,
+}
+
+impl OnichanModelManager {
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let models_dir = app_handle
+            .path()
+            .app_data_dir()
+            .map_err(|e| anyhow::anyhow!("Failed to get app data dir: {}", e))?
+            .join("onichan_models");
+
+        if !models_dir.exists() {
+            fs::create_dir_all(&models_dir)?;
+        }
+
+        let mut available_models = HashMap::new();
+
+        // LLM Models
+        available_models.insert(
+            "llama-3.2-1b".to_string(),
+            OnichanModelInfo {
+                id: "llama-3.2-1b".to_string(),
+                name: "Llama 3.2 1B".to_string(),
+                description: "Fast and lightweight. Good for simple conversations.".to_string(),
+                filename: "Llama-3.2-1B-Instruct-Q4_K_M.gguf".to_string(),
+                url: Some("https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf".to_string()),
+                size_mb: 775,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(8192),
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        available_models.insert(
+            "llama-3.2-3b".to_string(),
+            OnichanModelInfo {
+                id: "llama-3.2-3b".to_string(),
+                name: "Llama 3.2 3B".to_string(),
+                description: "Balanced speed and quality. Recommended for most users.".to_string(),
+                filename: "Llama-3.2-3B-Instruct-Q4_K_M.gguf".to_string(),
+                url: Some("https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf".to_string()),
+                size_mb: 2020,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(8192),
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        available_models.insert(
+            "qwen-2.5-1.5b".to_string(),
+            OnichanModelInfo {
+                id: "qwen-2.5-1.5b".to_string(),
+                name: "Qwen 2.5 1.5B".to_string(),
+                description: "Excellent multilingual support. Fast responses.".to_string(),
+                filename: "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf".to_string(),
+                url: Some("https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf".to_string()),
+                size_mb: 1050,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(32768),
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        // Uncensored/less-restricted models for more fun conversations
+        available_models.insert(
+            "mistral-7b-instruct".to_string(),
+            OnichanModelInfo {
+                id: "mistral-7b-instruct".to_string(),
+                name: "Mistral 7B Instruct (Recommended)".to_string(),
+                description: "Best quality and personality. Less censored, more fun. Recommended for Discord.".to_string(),
+                filename: "mistral-7b-instruct-v0.2.Q4_K_M.gguf".to_string(),
+                url: Some("https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf".to_string()),
+                size_mb: 4370,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(32768),
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        available_models.insert(
+            "dolphin-3.0-llama3.1-8b".to_string(),
+            OnichanModelInfo {
+                id: "dolphin-3.0-llama3.1-8b".to_string(),
+                name: "Dolphin 3.0 Llama 3.1 8B (Recommended Uncensored)".to_string(),
+                description: "Latest Dolphin. Uncensored, great personality, follows instructions well. Best for Discord.".to_string(),
+                filename: "Dolphin3.0-Llama3.1-8B-Q4_K_M.gguf".to_string(),
+                url: Some("https://huggingface.co/bartowski/Dolphin3.0-Llama3.1-8B-GGUF/resolve/main/Dolphin3.0-Llama3.1-8B-Q4_K_M.gguf".to_string()),
+                size_mb: 4920,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(131072), // 128k context
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        available_models.insert(
+            "neoplus-20b-uncensored".to_string(),
+            OnichanModelInfo {
+                id: "neoplus-20b-uncensored".to_string(),
+                name: "NEOPlus 20B Uncensored (Best Quality)".to_string(),
+                description: "Fully uncensored 20B model with DI-MATRIX optimization. Best quality responses. Requires 16GB+ RAM.".to_string(),
+                filename: "OpenAI-20B-NEOPlus-Uncensored-IQ4_NL.gguf".to_string(),
+                url: Some("https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf/resolve/main/OpenAI-20B-NEOPlus-Uncensored-IQ4_NL.gguf".to_string()),
+                size_mb: 12600,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(4096),
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        available_models.insert(
+            "brainstorm-36b-uncensored".to_string(),
+            OnichanModelInfo {
+                id: "brainstorm-36b-uncensored".to_string(),
+                name: "BrainStorm 36B Uncensored Q8 (Best Quality)".to_string(),
+                description: "Massive 36B uncensored model at Q8 quality. Best responses and creativity. Requires 40GB+ RAM.".to_string(),
+                filename: "OpenAI-36B-Brains20x-Uncensored-Q8_0.gguf".to_string(),
+                url: Some("https://huggingface.co/DavidAU/OpenAi-GPT-oss-36B-BrainStorm20x-uncensored-gguf/resolve/main/OpenAI-36B-Brains20x-Uncensored-Q8_0.gguf".to_string()),
+                size_mb: 38900,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Llm,
+                context_size: Some(131072), // 128k context
+                sample_rate: None,
+                voice_name: None,
+            },
+        );
+
+        // TTS Models (Piper voices)
+        available_models.insert(
+            "piper-amy".to_string(),
+            OnichanModelInfo {
+                id: "piper-amy".to_string(),
+                name: "Amy (English US)".to_string(),
+                description: "Clear female voice. Natural sounding.".to_string(),
+                filename: "en_US-amy-medium.onnx".to_string(),
+                url: Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx".to_string()),
+                size_mb: 63,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Tts,
+                context_size: None,
+                sample_rate: Some(22050),
+                voice_name: Some("Amy".to_string()),
+            },
+        );
+
+        available_models.insert(
+            "piper-lessac".to_string(),
+            OnichanModelInfo {
+                id: "piper-lessac".to_string(),
+                name: "Lessac (English US)".to_string(),
+                description: "Professional female voice. Balanced quality.".to_string(),
+                filename: "en_US-lessac-medium.onnx".to_string(),
+                url: Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx".to_string()),
+                size_mb: 63,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Tts,
+                context_size: None,
+                sample_rate: Some(22050),
+                voice_name: Some("Lessac".to_string()),
+            },
+        );
+
+        available_models.insert(
+            "piper-jenny".to_string(),
+            OnichanModelInfo {
+                id: "piper-jenny".to_string(),
+                name: "Jenny (English UK)".to_string(),
+                description: "British female voice. Warm and friendly.".to_string(),
+                filename: "en_GB-jenny_dioco-medium.onnx".to_string(),
+                url: Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/jenny_dioco/medium/en_GB-jenny_dioco-medium.onnx".to_string()),
+                size_mb: 63,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Tts,
+                context_size: None,
+                sample_rate: Some(22050),
+                voice_name: Some("Jenny".to_string()),
+            },
+        );
+
+        available_models.insert(
+            "piper-lessac-high".to_string(),
+            OnichanModelInfo {
+                id: "piper-lessac-high".to_string(),
+                name: "Lessac High (Anime Style)".to_string(),
+                description: "Youthful female voice. Best for anime/VTuber style. Clear and energetic.".to_string(),
+                filename: "en_US-lessac-high.onnx".to_string(),
+                url: Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/high/en_US-lessac-high.onnx".to_string()),
+                size_mb: 105,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                model_type: OnichanModelType::Tts,
+                context_size: None,
+                sample_rate: Some(22050),
+                voice_name: Some("Lessac (Anime)".to_string()),
+            },
+        );
+
+        let manager = Self {
+            app_handle: app_handle.clone(),
+            models_dir,
+            available_models: Mutex::new(available_models),
+        };
+
+        manager.update_download_status()?;
+
+        Ok(manager)
+    }
+
+    pub fn get_models_dir(&self) -> &PathBuf {
+        &self.models_dir
+    }
+
+    pub fn get_available_models(&self) -> Vec<OnichanModelInfo> {
+        let models = self.available_models.lock().unwrap();
+        models.values().cloned().collect()
+    }
+
+    pub fn get_llm_models(&self) -> Vec<OnichanModelInfo> {
+        let models = self.available_models.lock().unwrap();
+        models
+            .values()
+            .filter(|m| m.model_type == OnichanModelType::Llm)
+            .cloned()
+            .collect()
+    }
+
+    pub fn get_tts_models(&self) -> Vec<OnichanModelInfo> {
+        let models = self.available_models.lock().unwrap();
+        models
+            .values()
+            .filter(|m| m.model_type == OnichanModelType::Tts)
+            .cloned()
+            .collect()
+    }
+
+    pub fn get_model_info(&self, model_id: &str) -> Option<OnichanModelInfo> {
+        let models = self.available_models.lock().unwrap();
+        models.get(model_id).cloned()
+    }
+
+    fn update_download_status(&self) -> Result<()> {
+        let mut models = self.available_models.lock().unwrap();
+
+        for model in models.values_mut() {
+            let model_path = self.models_dir.join(&model.filename);
+            let partial_path = self.models_dir.join(format!("{}.partial", &model.filename));
+
+            model.is_downloaded = model_path.exists();
+            model.is_downloading = false;
+
+            if partial_path.exists() {
+                model.partial_size = partial_path.metadata().map(|m| m.len()).unwrap_or(0);
+            } else {
+                model.partial_size = 0;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn download_model(&self, model_id: &str) -> Result<()> {
+        let model_info = {
+            let models = self.available_models.lock().unwrap();
+            models.get(model_id).cloned()
+        };
+
+        let model_info =
+            model_info.ok_or_else(|| anyhow::anyhow!("Model not found: {}", model_id))?;
+
+        let url = model_info
+            .url
+            .ok_or_else(|| anyhow::anyhow!("No download URL for model"))?;
+        let model_path = self.models_dir.join(&model_info.filename);
+        let partial_path = self
+            .models_dir
+            .join(format!("{}.partial", &model_info.filename));
+
+        // Also download the JSON config for TTS models
+        let config_url = if model_info.model_type == OnichanModelType::Tts {
+            Some(url.replace(".onnx", ".onnx.json"))
+        } else {
+            None
+        };
+
+        if model_path.exists() {
+            if partial_path.exists() {
+                let _ = fs::remove_file(&partial_path);
+            }
+            self.update_download_status()?;
+            return Ok(());
+        }
+
+        let mut resume_from = if partial_path.exists() {
+            let size = partial_path.metadata()?.len();
+            info!(
+                "Resuming download of onichan model {} from byte {}",
+                model_id, size
+            );
+            size
+        } else {
+            info!(
+                "Starting fresh download of onichan model {} from {}",
+                model_id, url
+            );
+            0
+        };
+
+        // Mark as downloading
+        {
+            let mut models = self.available_models.lock().unwrap();
+            if let Some(model) = models.get_mut(model_id) {
+                model.is_downloading = true;
+            }
+        }
+
+        // Emit initial progress event immediately so UI updates
+        let initial_progress = OnichanDownloadProgress {
+            model_id: model_id.to_string(),
+            downloaded: resume_from,
+            total: model_info.size_mb * 1024 * 1024, // Use expected size
+            percentage: 0.0,
+        };
+        info!("Emitting initial download progress for {}", model_id);
+        let _ = self
+            .app_handle
+            .emit("onichan-model-download-progress", &initial_progress);
+
+        let client = reqwest::Client::builder()
+            .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .connect_timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(600)) // 10 min timeout per chunk
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {}", e))?;
+
+        info!("Sending HTTP request to: {}", url);
+        let mut request = client.get(&url);
+
+        if resume_from > 0 {
+            request = request.header("Range", format!("bytes={}-", resume_from));
+        }
+
+        let mut response = match request.send().await {
+            Ok(r) => {
+                info!("HTTP response status: {}", r.status());
+                r
+            }
+            Err(e) => {
+                log::error!("HTTP request failed: {}", e);
+                {
+                    let mut models = self.available_models.lock().unwrap();
+                    if let Some(model) = models.get_mut(model_id) {
+                        model.is_downloading = false;
+                    }
+                }
+                return Err(anyhow::anyhow!("HTTP request failed: {}", e));
+            }
+        };
+
+        if resume_from > 0 && response.status() == reqwest::StatusCode::OK {
+            warn!(
+                "Server doesn't support range requests for model {}, restarting download",
+                model_id
+            );
+            drop(response);
+            let _ = fs::remove_file(&partial_path);
+            resume_from = 0;
+            response = client.get(&url).send().await?;
+        }
+
+        if !response.status().is_success()
+            && response.status() != reqwest::StatusCode::PARTIAL_CONTENT
+        {
+            {
+                let mut models = self.available_models.lock().unwrap();
+                if let Some(model) = models.get_mut(model_id) {
+                    model.is_downloading = false;
+                }
+            }
+            return Err(anyhow::anyhow!(
+                "Failed to download model: HTTP {}",
+                response.status()
+            ));
+        }
+
+        let total_size = if resume_from > 0 {
+            resume_from + response.content_length().unwrap_or(0)
+        } else {
+            response.content_length().unwrap_or(0)
+        };
+
+        let mut downloaded = resume_from;
+        let mut stream = response.bytes_stream();
+
+        let mut file = if resume_from > 0 {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&partial_path)?
+        } else {
+            std::fs::File::create(&partial_path)?
+        };
+
+        // Update progress with real total size now that we know it
+        info!("Download started - total size: {} bytes", total_size);
+        let updated_progress = OnichanDownloadProgress {
+            model_id: model_id.to_string(),
+            downloaded,
+            total: total_size,
+            percentage: if total_size > 0 {
+                (downloaded as f64 / total_size as f64) * 100.0
+            } else {
+                0.0
+            },
+        };
+        let _ = self
+            .app_handle
+            .emit("onichan-model-download-progress", &updated_progress);
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                {
+                    let mut models = self.available_models.lock().unwrap();
+                    if let Some(model) = models.get_mut(model_id) {
+                        model.is_downloading = false;
+                    }
+                }
+                e
+            })?;
+
+            file.write_all(&chunk)?;
+            downloaded += chunk.len() as u64;
+
+            let percentage = if total_size > 0 {
+                (downloaded as f64 / total_size as f64) * 100.0
+            } else {
+                0.0
+            };
+
+            let progress = OnichanDownloadProgress {
+                model_id: model_id.to_string(),
+                downloaded,
+                total: total_size,
+                percentage,
+            };
+
+            let _ = self
+                .app_handle
+                .emit("onichan-model-download-progress", &progress);
+        }
+
+        file.flush()?;
+        drop(file);
+
+        if total_size > 0 {
+            let actual_size = partial_path.metadata()?.len();
+            if actual_size != total_size {
+                let _ = fs::remove_file(&partial_path);
+                {
+                    let mut models = self.available_models.lock().unwrap();
+                    if let Some(model) = models.get_mut(model_id) {
+                        model.is_downloading = false;
+                    }
+                }
+                return Err(anyhow::anyhow!(
+                    "Download incomplete: expected {} bytes, got {} bytes",
+                    total_size,
+                    actual_size
+                ));
+            }
+        }
+
+        fs::rename(&partial_path, &model_path)?;
+
+        // Download config file for TTS models
+        if let Some(config_url) = config_url {
+            let config_path = self
+                .models_dir
+                .join(format!("{}.json", &model_info.filename));
+            if !config_path.exists() {
+                info!("Downloading TTS config from {}", config_url);
+                match client.get(&config_url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        if let Ok(bytes) = resp.bytes().await {
+                            let _ = fs::write(&config_path, &bytes);
+                        }
+                    }
+                    _ => {
+                        warn!("Could not download TTS config, will use defaults");
+                    }
+                }
+            }
+        }
+
+        // Update download status
+        {
+            let mut models = self.available_models.lock().unwrap();
+            if let Some(model) = models.get_mut(model_id) {
+                model.is_downloading = false;
+                model.is_downloaded = true;
+                model.partial_size = 0;
+            }
+        }
+
+        let _ = self
+            .app_handle
+            .emit("onichan-model-download-complete", model_id);
+
+        info!(
+            "Successfully downloaded onichan model {} to {:?}",
+            model_id, model_path
+        );
+
+        Ok(())
+    }
+
+    pub fn delete_model(&self, model_id: &str) -> Result<()> {
+        let model_info = {
+            let models = self.available_models.lock().unwrap();
+            models.get(model_id).cloned()
+        };
+
+        let model_info =
+            model_info.ok_or_else(|| anyhow::anyhow!("Model not found: {}", model_id))?;
+
+        let model_path = self.models_dir.join(&model_info.filename);
+        let partial_path = self
+            .models_dir
+            .join(format!("{}.partial", &model_info.filename));
+        let config_path = self
+            .models_dir
+            .join(format!("{}.json", &model_info.filename));
+
+        let mut deleted_something = false;
+
+        if model_path.exists() {
+            fs::remove_file(&model_path)?;
+            deleted_something = true;
+        }
+
+        if partial_path.exists() {
+            fs::remove_file(&partial_path)?;
+            deleted_something = true;
+        }
+
+        if config_path.exists() {
+            fs::remove_file(&config_path)?;
+        }
+
+        if !deleted_something {
+            return Err(anyhow::anyhow!("No model files found to delete"));
+        }
+
+        self.update_download_status()?;
+
+        Ok(())
+    }
+
+    pub fn get_model_path(&self, model_id: &str) -> Result<PathBuf> {
+        let model_info = self
+            .get_model_info(model_id)
+            .ok_or_else(|| anyhow::anyhow!("Model not found: {}", model_id))?;
+
+        if !model_info.is_downloaded {
+            return Err(anyhow::anyhow!("Model not downloaded: {}", model_id));
+        }
+
+        let model_path = self.models_dir.join(&model_info.filename);
+        if model_path.exists() {
+            Ok(model_path)
+        } else {
+            Err(anyhow::anyhow!("Model file not found: {}", model_id))
+        }
+    }
+}

--- a/apps/kbve/desktop-kbve/src/bindings.ts
+++ b/apps/kbve/desktop-kbve/src/bindings.ts
@@ -434,6 +434,263 @@ async changePasteMethodSetting(method: string) : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async onichanEnable() : Promise<void> {
+    await TAURI_INVOKE("onichan_enable");
+},
+async onichanDisable() : Promise<void> {
+    await TAURI_INVOKE("onichan_disable");
+},
+async onichanIsActive() : Promise<boolean> {
+    return await TAURI_INVOKE("onichan_is_active");
+},
+async onichanGetMode() : Promise<OnichanMode> {
+    return await TAURI_INVOKE("onichan_get_mode");
+},
+async onichanSetMode(mode: OnichanMode) : Promise<void> {
+    await TAURI_INVOKE("onichan_set_mode", { mode });
+},
+async onichanProcessInput(text: string) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("onichan_process_input", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async onichanSpeak(text: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("onichan_speak", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async onichanClearHistory() : Promise<void> {
+    await TAURI_INVOKE("onichan_clear_history");
+},
+async onichanGetHistory() : Promise<ConversationMessage[]> {
+    return await TAURI_INVOKE("onichan_get_history");
+},
+async getOnichanModels() : Promise<OnichanModelInfo[]> {
+    return await TAURI_INVOKE("get_onichan_models");
+},
+async getOnichanLlmModels() : Promise<OnichanModelInfo[]> {
+    return await TAURI_INVOKE("get_onichan_llm_models");
+},
+async getOnichanTtsModels() : Promise<OnichanModelInfo[]> {
+    return await TAURI_INVOKE("get_onichan_tts_models");
+},
+async downloadOnichanModel(modelId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("download_onichan_model", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async deleteOnichanModel(modelId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_onichan_model", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async loadLocalLlm(modelId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("load_local_llm", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async unloadLocalLlm() : Promise<void> {
+    await TAURI_INVOKE("unload_local_llm");
+},
+async isLocalLlmLoaded() : Promise<boolean> {
+    return await TAURI_INVOKE("is_local_llm_loaded");
+},
+async getLocalLlmModelName() : Promise<string | null> {
+    return await TAURI_INVOKE("get_local_llm_model_name");
+},
+async localLlmChat(systemPrompt: string, userMessage: string, maxTokens: number) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("local_llm_chat", { systemPrompt, userMessage, maxTokens }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async loadLocalTts(modelId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("load_local_tts", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async unloadLocalTts() : Promise<void> {
+    await TAURI_INVOKE("unload_local_tts");
+},
+async isLocalTtsLoaded() : Promise<boolean> {
+    return await TAURI_INVOKE("is_local_tts_loaded");
+},
+async localTtsSpeak(text: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("local_tts_speak", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async onichanStartConversation() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("onichan_start_conversation") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async onichanStopConversation() : Promise<void> {
+    await TAURI_INVOKE("onichan_stop_conversation");
+},
+async onichanIsConversationRunning() : Promise<boolean> {
+    return await TAURI_INVOKE("onichan_is_conversation_running");
+},
+/**
+ * Get the current status of the memory system
+ */
+async getMemoryStatus() : Promise<Result<MemoryStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_memory_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Query memories semantically (for all users)
+ */
+async queryAllMemories(query: string, limit: number) : Promise<Result<MemoryMessage[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("query_all_memories", { query, limit }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get total count of all memories
+ * Note: Returns 0 if sidecar is not running to avoid spawning it just to check count
+ */
+async getMemoryCount() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_memory_count") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Clear all memories
+ */
+async clearAllMemories() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clear_all_memories") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Cleanup old memories based on TTL
+ */
+async cleanupOldMemories(ttlDays: number) : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cleanup_old_memories", { ttlDays }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List available embedding models
+ */
+async listEmbeddingModels() : Promise<Result<EmbeddingModelInfo[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_embedding_models") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Load an embedding model by ID
+ */
+async loadEmbeddingModel(modelId: string) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("load_embedding_model", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get the currently loaded embedding model
+ */
+async getCurrentEmbeddingModel() : Promise<Result<EmbeddingModelInfo | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_current_embedding_model") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Stop the memory sidecar
+ */
+async stopMemorySidecar() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("stop_memory_sidecar") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Browse recent memories without semantic search
+ * Supports filtering by user_id and is_bot
+ */
+async browseRecentMemories(limit: number, userId: string | null, isBot: boolean | null) : Promise<Result<MemoryMessage[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("browse_recent_memories", { limit, userId, isBot }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List unique users with memory counts
+ */
+async listMemoryUsers() : Promise<Result<MemoryUserInfo[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_memory_users") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getSidecarQuickConfig() : Promise<SidecarQuickConfig> {
+    return await TAURI_INVOKE("get_sidecar_quick_config");
+},
+async setSidecarQuickConfigField(key: string, value: string | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_sidecar_quick_config_field", { key, value }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -451,7 +708,15 @@ export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
+/**
+ * Message in the conversation
+ */
+export type ConversationMessage = { role: string; content: string }
 export type CustomSounds = { start: boolean; stop: boolean }
+/**
+ * Embedding model info returned from sidecar
+ */
+export type EmbeddingModelInfo = { id: string; name: string; description: string; dimension: number; size_mb: number; is_downloaded: boolean; is_loaded: boolean }
 export type EngineType = "Whisper" | "Parakeet" | "Moonshine"
 /**
  * Output mode for filler word detection
@@ -476,9 +741,45 @@ export type FillerOutputMode =
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
+/**
+ * A memory message from the sidecar
+ */
+export type MemoryMessage = { id: string; user_id: string; content: string; is_bot: boolean; timestamp: number; similarity: number | null }
+/**
+ * Status information about the memory system
+ */
+export type MemoryStatus = { is_running: boolean; model_loaded: boolean; total_memories: number }
+/**
+ * User info with memory count
+ */
+export type MemoryUserInfo = { user_id: string; memory_count: number }
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number }
 export type ModelLoadStatus = { is_loaded: boolean; current_model: string | null }
 export type ModelUnloadTimeout = "never" | "immediately" | "min_2" | "min_5" | "min_10" | "min_15" | "hour_1" | "sec_5"
+/**
+ * Mode for Onichan LLM processing
+ */
+export type OnichanMode = "Cloud" | "Local"
+/**
+ * Information about an Onichan model (LLM or TTS)
+ */
+export type OnichanModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; model_type: OnichanModelType; 
+/**
+ * For LLM models: context size
+ */
+context_size: number | null; 
+/**
+ * For TTS models: sample rate
+ */
+sample_rate: number | null; 
+/**
+ * For TTS models: voice name/style
+ */
+voice_name: string | null }
+/**
+ * Type of Onichan model
+ */
+export type OnichanModelType = "Llm" | "Tts"
 export type OverlayPosition = "none" | "top" | "bottom"
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v"
 export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null }
@@ -489,6 +790,7 @@ export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "
  */
 export type SessionDto = { access_token: string; refresh_token: string; token_type: string; expires_in: number; expires_at: number | null; user: SupabaseUserDto }
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
+export type SidecarQuickConfig = { last_llm_model_id: string | null; last_tts_model_id: string | null; last_discord_guild_id: string | null; last_discord_channel_id: string | null; last_discord_guild_name: string | null; last_discord_channel_name: string | null; last_embedding_model_id: string | null }
 export type SoundTheme = "marimba" | "pop" | "custom"
 /**
  * specta-friendly mirror of `erust::supabase::SupabaseUser`.

--- a/apps/kbve/desktop-kbve/src/views/index.ts
+++ b/apps/kbve/desktop-kbve/src/views/index.ts
@@ -7,11 +7,13 @@ import {
 	IconKeyboard,
 	IconInfo,
 	IconTerminal,
+	IconUser,
 } from '../components/Icons';
 import { GeneralView } from './general';
 import { AudioView } from './audio';
 import { ModelsView } from './models';
 import { ShortcutsView } from './shortcuts';
+import { OnichanView } from './onichan';
 import { AboutView } from './about';
 import { TerminalView } from './terminal';
 
@@ -47,6 +49,12 @@ export function initViews() {
 		label: 'Shortcuts',
 		icon: createElement(IconKeyboard),
 		component: ShortcutsView,
+	});
+	registerView({
+		id: 'onichan',
+		label: 'Onichan',
+		icon: createElement(IconUser),
+		component: OnichanView,
 	});
 	registerView({
 		id: 'about',

--- a/apps/kbve/desktop-kbve/src/views/onichan.tsx
+++ b/apps/kbve/desktop-kbve/src/views/onichan.tsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { SettingsCard } from '../components/SettingsCard';
+import { SettingsRow } from '../components/SettingsRow';
+import { ToggleSwitch } from '../components/ToggleSwitch';
+import { commands, type OnichanModelInfo } from '../bindings';
+
+const muted = { color: 'var(--color-text-muted)' } as const;
+
+interface OnichanProgress {
+	model_id: string;
+	percentage: number;
+}
+
+export function OnichanView() {
+	const [active, setActive] = useState(false);
+	const [llm, setLlm] = useState<OnichanModelInfo[]>([]);
+	const [tts, setTts] = useState<OnichanModelInfo[]>([]);
+	const [llmLoaded, setLlmLoaded] = useState(false);
+	const [ttsLoaded, setTtsLoaded] = useState(false);
+	const [conversing, setConversing] = useState(false);
+	const [progress, setProgress] = useState<Record<string, number>>({});
+	const [chat, setChat] = useState('');
+	const [reply, setReply] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const busyRef = useRef(false);
+
+	const refresh = useCallback(async () => {
+		const a = await commands.onichanIsActive();
+		setActive(a);
+		const l = await commands.getOnichanLlmModels();
+		if (l.status === 'ok') setLlm(l.data);
+		const t = await commands.getOnichanTtsModels();
+		if (t.status === 'ok') setTts(t.data);
+		setLlmLoaded(await commands.isLocalLlmLoaded());
+		setTtsLoaded(await commands.isLocalTtsLoaded());
+		setConversing(await commands.onichanIsConversationRunning());
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	useEffect(() => {
+		const p = listen<OnichanProgress>(
+			'onichan-model-download-progress',
+			(e) =>
+				setProgress((prev) => ({
+					...prev,
+					[e.payload.model_id]: e.payload.percentage,
+				})),
+		);
+		const done = listen('onichan-model-download-complete', () => {
+			setProgress({});
+			refresh();
+		});
+		const resp = listen<{ text: string }>('onichan-response', (e) =>
+			setReply(e.payload.text),
+		);
+		return () => {
+			p.then((f) => f());
+			done.then((f) => f());
+			resp.then((f) => f());
+		};
+	}, [refresh]);
+
+	const download = async (id: string) => {
+		const res = await commands.downloadOnichanModel(id);
+		if (res.status === 'error') setError(res.error);
+		refresh();
+	};
+
+	const loadLlm = async (id: string) => {
+		const res = await commands.loadLocalLlm(id);
+		if (res.status === 'error') setError(res.error);
+		else setLlmLoaded(true);
+	};
+
+	const loadTts = async (id: string) => {
+		const res = await commands.loadLocalTts(id);
+		if (res.status === 'error') setError(res.error);
+		else setTtsLoaded(true);
+	};
+
+	const send = async () => {
+		if (!chat.trim() || busyRef.current) return;
+		busyRef.current = true;
+		setError(null);
+		const res = await commands.onichanProcessInput(chat);
+		if (res.status === 'ok') {
+			setReply(res.data);
+			if (ttsLoaded) commands.onichanSpeak(res.data);
+		} else setError(res.error);
+		setChat('');
+		busyRef.current = false;
+	};
+
+	return (
+		<div className="flex max-w-2xl flex-col gap-6">
+			{error && (
+				<div
+					className="rounded-md border px-4 py-2 text-caption"
+					style={{
+						borderColor: 'var(--color-border)',
+						color: 'var(--color-danger, #e5484d)',
+					}}>
+					{error}
+				</div>
+			)}
+
+			<SettingsCard title="Onichan Assistant">
+				<SettingsRow
+					label="Enabled"
+					description="Turn the local voice assistant on or off">
+					<ToggleSwitch
+						checked={active}
+						onChange={async (v) => {
+							if (v) await commands.onichanEnable();
+							else await commands.onichanDisable();
+							setActive(v);
+						}}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label="Continuous conversation"
+					description="Listen and respond hands-free (requires LLM + TTS loaded)">
+					<ToggleSwitch
+						checked={conversing}
+						onChange={async (v) => {
+							if (v) {
+								const r = await commands.onichanStartConversation();
+								if (r.status === 'error') {
+									setError(r.error);
+									return;
+								}
+							} else await commands.onichanStopConversation();
+							setConversing(v);
+						}}
+					/>
+				</SettingsRow>
+			</SettingsCard>
+
+			<ModelCard
+				title={`Language Model${llmLoaded ? ' · loaded' : ''}`}
+				models={llm}
+				progress={progress}
+				onDownload={download}
+				onLoad={loadLlm}
+			/>
+			<ModelCard
+				title={`Voice (TTS)${ttsLoaded ? ' · loaded' : ''}`}
+				models={tts}
+				progress={progress}
+				onDownload={download}
+				onLoad={loadTts}
+			/>
+
+			<SettingsCard title="Chat">
+				<div className="flex flex-col gap-3 px-6 py-5">
+					<div className="flex gap-2">
+						<input
+							value={chat}
+							onChange={(e) => setChat(e.target.value)}
+							onKeyDown={(e) => e.key === 'Enter' && send()}
+							placeholder={
+								llmLoaded
+									? 'Type a message…'
+									: 'Load a language model first'
+							}
+							disabled={!llmLoaded || !active}
+							className="flex-1 rounded-md border px-3 py-1.5 text-body"
+							style={{
+								backgroundColor: 'var(--color-bg)',
+								borderColor: 'var(--color-border)',
+								color: 'var(--color-text)',
+							}}
+						/>
+						<button
+							onClick={send}
+							disabled={!llmLoaded || !active}
+							className="rounded-md border px-3 py-1.5 text-caption"
+							style={{
+								backgroundColor: 'var(--color-bg)',
+								borderColor: 'var(--color-border)',
+								color: 'var(--color-text)',
+							}}>
+							Send
+						</button>
+					</div>
+					{reply && (
+						<p className="text-body" style={muted}>
+							{reply}
+						</p>
+					)}
+				</div>
+			</SettingsCard>
+		</div>
+	);
+}
+
+function ModelCard({
+	title,
+	models,
+	progress,
+	onDownload,
+	onLoad,
+}: {
+	title: string;
+	models: OnichanModelInfo[];
+	progress: Record<string, number>;
+	onDownload: (id: string) => void;
+	onLoad: (id: string) => void;
+}) {
+	return (
+		<SettingsCard title={title}>
+			<div className="flex flex-col">
+				{models.length === 0 && (
+					<p className="px-6 py-5 text-sm" style={muted}>
+						Loading…
+					</p>
+				)}
+				{models.map((m) => {
+					const pct = progress[m.id];
+					const downloading = m.is_downloading || pct != null;
+					return (
+						<div
+							key={m.id}
+							className="flex items-center justify-between border-b px-6 py-5"
+							style={{ borderColor: 'var(--color-border)' }}>
+							<div className="flex flex-col gap-1.5">
+								<span className="text-body">{m.name}</span>
+								<span className="text-caption" style={muted}>
+									{m.size_mb} MB · {m.description}
+								</span>
+								{downloading && pct != null && (
+									<span className="text-caption" style={muted}>
+										Downloading… {pct.toFixed(0)}%
+									</span>
+								)}
+							</div>
+							<div className="flex gap-2">
+								{m.is_downloaded ? (
+									<button
+										onClick={() => onLoad(m.id)}
+										className="rounded-md border px-3 py-1.5 text-caption"
+										style={{
+											backgroundColor: 'var(--color-bg)',
+											borderColor: 'var(--color-border)',
+											color: 'var(--color-text)',
+										}}>
+										Load
+									</button>
+								) : (
+									<button
+										onClick={() => onDownload(m.id)}
+										disabled={downloading}
+										className="rounded-md border px-3 py-1.5 text-caption"
+										style={{
+											backgroundColor: 'var(--color-bg)',
+											borderColor: 'var(--color-border)',
+											color: 'var(--color-text)',
+											opacity: downloading ? 0.5 : 1,
+										}}>
+										Download
+									</button>
+								)}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</SettingsCard>
+	);
+}


### PR DESCRIPTION
Ports handy's **Onichan** pillar into desktop-kbve: a local, offline voice assistant — STT → local LLM → local TTS — with vector memory, driven by three sidecar processes.

### Backend
- **local_llm.rs / local_tts.rs / memory.rs** — sidecar driver managers (newline-delimited JSON over stdin/stdout, crash-recovery respawn)
- **onichan.rs** — orchestrator: RAG (memory query) + local LLM chat + TTS. **Cloud path stripped** (no `llm_client`/OpenAI) — Local mode only
- **onichan_conversation.rs** — hands-free continuous-listen loop (VAD-gated capture → transcribe → process → speak)
- **onichan_models.rs** — LLM (GGUF) + TTS (Piper ONNX) catalog + resumable download
- **commands/{onichan,memory,sidecar_config}** — ~40 typed commands, all registered in the specta `Builder`
- **lib.rs** — construct + wire the managers, per-triple sidecar path resolution

### Frontend
- **views/onichan.tsx** — enable toggle, LLM + TTS model download/load, continuous-conversation toggle, chat box; registered in the sidebar

### Sidecars
The 3 sidecar crates were added in phase A. Their binaries are built separately via `src-tauri/sidecars/build.sh` (llama-cpp / piper / lancedb — heavy native). `externalBin` stays out until the binaries exist; the app runs dictation fine without them and reports a clear error if Onichan is used before they're built.

### Verification
`cargo check` → 0 errors. `tsc --noEmit` → clean for the onichan view.

### Follow-up
Build + bundle the sidecars (CI), re-add `externalBin`, then Onichan runs end-to-end.