### PR TITLE
fix(agones): provision agones-sdk SA for palworld namespace (#14503)

### DIFF
--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -63,6 +63,7 @@ gameservers:
         - factorio
         - cryptothrone
         - arpg
+        - palworld
 
     # Port range for game server host ports.
     minPort: 7000


### PR DESCRIPTION
Follow-up to #14513. The palworld GameServer went to **Error**:
```
pods "palworld" is forbidden: error looking up service account palworld/agones-sdk: serviceaccount "agones-sdk" not found
```
Agones' Helm chart creates the per-namespace `agones-sdk` ServiceAccount + RoleBinding only for namespaces listed in `gameservers.namespaces` (`apps/kube/agones/values.yaml`). `palworld` was missing — added it alongside factorio/cryptothrone/arpg.

Once the `agones` ArgoCD app syncs, the SA appears in `palworld` and the GameServer can schedule its pod.

Note: separate non-blocking issue observed — `clickhouse-credentials` ExternalSecret fails (`SecretStore vector-remote-secret-store not found / not allowed` in palworld ns); CH creds are optional so the gameserver still boots. Folds into the deferred ClickHouse follow-up.