### PR TITLE
fix(agones-palworld): bump MDX 0.0.2 to publish images (#14503)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_palworld_relay
 pipeline: docker
 app_name: agones-palworld-relay
-version: "0.0.1"
+version: "0.0.2"
 source_path: apps/agones/palworld/relay
 version_toml: apps/agones/palworld/relay/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.1"
+version: "0.0.2"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -37,7 +37,7 @@ spec:
                       claimName: palworld-saves
             containers:
                 - name: palworld
-                  image: ghcr.io/kbve/agones-palworld:0.0.1
+                  image: ghcr.io/kbve/agones-palworld:0.0.2
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: PUID
@@ -109,7 +109,7 @@ spec:
                               command:
                                   - /usr/local/bin/agones-shim-prestop
                 - name: palworld-relay
-                  image: ghcr.io/kbve/agones-palworld-relay:0.0.1
+                  image: ghcr.io/kbve/agones-palworld-relay:0.0.2
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: PALWORLD_REST_ADDR


### PR DESCRIPTION
Follow-up to #14515. The palworld pod is stuck **ImagePullBackOff** — `ghcr.io/kbve/agones-palworld{,-relay}:0.0.1` return 403 because the images were never published.

**Cause:** ci-main's dispatch gate (`is_newer`) only builds when the MDX version (the publish lever) is **strictly greater** than `version.toml`. Both were `0.0.1` → equal → skipped → no `CI - Docker / agones-palworld` run ever fired.

**Fix:**
- Bump both MDX `version` `0.0.1` → `0.0.2` (game + relay) → `is_newer(0.0.2, 0.0.1)=true` → ci-docker builds & publishes `:0.0.2` + `:latest`; post-publish sync bumps version.toml to 0.0.2.
- Pin gameserver image tags to `:0.0.2` so ArgoCD pulls the tag that will exist.

Once merged → main: images publish, ArgoCD re-pulls, the GameServer pod schedules (agones-sdk SA from #14515 already present).