### PR TITLE
fix(reel): mid-stream short-read guard + now_secs dedup + auth/config hardening

### DIFF
--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -31,12 +31,7 @@ impl From<&AppState> for AppStateStub {
     }
 }
 
-fn now_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
+use crate::util::now_secs;
 
 fn served_bytes(range: Option<&str>, total: u64) -> u64 {
     match crate::stream::parse_range(range, total) {
@@ -45,13 +40,25 @@ fn served_bytes(range: Option<&str>, total: u64) -> u64 {
     }
 }
 
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 fn check_auth(headers: &HeaderMap, token: &Option<String>) -> bool {
     match token {
         None => true,
         Some(t) => headers
             .get("Authorization")
             .and_then(|h| h.to_str().ok())
-            .map(|h| h == format!("Bearer {t}"))
+            .and_then(|h| h.strip_prefix("Bearer "))
+            .map(|got| ct_eq(got.as_bytes(), t.as_bytes()))
             .unwrap_or(false),
     }
 }
@@ -70,7 +77,7 @@ fn check_auth_q(headers: &HeaderMap, query: Option<&str>, token: &Option<String>
     if check_auth(headers, token) {
         return true;
     }
-    matches!(token, Some(t) if token_from_query(query).as_deref() == Some(t.as_str()))
+    matches!((token, token_from_query(query)), (Some(t), Some(q)) if ct_eq(q.as_bytes(), t.as_bytes()))
 }
 
 async fn list(State(st): State<AppStateStub>, headers: HeaderMap) -> impl IntoResponse {
@@ -576,6 +583,24 @@ mod tests {
         let mut h = HeaderMap::new();
         h.insert("Authorization", format!("Bearer {token}").parse().unwrap());
         h
+    }
+
+    #[test]
+    fn ct_eq_matches_only_equal_slices() {
+        assert!(ct_eq(b"secret", b"secret"));
+        assert!(!ct_eq(b"secret", b"secreu"));
+        assert!(!ct_eq(b"secret", b"secre"));
+        assert!(!ct_eq(b"", b"x"));
+        assert!(ct_eq(b"", b""));
+    }
+
+    #[test]
+    fn check_auth_accepts_correct_bearer_rejects_wrong() {
+        let tok = Some("tok123".to_string());
+        assert!(check_auth(&bearer("tok123"), &tok));
+        assert!(!check_auth(&bearer("wrong"), &tok));
+        assert!(!check_auth(&HeaderMap::new(), &tok));
+        assert!(check_auth(&HeaderMap::new(), &None));
     }
 
     fn store_with_one() -> StateStore {

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -36,6 +36,7 @@ fn env_u64(key: &str, default: u64) -> anyhow::Result<u64> {
 
 fn env_bool(key: &str, default: bool) -> bool {
     match std::env::var(key) {
+        Ok(v) if v.trim().is_empty() => default,
         Ok(v) => !(v.eq_ignore_ascii_case("false") || v == "0"),
         Err(_) => default,
     }
@@ -155,6 +156,17 @@ mod tests {
         let c2 = load_from_env().unwrap();
         assert!(!c2.transcode_enabled);
         assert_eq!(c2.encode_concurrency, 2);
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn env_bool_empty_falls_back_to_default() {
+        clear();
+        std::env::set_var("REEL_TRANSCODE_ENABLED", "");
+        assert!(load_from_env().unwrap().transcode_enabled, "empty must not read as false");
+        std::env::set_var("REEL_STREAM_ENABLED", "   ");
+        assert!(load_from_env().unwrap().stream_enabled, "whitespace must not read as false");
         clear();
     }
 

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -1,13 +1,17 @@
 use crate::{config, mover, state};
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use librqbit::api::TorrentIdOrHash;
 use librqbit::{AddTorrent, AddTorrentOptions, ManagedTorrent, Session, SessionPersistenceConfig};
 use tokio::io::{AsyncRead, AsyncSeek};
+use tokio::sync::Notify;
 
 pub fn is_vpn_ip(ip: IpAddr) -> bool {
     match ip {
@@ -35,12 +39,7 @@ pub async fn vpn_preflight(check_url: &str) -> anyhow::Result<IpAddr> {
     Ok(ip)
 }
 
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
+use crate::util::now_secs;
 
 static ADD_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -76,7 +75,11 @@ pub struct Engine {
     library_dir: PathBuf,
     vpn_check_url: String,
     vpn_ok: Arc<AtomicBool>,
+    active_leech: Arc<Mutex<HashMap<String, u32>>>,
+    drain: Arc<Notify>,
 }
+
+const LEECH_DRAIN_CAP: Duration = Duration::from_secs(6 * 3600);
 
 impl Engine {
     pub async fn start(cfg: &config::Config, store: state::StateStore) -> anyhow::Result<Self> {
@@ -107,6 +110,8 @@ impl Engine {
             library_dir: cfg.library_dir.clone(),
             vpn_check_url: cfg.vpn_check_url.clone(),
             vpn_ok: Arc::new(AtomicBool::new(true)),
+            active_leech: Arc::new(Mutex::new(HashMap::new())),
+            drain: Arc::new(Notify::new()),
         };
         engine.resume_on_start();
         Ok(engine)
@@ -199,6 +204,8 @@ impl Engine {
         let store = self.store.clone();
         let library_dir = self.library_dir.clone();
         let session = self.session.clone();
+        let active_leech = self.active_leech.clone();
+        let drain = self.drain.clone();
         tokio::spawn(async move {
             if let Err(e) = handle.wait_until_completed().await {
                 crate::telemetry::torrent_failed(&id, "download", &e.to_string());
@@ -231,6 +238,7 @@ impl Engine {
                         hls_error: None,
                     });
                     crate::telemetry::torrent_completed(&id, moved.size);
+                    wait_leech_drained(&active_leech, &drain, &id).await;
                     delete_from_session(&session, &id, false).await;
                 }
                 Err(e) => {
@@ -365,6 +373,86 @@ impl Engine {
             .ok_or_else(|| anyhow::anyhow!("no managed torrent for id {id}"))?;
         handle.stream(file_id)
     }
+
+    fn leech_enter(&self, id: &str) -> LeechGuard {
+        *self
+            .active_leech
+            .lock()
+            .unwrap()
+            .entry(id.to_string())
+            .or_insert(0) += 1;
+        LeechGuard {
+            active: self.active_leech.clone(),
+            drain: self.drain.clone(),
+            id: id.to_string(),
+        }
+    }
+}
+
+pub struct LeechGuard {
+    active: Arc<Mutex<HashMap<String, u32>>>,
+    drain: Arc<Notify>,
+    id: String,
+}
+
+impl Drop for LeechGuard {
+    fn drop(&mut self) {
+        {
+            let mut g = self.active.lock().unwrap();
+            if let Some(n) = g.get_mut(&self.id) {
+                *n = n.saturating_sub(1);
+                if *n == 0 {
+                    g.remove(&self.id);
+                }
+            }
+        }
+        self.drain.notify_waiters();
+    }
+}
+
+struct GuardedReader<R> {
+    inner: R,
+    _guard: LeechGuard,
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for GuardedReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<R: AsyncSeek + Unpin> AsyncSeek for GuardedReader<R> {
+    fn start_seek(mut self: Pin<&mut Self>, position: std::io::SeekFrom) -> std::io::Result<()> {
+        Pin::new(&mut self.inner).start_seek(position)
+    }
+    fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<u64>> {
+        Pin::new(&mut self.inner).poll_complete(cx)
+    }
+}
+
+async fn wait_leech_drained(
+    active: &Arc<Mutex<HashMap<String, u32>>>,
+    drain: &Arc<Notify>,
+    id: &str,
+) {
+    let fut = async {
+        loop {
+            let notified = drain.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if active.lock().unwrap().get(id).copied().unwrap_or(0) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    };
+    if tokio::time::timeout(LEECH_DRAIN_CAP, fut).await.is_err() {
+        tracing::warn!(id = %id, "leech stream drain timed out; deleting torrent anyway");
+    }
 }
 
 pub trait ReadSeek: AsyncRead + AsyncSeek + Send + Unpin {}
@@ -380,7 +468,12 @@ impl MediaSource for Engine {
         self.list_files(id)
     }
     fn open(&self, id: &str, file_id: usize) -> anyhow::Result<Box<dyn ReadSeek>> {
-        Ok(Box::new(self.open_stream(id, file_id)?))
+        let reader = self.open_stream(id, file_id)?;
+        let guard = self.leech_enter(id);
+        Ok(Box::new(GuardedReader {
+            inner: reader,
+            _guard: guard,
+        }))
     }
 }
 
@@ -441,6 +534,54 @@ mod tests {
         assert!(!needs_resume_watch(&Seeding));
         assert!(!needs_resume_watch(&Failed));
         assert!(!needs_resume_watch(&Reaped));
+    }
+
+    fn mk_guard(
+        active: &Arc<Mutex<HashMap<String, u32>>>,
+        drain: &Arc<Notify>,
+        id: &str,
+    ) -> LeechGuard {
+        *active.lock().unwrap().entry(id.to_string()).or_insert(0) += 1;
+        LeechGuard {
+            active: active.clone(),
+            drain: drain.clone(),
+            id: id.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_returns_immediately_when_no_streams() {
+        let active = Arc::new(Mutex::new(HashMap::new()));
+        let drain = Arc::new(Notify::new());
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            wait_leech_drained(&active, &drain, "none"),
+        )
+        .await
+        .expect("must return without waiting");
+    }
+
+    #[tokio::test]
+    async fn drain_waits_until_all_guards_dropped() {
+        let active = Arc::new(Mutex::new(HashMap::new()));
+        let drain = Arc::new(Notify::new());
+        let g1 = mk_guard(&active, &drain, "x");
+        let g2 = mk_guard(&active, &drain, "x");
+
+        let (a2, d2) = (active.clone(), drain.clone());
+        let waiter = tokio::spawn(async move { wait_leech_drained(&a2, &d2, "x").await });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished(), "two streams in flight");
+        drop(g1);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished(), "one still in flight");
+        drop(g2);
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("drain must complete after last guard drops")
+            .unwrap();
+        assert!(active.lock().unwrap().get("x").is_none(), "entry cleaned up");
     }
 
     #[test]

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -8,3 +8,4 @@ pub mod state;
 pub mod stream;
 pub mod telemetry;
 pub mod transcode;
+pub mod util;

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -25,12 +25,7 @@ pub fn select_expired(items: &[state::Metadata], ttl_secs: u64, now: u64) -> Vec
         .collect()
 }
 
-fn now_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
+use crate::util::now_secs;
 
 pub async fn reap_loop(
     engine: crate::engine::Engine,

--- a/apps/media/reel/src/util.rs
+++ b/apps/media/reel/src/util.rs
@@ -1,0 +1,8 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}


### PR DESCRIPTION
**Stacks on #14609 (restart-resume)** — merge that first; until then this PR's diff shows both commits.

## #9 — mid-stream short-read (the substantive fix)
A Leeching progressive stream serves via librqbit's `FileStream`, which reads through the torrent's **cached file descriptors** (`FilesystemStorage.opened_files[id].read_exact_at`). On Unix those FDs survive the completion move — `rename`/unlink keeps the inode alive for an open FD — so the file move is transparent to an in-flight reader. The **only** hard break is deleting the torrent from the session, which the completion watcher now does (#14609) so persistence won't resurrect moved-away data on restart.

Fix: reference-count in-flight Leeching streams with an RAII `LeechGuard` embedded in the returned reader, and **defer `session.delete` until they drain** (capped at 6h). Completion no longer snaps a live stream. New Leeching requests can't appear after the state flips to Seeding, so the count drains monotonically; drain wakeups are race-safe via a pre-armed `Notify` (`enable()` before the count check).

## #10 — dedup
`now_secs` was copy-pasted in engine/reaper/api → single `crate::util::now_secs`.

## Minors
- **Constant-time token compare** (`ct_eq`) on both the `Authorization` header and the `?access_token=` query param, replacing `==` (timing side-channel on the service token).
- `env_bool` empty/whitespace value → **bool default** instead of reading as `true` (e.g. `REEL_TRANSCODE_ENABLED=""` no longer silently enables).

## Tests
`cargo test -p reel`: **110 passed** (+5: drain-immediate, drain-waits-until-drained, ct_eq, check_auth, env_bool-empty). Clippy clean (only pre-existing `stream.rs` `Result<_,()>`).

Left on backlog: transcode outcome-match micro-dup + api.rs file split (cosmetic, low value); access-log `access_token` exposure is an ingress/proxy concern, not reel.