### PR TITLE
feat(reel): browser player UI — raw/HLS delivery (Phase 3B)

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -317,6 +317,13 @@ export default defineConfig({
 					items: [{ autogenerate: { directory: 'store' } }],
 				},
 				{
+					label: 'Media',
+					collapsed: true,
+					items: [
+						{ label: 'Reel', link: '/media/reel/', attrs: { 'data-auth-visibility': 'auth' } },
+					],
+				},
+				{
 					label: 'Gaming',
 					collapsed: true,
 					items: [

--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -1,0 +1,96 @@
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import ReactReelPlayer from '@/components/media/ReactReelPlayer';
+---
+
+<BentoShell
+	id="reel-player-wrapper"
+	eyebrow="Media"
+	heading="Reel player.">
+	<div class="reel-dash not-content">
+		<div class="reel-dash__stream not-content">
+			<ReactReelPlayer client:only="react" />
+		</div>
+	</div>
+</BentoShell>
+
+<style>
+	.reel-dash {
+		padding: 1.5rem 1rem 3rem;
+	}
+
+	@media (min-width: 640px) {
+		.reel-dash {
+			padding-inline: 1.5rem;
+		}
+	}
+
+	.reel-dash__stream {
+		min-height: 60vh;
+	}
+
+	:global(.reel-player__stage) {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		background: #000;
+		border-radius: 0.75rem;
+		overflow: hidden;
+	}
+
+	:global(.reel-player__video) {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+
+	:global(.reel-player__overlay) {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		color: #e5e7eb;
+		text-align: center;
+		padding: 1rem;
+		pointer-events: none;
+	}
+
+	:global(.reel-player__error) {
+		color: #f87171;
+		font-size: 0.875rem;
+	}
+
+	:global(.reel-player__meta) {
+		color: #9ca3af;
+		font-size: 0.8125rem;
+	}
+
+	:global(.reel-player__notice) {
+		color: #fbbf24;
+		font-size: 0.8125rem;
+		margin: 0.75rem 0 0;
+	}
+
+	:global(.reel-player__controls) {
+		display: flex;
+		gap: 0.75rem;
+		margin-top: 1rem;
+	}
+
+	:global(.reel-player__controls button) {
+		padding: 0.5rem 1.25rem;
+		border-radius: 0.5rem;
+		border: 1px solid #3f3f46;
+		background: #18181b;
+		color: #e5e7eb;
+		cursor: pointer;
+	}
+
+	:global(.reel-player__controls button:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	$reelState,
+	$reelError,
+	$reelName,
+	$reelNotice,
+	ReelPlayer,
+} from './reelService';
+
+const STATE_LABEL: Record<string, string> = {
+	idle: 'Ready',
+	loading: 'Loading…',
+	probing: 'Preparing stream…',
+	raw: 'Playing',
+	hls: 'Playing (HLS)',
+	error: 'Error',
+};
+
+function readId(): string | null {
+	if (typeof window === 'undefined') return null;
+	return new URLSearchParams(window.location.search).get('id');
+}
+
+export default function ReactReelPlayer() {
+	const state = useStore($reelState);
+	const error = useStore($reelError);
+	const name = useStore($reelName);
+	const notice = useStore($reelNotice);
+	const videoRef = useRef<HTMLVideoElement>(null);
+	const [player] = useState(() => new ReelPlayer());
+	const [id] = useState(() => readId());
+
+	useEffect(() => {
+		return () => {
+			player.stop();
+		};
+	}, [player]);
+
+	const play = () => {
+		if (videoRef.current && id) {
+			void player.start(videoRef.current, id);
+		}
+	};
+
+	const busy = state === 'loading' || state === 'probing';
+	const playing = state === 'raw' || state === 'hls';
+
+	return (
+		<div className="reel-player">
+			<div className="reel-player__stage">
+				<video
+					ref={videoRef}
+					controls
+					playsInline
+					className="reel-player__video"
+				/>
+				{!playing && (
+					<div className="reel-player__overlay">
+						<p>{STATE_LABEL[state] ?? state}</p>
+						{name && <p className="reel-player__meta">{name}</p>}
+						{state === 'error' && error && (
+							<p className="reel-player__error">{error}</p>
+						)}
+						{!id && (
+							<p className="reel-player__error">
+								No torrent selected — add ?id=&lt;id&gt; to the URL.
+							</p>
+						)}
+					</div>
+				)}
+			</div>
+			{notice && <p className="reel-player__notice">{notice}</p>}
+			<div className="reel-player__controls">
+				{state === 'error' ? (
+					<button type="button" disabled={!id} onClick={play}>
+						Retry
+					</button>
+				) : (
+					<button
+						type="button"
+						disabled={busy || playing || !id}
+						onClick={play}>
+						{busy ? 'Preparing…' : 'Play'}
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -1,0 +1,233 @@
+import { atom } from 'nanostores';
+import { getAccessToken } from '@kbve/astro';
+import { authedApiFetch, ApiError } from '@/lib/apiFetch';
+import { DASH_PROXY_BASE } from '@/components/rnweb/dashProxyBase';
+
+export type ReelState = 'idle' | 'loading' | 'probing' | 'raw' | 'hls' | 'error';
+
+export const $reelState = atom<ReelState>('idle');
+export const $reelError = atom<string | null>(null);
+export const $reelName = atom<string | null>(null);
+export const $reelNotice = atom<string | null>(null);
+
+export interface ReelDetail {
+	id?: string;
+	name?: string;
+	state?: string;
+	hls?: string;
+	transcode?: string;
+	[key: string]: unknown;
+}
+
+const REEL_PATH: string =
+	(import.meta.env.PUBLIC_REEL_BASE as string | undefined) ?? '/api/reel';
+const MEDIA_BASE = `${DASH_PROXY_BASE}${REEL_PATH}`;
+const MANIFEST_MIME = 'application/vnd.apple.mpegurl';
+
+const MAX_POLLS = 25;
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_CAP_MS = 5000;
+
+async function mediaToken(): Promise<string | null> {
+	const dev = import.meta.env.PUBLIC_REEL_TOKEN as string | undefined;
+	if (dev) return dev;
+	return getAccessToken();
+}
+
+export function mediaUrl(id: string, suffix: string, token: string | null): string {
+	const base = `${MEDIA_BASE}/torrents/${encodeURIComponent(id)}${suffix}`;
+	if (!token) return base;
+	const sep = suffix.includes('?') ? '&' : '?';
+	return `${base}${sep}token=${encodeURIComponent(token)}`;
+}
+
+export function withToken(url: string, token: string): string {
+	if (url.includes('token=')) return url;
+	const sep = url.includes('?') ? '&' : '?';
+	return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
+export type ProbeAction = 'raw' | 'raw-leeching' | 'hls' | 'poll' | 'error';
+
+export function nextFromManifestStatus(status: number): ProbeAction {
+	switch (status) {
+		case 200:
+			return 'hls';
+		case 202:
+			return 'poll';
+		case 409:
+			return 'raw';
+		case 425:
+			return 'raw-leeching';
+		default:
+			return 'error';
+	}
+}
+
+export function backoffMs(attempt: number): number {
+	return Math.min(BACKOFF_BASE_MS * Math.pow(1.5, attempt), BACKOFF_CAP_MS);
+}
+
+export class ReelPlayer {
+	private hls: { destroy: () => void } | null = null;
+	private aborted = false;
+	private pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+	async start(video: HTMLVideoElement, id: string): Promise<void> {
+		this.stop(false);
+		this.aborted = false;
+		$reelError.set(null);
+		$reelNotice.set(null);
+		$reelName.set(null);
+		$reelState.set('loading');
+
+		const token = await mediaToken();
+		if (!token) {
+			this.fail('sign in to watch');
+			return;
+		}
+
+		try {
+			const detail = await authedApiFetch<ReelDetail>(
+				`${REEL_PATH}/torrents/${encodeURIComponent(id)}`,
+			);
+			$reelName.set(detail?.name ?? null);
+		} catch (e) {
+			if (e instanceof ApiError && e.status === 404) {
+				this.fail('torrent not found');
+				return;
+			}
+			if (e instanceof ApiError && e.status === 401) {
+				this.fail('sign in to watch');
+				return;
+			}
+			this.fail(e instanceof Error ? e.message : String(e));
+			return;
+		}
+
+		$reelState.set('probing');
+		await this.probe(video, id, token, 0);
+	}
+
+	private async probe(
+		video: HTMLVideoElement,
+		id: string,
+		token: string,
+		attempt: number,
+	): Promise<void> {
+		if (this.aborted) return;
+		const manifestUrl = mediaUrl(id, '/manifest.m3u8', token);
+		let status: number;
+		try {
+			const resp = await fetch(manifestUrl, { cache: 'no-store' });
+			status = resp.status;
+		} catch {
+			this.fail('network error reaching reel');
+			return;
+		}
+		if (this.aborted) return;
+
+		switch (nextFromManifestStatus(status)) {
+			case 'raw':
+				this.playRaw(video, id, token, false);
+				return;
+			case 'raw-leeching':
+				this.playRaw(video, id, token, true);
+				return;
+			case 'hls':
+				await this.playHls(video, manifestUrl, token);
+				return;
+			case 'poll':
+				if (attempt >= MAX_POLLS) {
+					this.fail('still preparing — retry in a moment');
+					return;
+				}
+				this.pollTimer = setTimeout(() => {
+					void this.probe(video, id, token, attempt + 1);
+				}, backoffMs(attempt));
+				return;
+			case 'error':
+				this.fail(
+					status === 503
+						? 'HLS delivery disabled'
+						: `unexpected status ${status}`,
+				);
+				return;
+		}
+	}
+
+	private playRaw(
+		video: HTMLVideoElement,
+		id: string,
+		token: string,
+		leeching: boolean,
+	): void {
+		if (this.aborted) return;
+		video.src = mediaUrl(id, '/stream', token);
+		$reelState.set('raw');
+		if (leeching) {
+			$reelNotice.set('still downloading — playing the available portion');
+		}
+		void video.play().catch(() => undefined);
+	}
+
+	private async playHls(
+		video: HTMLVideoElement,
+		manifestUrl: string,
+		token: string,
+	): Promise<void> {
+		if (this.aborted) return;
+		if (video.canPlayType(MANIFEST_MIME)) {
+			video.src = manifestUrl;
+			$reelState.set('hls');
+			void video.play().catch(() => undefined);
+			return;
+		}
+		const Hls = (await import('hls.js')).default;
+		if (this.aborted) return;
+		if (!Hls.isSupported()) {
+			this.fail('HLS is not supported in this browser');
+			return;
+		}
+		const hls = new Hls({
+			xhrSetup: (xhr: XMLHttpRequest, url: string) => {
+				xhr.open('GET', withToken(url, token), true);
+			},
+		});
+		this.hls = hls;
+		hls.on(Hls.Events.ERROR, (_evt, data) => {
+			if (data.fatal) this.fail(`HLS error: ${data.type}`);
+		});
+		hls.loadSource(manifestUrl);
+		hls.attachMedia(video);
+		$reelState.set('hls');
+		void video.play().catch(() => undefined);
+	}
+
+	private fail(message: string): void {
+		$reelError.set(message);
+		$reelState.set('error');
+		this.stop(false);
+	}
+
+	stop(reset = true): void {
+		this.aborted = true;
+		if (this.pollTimer) {
+			clearTimeout(this.pollTimer);
+			this.pollTimer = null;
+		}
+		if (this.hls) {
+			try {
+				this.hls.destroy();
+			} catch {
+				void 0;
+			}
+			this.hls = null;
+		}
+		if (reset) {
+			$reelState.set('idle');
+			$reelError.set(null);
+			$reelNotice.set(null);
+		}
+	}
+}

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -70,18 +70,21 @@ export function backoffMs(attempt: number): number {
 
 export class ReelPlayer {
 	private hls: { destroy: () => void } | null = null;
-	private aborted = false;
+	private generation = 0;
 	private pollTimer: ReturnType<typeof setTimeout> | null = null;
+	private video: HTMLVideoElement | null = null;
 
 	async start(video: HTMLVideoElement, id: string): Promise<void> {
-		this.stop(false);
-		this.aborted = false;
+		const gen = ++this.generation;
+		this.teardown();
+		this.video = video;
 		$reelError.set(null);
 		$reelNotice.set(null);
 		$reelName.set(null);
 		$reelState.set('loading');
 
 		const token = await mediaToken();
+		if (this.generation !== gen) return;
 		if (!token) {
 			this.fail('sign in to watch');
 			return;
@@ -91,8 +94,10 @@ export class ReelPlayer {
 			const detail = await authedApiFetch<ReelDetail>(
 				`${REEL_PATH}/torrents/${encodeURIComponent(id)}`,
 			);
+			if (this.generation !== gen) return;
 			$reelName.set(detail?.name ?? null);
 		} catch (e) {
+			if (this.generation !== gen) return;
 			if (e instanceof ApiError && e.status === 404) {
 				this.fail('torrent not found');
 				return;
@@ -106,7 +111,7 @@ export class ReelPlayer {
 		}
 
 		$reelState.set('probing');
-		await this.probe(video, id, token, 0);
+		await this.probe(video, id, token, 0, gen);
 	}
 
 	private async probe(
@@ -114,28 +119,30 @@ export class ReelPlayer {
 		id: string,
 		token: string,
 		attempt: number,
+		gen: number,
 	): Promise<void> {
-		if (this.aborted) return;
+		if (this.generation !== gen) return;
 		const manifestUrl = mediaUrl(id, '/manifest.m3u8', token);
 		let status: number;
 		try {
 			const resp = await fetch(manifestUrl, { cache: 'no-store' });
 			status = resp.status;
 		} catch {
+			if (this.generation !== gen) return;
 			this.fail('network error reaching reel');
 			return;
 		}
-		if (this.aborted) return;
+		if (this.generation !== gen) return;
 
 		switch (nextFromManifestStatus(status)) {
 			case 'raw':
-				this.playRaw(video, id, token, false);
+				this.playRaw(video, id, token, false, gen);
 				return;
 			case 'raw-leeching':
-				this.playRaw(video, id, token, true);
+				this.playRaw(video, id, token, true, gen);
 				return;
 			case 'hls':
-				await this.playHls(video, manifestUrl, token);
+				await this.playHls(video, manifestUrl, token, gen);
 				return;
 			case 'poll':
 				if (attempt >= MAX_POLLS) {
@@ -143,7 +150,7 @@ export class ReelPlayer {
 					return;
 				}
 				this.pollTimer = setTimeout(() => {
-					void this.probe(video, id, token, attempt + 1);
+					void this.probe(video, id, token, attempt + 1, gen);
 				}, backoffMs(attempt));
 				return;
 			case 'error':
@@ -161,8 +168,9 @@ export class ReelPlayer {
 		id: string,
 		token: string,
 		leeching: boolean,
+		gen: number,
 	): void {
-		if (this.aborted) return;
+		if (this.generation !== gen) return;
 		video.src = mediaUrl(id, '/stream', token);
 		$reelState.set('raw');
 		if (leeching) {
@@ -175,8 +183,9 @@ export class ReelPlayer {
 		video: HTMLVideoElement,
 		manifestUrl: string,
 		token: string,
+		gen: number,
 	): Promise<void> {
-		if (this.aborted) return;
+		if (this.generation !== gen) return;
 		if (video.canPlayType(MANIFEST_MIME)) {
 			video.src = manifestUrl;
 			$reelState.set('hls');
@@ -184,7 +193,7 @@ export class ReelPlayer {
 			return;
 		}
 		const Hls = (await import('hls.js')).default;
-		if (this.aborted) return;
+		if (this.generation !== gen) return;
 		if (!Hls.isSupported()) {
 			this.fail('HLS is not supported in this browser');
 			return;
@@ -204,14 +213,7 @@ export class ReelPlayer {
 		void video.play().catch(() => undefined);
 	}
 
-	private fail(message: string): void {
-		$reelError.set(message);
-		$reelState.set('error');
-		this.stop(false);
-	}
-
-	stop(reset = true): void {
-		this.aborted = true;
+	private teardown(): void {
 		if (this.pollTimer) {
 			clearTimeout(this.pollTimer);
 			this.pollTimer = null;
@@ -224,7 +226,28 @@ export class ReelPlayer {
 			}
 			this.hls = null;
 		}
+	}
+
+	private fail(message: string): void {
+		$reelError.set(message);
+		$reelState.set('error');
+		this.teardown();
+	}
+
+	stop(reset = true): void {
+		this.generation++;
+		this.teardown();
+		if (this.video) {
+			try {
+				this.video.pause();
+				this.video.removeAttribute('src');
+				this.video.load();
+			} catch {
+				void 0;
+			}
+		}
 		if (reset) {
+			this.video = null;
 			$reelState.set('idle');
 			$reelError.set(null);
 			$reelNotice.set(null);

--- a/apps/kbve/astro-kbve/src/content/docs/media/reel/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/media/reel/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Reel Player
+description: Browser player for reel — streams ephemeral legal torrents as raw progressive MP4 or live HLS.
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+sidebar:
+    label: Reel
+    order: 7
+    attrs:
+        data-auth-visibility: auth
+tags:
+    - media
+    - reel
+    - streaming
+---
+
+import AstroReelPlayer from '@/components/media/AstroReelPlayer.astro';
+
+<AstroReelPlayer />

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -63,10 +63,7 @@ fn check_auth_q(headers: &HeaderMap, query: Option<&str>, token: &Option<String>
     if check_auth(headers, token) {
         return true;
     }
-    match token {
-        None => true,
-        Some(t) => token_from_query(query).as_deref() == Some(t.as_str()),
-    }
+    matches!(token, Some(t) if token_from_query(query).as_deref() == Some(t.as_str()))
 }
 
 async fn list(State(st): State<AppStateStub>, headers: HeaderMap) -> impl IntoResponse {

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -49,6 +49,26 @@ fn check_auth(headers: &HeaderMap, token: &Option<String>) -> bool {
     }
 }
 
+fn token_from_query(query: Option<&str>) -> Option<String> {
+    query?.split('&').find_map(|pair| {
+        let mut it = pair.splitn(2, '=');
+        match (it.next(), it.next()) {
+            (Some("token"), Some(v)) => Some(v.to_string()),
+            _ => None,
+        }
+    })
+}
+
+fn check_auth_q(headers: &HeaderMap, query: Option<&str>, token: &Option<String>) -> bool {
+    if check_auth(headers, token) {
+        return true;
+    }
+    match token {
+        None => true,
+        Some(t) => token_from_query(query).as_deref() == Some(t.as_str()),
+    }
+}
+
 async fn list(State(st): State<AppStateStub>, headers: HeaderMap) -> impl IntoResponse {
     if !check_auth(&headers, &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
@@ -155,9 +175,10 @@ async fn stream_file(
     State(st): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
     method: axum::http::Method,
 ) -> impl IntoResponse {
-    if !check_auth(&headers, &st.token) {
+    if !check_auth_q(&headers, query.as_deref(), &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
     if !st.stream_enabled {
@@ -241,8 +262,9 @@ async fn manifest(
     State(st): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
 ) -> impl IntoResponse {
-    if !check_auth(&headers, &st.token) {
+    if !check_auth_q(&headers, query.as_deref(), &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
     if !st.hls.enabled() {
@@ -344,9 +366,10 @@ async fn hls_segment(
     State(st): State<AppState>,
     headers: HeaderMap,
     Path((id, segment)): Path<(String, String)>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
     method: axum::http::Method,
 ) -> impl IntoResponse {
-    if !check_auth(&headers, &st.token) {
+    if !check_auth_q(&headers, query.as_deref(), &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
     if !hls::valid_segment_name(&segment) {
@@ -708,6 +731,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn token_from_query_extracts_token() {
+        assert_eq!(token_from_query(Some("token=abc")).as_deref(), Some("abc"));
+        assert_eq!(
+            token_from_query(Some("foo=1&token=abc&bar=2")).as_deref(),
+            Some("abc")
+        );
+        assert_eq!(token_from_query(Some("foo=1")), None);
+        assert_eq!(token_from_query(None), None);
+        assert_eq!(token_from_query(Some("token=")).as_deref(), Some(""));
+    }
+
+    #[test]
+    fn check_auth_q_accepts_header_or_query() {
+        let token = Some("secret".to_string());
+        let empty = HeaderMap::new();
+        let mut hdr = HeaderMap::new();
+        hdr.insert("Authorization", "Bearer secret".parse().unwrap());
+
+        assert!(check_auth_q(&hdr, None, &token));
+        assert!(check_auth_q(&empty, Some("token=secret"), &token));
+        assert!(check_auth_q(&empty, Some("x=1&token=secret"), &token));
+        assert!(!check_auth_q(&empty, Some("token=wrong"), &token));
+        assert!(!check_auth_q(&empty, None, &token));
+        assert!(!check_auth_q(&empty, Some("nope=secret"), &token));
+        assert!(check_auth_q(&empty, None, &None));
     }
 
     #[tokio::test]

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
 		"gsap": "^3.15.0",
 		"guacamole-common-js": "^1.5.0",
 		"happy-dom": "20.10.6",
+		"hls.js": "^1.5.20",
 		"html-react-parser": "^5.1.18",
 		"lucide": "^0.575.0",
 		"lucide-react": "^0.575.0",


### PR DESCRIPTION
## Phase 3B — reel browser player

Final piece of the reel pipeline. A React island in **astro-kbve** plays a torrent by id, consuming the 2B stream + 3A HLS endpoints. Depends on P1 #14481, P2A #14486, P2B #14493, P3A #14498 (all merged).

### Frontend (`apps/kbve/astro-kbve`)
- `src/components/media/reelService.ts` — nanostores state + `ReelPlayer` + pure helpers (`mediaUrl`, `nextFromManifestStatus`, `backoffMs`).
- `src/components/media/ReactReelPlayer.tsx` — `client:only` island (video + controls), reads `?id=`.
- `src/components/media/AstroReelPlayer.astro` — wrapper + styles.
- `src/content/docs/media/reel/index.mdx` — route `/media/reel/`.
- `astro.config.mjs` — auth-gated **Media → Reel** sidebar entry.
- `package.json` — adds `hls.js` (dynamically imported; no eager bundle cost).

### Flow
island reads `?id=` → `authedApiFetch GET /torrents/{id}` (Bearer header) → probe `GET /manifest.m3u8?token=`:
- `409` → raw progressive `<video src=/stream?token=>`
- `202` → exponential-backoff poll (cap 5s, ≤25 polls)
- `200` → hls.js (Safari native else dynamic import); segment fetches carry `?token=` via `xhrSetup`
- `425` → raw progressive while still leeching

### Backend (`apps/media/reel`)
Media-element requests (`<video src>`, hls `.ts` fetches) cannot send an `Authorization` header, so `stream` / `manifest.m3u8` / `hls/{segment}` now accept the token via `?token=` query as a fallback (`check_auth_q`). Header path unchanged; JSON/mutating routes stay header-only. +2 unit tests.

### Auth model
Media URLs carry the Supabase JWT as `?token=`. In prod, **kbve-gate** is the auth boundary (validates the JWT, reel runs behind the VPN); `PUBLIC_REEL_TOKEN` is a local-dev escape hatch. Wiring the gate route for reel is infra (follow-up).

### Verification
- reel: `cargo test -p reel` → 85 pass, 4 ignored; clippy clean on changed code.
- astro TS/eslint/build defer to CI (worktree has no node_modules).
- Opus whole-branch review: no Critical; the two Important items are the documented auth-boundary + JWT-in-query limitations; robustness minors (session generation-guard, raw-video pause) applied.

### Known limitations / follow-ups
- Not reachable end-to-end in prod until the kbve-gate route for reel is wired.
- JWT in query string → short-lived scoped media token is the hardening follow-up.
- Player targets a known id; a torrent browser/list UI is out of scope.