### PR TITLE
fix(palworld): drop SYSTEM chat spam + real prestop restart warning (v0.0.9)

### DIFF
--- a/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
@@ -59,7 +59,7 @@ local function on_chat(self, a, b)
     if (not text or #text == 0) and b ~= nil then
         player, text = extract(b)
     end
-    if player and text and #text > 0 then
+    if player and text and #text > 0 and player:upper() ~= "SYSTEM" then
         append(player, text)
     end
 end

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.8"
+version: "0.0.9"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -42,7 +42,7 @@ spec:
                   emptyDir: {}
             containers:
                 - name: palworld
-                  image: ghcr.io/kbve/agones-palworld:0.0.8
+                  image: ghcr.io/kbve/agones-palworld:0.0.9
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: PUID


### PR DESCRIPTION
## Palworld relay + restart polish (v0.0.9)

Follow-up to #14599 (chat capture, live on 0.0.8). Two fixes, both in the 0.0.9 image:

### 1. Drop SYSTEM-sender chat from the IRC relay
The `PalGameStateInGame:BroadcastChatMessage` hook also fires for the base image's hourly auto-save / auto-backup announcements (`Sender=SYSTEM`), which flooded IRC:
```
[IRC] palworld-bot: <SYSTEM> [20:00:00] Saving in 5 seconds...
[IRC] palworld-bot: <SYSTEM> [20:00:20] Backup done
```
`on_chat` now skips `Sender==SYSTEM` — relay only real player chat. Every spam line in the live `chat.log` is `\tSYSTEM\t…`, so the filter is exact.

### 2. Make the prestop 30s restart warning real
`shim/agones-shim-prestop.sh` announced "Server restarting in 30s" then **returned immediately**. k8s only defers SIGTERM until preStop returns, so the base image's save-and-exit trap fired ~1s later — the countdown never happened:
```
<SYSTEM> Server restarting in 30s — progress will be saved.
<SYSTEM> Restarting now. See you in a minute.
<SYSTEM> [20:25:28] Server shutdown requested. Saving...
<SYSTEM> [20:25:29] Saving done. Server shutting down...    ← 1s, not 30s
```
The shim now `sleep`s `WARN_SECS` (holding the pod open so termination is genuinely deferred), then requests the graceful save+shutdown. `terminationGracePeriodSeconds` is 120s, well above the 30s default.

**Verification:** `luac -p` + `sh -n` clean. Container e2e (CI) unchanged.
**Version:** MDX `agones-palworld` → `0.0.9`; gameserver image `0.0.9`. `version.toml` synced by pipeline.
