### PR TITLE
fix(dashboard): kanban in bento shell + ScrollTrigger view manager

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -529,7 +529,6 @@ const prCount = Object.values(columns)
 		border-radius: 12px;
 		border: 1px solid var(--sl-color-gray-5, #262626);
 		background: var(--sl-color-bg-nav, #111);
-		opacity: 0;
 	}
 	.kb-section-content {
 		display: flex;
@@ -1048,12 +1047,6 @@ const prCount = Object.values(columns)
 		.kb-section[data-section='4'],
 		.kb-section[data-section='5'] {
 			display: none;
-		}
-	}
-
-	@media (scripting: none) {
-		.kb-section {
-			opacity: 1;
 		}
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -111,291 +111,235 @@ const issueCount = Object.values(columns)
 const prCount = Object.values(columns)
 	.flat()
 	.filter((i: any) => i.type === 'PULL_REQUEST').length;
-
-const sectionNames = [
-	'Summary',
-	'Donut',
-	'Treemap',
-	'Timeline',
-	'Sankey',
-	'Heatmap',
-	'Breakdown',
-	'Board',
-	'Contributors',
-	'Items',
-];
 ---
 
-<div id="kb-snap-container" class="kb-snap-container not-content">
-	<!-- Section dot navigation -->
-	<nav class="kb-dot-nav" aria-label="Section navigation">
-		{
-			sectionNames.map((name, i) => (
-				<button class="kb-dot" data-section-idx={i} title={name}>
-					<span class="kb-dot-label">{name}</span>
-				</button>
-			))
-		}
-	</nav>
-
-	<!-- Section label indicator (top-right) -->
-	<div id="kb-section-label" class="kb-section-label">
-		<span class="kb-section-label-index">01</span>
-		<span class="kb-section-label-sep">/</span>
-		<span class="kb-section-label-total">
-			{String(sectionNames.length).padStart(2, '0')}
-		</span>
-		<span class="kb-section-label-name">Summary</span>
-	</div>
-
+<div class="kb-sections not-content">
 	<!-- ═══ Section 0: Summary ═══ -->
 	<section class="kb-section" data-section="0">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content">
-					<div class="kb-card">
-						<div class="kb-header-row">
-							<div class="kb-title-group">
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									width="22"
-									height="22"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="var(--sl-color-accent, #06b6d4)"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round">
-									<rect
-										x="3"
-										y="3"
-										width="18"
-										height="18"
-										rx="2">
-									</rect><path d="M8 7v7"></path><path
-										d="M12 7v4">
-									</path><path d="M16 7v10"></path>
-								</svg>
-								<div>
-									<h2 class="kb-main-title">
-										{project.title} Project Board
-									</h2>
-									<p class="kb-subtitle">
-										Daily auto-generated snapshot of the
-										project pipeline
-									</p>
+		<div class="kb-section-content">
+			<div class="kb-card">
+				<div class="kb-header-row">
+					<div class="kb-title-group">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="22"
+							height="22"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="var(--sl-color-accent, #06b6d4)"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round">
+							<rect x="3" y="3" width="18" height="18" rx="2">
+							</rect><path d="M8 7v7"></path><path d="M12 7v4">
+							</path><path d="M16 7v10"></path>
+						</svg>
+						<div>
+							<h2 class="kb-main-title">
+								{project.title} Project Board
+							</h2>
+							<p class="kb-subtitle">
+								Daily auto-generated snapshot of the project
+								pipeline
+							</p>
+						</div>
+					</div>
+					<div class="kb-meta-group">
+						<span class="kb-sync">Synced {syncStr}</span>
+						<a
+							href={project.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="kb-github-link">
+							GitHub ↗
+						</a>
+					</div>
+				</div>
+
+				<div class="kb-stats-row">
+					<div class="kb-stat">
+						<span
+							class="kb-stat-value"
+							style="color: var(--sl-color-accent, #06b6d4)">
+							{total}
+						</span><span class="kb-stat-label">Total</span>
+					</div>
+					<div class="kb-stat">
+						<span class="kb-stat-value" style="color: #f59e0b">
+							{active}
+						</span><span class="kb-stat-label">Active</span>
+					</div>
+					<div class="kb-stat">
+						<span
+							class="kb-stat-value"
+							style={`color: ${errorCount > 0 ? '#ef4444' : '#22c55e'}`}>
+							{errorCount}
+						</span><span class="kb-stat-label">Error</span>
+					</div>
+					<div class="kb-stat">
+						<span class="kb-stat-value" style="color: #22c55e">
+							{done}
+						</span><span class="kb-stat-label">Done</span>
+					</div>
+				</div>
+
+				<div class="kb-dist">
+					<div class="kb-dist-bar">
+						{
+							entries.map((e) => (
+								<div
+									title={`${e.name}: ${e.count}`}
+									style={`width:${(e.count / barTotal) * 100}%;background:${e.color};min-width:${e.count > 0 ? '2px' : '0'}`}
+								/>
+							))
+						}
+					</div>
+					<div class="kb-dist-legend">
+						{
+							entries.map((e) => (
+								<span class="kb-dist-item">
+									<span
+										class="kb-dist-dot"
+										style={`background:${e.color}`}
+									/>
+									{e.name} {e.count}
+								</span>
+							))
+						}
+					</div>
+				</div>
+			</div>
+
+			<!-- Desktop-only: Phase overview + Quick nav + Recent items -->
+			<div class="hidden lg:grid kb-summary-extras">
+				<!-- Phase mini-bars -->
+				<div class="kb-card kb-summary-phases">
+					<h4 class="kb-mini-title">Work Phases</h4>
+					{
+						phases.map((p) => (
+							<div class="kb-mini-phase">
+								<span
+									class="kb-mini-phase-dot"
+									style={`background:${p.color}`}
+								/>
+								<span class="kb-mini-phase-name">
+									{p.label}
+								</span>
+								<div class="kb-mini-phase-track">
+									<div
+										class="kb-mini-phase-fill"
+										style={`width:${(p.value / phaseTotal) * 100}%;background:${p.color}`}
+									/>
 								</div>
+								<span
+									class="kb-mini-phase-val"
+									style={`color:${p.color}`}>
+									{p.value}
+								</span>
+								<span class="kb-mini-phase-pct">
+									{((p.value / phaseTotal) * 100).toFixed(0)}%
+								</span>
 							</div>
-							<div class="kb-meta-group">
-								<span class="kb-sync">Synced {syncStr}</span>
+						))
+					}
+				</div>
+
+				<!-- Quick nav tiles -->
+				<div class="kb-card kb-summary-nav">
+					<h4 class="kb-mini-title">Explore</h4>
+					<div class="kb-nav-tiles">
+						{
+							[
+								{
+									name: 'Donut',
+									hash: '#donut',
+									color: '#8b5cf6',
+									desc: 'Column distribution',
+								},
+								{
+									name: 'Treemap',
+									hash: '#treemap',
+									color: '#3b82f6',
+									desc: 'Size comparison',
+								},
+								{
+									name: 'Timeline',
+									hash: '#timeline',
+									color: '#06b6d4',
+									desc: 'Items by date',
+								},
+								{
+									name: 'Sankey',
+									hash: '#sankey',
+									color: '#22c55e',
+									desc: 'Pipeline flow',
+								},
+								{
+									name: 'Heatmap',
+									hash: '#heatmap',
+									color: '#f59e0b',
+									desc: 'Activity grid',
+								},
+								{
+									name: 'Board',
+									hash: '#board',
+									color: '#f97316',
+									desc: 'Kanban columns',
+								},
+							].map((t) => (
 								<a
-									href={project.url}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="kb-github-link">
-									GitHub ↗
+									href={t.hash}
+									class="kb-nav-tile"
+									style={`border-color:${t.color}22`}>
+									<span
+										class="kb-nav-tile-dot"
+										style={`background:${t.color}`}
+									/>
+									<span class="kb-nav-tile-name">
+										{t.name}
+									</span>
+									<span class="kb-nav-tile-desc">
+										{t.desc}
+									</span>
 								</a>
-							</div>
-						</div>
-
-						<div class="kb-stats-row">
-							<div class="kb-stat">
-								<span
-									class="kb-stat-value"
-									style="color: var(--sl-color-accent, #06b6d4)">
-									{total}
-								</span><span class="kb-stat-label">Total</span>
-							</div>
-							<div class="kb-stat">
-								<span
-									class="kb-stat-value"
-									style="color: #f59e0b">
-									{active}
-								</span><span class="kb-stat-label">Active</span>
-							</div>
-							<div class="kb-stat">
-								<span
-									class="kb-stat-value"
-									style={`color: ${errorCount > 0 ? '#ef4444' : '#22c55e'}`}>
-									{errorCount}
-								</span><span class="kb-stat-label">Error</span>
-							</div>
-							<div class="kb-stat">
-								<span
-									class="kb-stat-value"
-									style="color: #22c55e">
-									{done}
-								</span><span class="kb-stat-label">Done</span>
-							</div>
-						</div>
-
-						<div class="kb-dist">
-							<div class="kb-dist-bar">
-								{
-									entries.map((e) => (
-										<div
-											title={`${e.name}: ${e.count}`}
-											style={`width:${(e.count / barTotal) * 100}%;background:${e.color};min-width:${e.count > 0 ? '2px' : '0'}`}
-										/>
-									))
-								}
-							</div>
-							<div class="kb-dist-legend">
-								{
-									entries.map((e) => (
-										<span class="kb-dist-item">
-											<span
-												class="kb-dist-dot"
-												style={`background:${e.color}`}
-											/>
-											{e.name} {e.count}
-										</span>
-									))
-								}
-							</div>
-						</div>
+							))
+						}
 					</div>
+				</div>
 
-					<!-- Desktop-only: Phase overview + Quick nav + Recent items -->
-					<div class="hidden lg:grid kb-summary-extras">
-						<!-- Phase mini-bars -->
-						<div class="kb-card kb-summary-phases">
-							<h4 class="kb-mini-title">Work Phases</h4>
-							{
-								phases.map((p) => (
-									<div class="kb-mini-phase">
-										<span
-											class="kb-mini-phase-dot"
-											style={`background:${p.color}`}
-										/>
-										<span class="kb-mini-phase-name">
-											{p.label}
-										</span>
-										<div class="kb-mini-phase-track">
-											<div
-												class="kb-mini-phase-fill"
-												style={`width:${(p.value / phaseTotal) * 100}%;background:${p.color}`}
-											/>
-										</div>
-										<span
-											class="kb-mini-phase-val"
-											style={`color:${p.color}`}>
-											{p.value}
-										</span>
-										<span class="kb-mini-phase-pct">
-											{(
-												(p.value / phaseTotal) *
-												100
-											).toFixed(0)}
-											%
-										</span>
-									</div>
-								))
-							}
-						</div>
-
-						<!-- Quick nav tiles -->
-						<div class="kb-card kb-summary-nav">
-							<h4 class="kb-mini-title">Explore</h4>
-							<div class="kb-nav-tiles">
-								{
-									[
-										{
-											name: 'Donut',
-											hash: '#donut',
-											color: '#8b5cf6',
-											desc: 'Column distribution',
-										},
-										{
-											name: 'Treemap',
-											hash: '#treemap',
-											color: '#3b82f6',
-											desc: 'Size comparison',
-										},
-										{
-											name: 'Timeline',
-											hash: '#timeline',
-											color: '#06b6d4',
-											desc: 'Items by date',
-										},
-										{
-											name: 'Sankey',
-											hash: '#sankey',
-											color: '#22c55e',
-											desc: 'Pipeline flow',
-										},
-										{
-											name: 'Heatmap',
-											hash: '#heatmap',
-											color: '#f59e0b',
-											desc: 'Activity grid',
-										},
-										{
-											name: 'Board',
-											hash: '#board',
-											color: '#f97316',
-											desc: 'Kanban columns',
-										},
-									].map((t) => (
-										<a
-											href={t.hash}
-											class="kb-nav-tile"
-											style={`border-color:${t.color}22`}>
-											<span
-												class="kb-nav-tile-dot"
-												style={`background:${t.color}`}
-											/>
-											<span class="kb-nav-tile-name">
-												{t.name}
-											</span>
-											<span class="kb-nav-tile-desc">
-												{t.desc}
-											</span>
-										</a>
-									))
-								}
-							</div>
-						</div>
-
-						<!-- Type breakdown mini -->
-						<div class="kb-card kb-summary-types">
-							<h4 class="kb-mini-title">Item Types</h4>
-							<div class="kb-type-mini-row">
-								<span
-									class="kb-type-mini-bar"
-									style={`flex:${issueCount}`}>
-									<span
-										class="kb-type-mini-fill"
-										style="background:#22c55e">
-									</span>
-								</span>
-								<span
-									class="kb-type-mini-bar"
-									style={`flex:${prCount}`}>
-									<span
-										class="kb-type-mini-fill"
-										style="background:#8b5cf6">
-									</span>
-								</span>
-							</div>
-							<div class="kb-type-mini-legend">
-								<span>
-									<span style="color:#22c55e">●</span> Issues <strong>
-										{issueCount}
-									</strong>
-								</span>
-								<span>
-									<span style="color:#8b5cf6">●</span> PRs <strong>
-										{prCount}
-									</strong>
-								</span>
-							</div>
-						</div>
+				<!-- Type breakdown mini -->
+				<div class="kb-card kb-summary-types">
+					<h4 class="kb-mini-title">Item Types</h4>
+					<div class="kb-type-mini-row">
+						<span
+							class="kb-type-mini-bar"
+							style={`flex:${issueCount}`}>
+							<span
+								class="kb-type-mini-fill"
+								style="background:#22c55e">
+							</span>
+						</span>
+						<span
+							class="kb-type-mini-bar"
+							style={`flex:${prCount}`}>
+							<span
+								class="kb-type-mini-fill"
+								style="background:#8b5cf6">
+							</span>
+						</span>
 					</div>
-
-					<p class="kb-scroll-hint">
-						Scroll to explore visualizations ↓
-					</p>
+					<div class="kb-type-mini-legend">
+						<span>
+							<span style="color:#22c55e">●</span> Issues <strong>
+								{issueCount}
+							</strong>
+						</span>
+						<span>
+							<span style="color:#8b5cf6">●</span> PRs <strong>
+								{prCount}
+							</strong>
+						</span>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -403,178 +347,148 @@ const sectionNames = [
 
 	<!-- ═══ Section 1: Donut ═══ -->
 	<section class="kb-section" data-section="1">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanDonut client:only="react" sectionIndex={1} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanDonut client:only="react" sectionIndex={1} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 2: Treemap ═══ -->
 	<section class="kb-section" data-section="2">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanTreemap client:only="react" sectionIndex={2} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanTreemap client:only="react" sectionIndex={2} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 3: Timeline ═══ -->
 	<section class="kb-section" data-section="3">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanTimeline client:only="react" sectionIndex={3} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanTimeline client:only="react" sectionIndex={3} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 4: Sankey ═══ -->
 	<section class="kb-section" data-section="4">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanSankey client:only="react" sectionIndex={4} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanSankey client:only="react" sectionIndex={4} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 5: Heatmap ═══ -->
 	<section class="kb-section" data-section="5">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanHeatmap client:only="react" sectionIndex={5} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanHeatmap client:only="react" sectionIndex={5} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 6: Breakdown (static) ═══ -->
 	<section class="kb-section" data-section="6">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content">
-					<div class="kb-breakdown-wrap">
-						<!-- Phase bars -->
-						<div class="kb-card">
-							<h3 class="kb-section-title">Work Distribution</h3>
-							<div class="kb-phase-bars">
-								{
-									phases.map((p) => (
-										<div class="kb-phase-row">
-											<span class="kb-phase-label">
-												{p.label}
-											</span>
-											<div class="kb-phase-track">
-												<div
-													class="kb-phase-fill"
-													style={`width:${(p.value / phaseTotal) * 100}%;background:${p.color}`}
-												/>
-											</div>
-											<span
-												class="kb-phase-count"
-												style={`color:${p.color}`}>
-												{p.value}
-											</span>
-										</div>
-									))
-								}
-							</div>
-						</div>
-
-						<!-- Pipeline -->
-						<div class="kb-card">
-							<h3 class="kb-section-title">Pipeline</h3>
-							<div class="kb-pipeline">
-								{
-									columnOrder.map((col, i) => {
-										const count = summary[col] ?? 0;
-										const color = columnColors[col];
-										return (
-											<div class="kb-pipe-stage">
-												<div
-													class="kb-pipe-node"
-													style={`border-color:${color};color:${color}`}>
-													<span class="kb-pipe-count">
-														{count}
-													</span>
-													<span class="kb-pipe-name">
-														{col}
-													</span>
-												</div>
-												{i < columnOrder.length - 1 && (
-													<div class="kb-pipe-arrow">
-														→
-													</div>
-												)}
-											</div>
-										);
-									})
-								}
-							</div>
-						</div>
-
-						<!-- Top labels -->
-						<div class="kb-card">
-							<h3 class="kb-section-title">Top Labels</h3>
-							<div
-								class="kb-breakdown-types"
-								style="margin-bottom:0.75rem">
-								<div class="kb-type-row">
+		<div class="kb-section-content">
+			<div class="kb-breakdown-wrap">
+				<!-- Phase bars -->
+				<div class="kb-card">
+					<h3 class="kb-section-title">Work Distribution</h3>
+					<div class="kb-phase-bars">
+						{
+							phases.map((p) => (
+								<div class="kb-phase-row">
+									<span class="kb-phase-label">
+										{p.label}
+									</span>
+									<div class="kb-phase-track">
+										<div
+											class="kb-phase-fill"
+											style={`width:${(p.value / phaseTotal) * 100}%;background:${p.color}`}
+										/>
+									</div>
 									<span
-										class="kb-type-icon"
-										style="color:#22c55e">
-										●
-									</span><span class="kb-type-label">
-										Issues
-									</span><span class="kb-type-value">
-										{issueCount}
+										class="kb-phase-count"
+										style={`color:${p.color}`}>
+										{p.value}
 									</span>
 								</div>
-								<div class="kb-type-row">
-									<span
-										class="kb-type-icon"
-										style="color:#8b5cf6">
-										●
-									</span><span class="kb-type-label">
-										Pull Requests
-									</span><span class="kb-type-value">
-										{prCount}
-									</span>
-								</div>
-							</div>
-							<div class="kb-top-labels">
-								{
-									topLabels.map(([label, count]) => (
-										<div class="kb-label-row">
-											<span
-												class="kb-label-name"
-												style={`color:${labelColor(label)}`}>
-												{label}
-											</span>
-											<span class="kb-label-bar-track">
-												<span
-													class="kb-label-bar-fill"
-													style={`width:${(count / topLabels[0][1]) * 100}%;background:${labelColor(label)}`}
-												/>
-											</span>
-											<span
-												class="kb-label-count"
-												style={`color:${labelColor(label)}`}>
+							))
+						}
+					</div>
+				</div>
+
+				<!-- Pipeline -->
+				<div class="kb-card">
+					<h3 class="kb-section-title">Pipeline</h3>
+					<div class="kb-pipeline">
+						{
+							columnOrder.map((col, i) => {
+								const count = summary[col] ?? 0;
+								const color = columnColors[col];
+								return (
+									<div class="kb-pipe-stage">
+										<div
+											class="kb-pipe-node"
+											style={`border-color:${color};color:${color}`}>
+											<span class="kb-pipe-count">
 												{count}
 											</span>
+											<span class="kb-pipe-name">
+												{col}
+											</span>
 										</div>
-									))
-								}
-							</div>
+										{i < columnOrder.length - 1 && (
+											<div class="kb-pipe-arrow">→</div>
+										)}
+									</div>
+								);
+							})
+						}
+					</div>
+				</div>
+
+				<!-- Top labels -->
+				<div class="kb-card">
+					<h3 class="kb-section-title">Top Labels</h3>
+					<div
+						class="kb-breakdown-types"
+						style="margin-bottom:0.75rem">
+						<div class="kb-type-row">
+							<span class="kb-type-icon" style="color:#22c55e">
+								●
+							</span><span class="kb-type-label">
+								Issues
+							</span><span class="kb-type-value">
+								{issueCount}
+							</span>
 						</div>
+						<div class="kb-type-row">
+							<span class="kb-type-icon" style="color:#8b5cf6">
+								●
+							</span><span class="kb-type-label">
+								Pull Requests
+							</span><span class="kb-type-value">
+								{prCount}
+							</span>
+						</div>
+					</div>
+					<div class="kb-top-labels">
+						{
+							topLabels.map(([label, count]) => (
+								<div class="kb-label-row">
+									<span
+										class="kb-label-name"
+										style={`color:${labelColor(label)}`}>
+										{label}
+									</span>
+									<span class="kb-label-bar-track">
+										<span
+											class="kb-label-bar-fill"
+											style={`width:${(count / topLabels[0][1]) * 100}%;background:${labelColor(label)}`}
+										/>
+									</span>
+									<span
+										class="kb-label-count"
+										style={`color:${labelColor(label)}`}>
+										{count}
+									</span>
+								</div>
+							))
+						}
 					</div>
 				</div>
 			</div>
@@ -583,259 +497,49 @@ const sectionNames = [
 
 	<!-- ═══ Section 7: Kanban Board ═══ -->
 	<section class="kb-section" data-section="7">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-board-section">
-					<ReactKanbanBoard client:only="react" sectionIndex={7} />
-				</div>
-			</div>
+		<div class="kb-section-content kb-board-section">
+			<ReactKanbanBoard client:only="react" sectionIndex={7} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 8: Contributors ═══ -->
 	<section class="kb-section" data-section="8">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-chart-center">
-					<ReactKanbanAssignees
-						client:only="react"
-						sectionIndex={8}
-					/>
-				</div>
-			</div>
+		<div class="kb-section-content kb-chart-center">
+			<ReactKanbanAssignees client:only="react" sectionIndex={8} />
 		</div>
 	</section>
 
 	<!-- ═══ Section 9: Item Browser ═══ -->
 	<section class="kb-section" data-section="9">
-		<div class="kb-section-outer">
-			<div class="kb-section-inner">
-				<div class="kb-section-content kb-browser-section">
-					<ReactKanbanBrowser client:only="react" />
-				</div>
-			</div>
+		<div class="kb-section-content kb-browser-section">
+			<ReactKanbanBrowser client:only="react" />
 		</div>
 	</section>
 </div>
 
-<!-- GSAP Section Controller -->
-<script>
-	import gsap from 'gsap';
-	import { Observer } from 'gsap/Observer';
-	import { onSwap } from '@kbve/astro/utils/clientRouter';
-
-	gsap.registerPlugin(Observer);
-
-	function initKanbanSections() {
-		const sections = document.querySelectorAll<HTMLElement>('.kb-section');
-		const outerWrappers =
-			document.querySelectorAll<HTMLElement>('.kb-section-outer');
-		const innerWrappers =
-			document.querySelectorAll<HTMLElement>('.kb-section-inner');
-		const dots = document.querySelectorAll<HTMLElement>('.kb-dot');
-
-		if (sections.length === 0) return;
-
-		let currentIndex = -1;
-		let animating = false;
-		const wrap = gsap.utils.wrap(0, sections.length);
-
-		gsap.set(outerWrappers, { yPercent: 100 });
-		gsap.set(innerWrappers, { yPercent: -100 });
-
-		const sectionLabel = document.getElementById('kb-section-label');
-		const sectionNames = [
-			'Summary',
-			'Donut',
-			'Treemap',
-			'Timeline',
-			'Sankey',
-			'Heatmap',
-			'Breakdown',
-			'Board',
-			'Contributors',
-			'Items',
-		];
-		// Lowercase slug map for hash navigation
-		const sectionSlugs = sectionNames.map((n) => n.toLowerCase());
-		const slugToIndex = new Map(sectionSlugs.map((s, i) => [s, i]));
-
-		function updateDots(index: number) {
-			dots.forEach((dot, i) => {
-				dot.classList.toggle('kb-dot--active', i === index);
-			});
-			// Update section label indicator
-			if (sectionLabel) {
-				const idxEl = sectionLabel.querySelector(
-					'.kb-section-label-index',
-				);
-				const nameEl = sectionLabel.querySelector(
-					'.kb-section-label-name',
-				);
-				if (idxEl)
-					idxEl.textContent = String(index + 1).padStart(2, '0');
-				if (nameEl) nameEl.textContent = sectionNames[index] ?? '';
-			}
-		}
-
-		function gotoSection(index: number, direction: number) {
-			index = wrap(index);
-			if (index === currentIndex) return;
-			animating = true;
-			const fromTop = direction === -1;
-			const dFactor = fromTop ? -1 : 1;
-
-			const tl = gsap.timeline({
-				defaults: { duration: 1.0, ease: 'power1.inOut' },
-				onComplete: () => {
-					animating = false;
-					// Signal active section for lazy D3 init
-					document.documentElement.setAttribute(
-						'data-active-section',
-						String(index),
-					);
-				},
-			});
-
-			if (currentIndex >= 0) {
-				gsap.set(sections[currentIndex], { zIndex: 0 });
-				tl.to(sections[currentIndex], {
-					autoAlpha: 0,
-					duration: 0.5,
-				});
-			}
-
-			gsap.set(sections[index], { autoAlpha: 1, zIndex: 1 });
-			tl.fromTo(
-				[outerWrappers[index], innerWrappers[index]],
-				{
-					yPercent: (i: number) =>
-						i ? -100 * dFactor : 100 * dFactor,
-				},
-				{ yPercent: 0 },
-				0,
-			);
-
-			currentIndex = index;
-			updateDots(index);
-
-			// Update URL hash without triggering hashchange
-			const slug = sectionSlugs[index];
-			if (slug) {
-				history.replaceState(null, '', `#${slug}`);
-			}
-		}
-
-		// Handle hashchange (browser back/forward or manual URL entry)
-		const onHashChange = () => {
-			const hash = location.hash.replace('#', '').toLowerCase();
-			const idx = slugToIndex.get(hash);
-			if (idx != null && !animating && idx !== currentIndex) {
-				gotoSection(idx, idx > currentIndex ? 1 : -1);
-			}
-		};
-		window.addEventListener('hashchange', onHashChange);
-
-		// Dot click navigation
-		const dotHandlers: Array<[HTMLElement, () => void]> = [];
-		dots.forEach((dot) => {
-			const handler = () => {
-				const idx = parseInt(
-					dot.getAttribute('data-section-idx') ?? '0',
-					10,
-				);
-				if (!animating && idx !== currentIndex) {
-					gotoSection(idx, idx > currentIndex ? 1 : -1);
-				}
-			};
-			dot.addEventListener('click', handler);
-			dotHandlers.push([dot, handler]);
-		});
-
-		// GSAP Observer for wheel/touch/pointer
-		const observer = Observer.create({
-			type: 'wheel,touch,pointer',
-			wheelSpeed: -1,
-			onDown: () => !animating && gotoSection(currentIndex - 1, -1),
-			onUp: () => !animating && gotoSection(currentIndex + 1, 1),
-			tolerance: 10,
-			preventDefault: true,
-			target: document.getElementById('kb-snap-container'),
-		});
-
-		// Hide page scrollbar — GSAP Observer handles all scroll
-		const prevHtmlOverflow = document.documentElement.style.overflow;
-		const prevBodyOverflow = document.body.style.overflow;
-		document.documentElement.style.overflow = 'hidden';
-		document.body.style.overflow = 'hidden';
-
-		// Start at section from hash, or default to 0
-		const initHash = location.hash.replace('#', '').toLowerCase();
-		const initIdx = slugToIndex.get(initHash) ?? 0;
-		gotoSection(initIdx, 1);
-
-		onSwap(() => {
-			window.removeEventListener('hashchange', onHashChange);
-			dotHandlers.forEach(([d, h]) => d.removeEventListener('click', h));
-			observer.kill();
-			document.documentElement.style.overflow = prevHtmlOverflow;
-			document.body.style.overflow = prevBodyOverflow;
-		});
-	}
-
-	// `astro:page-load` fires on both initial hard load and every
-	// ClientRouter swap, so no separate DOMContentLoaded path needed.
-	document.addEventListener('astro:page-load', initKanbanSections);
-</script>
-
 <style>
-	/* ── Snap container ── */
-	.kb-snap-container {
-		position: fixed;
-		inset: var(--sl-nav-height, 3.5rem) 0 0
-			var(--sl-content-inline-start, 0);
-		overflow: hidden;
-		background: var(--sl-color-bg, #0a0a0a);
-		z-index: 1;
-	}
-
-	/* ── Sections ── */
-	.kb-section {
-		position: absolute;
-		top: 3.5rem;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		width: auto;
-		height: auto;
-		visibility: hidden;
-	}
-	/* Progressive enhancement: the first section is visible without JS so a
-	   failed GSAP init (or blocked import) shows the Summary instead of a
-	   blank board. GSAP takes over visibility once it hydrates. */
-	.kb-section[data-section='0'] {
-		visibility: visible;
-	}
-	.kb-section-outer,
-	.kb-section-inner {
+	.kb-sections {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
 		width: 100%;
-		height: 100%;
-		overflow-y: hidden;
+	}
+	.kb-section {
+		width: 100%;
+		border-radius: 12px;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		background: var(--sl-color-bg-nav, #111);
+		opacity: 1;
 	}
 	.kb-section-content {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-		padding: 1rem 1.5rem;
-		max-width: 1200px;
-		margin: 0 auto;
+		align-items: stretch;
+		padding: 1.25rem 1.5rem;
 		gap: 1rem;
 		box-sizing: border-box;
 	}
 	.kb-chart-center {
-		justify-content: center;
 		align-items: center;
 	}
 	.kb-browser-section {
@@ -876,107 +580,6 @@ const sectionNames = [
 		flex: 1;
 		min-height: 0;
 		overflow-y: auto;
-	}
-
-	/* ── Dot navigation ── */
-	.kb-dot-nav {
-		position: fixed;
-		right: 1rem;
-		top: 50%;
-		transform: translateY(-50%);
-		z-index: 50;
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-		align-items: flex-end;
-	}
-	.kb-dot {
-		width: 10px;
-		height: 10px;
-		border-radius: 50%;
-		border: 1px solid var(--sl-color-gray-4, #6b7280);
-		background: transparent;
-		cursor: pointer;
-		transition: all 0.25s ease;
-		padding: 0;
-		position: relative;
-	}
-	.kb-dot--active {
-		background: var(--sl-color-accent, #06b6d4);
-		border-color: var(--sl-color-accent, #06b6d4);
-		box-shadow: 0 0 8px rgba(6, 182, 212, 0.4);
-		transform: scale(1.3);
-	}
-	.kb-dot-label {
-		position: absolute;
-		right: 20px;
-		top: 50%;
-		transform: translateY(-50%);
-		font-size: 0.65rem;
-		color: var(--sl-color-gray-3, #8b949e);
-		white-space: nowrap;
-		opacity: 0;
-		transition: opacity 0.2s;
-		pointer-events: none;
-	}
-	.kb-dot:hover .kb-dot-label {
-		opacity: 1;
-	}
-	.kb-dot--active .kb-dot-label {
-		color: var(--sl-color-accent, #06b6d4);
-	}
-
-	/* ── Section label indicator ── */
-	.kb-section-label {
-		position: fixed;
-		top: 5rem;
-		right: 2.5rem;
-		z-index: 50;
-		display: flex;
-		align-items: baseline;
-		gap: 3px;
-		font-variant-numeric: tabular-nums;
-		pointer-events: none;
-	}
-	.kb-section-label-index {
-		font-size: 1.1rem;
-		font-weight: 700;
-		color: var(--sl-color-accent, #06b6d4);
-	}
-	.kb-section-label-sep {
-		font-size: 0.8rem;
-		color: var(--sl-color-gray-4, #6b7280);
-		margin: 0 1px;
-	}
-	.kb-section-label-total {
-		font-size: 0.8rem;
-		font-weight: 500;
-		color: var(--sl-color-gray-4, #6b7280);
-	}
-	.kb-section-label-name {
-		font-size: 0.7rem;
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--sl-color-gray-3, #8b949e);
-		margin-left: 8px;
-	}
-
-	/* ── Scroll hint ── */
-	.kb-scroll-hint {
-		margin: 0;
-		font-size: 0.75rem;
-		color: var(--sl-color-gray-4, #6b7280);
-		animation: kb-bounce 2s ease-in-out infinite;
-	}
-	@keyframes kb-bounce {
-		0%,
-		100% {
-			transform: translateY(0);
-		}
-		50% {
-			transform: translateY(6px);
-		}
 	}
 
 	/* ── Card base ── */
@@ -1439,13 +1042,6 @@ const sectionNames = [
 		}
 		.kb-stat-value {
 			font-size: 1rem;
-		}
-		.kb-dot-nav {
-			right: 0.5rem;
-		}
-		.kb-section-label {
-			right: 1.5rem;
-			top: calc(var(--sl-nav-height, 3.5rem) + 4.5rem);
 		}
 
 		/* Hide complex charts on small screens */

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -529,7 +529,7 @@ const prCount = Object.values(columns)
 		border-radius: 12px;
 		border: 1px solid var(--sl-color-gray-5, #262626);
 		background: var(--sl-color-bg-nav, #111);
-		opacity: 1;
+		opacity: 0;
 	}
 	.kb-section-content {
 		display: flex;
@@ -1050,4 +1050,27 @@ const prCount = Object.values(columns)
 			display: none;
 		}
 	}
+
+	@media (scripting: none) {
+		.kb-section {
+			opacity: 1;
+		}
+	}
 </style>
+
+<script>
+	import { initKanbanViewManager } from './kanbanViewManager';
+	import { onSwap } from '@kbve/astro/utils/clientRouter';
+
+	let teardown: (() => void) | null = null;
+
+	document.addEventListener('astro:page-load', () => {
+		teardown?.();
+		teardown = initKanbanViewManager();
+	});
+
+	onSwap(() => {
+		teardown?.();
+		teardown = null;
+	});
+</script>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -512,7 +512,7 @@ const prCount = Object.values(columns)
 	<!-- ═══ Section 9: Item Browser ═══ -->
 	<section class="kb-section" data-section="9">
 		<div class="kb-section-content kb-browser-section">
-			<ReactKanbanBrowser client:only="react" />
+			<ReactKanbanBrowser client:only="react" sectionIndex={9} />
 		</div>
 	</section>
 </div>
@@ -1031,7 +1031,7 @@ const prCount = Object.values(columns)
 	/* ── Responsive: hide heavy D3 charts on mobile, adapt layouts ── */
 	@media (max-width: 640px) {
 		.kb-section-content {
-			padding: calc(var(--sl-nav-height, 3.5rem) + 0.5rem) 1rem 1rem;
+			padding: 1rem;
 		}
 		.kb-stats-row {
 			gap: 0.5rem;

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanAssignees.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanAssignees.tsx
@@ -26,13 +26,10 @@ const COLORS = [
 export default function ReactKanbanAssignees({ sectionIndex }: Props) {
 	const active = useKanbanSection(sectionIndex);
 	const [data] = useKanbanData();
-	const rendered = useRef(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		if (!active || !data || rendered.current || !containerRef.current)
-			return;
-		rendered.current = true;
+		if (!active || !data || !containerRef.current) return;
 
 		// Count items per assignee
 		const assigneeCounts: Record<string, number> = {};
@@ -205,6 +202,11 @@ export default function ReactKanbanAssignees({ sectionIndex }: Props) {
 		wrapper.appendChild(barSvg);
 		wrapper.appendChild(donutSvg);
 		container.appendChild(wrapper);
+
+		return () => {
+			while (container.firstChild)
+				container.removeChild(container.firstChild);
+		};
 	}, [active, data]);
 
 	return (
@@ -227,7 +229,22 @@ export default function ReactKanbanAssignees({ sectionIndex }: Props) {
 				}}>
 				Contributors
 			</h3>
-			<div ref={containerRef} style={{ width: '100%', maxWidth: 800 }} />
+			{active ? (
+				<div
+					ref={containerRef}
+					style={{ width: '100%', maxWidth: 800 }}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 800,
+						height: 300,
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBoard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBoard.tsx
@@ -131,7 +131,13 @@ export default function ReactKanbanBoard({ sectionIndex }: Props) {
 					display: 'flex',
 					alignItems: 'center',
 					justifyContent: 'center',
+					width: '100%',
 					height: '100%',
+					minHeight: 320,
+					borderRadius: 12,
+					background: active
+						? 'transparent'
+						: 'var(--sl-color-gray-6, #1a1a1a)',
 					color: 'var(--sl-color-gray-4)',
 					fontSize: '0.85rem',
 				}}>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBrowser.tsx
@@ -2,58 +2,17 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { Loader2, GitPullRequest, CircleDot, ExternalLink } from 'lucide-react';
 import { openTooltip, closeTooltip } from '@kbve/droid';
 import { showItemModal } from './kanbanItemModal';
+import {
+	useKanbanSection,
+	useKanbanData,
+	COLUMN_COLORS,
+	COLUMN_ORDER,
+	type KanbanItem,
+} from './useKanbanSection';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface KanbanItem {
-	type: 'ISSUE' | 'PULL_REQUEST';
-	number: number;
-	title: string;
-	state: string;
-	url: string;
-	assignees: string[];
-	labels: string[];
-	matrix: string | null;
-	date: string;
-	milestone: string | null;
+interface Props {
+	sectionIndex: number;
 }
-
-interface KanbanData {
-	generated_at: string;
-	project: { title: string; url: string; total_items: number };
-	summary: Record<string, number>;
-	columns: Record<string, KanbanItem[]>;
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const COLUMN_COLORS: Record<string, string> = {
-	Theory: '#8b5cf6',
-	AI: '#06b6d4',
-	Todo: '#3b82f6',
-	Backlog: '#6366f1',
-	Error: '#ef4444',
-	Support: '#f59e0b',
-	Staging: '#f97316',
-	Review: '#eab308',
-	Done: '#22c55e',
-};
-
-const COLUMN_ORDER = [
-	'Theory',
-	'AI',
-	'Todo',
-	'Backlog',
-	'Error',
-	'Support',
-	'Staging',
-	'Review',
-	'Done',
-];
 
 const DONE_DISPLAY_LIMIT = 25;
 
@@ -284,35 +243,33 @@ function ItemRow({
 // Main — interactive tabbed item browser
 // ---------------------------------------------------------------------------
 
-export default function ReactKanbanBrowser() {
-	const [data, setData] = useState<KanbanData | null>(null);
-	const [error, setError] = useState<string | null>(null);
+export default function ReactKanbanBrowser({ sectionIndex }: Props) {
+	const active = useKanbanSection(sectionIndex);
+	const [data, error] = useKanbanData();
 	const [activeTab, setActiveTab] = useState('Theory');
 	const { tipRef, show, move, hide } = useKanbanTooltip();
+	const tabInitialized = useRef(false);
 
 	useEffect(() => {
-		let cancelled = false;
-		fetch('/data/nx/nx-kanban.json', { signal: AbortSignal.timeout(10000) })
-			.then((r) => {
-				if (!r.ok) throw new Error(`HTTP ${r.status}`);
-				return r.json();
-			})
-			.then((d: KanbanData) => {
-				if (!cancelled) {
-					setData(d);
-					const first = COLUMN_ORDER.find(
-						(c) => c !== 'Done' && (d.columns[c]?.length ?? 0) > 0,
-					);
-					if (first) setActiveTab(first);
-				}
-			})
-			.catch((e) => {
-				if (!cancelled) setError(e.message);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
+		if (!data || tabInitialized.current) return;
+		tabInitialized.current = true;
+		const first = COLUMN_ORDER.find(
+			(c) => c !== 'Done' && (data.columns[c]?.length ?? 0) > 0,
+		);
+		if (first) setActiveTab(first);
+	}, [data]);
+
+	if (!active) {
+		return (
+			<div
+				style={{
+					minHeight: 400,
+					background: 'var(--sl-color-gray-6, #1a1a1a)',
+					borderRadius: 12,
+				}}
+			/>
+		);
+	}
 
 	if (error) {
 		return (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanDonut.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanDonut.tsx
@@ -114,6 +114,7 @@ export default function ReactKanbanDonut({ sectionIndex }: Props) {
 
 		return () => {
 			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.hide();
 			tooltip.el.remove();
 		};
 	}, [active, data]);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanDonut.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanDonut.tsx
@@ -17,18 +17,9 @@ export default function ReactKanbanDonut({ sectionIndex }: Props) {
 	const [data] = useKanbanData();
 	const svgRef = useRef<SVGSVGElement>(null);
 	const wrapRef = useRef<HTMLDivElement>(null);
-	const rendered = useRef(false);
 
 	useEffect(() => {
-		if (
-			!active ||
-			!data ||
-			rendered.current ||
-			!svgRef.current ||
-			!wrapRef.current
-		)
-			return;
-		rendered.current = true;
+		if (!active || !data || !svgRef.current || !wrapRef.current) return;
 
 		const tooltip = createChartTooltip(wrapRef.current, 'donut');
 		const summary = data.summary;
@@ -120,6 +111,11 @@ export default function ReactKanbanDonut({ sectionIndex }: Props) {
 		text2.setAttribute('font-weight', '500');
 		text2.textContent = 'TOTAL ITEMS';
 		g.appendChild(text2);
+
+		return () => {
+			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.el.remove();
+		};
 	}, [active, data]);
 
 	return (
@@ -142,13 +138,25 @@ export default function ReactKanbanDonut({ sectionIndex }: Props) {
 				}}>
 				Column Distribution
 			</h3>
-			<svg
-				ref={svgRef}
-				width={420}
-				height={420}
-				viewBox="0 0 420 420"
-				style={{ maxWidth: '100%', height: 'auto' }}
-			/>
+			{active ? (
+				<svg
+					ref={svgRef}
+					width={420}
+					height={420}
+					viewBox="0 0 420 420"
+					style={{ maxWidth: '100%', height: 'auto' }}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 420,
+						aspectRatio: '1 / 1',
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanHeatmap.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanHeatmap.tsx
@@ -48,7 +48,11 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 		}
 
 		const dates = Object.keys(dateCounts).sort();
-		if (dates.length === 0) return () => tooltip.el.remove();
+		if (dates.length === 0)
+			return () => {
+				tooltip.hide();
+				tooltip.el.remove();
+			};
 
 		// Measure container width to compute cell size
 		const containerWidth = container.offsetWidth;
@@ -283,6 +287,7 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 		return () => {
 			while (container.firstChild)
 				container.removeChild(container.firstChild);
+			tooltip.hide();
 			tooltip.el.remove();
 		};
 	}, [active, data]);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanHeatmap.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanHeatmap.tsx
@@ -14,12 +14,9 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 	const active = useKanbanSection(sectionIndex);
 	const [data] = useKanbanData();
 	const containerRef = useRef<HTMLDivElement>(null);
-	const rendered = useRef(false);
 
 	useEffect(() => {
-		if (!active || !data || rendered.current || !containerRef.current)
-			return;
-		rendered.current = true;
+		if (!active || !data || !containerRef.current) return;
 
 		const container = containerRef.current;
 		const tooltip = createChartTooltip(container, 'heatmap');
@@ -51,7 +48,7 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 		}
 
 		const dates = Object.keys(dateCounts).sort();
-		if (dates.length === 0) return;
+		if (dates.length === 0) return () => tooltip.el.remove();
 
 		// Measure container width to compute cell size
 		const containerWidth = container.offsetWidth;
@@ -282,6 +279,12 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 		svg.appendChild(totalText);
 
 		container.appendChild(svg);
+
+		return () => {
+			while (container.firstChild)
+				container.removeChild(container.firstChild);
+			tooltip.el.remove();
+		};
 	}, [active, data]);
 
 	return (
@@ -304,7 +307,22 @@ export default function ReactKanbanHeatmap({ sectionIndex }: Props) {
 				}}>
 				Activity Heatmap
 			</h3>
-			<div ref={containerRef} style={{ width: '100%', maxWidth: 1100 }} />
+			{active ? (
+				<div
+					ref={containerRef}
+					style={{ width: '100%', maxWidth: 1100 }}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 1100,
+						height: 220,
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanSankey.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanSankey.tsx
@@ -17,18 +17,9 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 	const [data] = useKanbanData();
 	const svgRef = useRef<SVGSVGElement>(null);
 	const wrapRef = useRef<HTMLDivElement>(null);
-	const rendered = useRef(false);
 
 	useEffect(() => {
-		if (
-			!active ||
-			!data ||
-			rendered.current ||
-			!svgRef.current ||
-			!wrapRef.current
-		)
-			return;
-		rendered.current = true;
+		if (!active || !data || !svgRef.current || !wrapRef.current) return;
 
 		const tooltip = createChartTooltip(wrapRef.current, 'sankey');
 
@@ -89,7 +80,7 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 			});
 		}
 
-		if (links.length === 0) return;
+		if (links.length === 0) return () => tooltip.el.remove();
 
 		const sankeyGen = sankey<any, any>()
 			.nodeId((d: any) => d.index)
@@ -215,6 +206,11 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 				svg.appendChild(text);
 			}
 		}
+
+		return () => {
+			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.el.remove();
+		};
 	}, [active, data]);
 
 	return (
@@ -237,13 +233,25 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 				}}>
 				Pipeline Flow
 			</h3>
-			<svg
-				ref={svgRef}
-				width={900}
-				height={420}
-				viewBox="0 0 900 420"
-				style={{ maxWidth: '100%', height: 'auto' }}
-			/>
+			{active ? (
+				<svg
+					ref={svgRef}
+					width={900}
+					height={420}
+					viewBox="0 0 900 420"
+					style={{ maxWidth: '100%', height: 'auto' }}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 900,
+						aspectRatio: '900 / 420',
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanSankey.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanSankey.tsx
@@ -80,7 +80,11 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 			});
 		}
 
-		if (links.length === 0) return () => tooltip.el.remove();
+		if (links.length === 0)
+			return () => {
+				tooltip.hide();
+				tooltip.el.remove();
+			};
 
 		const sankeyGen = sankey<any, any>()
 			.nodeId((d: any) => d.index)
@@ -209,6 +213,7 @@ export default function ReactKanbanSankey({ sectionIndex }: Props) {
 
 		return () => {
 			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.hide();
 			tooltip.el.remove();
 		};
 	}, [active, data]);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTimeline.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTimeline.tsx
@@ -37,7 +37,11 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 			}
 		}
 
-		if (items.length === 0) return () => tooltip.el.remove();
+		if (items.length === 0)
+			return () => {
+				tooltip.hide();
+				tooltip.el.remove();
+			};
 
 		const width = 900;
 		const height = 400;
@@ -162,6 +166,7 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 
 		return () => {
 			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.hide();
 			tooltip.el.remove();
 		};
 	}, [active, data]);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTimeline.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTimeline.tsx
@@ -20,18 +20,9 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 	const [data] = useKanbanData();
 	const svgRef = useRef<SVGSVGElement>(null);
 	const wrapRef = useRef<HTMLDivElement>(null);
-	const rendered = useRef(false);
 
 	useEffect(() => {
-		if (
-			!active ||
-			!data ||
-			rendered.current ||
-			!svgRef.current ||
-			!wrapRef.current
-		)
-			return;
-		rendered.current = true;
+		if (!active || !data || !svgRef.current || !wrapRef.current) return;
 
 		const tooltip = createChartTooltip(wrapRef.current, 'timeline');
 
@@ -46,7 +37,7 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 			}
 		}
 
-		if (items.length === 0) return;
+		if (items.length === 0) return () => tooltip.el.remove();
 
 		const width = 900;
 		const height = 400;
@@ -168,6 +159,11 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 				circle.style.opacity = '0.8';
 			});
 		}
+
+		return () => {
+			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.el.remove();
+		};
 	}, [active, data]);
 
 	return (
@@ -190,13 +186,25 @@ export default function ReactKanbanTimeline({ sectionIndex }: Props) {
 				}}>
 				Items by Date
 			</h3>
-			<svg
-				ref={svgRef}
-				width={900}
-				height={400}
-				viewBox="0 0 900 400"
-				style={{ maxWidth: '100%', height: 'auto' }}
-			/>
+			{active ? (
+				<svg
+					ref={svgRef}
+					width={900}
+					height={400}
+					viewBox="0 0 900 400"
+					style={{ maxWidth: '100%', height: 'auto' }}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 900,
+						aspectRatio: '900 / 400',
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTreemap.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTreemap.tsx
@@ -17,18 +17,9 @@ export default function ReactKanbanTreemap({ sectionIndex }: Props) {
 	const [data] = useKanbanData();
 	const svgRef = useRef<SVGSVGElement>(null);
 	const wrapRef = useRef<HTMLDivElement>(null);
-	const rendered = useRef(false);
 
 	useEffect(() => {
-		if (
-			!active ||
-			!data ||
-			rendered.current ||
-			!svgRef.current ||
-			!wrapRef.current
-		)
-			return;
-		rendered.current = true;
+		if (!active || !data || !svgRef.current || !wrapRef.current) return;
 
 		const tooltip = createChartTooltip(wrapRef.current, 'treemap');
 		const summary = data.summary;
@@ -128,6 +119,11 @@ export default function ReactKanbanTreemap({ sectionIndex }: Props) {
 				rect.style.opacity = '0.85';
 			});
 		}
+
+		return () => {
+			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.el.remove();
+		};
 	}, [active, data]);
 
 	return (
@@ -150,13 +146,29 @@ export default function ReactKanbanTreemap({ sectionIndex }: Props) {
 				}}>
 				Column Size Treemap
 			</h3>
-			<svg
-				ref={svgRef}
-				width={800}
-				height={450}
-				viewBox="0 0 800 450"
-				style={{ maxWidth: '100%', height: 'auto', borderRadius: 10 }}
-			/>
+			{active ? (
+				<svg
+					ref={svgRef}
+					width={800}
+					height={450}
+					viewBox="0 0 800 450"
+					style={{
+						maxWidth: '100%',
+						height: 'auto',
+						borderRadius: 10,
+					}}
+				/>
+			) : (
+				<div
+					style={{
+						width: '100%',
+						maxWidth: 800,
+						aspectRatio: '800 / 450',
+						borderRadius: 12,
+						background: 'var(--sl-color-gray-6, #1a1a1a)',
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTreemap.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanTreemap.tsx
@@ -122,6 +122,7 @@ export default function ReactKanbanTreemap({ sectionIndex }: Props) {
 
 		return () => {
 			while (svg.firstChild) svg.removeChild(svg.firstChild);
+			tooltip.hide();
 			tooltip.el.remove();
 		};
 	}, [active, data]);

--- a/apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts
@@ -1,0 +1,60 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const KEEP_WARM = 2;
+
+export function initKanbanViewManager(): () => void {
+	const sections = Array.from(
+		document.querySelectorAll<HTMLElement>('.kb-section'),
+	);
+	if (sections.length === 0) return () => {};
+
+	const total = sections.length;
+	let centered = -1;
+
+	const publishLive = (center: number) => {
+		if (center === centered) return;
+		centered = center;
+		const live: number[] = [];
+		for (let i = 0; i < total; i++) {
+			if (Math.abs(i - center) <= KEEP_WARM) live.push(i);
+		}
+		document.documentElement.dataset.liveSections = live.join(',');
+	};
+
+	const reveal = (el: HTMLElement) =>
+		gsap.to(el, {
+			opacity: 1,
+			y: 0,
+			duration: 0.5,
+			ease: 'power1.out',
+			overwrite: 'auto',
+		});
+
+	gsap.set(sections, { y: 12 });
+
+	const triggers = sections.map((section, i) =>
+		ScrollTrigger.create({
+			trigger: section,
+			start: 'top 85%',
+			end: 'bottom 15%',
+			onEnter: () => reveal(section),
+			onEnterBack: () => reveal(section),
+			onToggle: (self) => {
+				if (self.isActive) publishLive(i);
+			},
+		}),
+	);
+
+	// Seed the initial live-set from whichever section is nearest the top.
+	const firstActive = triggers.findIndex((t) => t.isActive);
+	publishLive(firstActive >= 0 ? firstActive : 0);
+	ScrollTrigger.refresh();
+
+	return () => {
+		triggers.forEach((t) => t.kill());
+		delete document.documentElement.dataset.liveSections;
+	};
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts
@@ -33,7 +33,7 @@ export function initKanbanViewManager(): () => void {
 			overwrite: 'auto',
 		});
 
-	gsap.set(sections, { y: 12 });
+	gsap.set(sections, { opacity: 0, y: 12 });
 
 	const triggers = sections.map((section, i) =>
 		ScrollTrigger.create({
@@ -48,10 +48,18 @@ export function initKanbanViewManager(): () => void {
 		}),
 	);
 
+	ScrollTrigger.refresh();
+
+	// Reveal whichever sections are already active at init so above-the-fold
+	// sections (e.g. Summary) appear immediately instead of waiting for a
+	// scroll-crossing onEnter/onEnterBack event.
+	triggers.forEach((t, i) => {
+		if (t.isActive) reveal(sections[i]);
+	});
+
 	// Seed the initial live-set from whichever section is nearest the top.
 	const firstActive = triggers.findIndex((t) => t.isActive);
 	publishLive(firstActive >= 0 ? firstActive : 0);
-	ScrollTrigger.refresh();
 
 	return () => {
 		triggers.forEach((t) => t.kill());

--- a/apps/kbve/astro-kbve/src/components/dashboard/useKanbanSection.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/useKanbanSection.ts
@@ -1,39 +1,38 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Hook that watches for a section becoming active via the GSAP controller.
- * The GSAP script sets `data-active-section` on `<html>` with the current index.
- * Once a section has been activated, `hasActivated` stays true permanently
- * (charts render once and stay).
+ * Hook that tracks whether a section is in the live-set published on
+ * `document.documentElement.dataset.liveSections`. Returns true while
+ * the section index is present in the comma-separated list; reacts to
+ * changes via MutationObserver. Charts mount/unmount as sections enter/leave.
  */
 export function useKanbanSection(sectionIndex: number): boolean {
-	const [hasActivated, setHasActivated] = useState(false);
+	const [live, setLive] = useState(false);
 
 	useEffect(() => {
-		if (hasActivated) return;
-
-		const check = () => {
-			const attr = document.documentElement.getAttribute(
-				'data-active-section',
-			);
-			if (attr != null && parseInt(attr, 10) === sectionIndex) {
-				setHasActivated(true);
-			}
+		const read = () => {
+			const attr =
+				document.documentElement.getAttribute('data-live-sections') ??
+				'';
+			const set = attr
+				.split(',')
+				.map((s) => parseInt(s, 10))
+				.filter((n) => !Number.isNaN(n));
+			setLive(set.includes(sectionIndex));
 		};
 
-		// Check immediately in case we're already on this section
-		check();
+		read();
 
-		const observer = new MutationObserver(check);
+		const observer = new MutationObserver(read);
 		observer.observe(document.documentElement, {
 			attributes: true,
-			attributeFilter: ['data-active-section'],
+			attributeFilter: ['data-live-sections'],
 		});
 
 		return () => observer.disconnect();
-	}, [sectionIndex, hasActivated]);
+	}, [sectionIndex]);
 
-	return hasActivated;
+	return live;
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-22-kanban-shell-viewmanager.md
+++ b/docs/superpowers/plans/2026-07-22-kanban-shell-viewmanager.md
@@ -1,0 +1,517 @@
+# Kanban Dashboard Shell + View Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/dashboard/kanban/` render inside the dashboard bento shell (rail + breadcrumb visible) as native stacked scroll, with GSAP-ScrollTrigger-driven reveal + mount/unmount view management for the D3 chart islands.
+
+**Architecture:** Strip the `position:fixed` fullpage-snap overlay and GSAP `Observer` wheel-hijack from `AstroKanbanDashboard.astro`; sections become normal-flow bento bands inside `dash-main`. A new `kanbanViewManager.ts` registers one ScrollTrigger per section: reveal-on-enter + publishes a live-set (±2 sections) to `html[data-live-sections]`. `useKanbanSection` changes from latch-forever to live-set membership, so charts mount when near and unmount when >2 sections away.
+
+**Tech Stack:** Astro (Starlight SSG), GSAP + ScrollTrigger, React 18 islands, D3 (d3-shape/d3-scale/etc), pnpm/nx.
+
+## Global Constraints
+
+- Build only via `pnpm nx run astro-kbve:build` — never bare `astro build`.
+- Stale content cache: if shell/frontmatter renders stale, `rm -rf apps/kbve/astro-kbve/.astro node_modules/.vite` before rebuild.
+- Do NOT modify `MarkdownContent.astro` — its `isDashboard` branch already supplies the shell for `/dashboard/kanban/`.
+- Do NOT modify the data pipeline (`nx-kanban.json`, `/data/nx/nx-kanban.json`).
+- No code comments beyond what already exists in-file (repo preference: minimal comments).
+- Work in a git worktree; do not commit to `dev`/`main` directly.
+- Base path for all files below: `apps/kbve/astro-kbve/src/components/dashboard/`.
+
+---
+
+### Task 1: De-fix the layout — stacked bento sections
+
+Convert `AstroKanbanDashboard.astro` from fixed fullpage overlay to normal-flow section stack. Remove the Observer/fullpage GSAP script, dot-nav, and section-label. (View manager wired in Task 4.)
+
+**Files:**
+
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro`
+
+**Interfaces:**
+
+- Produces: `.kb-sections` container; `.kb-section[data-section={i}]` bands (i = 0..9); each chart mount point retains `sectionIndex` prop. Consumed by Task 4's view manager.
+
+- [ ] **Step 1: Remove the GSAP Observer `<script>` block entirely**
+
+Delete the whole `<!-- GSAP Section Controller -->` `<script>…</script>` block (the `import gsap … initKanbanSections … astro:page-load` block). Task 4 replaces it.
+
+- [ ] **Step 2: Remove dot-nav + section-label markup**
+
+Delete the `<nav class="kb-dot-nav">…</nav>` block and the `<div id="kb-section-label">…</div>` block from the template. Delete the `sectionNames` const if now unused in the frontmatter (it is only used by those two blocks and the deleted script — remove it).
+
+- [ ] **Step 3: Rewrite the container + section wrappers**
+
+Replace the outer `<div id="kb-snap-container" class="kb-snap-container not-content">` with `<div class="kb-sections not-content">`. For every section, collapse the triple wrapper:
+
+Before:
+
+```html
+<section class="kb-section" data-section="1">
+	<div class="kb-section-outer">
+		<div class="kb-section-inner">
+			<div class="kb-section-content kb-chart-center">
+				<ReactKanbanDonut client:only="react" sectionIndex="{1}" />
+			</div>
+		</div>
+	</div>
+</section>
+```
+
+After:
+
+```html
+<section class="kb-section" data-section="1">
+	<div class="kb-section-content kb-chart-center">
+		<ReactKanbanDonut client:only="react" sectionIndex="{1}" />
+	</div>
+</section>
+```
+
+Apply to all 10 sections (0..9). Keep the inner `kb-section-content` + its modifier classes (`kb-chart-center`, `kb-board-section`, `kb-browser-section`) and all existing content markup unchanged.
+
+- [ ] **Step 4: Replace the layout CSS**
+
+In the `<style>` block, delete these rules entirely: `.kb-snap-container`, `.kb-section` (the `position:absolute` version), `.kb-section[data-section='0']`, `.kb-section-outer`, `.kb-section-inner`, `.kb-dot-nav`, `.kb-dot`, `.kb-dot--active`, `.kb-dot-label`, `.kb-dot:hover .kb-dot-label`, `.kb-dot--active .kb-dot-label`, `.kb-section-label` and all `.kb-section-label-*` rules, `.kb-scroll-hint` + `@keyframes kb-bounce`.
+
+Add:
+
+```css
+.kb-sections {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	width: 100%;
+}
+.kb-section {
+	width: 100%;
+	border-radius: 12px;
+	border: 1px solid var(--sl-color-gray-5, #262626);
+	background: var(--sl-color-bg-nav, #111);
+	opacity: 0;
+}
+.kb-section-content {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	padding: 1.25rem 1.5rem;
+	gap: 1rem;
+	box-sizing: border-box;
+}
+.kb-chart-center {
+	align-items: center;
+}
+```
+
+Leave all the content-piece styles (`.kb-card`, `.kb-header-row`, `.kb-stat*`, `.kb-dist*`, `.kb-breakdown*`, `.kb-phase*`, `.kb-pipe*`, `.kb-label*`, `.kb-summary*`, `.kb-board-section`, `.kb-browser-section`, etc.) as-is.
+
+- [ ] **Step 5: Remove the scroll-hint paragraph**
+
+Delete `<p class="kb-scroll-hint">Scroll to explore visualizations ↓</p>` from the Summary section.
+
+- [ ] **Step 6: Delete the `astro:page-load`-dependent progressive-enhancement note**
+
+None needed — `.kb-section { opacity: 0 }` will be flipped to visible by the view manager; add a no-JS fallback in Task 4. For now, temporarily set `.kb-section { opacity: 1 }` so a build in this task renders visibly; Task 4 changes it back to `0` and adds the reveal.
+
+- [ ] **Step 7: Build**
+
+Run: `pnpm nx run astro-kbve:build`
+Expected: build succeeds, no TS errors about removed `sectionNames`.
+
+- [ ] **Step 8: Verify shell + no overlay in built HTML**
+
+Run: `grep -c 'kb-snap-container\|kb-dot-nav\|position: fixed' dist/apps/astro-kbve/dashboard/kanban/index.html`
+Expected: `0`.
+Run: `grep -c 'dash-grid__rail\|dash-breadcrumb' dist/apps/astro-kbve/dashboard/kanban/index.html`
+Expected: `>0` (rail + breadcrumb present, no longer covered).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+git commit -m "refactor(kanban): stacked bento sections, drop fixed fullpage overlay"
+```
+
+---
+
+### Task 2: Live-set gate — rewrite `useKanbanSection`
+
+Change the section gate from latch-forever to live-set membership so charts unmount when far.
+
+**Files:**
+
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/useKanbanSection.ts:9-37`
+
+**Interfaces:**
+
+- Produces: `useKanbanSection(sectionIndex: number): boolean` — returns `true` while `sectionIndex` ∈ the comma list in `document.documentElement.dataset.liveSections`, else `false`. Reacts to changes via MutationObserver on `data-live-sections`. Consumed by all `ReactKanban*` islands.
+
+- [ ] **Step 1: Replace the hook body**
+
+Replace lines 9-37 (`export function useKanbanSection …`) with:
+
+```ts
+export function useKanbanSection(sectionIndex: number): boolean {
+	const [live, setLive] = useState(false);
+
+	useEffect(() => {
+		const read = () => {
+			const attr =
+				document.documentElement.getAttribute('data-live-sections') ??
+				'';
+			const set = attr
+				.split(',')
+				.map((s) => parseInt(s, 10))
+				.filter((n) => !Number.isNaN(n));
+			setLive(set.includes(sectionIndex));
+		};
+
+		read();
+
+		const observer = new MutationObserver(read);
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-live-sections'],
+		});
+
+		return () => observer.disconnect();
+	}, [sectionIndex]);
+
+	return live;
+}
+```
+
+Update the JSDoc above it to describe live-set membership (replace the "stays true permanently" line). Keep `useState`/`useEffect` imports (already present).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm nx run astro-kbve:build`
+Expected: build succeeds (charts still consume the same `(number) => boolean` signature).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/dashboard/useKanbanSection.ts
+git commit -m "feat(kanban): useKanbanSection tracks live-set membership (mount/unmount)"
+```
+
+---
+
+### Task 3: Chart islands — unmount cleanup + skeleton
+
+Make each D3 chart tear down on unmount and hold height with a skeleton. Same mechanical transform for the 7 chart islands.
+
+**Files:**
+
+- Modify: `ReactKanbanDonut.tsx`, `ReactKanbanTreemap.tsx`, `ReactKanbanTimeline.tsx`, `ReactKanbanSankey.tsx`, `ReactKanbanHeatmap.tsx`, `ReactKanbanBoard.tsx`, `ReactKanbanAssignees.tsx` (all under the dashboard base path)
+
+**Interfaces:**
+
+- Consumes: `useKanbanSection(sectionIndex)` (Task 2), `createChartTooltip` (returns `{ el: HTMLDivElement, … }`).
+
+**Transform rules (apply to each of the 7 files):**
+
+1. Remove the `const rendered = useRef(false);` line and every reference to `rendered.current` (both the `|| rendered.current` guard condition and the `rendered.current = true;` assignment).
+2. In the draw `useEffect`, keep the guard `if (!active || !data || !svgRef.current || !wrapRef.current) return;` (drop only the `rendered.current` clause).
+3. Capture the tooltip and svg in locals, and add a cleanup return that removes them so unmount frees the D3 DOM + tooltip node.
+4. Gate the heavy DOM in render: when `!active`, render a skeleton box of the chart's natural height instead of the `<svg>`; keep the wrapper `<div ref={wrapRef}>` and `<h3>` title always mounted.
+
+- [ ] **Step 1: Donut — apply the transform (reference implementation)**
+
+In `ReactKanbanDonut.tsx`:
+
+Remove `const rendered = useRef(false);` and its uses. Change the effect to add cleanup:
+
+```tsx
+useEffect(() => {
+	if (!active || !data || !svgRef.current || !wrapRef.current) return;
+
+	const tooltip = createChartTooltip(wrapRef.current, 'donut');
+	const svg = svgRef.current;
+	// … existing draw code, but reference `svg` local instead of svgRef.current …
+
+	return () => {
+		while (svg.firstChild) svg.removeChild(svg.firstChild);
+		tooltip.el.remove();
+	};
+}, [active, data]);
+```
+
+Change the render to gate the svg:
+
+```tsx
+return (
+	<div
+		ref={wrapRef}
+		style={{
+			display: 'flex',
+			flexDirection: 'column',
+			alignItems: 'center',
+			gap: '1rem',
+		}}>
+		<h3
+			style={{
+				margin: 0,
+				fontSize: '0.8rem',
+				fontWeight: 600,
+				textTransform: 'uppercase',
+				letterSpacing: '0.05em',
+				color: 'var(--sl-color-gray-3, #8b949e)',
+			}}>
+			Column Distribution
+		</h3>
+		{active ? (
+			<svg
+				ref={svgRef}
+				width={420}
+				height={420}
+				viewBox="0 0 420 420"
+				style={{ maxWidth: '100%', height: 'auto' }}
+			/>
+		) : (
+			<div
+				style={{
+					width: '100%',
+					maxWidth: 420,
+					aspectRatio: '1 / 1',
+					borderRadius: 12,
+					background: 'var(--sl-color-gray-6, #1a1a1a)',
+				}}
+			/>
+		)}
+	</div>
+);
+```
+
+- [ ] **Step 2: Apply the same transform to the other 6 charts**
+
+For `ReactKanbanTreemap.tsx`, `ReactKanbanTimeline.tsx`, `ReactKanbanSankey.tsx`, `ReactKanbanHeatmap.tsx`, `ReactKanbanBoard.tsx`, `ReactKanbanAssignees.tsx`:
+
+- Remove `rendered` ref + uses.
+- Add the `return () => { clear svg children; tooltip.el.remove(); }` cleanup to the draw effect (adapt the svg-clear to whatever container each uses — if a chart draws into a `<div>` container instead of `<svg>`, clear that node's children: `while (node.firstChild) node.removeChild(node.firstChild);`).
+- Gate the chart node behind `active ? <chart/> : <skeleton/>`, where the skeleton is a `<div>` with the same width/aspect as the mounted chart (match the chart's `width`/`height`/`viewBox` — use `aspectRatio` derived from those, `background: 'var(--sl-color-gray-6, #1a1a1a)'`, `borderRadius: 12`).
+- If a chart has no tooltip (`createChartTooltip` not used), omit the `tooltip.el.remove()` line.
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm nx run astro-kbve:build`
+Expected: build succeeds, no unused-var errors for removed `rendered`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/dashboard/ReactKanban*.tsx
+git commit -m "feat(kanban): charts teardown D3 on unmount + height-preserving skeleton"
+```
+
+---
+
+### Task 4: View manager — ScrollTrigger reveal + live-set
+
+New module driving reveal animation and the ±2 live-set. Wire it into the Astro script with `astro:page-load` init + `onSwap` teardown.
+
+**Files:**
+
+- Create: `apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts`
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro` (add script block + set `.kb-section{opacity:0}`)
+
+**Interfaces:**
+
+- Produces: `initKanbanViewManager(): () => void` — registers ScrollTriggers, returns a teardown fn. Writes `document.documentElement.dataset.liveSections`. Consumed by the Astro `<script>`.
+
+- [ ] **Step 1: Write the view manager module**
+
+Create `kanbanViewManager.ts`:
+
+```ts
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const KEEP_WARM = 2;
+
+export function initKanbanViewManager(): () => void {
+	const sections = Array.from(
+		document.querySelectorAll<HTMLElement>('.kb-section'),
+	);
+	if (sections.length === 0) return () => {};
+
+	const total = sections.length;
+	let centered = -1;
+
+	const publishLive = (center: number) => {
+		if (center === centered) return;
+		centered = center;
+		const live: number[] = [];
+		for (let i = 0; i < total; i++) {
+			if (Math.abs(i - center) <= KEEP_WARM) live.push(i);
+		}
+		document.documentElement.dataset.liveSections = live.join(',');
+	};
+
+	const reveal = (el: HTMLElement) =>
+		gsap.to(el, {
+			opacity: 1,
+			y: 0,
+			duration: 0.5,
+			ease: 'power1.out',
+			overwrite: 'auto',
+		});
+
+	gsap.set(sections, { y: 12 });
+
+	const triggers = sections.map((section, i) =>
+		ScrollTrigger.create({
+			trigger: section,
+			start: 'top 85%',
+			end: 'bottom 15%',
+			onEnter: () => reveal(section),
+			onEnterBack: () => reveal(section),
+			onToggle: (self) => {
+				if (self.isActive) publishLive(i);
+			},
+		}),
+	);
+
+	// Seed the initial live-set from whichever section is nearest the top.
+	const firstActive = triggers.findIndex((t) => t.isActive);
+	publishLive(firstActive >= 0 ? firstActive : 0);
+	ScrollTrigger.refresh();
+
+	return () => {
+		triggers.forEach((t) => t.kill());
+		delete document.documentElement.dataset.liveSections;
+	};
+}
+```
+
+- [ ] **Step 2: Wire the Astro script + reveal base state**
+
+In `AstroKanbanDashboard.astro`, set `.kb-section { opacity: 0 }` in the style block (revert the Task 1 Step 6 temporary `opacity:1`). Add a new script block at the end of the file:
+
+```astro
+<script>
+	import { initKanbanViewManager } from './kanbanViewManager';
+	import { onSwap } from '@kbve/astro/utils/clientRouter';
+
+	let teardown: (() => void) | null = null;
+
+	document.addEventListener('astro:page-load', () => {
+		teardown?.();
+		teardown = initKanbanViewManager();
+	});
+
+	onSwap(() => {
+		teardown?.();
+		teardown = null;
+	});
+</script>
+```
+
+- [ ] **Step 3: No-JS fallback**
+
+Add to the style block so sections are visible if JS never runs:
+
+```css
+@media (scripting: none) {
+	.kb-section {
+		opacity: 1;
+	}
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `pnpm nx run astro-kbve:build`
+Expected: build succeeds; `gsap/ScrollTrigger` resolves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/dashboard/kanbanViewManager.ts apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+git commit -m "feat(kanban): ScrollTrigger view manager — reveal + ±2 live-set"
+```
+
+---
+
+### Task 5: Gate the Browser island + carry over mobile rules
+
+Bring section 9 (Browser) into the live-set and preserve the mobile chart-hiding rules under the new layout.
+
+**Files:**
+
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro`
+- Modify: `apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBrowser.tsx`
+
+- [ ] **Step 1: Pass `sectionIndex` to Browser**
+
+In `AstroKanbanDashboard.astro`, change `<ReactKanbanBrowser client:only="react" />` to `<ReactKanbanBrowser client:only="react" sectionIndex={9} />`.
+
+- [ ] **Step 2: Gate Browser on the live-set**
+
+In `ReactKanbanBrowser.tsx`, add a `sectionIndex: number` prop, call `const active = useKanbanSection(sectionIndex);`, and render a skeleton (`<div>` min-height ~400px, `background: 'var(--sl-color-gray-6, #1a1a1a)'`, `borderRadius: 12`) when `!active`, the existing browser UI when `active`. If the browser holds heavy state/effects, guard them on `active` too.
+
+- [ ] **Step 3: Carry over mobile rules**
+
+In `AstroKanbanDashboard.astro` style block, confirm the `@media (max-width: 640px)` rules that hide Sankey/Heatmap still target `.kb-section[data-section='4']` / `[data-section='5']` (they do — `data-section` attributes are retained). Remove the now-defunct `.kb-dot-nav` / `.kb-section-label` selectors inside that media block. Keep `.kb-section-content` padding rule (drop the `var(--sl-nav-height…)` top padding that existed for the fixed overlay — with normal flow it is no longer needed; set to `padding: 1rem`).
+
+- [ ] **Step 4: Build**
+
+Run: `pnpm nx run astro-kbve:build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro apps/kbve/astro-kbve/src/components/dashboard/ReactKanbanBrowser.tsx
+git commit -m "feat(kanban): gate Browser island on live-set + carry mobile rules"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+Drive the built page and confirm shell + view management behavior.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Serve the built site**
+
+Run: `pnpm nx run astro-kbve:preview` (or serve `dist/apps/astro-kbve`) and open `/dashboard/kanban/`.
+
+- [ ] **Step 2: Shell present, no overlay**
+
+Confirm rail + breadcrumb visible beside content; page scrolls natively; `document.body.style.overflow` is `''` (not `hidden`); no full-viewport fixed layer.
+
+- [ ] **Step 3: Reveal**
+
+Scroll down — each section fades/slides in on first entry.
+
+- [ ] **Step 4: Mount within band**
+
+In devtools, watch `document.documentElement.dataset.liveSections`. It updates as you scroll; charts within ±2 of the active section have their `<svg>`/chart node in the DOM.
+
+- [ ] **Step 5: Unmount far**
+
+Scroll so a chart is >2 sections away → its chart node is replaced by the skeleton `<div>` (verify node removed in Elements panel); no scroll-jump when it swaps.
+
+- [ ] **Step 6: Re-entry**
+
+Scroll back → chart re-renders correctly.
+
+- [ ] **Step 7: Navigation cleanup**
+
+In console run `ScrollTrigger.getAll().length` after navigating away (ClientRouter) and back — no growth/duplicates. `data-live-sections` absent after teardown, re-seeded after return.
+
+- [ ] **Step 8: Mobile**
+
+Narrow to <640px: sections stack + scroll; Sankey (4) + Heatmap (5) hidden.
+
+- [ ] **Step 9: No-JS**
+
+Disable JS, reload: Summary (static) visible; sections not stuck at `opacity:0`.
+
+- [ ] **Step 10: Finish the branch**
+
+Invoke superpowers:finishing-a-development-branch to open the PR.

--- a/docs/superpowers/specs/2026-07-22-kanban-shell-viewmanager-design.md
+++ b/docs/superpowers/specs/2026-07-22-kanban-shell-viewmanager-design.md
@@ -1,0 +1,154 @@
+# Kanban Dashboard — Shell Integration + View Management Redesign
+
+**Date:** 2026-07-22
+**Route:** `/dashboard/kanban/`
+**Files:** `apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro`, `useKanbanSection.ts`, new `kanbanViewManager.ts`, the 8 `ReactKanban*` islands (7 charts + Browser).
+
+## Problem
+
+The kanban dashboard renders as a full-viewport GSAP "fullpage-snap" takeover:
+
+- `.kb-snap-container { position: fixed; inset: nav 0 0 content-start }` covers the whole viewport.
+- The GSAP `Observer` hijacks wheel/touch, sets `document.body.style.overflow = 'hidden'`, and animates one section at a time via `yPercent`.
+
+Two consequences:
+
+1. **Bento shell + rail invisible.** `MarkdownContent.astro`'s `isDashboard` branch DOES render the rail + breadcrumb for `/dashboard/kanban/`, but the fixed overlay paints over them. The rail exists in the DOM, covered.
+2. **GSAP fights the shell.** The viewport-owning fullpage system is built for a standalone route, not a component nested in the Starlight docs shell + bento grid. Wheel-snap no-ops or looks broken because the fixed layer and the shell's own scroll disagree.
+
+The two layouts (full-viewport GSAP fullpage vs. bento-shell-with-rail) are mutually exclusive as built.
+
+Additionally, all 8 chart islands are `client:only="react"` — every React shell hydrates and fetches on load; D3 render is gated by `useKanbanSection` (latch-once, **never unmounts**). No real unload path.
+
+## Goals
+
+- Kanban lives **inside** the dashboard shell `dash-main` column. Rail + breadcrumb always visible. No `position:fixed`, no `body{overflow:hidden}`, no viewport takeover.
+- Native vertical scroll within the shell (no wheel-hijack).
+- **Proper view management:** heavy D3 chart islands mount as they near the viewport and **unmount** when far, with hysteresis to avoid thrash.
+- GSAP repurposed (not removed): `ScrollTrigger` drives reveal-on-enter animation + the live-set that gates mount/unmount.
+- Clean lifecycle: init on `astro:page-load`, full teardown on `onSwap` (ClientRouter navigation).
+
+## Non-Goals
+
+- No change to the chart internals / D3 logic beyond mount/unmount lifecycle + a height-preserving skeleton.
+- No change to `MarkdownContent.astro` (its `isDashboard` branch already supplies the shell for `/dashboard/kanban/`).
+- No change to the data pipeline (`nx-kanban.json`, `/data/nx/nx-kanban.json` fetch).
+- Dot-nav is removed (see Decisions), not reworked.
+
+## Decisions
+
+| Decision               | Choice                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| Scroll paradigm        | Native stacked scroll inside `dash-main` + lazy mount/unmount                          |
+| Right-side dot-nav     | **Dropped** — the dashboard rail is the single nav system                              |
+| View-manager mechanism | GSAP `ScrollTrigger` (reveal + live-set), not raw IntersectionObserver                 |
+| Mount/unmount policy   | **Keep-warm ±2 sections**; unmount only when a section is >2 away from the active band |
+| Re-entry               | Distant charts re-init D3 from scratch on return (acceptable given ±2 keep-warm)       |
+
+## Architecture
+
+### 1. Layout rewrite — `AstroKanbanDashboard.astro`
+
+Remove:
+
+- `.kb-snap-container { position: fixed; inset: … }` and the `background`/`z-index` viewport styling.
+- `.kb-section { position:absolute; top:3.5rem; … visibility:hidden }` absolute stacking + the `[data-section='0']{visibility:visible}` progressive-enhancement hack.
+- The `.kb-section-outer` / `.kb-section-inner` `yPercent` wrapper machinery (only existed for the fullpage snap).
+- The GSAP `Observer` script block (wheel/touch hijack, body overflow mutation, `gotoSection`, dot handlers, hashchange nav).
+- The `.kb-dot-nav`, `.kb-dot`, `.kb-section-label` markup + styles.
+
+Replace with:
+
+- `.kb-sections` — a normal-flow vertical stack. Each `.kb-section` is a `bento-section` band containing a `bento-frame`/`kb-card` of natural height. Sections flow and scroll with the shell's native scroll; no fixed heights, no overlays.
+- Keep the existing per-section content markup (Summary static block, chart mount points, Breakdown static block, Board, Browser).
+- Each chart mount point keeps `data-section={i}` for the view manager to register against.
+- Bento alignment: sections use `bento-section` + `bento-frame--fluid` so they inherit the shell's hairlines/spacing. The `MarkdownContent` neutralizer (`.dash-main :global(.bento-frame){max-width:none;…}`) already prevents double-framing.
+
+### 2. View manager — new `kanbanViewManager.ts`
+
+One module, imported by the Astro `<script>`:
+
+```
+init():
+  register gsap ScrollTrigger.create per `.kb-section[data-section]`:
+    - start/end spanning the section
+    - onEnter (once): gsap reveal (opacity 0→1, y 12→0) on the section's card
+  compute a "live set" = indices within ±2 of the currently-centered section
+  on scroll (throttled via ScrollTrigger's own rAF): if live set changed,
+    write document.documentElement.dataset.liveSections = "a,b,c"
+teardown():
+  ScrollTrigger.getAll().forEach(t => t.kill())
+  remove dataset.liveSections
+```
+
+- Live-set band = **±2**. A section unmounts only when its index leaves that band (keep-warm), satisfying "unmount far only."
+- The centered-section index derived from ScrollTrigger progress / viewport midpoint against section offsets.
+- No `Observer`, no wheel preventDefault, no body-overflow mutation.
+
+### 3. Island gate rewrite — `useKanbanSection.ts`
+
+Change `useKanbanSection(i)` from **latch-forever** to **live-set membership**:
+
+```
+useKanbanSection(i): boolean
+  reads document.documentElement.dataset.liveSections (comma list)
+  returns liveSet.has(i)
+  MutationObserver on attribute `data-live-sections` updates on change
+```
+
+- When `i` enters the live set → hook returns `true` → chart mounts + D3 runs.
+- When `i` leaves (>2 away) → returns `false` → chart child unmounts → D3/SVG torn down (React unmount + existing cleanup effects).
+- `useKanbanData` unchanged (each island fetches; browser caches the JSON).
+
+### 4. Chart islands — `ReactKanban*.tsx`
+
+Minimal change — they already gate render on `useKanbanSection`. Required:
+
+- Ensure the chart's outer wrapper renders a **height-preserving skeleton** when the gate is `false` (fixed min-height matching the mounted chart) so unmount/mount does not cause scroll-jump. If the current fallback is `null`, replace with a skeleton box.
+- Verify each chart's `useEffect` cleanup fully removes D3 selections / event listeners / ResizeObservers on unmount (they will now actually unmount).
+- `client:only="react"` retained (SSR of D3 not viable); the React shell is cheap — the heavy D3 body is what mounts/unmounts via the gate.
+- `ReactKanbanBrowser` (section 9) currently takes no `sectionIndex` and is ungated. Add `sectionIndex={9}` so it participates in the live-set (mount/unmount) like the others.
+
+### 5. Lifecycle
+
+```
+document.addEventListener('astro:page-load', () => viewManager.init())
+onSwap(() => viewManager.teardown())
+```
+
+`astro:page-load` fires on hard load + every ClientRouter swap (ClientRouter is active — Sidebar/tooltip islands already depend on it). `onSwap` guarantees ScrollTriggers + MutationObservers don't leak across navigation.
+
+## Data Flow
+
+```
+nx-kanban.json ──(build)──> AstroKanbanDashboard static blocks (Summary, Breakdown, Pipeline)
+                    │
+                    └─(runtime fetch /data/nx/nx-kanban.json)─> each mounted ReactKanban* island
+
+scroll ──> GSAP ScrollTrigger ──> centered index ──> live-set(±2) ──> html[data-live-sections]
+                                        │                                      │
+                                   reveal anim                          useKanbanSection(i)
+                                                                               │
+                                                                   mount/unmount D3 chart
+```
+
+## Testing / Verification
+
+Manual (via `/run` or built HTML), since this is layout + scroll behavior:
+
+1. **Shell present:** `/dashboard/kanban/` shows rail + breadcrumb beside content; no full-viewport overlay; page scrolls natively (no `body{overflow:hidden}`).
+2. **Reveal:** sections fade/slide in on first entry.
+3. **Mount:** scrolling a chart into the ±2 band mounts it (D3 renders); DOM node count grows.
+4. **Unmount:** scrolling >2 sections away removes the chart's SVG from the DOM (verify via devtools node count drop); skeleton holds height (no scroll-jump).
+5. **Re-entry:** returning re-renders the chart correctly.
+6. **Navigation:** ClientRouter away + back re-inits cleanly; no duplicate ScrollTriggers (check `ScrollTrigger.getAll().length`), no leaked MutationObservers.
+7. **Mobile:** sections stack + scroll; heavy Sankey/Heatmap remain hidden per existing `@media(max-width:640px)` rules (carry those over).
+8. **No-JS fallback:** first section (Summary, static) visible without JS.
+
+Build via `pnpm nx run astro-kbve:build`. If frontmatter/shell looks stale, `rm -rf apps/kbve/astro-kbve/.astro node_modules/.vite` before rebuild (known Astro content-layer cache gotcha).
+
+## Risks
+
+- **Scroll-jump on unmount** if skeleton height ≠ chart height. Mitigation: fixed min-heights per section matching mounted chart; test #4.
+- **ScrollTrigger + shell scroll container:** the shell scrolls the document (not an inner overflow container), so default ScrollTrigger (scroller = viewport) applies. Confirm no ancestor of `.kb-sections` establishes its own scroll/containing block; if one does, pass `scroller` explicitly.
+- **D3 cleanup gaps:** charts that previously never unmounted may have incomplete teardown; audit each `useEffect` return.


### PR DESCRIPTION
## Problem

`/dashboard/kanban/` rendered as a `position:fixed` fullpage-snap overlay (introduced in #14458). Two bugs:

- **Rail + breadcrumb invisible** — the dashboard shell's `isDashboard` branch renders them, but the fixed overlay painted over them. Recurring "full-viewport island inside the Starlight docs shell" flaw.
- **GSAP fought the shell** — the `Observer` wheel-hijack + `body{overflow:hidden}` viewport takeover is built for a standalone route, not a component nested in the bento shell.

## Change

Rework kanban into the dashboard shell as **native stacked scroll** with real view management:

- **Layout** — drop the fixed overlay / `Observer` / dot-nav / section-label; sections are normal-flow bento bands inside `dash-main`. Rail + breadcrumb always visible.
- **View manager** (`kanbanViewManager.ts`) — one GSAP `ScrollTrigger` per section: reveal-on-enter + publishes a ±2 "live-set" to `html[data-live-sections]`.
- **Gate** — `useKanbanSection` reads live-set membership (mount/unmount, was latch-forever). Charts within ±2 sections mount; charts >2 away unmount (D3 torn down) with a height-preserving skeleton.
- **Lifecycle** — `astro:page-load` init + `onSwap` teardown; no leaked ScrollTriggers/observers across ClientRouter nav.
- Dot-nav dropped (rail is the nav); Browser island (section 9) gated too.

## Verification

- Build green (`nx run astro-kbve:build`) at every step. Built HTML confirms: shell present, 0 overlay artifacts, 10 sections, view-manager + live-set reader wired, no-JS fallback, Browser `sectionIndex:9`.
- Whole-branch review caught + fixed a Critical (sections stuck `opacity:0` on load — `onEnter` doesn't fire for above-fold sections; now hidden via `gsap.set` so failed/no-JS stays visible, and initially-active sections revealed in the seed). Re-reviewed clean.
- **Live scroll behavior (reveal, mount/unmount, mobile hide) needs a browser check on the PR preview.**

Design spec + plan under `docs/superpowers/`.