### PR TITLE
fix(reel): PSA privileged ns + ESO RBAC namespace (unblock reel pod + token)

### DIFF
--- a/apps/kube/kbve/manifest/reel-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/reel-externalsecret.yaml
@@ -5,6 +5,11 @@
 # `api-token`) in ns kbve, which kbve-deployment.yaml maps to REEL_API_TOKEN
 # (optional: true) and injects as the upstream bearer to reel. No second sealed
 # copy — rotate the token once in ns reel and ESO propagates it here.
+#
+# NOTE: the Role/RoleBinding that grant this SA `get` on reel/reel-api live in
+# the reel app (apps/kube/reel/manifest/reel-api-reader-rbac.yaml), NOT here —
+# this kustomization forces `namespace: kbve`, which would rewrite ns-reel RBAC
+# into ns kbve and break the cross-namespace read.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,31 +18,6 @@ metadata:
     labels:
         app: kbve
         component: external-secrets
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-    name: kbve-read-reel-api
-    namespace: reel
-rules:
-    - apiGroups: ['']
-      resources: ['secrets']
-      resourceNames: ['reel-api']
-      verbs: ['get']
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-    name: kbve-read-reel-api
-    namespace: reel
-roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: kbve-read-reel-api
-subjects:
-    - kind: ServiceAccount
-      name: kbve-reel-external-secrets
-      namespace: kbve
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore

--- a/apps/kube/reel/manifest/namespace.yaml
+++ b/apps/kube/reel/manifest/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: reel
   labels:
     name: reel
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/kube/reel/manifest/reel-api-reader-rbac.yaml
+++ b/apps/kube/reel/manifest/reel-api-reader-rbac.yaml
@@ -1,0 +1,29 @@
+# Grants the kbve-namespace ESO ServiceAccount read access to the reel-api
+# secret in ns reel, so axum-kbve's ExternalSecret (apps/kube/kbve/manifest/
+# reel-externalsecret.yaml) can sync the token into ns kbve. Lives in the reel
+# app (dir-recurse, no namespace transformer) so it stays in ns reel — the kbve
+# app's kustomization would rewrite it to ns kbve.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: kbve-read-reel-api
+    namespace: reel
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['reel-api']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-reel-api
+    namespace: reel
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kbve-read-reel-api
+subjects:
+    - kind: ServiceAccount
+      name: kbve-reel-external-secrets
+      namespace: kbve


### PR DESCRIPTION
## Unblock reel go-live — two in-cluster failures

reel Phase 4 + token (#14509, #14520) merged, image published, but the reel pod never started and the token ESO never synced. Diagnosed live:

### 1. Pod `FailedCreate` — PodSecurity
ns `reel` enforces PodSecurity `baseline`, which forbids gluetun's `NET_ADMIN`:
```
pods "reel-..." is forbidden: violates PodSecurity "baseline:latest":
non-default capabilities (container "gluetun" must not include "NET_ADMIN")
```
Fix: label the namespace `pod-security.kubernetes.io/enforce: privileged` (+ audit/warn), mirroring kasm's VPN namespace.

### 2. Token ESO `SecretStore ValidationFailed`
The `reel-config` ExternalSecret couldn't read `reel/reel-api` — its Role/RoleBinding, though written with `namespace: reel`, landed in ns **kbve**. Cause: `apps/kube/kbve/manifest/kustomization.yaml` sets `namespace: kbve`, whose kustomize namespace-transformer rewrote the cross-namespace RBAC.
Fix: move the Role/RoleBinding into the **reel** app (`apps/kube/reel/manifest/reel-api-reader-rbac.yaml`, dir-recurse — no namespace transformer) so they stay in ns reel. SA + SecretStore + ExternalSecret remain in the kbve app (correctly ns kbve).

### After merge (dev→main→ArgoCD)
- reel pod schedules (NET_ADMIN allowed) → starts behind the VPN.
- ESO RBAC lands in ns reel → SecretStore validates → `reel-config` syncs → kbve injects the token.

### Also (manual, done separately)
An orphaned `reel-config` SealedSecret (the #14509 stub, `illegal base64`) lingered in ns kbve after #14520 removed it from git; pruned by hand.

### Verified live
reel app Synced-but-Degraded; `reel-api` secret decrypted in ns reel; `vpn-wireguard` ESO healthy; PVC Bound. Only these two blockers remained.