### PR TITLE
fix(agones-palworld): real kubeseal SealedSecrets (#14503)

### DIFF
--- a/apps/kube/agones/palworld/manifests/credentials-sealed-secret.yaml
+++ b/apps/kube/agones/palworld/manifests/credentials-sealed-secret.yaml
@@ -2,12 +2,12 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-    name: palworld-credentials
-    namespace: palworld
+  name: palworld-credentials
+  namespace: palworld
 spec:
-    encryptedData:
-        server_password: PLACEHOLDER_RESEAL_AGAINST_CLUSTER
-    template:
-        metadata:
-            name: palworld-credentials
-            namespace: palworld
+  encryptedData:
+    server_password: AgCqWf1Cu8rg5ioQhdHc8PKnrwpNeDb0lxFsmBysxwa5a+3QZ/zdwX7he/ACbjiCLRufEQhMkaCeOcUB8JI/Q/EZr6jXzTVkMNuTZMncD6ZO+3vvodeKd+AzwcmTIuSIbRPwXUDZP5g96Skk23p+UHE47hQV9Rl4fe+TyO+2pERN/5ARZA/tg4gQzW7mB6y6xaFYyz1yLaLj8FZRgwezPPkHH5iFJ21kqxZdcui/iOM2pmPj9Vsdn84GvRlhbK0EGLQeH7X3lWM8PFfZ9lH1EQF+QX4OzijOrONIbcWqwPuWke9Oh7uVJoOVIrHQ4g8YaSrQfgBnJ5oHT/VxrfBoAClxpcnk0jPBYYM3cd0BUzzFqE6Fz8zTSTsqPF0mKROaTUmSZ2B5SJg0kCSb8DsPWHYIwOmiv+t78399bT1LD+dY8v0zBv6y4ppJdJJ2iIVNm/e9WsFigqbf0NYXJnVC8rk0PCauoQp+B1ITzZR6cMURwpYMeDmMAN5kPHhA91EyRaBL9phAPYLnTOg5InqhsJeG2w31FeALjL9Ntp5n733n5BlgsdU0p1HU+QxmVfo++WxGQpjgAP86uftk6LGV5VpLa/dkzbv4ysGVfF5smxppxK/vNcaddXhVgCe1irBi6X1Gmi/cqxIb/ttvYX7P6G/mnSuwJANna720jEEE1MNOhgTfQMN8q0qJ1SKJYdndeEU=
+  template:
+    metadata:
+      name: palworld-credentials
+      namespace: palworld

--- a/apps/kube/agones/palworld/manifests/rcon-sealed-secret.yaml
+++ b/apps/kube/agones/palworld/manifests/rcon-sealed-secret.yaml
@@ -2,13 +2,13 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-    name: palworld-rcon
-    namespace: palworld
+  name: palworld-rcon
+  namespace: palworld
 spec:
-    encryptedData:
-        admin_password: PLACEHOLDER_RESEAL_AGAINST_CLUSTER
-        rcon_password: PLACEHOLDER_RESEAL_AGAINST_CLUSTER
-    template:
-        metadata:
-            name: palworld-rcon
-            namespace: palworld
+  encryptedData:
+    admin_password: AgBUBPZ49V2g152sk2nCZrRN6e4q234Knq16TrWCkTpSxNszueyURblq5jtobj1TI9akcI2Z3mrNTqqcX7Qizu+ZMCd6fOusPf/Vgk3QazyrcvcR4bEprKd3WNSskTvfVtj6xack3+vZ92P4iRR+4/B83oV8cD8D4yZAGqB1U0IQi1J9kb8X7YnGokRgR8AoLYnEP5ZGkKZHZ6dGLecFW7b1UJoS8IhWnw03BdMrJg6sWWcooe965eGiDy6RQV6YAfvxVUAEqujdYoAYEmr1ATKznWoQC5gjPIhSpiWoWAGVJ6y6MTDy8Aim50qbGTlREr1DN1OytxLd+MJVJuiiH4T4b3aAWdpg/NRjwSRb8nI9DXdtYXaLO9uGfVO1dMGCzWp3oF4gxm05M3myOjSYjQ4BqsgkmHmm/SIb6eLGIiTe4Umm3cao+4x9Oqe33eS/iP01SR27AD+8rErVVuLU9rkKZkweWSLMHpZQJe/LHHK3Oxf4MreLF7OGMG574/DFOrfBBILtg7D6IvURYzPkMnjqEli0SnQOf8n7GW6yTaw1IT3VthKdH7rlqJLqgQZ389DaGwxzsWPMoGUVuQbFryG87Vqx7mhFmKHRGmz24OKqTmo0qEB0LFYqumepvJyJg52JRkGevEMz5uhdo9vRK0VfjYnlbmp/kd6uE7YD4mBRWGxN2cuQD49omNbaD+hK9HfbnBT7YDuBqOSF4JOd9oOoAO7Up4MTg/fb9hANy8CdlFd+s88dKKE6ZYlcvueYXKo=
+    rcon_password: AgB76TkG3tF7NAzTgitN1l0zN6jcZIu1R5B3P+JYDxAQewxaia2V37QvSWXnd+iDw+bRksMouaM0z4GV2zjhE6NxJeG3yt/QK6NmDL9dSSshabvv8MR4TNCS+6bAB60aO50EKfPy8ZNpsO0pxK7puPizdazmqWcgTgMUrORNcCrqIjdbSCBY2FlN7HxGfsn54Lan6UbOo6BEIzEub4oGPyUhW55Sfs1i+Y9vfMEjwFBQpH9LUpx2Uhvyd3DWJR7tQDm1xXWJrUojmFqGbQgLA+Pq8iQDw0Q4iVqIhBFB4L8sVtZz0Bqzi1SmaNQDeBtmc3L3q/khrj2zXNtN6loCjGgc2ySZ4JEY6n65PoYpGgYtqIHuz0dEs3GgCQRB2QRMA2/9LHYOsHVJKnuCYxRijRB+sDu4PgidDbs4xrzKrg0DBeu7GiYw843JWkDVoXY7slEpHTOigIBnfD6hD87u5lSf4cJMfDIiX6UQxNHGEqCqV+ZmRmohxffzjrweTinoNEeAN40psdg7vWGPeuOdv8yDn/yf2wl5dLQiGazmVd8Rq0Y5JO9zwp81p7a/p+crbB6mNzvSmwutBse0drrzDnWqzHnRy3cWpe+zMBPJncg0LKYdNTsq4jVvlQD6jpwb28ubDVRZoKqSVYM8ZzfOa4Q3KMf880DaDwkvN6KdDCr6o+kP/7wDde7O7Tc5NwzSCuvJvDZKeg0wdx83YbQq6yoAH5tEapSA3pzf7rEOJ+LfOGKROlXRJxq+kzwfOPGcLoc=
+  template:
+    metadata:
+      name: palworld-rcon
+      namespace: palworld

--- a/apps/kube/agones/palworld/seal-credentials.sh
+++ b/apps/kube/agones/palworld/seal-credentials.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="palworld"
+SECRET_NAME="palworld-credentials"
+OUT="$(dirname "$0")/manifests/credentials-sealed-secret.yaml"
+CONTROLLER_NS="kube-system"
+CONTROLLER_NAME="sealed-secrets-controller"
+
+if ! command -v kubeseal >/dev/null 2>&1; then
+    echo "kubeseal not found in PATH — install from https://github.com/bitnami-labs/sealed-secrets/releases" >&2
+    exit 1
+fi
+
+read -rsp "Palworld server join password (blank = open server): " SERVER_PASSWORD
+echo
+
+kubectl create secret generic "${SECRET_NAME}" \
+    --namespace="${NS}" \
+    --from-literal="server_password=${SERVER_PASSWORD}" \
+    --dry-run=client -o yaml \
+| kubeseal \
+    --controller-namespace="${CONTROLLER_NS}" \
+    --controller-name="${CONTROLLER_NAME}" \
+    --format=yaml \
+> "${OUT}"
+
+unset SERVER_PASSWORD
+
+echo "Sealed → ${OUT}"
+echo "Commit and ArgoCD will sync."

--- a/apps/kube/agones/palworld/seal-rcon.sh
+++ b/apps/kube/agones/palworld/seal-rcon.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="palworld"
+SECRET_NAME="palworld-rcon"
+OUT="$(dirname "$0")/manifests/rcon-sealed-secret.yaml"
+CONTROLLER_NS="kube-system"
+CONTROLLER_NAME="sealed-secrets-controller"
+
+if ! command -v kubeseal >/dev/null 2>&1; then
+    echo "kubeseal not found in PATH — install from https://github.com/bitnami-labs/sealed-secrets/releases" >&2
+    exit 1
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl not found in PATH" >&2
+    exit 1
+fi
+
+ADMIN_PW="$(openssl rand -hex 24)"
+RCON_PW="$(openssl rand -hex 24)"
+
+kubectl create secret generic "${SECRET_NAME}" \
+    --namespace="${NS}" \
+    --from-literal="admin_password=${ADMIN_PW}" \
+    --from-literal="rcon_password=${RCON_PW}" \
+    --dry-run=client -o yaml \
+| kubeseal \
+    --controller-namespace="${CONTROLLER_NS}" \
+    --controller-name="${CONTROLLER_NAME}" \
+    --format=yaml \
+> "${OUT}"
+
+unset ADMIN_PW RCON_PW
+
+echo "Sealed → ${OUT}"
+echo "admin_password + rcon_password generated locally; plaintext never written to disk."
+echo "Retrieve the live admin password after deploy with:"
+echo "  kubectl -n ${NS} get secret ${SECRET_NAME} -o jsonpath='{.data.admin_password}' | base64 -d"


### PR DESCRIPTION
Follow-up to #14503 / PR #14507 (merged before this landed).

Replaces the placeholder SealedSecrets that shipped in #14507 with real sealed values:

- ✅ **`palworld-rcon`** — `admin_password` + `rcon_password` (`openssl rand -hex 24`), sealed against `kube-system/sealed-secrets-controller`.
- ✅ **`palworld-credentials`** — `server_password` empty (open server).
- Plaintext never hits disk. Rotation scripts added: `apps/kube/agones/palworld/seal-rcon.sh` / `seal-credentials.sh`.
- Retrieve live admin pw post-deploy: `kubectl -n palworld get secret palworld-rcon -o jsonpath='{.data.admin_password}' | base64 -d`.

**CI manifest:** left untouched — `ci-manifest-sync` already regenerated `ci-dispatch-manifest.json` from the palworld MDX on the #14507 merge to dev (run succeeded, no drift). The MDX docs are the source of truth; nothing to hand-edit here.

Still open (separate follow-up): ClickHouse `gameops.palworld_snapshots_raw` / `palworld_player_events_raw` DDL.
