### PR TITLE
feat(reel): VPN leak watchdog + reaper in-flight guards

### DIFF
--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -382,6 +382,9 @@ async fn hls_segment(
     };
     let path = std::path::Path::new(&dir).join(&segment);
     let head_only = method == axum::http::Method::HEAD;
+    if !head_only {
+        let _ = st.store.touch(&id, now_secs());
+    }
     let range = headers.get("range").and_then(|h| h.to_str().ok());
     let ct = if segment.ends_with(".ts") {
         "video/mp2t"

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub state_file: PathBuf,
     pub api_addr: String,
     pub vpn_check_url: String,
+    pub vpn_watchdog_secs: u64,
     pub api_token: Option<String>,
     pub transcode_enabled: bool,
     pub remux_concurrency: usize,
@@ -46,6 +47,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         state_file: PathBuf::from(env_or("REEL_STATE_FILE", "/data/reel-state.json")),
         api_addr: env_or("REEL_API_ADDR", "0.0.0.0:8080"),
         vpn_check_url: env_or("REEL_VPN_CHECK_URL", "https://api.ipify.org"),
+        vpn_watchdog_secs: env_u64("REEL_VPN_WATCHDOG_SECS", 60)?,
         api_token: std::env::var("REEL_API_TOKEN").ok(),
         transcode_enabled: env_bool("REEL_TRANSCODE_ENABLED", true),
         remux_concurrency: env_u64("REEL_REMUX_CONCURRENCY", 3)? as usize,
@@ -66,7 +68,7 @@ mod tests {
     fn clear() {
         for k in ["REEL_TTL_SECS","REEL_REAP_INTERVAL_SECS","REEL_ACTIVE_DIR",
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
-                  "REEL_VPN_CHECK_URL","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
+                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
                   "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS"] {
@@ -81,6 +83,7 @@ mod tests {
         let c = load_from_env().unwrap();
         assert_eq!(c.ttl_secs, 21600);
         assert_eq!(c.reap_interval_secs, 300);
+        assert_eq!(c.vpn_watchdog_secs, 60);
         assert_eq!(c.active_dir, std::path::PathBuf::from("/data/active"));
         assert_eq!(c.api_addr, "0.0.0.0:8080");
         assert!(c.api_token.is_none());

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -2,7 +2,7 @@ use crate::{config, mover, state};
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use librqbit::api::TorrentIdOrHash;
@@ -53,12 +53,29 @@ fn unique_subdir() -> String {
     format!("{nanos}-{n}")
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum VpnAction {
+    None,
+    Pause,
+    Resume,
+}
+
+pub fn next_vpn_action(prev_ok: bool, now_ok: bool) -> VpnAction {
+    match (prev_ok, now_ok) {
+        (true, false) => VpnAction::Pause,
+        (false, true) => VpnAction::Resume,
+        _ => VpnAction::None,
+    }
+}
+
 #[derive(Clone)]
 pub struct Engine {
     session: Arc<Session>,
     store: state::StateStore,
     active_dir: PathBuf,
     library_dir: PathBuf,
+    vpn_check_url: String,
+    vpn_ok: Arc<AtomicBool>,
 }
 
 impl Engine {
@@ -73,10 +90,52 @@ impl Engine {
             store,
             active_dir: cfg.active_dir.clone(),
             library_dir: cfg.library_dir.clone(),
+            vpn_check_url: cfg.vpn_check_url.clone(),
+            vpn_ok: Arc::new(AtomicBool::new(true)),
         })
     }
 
+    pub fn vpn_ok(&self) -> bool {
+        self.vpn_ok.load(Ordering::Relaxed)
+    }
+
+    fn all_handles(&self) -> Vec<Arc<ManagedTorrent>> {
+        self.session
+            .with_torrents(|it| it.map(|(_, h)| h.clone()).collect())
+    }
+
+    pub async fn vpn_recheck(&self) -> bool {
+        let now_ok = vpn_preflight(&self.vpn_check_url).await.is_ok();
+        let prev_ok = self.vpn_ok.load(Ordering::Relaxed);
+        match next_vpn_action(prev_ok, now_ok) {
+            VpnAction::Pause => {
+                tracing::error!(
+                    "vpn egress check failed; pausing all torrents (possible ip leak)"
+                );
+                for h in self.all_handles() {
+                    if let Err(e) = self.session.pause(&h).await {
+                        tracing::warn!(error = %e, "torrent pause failed");
+                    }
+                }
+            }
+            VpnAction::Resume => {
+                tracing::info!("vpn egress restored; resuming torrents");
+                for h in self.all_handles() {
+                    if let Err(e) = self.session.unpause(&h).await {
+                        tracing::warn!(error = %e, "torrent unpause failed");
+                    }
+                }
+            }
+            VpnAction::None => {}
+        }
+        self.vpn_ok.store(now_ok, Ordering::Relaxed);
+        now_ok
+    }
+
     pub async fn add(&self, source: &str) -> anyhow::Result<String> {
+        if !self.vpn_ok() {
+            anyhow::bail!("vpn egress unavailable; refusing to add torrent");
+        }
         let out_dir = self.active_dir.join(unique_subdir());
         let opts = AddTorrentOptions {
             output_folder: Some(out_dir.to_string_lossy().into_owned()),
@@ -237,6 +296,15 @@ impl Engine {
     }
 }
 
+pub async fn vpn_watchdog_loop(engine: Engine, interval_secs: u64) {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        engine.vpn_recheck().await;
+    }
+}
+
 pub fn remove_entry_files(path: &str, transcode_path: Option<&str>) {
     for p in std::iter::once(path).chain(transcode_path) {
         let pb = std::path::Path::new(p);
@@ -264,6 +332,14 @@ mod tests {
         remove_entry_files(&src.display().to_string(), Some(&tc.display().to_string()));
         assert!(!src.exists());
         assert!(!tc.exists());
+    }
+
+    #[test]
+    fn vpn_action_transitions() {
+        assert_eq!(next_vpn_action(true, true), VpnAction::None);
+        assert_eq!(next_vpn_action(true, false), VpnAction::Pause);
+        assert_eq!(next_vpn_action(false, true), VpnAction::Resume);
+        assert_eq!(next_vpn_action(false, false), VpnAction::None);
     }
 
     #[test]

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -33,6 +33,8 @@ async fn main() -> anyhow::Result<()> {
         cfg.reap_interval_secs,
     ));
 
+    tokio::spawn(engine::vpn_watchdog_loop(eng.clone(), cfg.vpn_watchdog_secs));
+
     let app = api::router(api::AppState {
         engine: eng,
         store,

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -1,9 +1,26 @@
 use crate::state;
 
+pub fn is_reapable(m: &state::Metadata) -> bool {
+    use state::{HlsStatus, TorrentState, TranscodeStatus};
+    if m.state == TorrentState::Leeching {
+        return false;
+    }
+    if matches!(
+        m.transcode,
+        TranscodeStatus::Pending | TranscodeStatus::Remuxing | TranscodeStatus::Encoding
+    ) {
+        return false;
+    }
+    if m.hls == HlsStatus::Starting {
+        return false;
+    }
+    true
+}
+
 pub fn select_expired(items: &[state::Metadata], ttl_secs: u64, now: u64) -> Vec<String> {
     items
         .iter()
-        .filter(|m| now.saturating_sub(m.last_access) > ttl_secs)
+        .filter(|m| now.saturating_sub(m.last_access) > ttl_secs && is_reapable(m))
         .map(|m| m.id.clone())
         .collect()
 }
@@ -63,5 +80,50 @@ mod tests {
         let items = vec![meta("old", 0), meta("fresh", 100)];
         let expired = select_expired(&items, 50, 120);
         assert_eq!(expired, vec!["old".to_string()]);
+    }
+
+    #[test]
+    fn leeching_is_not_reapable() {
+        let mut m = meta("d", 0);
+        m.state = TorrentState::Leeching;
+        assert!(!is_reapable(&m));
+    }
+
+    #[test]
+    fn in_flight_transcode_is_not_reapable() {
+        for s in [
+            TranscodeStatus::Pending,
+            TranscodeStatus::Remuxing,
+            TranscodeStatus::Encoding,
+        ] {
+            let mut m = meta("t", 0);
+            m.transcode = s;
+            assert!(!is_reapable(&m));
+        }
+    }
+
+    #[test]
+    fn hls_starting_is_not_reapable() {
+        let mut m = meta("h", 0);
+        m.hls = HlsStatus::Starting;
+        assert!(!is_reapable(&m));
+    }
+
+    #[test]
+    fn seeding_and_idle_live_are_reapable() {
+        let seeding = meta("s", 0);
+        assert!(is_reapable(&seeding));
+        let mut live = meta("l", 0);
+        live.hls = HlsStatus::Live;
+        assert!(is_reapable(&live));
+    }
+
+    #[test]
+    fn select_expired_skips_active_download() {
+        let mut leech = meta("dl", 0);
+        leech.state = TorrentState::Leeching;
+        let items = vec![leech, meta("done", 0)];
+        let expired = select_expired(&items, 50, 120);
+        assert_eq!(expired, vec!["done".to_string()]);
     }
 }


### PR DESCRIPTION
Safety hardening for reel, from a post-go-live code audit. Two self-contained fixes.

## #1 VPN leak watchdog (highest severity)
`vpn_preflight` ran only at startup — a VPN drop after boot went undetected, so librqbit could keep seeding/leeching (gluetun's killswitch is the netns-level barrier; this is app-level detection + graceful degradation).

- `vpn_watchdog_loop` re-checks egress IP every `REEL_VPN_WATCHDOG_SECS` (default 60).
- On leak: pause all torrents (`session.pause`), set `vpn_ok=false`, refuse new `add()`s.
- On recovery: `session.unpause` all, clear flag.
- Pure `next_vpn_action(prev_ok, now_ok)` transition helper (unit-tested, no network).
- Deliberately does **not** touch `/healthz` (k8s liveness probe — 503 there would restart-loop the pod). Leak surfaced via flag + logs.

## #5 Reaper reaps mid-delivery
`select_expired` reaped any TTL-expired entry regardless of activity; `hls_segment` never refreshed `last_access`.

- `is_reapable`: skips `Leeching` (active download), in-flight transcode (`Pending`/`Remuxing`/`Encoding`), and HLS `Starting`.
- `hls_segment` GET now touches `last_access` → active playback keeps its entry fresh; idle `Live` still reaps to free ffmpeg.

## Tests
7 new unit tests (transition table + reapability matrix). `cargo test -p reel`: 91 passed. Clippy clean on changed files (one pre-existing `stream.rs` warning untouched).

## Notes
- Known tradeoff: a permanently-stuck `Leeching` torrent never reaps — ties to audit item #4 (no `TorrentState::Failed`). Follow-up.
- New env var has a safe default; no k8s manifest change required. Image ships on the next reel version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)