### PR TITLE
fix(agones-palworld): disable bUseUObjectArrayCache (UE4SS boot hang)

### DIFF
--- a/apps/agones/palworld/Dockerfile
+++ b/apps/agones/palworld/Dockerfile
@@ -23,9 +23,11 @@ RUN set -eux; \
         -e 's/^GuiConsoleVisible = .*/GuiConsoleVisible = 0/' \
         -e 's/^ConsoleEnabled = .*/ConsoleEnabled = 1/' \
         -e 's/^DumpOffsetsAndSizes = .*/DumpOffsetsAndSizes = 0/' \
+        -e 's/^bUseUObjectArrayCache = .*/bUseUObjectArrayCache = false/' \
         /opt/ue4ss/UE4SS-settings.ini; \
     grep -q '^GuiConsoleEnabled = 0' /opt/ue4ss/UE4SS-settings.ini; \
-    grep -q '^ConsoleEnabled = 1' /opt/ue4ss/UE4SS-settings.ini
+    grep -q '^ConsoleEnabled = 1' /opt/ue4ss/UE4SS-settings.ini; \
+    grep -q '^bUseUObjectArrayCache = false' /opt/ue4ss/UE4SS-settings.ini
 
 COPY apps/agones/palworld/mods/PalChatRelay /opt/ue4ss/Mods/PalChatRelay
 COPY apps/agones/palworld/ue4ss-launch.sh /usr/local/bin/ue4ss-launch


### PR DESCRIPTION
The real boot-hang fix. Our e2e froze at TUObjectArray resolution; a confirmed-working Docker/Pterodactyl UE4SS config disables `bUseUObjectArrayCache` to stop the loader refusing to boot.

Adds `bUseUObjectArrayCache = false` to the UE4SS-settings sed (alongside the ConsoleEnabled=1 + GuiConsoleEnabled=0 headless config already on dev). No version bump — still 0.0.5 (never published).

Note: this fix was accidentally pushed to #14551's branch *after* that PR merged, so it wasn't in dev. This lands it properly.