### PR TITLE
fix(agones-palworld): bump gameserver RAM to 32Gi

### DIFF
--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -87,11 +87,11 @@ spec:
                         mountPath: /palworld/Pal/Saved
                   resources:
                       requests:
-                          cpu: '2'
-                          memory: '8Gi'
+                          cpu: '4'
+                          memory: '16Gi'
                       limits:
                           cpu: '6'
-                          memory: '16Gi'
+                          memory: '32Gi'
                   securityContext:
                       allowPrivilegeEscalation: true
                       capabilities:


### PR DESCRIPTION
## What
Bump Palworld GameServer resources in `apps/kube/agones/palworld/manifests/gameserver.yaml`:
- request: cpu `2`→`4`, memory `8Gi`→`16Gi`
- limit: memory `16Gi`→`32Gi` (cpu `6` unchanged)

## Why
Palworld RAM scales with player count **and leaks over uptime**. Prior `16Gi` limit risks OOMKill on populated / long-running servers. Upstream spec: 16GB min, 32GB recommended for stable operation. Agones recycling resets the leak.

## Docs
[agones-palworld-relay.mdx](https://github.com/KBVE/kbve/blob/main/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx)