### PR TITLE
feat(reel): background state persister + structured Vector→ClickHouse telemetry

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -46,6 +46,8 @@ spec:
             - { name: REEL_STATE_FILE, value: "/data/reel-state.json" }
             - { name: REEL_TTL_SECS, value: "21600" }
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
+            - { name: RUST_LOG, value: "reel=info,warn" }
+            - { name: REEL_LOG_JSON, value: "true" }
           envFrom:
             - secretRef: { name: reel-api }
           ports:

--- a/apps/media/reel/Cargo.toml
+++ b/apps/media/reel/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 axum = { version = "0.8.5", features = ["macros", "json"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 librqbit = "8"

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -38,6 +38,13 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+fn served_bytes(range: Option<&str>, total: u64) -> u64 {
+    match crate::stream::parse_range(range, total) {
+        Ok(Some(r)) => r.end.saturating_sub(r.start) + 1,
+        _ => total,
+    }
+}
+
 fn check_auth(headers: &HeaderMap, token: &Option<String>) -> bool {
     match token {
         None => true,
@@ -219,6 +226,7 @@ async fn stream_file(
                 Ok(m) => m.len(),
                 Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             };
+            crate::telemetry::stream_served(&id, served_bytes(range, total), "progressive", range.is_some());
             crate::stream::serve_range(file, total, range, ct, head_only).await
         }
         state::TorrentState::Leeching => {
@@ -249,6 +257,7 @@ async fn stream_file(
                 Ok(s) => s,
                 Err(_) => return StatusCode::TOO_EARLY.into_response(),
             };
+            crate::telemetry::stream_served(&id, served_bytes(range, total), "leeching", range.is_some());
             crate::stream::serve_range(stream, total, range, ct, head_only).await
         }
         _ => StatusCode::CONFLICT.into_response(),
@@ -406,6 +415,7 @@ async fn hls_segment(
         Ok(m) => m.len(),
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
+    crate::telemetry::stream_served(&id, served_bytes(range, total), "hls", range.is_some());
     crate::stream::serve_range(file, total, range, ct, head_only).await
 }
 

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub api_addr: String,
     pub vpn_check_url: String,
     pub vpn_watchdog_secs: u64,
+    pub state_flush_ms: u64,
     pub upload_limit_bps: Option<u32>,
     pub api_token: Option<String>,
     pub transcode_enabled: bool,
@@ -49,6 +50,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         api_addr: env_or("REEL_API_ADDR", "0.0.0.0:8080"),
         vpn_check_url: env_or("REEL_VPN_CHECK_URL", "https://api.ipify.org"),
         vpn_watchdog_secs: env_u64("REEL_VPN_WATCHDOG_SECS", 60)?,
+        state_flush_ms: env_u64("REEL_STATE_FLUSH_MS", crate::state::DEFAULT_STATE_FLUSH_MS)?,
         upload_limit_bps: match env_u64("REEL_UPLOAD_LIMIT_BPS", 0)? {
             0 => None,
             n => Some(n.min(u32::MAX as u64) as u32),
@@ -73,7 +75,7 @@ mod tests {
     fn clear() {
         for k in ["REEL_TTL_SECS","REEL_REAP_INTERVAL_SECS","REEL_ACTIVE_DIR",
                   "REEL_LIBRARY_DIR","REEL_STATE_FILE","REEL_API_ADDR",
-                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
+                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_STATE_FLUSH_MS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
                   "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS"] {
@@ -89,6 +91,7 @@ mod tests {
         assert_eq!(c.ttl_secs, 21600);
         assert_eq!(c.reap_interval_secs, 300);
         assert_eq!(c.vpn_watchdog_secs, 60);
+        assert_eq!(c.state_flush_ms, 1000);
         assert!(c.upload_limit_bps.is_none());
         assert_eq!(c.active_dir, std::path::PathBuf::from("/data/active"));
         assert_eq!(c.api_addr, "0.0.0.0:8080");

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -120,9 +120,7 @@ impl Engine {
         let prev_ok = self.vpn_ok.load(Ordering::Relaxed);
         match next_vpn_action(prev_ok, now_ok) {
             VpnAction::Pause => {
-                tracing::error!(
-                    "vpn egress check failed; pausing all torrents (possible ip leak)"
-                );
+                crate::telemetry::vpn_leak();
                 for h in self.all_handles() {
                     if let Err(e) = self.session.pause(&h).await {
                         tracing::warn!(error = %e, "torrent pause failed");
@@ -130,7 +128,7 @@ impl Engine {
                 }
             }
             VpnAction::Resume => {
-                tracing::info!("vpn egress restored; resuming torrents");
+                crate::telemetry::vpn_restored();
                 for h in self.all_handles() {
                     if let Err(e) = self.session.unpause(&h).await {
                         tracing::warn!(error = %e, "torrent unpause failed");
@@ -178,13 +176,14 @@ impl Engine {
             hls_dir: None,
             hls_error: None,
         })?;
+        crate::telemetry::torrent_added(&id, source.split_once(':').map(|(s, _)| s).unwrap_or("unknown"));
 
         let store = self.store.clone();
         let library_dir = self.library_dir.clone();
         let id_task = id.clone();
         tokio::spawn(async move {
             if let Err(e) = handle.wait_until_completed().await {
-                tracing::error!(id = %id_task, error = %e, "torrent failed");
+                crate::telemetry::torrent_failed(&id_task, "download", &e.to_string());
                 let _ = store.update(&id_task, |m| {
                     m.state = state::TorrentState::Failed;
                     m.error = Some(format!("download failed: {e}"));
@@ -211,10 +210,10 @@ impl Engine {
                         hls_dir: None,
                         hls_error: None,
                     });
-                    tracing::info!(id = %id_task, "moved to library");
+                    crate::telemetry::torrent_completed(&id_task, moved.size);
                 }
                 Err(e) => {
-                    tracing::error!(id = %id_task, error = %e, "move failed");
+                    crate::telemetry::torrent_failed(&id_task, "move", &e.to_string());
                     let _ = store.update(&id_task, |m| {
                         m.state = state::TorrentState::Failed;
                         m.error = Some(format!("move failed: {e}"));
@@ -244,10 +243,9 @@ impl Engine {
             let meta = self.store.get(&id);
             match self.delete(&id).await {
                 Ok(true) => {
-                    if let Some(m) = meta {
-                        tracing::info!(id = %id, name = %m.name, size = m.size, "reaped");
-                    } else {
-                        tracing::info!(id = %id, "reaped");
+                    match meta {
+                        Some(m) => crate::telemetry::reaped(&id, &m.name, m.size),
+                        None => crate::telemetry::reaped(&id, "", 0),
                     }
                     reaped.push(id);
                 }
@@ -333,7 +331,7 @@ fn reconcile_on_start(store: &state::StateStore) {
                 m.error = Some("interrupted by restart; not resumable".into());
                 ((), true)
             });
-            tracing::warn!(id = %m.id, name = %m.name, "leeching torrent failed on restart (no session persistence)");
+            crate::telemetry::reconcile_failed(&m.id, &m.name);
         }
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -182,7 +182,7 @@ impl HlsManager {
         let this = self.clone();
         tokio::spawn(async move {
             if let Err(e) = this.run_hls(&id, &meta, delivery).await {
-                tracing::error!(id = %id, error = %e, "hls start failed");
+                crate::telemetry::hls_failed(&id, &e.to_string());
                 let _ = this.store.update(&id, |m| {
                     m.hls = HlsStatus::Failed;
                     m.hls_error = Some(e.to_string());

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -6,4 +6,5 @@ pub mod mover;
 pub mod reaper;
 pub mod state;
 pub mod stream;
+pub mod telemetry;
 pub mod transcode;

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -35,6 +35,8 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(engine::vpn_watchdog_loop(eng.clone(), cfg.vpn_watchdog_secs));
 
+    tokio::spawn(state::persist_loop(store.clone(), cfg.state_flush_ms));
+
     let app = api::router(api::AppState {
         engine: eng,
         store,

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -2,9 +2,19 @@ use reel::{api, config, engine, reaper, state};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let log_json = std::env::var("REEL_LOG_JSON")
+        .map(|v| !(v.eq_ignore_ascii_case("false") || v == "0"))
+        .unwrap_or(true);
+    let filter = tracing_subscriber::EnvFilter::from_default_env();
+    if log_json {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .json()
+            .flatten_event(true)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
 
     let cfg = config::load_from_env()?;
     let store = state::StateStore::load(cfg.state_file.clone())?;

--- a/apps/media/reel/src/state.rs
+++ b/apps/media/reel/src/state.rs
@@ -1,6 +1,13 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+
+static PERSIST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+pub const DEFAULT_STATE_FLUSH_MS: u64 = 1000;
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TorrentState { Leeching, Seeding, Reaped, Failed }
@@ -40,6 +47,7 @@ pub struct Metadata {
 pub struct StateStore {
     inner: Arc<Mutex<HashMap<String, Metadata>>>,
     path: PathBuf,
+    dirty: Arc<Notify>,
 }
 
 impl StateStore {
@@ -50,20 +58,41 @@ impl StateStore {
         } else {
             HashMap::new()
         };
-        Ok(Self { inner: Arc::new(Mutex::new(map)), path })
+        Ok(Self {
+            inner: Arc::new(Mutex::new(map)),
+            path,
+            dirty: Arc::new(Notify::new()),
+        })
     }
 
-    fn persist(&self, map: &HashMap<String, Metadata>) -> anyhow::Result<()> {
-        let tmp = self.path.with_extension("json.tmp");
-        std::fs::write(&tmp, serde_json::to_vec_pretty(map)?)?;
-        std::fs::rename(&tmp, &self.path)?;
+    fn write_file(path: &std::path::Path, map: &HashMap<String, Metadata>) -> anyhow::Result<()> {
+        let seq = PERSIST_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = path.with_extension(format!("json.tmp.{seq}"));
+        let bytes = serde_json::to_vec_pretty(map)?;
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, path)?;
         Ok(())
     }
 
+    fn snapshot(&self) -> HashMap<String, Metadata> {
+        self.inner.lock().unwrap().clone()
+    }
+
+    fn persist_now(&self) -> anyhow::Result<()> {
+        let snap = self.snapshot();
+        Self::write_file(&self.path, &snap)
+    }
+
+    pub fn flush(&self) -> anyhow::Result<()> {
+        self.persist_now()
+    }
+
     pub fn upsert(&self, m: Metadata) -> anyhow::Result<()> {
-        let mut g = self.inner.lock().unwrap();
-        g.insert(m.id.clone(), m);
-        self.persist(&g)
+        {
+            let mut g = self.inner.lock().unwrap();
+            g.insert(m.id.clone(), m);
+        }
+        self.persist_now()
     }
 
     pub fn get(&self, id: &str) -> Option<Metadata> {
@@ -75,17 +104,28 @@ impl StateStore {
     }
 
     pub fn touch(&self, id: &str, now: u64) -> anyhow::Result<bool> {
-        let mut g = self.inner.lock().unwrap();
-        match g.get_mut(id) {
-            Some(m) => { m.last_access = now; self.persist(&g)?; Ok(true) }
-            None => Ok(false),
+        let hit = {
+            let mut g = self.inner.lock().unwrap();
+            match g.get_mut(id) {
+                Some(m) => {
+                    m.last_access = now;
+                    true
+                }
+                None => false,
+            }
+        };
+        if hit {
+            self.dirty.notify_one();
         }
+        Ok(hit)
     }
 
     pub fn remove(&self, id: &str) -> anyhow::Result<Option<Metadata>> {
-        let mut g = self.inner.lock().unwrap();
-        let removed = g.remove(id);
-        self.persist(&g)?;
+        let removed = {
+            let mut g = self.inner.lock().unwrap();
+            g.remove(id)
+        };
+        self.persist_now()?;
         Ok(removed)
     }
 
@@ -93,18 +133,35 @@ impl StateStore {
     where
         F: FnOnce(&mut Metadata) -> (R, bool),
     {
-        let mut g = self.inner.lock().unwrap();
-        match g.get_mut(id) {
-            Some(m) => {
-                let (r, dirty) = f(m);
-                if dirty {
-                    let snap = g.clone();
-                    drop(g);
-                    self.persist(&snap)?;
+        let (result, dirty) = {
+            let mut g = self.inner.lock().unwrap();
+            match g.get_mut(id) {
+                Some(m) => {
+                    let (r, dirty) = f(m);
+                    (Some(r), dirty)
                 }
-                Ok(Some(r))
+                None => (None, false),
             }
-            None => Ok(None),
+        };
+        if dirty {
+            self.persist_now()?;
+        }
+        Ok(result)
+    }
+}
+
+pub async fn persist_loop(store: StateStore, debounce_ms: u64) {
+    loop {
+        store.dirty.notified().await;
+        if debounce_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(debounce_ms)).await;
+        }
+        let snap = store.snapshot();
+        let path = store.path.clone();
+        match tokio::task::spawn_blocking(move || StateStore::write_file(&path, &snap)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(error = %e, "state flush failed"),
+            Err(e) => tracing::warn!(error = %e, "state flush task panicked"),
         }
     }
 }
@@ -152,6 +209,38 @@ mod tests {
         assert!(s.touch("a", 999).unwrap());
         assert_eq!(s.get("a").unwrap().last_access, 999);
         assert!(!s.touch("missing", 1).unwrap());
+    }
+
+    #[test]
+    fn touch_defers_disk_write_until_flush() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        let s = StateStore::load(p.clone()).unwrap();
+        s.upsert(meta("a", 100)).unwrap();
+        s.touch("a", 999).unwrap();
+        assert_eq!(s.get("a").unwrap().last_access, 999);
+        assert_eq!(
+            StateStore::load(p.clone()).unwrap().get("a").unwrap().last_access,
+            100,
+            "touch must not hit disk inline"
+        );
+        s.flush().unwrap();
+        assert_eq!(
+            StateStore::load(p).unwrap().get("a").unwrap().last_access,
+            999,
+            "flush persists coalesced touches"
+        );
+    }
+
+    #[test]
+    fn upsert_and_remove_persist_synchronously() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        let s = StateStore::load(p.clone()).unwrap();
+        s.upsert(meta("a", 1)).unwrap();
+        assert!(StateStore::load(p.clone()).unwrap().get("a").is_some());
+        s.remove("a").unwrap();
+        assert!(StateStore::load(p).unwrap().get("a").is_none());
     }
 
     #[test]

--- a/apps/media/reel/src/telemetry.rs
+++ b/apps/media/reel/src/telemetry.rs
@@ -1,0 +1,52 @@
+//! Structured lifecycle events. Emitted as JSON on stdout, tailed by the
+//! cluster Vector DaemonSet (kubernetes_logs) into ClickHouse
+//! observability.logs_distributed. Each helper carries a stable `event`
+//! field so downstream queries do not depend on log message wording.
+
+pub fn torrent_added(id: &str, scheme: &str) {
+    tracing::info!(event = "torrent_added", id, scheme, "torrent added");
+}
+
+pub fn torrent_completed(id: &str, size: u64) {
+    tracing::info!(event = "torrent_completed", id, size, "torrent moved to library");
+}
+
+pub fn torrent_failed(id: &str, phase: &str, reason: &str) {
+    tracing::warn!(event = "torrent_failed", id, phase, reason, "torrent failed");
+}
+
+pub fn reaped(id: &str, name: &str, size: u64) {
+    tracing::info!(event = "reaped", id, name, size, "reaped");
+}
+
+pub fn reconcile_failed(id: &str, name: &str) {
+    tracing::warn!(
+        event = "reconcile_failed",
+        id,
+        name,
+        "leeching torrent failed on restart (no session persistence)"
+    );
+}
+
+pub fn transcode_failed(id: &str, reason: &str) {
+    tracing::error!(event = "transcode_failed", id, reason, "transcode failed");
+}
+
+pub fn hls_failed(id: &str, reason: &str) {
+    tracing::error!(event = "hls_failed", id, reason, "hls start failed");
+}
+
+pub fn stream_served(id: &str, bytes: u64, delivery: &str, partial: bool) {
+    tracing::info!(event = "stream_served", id, bytes, delivery, partial, "stream served");
+}
+
+pub fn vpn_leak() {
+    tracing::error!(
+        event = "vpn_leak",
+        "vpn egress check failed; pausing all torrents (possible ip leak)"
+    );
+}
+
+pub fn vpn_restored() {
+    tracing::info!(event = "vpn_restored", "vpn egress restored; resuming torrents");
+}

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -284,7 +284,7 @@ impl Transcoder {
         let this = self.clone();
         tokio::spawn(async move {
             if let Err(e) = this.run_job(&id, &meta).await {
-                tracing::error!(id = %id, error = %e, "transcode failed");
+                crate::telemetry::transcode_failed(&id, &e.to_string());
                 let _ = this.store.update(&id, |m| {
                     m.transcode = TranscodeStatus::Failed;
                     m.transcode_error = Some(e.to_string());


### PR DESCRIPTION
Two reel hardening items in one worktree (they share `main.rs`): perf (#6) and observability (#7). Both build on the merged watchdog/robustness work.

## #6 — Background state persister (perf)
Every `stream`/`manifest`/`hls_segment` request called `store.touch()`, which serialized and rewrote the **entire** state map (`write`+`rename`) **while holding the `std::Mutex`** on async runtime threads — full-map write per HTTP request, under lock, blocking the executor.

- **touch()** → in-memory update under a brief lock, then `Notify` a background task. Zero disk I/O on the request path.
- **persist_loop** (spawned in `main`) → `notified().await` → coalescing window (`REEL_STATE_FLUSH_MS`, default 1000) → snapshot → **`spawn_blocking`** the write (blocking fs off async workers). A burst of touches collapses to one write.
- Structural mutations (upsert/remove/update) still persist synchronously off-lock. Unique temp filenames per write (off-lock exposed a shared-`.tmp` race). `flush()` for tests/shutdown.

## #7 — Observability via Vector → ClickHouse (no Prometheus)
The cluster **Vector DaemonSet** (`kubernetes_logs`) already tails every pod's stdout into CH `observability.logs_distributed` (`parse_json` + `skip_unknown_fields`). So reel emits **structured JSON events** on stdout — no `/metrics` endpoint, no new deps, no CH table, no Vector change, no `:5500` push.

- `src/telemetry.rs`: canonical helpers with a stable `event` field (`torrent_added/completed/failed`, `reaped`, `reconcile_failed`, `transcode_failed`, `hls_failed`, `stream_served{bytes,delivery,partial}`, `vpn_leak/vpn_restored`). The audit's counters become events CH aggregates.
- `main.rs`: JSON log format (`REEL_LOG_JSON`, default on) with flattened fields so Vector lifts them into `metadata`; pretty fallback for dev.
- Instrumented engine/transcode/hls/api sites. `stream_served` reports range-aware served bytes per delivery mode.
- `reel.yaml`: `RUST_LOG=reel=info,warn` (EnvFilter enables nothing without it → info events dropped) + `REEL_LOG_JSON=true`. reel ns isn't in Vector's noise-filter list, so info is retained.

## Tests
`cargo test -p reel`: **96 passed**, clippy clean (pre-existing `stream.rs` warning untouched).

## Notes
- All new env vars default sanely. Manifest deltas (reel.yaml) apply on merge to main; code ships on the next reel version bump.
- Follow-ups: wire `flush()` into an axum graceful-shutdown; optional jedi `observ` → `:5500` error/panic feed into `telemetry.errors_raw` for the errors dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)