### PR TITLE
Atomic: agones-palworld v0.0.10 post-publish sync

### DIFF
--- a/apps/agones/palworld/version.toml
+++ b/apps/agones/palworld/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.9"
+version = "0.0.10"

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -42,7 +42,7 @@ spec:
                   emptyDir: {}
             containers:
                 - name: palworld
-                  image: ghcr.io/kbve/agones-palworld:0.0.9
+                  image: ghcr.io/kbve/agones-palworld:0.0.10
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: PUID


### PR DESCRIPTION
Post-publish sync v0.0.10 (version.toml + gameserver.yaml -> 0.0.10). Recovers stuck release-bot sync (transient GraphQL error blocked its gh pr create; rerun guard skips existing branch). 0.0.10 image already published; unblocks ArgoCD adopting the 30s prestop-warning fix.