### PR TITLE
feat(reel): restart recovery, Failed state, HLS boot reset, seed cap + reloader

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
         kbve.com/managed-by: argocd
     annotations:
         configmap.reloader.stakater.com/reload: kube-root-ca.crt
-        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials,vibeshine-config,cube-credentials
+        secret.reloader.stakater.com/reload: supabase-shared,forgejo-deploy-keys,valkey-auth,arpg-discord,clickhouse-credentials,vibeshine-config,cube-credentials,reel-config
 spec:
     replicas: 1
     strategy:

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -45,6 +45,7 @@ spec:
             - { name: REEL_LIBRARY_DIR, value: "/data/library" }
             - { name: REEL_STATE_FILE, value: "/data/reel-state.json" }
             - { name: REEL_TTL_SECS, value: "21600" }
+            - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
           envFrom:
             - secretRef: { name: reel-api }
           ports:

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -628,6 +628,7 @@ mod tests {
             completed_at: Some(10),
             last_access: 10,
             state: TorrentState::Seeding,
+            error: None,
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
@@ -678,6 +679,7 @@ mod tests {
             completed_at: None,
             last_access: 10,
             state: TorrentState::Leeching,
+            error: None,
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
@@ -854,6 +856,7 @@ mod tests {
             completed_at: None,
             last_access: 10,
             state: TorrentState::Leeching,
+            error: None,
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
@@ -875,7 +878,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn manifest_live_with_hls_dir_serves_200() {
+    async fn manifest_ready_with_hls_dir_serves_200() {
         let dir = tempdir().unwrap();
         let hls_dir = dir.path().join("hls");
         std::fs::create_dir_all(&hls_dir).unwrap();
@@ -889,10 +892,11 @@ mod tests {
             completed_at: Some(10),
             last_access: 10,
             state: TorrentState::Seeding,
+            error: None,
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
-            hls: HlsStatus::Live,
+            hls: HlsStatus::Ready,
             hls_dir: Some(hls_dir.display().to_string()),
             hls_error: None,
         })

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub api_addr: String,
     pub vpn_check_url: String,
     pub vpn_watchdog_secs: u64,
+    pub upload_limit_bps: Option<u32>,
     pub api_token: Option<String>,
     pub transcode_enabled: bool,
     pub remux_concurrency: usize,
@@ -48,6 +49,10 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         api_addr: env_or("REEL_API_ADDR", "0.0.0.0:8080"),
         vpn_check_url: env_or("REEL_VPN_CHECK_URL", "https://api.ipify.org"),
         vpn_watchdog_secs: env_u64("REEL_VPN_WATCHDOG_SECS", 60)?,
+        upload_limit_bps: match env_u64("REEL_UPLOAD_LIMIT_BPS", 0)? {
+            0 => None,
+            n => Some(n.min(u32::MAX as u64) as u32),
+        },
         api_token: std::env::var("REEL_API_TOKEN").ok(),
         transcode_enabled: env_bool("REEL_TRANSCODE_ENABLED", true),
         remux_concurrency: env_u64("REEL_REMUX_CONCURRENCY", 3)? as usize,
@@ -68,7 +73,7 @@ mod tests {
     fn clear() {
         for k in ["REEL_TTL_SECS","REEL_REAP_INTERVAL_SECS","REEL_ACTIVE_DIR",
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
-                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
+                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
                   "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS"] {
@@ -84,6 +89,7 @@ mod tests {
         assert_eq!(c.ttl_secs, 21600);
         assert_eq!(c.reap_interval_secs, 300);
         assert_eq!(c.vpn_watchdog_secs, 60);
+        assert!(c.upload_limit_bps.is_none());
         assert_eq!(c.active_dir, std::path::PathBuf::from("/data/active"));
         assert_eq!(c.api_addr, "0.0.0.0:8080");
         assert!(c.api_token.is_none());
@@ -98,6 +104,18 @@ mod tests {
         let c = load_from_env().unwrap();
         assert_eq!(c.ttl_secs, 60);
         assert_eq!(c.api_token.as_deref(), Some("secret"));
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn upload_limit_parses_zero_as_unlimited() {
+        clear();
+        assert!(load_from_env().unwrap().upload_limit_bps.is_none());
+        std::env::set_var("REEL_UPLOAD_LIMIT_BPS", "0");
+        assert!(load_from_env().unwrap().upload_limit_bps.is_none());
+        std::env::set_var("REEL_UPLOAD_LIMIT_BPS", "1048576");
+        assert_eq!(load_from_env().unwrap().upload_limit_bps, Some(1_048_576));
         clear();
     }
 

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -84,7 +84,18 @@ impl Engine {
         tracing::info!(%ip, "vpn preflight ok");
         std::fs::create_dir_all(&cfg.active_dir)?;
         std::fs::create_dir_all(&cfg.library_dir)?;
-        let session = Session::new(cfg.active_dir.clone()).await?;
+        let opts = librqbit::SessionOptions {
+            ratelimits: librqbit::limits::LimitsConfig {
+                upload_bps: cfg.upload_limit_bps.and_then(std::num::NonZeroU32::new),
+                download_bps: None,
+            },
+            ..Default::default()
+        };
+        if let Some(bps) = opts.ratelimits.upload_bps {
+            tracing::info!(upload_bps = bps.get(), "seeding upload rate limit enabled");
+        }
+        let session = Session::new_with_opts(cfg.active_dir.clone(), opts).await?;
+        reconcile_on_start(&store);
         Ok(Self {
             session,
             store,
@@ -159,6 +170,7 @@ impl Engine {
             completed_at: None,
             last_access: now_secs(),
             state: state::TorrentState::Leeching,
+            error: None,
             transcode: state::TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,
@@ -173,6 +185,11 @@ impl Engine {
         tokio::spawn(async move {
             if let Err(e) = handle.wait_until_completed().await {
                 tracing::error!(id = %id_task, error = %e, "torrent failed");
+                let _ = store.update(&id_task, |m| {
+                    m.state = state::TorrentState::Failed;
+                    m.error = Some(format!("download failed: {e}"));
+                    ((), true)
+                });
                 return;
             }
             match mover::move_completed(&out_dir, &library_dir) {
@@ -186,6 +203,7 @@ impl Engine {
                         completed_at: Some(now),
                         last_access: now,
                         state: state::TorrentState::Seeding,
+                        error: None,
                         transcode: state::TranscodeStatus::None,
                         transcode_path: None,
                         transcode_error: None,
@@ -195,7 +213,14 @@ impl Engine {
                     });
                     tracing::info!(id = %id_task, "moved to library");
                 }
-                Err(e) => tracing::error!(id = %id_task, error = %e, "move failed"),
+                Err(e) => {
+                    tracing::error!(id = %id_task, error = %e, "move failed");
+                    let _ = store.update(&id_task, |m| {
+                        m.state = state::TorrentState::Failed;
+                        m.error = Some(format!("move failed: {e}"));
+                        ((), true)
+                    });
+                }
             }
         });
         Ok(id)
@@ -296,6 +321,23 @@ impl Engine {
     }
 }
 
+pub fn needs_fail_on_restart(state: &state::TorrentState) -> bool {
+    matches!(state, state::TorrentState::Leeching)
+}
+
+fn reconcile_on_start(store: &state::StateStore) {
+    for m in store.list() {
+        if needs_fail_on_restart(&m.state) {
+            let _ = store.update(&m.id, |m| {
+                m.state = state::TorrentState::Failed;
+                m.error = Some("interrupted by restart; not resumable".into());
+                ((), true)
+            });
+            tracing::warn!(id = %m.id, name = %m.name, "leeching torrent failed on restart (no session persistence)");
+        }
+    }
+}
+
 pub async fn vpn_watchdog_loop(engine: Engine, interval_secs: u64) {
     let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
     ticker.tick().await;
@@ -332,6 +374,53 @@ mod tests {
         remove_entry_files(&src.display().to_string(), Some(&tc.display().to_string()));
         assert!(!src.exists());
         assert!(!tc.exists());
+    }
+
+    #[test]
+    fn needs_fail_on_restart_only_leeching() {
+        use state::TorrentState::*;
+        assert!(needs_fail_on_restart(&Leeching));
+        assert!(!needs_fail_on_restart(&Seeding));
+        assert!(!needs_fail_on_restart(&Failed));
+        assert!(!needs_fail_on_restart(&Reaped));
+    }
+
+    #[test]
+    fn reconcile_fails_stranded_leeching_keeps_seeding() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = state::StateStore::load(dir.path().join("s.json")).unwrap();
+        let mut leech = mk_meta("1", state::TorrentState::Leeching);
+        leech.name = "dl".into();
+        store.upsert(leech).unwrap();
+        store
+            .upsert(mk_meta("2", state::TorrentState::Seeding))
+            .unwrap();
+
+        reconcile_on_start(&store);
+
+        let a = store.get("1").unwrap();
+        assert_eq!(a.state, state::TorrentState::Failed);
+        assert!(a.error.as_deref().unwrap().contains("restart"));
+        assert_eq!(store.get("2").unwrap().state, state::TorrentState::Seeding);
+    }
+
+    fn mk_meta(id: &str, st: state::TorrentState) -> state::Metadata {
+        state::Metadata {
+            id: id.into(),
+            name: id.into(),
+            path: format!("/lib/{id}"),
+            size: 1,
+            completed_at: None,
+            last_access: 0,
+            state: st,
+            error: None,
+            transcode: state::TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: state::HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
+        }
     }
 
     #[test]

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -92,7 +92,7 @@ impl HlsManager {
         segment_secs: u32,
         enabled: bool,
     ) -> Self {
-        Self {
+        let this = Self {
             store,
             encode_sem: Arc::new(Semaphore::new(encode_conc.max(1))),
             ffmpeg_bin,
@@ -100,7 +100,17 @@ impl HlsManager {
             enabled,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
+        };
+        for m in this.store.list() {
+            if matches!(m.hls, HlsStatus::Starting | HlsStatus::Live) {
+                let _ = this.store.update(&m.id, |m| {
+                    m.hls = HlsStatus::Failed;
+                    m.hls_error = Some("interrupted by restart".into());
+                    ((), true)
+                });
+            }
         }
+        this
     }
 
     pub fn cached_delivery(&self, id: &str) -> Option<Delivery> {

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -66,6 +66,7 @@ mod tests {
             completed_at: Some(last_access),
             last_access,
             state: TorrentState::Seeding,
+            error: None,
             transcode: TranscodeStatus::None,
             transcode_path: None,
             transcode_error: None,

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum TorrentState { Queued, Leeching, Seeding, Reaped }
+pub enum TorrentState { Leeching, Seeding, Reaped, Failed }
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub enum TranscodeStatus { #[default] None, Pending, Remuxing, Encoding, Ready, Failed }
@@ -20,6 +20,8 @@ pub struct Metadata {
     pub completed_at: Option<u64>,
     pub last_access: u64,
     pub state: TorrentState,
+    #[serde(default)]
+    pub error: Option<String>,
     #[serde(default)]
     pub transcode: TranscodeStatus,
     #[serde(default)]
@@ -116,7 +118,7 @@ mod tests {
         Metadata {
             id: id.into(), name: format!("t-{id}"), path: format!("/lib/{id}"),
             size: 10, completed_at: Some(last_access), last_access,
-            state: TorrentState::Seeding,
+            state: TorrentState::Seeding, error: None,
             transcode: TranscodeStatus::None, transcode_path: None, transcode_error: None,
             hls: HlsStatus::None, hls_dir: None, hls_error: None,
         }

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -444,6 +444,7 @@ mod transcoder_tests {
             completed_at: Some(1),
             last_access: 1,
             state: TorrentState::Seeding,
+            error: None,
             transcode,
             transcode_path: None,
             transcode_error: None,

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -37,6 +37,7 @@ async fn hls_transcode_integration() {
         completed_at: Some(0),
         last_access: 0,
         state: reel::state::TorrentState::Seeding,
+        error: None,
         transcode: reel::state::TranscodeStatus::None,
         transcode_path: None,
         transcode_error: None,


### PR DESCRIPTION
Robustness bundle from the reel post-go-live audit (stacks on #14558), plus the last go-live wiring gap and a seed-bandwidth cap.

## #4 `TorrentState::Failed`
Download errors were logged and dropped, leaving entries stuck `Leeching`.
- Add `Failed` variant (drop dead unused `Queued`) + `Metadata.error`.
- `add()` sets `state=Failed` + error on `wait_until_completed` failure and on move failure.

## #2 Restart reconcile
reel runs librqbit with `persistence=None` (confirmed in 8.1.1), so a mid-download `Leeching` entry has **no handle** after a pod restart — stranded forever, every stream/manifest returns 425.
- `reconcile_on_start` marks orphaned `Leeching` → `Failed` (`"interrupted by restart; not resumable"`) so a client can delete + re-add instead of hanging.
- Pure `needs_fail_on_restart` helper (unit-tested).
- **Follow-up:** true download-resume = librqbit `persistence`+`fastresume` + persist source magnet + re-key state by infohash (session ids reassign on restart). Bigger, deferred.

## #3 HLS boot reset
`HlsManager::new` now resets `Starting`/`Live` → `Failed` (dead ffmpeg child after restart), mirroring the existing transcoder reset. `Ready` is kept — the HLS dir lives on the longhorn PVC and survives.

## Seed bandwidth cap (requested)
`Session` is now built via `new_with_opts` with `ratelimits.upload_bps` from `REEL_UPLOAD_LIMIT_BPS` (0/unset = unlimited). `reel.yaml` sets **2 MiB/s** to bound seeding egress. Combined with the idle-TTL reaper, total upload is capped in both rate and duration.

## Reloader (closes the last go-live gap)
The live `kbve-deployment` pod booted **before** the ESO-synced `reel-config` token existed, and reloader wasn't watching `reel-config` → `REEL_API_TOKEN` unset in the running pod → the axum proxy injected no bearer → reel returned **401**. Adding `reel-config` to the `secret.reloader.stakater.com/reload` list rolls the pod on apply (token injected now) and auto-restarts on future token rotations.

## Tests
4 new unit tests (Failed-on-restart matrix, reconcile, upload-limit parse). `cargo test -p reel`: **94 passed**. Clippy clean on changed files (one pre-existing `stream.rs` warning untouched).

## Notes
- New env vars have safe defaults; only `reel.yaml`/`kbve-deployment.yaml` manifest deltas are behavioral. Code ships to the pod on the next reel version bump; the reloader delta applies via ArgoCD on merge to main.

🤖 Generated with [KBVE Code](https://kbve.com/application/)