### PR TITLE
feat(agones-palworld): persistent hourly save backups

### DIFF
--- a/apps/kube/agones/palworld/manifests/backups-pvc.yaml
+++ b/apps/kube/agones/palworld/manifests/backups-pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: palworld-backups
+    namespace: palworld
+    labels:
+        app.kubernetes.io/part-of: palworld
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+        kbve.com/managed-by: argocd
+spec:
+    accessModes:
+        - ReadWriteOnce
+    storageClassName: longhorn
+    resources:
+        requests:
+            storage: 5Gi

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -35,6 +35,9 @@ spec:
                 - name: palworld-saves
                   persistentVolumeClaim:
                       claimName: palworld-saves
+                - name: palworld-backups
+                  persistentVolumeClaim:
+                      claimName: palworld-backups
                 - name: chat-relay
                   emptyDir: {}
             containers:
@@ -65,7 +68,7 @@ spec:
                       - name: COMMUNITY_SERVER
                         value: 'false'
                       - name: BACKUP_ENABLED
-                        value: 'false'
+                        value: 'true'
                       - name: RESTART_ENABLED
                         value: 'false'
                       - name: PLAYER_DETECTION_ENABLED
@@ -93,6 +96,8 @@ spec:
                   volumeMounts:
                       - name: palworld-saves
                         mountPath: /palworld/Pal/Saved
+                      - name: palworld-backups
+                        mountPath: /palworld/backups
                       - name: chat-relay
                         mountPath: /shared/chat
                   resources:


### PR DESCRIPTION
## Context — saves already persist (verified in-cluster)
- `/palworld/Pal/Saved` is the `palworld-saves` PVC (Longhorn); saves live there.
- The Wine world id (`DedicatedServerName=CB8B6E…`) is pinned in the WindowsServer `GameUserSettings.ini` **on the PVC** — so recreates reload the same world. Proven: the 0.0.5→0.0.6 GS recreate reused the world (no new world minted).

## Gap this fixes
- `BACKUP_ENABLED=false`, and even enabled the default `BACKUP_PATH=/palworld/backups` sat on the **ephemeral node disk** (only `Pal/Saved` was a PVC) → backups vanished on every recreate.
- ripps818's `backupmanager` tars **all of `Pal/Saved`**, so `BACKUP_PATH` cannot be nested inside the saves PVC (it would recurse). Backups need their own volume.

## Change
- New `palworld-backups` PVC (5Gi Longhorn) mounted at `/palworld/backups`.
- `BACKUP_ENABLED=true` → hourly `restapi_save` + tar snapshot, retention 72 (~150MB; saves are ~2MB).

Manifest-only — ArgoCD deploys, no image rebuild. Protects against corrupt/half-written saves from Wine crashes or mid-boot kills.