### PR TITLE
feat(desktop-kbve): scaffold Mac App Store build variant

### DIFF
--- a/.github/workflows/ci-tauri-builder.yml
+++ b/.github/workflows/ci-tauri-builder.yml
@@ -30,6 +30,21 @@ on:
                 required: false
                 type: string
                 default: 'linux,macos,windows,wasm'
+            features:
+                description: 'Cargo features to enable (space/comma list, e.g. "appstore")'
+                required: false
+                type: string
+                default: ''
+            config:
+                description: 'Extra tauri config to merge via -c (path relative to project_path, e.g. src-tauri/tauri.appstore.conf.json)'
+                required: false
+                type: string
+                default: ''
+            appstore:
+                description: 'macOS build targets the Mac App Store (sandboxed .app → .pkg → App Store Connect upload)'
+                required: false
+                type: boolean
+                default: false
 
 jobs:
     # --- Fork guard for self-hosted runners ---
@@ -165,7 +180,12 @@ jobs:
             - name: Build Tauri App
               shell: bash
               working-directory: ${{ inputs.project_path }}
-              run: cargo tauri build
+              run: |
+                  ARGS=""
+                  [ -n "${{ inputs.features }}" ] && ARGS="$ARGS --features ${{ inputs.features }}"
+                  [ -n "${{ inputs.config }}" ] && ARGS="$ARGS -c ${{ inputs.config }}"
+                  echo "cargo tauri build$ARGS"
+                  cargo tauri build $ARGS
               env:
                   CI: true
                   APPIMAGE_EXTRACT_AND_RUN: '1'
@@ -268,9 +288,15 @@ jobs:
             - name: Build Tauri App
               shell: bash
               working-directory: ${{ inputs.project_path }}
-              run: cargo tauri build
+              run: |
+                  ARGS=""
+                  [ -n "${{ inputs.features }}" ] && ARGS="$ARGS --features ${{ inputs.features }}"
+                  [ -n "${{ inputs.config }}" ] && ARGS="$ARGS -c ${{ inputs.config }}"
+                  echo "cargo tauri build$ARGS"
+                  cargo tauri build $ARGS
               env:
                   CI: true
+                  # App Store variant signs with the App Store cert (below step); Developer ID / notarize path uses these.
                   APPLE_CERTIFICATE: ${{ inputs.notarize && secrets.APPLE_CERTIFICATE || '' }}
                   APPLE_CERTIFICATE_PASSWORD: ${{ inputs.notarize && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
                   APPLE_SIGNING_IDENTITY: ${{ inputs.notarize && secrets.APPLE_SIGNING_IDENTITY || '' }}
@@ -287,6 +313,67 @@ jobs:
                       dist/target/release/bundle/macos/*.app
                   if-no-files-found: warn
                   retention-days: 14
+
+            # --- Mac App Store: sign sandboxed .app → .pkg → App Store Connect upload ---
+            # App Store uses a DIFFERENT cert class than notarization: Apple Distribution
+            # (app) + Mac Installer Distribution (.pkg) — the existing APPLE_CERTIFICATE is
+            # Developer ID and cannot sign for the store. Upload reuses APPLE_ID/APPLE_PASSWORD
+            # (app-specific password). Cert secret absent → warn + skip (sandboxed .app is
+            # still built + uploaded above so the variant is testable before certs land).
+            - name: Package + upload to App Store Connect
+              if: inputs.appstore && success()
+              shell: bash
+              env:
+                  # New — App Store distribution certs (one p12 may hold both app + installer certs).
+                  APPSTORE_CERT: ${{ secrets.APPLE_APPSTORE_CERTIFICATE }}
+                  APPSTORE_CERT_PASSWORD: ${{ secrets.APPLE_APPSTORE_CERTIFICATE_PASSWORD }}
+                  APP_IDENTITY: ${{ secrets.APPLE_APPSTORE_APP_IDENTITY }}
+                  INSTALLER_IDENTITY: ${{ secrets.APPLE_APPSTORE_INSTALLER_IDENTITY }}
+                  PROVISIONING_PROFILE: ${{ secrets.APPLE_APPSTORE_PROVISIONING_PROFILE }}
+                  # Reused from the existing notarization secret set.
+                  APPLE_ID: ${{ secrets.APPLE_ID }}
+                  APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+              working-directory: ${{ inputs.project_path }}
+              run: |
+                  set -euo pipefail
+                  if [ -z "${APPSTORE_CERT:-}" ]; then
+                    echo "::warning::App Store distribution cert not set (APPLE_APPSTORE_CERTIFICATE). Skipping package+upload; sandboxed .app artifact is available."
+                    exit 0
+                  fi
+
+                  # shellcheck disable=SC2012
+                  APP_PATH=$(ls -d dist/target/release/bundle/macos/*.app | head -n1)
+                  echo "App bundle: $APP_PATH"
+
+                  # Import App Store app + installer signing certs into a temp keychain.
+                  KEYCHAIN="$RUNNER_TEMP/appstore.keychain-db"
+                  KP="$(uuidgen)"
+                  security create-keychain -p "$KP" "$KEYCHAIN"
+                  security set-keychain-settings -lut 21600 "$KEYCHAIN"
+                  security unlock-keychain -p "$KP" "$KEYCHAIN"
+                  echo "$APPSTORE_CERT" | base64 --decode > "$RUNNER_TEMP/appstore.p12"
+                  security import "$RUNNER_TEMP/appstore.p12" -P "$APPSTORE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN"
+                  security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+                  security set-key-partition-list -S apple-tool:,apple: -k "$KP" "$KEYCHAIN" >/dev/null
+
+                  # Embed provisioning profile (Mac App Store type).
+                  if [ -n "${PROVISIONING_PROFILE:-}" ]; then
+                    echo "$PROVISIONING_PROFILE" | base64 --decode > "$APP_PATH/Contents/embedded.provisionprofile"
+                  fi
+
+                  # Re-sign the sandboxed app with the Apple Distribution identity + entitlements, then wrap in a .pkg.
+                  codesign --force --deep --options runtime \
+                    --entitlements src-tauri/entitlements.appstore.plist \
+                    --sign "$APP_IDENTITY" "$APP_PATH"
+                  PKG_PATH="$RUNNER_TEMP/${{ inputs.app_name }}.pkg"
+                  productbuild --component "$APP_PATH" /Applications --sign "$INSTALLER_IDENTITY" "$PKG_PATH"
+
+                  # Upload to App Store Connect (reuses the app-specific password).
+                  xcrun altool --upload-app -f "$PKG_PATH" -t macos \
+                    -u "$APPLE_ID" -p "$APPLE_PASSWORD"
+
+                  security delete-keychain "$KEYCHAIN" || true
 
             - name: Create test marker
               if: success()
@@ -373,7 +460,12 @@ jobs:
             - name: Build Tauri App
               shell: bash
               working-directory: ${{ inputs.project_path }}
-              run: cargo tauri build
+              run: |
+                  ARGS=""
+                  [ -n "${{ inputs.features }}" ] && ARGS="$ARGS --features ${{ inputs.features }}"
+                  [ -n "${{ inputs.config }}" ] && ARGS="$ARGS -c ${{ inputs.config }}"
+                  echo "cargo tauri build$ARGS"
+                  cargo tauri build $ARGS
               env:
                   CI: true
 

--- a/.github/workflows/ci-tauri.yml
+++ b/.github/workflows/ci-tauri.yml
@@ -12,6 +12,7 @@ on:
                     - chuck-launcher
                     - isometric
                     - desktop-kbve
+                    - desktop-kbve-appstore
 
 permissions:
     contents: read
@@ -22,26 +23,47 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 2
         outputs:
+            project: ${{ steps.map.outputs.project }}
             project_path: ${{ steps.map.outputs.project_path }}
             notarize: ${{ steps.map.outputs.notarize }}
             platforms: ${{ steps.map.outputs.platforms }}
+            features: ${{ steps.map.outputs.features }}
+            config: ${{ steps.map.outputs.config }}
+            appstore: ${{ steps.map.outputs.appstore }}
         steps:
             - id: map
               shell: bash
               run: |
+                  # defaults (a build off these unless the case overrides)
+                  echo "features=" >> "$GITHUB_OUTPUT"
+                  echo "config=" >> "$GITHUB_OUTPUT"
+                  echo "appstore=false" >> "$GITHUB_OUTPUT"
                   case "${{ inputs.app }}" in
                     chuck-launcher)
+                      echo "project=chuck-launcher" >> "$GITHUB_OUTPUT"
                       echo "project_path=apps/chuckrpg/chuck-launcher" >> "$GITHUB_OUTPUT"
                       echo "notarize=true" >> "$GITHUB_OUTPUT"
                       echo "platforms=macos" >> "$GITHUB_OUTPUT" ;;
                     isometric)
+                      echo "project=isometric" >> "$GITHUB_OUTPUT"
                       echo "project_path=apps/kbve/isometric" >> "$GITHUB_OUTPUT"
                       echo "notarize=false" >> "$GITHUB_OUTPUT"
                       echo "platforms=linux,macos,windows,wasm" >> "$GITHUB_OUTPUT" ;;
                     desktop-kbve)
+                      # Developer ID / self-distributed: full-power DMG (global hotkey + auto-paste).
+                      echo "project=desktop-kbve" >> "$GITHUB_OUTPUT"
+                      echo "project_path=apps/kbve/desktop-kbve" >> "$GITHUB_OUTPUT"
+                      echo "notarize=true" >> "$GITHUB_OUTPUT"
+                      echo "platforms=linux,macos,windows" >> "$GITHUB_OUTPUT" ;;
+                    desktop-kbve-appstore)
+                      # Mac App Store: sandboxed variant. clipboard-only paste, no enigo inject.
+                      echo "project=desktop-kbve" >> "$GITHUB_OUTPUT"
                       echo "project_path=apps/kbve/desktop-kbve" >> "$GITHUB_OUTPUT"
                       echo "notarize=false" >> "$GITHUB_OUTPUT"
-                      echo "platforms=linux,macos,windows" >> "$GITHUB_OUTPUT" ;;
+                      echo "platforms=macos" >> "$GITHUB_OUTPUT"
+                      echo "features=appstore" >> "$GITHUB_OUTPUT"
+                      echo "config=src-tauri/tauri.appstore.conf.json" >> "$GITHUB_OUTPUT"
+                      echo "appstore=true" >> "$GITHUB_OUTPUT" ;;
                     *)
                       echo "unknown app: ${{ inputs.app }}" >&2; exit 1 ;;
                   esac
@@ -51,9 +73,12 @@ jobs:
         needs: resolve
         uses: ./.github/workflows/ci-tauri-builder.yml
         with:
-            project: ${{ inputs.app }}
+            project: ${{ needs.resolve.outputs.project }}
             project_path: ${{ needs.resolve.outputs.project_path }}
             app_name: ${{ inputs.app }}
             notarize: ${{ fromJSON(needs.resolve.outputs.notarize) }}
             platforms: ${{ needs.resolve.outputs.platforms }}
+            features: ${{ needs.resolve.outputs.features }}
+            config: ${{ needs.resolve.outputs.config }}
+            appstore: ${{ fromJSON(needs.resolve.outputs.appstore) }}
         secrets: inherit

--- a/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
+++ b/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
@@ -32,6 +32,13 @@ path = "src/main.rs"
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+default = []
+# Mac App Store variant: sandbox forbids injecting keystrokes into other apps,
+# so the paste path degrades to clipboard-only (user presses Cmd+V). Global
+# hotkey survives (global-hotkey uses Carbon RegisterEventHotKey, not CGEventTap).
+appstore = []
+
 [dependencies]
 erust = { path = "../../../../packages/rust/erust", default-features = false, features = ["tauri"] }
 tauri = { version = "2.9", features = [

--- a/apps/kbve/desktop-kbve/src-tauri/entitlements.appstore.plist
+++ b/apps/kbve/desktop-kbve/src-tauri/entitlements.appstore.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/kbve/desktop-kbve/src-tauri/src/clipboard.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/clipboard.rs
@@ -1,5 +1,9 @@
+#[cfg(not(feature = "appstore"))]
 use crate::input::{self, EnigoState};
-use crate::settings::{get_settings, ClipboardHandling, PasteMethod};
+#[cfg(not(feature = "appstore"))]
+use crate::settings::ClipboardHandling;
+use crate::settings::{get_settings, PasteMethod};
+#[cfg(not(feature = "appstore"))]
 use enigo::Enigo;
 use log::info;
 use tauri::{AppHandle, Manager};
@@ -11,6 +15,7 @@ use crate::utils::is_wayland;
 use std::process::Command;
 
 /// Pastes text using the clipboard: saves current content, writes text, sends paste keystroke, restores clipboard.
+#[cfg(not(feature = "appstore"))]
 fn paste_via_clipboard(
     enigo: &mut Enigo,
     text: &str,
@@ -349,6 +354,7 @@ fn send_key_combo_via_xdotool(paste_method: &PasteMethod) -> Result<(), String> 
 }
 
 /// Types text directly by simulating individual key presses.
+#[cfg(not(feature = "appstore"))]
 fn paste_direct(enigo: &mut Enigo, text: &str) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
@@ -361,6 +367,7 @@ fn paste_direct(enigo: &mut Enigo, text: &str) -> Result<(), String> {
     input::paste_text_direct(enigo, text)
 }
 
+#[cfg(not(feature = "appstore"))]
 pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     let settings = get_settings(&app_handle);
     let paste_method = settings.paste_method;
@@ -403,6 +410,39 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
             .write_text(&text)
             .map_err(|e| format!("Failed to copy to clipboard: {}", e))?;
     }
+
+    Ok(())
+}
+
+/// App Store (sandboxed) paste path. The macOS App Store sandbox forbids injecting
+/// keystrokes into other apps (no Accessibility / CGEvent posting), so we cannot
+/// auto-paste. Transcript is written to the clipboard and a `dictation-copied`
+/// event is emitted for the UI to prompt the user to press Cmd+V.
+#[cfg(feature = "appstore")]
+pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
+    use tauri::Emitter;
+
+    let settings = get_settings(&app_handle);
+
+    let text = if settings.append_trailing_space {
+        format!("{} ", text)
+    } else {
+        text
+    };
+
+    if settings.paste_method == PasteMethod::None {
+        info!("PasteMethod::None selected - skipping clipboard write");
+        return Ok(());
+    }
+
+    info!("App Store sandbox: writing transcript to clipboard (no auto-paste)");
+
+    let clipboard = app_handle.clipboard();
+    clipboard
+        .write_text(&text)
+        .map_err(|e| format!("Failed to write to clipboard: {}", e))?;
+
+    let _ = app_handle.emit("dictation-copied", &text);
 
     Ok(())
 }

--- a/apps/kbve/desktop-kbve/src-tauri/tauri.appstore.conf.json
+++ b/apps/kbve/desktop-kbve/src-tauri/tauri.appstore.conf.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schema.tauri.app/config/2",
+	"app": {
+		"macOSPrivateApi": false
+	},
+	"bundle": {
+		"targets": ["app"],
+		"category": "public.app-category.productivity",
+		"macOS": {
+			"entitlements": "entitlements.appstore.plist",
+			"minimumSystemVersion": "12.0"
+		}
+	}
+}


### PR DESCRIPTION
## What

Scaffolds a **Mac App Store** build variant for `desktop-kbve`, alongside the existing full-power **notarized DMG**. Two-file router+builder pattern, unchanged in shape:

- **Router** `ci-tauri.yml` — new `desktop-kbve-appstore` app entry
- **Builder** `ci-tauri-builder.yml` — `features`/`config`/`appstore` inputs + App Store Connect upload branch

## Platform split

- **desktop-kbve → Mac App Store** (this PR) + Developer ID DMG
- **iPhone/iOS → kbve-react-native** (`ci-react-native-ios.yml`), NOT desktop-kbve

## Sandbox reality

| Feature | DMG | App Store |
|---|---|---|
| global hotkey (chord) | ✓ | ✓ RegisterEventHotKey (not CGEventTap) |
| record + whisper STT | ✓ | ✓ (+ audio-input entitlement) |
| result → clipboard | ✓ | ✓ |
| auto-paste into other app | ✓ enigo | ✗ → clipboard-only + `dictation-copied` event (user Cmd+V) |

Only hard casualty is auto-paste (Accessibility/CGEvent forbidden in sandbox). Handy/Wispr/MacWhisper/Superwhisper all ship DMG for this reason — DMG variant stays full-power.

## Changes

- Cargo `appstore` feature; `clipboard.rs` `paste()` cfg-split (enigo inject vs clipboard-write + emit)
- `entitlements.appstore.plist`: app-sandbox, audio-input, network client, user-selected files
- `tauri.appstore.conf.json` overlay: `macOSPrivateApi: false`, `.app`-only bundle, productivity category, min macOS 12
- Builder App Store step: keychain import → codesign w/ entitlements → `productbuild` `.pkg` → `xcrun altool --upload-app`, **guarded on cert presence** (absent → warn + skip; sandboxed `.app` still built)

`cargo check --features appstore`: 0 errors.

## Secrets

Existing `APPLE_*` set is **Developer ID / notarization** — a different cert class than App Store. Reconciled:

**Reused (already set):** `APPLE_ID`, `APPLE_PASSWORD` (altool upload), `APPLE_TEAM_ID`.

**Still needed (App Store distribution certs — genuinely absent):**
- `APPLE_APPSTORE_CERTIFICATE` (+`_PASSWORD`) — base64 p12 holding **Apple Distribution** + **Mac Installer Distribution** certs
- `APPLE_APPSTORE_APP_IDENTITY` — e.g. `Apple Distribution: … (TEAMID)`
- `APPLE_APPSTORE_INSTALLER_IDENTITY` — e.g. `3rd Party Mac Developer Installer: … (TEAMID)`
- `APPLE_APPSTORE_PROVISIONING_PROFILE` — base64 Mac App Store `.provisionprofile`

## Follow-up (not in this PR)

- Verify overlay transparency survives `macOSPrivateApi: false`
- Verify Onichan sidecar bundling inside sandboxed `.app`
- Consider IMKit input-method for true sanctioned auto-insert (heavy, v2)