### PR TITLE
fix(palworld): real prestop 30s restart warning (v0.0.10)

### DIFF
--- a/apps/agones/palworld/shim/agones-shim-prestop.sh
+++ b/apps/agones/palworld/shim/agones-shim-prestop.sh
@@ -14,15 +14,21 @@ fi
 base="http://${REST_HOST}:${REST_PORT}/v1/api"
 auth="admin:${ADMIN_PASS}"
 
-echo "[prestop] announcing restart"
+echo "[prestop] announcing restart (${WARN_SECS}s warning)"
 curl -fsS -u "$auth" -X POST "$base/announce" \
     -H 'Content-Type: application/json' \
     -d "{\"message\":\"Server restarting in ${WARN_SECS}s — progress will be saved.\"}" >/dev/null 2>&1 || true
 
+if [ "$WARN_SECS" -gt 0 ] 2>/dev/null; then
+    sleep "$WARN_SECS"
+fi
+
 echo "[prestop] requesting graceful shutdown (save)"
 curl -fsS -u "$auth" -X POST "$base/shutdown" \
     -H 'Content-Type: application/json' \
-    -d "{\"waittime\":${WARN_SECS},\"message\":\"Restarting now. See you in a minute.\"}" >/dev/null 2>&1 || true
+    -d "{\"waittime\":1,\"message\":\"Restarting now. See you in a minute.\"}" >/dev/null 2>&1 || true
+
+sleep 3
 
 echo "[prestop] done"
 exit 0

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.9"
+version: "0.0.10"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Make the prestop 30s restart warning real (v0.0.10)

`shim/agones-shim-prestop.sh` announced "Server restarting in 30s" then **returned immediately**. k8s only defers SIGTERM until the preStop hook returns, so the base image's save-and-exit trap fired ~1s later — the countdown never happened:

```
<SYSTEM> Server restarting in 30s — progress will be saved.
<SYSTEM> Restarting now. See you in a minute.
<SYSTEM> [20:25:28] Server shutdown requested. Saving...
<SYSTEM> [20:25:29] Saving done. Server shutting down...   ← 1s, not 30s
```

**Fix:** the shim now `sleep`s `WARN_SECS` (holding the pod open so k8s genuinely defers termination for the warning window), then requests the graceful save+shutdown. `terminationGracePeriodSeconds` is 120s, well above the 30s default. Guarded against a non-numeric `PRESTOP_WARN_SECS`.

**Verification:** `sh -n` clean.
**Version:** MDX `agones-palworld` → `0.0.10` only; the gameserver image tag is synced from MDX by the manifest pipeline (not hand-edited).
