### PR TITLE
feat(agones-palworld): auto-roll gameserver on image bump (rotator)

### DIFF
--- a/apps/kube/agones/palworld/manifests/rotation-deployment.yaml
+++ b/apps/kube/agones/palworld/manifests/rotation-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: palworld-rotator
+    namespace: palworld
+    labels:
+        app: palworld-rotator
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+        kbve.com/managed-by: argocd
+spec:
+    replicas: 1
+    strategy:
+        type: Recreate
+    selector:
+        matchLabels:
+            app: palworld-rotator
+    template:
+        metadata:
+            labels:
+                app: palworld-rotator
+        spec:
+            serviceAccountName: palworld-rotator
+            automountServiceAccountToken: true
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: rotator
+                  image: ghcr.io/kbve/kubectl:0.1.6
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - rotate-gameserver
+                      - --watch
+                      - --interval=15
+                      - --namespace=palworld
+                      - --gameserver=palworld
+                      - --container=palworld
+                      - --delete-timeout=180
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                      readOnlyRootFilesystem: true
+                  livenessProbe:
+                      exec:
+                          command:
+                              - /bin/sh
+                              - -c
+                              - test $(( $(date +%s) - $(stat -c %Y /tmp/.rotator-heartbeat) )) -lt
+                                60
+                      initialDelaySeconds: 20
+                      periodSeconds: 20
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  resources:
+                      requests:
+                          cpu: 25m
+                          memory: 64Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 16Mi

--- a/apps/kube/agones/palworld/manifests/rotation-rbac.yaml
+++ b/apps/kube/agones/palworld/manifests/rotation-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: palworld-rotator
+    namespace: palworld
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: palworld-rotator
+    namespace: palworld
+rules:
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs: ['get', 'list']
+    - apiGroups: ['agones.dev']
+      resources: ['gameservers']
+      verbs: ['get', 'list', 'watch', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: palworld-rotator
+    namespace: palworld
+subjects:
+    - kind: ServiceAccount
+      name: palworld-rotator
+      namespace: palworld
+roleRef:
+    kind: Role
+    name: palworld-rotator
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## What
Adds a `palworld-rotator` so the standalone Agones GameServer **auto-rolls** to a new image on every version bump — no manual `kubectl delete gameserver`.

## Why
Standalone Agones GameServers are immutable — ArgoCD updates the spec but the running pod keeps the old image (exactly what we just hit rolling 0.0.3). Factorio already solved this with `ghcr.io/kbve/kubectl`'s `rotate-gameserver --watch`.

## How (copied from Factorio, retargeted to palworld)
- `rotation-deployment.yaml` — `ghcr.io/kbve/kubectl:0.1.6 rotate-gameserver --watch --namespace=palworld --gameserver=palworld --container=palworld --delete-timeout=180`. Watches running-pod-image vs manifest-image; on drift, deletes the GameServer → ArgoCD selfHeal recreates on the new image.
- `rotation-rbac.yaml` — SA + Role (get/list pods; get/list/watch/delete gameservers) + binding, namespace-scoped.
- `--delete-timeout=180` > the GameServer's 120s `terminationGracePeriodSeconds`, so the prestop REST `/shutdown` save always finishes before recreate. No data loss.

ArgoCD applies the manifests dir as a directory, so these auto-register. Parity with `apps/kube/agones/factorio/manifests/rotation-{deployment,rbac}.yaml`.

## Note
Downtime per roll is inherent to a single persistent world on an RWO PVC (Agones only offers zero-downtime via Fleets, which don't fit one save). This makes the recreate automatic + save-safe, not instant.