### PR TITLE
fix(palworld): resilient PalChatRelay chat capture (retry-forever + candidate probe)

### DIFF
--- a/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
@@ -2,19 +2,14 @@ local CHAT_LOG = os.getenv("PALWORLD_CHAT_LOG") or "/shared/chat/chat.log"
 local RETRY_MS = 15000
 
 local CANDIDATES = {
+    "/Script/Pal.PalGameStateInGame:BroadcastChatMessage",
     "/Script/Pal.PalNetworkChatManager:BroadcastChat",
     "/Script/Pal.PalNetworkChatManager:BroadcastChatMessage",
-    "/Script/Pal.PalNetworkChatManager:RecvChat",
-    "/Script/Pal.PalNetworkChatManager:OnRecvChatMessage",
-    "/Script/Pal.PalNetworkChatManager:ReceiveChatMessage",
-    "/Script/Pal.PalNetworkChatManager:SendChatMessage",
-    "/Script/Pal.PalPlayerControllerInGameForServer:RequestSendChat",
 }
 
 local CLASS_PROBES = {
+    "/Script/Pal.PalGameStateInGame",
     "/Script/Pal.PalNetworkChatManager",
-    "/Script/Pal.Default__PalNetworkChatManager",
-    "/Script/Pal.PalPlayerControllerInGameForServer",
 }
 
 local function log(msg)
@@ -42,10 +37,9 @@ end
 local function extract(param)
     local ok, player, text = pcall(function()
         local p = param:get()
-        local name = (p.SenderPlayerName and tostring(p.SenderPlayerName:ToString()))
+        local name = (p.Sender and tostring(p.Sender:ToString()))
+            or (p.SenderPlayerName and tostring(p.SenderPlayerName:ToString()))
             or (p.PlayerName and tostring(p.PlayerName:ToString()))
-            or (p.SenderName and tostring(p.SenderName:ToString()))
-            or (p.Name and tostring(p.Name:ToString()))
             or "?"
         local msg = (p.Message and tostring(p.Message:ToString()))
             or (p.Text and tostring(p.Text:ToString()))

--- a/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
@@ -1,5 +1,21 @@
 local CHAT_LOG = os.getenv("PALWORLD_CHAT_LOG") or "/shared/chat/chat.log"
-local CHAT_FUNC = "/Script/Pal.PalNetworkChatManager:BroadcastChat"
+local RETRY_MS = 15000
+
+local CANDIDATES = {
+    "/Script/Pal.PalNetworkChatManager:BroadcastChat",
+    "/Script/Pal.PalNetworkChatManager:BroadcastChatMessage",
+    "/Script/Pal.PalNetworkChatManager:RecvChat",
+    "/Script/Pal.PalNetworkChatManager:OnRecvChatMessage",
+    "/Script/Pal.PalNetworkChatManager:ReceiveChatMessage",
+    "/Script/Pal.PalNetworkChatManager:SendChatMessage",
+    "/Script/Pal.PalPlayerControllerInGameForServer:RequestSendChat",
+}
+
+local CLASS_PROBES = {
+    "/Script/Pal.PalNetworkChatManager",
+    "/Script/Pal.Default__PalNetworkChatManager",
+    "/Script/Pal.PalPlayerControllerInGameForServer",
+}
 
 local function log(msg)
     print("[PalChatRelay] " .. msg)
@@ -23,38 +39,70 @@ local function append(player, text)
     f:close()
 end
 
-local function on_chat(self, chat_param)
+local function extract(param)
     local ok, player, text = pcall(function()
-        local p = chat_param:get()
-        return tostring(p.SenderPlayerName:ToString()), tostring(p.Message:ToString())
+        local p = param:get()
+        local name = (p.SenderPlayerName and tostring(p.SenderPlayerName:ToString()))
+            or (p.PlayerName and tostring(p.PlayerName:ToString()))
+            or (p.SenderName and tostring(p.SenderName:ToString()))
+            or (p.Name and tostring(p.Name:ToString()))
+            or "?"
+        local msg = (p.Message and tostring(p.Message:ToString()))
+            or (p.Text and tostring(p.Text:ToString()))
+            or (p.ChatText and tostring(p.ChatText:ToString()))
+            or (p.Chat and tostring(p.Chat:ToString()))
+            or ""
+        return name, msg
     end)
-    if ok and player and text and #text > 0 then
+    if ok then
+        return player, text
+    end
+    return nil, nil
+end
+
+local function on_chat(self, a, b)
+    local player, text = extract(a)
+    if (not text or #text == 0) and b ~= nil then
+        player, text = extract(b)
+    end
+    if player and text and #text > 0 then
         append(player, text)
     end
 end
 
+local function probe_classes()
+    for _, c in ipairs(CLASS_PROBES) do
+        local ok, obj = pcall(StaticFindObject, c)
+        local found = ok and obj and obj:IsValid()
+        log("probe " .. c .. " -> " .. (found and "FOUND" or "absent"))
+    end
+end
+
 local registered = false
+
 local function try_register()
     if registered then
+        return true
+    end
+    for _, fn in ipairs(CANDIDATES) do
+        if pcall(RegisterHook, fn, on_chat) then
+            registered = true
+            log("chat hook registered on " .. fn)
+            return true
+        end
+    end
+    return false
+end
+
+local function schedule()
+    if try_register() then
         return
     end
-    if pcall(RegisterHook, CHAT_FUNC, on_chat) then
-        registered = true
-        log("chat hook registered on " .. CHAT_FUNC)
-    else
-        log("chat function not ready; will retry")
-    end
+    probe_classes()
+    log("no chat candidate resolved; retrying in " .. (RETRY_MS / 1000) .. "s")
+    pcall(ExecuteWithDelay, RETRY_MS, schedule)
 end
 
-log("loaded; chat log = " .. CHAT_LOG)
-
--- The chat manager class is not loaded at mod-init; defer registration so
--- RegisterHook does not error at startup. Retry a few times as the world loads.
-try_register()
-if not registered then
-    pcall(function()
-        ExecuteWithDelay(20000, try_register)
-        ExecuteWithDelay(60000, try_register)
-        ExecuteWithDelay(120000, try_register)
-    end)
-end
+log("loaded; chat log = " .. CHAT_LOG .. "; capture v2 (retry-forever + probe)")
+probe_classes()
+schedule()

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.7"
+version: "0.0.8"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -42,7 +42,7 @@ spec:
                   emptyDir: {}
             containers:
                 - name: palworld
-                  image: ghcr.io/kbve/agones-palworld:0.0.7
+                  image: ghcr.io/kbve/agones-palworld:0.0.8
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: PUID


### PR DESCRIPTION
## Fix Palworld → IRC outbound chat capture

**Problem:** Discord→IRC→Palworld works (REST `/announce`), but in-game chat never reaches IRC. Root cause on live build `v1.0.1.100619`:
- PalChatRelay Lua hooked `/Script/Pal.PalNetworkChatManager:BroadcastChat`, which **never resolves** on this build — `RegisterHook` throws every attempt (`pcall` → "chat function not ready").
- The mod **gave up after 120s** (3 `ExecuteWithDelay` tries). With the server broken 14h (0 players), the chat manager class likely never instantiated, and retries stopped before any player could join.

So the hook never attached → `chat.log` never written → `chat_tail` had nothing to relay.

**Fix** (`mods/PalChatRelay/scripts/main.lua`, UE4SS v3.0.1):
- **Retry forever** (recursive `ExecuteWithDelay`, 15s) — self-heals if the class only resolves once a client connects.
- **Candidate list** of chat functions; `pcall`-register the first that attaches (wrong ones throw, caught). Logs the winner.
- **Class-existence probes** (`StaticFindObject`) logged each pass — if nothing attaches, logs reveal whether `PalNetworkChatManager` exists, guiding a fast follow-up.
- Player/text extraction tolerant of field-name and arg-position variants.

Additive only; inbound `/announce` path untouched. Relay `chat_tail`/dedup unchanged.

**Verification:** `luac -p` clean. Container e2e (CI) still asserts `PalChatRelay] loaded`. Post-deploy: a player chats in-game → read `UE4SS.log` to confirm which candidate attached (the probe logs pin the real function name if the list needs refining).

**Version:** MDX `agones-palworld` → `0.0.8` (publish lever); gameserver image pinned `0.0.8`. `version.toml` synced by pipeline.

### Docs
- [agones-palworld.mdx](https://github.com/KBVE/kbve/blob/palworld-chat-capture/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx)
