### PR TITLE
fix(desktop-kbve): resolve lint errors

### DIFF
--- a/apps/kbve/desktop-kbve/eslint.config.mjs
+++ b/apps/kbve/desktop-kbve/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
 			'**/vite.config.*.timestamp*',
 			'**/vitest.config.*.timestamp*',
 			'src-tauri/**',
+			'**/src/bindings.ts',
 		],
 	},
 ];

--- a/apps/kbve/desktop-kbve/src/views/models.tsx
+++ b/apps/kbve/desktop-kbve/src/views/models.tsx
@@ -28,6 +28,7 @@ export function ModelsView() {
 	}, []);
 
 	useEffect(() => {
+		// eslint-disable-next-line react-hooks/set-state-in-effect
 		refresh();
 	}, [refresh]);
 
@@ -117,7 +118,9 @@ export function ModelsView() {
 											</span>
 										)}
 									</span>
-									<span className="text-caption" style={muted}>
+									<span
+										className="text-caption"
+										style={muted}>
 										{m.engine_type} · {m.size_mb} MB ·{' '}
 										{m.description}
 									</span>

--- a/apps/kbve/desktop-kbve/src/views/shortcuts.tsx
+++ b/apps/kbve/desktop-kbve/src/views/shortcuts.tsx
@@ -2,11 +2,7 @@ import { useEffect, useState } from 'react';
 import { SettingsCard } from '../components/SettingsCard';
 import { SettingsRow } from '../components/SettingsRow';
 import { ToggleSwitch } from '../components/ToggleSwitch';
-import {
-	commands,
-	type ShortcutBinding,
-	type PasteMethod,
-} from '../bindings';
+import { commands, type ShortcutBinding, type PasteMethod } from '../bindings';
 
 const PASTE_METHODS: { value: PasteMethod; label: string }[] = [
 	{ value: 'ctrl_v', label: 'Ctrl/Cmd + V' },
@@ -36,6 +32,7 @@ export function ShortcutsView() {
 	};
 
 	useEffect(() => {
+		// eslint-disable-next-line react-hooks/set-state-in-effect
 		load();
 	}, []);
 
@@ -76,6 +73,7 @@ export function ShortcutsView() {
 						label={b.name}
 						description={b.description}>
 						<BindingEditor
+							key={b.current_binding}
 							binding={b}
 							onSave={(v) => save(b.id, v)}
 							onReset={() => reset(b.id)}
@@ -134,7 +132,6 @@ function BindingEditor({
 	onReset: () => void;
 }) {
 	const [value, setValue] = useState(binding.current_binding);
-	useEffect(() => setValue(binding.current_binding), [binding.current_binding]);
 	const dirty = value !== binding.current_binding;
 
 	return (


### PR DESCRIPTION
Resolves `desktop-kbve:lint` failure (7 errors).

## Changes
- **bindings.ts** (4 errors: import/first ×3, no-empty-function) — tauri-specta generated file marked "do not edit". Added `**/src/bindings.ts` to eslint ignores so regeneration stays clean.
- **shortcuts.tsx:137** (set-state-in-effect) — replaced prop→state sync effect with `key={b.current_binding}` remount on `BindingEditor`. No behavior change.
- **shortcuts.tsx:39, models.tsx:31** (set-state-in-effect) — mount async data-loaders; rule false-positives on async setState. `eslint-disable-next-line`.

Lint now passes (117 warnings remain, non-failing).