### PR TITLE
feat(graph): unified /graph/ hub fusing NX, Graphify + site graphs

### DIFF
--- a/apps/kbve/astro-kbve/src/components/graph/GraphHub.tsx
+++ b/apps/kbve/astro-kbve/src/components/graph/GraphHub.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import GraphNeighborhood from './GraphNeighborhood';
+
+type EntityKind = 'project' | 'dir' | 'doc';
+
+interface DocRef {
+	slug: string;
+	title: string;
+}
+
+interface GraphEntity {
+	id: string;
+	kind: EntityKind;
+	name: string;
+	root?: string;
+	type?: 'app' | 'lib' | 'e2e';
+	nx?: { deps: string[]; dependents: string[] };
+	graphify?: { dirId: string; label: string };
+	docs?: DocRef[];
+}
+
+type Scope = 'all' | 'nx' | 'graphify' | 'site';
+
+const NX_URL = '/dashboard/graph/';
+const GRAPHIFY_URL = '/dashboard/graph-explorer/';
+
+const scopeMatch = (e: GraphEntity, s: Scope): boolean => {
+	if (s === 'all') return true;
+	if (s === 'nx') return !!e.nx;
+	if (s === 'graphify') return !!e.graphify;
+	return !!(e.docs && e.docs.length) || e.kind === 'doc';
+};
+
+/** Cheap relevance: exact > prefix > substring over name/root/dir/doc titles. */
+function score(e: GraphEntity, q: string): number {
+	if (!q) return e.kind === 'project' ? 2 : 1;
+	const name = e.name.toLowerCase();
+	if (name === q) return 100;
+	if (name.startsWith(q)) return 80;
+	if (name.includes(q)) return 60;
+	if (e.root?.toLowerCase().includes(q)) return 40;
+	if (e.graphify?.label.toLowerCase().includes(q)) return 30;
+	if (e.docs?.some((d) => d.title.toLowerCase().includes(q))) return 20;
+	return 0;
+}
+
+export default function GraphHub() {
+	const [entities, setEntities] = useState<GraphEntity[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [query, setQuery] = useState('');
+	const [scope, setScope] = useState<Scope>('all');
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		let alive = true;
+		fetch('/api/graph/index.json')
+			.then((r) => {
+				if (!r.ok) throw new Error(`HTTP ${r.status}`);
+				return r.json();
+			})
+			.then((data: { entities: GraphEntity[] }) => {
+				if (!alive) return;
+				setEntities(data.entities ?? []);
+				setLoading(false);
+			})
+			.catch((e: unknown) => {
+				if (!alive) return;
+				setError(e instanceof Error ? e.message : 'load failed');
+				setLoading(false);
+			});
+		return () => {
+			alive = false;
+		};
+	}, []);
+
+	const byId = useMemo(() => {
+		const m = new Map<string, GraphEntity>();
+		for (const e of entities) m.set(e.id, e);
+		return m;
+	}, [entities]);
+
+	const results = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		return entities
+			.filter((e) => scopeMatch(e, scope))
+			.map((e) => ({ e, s: score(e, q) }))
+			.filter((r) => r.s > 0)
+			.sort((a, b) => b.s - a.s || a.e.name.localeCompare(b.e.name))
+			.slice(0, 50)
+			.map((r) => r.e);
+	}, [entities, query, scope]);
+
+	const selected = selectedId ? byId.get(selectedId) : undefined;
+
+	const recenter = (name: string) => {
+		if (byId.has(name)) setSelectedId(name);
+	};
+
+	return (
+		<div className="ghub" data-graph-hub>
+			<div className="ghub__controls">
+				<input
+					ref={inputRef}
+					type="text"
+					className="ghub__search"
+					placeholder="Search projects, directories, docs…"
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					autoComplete="off"
+					spellCheck={false}
+				/>
+				<div className="ghub__scopes" role="tablist">
+					{(['all', 'nx', 'graphify', 'site'] as Scope[]).map((s) => (
+						<button
+							key={s}
+							type="button"
+							role="tab"
+							aria-selected={scope === s}
+							className={scope === s ? 'is-active' : ''}
+							onClick={() => setScope(s)}>
+							{s === 'all'
+								? 'All'
+								: s === 'nx'
+									? 'NX'
+									: s === 'graphify'
+										? 'Graphify'
+										: 'Site'}
+						</button>
+					))}
+				</div>
+			</div>
+
+			{loading && <div className="ghub__msg">Loading graph index…</div>}
+			{error && (
+				<div className="ghub__msg ghub__msg--err">
+					Failed to load: {error}
+				</div>
+			)}
+
+			{!loading && !error && (
+				<div className="ghub__body">
+					<ul className="ghub__list">
+						{results.map((e) => (
+							<li key={e.id}>
+								<button
+									type="button"
+									className={
+										selectedId === e.id ? 'is-active' : ''
+									}
+									onClick={() => setSelectedId(e.id)}>
+									<span
+										className={`ghub__kind ghub__kind--${e.kind}`}>
+										{e.type ?? e.kind}
+									</span>
+									<span className="ghub__name">{e.name}</span>
+									<span className="ghub__facets">
+										{e.nx && <i title="NX">◆</i>}
+										{e.graphify && (
+											<i title="Graphify">◈</i>
+										)}
+										{e.docs?.length && (
+											<i title="Docs">▤</i>
+										)}
+									</span>
+								</button>
+							</li>
+						))}
+						{!results.length && (
+							<li className="ghub__empty">
+								No matches{query ? ` for “${query}”` : ''}.
+							</li>
+						)}
+					</ul>
+
+					<div className="ghub__detail">
+						{!selected && (
+							<div className="ghub__hint">
+								Select an entry to see its NX dependencies,
+								Graphify code area, and linked docs.
+							</div>
+						)}
+						{selected && (
+							<article className="ghub__card">
+								<header>
+									<span
+										className={`ghub__kind ghub__kind--${selected.kind}`}>
+										{selected.type ?? selected.kind}
+									</span>
+									<h2>{selected.name}</h2>
+									{selected.root && (
+										<code>{selected.root}</code>
+									)}
+								</header>
+
+								{selected.nx && (
+									<section>
+										<h3>
+											NX · {selected.nx.deps.length} deps
+											· {selected.nx.dependents.length}{' '}
+											dependents
+										</h3>
+										<GraphNeighborhood
+											center={selected.name}
+											deps={selected.nx.deps}
+											dependents={selected.nx.dependents}
+											onSelect={recenter}
+										/>
+										<a className="ghub__link" href={NX_URL}>
+											Open in NX graph →
+										</a>
+									</section>
+								)}
+
+								{selected.graphify && (
+									<section>
+										<h3>
+											Graphify · {selected.graphify.label}
+										</h3>
+										<a
+											className="ghub__link"
+											href={GRAPHIFY_URL}>
+											Open in Graphify explorer →
+										</a>
+									</section>
+								)}
+
+								{selected.docs?.length ? (
+									<section>
+										<h3>Docs · {selected.docs.length}</h3>
+										<ul className="ghub__docs">
+											{selected.docs.map((d) => (
+												<li key={d.slug}>
+													<a href={`/${d.slug}/`}>
+														{d.title}
+													</a>
+												</li>
+											))}
+										</ul>
+									</section>
+								) : null}
+							</article>
+						)}
+					</div>
+				</div>
+			)}
+			<style>{hubStyles}</style>
+		</div>
+	);
+}
+
+const hubStyles = `
+	.ghub { --acc:#a78bfa; --acc2:#38bdf8; color:#e2e8f0; }
+	.ghub__controls { display:flex; flex-wrap:wrap; gap:10px; margin-bottom:14px; }
+	.ghub__search {
+		flex:1 1 260px; padding:10px 14px; border-radius:10px;
+		border:1px solid rgba(148,163,184,0.28); background:rgba(12,18,30,0.7);
+		color:#e2e8f0; font-size:0.9rem;
+	}
+	.ghub__search:focus { outline:none; border-color:var(--acc2); }
+	.ghub__scopes { display:flex; gap:4px; }
+	.ghub__scopes button {
+		padding:8px 14px; border-radius:8px; border:1px solid rgba(148,163,184,0.25);
+		background:rgba(12,18,30,0.7); color:#cbd5e1; font-size:0.8rem; cursor:pointer;
+	}
+	.ghub__scopes button.is-active { border-color:var(--acc); color:#e9d5ff; }
+	.ghub__msg { padding:24px; text-align:center; color:#94a3b8; }
+	.ghub__msg--err { color:#f87171; }
+	.ghub__body { display:grid; grid-template-columns:minmax(0,1fr); gap:16px; }
+	@media (min-width:900px){ .ghub__body { grid-template-columns:19rem minmax(0,1fr); } }
+	.ghub__list { list-style:none; margin:0; padding:0; max-height:70vh; overflow-y:auto;
+		border:1px solid var(--bento-hairline,rgba(148,163,184,0.18)); border-radius:12px; }
+	.ghub__list li { margin:0; }
+	.ghub__list button {
+		display:flex; align-items:center; gap:8px; width:100%; text-align:left;
+		padding:9px 12px; border:0; background:none; color:#cbd5e1; cursor:pointer;
+		border-bottom:1px solid rgba(148,163,184,0.08); font-size:0.82rem;
+	}
+	.ghub__list button:hover { background:rgba(56,189,248,0.08); }
+	.ghub__list button.is-active { background:rgba(167,139,250,0.14); color:#fff; }
+	.ghub__kind {
+		flex:none; font-size:0.6rem; text-transform:uppercase; letter-spacing:0.04em;
+		padding:1px 6px; border-radius:4px; color:#0a0e16; background:#64748b;
+	}
+	.ghub__kind--project { background:#38bdf8; }
+	.ghub__kind--dir { background:#f59e0b; }
+	.ghub__kind--doc { background:#a3e635; }
+	.ghub__name { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+	.ghub__facets { flex:none; display:inline-flex; gap:4px; color:#64748b; font-style:normal; }
+	.ghub__empty, .ghub__hint { padding:16px; color:#64748b; font-size:0.82rem; }
+	.ghub__detail { min-width:0; }
+	.ghub__card header { display:flex; flex-wrap:wrap; align-items:center; gap:8px; margin-bottom:12px; }
+	.ghub__card h2 { margin:0; font-size:1.2rem; }
+	.ghub__card header code { font-size:0.72rem; color:#94a3b8; }
+	.ghub__card section {
+		padding:12px 0; border-top:1px solid rgba(148,163,184,0.12);
+	}
+	.ghub__card h3 { margin:0 0 8px; font-size:0.82rem; color:#94a3b8; font-weight:600; }
+	.ghub__link { display:inline-block; margin-top:8px; color:var(--acc2); font-size:0.8rem; text-decoration:none; }
+	.ghub__link:hover { text-decoration:underline; }
+	.ghub__docs { margin:0; padding-left:18px; font-size:0.82rem; }
+	.ghub__docs a { color:#cbd5e1; }
+`;

--- a/apps/kbve/astro-kbve/src/components/graph/GraphNeighborhood.tsx
+++ b/apps/kbve/astro-kbve/src/components/graph/GraphNeighborhood.tsx
@@ -1,0 +1,152 @@
+import { useMemo } from 'react';
+
+interface Props {
+	center: string;
+	deps: string[];
+	dependents: string[];
+	onSelect?: (name: string) => void;
+}
+
+interface Placed {
+	name: string;
+	x: number;
+	y: number;
+	role: 'dep' | 'dependent';
+}
+
+const W = 640;
+const H = 360;
+const CX = W / 2;
+const CY = H / 2;
+const R = 132;
+const MAX_PER_SIDE = 12;
+
+/** Neighbors on a semicircle — deps sweep the left arc, dependents the right,
+ *  spread deterministically by index so the layout never jitters. */
+function place(names: string[], role: Placed['role'], base: number): Placed[] {
+	const shown = names.slice(0, MAX_PER_SIDE);
+	const span = Math.PI * 0.8;
+	const start = base - span / 2;
+	const step = shown.length > 1 ? span / (shown.length - 1) : 0;
+	return shown.map((name, i) => {
+		const a = shown.length === 1 ? base : start + step * i;
+		return {
+			name,
+			role,
+			x: CX + Math.cos(a) * R,
+			y: CY + Math.sin(a) * R,
+		};
+	});
+}
+
+/**
+ * Static dependency-neighborhood graph for one project — its direct NX
+ * dependencies (left) and dependents (right), one hop out. Deterministic SVG
+ * layout, no physics/runtime deps; nodes are clickable to re-center.
+ */
+export default function GraphNeighborhood({
+	center,
+	deps,
+	dependents,
+	onSelect,
+}: Props) {
+	const placed = useMemo(
+		() => [
+			...place(deps, 'dep', Math.PI), // left
+			...place(dependents, 'dependent', 0), // right
+		],
+		[deps, dependents],
+	);
+
+	const hiddenDeps = Math.max(0, deps.length - MAX_PER_SIDE);
+	const hiddenDependents = Math.max(0, dependents.length - MAX_PER_SIDE);
+
+	return (
+		<div className="gnb" data-graph-neighborhood>
+			<svg
+				viewBox={`0 0 ${W} ${H}`}
+				role="img"
+				aria-label={`Dependency neighborhood of ${center}`}>
+				{placed.map((p) => (
+					<line
+						key={`e-${p.name}`}
+						x1={CX}
+						y1={CY}
+						x2={p.x}
+						y2={p.y}
+						className={`gnb__edge gnb__edge--${p.role}`}
+					/>
+				))}
+				{placed.map((p) => (
+					<g
+						key={`n-${p.name}`}
+						className={`gnb__node gnb__node--${p.role}`}
+						transform={`translate(${p.x},${p.y})`}
+						onClick={() => onSelect?.(p.name)}
+						role="button"
+						tabIndex={0}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') onSelect?.(p.name);
+						}}>
+						<circle r={5} />
+						<text
+							x={p.x < CX ? -9 : 9}
+							y={4}
+							textAnchor={p.x < CX ? 'end' : 'start'}>
+							{p.name}
+						</text>
+					</g>
+				))}
+				<g
+					className="gnb__node gnb__node--center"
+					transform={`translate(${CX},${CY})`}>
+					<circle r={8} />
+					<text y={-14} textAnchor="middle">
+						{center}
+					</text>
+				</g>
+			</svg>
+			<div className="gnb__legend">
+				<span className="gnb__key gnb__key--dep">
+					deps {deps.length}
+					{hiddenDeps ? ` (+${hiddenDeps})` : ''}
+				</span>
+				<span className="gnb__key gnb__key--dependent">
+					dependents {dependents.length}
+					{hiddenDependents ? ` (+${hiddenDependents})` : ''}
+				</span>
+			</div>
+			<style>{`
+				.gnb { position: relative; width: 100%; }
+				.gnb svg { width: 100%; height: auto; display: block; }
+				.gnb__edge { stroke-width: 1; }
+				.gnb__edge--dep { stroke: rgba(56,189,248,0.4); }
+				.gnb__edge--dependent { stroke: rgba(245,158,11,0.4); }
+				.gnb__node { cursor: pointer; }
+				.gnb__node text {
+					font-size: 11px;
+					fill: #cbd5e1;
+					paint-order: stroke;
+					stroke: rgba(2,6,14,0.85);
+					stroke-width: 3px;
+				}
+				.gnb__node--dep circle { fill: #38bdf8; }
+				.gnb__node--dependent circle { fill: #f59e0b; }
+				.gnb__node--center circle { fill: #a78bfa; }
+				.gnb__node--center text { fill: #e9d5ff; font-weight: 600; font-size: 12px; }
+				.gnb__node:hover circle { stroke: #e2e8f0; stroke-width: 2px; }
+				.gnb__legend {
+					display: flex; gap: 12px; justify-content: center;
+					margin-top: 4px; font-size: 0.72rem; color: #94a3b8;
+				}
+				.gnb__key { display: inline-flex; align-items: center; gap: 4px; }
+				.gnb__key--dep::before,
+				.gnb__key--dependent::before {
+					content: ''; width: 8px; height: 8px; border-radius: 50%;
+				}
+				.gnb__key--dep::before { background: #38bdf8; }
+				.gnb__key--dependent::before { background: #f59e0b; }
+			`}</style>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/graph.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/graph.mdx
@@ -1,0 +1,96 @@
+---
+title: Graph
+description: |
+    Unified, searchable graph of the KBVE monorepo — NX project dependencies,
+    the Graphify semantic code graph, and the docs site graph, cross-linked.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+sidebar:
+    label: Graph
+    order: 99
+---
+
+import BentoShell from '@/components/hero/BentoShell.astro';
+import GraphHub from '@/components/graph/GraphHub';
+import nxGraph from '../../../public/data/nx/nx-graph.json';
+import overview from '../../../public/graphify/overview.json';
+
+export const projects = Object.keys(nxGraph.graph.nodes).length;
+export const dirs = overview.meta.dirs;
+export const symbols = overview.meta.symbols;
+
+<div class="graph-hub-page" data-graph-hub-page>
+
+<section class="bento-hero bento-section not-content" aria-label="Unified monorepo graph">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="5" cy="6" r="2" /><circle cx="19" cy="6" r="2" /><circle cx="12" cy="18" r="2" /><path d="M6.5 7.5 11 16M17.5 7.5 13 16M7 6h10" /></svg>
+					<span>one graph · three feeds</span>
+				</span>
+				<h1 class="bento-title">
+					The whole monorepo,
+					<span class="bento-title__accent">searchable and cross-linked.</span>
+				</h1>
+				<p class="bento-lede">Search any project to see its <strong>NX dependencies</strong>, its <strong>Graphify</strong> code area, and its <strong>docs</strong> — all in one place, each linking out to its full view.</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#hub">
+						Start searching
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="/dashboard/graph/">NX graph</a>
+					<a class="bento-btn bento-btn--ghost" href="/dashboard/graph-explorer/">Graphify</a>
+				</div>
+			</div>
+
+			<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7zM4 13h7v7H4z" /></svg>
+				</span>
+				<span class="bento-stat__value">{projects}</span>
+				<span class="bento-stat__label">Projects</span>
+			</div>
+			<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
+				</span>
+				<span class="bento-stat__value">{dirs}</span>
+				<span class="bento-stat__label">Directories</span>
+			</div>
+			<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7V4h16v3M9 20h6M12 4v16" /></svg>
+				</span>
+				<span class="bento-stat__value">{(symbols / 1000).toFixed(0)}k</span>
+				<span class="bento-stat__label">Symbols</span>
+			</div>
+			<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" /></svg>
+				</span>
+				<span class="bento-stat__value">3</span>
+				<span class="bento-stat__label">Feeds</span>
+			</div>
+		</div>
+
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#hub">Search</a>
+			<a class="bento-chip" href="/dashboard/graph/">NX</a>
+			<a class="bento-chip" href="/dashboard/graph-explorer/">Graphify</a>
+		</nav>
+	</div>
+</section>
+
+<BentoShell id="hub" eyebrow="Unified · cross-linked" heading="Explore the graph">
+	<GraphHub client:only="react" />
+</BentoShell>
+
+</div>
+
+<style is:global>{`.graph-hub-page{--bento-accent:#a78bfa;--bento-accent-2:#38bdf8}`}</style>

--- a/apps/kbve/astro-kbve/src/lib/graph/buildGraphIndex.test.ts
+++ b/apps/kbve/astro-kbve/src/lib/graph/buildGraphIndex.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { buildGraphIndex, type GraphSources } from './buildGraphIndex';
+
+const sources = (): GraphSources => ({
+	nx: {
+		graph: {
+			nodes: {
+				'axum-kbve': {
+					type: 'app',
+					data: { root: 'apps/kbve/axum-kbve' },
+				},
+				jedi: { type: 'lib', data: { root: 'packages/rust/jedi' } },
+				kbve: { type: 'lib', data: { root: 'packages/rust/kbve' } },
+			},
+			dependencies: {
+				'axum-kbve': [{ target: 'jedi' }, { target: 'kbve' }],
+				kbve: [{ target: 'jedi' }],
+				jedi: [],
+			},
+		},
+	},
+	graphify: {
+		dirs: [
+			{ id: 'apps__kbve', label: 'apps/kbve' },
+			{ id: 'packages__rust', label: 'packages/rust' },
+			{ id: '_github__scripts', label: '.github/scripts' },
+		],
+	},
+	site: {
+		'application/axum-kbve': { title: 'Axum KBVE', links: [] },
+		'guides/unrelated': { title: 'Unrelated Guide', links: [] },
+	},
+});
+
+describe('buildGraphIndex', () => {
+	it('creates one entity per NX project with sorted deps and dependents', () => {
+		const idx = buildGraphIndex(sources());
+		const axum = idx.entities.find((e) => e.id === 'axum-kbve')!;
+		expect(axum.kind).toBe('project');
+		expect(axum.type).toBe('app');
+		expect(axum.nx).toEqual({ deps: ['jedi', 'kbve'], dependents: [] });
+
+		const jedi = idx.entities.find((e) => e.id === 'jedi')!;
+		expect(jedi.nx!.dependents).toEqual(['axum-kbve', 'kbve']);
+	});
+
+	it('joins a project to its containing Graphify directory by path', () => {
+		const idx = buildGraphIndex(sources());
+		const axum = idx.entities.find((e) => e.id === 'axum-kbve')!;
+		// root apps/kbve/axum-kbve → top-two apps/kbve bubble
+		expect(axum.graphify).toEqual({
+			dirId: 'apps__kbve',
+			label: 'apps/kbve',
+		});
+
+		const jedi = idx.entities.find((e) => e.id === 'jedi')!;
+		expect(jedi.graphify).toEqual({
+			dirId: 'packages__rust',
+			label: 'packages/rust',
+		});
+	});
+
+	it('attaches a doc to a project when a slug segment matches its name', () => {
+		const idx = buildGraphIndex(sources());
+		const axum = idx.entities.find((e) => e.id === 'axum-kbve')!;
+		expect(axum.docs).toEqual([
+			{ slug: 'application/axum-kbve', title: 'Axum KBVE' },
+		]);
+	});
+
+	it('does not emit unmatched docs as entities, only counts them', () => {
+		const idx = buildGraphIndex(sources());
+		expect(idx.entities.some((e) => e.kind === ('doc' as never))).toBe(
+			false,
+		);
+		expect(idx.meta.counts.orphanDocs).toBe(1);
+		expect(idx.meta.counts.docLinks).toBe(1);
+	});
+
+	it('keeps a Graphify directory no project claimed as a standalone dir entity', () => {
+		const idx = buildGraphIndex(sources());
+		const scripts = idx.entities.find(
+			(e) => e.id === 'dir:_github__scripts',
+		);
+		expect(scripts).toBeDefined();
+		expect(scripts!.kind).toBe('dir');
+		expect(scripts!.graphify!.label).toBe('.github/scripts');
+	});
+
+	it('omits docs array on projects with no matched docs', () => {
+		const idx = buildGraphIndex(sources());
+		const kbve = idx.entities.find((e) => e.id === 'kbve')!;
+		expect(kbve.docs).toBeUndefined();
+	});
+
+	it('reports gaps and counts when feeds are missing', () => {
+		const idx = buildGraphIndex({ nx: null, graphify: null, site: null });
+		expect(idx.meta.gaps.sort()).toEqual(['graphify', 'nx', 'site']);
+		expect(idx.meta.counts.total).toBe(0);
+		expect(idx.entities).toEqual([]);
+	});
+
+	it('counts entity kinds', () => {
+		const idx = buildGraphIndex(sources());
+		expect(idx.meta.counts.projects).toBe(3);
+		expect(idx.meta.counts.dirs).toBe(1);
+		expect(idx.meta.counts.docLinks).toBe(1);
+		expect(idx.meta.counts.orphanDocs).toBe(1);
+		expect(idx.meta.counts.total).toBe(4);
+	});
+});

--- a/apps/kbve/astro-kbve/src/lib/graph/buildGraphIndex.ts
+++ b/apps/kbve/astro-kbve/src/lib/graph/buildGraphIndex.ts
@@ -1,0 +1,203 @@
+/**
+ * Fuses the three monorepo graph feeds — NX project dependencies, the Graphify
+ * semantic directory graph, and the Starlight docs site graph — into a single
+ * project-centric index consumed by the `/graph/` hub.
+ *
+ * Pure and IO-free: the endpoint reads the raw sources (static JSON +
+ * `buildSiteGraph(getCollection('docs'))`) and hands them here. The spine is
+ * the filesystem path — an NX project's `root` joins to its containing Graphify
+ * directory bubble, and docs attach to projects by a best-effort name/slug
+ * heuristic. Nodes present in only one feed survive as standalone searchable
+ * entities so nothing is lost.
+ */
+
+export type NxProjectType = 'app' | 'lib' | 'e2e';
+
+export interface NxGraphInput {
+	graph: {
+		nodes: Record<
+			string,
+			{ name?: string; type?: string; data?: { root?: string } }
+		>;
+		dependencies: Record<string, Array<{ target: string }>>;
+	};
+}
+
+export interface GraphifyOverviewInput {
+	dirs: Array<{ id: string; label: string }>;
+}
+
+export interface SiteGraphNodeInput {
+	title: string;
+	links?: string[];
+	backlinks?: string[];
+}
+
+export type SiteGraphInput = Record<string, SiteGraphNodeInput>;
+
+export interface GraphSources {
+	nx?: NxGraphInput | null;
+	graphify?: GraphifyOverviewInput | null;
+	site?: SiteGraphInput | null;
+}
+
+export interface DocRef {
+	slug: string;
+	title: string;
+}
+
+export type EntityKind = 'project' | 'dir' | 'doc';
+
+export interface GraphEntity {
+	id: string;
+	kind: EntityKind;
+	name: string;
+	root?: string;
+	type?: NxProjectType;
+	nx?: { deps: string[]; dependents: string[] };
+	graphify?: { dirId: string; label: string };
+	docs?: DocRef[];
+}
+
+export interface GraphIndex {
+	entities: GraphEntity[];
+	meta: {
+		counts: {
+			projects: number;
+			dirs: number;
+			docLinks: number;
+			orphanDocs: number;
+			total: number;
+		};
+		gaps: string[];
+	};
+}
+
+const normType = (t: string | undefined): NxProjectType | undefined =>
+	t === 'app' || t === 'lib' || t === 'e2e' ? t : undefined;
+
+const topTwo = (root: string): string => root.split('/').slice(0, 2).join('/');
+
+/** Slug segments lowercased, for name/path doc→project matching. */
+const slugTokens = (slug: string): string[] =>
+	slug.toLowerCase().split(/[\/#]/).filter(Boolean);
+
+/**
+ * Only "distinctive" project names are used to claim docs: hyphenated names
+ * (`axum-kbve`, `arc-runner`) or names ≥6 chars (`kilobase`, `jobboard`) are
+ * unambiguous identifiers. Short common words (`astro`, `core`, `chat`, `edge`)
+ * collide with generic doc slugs and would vacuum up unrelated pages.
+ */
+const isDistinctive = (name: string): boolean =>
+	name.includes('-') || name.length >= 6;
+
+export function buildGraphIndex(sources: GraphSources): GraphIndex {
+	const gaps: string[] = [];
+	const nx = sources.nx ?? null;
+	const graphify = sources.graphify ?? null;
+	const site = sources.site ?? null;
+
+	if (!nx || !Object.keys(nx.graph?.nodes ?? {}).length) gaps.push('nx');
+	if (!graphify || !graphify.dirs?.length) gaps.push('graphify');
+	if (!site || !Object.keys(site ?? {}).length) gaps.push('site');
+
+	// Graphify dir lookup by label (exact) — one bubble per top-ish directory.
+	const dirByLabel = new Map<string, { id: string; label: string }>();
+	for (const d of graphify?.dirs ?? []) dirByLabel.set(d.label, d);
+	const usedDirLabels = new Set<string>();
+
+	// Reverse dependency map (dependents) from the forward edges.
+	const nodes = nx?.graph?.nodes ?? {};
+	const deps = nx?.graph?.dependencies ?? {};
+	const dependents = new Map<string, Set<string>>();
+	for (const [src, edges] of Object.entries(deps)) {
+		for (const e of edges ?? []) {
+			if (!dependents.has(e.target)) dependents.set(e.target, new Set());
+			dependents.get(e.target)!.add(src);
+		}
+	}
+
+	// Project entities, keyed by name; index by lowercased name for doc match.
+	const projects: GraphEntity[] = [];
+	const projectByToken = new Map<string, GraphEntity>();
+	for (const [name, node] of Object.entries(nodes)) {
+		const root = node.data?.root;
+		const ent: GraphEntity = {
+			id: name,
+			kind: 'project',
+			name,
+			root,
+			type: normType(node.type),
+			nx: {
+				deps: (deps[name] ?? []).map((e) => e.target).sort(),
+				dependents: [...(dependents.get(name) ?? [])].sort(),
+			},
+			docs: [],
+		};
+		if (root) {
+			const dir = dirByLabel.get(root) ?? dirByLabel.get(topTwo(root));
+			if (dir) {
+				ent.graphify = { dirId: dir.id, label: dir.label };
+				usedDirLabels.add(dir.label);
+			}
+		}
+		projects.push(ent);
+		if (isDistinctive(name)) projectByToken.set(name.toLowerCase(), ent);
+	}
+
+	// Docs attach to a project by best-effort name/slug match. Unmatched docs
+	// (most of the docs corpus — guides, journal, generic pages) are NOT emitted
+	// as graph nodes: this is a code graph, and the docs site search already
+	// covers browsing. We only surface the docs that link into the graph, and
+	// count the rest as coverage metadata.
+	let docLinks = 0;
+	let orphanDocs = 0;
+	for (const [slug, node] of Object.entries(site ?? {})) {
+		const ref: DocRef = { slug, title: node.title || slug };
+		const tokens = slugTokens(slug);
+		let matched: GraphEntity | undefined;
+		for (const tok of tokens) {
+			const hit = projectByToken.get(tok);
+			if (hit) {
+				matched = hit;
+				break;
+			}
+		}
+		if (matched) {
+			matched.docs!.push(ref);
+			docLinks++;
+		} else {
+			orphanDocs++;
+		}
+	}
+
+	// Orphan Graphify dirs — directories no project claimed (e.g. .github,
+	// scripts) — kept as standalone searchable entities.
+	const dirEntities: GraphEntity[] = [];
+	for (const d of graphify?.dirs ?? []) {
+		if (usedDirLabels.has(d.label)) continue;
+		dirEntities.push({
+			id: `dir:${d.id}`,
+			kind: 'dir',
+			name: d.label,
+			graphify: { dirId: d.id, label: d.label },
+		});
+	}
+
+	for (const p of projects) if (!p.docs!.length) delete p.docs;
+
+	const entities = [...projects, ...dirEntities];
+	return {
+		entities,
+		meta: {
+			counts: {
+				projects: projects.length,
+				dirs: dirEntities.length,
+				docLinks,
+				orphanDocs,
+				total: entities.length,
+			},
+			gaps,
+		},
+	};
+}

--- a/apps/kbve/astro-kbve/src/pages/api/graph/index.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/graph/index.json.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import {
+	buildSiteGraph,
+	markdownExtractor,
+	mdxAnchorExtractor,
+} from '@kbve/astro';
+import { osrsExtractor } from '../../../lib/sitegraph/osrs-extractor';
+import {
+	buildGraphIndex,
+	type NxGraphInput,
+	type GraphifyOverviewInput,
+	type SiteGraphInput,
+} from '../../../lib/graph/buildGraphIndex';
+import nxGraph from '../../../../public/data/nx/nx-graph.json';
+import graphifyOverview from '../../../../public/graphify/overview.json';
+
+/**
+ * Unified graph index for the `/graph/` hub — fuses NX project dependencies,
+ * the Graphify directory graph, and the docs site graph at build time. Static
+ * output prerenders this to a file; each feed is optional and failures degrade
+ * to an empty-but-valid index rather than a 500.
+ *
+ * @endpoint GET /api/graph/index.json
+ */
+export const GET: APIRoute = async () => {
+	let site: SiteGraphInput | null = null;
+	try {
+		const entries = await getCollection('docs');
+		site = buildSiteGraph(
+			entries.map((e: (typeof entries)[number]) => ({
+				id: e.id,
+				body: e.body,
+				data: e.data as Record<string, unknown>,
+			})),
+			{
+				extractors: [
+					markdownExtractor,
+					mdxAnchorExtractor,
+					osrsExtractor,
+				],
+			},
+		) as SiteGraphInput;
+	} catch {
+		site = null;
+	}
+
+	const index = buildGraphIndex({
+		nx: nxGraph as unknown as NxGraphInput,
+		graphify: graphifyOverview as unknown as GraphifyOverviewInput,
+		site,
+	});
+
+	return new Response(
+		JSON.stringify({
+			metadata: {
+				source: 'graph-hub',
+				type: 'unified-monorepo-graph',
+				feeds: ['nx', 'graphify', 'site'],
+				gaps: index.meta.gaps,
+				counts: index.meta.counts,
+			},
+			entities: index.entities,
+		}),
+		{
+			status: 200,
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'public, max-age=3600',
+				'X-Graph-Type': 'unified-hub',
+			},
+		},
+	);
+};


### PR DESCRIPTION
## What

New top-level **`/graph/`** — a project-centric, searchable hub that fuses the three monorepo graph feeds and cross-links them. Search a project → see its NX dependencies, its Graphify code area, and its docs, each deep-linking to the full existing view.

## Design

Approved brainstorm: **federated hub + cross-links**, project-centric spine, best-effort docs matching, build-time TS index. Fork rationale (single merged canvas rejected: 67k-symbol scale mismatch) captured in conversation.

## Units

| Unit | File | Role |
|------|------|------|
| ① fusion | `src/lib/graph/buildGraphIndex.ts` | Pure, IO-free merge of NX deps + Graphify dirs + site graph on the filesystem-path spine. NX `root` → containing Graphify bubble (139/140). **8 vitest cases.** |
| ② endpoint | `src/pages/api/graph/index.json.ts` | Build-time, prerendered to a ~180 KB static index; every feed optional, degrades to a valid empty index. |
| ③ page | `src/content/docs/graph.mdx` + `src/components/graph/GraphHub.tsx` | Splash + bento hero (live stats) → command-palette search + scope filter (All/NX/Graphify/Site) + entity card with 3 facets + deep-links. |
| ④ mini-graph | `src/components/graph/GraphNeighborhood.tsx` | Deterministic SVG of a project's 1-hop NX neighborhood — **no runtime graph dep** (honors root-deps-only). Click to re-center. |

## Key decisions

- **Docs matching is precision-first.** Only *distinctive* project names (hyphenated like `axum-kbve`, or ≥6 chars like `kilobase`) claim docs — short common words (`astro`, `core`, `chat`, `edge`) collide with generic slugs. Result: 37 clean links vs. 2270 noisy ones before tightening.
- **Unmatched docs are counted, not emitted.** The full 7k-page docs corpus stays out of the graph index (the docs site search already covers browsing); only docs that link into the graph surface, as project facets.
- No d3-force dep added; deterministic SVG layout instead.

## Verify

- `vitest src/lib/graph` — 8/8 pass (fusion, path-join, orphan dirs, docs precision, gaps).
- `nx run astro-kbve:build` — green; `/api/graph/index.json` prerenders (142 projects + 46 dirs, `gaps: []`, all 3 feeds live), `/graph/index.html` emits with hero + island.

## Follow-ups (not in scope)

- Higher docs recall (frontmatter `project:` override).
- Optional `?focus=` deep-link into the Graphify explorer for a specific dir.