### PR TITLE
feat(graph): unify /graph/ into one graph, fused at the wrapper level

### DIFF
--- a/apps/kbve/astro-kbve/public/graphify/overview.json
+++ b/apps/kbve/astro-kbve/public/graphify/overview.json
@@ -1,1 +1,1115 @@
-{"meta":{"dirs":69,"files":6502,"symbols":66742,"dirEdges":135,"built_at_commit":"bd099ec97dcc1eebab335c4db83194a74166b848","scale":6000.0,"relations":["imports","calls","references","contains","extends","other"]},"dirs":[{"id":"_agents__skills","label":".agents/skills","x":-964.48,"y":-29.29,"r":85.68,"n":36,"files":2,"c":936},{"id":"_eslintrc_json","label":".eslintrc.json","x":-2835.6,"y":-880.08,"r":76.56,"n":4,"files":1,"c":2819},{"id":"_github__deprecated","label":".github/deprecated","x":-2948.5,"y":-264.22,"r":83.62,"n":26,"files":4,"c":1791},{"id":"_github__scripts","label":".github/scripts","x":171.13,"y":-611.37,"r":86.05,"n":38,"files":5,"c":1703},{"id":"_github__skills","label":".github/skills","x":-302.32,"y":636.91,"r":85.68,"n":36,"files":2,"c":960},{"id":"_husky__pre-push","label":".husky/pre-push","x":343.55,"y":-2797.58,"r":75.22,"n":2,"files":1,"c":4185},{"id":"_opencode__skills","label":".opencode/skills","x":-994.88,"y":350.54,"r":85.68,"n":36,"files":2,"c":963},{"id":"_prettierrc_mjs","label":".prettierrc.mjs","x":1025.75,"y":2763.96,"r":74.28,"n":1,"files":1,"c":12617},{"id":"@astrojs__starlight","label":"@astrojs/starlight","x":-229.28,"y":920.35,"r":77.58,"n":6,"files":6,"c":355},{"id":"apps__agones","label":"apps/agones","x":-230.9,"y":1299.96,"r":182.04,"n":2331,"files":222,"c":17},{"id":"apps__angelscript","label":"apps/angelscript","x":2799.83,"y":-367.41,"r":80.22,"n":13,"files":1,"c":1575},{"id":"apps__chuckrpg","label":"apps/chuckrpg","x":474.28,"y":-852.62,"r":131.26,"n":676,"files":105,"c":305},{"id":"apps__cryptothrone","label":"apps/cryptothrone","x":-1059.15,"y":-490.86,"r":140.87,"n":913,"files":164,"c":23},{"id":"apps__deathslayer","label":"apps/deathslayer","x":-37.19,"y":446.13,"r":98.48,"n":135,"files":12,"c":601},{"id":"apps__discordsh","label":"apps/discordsh","x":-438.7,"y":-1432.0,"r":184.47,"n":2435,"files":185,"c":10},{"id":"apps__herbmail","label":"apps/herbmail","x":630.44,"y":1133.83,"r":170.14,"n":1854,"files":241,"c":41},{"id":"apps__irc","label":"apps/irc","x":-348.56,"y":301.55,"r":124.82,"n":537,"files":89,"c":465},{"id":"apps__jobboard","label":"apps/jobboard","x":132.15,"y":1023.49,"r":131.96,"n":692,"files":77,"c":14},{"id":"apps__kbve","label":"apps/kbve","x":670.74,"y":-1380.0,"r":311.53,"n":11045,"files":1345,"c":39},{"id":"apps__kube","label":"apps/kube","x":428.7,"y":-81.51,"r":89.95,"n":62,"files":26,"c":2589},{"id":"apps__mc","label":"apps/mc","x":521.32,"y":-452.97,"r":151.15,"n":1206,"files":149,"c":220},{"id":"apps__memes","label":"apps/memes","x":-1012.26,"y":692.96,"r":132.9,"n":714,"files":74,"c":36},{"id":"apps__metrics","label":"apps/metrics","x":180.0,"y":-303.53,"r":101.45,"n":167,"files":13,"c":424},{"id":"apps__pydesk","label":"apps/pydesk","x":250.07,"y":592.47,"r":103.91,"n":196,"files":11,"c":232},{"id":"apps__rareicon","label":"apps/rareicon","x":-763.37,"y":-962.03,"r":266.75,"n":7301,"files":643,"c":7},{"id":"apps__rentearth","label":"apps/rentearth","x":1081.08,"y":614.83,"r":173.24,"n":1973,"files":214,"c":90},{"id":"apps__rows","label":"apps/rows","x":-641.49,"y":554.25,"r":141.95,"n":942,"files":61,"c":49},{"id":"apps__vm","label":"apps/vm","x":371.87,"y":257.1,"r":132.9,"n":714,"files":49,"c":155},{"id":"apps__windmill","label":"apps/windmill","x":-667.03,"y":-43.73,"r":92.13,"n":78,"files":17,"c":2027},{"id":"astro:components","label":"astro:components","x":-777.63,"y":-309.0,"r":74.28,"n":1,"files":1,"c":236},{"id":"astro:content","label":"astro:content","x":-740.79,"y":233.01,"r":74.28,"n":1,"files":1,"c":505},{"id":"babel_config_json","label":"babel.config.json","x":953.36,"y":-2704.74,"r":75.22,"n":2,"files":1,"c":3526},{"id":"d3-geo","label":"d3-geo","x":-1481.53,"y":2675.44,"r":74.28,"n":1,"files":1,"c":12453},{"id":"glbclips_mjs","label":"glbclips.mjs","x":2791.09,"y":1042.95,"r":77.1,"n":5,"files":1,"c":3031},{"id":"gsap","label":"gsap","x":-852.82,"y":2785.05,"r":74.28,"n":1,"files":1,"c":12462},{"id":"gsap__Observer","label":"gsap/Observer","x":-67.86,"y":-464.85,"r":74.28,"n":1,"files":1,"c":608},{"id":"gsap__ScrollTrigger","label":"gsap/ScrollTrigger","x":-612.46,"y":-526.4,"r":74.28,"n":1,"files":1,"c":608},{"id":"kbve_sh","label":"kbve.sh","x":-315.24,"y":-775.18,"r":85.29,"n":34,"files":1,"c":766},{"id":"marked","label":"marked","x":-1940.65,"y":2285.12,"r":74.28,"n":1,"files":1,"c":12463},{"id":"node:fs","label":"node:fs","x":406.52,"y":846.32,"r":74.28,"n":1,"files":1,"c":1289},{"id":"node:url","label":"node:url","x":-228.45,"y":-249.6,"r":74.28,"n":1,"files":1,"c":1289},{"id":"nx_json","label":"nx.json","x":2971.46,"y":280.46,"r":91.74,"n":75,"files":1,"c":1372},{"id":"package_json","label":"package.json","x":726.34,"y":186.11,"r":108.61,"n":258,"files":1,"c":33},{"id":"packages__data","label":"packages/data","x":-605.97,"y":995.7,"r":180.92,"n":2284,"files":82,"c":25},{"id":"packages__docker","label":"packages/docker","x":772.95,"y":-156.82,"r":117.47,"n":398,"files":27,"c":417},{"id":"packages__npm","label":"packages/npm","x":1191.72,"y":86.3,"r":246.75,"n":5879,"files":935,"c":12},{"id":"packages__python","label":"packages/python","x":631.62,"y":575.41,"r":157.95,"n":1422,"files":173,"c":121},{"id":"packages__rust","label":"packages/rust","x":22.77,"y":-1100.41,"r":263.78,"n":7080,"files":504,"c":4},{"id":"packages__unity","label":"packages/unity","x":-6.79,"y":50.22,"r":178.59,"n":2187,"files":249,"c":54},{"id":"packages__unreal","label":"packages/unreal","x":1083.77,"y":-665.17,"r":330.0,"n":12814,"files":771,"c":0},{"id":"project_json","label":"project.json","x":-746.84,"y":-2933.16,"r":82.69,"n":22,"files":1,"c":1189},{"id":"react","label":"react","x":-2923.48,"y":930.44,"r":74.28,"n":1,"files":1,"c":12619},{"id":"react-dom__client","label":"react-dom/client","x":-2619.08,"y":1424.02,"r":74.28,"n":1,"files":1,"c":12618},{"id":"scripts__check-version-drift_sh","label":"scripts/check-version-drift.sh","x":-2208.73,"y":-1926.43,"r":78.45,"n":8,"files":1,"c":2477},{"id":"scripts__ci","label":"scripts/ci","x":-2405.16,"y":1925.11,"r":75.22,"n":2,"files":1,"c":4401},{"id":"scripts__deno-fmt_sh","label":"scripts/deno-fmt.sh","x":1924.52,"y":2245.67,"r":75.22,"n":2,"files":1,"c":4402},{"id":"scripts__deploy_isometric_quick_sh","label":"scripts/deploy_isometric_quick.sh","x":-1972.31,"y":-2353.08,"r":78.84,"n":9,"files":1,"c":2314},{"id":"scripts__kubectl-namespace-orphan-check_sh","label":"scripts/kubectl-namespace-orphan-check.sh","x":-1379.46,"y":-2684.55,"r":75.22,"n":2,"files":1,"c":4403},{"id":"scripts__populate-item-recipes_py","label":"scripts/populate-item-recipes.py","x":-2971.46,"y":356.66,"r":76.56,"n":4,"files":1,"c":2882},{"id":"scripts__populate-npc-data_py","label":"scripts/populate-npc-data.py","x":239.77,"y":3000.0,"r":77.58,"n":6,"files":1,"c":2187},{"id":"scripts__resolve-docker-digests_sh","label":"scripts/resolve-docker-digests.sh","x":2044.97,"y":-2091.34,"r":75.22,"n":2,"files":1,"c":4404},{"id":"scripts__vm-windows-bootstrap_ps1","label":"scripts/vm-windows-bootstrap.ps1","x":-2630.6,"y":-1456.58,"r":75.95,"n":3,"files":1,"c":3626},{"id":"tools__scripts","label":"tools/scripts","x":-85.87,"y":-3000.0,"r":76.56,"n":4,"files":2,"c":4405},{"id":"topojson-client","label":"topojson-client","x":2823.05,"y":-955.36,"r":74.28,"n":1,"files":1,"c":12620},{"id":"tsconfig_base_json","label":"tsconfig.base.json","x":1466.14,"y":-2594.13,"r":87.63,"n":47,"files":1,"c":1569},{"id":"tsconfig_json","label":"tsconfig.json","x":2427.62,"y":1656.15,"r":76.56,"n":4,"files":1,"c":2476},{"id":"virtual:starlight__components","label":"virtual:starlight/components","x":-498.67,"y":-279.5,"r":77.58,"n":6,"files":6,"c":977},{"id":"virtual:starlight__user-config","label":"virtual:starlight/user-config","x":-334.61,"y":-496.29,"r":74.28,"n":1,"files":1,"c":977},{"id":"world-atlas__countries-110m_json","label":"world-atlas/countries-110m.json","x":-26.99,"y":738.71,"r":74.28,"n":1,"files":1,"c":307}],"dirEdges":[[0,45,1.0,5],[3,18,1.0,5],[3,23,2.0,5],[4,45,1.0,5],[6,45,1.0,5],[9,47,200.0,2],[9,18,43.0,5],[9,27,17.0,2],[9,45,261.0,0],[9,12,15.0,5],[9,15,11.0,5],[9,23,8.0,5],[9,24,10.0,5],[9,43,6.0,5],[11,18,4.0,5],[11,45,21.0,0],[8,11,3.0,0],[8,12,2.0,0],[8,14,2.0,0],[8,15,2.0,0],[8,16,2.0,0],[8,21,2.0,0],[8,24,3.0,0],[11,66,5.0,0],[11,67,1.0,0],[12,67,1.0,0],[15,67,1.0,0],[16,67,1.0,0],[21,67,1.0,0],[24,67,1.0,0],[12,66,5.0,0],[15,66,5.0,0],[16,66,5.0,0],[21,66,5.0,0],[24,66,5.0,0],[14,45,35.0,0],[16,45,39.0,0],[18,45,645.0,0],[24,45,10.0,0],[11,47,20.0,2],[11,48,2.0,1],[11,25,2.0,1],[11,49,3.0,2],[12,18,21.0,5],[12,45,190.0,0],[12,43,18.0,0],[12,23,2.0,5],[12,15,1.0,5],[12,47,24.0,2],[12,48,3.0,1],[13,47,12.0,2],[13,18,1.0,5],[14,18,8.0,0],[14,43,3.0,0],[15,45,57.0,0],[21,45,79.0,0],[14,47,449.0,2],[14,48,4.0,1],[14,37,3.0,0],[14,25,1.0,4],[14,19,1.0,0],[15,18,41.0,5],[15,23,5.0,5],[15,43,5.0,5],[15,21,2.0,5],[16,18,3.0,5],[16,47,25.0,2],[16,22,1.0,1],[16,48,6.0,1],[17,47,44.0,2],[17,48,14.0,1],[17,18,39.0,2],[17,43,30.0,0],[17,45,125.0,0],[17,23,7.0,5],[18,23,98.0,5],[18,43,401.0,0],[18,24,5.0,2],[18,25,2.0,5],[18,20,4.0,5],[18,27,97.0,2],[18,47,882.0,2],[18,19,1.0,5],[18,21,1.0,5],[18,30,11.0,0],[24,30,3.0,0],[18,35,1.0,0],[35,45,1.0,0],[35,47,1.0,0],[18,39,1.0,0],[18,40,1.0,0],[8,18,3.0,0],[18,29,1.0,0],[18,68,1.0,5],[18,66,1.0,0],[18,28,1.0,5],[18,48,102.0,1],[18,49,10.0,4],[20,47,73.0,2],[20,27,3.0,2],[20,43,1.0,4],[21,23,2.0,5],[21,47,44.0,2],[21,48,11.0,1],[22,47,31.0,2],[22,48,3.0,1],[23,45,26.0,5],[23,24,5.0,5],[23,43,1.0,2],[23,37,1.0,0],[23,46,8.0,1],[24,43,36.0,0],[24,48,24.0,0],[24,49,11.0,2],[25,47,10.0,4],[25,48,2.0,1],[25,49,143.0,2],[25,42,1.0,0],[25,45,1.0,1],[25,26,1.0,4],[26,47,171.0,2],[26,48,68.0,1],[27,47,150.0,2],[27,48,16.0,1],[27,43,2.0,4],[28,45,2.0,5],[37,46,1.0,0],[42,49,7.0,0],[43,45,26.0,0],[43,47,11.0,4],[44,46,1.0,0],[36,45,1.0,0],[45,48,1.0,1],[46,49,3.0,2],[47,48,14.0,1]]}
+{
+	"meta": {
+		"dirs": 69,
+		"files": 6502,
+		"symbols": 66742,
+		"dirEdges": 135,
+		"built_at_commit": "bd099ec97dcc1eebab335c4db83194a74166b848",
+		"scale": 6000.0,
+		"relations": [
+			"imports",
+			"calls",
+			"references",
+			"contains",
+			"extends",
+			"other",
+			"depends"
+		],
+		"nxEdges": 27,
+		"nxProjects": 140,
+		"docRefs": 23
+	},
+	"dirs": [
+		{
+			"id": "_agents__skills",
+			"label": ".agents/skills",
+			"x": -964.48,
+			"y": -29.29,
+			"r": 85.68,
+			"n": 36,
+			"files": 2,
+			"c": 936
+		},
+		{
+			"id": "_eslintrc_json",
+			"label": ".eslintrc.json",
+			"x": -2835.6,
+			"y": -880.08,
+			"r": 76.56,
+			"n": 4,
+			"files": 1,
+			"c": 2819
+		},
+		{
+			"id": "_github__deprecated",
+			"label": ".github/deprecated",
+			"x": -2948.5,
+			"y": -264.22,
+			"r": 83.62,
+			"n": 26,
+			"files": 4,
+			"c": 1791
+		},
+		{
+			"id": "_github__scripts",
+			"label": ".github/scripts",
+			"x": 171.13,
+			"y": -611.37,
+			"r": 86.05,
+			"n": 38,
+			"files": 5,
+			"c": 1703
+		},
+		{
+			"id": "_github__skills",
+			"label": ".github/skills",
+			"x": -302.32,
+			"y": 636.91,
+			"r": 85.68,
+			"n": 36,
+			"files": 2,
+			"c": 960
+		},
+		{
+			"id": "_husky__pre-push",
+			"label": ".husky/pre-push",
+			"x": 343.55,
+			"y": -2797.58,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 4185
+		},
+		{
+			"id": "_opencode__skills",
+			"label": ".opencode/skills",
+			"x": -994.88,
+			"y": 350.54,
+			"r": 85.68,
+			"n": 36,
+			"files": 2,
+			"c": 963
+		},
+		{
+			"id": "_prettierrc_mjs",
+			"label": ".prettierrc.mjs",
+			"x": 1025.75,
+			"y": 2763.96,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12617
+		},
+		{
+			"id": "@astrojs__starlight",
+			"label": "@astrojs/starlight",
+			"x": -229.28,
+			"y": 920.35,
+			"r": 77.58,
+			"n": 6,
+			"files": 6,
+			"c": 355
+		},
+		{
+			"id": "apps__agones",
+			"label": "apps/agones",
+			"x": -230.9,
+			"y": 1299.96,
+			"r": 182.04,
+			"n": 2331,
+			"files": 222,
+			"c": 17,
+			"nx": {
+				"projects": [
+					{ "name": "kbve-spider", "type": "app" },
+					{ "name": "kbve-orc", "type": "app" },
+					{ "name": "cryptothrone-server", "type": "app" },
+					{ "name": "agones-factorio-relay", "type": "app" },
+					{ "name": "agones-palworld-relay", "type": "app" },
+					{ "name": "arpg-e2e", "type": "e2e" },
+					{ "name": "arpg-server", "type": "app" },
+					{ "name": "agones-factorio", "type": "app" },
+					{ "name": "agones-palworld", "type": "app" },
+					{ "name": "arpg-web", "type": "app" },
+					{ "name": "arpg", "type": "app" }
+				]
+			},
+			"ref": "/project/agones/"
+		},
+		{
+			"id": "apps__angelscript",
+			"label": "apps/angelscript",
+			"x": 2799.83,
+			"y": -367.41,
+			"r": 80.22,
+			"n": 13,
+			"files": 1,
+			"c": 1575,
+			"nx": { "projects": [{ "name": "angelscript", "type": "app" }] }
+		},
+		{
+			"id": "apps__chuckrpg",
+			"label": "apps/chuckrpg",
+			"x": 474.28,
+			"y": -852.62,
+			"r": 131.26,
+			"n": 676,
+			"files": 105,
+			"c": 305,
+			"nx": {
+				"projects": [
+					{ "name": "axum-chuckrpg-e2e", "type": "e2e" },
+					{ "name": "unreal-cleanroom", "type": "app" },
+					{ "name": "astro-chuckrpg", "type": "app" },
+					{ "name": "chuck-launcher", "type": "app" },
+					{ "name": "axum-chuckrpg", "type": "app" }
+				]
+			},
+			"ref": "/project/chuckrpg/"
+		},
+		{
+			"id": "apps__cryptothrone",
+			"label": "apps/cryptothrone",
+			"x": -1059.15,
+			"y": -490.86,
+			"r": 140.87,
+			"n": 913,
+			"files": 164,
+			"c": 23,
+			"nx": {
+				"projects": [
+					{ "name": "astro-cryptothrone-e2e", "type": "e2e" },
+					{ "name": "astro-cryptothrone", "type": "app" },
+					{ "name": "axum-cryptothrone", "type": "app" },
+					{ "name": "cryptothrone", "type": "app" }
+				]
+			},
+			"ref": "/project/cryptothrone/"
+		},
+		{
+			"id": "apps__deathslayer",
+			"label": "apps/deathslayer",
+			"x": -37.19,
+			"y": 446.13,
+			"r": 98.48,
+			"n": 135,
+			"files": 12,
+			"c": 601,
+			"nx": {
+				"projects": [{ "name": "deathslayer-launcher", "type": "app" }]
+			}
+		},
+		{
+			"id": "apps__discordsh",
+			"label": "apps/discordsh",
+			"x": -438.7,
+			"y": -1432.0,
+			"r": 184.47,
+			"n": 2435,
+			"files": 185,
+			"c": 10,
+			"nx": {
+				"projects": [
+					{ "name": "axum-discordsh-e2e", "type": "e2e" },
+					{ "name": "discordsh-bot-e2e", "type": "e2e" },
+					{ "name": "notification-bot", "type": "app" },
+					{ "name": "astro-discordsh", "type": "app" },
+					{ "name": "axum-discordsh", "type": "app" },
+					{ "name": "discordsh-bot", "type": "app" },
+					{ "name": "discordsh-e2e", "type": "e2e" },
+					{ "name": "discordsh", "type": "app" }
+				]
+			},
+			"ref": "/project/discordsh/"
+		},
+		{
+			"id": "apps__herbmail",
+			"label": "apps/herbmail",
+			"x": 630.44,
+			"y": 1133.83,
+			"r": 170.14,
+			"n": 1854,
+			"files": 241,
+			"c": 41,
+			"nx": {
+				"projects": [
+					{ "name": "astro-herbmail", "type": "app" },
+					{ "name": "axum-herbmail", "type": "app" },
+					{ "name": "herbmail-game", "type": "app" },
+					{ "name": "herbmail-e2e", "type": "e2e" },
+					{ "name": "herbmail", "type": "app" }
+				]
+			},
+			"ref": "/project/herbmail/"
+		},
+		{
+			"id": "apps__irc",
+			"label": "apps/irc",
+			"x": -348.56,
+			"y": 301.55,
+			"r": 124.82,
+			"n": 537,
+			"files": 89,
+			"c": 465,
+			"nx": {
+				"projects": [
+					{ "name": "irc-gateway", "type": "app" },
+					{ "name": "astro-irc", "type": "app" },
+					{ "name": "irc-e2e", "type": "e2e" },
+					{ "name": "irc", "type": "app" }
+				]
+			},
+			"ref": "/project/irc-gateway/"
+		},
+		{
+			"id": "apps__jobboard",
+			"label": "apps/jobboard",
+			"x": 132.15,
+			"y": 1023.49,
+			"r": 131.96,
+			"n": 692,
+			"files": 77,
+			"c": 14,
+			"nx": { "projects": [{ "name": "jobboard", "type": "app" }] },
+			"ref": "/project/jobboard/"
+		},
+		{
+			"id": "apps__kbve",
+			"label": "apps/kbve",
+			"x": 670.74,
+			"y": -1380.0,
+			"r": 311.53,
+			"n": 11045,
+			"files": 1345,
+			"c": 39,
+			"nx": {
+				"projects": [
+					{ "name": "isometric-game", "type": "lib" },
+					{ "name": "kbve-react-native", "type": "app" },
+					{ "name": "astro-kbve-e2e", "type": "e2e" },
+					{ "name": "axum-kbve-e2e", "type": "e2e" },
+					{ "name": "desktop-kbve", "type": "app" },
+					{ "name": "astro-kbve", "type": "app" },
+					{ "name": "axum-kbve", "type": "app" },
+					{ "name": "isometric", "type": "app" },
+					{ "name": "kbve-gate", "type": "app" },
+					{ "name": "edge-e2e", "type": "e2e" },
+					{ "name": "kilobase", "type": "app" },
+					{ "name": "edge", "type": "app" }
+				]
+			},
+			"ref": "/music/kbve/"
+		},
+		{
+			"id": "apps__kube",
+			"label": "apps/kube",
+			"x": 428.7,
+			"y": -81.51,
+			"r": 89.95,
+			"n": 62,
+			"files": 26,
+			"c": 2589
+		},
+		{
+			"id": "apps__mc",
+			"label": "apps/mc",
+			"x": 521.32,
+			"y": -452.97,
+			"r": 151.15,
+			"n": 1206,
+			"files": 149,
+			"c": 220,
+			"nx": {
+				"projects": [
+					{ "name": "behavior_statetree", "type": "lib" },
+					{ "name": "mc-velocity", "type": "app" },
+					{ "name": "mc_auth", "type": "lib" },
+					{ "name": "mc-lobby", "type": "app" },
+					{ "name": "mc", "type": "app" }
+				]
+			},
+			"ref": "/project/mc/"
+		},
+		{
+			"id": "apps__memes",
+			"label": "apps/memes",
+			"x": -1012.26,
+			"y": 692.96,
+			"r": 132.9,
+			"n": 714,
+			"files": 74,
+			"c": 36,
+			"nx": {
+				"projects": [
+					{ "name": "astro-memes", "type": "app" },
+					{ "name": "axum-memes", "type": "app" },
+					{ "name": "memes-e2e", "type": "e2e" },
+					{ "name": "memes", "type": "app" }
+				]
+			},
+			"ref": "/project/memes/"
+		},
+		{
+			"id": "apps__metrics",
+			"label": "apps/metrics",
+			"x": 180.0,
+			"y": -303.53,
+			"r": 101.45,
+			"n": 167,
+			"files": 13,
+			"c": 424,
+			"nx": {
+				"projects": [
+					{ "name": "metrics-e2e", "type": "e2e" },
+					{ "name": "met", "type": "app" }
+				]
+			},
+			"ref": "/project/metrics/"
+		},
+		{
+			"id": "apps__pydesk",
+			"label": "apps/pydesk",
+			"x": 250.07,
+			"y": 592.47,
+			"r": 103.91,
+			"n": 196,
+			"files": 11,
+			"c": 232,
+			"nx": { "projects": [{ "name": "pydesk", "type": "app" }] }
+		},
+		{
+			"id": "apps__rareicon",
+			"label": "apps/rareicon",
+			"x": -763.37,
+			"y": -962.03,
+			"r": 266.75,
+			"n": 7301,
+			"files": 643,
+			"c": 7,
+			"nx": {
+				"projects": [
+					{ "name": "astro-rareicon-e2e", "type": "e2e" },
+					{ "name": "axum-rareicon-e2e", "type": "e2e" },
+					{ "name": "astro-rareicon", "type": "app" },
+					{ "name": "unity-rareicon", "type": "app" },
+					{ "name": "axum-rareicon", "type": "app" }
+				]
+			},
+			"ref": "/arcade/rareicon/"
+		},
+		{
+			"id": "apps__rentearth",
+			"label": "apps/rentearth",
+			"x": 1081.08,
+			"y": 614.83,
+			"r": 173.24,
+			"n": 1973,
+			"files": 214,
+			"c": 90,
+			"nx": {
+				"projects": [
+					{ "name": "rentearth-web", "type": "app" },
+					{ "name": "unreal-rentearth", "type": "app" },
+					{ "name": "axum-rentearth", "type": "app" }
+				]
+			},
+			"ref": "/project/unreal-rentearth/"
+		},
+		{
+			"id": "apps__rows",
+			"label": "apps/rows",
+			"x": -641.49,
+			"y": 554.25,
+			"r": 141.95,
+			"n": 942,
+			"files": 61,
+			"c": 49,
+			"nx": { "projects": [{ "name": "rows", "type": "app" }] },
+			"ref": "/project/rows/"
+		},
+		{
+			"id": "apps__vm",
+			"label": "apps/vm",
+			"x": 371.87,
+			"y": 257.1,
+			"r": 132.9,
+			"n": 714,
+			"files": 49,
+			"c": 155,
+			"nx": {
+				"projects": [
+					{ "name": "firecracker-ctl-e2e", "type": "e2e" },
+					{ "name": "aria2-proxy-e2e", "type": "e2e" },
+					{ "name": "firecracker-ctl", "type": "app" },
+					{ "name": "iot-edge-worker", "type": "app" },
+					{ "name": "factorio-ctl", "type": "app" },
+					{ "name": "aria2-proxy", "type": "lib" },
+					{ "name": "kubectl-e2e", "type": "e2e" },
+					{ "name": "kbve-kubectl", "type": "app" }
+				]
+			},
+			"ref": "/dashboard/vm/"
+		},
+		{
+			"id": "apps__windmill",
+			"label": "apps/windmill",
+			"x": -667.03,
+			"y": -43.73,
+			"r": 92.13,
+			"n": 78,
+			"files": 17,
+			"c": 2027,
+			"ref": "/application/windmill/"
+		},
+		{
+			"id": "astro:components",
+			"label": "astro:components",
+			"x": -777.63,
+			"y": -309.0,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 236
+		},
+		{
+			"id": "astro:content",
+			"label": "astro:content",
+			"x": -740.79,
+			"y": 233.01,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 505
+		},
+		{
+			"id": "babel_config_json",
+			"label": "babel.config.json",
+			"x": 953.36,
+			"y": -2704.74,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 3526
+		},
+		{
+			"id": "d3-geo",
+			"label": "d3-geo",
+			"x": -1481.53,
+			"y": 2675.44,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12453
+		},
+		{
+			"id": "glbclips_mjs",
+			"label": "glbclips.mjs",
+			"x": 2791.09,
+			"y": 1042.95,
+			"r": 77.1,
+			"n": 5,
+			"files": 1,
+			"c": 3031
+		},
+		{
+			"id": "gsap",
+			"label": "gsap",
+			"x": -852.82,
+			"y": 2785.05,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12462
+		},
+		{
+			"id": "gsap__Observer",
+			"label": "gsap/Observer",
+			"x": -67.86,
+			"y": -464.85,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 608,
+			"ref": "/mc/blocks/observer/"
+		},
+		{
+			"id": "gsap__ScrollTrigger",
+			"label": "gsap/ScrollTrigger",
+			"x": -612.46,
+			"y": -526.4,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 608
+		},
+		{
+			"id": "kbve_sh",
+			"label": "kbve.sh",
+			"x": -315.24,
+			"y": -775.18,
+			"r": 85.29,
+			"n": 34,
+			"files": 1,
+			"c": 766
+		},
+		{
+			"id": "marked",
+			"label": "marked",
+			"x": -1940.65,
+			"y": 2285.12,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12463
+		},
+		{
+			"id": "node:fs",
+			"label": "node:fs",
+			"x": 406.52,
+			"y": 846.32,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 1289
+		},
+		{
+			"id": "node:url",
+			"label": "node:url",
+			"x": -228.45,
+			"y": -249.6,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 1289
+		},
+		{
+			"id": "nx_json",
+			"label": "nx.json",
+			"x": 2971.46,
+			"y": 280.46,
+			"r": 91.74,
+			"n": 75,
+			"files": 1,
+			"c": 1372
+		},
+		{
+			"id": "package_json",
+			"label": "package.json",
+			"x": 726.34,
+			"y": 186.11,
+			"r": 108.61,
+			"n": 258,
+			"files": 1,
+			"c": 33
+		},
+		{
+			"id": "packages__data",
+			"label": "packages/data",
+			"x": -605.97,
+			"y": 995.7,
+			"r": 180.92,
+			"n": 2284,
+			"files": 82,
+			"c": 25,
+			"nx": {
+				"projects": [
+					{ "name": "data-proto", "type": "lib" },
+					{ "name": "data-sql", "type": "lib" }
+				]
+			}
+		},
+		{
+			"id": "packages__docker",
+			"label": "packages/docker",
+			"x": 772.95,
+			"y": -156.82,
+			"r": 117.47,
+			"n": 398,
+			"files": 27,
+			"c": 417,
+			"nx": {
+				"projects": [
+					{ "name": "firecracker-python-net", "type": "lib" },
+					{ "name": "firecracker-python-web", "type": "lib" },
+					{ "name": "firecracker-node-web", "type": "lib" },
+					{ "name": "chisel-ubuntu-axum", "type": "lib" },
+					{ "name": "kasm-cloakbrowser", "type": "lib" },
+					{ "name": "steamcmd-ubuntu", "type": "lib" },
+					{ "name": "arc-runner-e2e", "type": "e2e" },
+					{ "name": "arc-runner", "type": "lib" },
+					{ "name": "kasm-void", "type": "lib" }
+				]
+			},
+			"ref": "/application/docker/"
+		},
+		{
+			"id": "packages__npm",
+			"label": "packages/npm",
+			"x": 1191.72,
+			"y": 86.3,
+			"r": 246.75,
+			"n": 5879,
+			"files": 935,
+			"c": 12,
+			"nx": {
+				"projects": [
+					{ "name": "khashvault-e2e", "type": "e2e" },
+					{ "name": "devops-e2e", "type": "e2e" },
+					{ "name": "khashvault", "type": "lib" },
+					{ "name": "astro-e2e", "type": "e2e" },
+					{ "name": "droid-e2e", "type": "e2e" },
+					{ "name": "laser-e2e", "type": "e2e" },
+					{ "name": "rn-astro", "type": "lib" },
+					{ "name": "devops", "type": "lib" },
+					{ "name": "observ", "type": "lib" },
+					{ "name": "astro", "type": "lib" },
+					{ "name": "droid", "type": "lib" },
+					{ "name": "kbve-tauri", "type": "lib" },
+					{ "name": "laser", "type": "lib" },
+					{ "name": "chat", "type": "lib" },
+					{ "name": "core", "type": "lib" },
+					{ "name": "fx", "type": "lib" },
+					{ "name": "rn", "type": "lib" }
+				]
+			},
+			"ref": "/project/khashvault/"
+		},
+		{
+			"id": "packages__python",
+			"label": "packages/python",
+			"x": 631.62,
+			"y": 575.41,
+			"r": 157.95,
+			"n": 1422,
+			"files": 173,
+			"c": 121,
+			"nx": {
+				"projects": [
+					{ "name": "graphify-wrapper", "type": "lib" },
+					{ "name": "python-fudster", "type": "lib" },
+					{ "name": "python-kbve", "type": "lib" }
+				]
+			},
+			"ref": "/application/python/"
+		},
+		{
+			"id": "packages__rust",
+			"label": "packages/rust",
+			"x": 22.77,
+			"y": -1100.41,
+			"r": 263.78,
+			"n": 7080,
+			"files": 504,
+			"c": 4,
+			"nx": {
+				"projects": [
+					{ "name": "bevy_statemachine", "type": "lib" },
+					{ "name": "bevy_pathfinder", "type": "lib" },
+					{ "name": "bevy_inventory", "type": "lib" },
+					{ "name": "bevy_behavior", "type": "lib" },
+					{ "name": "bevy_kbve_net", "type": "lib" },
+					{ "name": "bevy_battle", "type": "lib" },
+					{ "name": "bevy_player", "type": "lib" },
+					{ "name": "bevy_quests", "type": "lib" },
+					{ "name": "bevy_skills", "type": "lib" },
+					{ "name": "bevy_spells", "type": "lib" },
+					{ "name": "bevy_tasker", "type": "lib" },
+					{ "name": "bevy_items", "type": "lib" },
+					{ "name": "bevy_mapdb", "type": "lib" },
+					{ "name": "bevy_chat", "type": "lib" },
+					{ "name": "bevy_supa", "type": "lib" },
+					{ "name": "embeddb-derive", "type": "lib" },
+					{ "name": "bevy_cam", "type": "lib" },
+					{ "name": "bevy_npc", "type": "lib" },
+					{ "name": "bevy_db", "type": "lib" },
+					{ "name": "uniti", "type": "lib" },
+					{ "name": "kbve_wgpu", "type": "lib" },
+					{ "name": "embeddb", "type": "lib" },
+					{ "name": "simgrid", "type": "lib" },
+					{ "name": "erust", "type": "lib" },
+					{ "name": "holy", "type": "lib" },
+					{ "name": "jedi", "type": "lib" },
+					{ "name": "kbve", "type": "lib" },
+					{ "name": "q", "type": "lib" }
+				]
+			},
+			"ref": "/application/rust/"
+		},
+		{
+			"id": "packages__unity",
+			"label": "packages/unity",
+			"x": -6.79,
+			"y": 50.22,
+			"r": 178.59,
+			"n": 2187,
+			"files": 249,
+			"c": 54,
+			"ref": "/application/unity/"
+		},
+		{
+			"id": "packages__unreal",
+			"label": "packages/unreal",
+			"x": 1083.77,
+			"y": -665.17,
+			"r": 330.0,
+			"n": 12814,
+			"files": 771,
+			"c": 0,
+			"ref": "/application/unreal/"
+		},
+		{
+			"id": "project_json",
+			"label": "project.json",
+			"x": -746.84,
+			"y": -2933.16,
+			"r": 82.69,
+			"n": 22,
+			"files": 1,
+			"c": 1189
+		},
+		{
+			"id": "react",
+			"label": "react",
+			"x": -2923.48,
+			"y": 930.44,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12619
+		},
+		{
+			"id": "react-dom__client",
+			"label": "react-dom/client",
+			"x": -2619.08,
+			"y": 1424.02,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12618
+		},
+		{
+			"id": "scripts__check-version-drift_sh",
+			"label": "scripts/check-version-drift.sh",
+			"x": -2208.73,
+			"y": -1926.43,
+			"r": 78.45,
+			"n": 8,
+			"files": 1,
+			"c": 2477
+		},
+		{
+			"id": "scripts__ci",
+			"label": "scripts/ci",
+			"x": -2405.16,
+			"y": 1925.11,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 4401
+		},
+		{
+			"id": "scripts__deno-fmt_sh",
+			"label": "scripts/deno-fmt.sh",
+			"x": 1924.52,
+			"y": 2245.67,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 4402
+		},
+		{
+			"id": "scripts__deploy_isometric_quick_sh",
+			"label": "scripts/deploy_isometric_quick.sh",
+			"x": -1972.31,
+			"y": -2353.08,
+			"r": 78.84,
+			"n": 9,
+			"files": 1,
+			"c": 2314
+		},
+		{
+			"id": "scripts__kubectl-namespace-orphan-check_sh",
+			"label": "scripts/kubectl-namespace-orphan-check.sh",
+			"x": -1379.46,
+			"y": -2684.55,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 4403
+		},
+		{
+			"id": "scripts__populate-item-recipes_py",
+			"label": "scripts/populate-item-recipes.py",
+			"x": -2971.46,
+			"y": 356.66,
+			"r": 76.56,
+			"n": 4,
+			"files": 1,
+			"c": 2882
+		},
+		{
+			"id": "scripts__populate-npc-data_py",
+			"label": "scripts/populate-npc-data.py",
+			"x": 239.77,
+			"y": 3000.0,
+			"r": 77.58,
+			"n": 6,
+			"files": 1,
+			"c": 2187
+		},
+		{
+			"id": "scripts__resolve-docker-digests_sh",
+			"label": "scripts/resolve-docker-digests.sh",
+			"x": 2044.97,
+			"y": -2091.34,
+			"r": 75.22,
+			"n": 2,
+			"files": 1,
+			"c": 4404
+		},
+		{
+			"id": "scripts__vm-windows-bootstrap_ps1",
+			"label": "scripts/vm-windows-bootstrap.ps1",
+			"x": -2630.6,
+			"y": -1456.58,
+			"r": 75.95,
+			"n": 3,
+			"files": 1,
+			"c": 3626
+		},
+		{
+			"id": "tools__scripts",
+			"label": "tools/scripts",
+			"x": -85.87,
+			"y": -3000.0,
+			"r": 76.56,
+			"n": 4,
+			"files": 2,
+			"c": 4405
+		},
+		{
+			"id": "topojson-client",
+			"label": "topojson-client",
+			"x": 2823.05,
+			"y": -955.36,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 12620
+		},
+		{
+			"id": "tsconfig_base_json",
+			"label": "tsconfig.base.json",
+			"x": 1466.14,
+			"y": -2594.13,
+			"r": 87.63,
+			"n": 47,
+			"files": 1,
+			"c": 1569
+		},
+		{
+			"id": "tsconfig_json",
+			"label": "tsconfig.json",
+			"x": 2427.62,
+			"y": 1656.15,
+			"r": 76.56,
+			"n": 4,
+			"files": 1,
+			"c": 2476
+		},
+		{
+			"id": "virtual:starlight__components",
+			"label": "virtual:starlight/components",
+			"x": -498.67,
+			"y": -279.5,
+			"r": 77.58,
+			"n": 6,
+			"files": 6,
+			"c": 977
+		},
+		{
+			"id": "virtual:starlight__user-config",
+			"label": "virtual:starlight/user-config",
+			"x": -334.61,
+			"y": -496.29,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 977
+		},
+		{
+			"id": "world-atlas__countries-110m_json",
+			"label": "world-atlas/countries-110m.json",
+			"x": -26.99,
+			"y": 738.71,
+			"r": 74.28,
+			"n": 1,
+			"files": 1,
+			"c": 307
+		}
+	],
+	"dirEdges": [
+		[0, 45, 1.0, 5],
+		[3, 18, 1.0, 5],
+		[3, 23, 2.0, 5],
+		[4, 45, 1.0, 5],
+		[6, 45, 1.0, 5],
+		[9, 47, 200.0, 2],
+		[9, 18, 43.0, 5],
+		[9, 27, 17.0, 2],
+		[9, 45, 261.0, 0],
+		[9, 12, 15.0, 5],
+		[9, 15, 11.0, 5],
+		[9, 23, 8.0, 5],
+		[9, 24, 10.0, 5],
+		[9, 43, 6.0, 5],
+		[11, 18, 4.0, 5],
+		[11, 45, 21.0, 0],
+		[8, 11, 3.0, 0],
+		[8, 12, 2.0, 0],
+		[8, 14, 2.0, 0],
+		[8, 15, 2.0, 0],
+		[8, 16, 2.0, 0],
+		[8, 21, 2.0, 0],
+		[8, 24, 3.0, 0],
+		[11, 66, 5.0, 0],
+		[11, 67, 1.0, 0],
+		[12, 67, 1.0, 0],
+		[15, 67, 1.0, 0],
+		[16, 67, 1.0, 0],
+		[21, 67, 1.0, 0],
+		[24, 67, 1.0, 0],
+		[12, 66, 5.0, 0],
+		[15, 66, 5.0, 0],
+		[16, 66, 5.0, 0],
+		[21, 66, 5.0, 0],
+		[24, 66, 5.0, 0],
+		[14, 45, 35.0, 0],
+		[16, 45, 39.0, 0],
+		[18, 45, 645.0, 0],
+		[24, 45, 10.0, 0],
+		[11, 47, 20.0, 2],
+		[11, 48, 2.0, 1],
+		[11, 25, 2.0, 1],
+		[11, 49, 3.0, 2],
+		[12, 18, 21.0, 5],
+		[12, 45, 190.0, 0],
+		[12, 43, 18.0, 0],
+		[12, 23, 2.0, 5],
+		[12, 15, 1.0, 5],
+		[12, 47, 24.0, 2],
+		[12, 48, 3.0, 1],
+		[13, 47, 12.0, 2],
+		[13, 18, 1.0, 5],
+		[14, 18, 8.0, 0],
+		[14, 43, 3.0, 0],
+		[15, 45, 57.0, 0],
+		[21, 45, 79.0, 0],
+		[14, 47, 449.0, 2],
+		[14, 48, 4.0, 1],
+		[14, 37, 3.0, 0],
+		[14, 25, 1.0, 4],
+		[14, 19, 1.0, 0],
+		[15, 18, 41.0, 5],
+		[15, 23, 5.0, 5],
+		[15, 43, 5.0, 5],
+		[15, 21, 2.0, 5],
+		[16, 18, 3.0, 5],
+		[16, 47, 25.0, 2],
+		[16, 22, 1.0, 1],
+		[16, 48, 6.0, 1],
+		[17, 47, 44.0, 2],
+		[17, 48, 14.0, 1],
+		[17, 18, 39.0, 2],
+		[17, 43, 30.0, 0],
+		[17, 45, 125.0, 0],
+		[17, 23, 7.0, 5],
+		[18, 23, 98.0, 5],
+		[18, 43, 401.0, 0],
+		[18, 24, 5.0, 2],
+		[18, 25, 2.0, 5],
+		[18, 20, 4.0, 5],
+		[18, 27, 97.0, 2],
+		[18, 47, 882.0, 2],
+		[18, 19, 1.0, 5],
+		[18, 21, 1.0, 5],
+		[18, 30, 11.0, 0],
+		[24, 30, 3.0, 0],
+		[18, 35, 1.0, 0],
+		[35, 45, 1.0, 0],
+		[35, 47, 1.0, 0],
+		[18, 39, 1.0, 0],
+		[18, 40, 1.0, 0],
+		[8, 18, 3.0, 0],
+		[18, 29, 1.0, 0],
+		[18, 68, 1.0, 5],
+		[18, 66, 1.0, 0],
+		[18, 28, 1.0, 5],
+		[18, 48, 102.0, 1],
+		[18, 49, 10.0, 4],
+		[20, 47, 73.0, 2],
+		[20, 27, 3.0, 2],
+		[20, 43, 1.0, 4],
+		[21, 23, 2.0, 5],
+		[21, 47, 44.0, 2],
+		[21, 48, 11.0, 1],
+		[22, 47, 31.0, 2],
+		[22, 48, 3.0, 1],
+		[23, 45, 26.0, 5],
+		[23, 24, 5.0, 5],
+		[23, 43, 1.0, 2],
+		[23, 37, 1.0, 0],
+		[23, 46, 8.0, 1],
+		[24, 43, 36.0, 0],
+		[24, 48, 24.0, 0],
+		[24, 49, 11.0, 2],
+		[25, 47, 10.0, 4],
+		[25, 48, 2.0, 1],
+		[25, 49, 143.0, 2],
+		[25, 42, 1.0, 0],
+		[25, 45, 1.0, 1],
+		[25, 26, 1.0, 4],
+		[26, 47, 171.0, 2],
+		[26, 48, 68.0, 1],
+		[27, 47, 150.0, 2],
+		[27, 48, 16.0, 1],
+		[27, 43, 2.0, 4],
+		[28, 45, 2.0, 5],
+		[37, 46, 1.0, 0],
+		[42, 49, 7.0, 0],
+		[43, 45, 26.0, 0],
+		[43, 47, 11.0, 4],
+		[44, 46, 1.0, 0],
+		[36, 45, 1.0, 0],
+		[45, 48, 1.0, 1],
+		[46, 49, 3.0, 2],
+		[47, 48, 14.0, 1],
+		[9, 45, 3, 6],
+		[9, 47, 9, 6],
+		[11, 45, 4, 6],
+		[11, 47, 1, 6],
+		[12, 45, 4, 6],
+		[12, 47, 2, 6],
+		[13, 45, 1, 6],
+		[14, 45, 2, 6],
+		[14, 47, 15, 6],
+		[15, 45, 3, 6],
+		[15, 47, 2, 6],
+		[16, 45, 4, 6],
+		[16, 47, 3, 6],
+		[17, 45, 4, 6],
+		[17, 47, 1, 6],
+		[18, 45, 12, 6],
+		[18, 47, 17, 6],
+		[20, 47, 5, 6],
+		[21, 45, 2, 6],
+		[21, 47, 2, 6],
+		[22, 47, 2, 6],
+		[24, 45, 2, 6],
+		[24, 47, 1, 6],
+		[25, 47, 1, 6],
+		[26, 47, 2, 6],
+		[27, 47, 2, 6],
+		[47, 18, 1, 6]
+	]
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/MonorepoGraphExplorer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/MonorepoGraphExplorer.tsx
@@ -1,10 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
-import {
-	useMonorepoGraph,
-	REL_COLORS,
-	REL_LABELS,
-} from './useMonorepoGraph';
+import { useMonorepoGraph, REL_COLORS, REL_LABELS } from './useMonorepoGraph';
 import TieredGraphScene, {
 	type ColorMode,
 	type HoverInfo,
@@ -19,6 +15,8 @@ interface PickedDir {
 	label: string;
 	n: number;
 	files: number;
+	ref?: string;
+	nx?: { projects: { name: string; type?: string }[] };
 }
 
 const rgb = (c: [number, number, number]) =>
@@ -55,10 +53,10 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 			.slice(0, 8);
 	}, [overview, query]);
 
-	const focus = (id: string, label: string, n: number, files: number) => {
+	const focus = (d: PickedDir) => {
 		seq.current += 1;
-		setFocusRequest({ id, seq: seq.current });
-		setPicked({ id, label, n, files });
+		setFocusRequest({ id: d.id, seq: seq.current });
+		setPicked(d);
 		setQuery('');
 	};
 
@@ -80,8 +78,7 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 							near: 0.1,
 							far: 1000,
 						}}
-						dpr={[1, 2]}
-					>
+						dpr={[1, 2]}>
 						<color attach="background" args={['#0a0e16']} />
 						<TieredGraphScene
 							overview={overview}
@@ -99,9 +96,7 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 
 					<div className="mgx__legend">
 						<strong>{overview.meta.dirs}</strong> dirs ·{' '}
-						<strong>
-							{overview.meta.files.toLocaleString()}
-						</strong>{' '}
+						<strong>{overview.meta.files.toLocaleString()}</strong>{' '}
 						files ·{' '}
 						<strong>
 							{overview.meta.symbols.toLocaleString()}
@@ -133,15 +128,7 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 										<li key={d.id}>
 											<button
 												type="button"
-												onClick={() =>
-													focus(
-														d.id,
-														d.label,
-														d.n,
-														d.files,
-													)
-												}
-											>
+												onClick={() => focus(d)}>
 												{d.label}
 												<span>{d.n}</span>
 											</button>
@@ -153,8 +140,7 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 						<button
 							type="button"
 							className={colorMode === 'dir' ? 'is-active' : ''}
-							onClick={() => setColorMode('dir')}
-						>
+							onClick={() => setColorMode('dir')}>
 							Color: directory
 						</button>
 						<button
@@ -162,8 +148,7 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 							className={
 								colorMode === 'community' ? 'is-active' : ''
 							}
-							onClick={() => setColorMode('community')}
-						>
+							onClick={() => setColorMode('community')}>
 							Color: community
 						</button>
 					</div>
@@ -177,10 +162,31 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 								{picked.n.toLocaleString()} symbols ·{' '}
 								{picked.files} files
 							</div>
+							{picked.nx && picked.nx.projects.length > 0 && (
+								<div className="mgx__panel-nx">
+									{picked.nx.projects.slice(0, 8).map((p) => (
+										<span
+											key={p.name}
+											className="mgx__nx-chip"
+											data-type={p.type}>
+											{p.name}
+										</span>
+									))}
+									{picked.nx.projects.length > 8 && (
+										<span className="mgx__nx-chip">
+											+{picked.nx.projects.length - 8}
+										</span>
+									)}
+								</div>
+							)}
+							{picked.ref && (
+								<a className="mgx__panel-ref" href={picked.ref}>
+									Read the docs →
+								</a>
+							)}
 							<button
 								type="button"
-								onClick={() => setPicked(null)}
-							>
+								onClick={() => setPicked(null)}>
 								dismiss
 							</button>
 						</div>
@@ -195,14 +201,14 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 									window.innerWidth - 260,
 								),
 								top: hover.y + 14,
-							}}
-						>
+							}}>
 							<span
-								className={`mgx__kind mgx__kind--${hover.kind}`}
-							>
+								className={`mgx__kind mgx__kind--${hover.kind}`}>
 								{hover.kind}
 							</span>
-							<span className="mgx__tip-label">{hover.label}</span>
+							<span className="mgx__tip-label">
+								{hover.label}
+							</span>
 							<span className="mgx__tip-sub">{hover.sub}</span>
 						</div>
 					)}
@@ -362,6 +368,28 @@ export default function MonorepoGraphExplorer({ base }: Props) {
 					max-width: 260px;
 				}
 				.mgx__panel-title { font-weight: 600; }
+					.mgx__panel-nx { display: flex; flex-wrap: wrap; gap: 4px; margin: 0 0 6px; }
+					.mgx__nx-chip {
+						font-size: 0.64rem;
+						padding: 1px 6px;
+						border-radius: 5px;
+						background: rgba(184, 148, 255, 0.16);
+						color: #d8c7ff;
+						border: 1px solid rgba(184, 148, 255, 0.3);
+					}
+					.mgx__nx-chip[data-type='app'] {
+						background: rgba(56, 189, 248, 0.16);
+						color: #bae6fd;
+						border-color: rgba(56, 189, 248, 0.3);
+					}
+					.mgx__panel-ref {
+						display: inline-block;
+						margin-bottom: 8px;
+						color: #38bdf8;
+						font-size: 0.72rem;
+						text-decoration: none;
+					}
+					.mgx__panel-ref:hover { text-decoration: underline; }
 				.mgx__panel-sub {
 					color: #94a3b8;
 					font-size: 0.7rem;

--- a/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/TieredGraphScene.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/TieredGraphScene.tsx
@@ -1,10 +1,4 @@
-import {
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useThree, useFrame, type ThreeEvent } from '@react-three/fiber';
 import { MapControls } from '@react-three/drei';
 import type { MapControls as MapControlsImpl } from 'three-stdlib';
@@ -40,6 +34,8 @@ interface DirNodeLike {
 	label: string;
 	n: number;
 	files: number;
+	ref?: string;
+	nx?: { projects: { name: string; type?: string }[] };
 }
 
 interface Props {
@@ -148,7 +144,14 @@ export default function TieredGraphScene({
 		startFly(d.x, d.y, fitZoom.current * 6);
 		setActiveSlug(d.id);
 		loadDir(d.id).then((c) => c && setChunkVersion((v) => v + 1));
-		onPickDir({ id: d.id, label: d.label, n: d.n, files: d.files });
+		onPickDir({
+			id: d.id,
+			label: d.label,
+			n: d.n,
+			files: d.files,
+			ref: d.ref,
+			nx: d.nx,
+		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [focusRequest]);
 
@@ -292,14 +295,17 @@ export default function TieredGraphScene({
 			</lineSegments>
 			{dirHiEdgeGeo && (
 				<lineSegments geometry={dirHiEdgeGeo}>
-					<lineBasicMaterial vertexColors transparent opacity={0.95} />
+					<lineBasicMaterial
+						vertexColors
+						transparent
+						opacity={0.95}
+					/>
 				</lineSegments>
 			)}
 
 			<instancedMesh
 				ref={dirOutline}
-				args={[CIRCLE, undefined, overview.dirs.length]}
-			>
+				args={[CIRCLE, undefined, overview.dirs.length]}>
 				<meshBasicMaterial transparent opacity={0.9} />
 			</instancedMesh>
 
@@ -334,11 +340,12 @@ export default function TieredGraphScene({
 						label: d.label,
 						n: d.n,
 						files: d.files,
+						ref: d.ref,
+						nx: d.nx,
 					});
 					loadDir(d.id);
 					startFly(d.x, d.y, fitZoom.current * 6);
-				}}
-			>
+				}}>
 				<meshBasicMaterial ref={dirMat} transparent opacity={0.9} />
 			</instancedMesh>
 
@@ -396,10 +403,7 @@ function DirDetail({
 	const fileLabelOp = useRef(0);
 	const [hoverFile, setHoverFile] = useState<number | null>(null);
 
-	const fileAdj = useMemo(
-		() => buildAdjacency(chunk.fileEdges),
-		[chunk],
-	);
+	const fileAdj = useMemo(() => buildAdjacency(chunk.fileEdges), [chunk]);
 
 	useLayoutEffect(() => {
 		const mesh = fileMesh.current;
@@ -455,7 +459,10 @@ function DirDetail({
 	}, [chunk, colorMode, dirIndex, dirTotal]);
 
 	const fileEdgeGeo = useMemo(
-		() => buildEdgeGeo(chunk.files, chunk.fileEdges, 0.5, { minBright: 0.35 }),
+		() =>
+			buildEdgeGeo(chunk.files, chunk.fileEdges, 0.5, {
+				minBright: 0.35,
+			}),
 		[chunk],
 	);
 	const fileHiEdgeGeo = useMemo(() => {
@@ -466,9 +473,10 @@ function DirDetail({
 		});
 	}, [chunk, hoverFile]);
 	const symEdgeGeo = useMemo(
-		() => buildEdgeGeo(chunk.symbols, chunk.symbolEdges, 1.5, {
-			minBright: 0.25,
-		}),
+		() =>
+			buildEdgeGeo(chunk.symbols, chunk.symbolEdges, 1.5, {
+				minBright: 0.25,
+			}),
 		[chunk],
 	);
 
@@ -498,7 +506,8 @@ function DirDetail({
 			1,
 		);
 		if (fileGroup.current) fileGroup.current.visible = fileT > 0.02;
-		if (fileMat.current) fileMat.current.opacity = fileT * (1 - symT * 0.55);
+		if (fileMat.current)
+			fileMat.current.opacity = fileT * (1 - symT * 0.55);
 		if (symGroup.current) symGroup.current.visible = symT > 0.02;
 		if (symMat.current) symMat.current.opacity = symT;
 		fileLabelOp.current = fileT * (1 - symT * 0.7);
@@ -549,8 +558,7 @@ function DirDetail({
 							'_blank',
 							'noopener',
 						);
-					}}
-				>
+					}}>
 					<meshBasicMaterial ref={fileMat} transparent opacity={0} />
 				</instancedMesh>
 			</group>
@@ -589,8 +597,7 @@ function DirDetail({
 								'_blank',
 								'noopener',
 							);
-					}}
-				>
+					}}>
 					<meshBasicMaterial ref={symMat} transparent opacity={0} />
 				</instancedMesh>
 			</group>

--- a/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/useMonorepoGraph.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/useMonorepoGraph.ts
@@ -9,6 +9,10 @@ export interface DirNode {
 	n: number;
 	files: number;
 	c: number;
+	/** Doc reference for this code area (e.g. ``/application/rust/``). */
+	ref?: string;
+	/** NX projects rooted in this directory (unified-graph overlay). */
+	nx?: { projects: { name: string; type?: string }[] };
 }
 
 /** Edge as emitted by graphify_tiered.py: [source, target, weight, relIdx]. */
@@ -65,6 +69,7 @@ export const REL_COLORS: [number, number, number][] = [
 	[0.5, 0.85, 0.55], // contains  — green
 	[0.95, 0.5, 0.85], // extends   — magenta
 	[0.45, 0.5, 0.62], // other     — slate
+	[0.72, 0.4, 1.0], // depends   — violet (NX project deps)
 ];
 
 export const REL_LABELS = [
@@ -74,6 +79,7 @@ export const REL_LABELS = [
 	'contains',
 	'extends',
 	'other',
+	'depends',
 ];
 
 interface State {
@@ -106,16 +112,14 @@ export function useMonorepoGraph(base = '/graphify') {
 				return r.json();
 			})
 			.then((overview: Overview) => {
-				if (alive)
-					setState({ overview, loading: false, error: null });
+				if (alive) setState({ overview, loading: false, error: null });
 			})
 			.catch((e: unknown) => {
 				if (alive)
 					setState({
 						overview: null,
 						loading: false,
-						error:
-							e instanceof Error ? e.message : 'load failed',
+						error: e instanceof Error ? e.message : 'load failed',
 					});
 			});
 		return () => {
@@ -127,8 +131,7 @@ export function useMonorepoGraph(base = '/graphify') {
 		(slug: string): Promise<DirChunk | null> => {
 			if (chunks.current.has(slug))
 				return Promise.resolve(chunks.current.get(slug)!);
-			if (inflight.current.has(slug))
-				return inflight.current.get(slug)!;
+			if (inflight.current.has(slug)) return inflight.current.get(slug)!;
 			const p = fetch(`${base}/dir/${slug}.json`)
 				.then((r) => {
 					if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -165,7 +168,10 @@ export function communityColor(id: number): [number, number, number] {
 }
 
 /** Deterministic color for a directory index (evenly spaced hues). */
-export function dirColor(index: number, total: number): [number, number, number] {
+export function dirColor(
+	index: number,
+	total: number,
+): [number, number, number] {
 	return hslToRgb((index / Math.max(total, 1)) % 1, 0.55, 0.62);
 }
 

--- a/apps/kbve/astro-kbve/src/content/docs/graph.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/graph.mdx
@@ -15,7 +15,7 @@ sidebar:
 ---
 
 import BentoShell from '@/components/hero/BentoShell.astro';
-import GraphHub from '@/components/graph/GraphHub';
+import AstroGraphExplorer from '@/components/dashboard/AstroGraphExplorer.astro';
 import nxGraph from '../../../public/data/nx/nx-graph.json';
 import overview from '../../../public/graphify/overview.json';
 
@@ -36,12 +36,12 @@ export const symbols = overview.meta.symbols;
 				</span>
 				<h1 class="bento-title">
 					The whole monorepo,
-					<span class="bento-title__accent">searchable and cross-linked.</span>
+					<span class="bento-title__accent">one living graph.</span>
 				</h1>
-				<p class="bento-lede">Search any project to see its <strong>NX dependencies</strong>, its <strong>Graphify</strong> code area, and its <strong>docs</strong> — all in one place, each linking out to its full view.</p>
+				<p class="bento-lede">One graph fuses <strong>Graphify</strong> code analysis, <strong>NX</strong> dependency edges, and <strong>doc references</strong>. Scroll to drill from directories into files and symbols; click a node for its projects and docs.</p>
 				<div class="bento-cta">
 					<a class="bento-btn bento-btn--primary" href="#hub">
-						Start searching
+						Open the graph
 						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" /></svg>
 					</a>
 					<a class="bento-btn bento-btn--ghost" href="/dashboard/graph/">NX graph</a>
@@ -87,10 +87,13 @@ export const symbols = overview.meta.symbols;
 	</div>
 </section>
 
-<BentoShell id="hub" eyebrow="Unified · cross-linked" heading="Explore the graph">
-	<GraphHub client:only="react" />
+<BentoShell id="hub" eyebrow="Unified · Graphify + NX + docs" heading="Explore the graph">
+	<AstroGraphExplorer />
+	<p class="graph-hub-fallback">
+		Prefer a searchable list? <a href="/graph/list/">Open the list view →</a>
+	</p>
 </BentoShell>
 
 </div>
 
-<style is:global>{`.graph-hub-page{--bento-accent:#a78bfa;--bento-accent-2:#38bdf8}`}</style>
+<style is:global>{`.graph-hub-page{--bento-accent:#a78bfa;--bento-accent-2:#38bdf8}.graph-hub-fallback{margin:12px 0 0;font-size:0.8rem;color:#94a3b8;text-align:center}.graph-hub-fallback a{color:#38bdf8}`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/graph/list.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/graph/list.mdx
@@ -1,0 +1,31 @@
+---
+title: Graph — List View
+description: |
+    Searchable list fallback for the unified monorepo graph — projects,
+    directories, NX dependencies, and doc references.
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+sidebar:
+    label: Graph List
+    order: 100
+---
+
+import BentoShell from '@/components/hero/BentoShell.astro';
+import GraphHub from '@/components/graph/GraphHub';
+
+<div class="graph-hub-page" data-graph-hub-page>
+
+<BentoShell id="hub" eyebrow="Fallback · searchable list" heading="Graph — list view">
+	<p class="graph-hub-fallback">
+		<a href="/graph/">← Back to the unified graph</a>
+	</p>
+	<GraphHub client:only="react" />
+</BentoShell>
+
+</div>
+
+<style is:global>{`.graph-hub-page{--bento-accent:#a78bfa;--bento-accent-2:#38bdf8}.graph-hub-fallback{margin:0 0 12px;font-size:0.8rem;color:#94a3b8}.graph-hub-fallback a{color:#38bdf8}`}</style>

--- a/packages/data/graphify/scripts/build-tiered-graph.sh
+++ b/packages/data/graphify/scripts/build-tiered-graph.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #   1. graphify update    — re-extract code symbols (tree-sitter AST, no LLM)
 #   2. graphify cluster    — Leiden communities (deterministic, no LLM, no viz)
 #   3. graphify_tiered.py  — precompute the dir -> file -> symbol LOD chunks
+#   4. enrich_unified.py   — fuse NX project deps + doc references into one graph
 #
 # Output lands in apps/kbve/astro-kbve/public/graphify/ so the static Astro
 # build serves it. Requires the graphify CLI: `uv tool install graphifyy`.
@@ -26,13 +27,18 @@ graphify update "$ROOT" --no-cluster
 echo "🧩 [2/3] clustering (Leiden, no LLM)…"
 graphify cluster-only "$ROOT" --no-viz --no-label
 
-echo "📐 [3/3] precomputing tiered LOD layout…"
+echo "📐 [3/4] precomputing tiered LOD layout…"
 rm -rf "$OUT"
 # Pin the scientific stack: the force layout (spring/forceatlas2, seed 1337) is
 # only reproducible for a fixed networkx/numpy/scipy — floating them churns node
 # coordinates on every rebuild and buries real code changes in layout noise.
 uv run --with 'networkx==3.4.2' --with 'numpy==2.2.6' --with 'scipy==1.15.3' python \
 	"$SCRIPT_DIR/graphify_tiered.py" "$GRAPH" "$OUT"
+
+echo "🔗 [4/4] fusing NX project deps + doc references (unified graph)…"
+uv run python "$SCRIPT_DIR/enrich_unified.py" "$OUT/overview.json" \
+	--nx-graph "$ROOT/apps/kbve/astro-kbve/public/data/nx/nx-graph.json" \
+	--docs-root "$ROOT/apps/kbve/astro-kbve/src/content/docs"
 
 echo "✅ wrote $OUT"
 du -sh "$OUT"

--- a/packages/data/graphify/scripts/enrich_unified.py
+++ b/packages/data/graphify/scripts/enrich_unified.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Digest the three monorepo graphs into one at the graphify-wrapper level.
+
+Runs as the final step of ``build-tiered-graph.sh``: takes the tiered Graphify
+``overview.json`` (directory→file→symbol code analysis) and folds in the other
+two feeds at the directory tier so the dashboard explorer renders a single
+unified graph:
+
+  * NX      — project identity on directory nodes (``nx.projects``) plus
+              project→project dependency edges collapsed to dir→dir edges under
+              a new ``depends`` relation.
+  * Docs    — a reference URL per node (``ref``): the doc that documents that
+              code area (e.g. ``packages/rust`` → ``/application/rust``). Docs
+              are references hanging off code nodes, not nodes themselves.
+
+Pure functions do the fusion so they unit-test without the graphify binary or a
+live build; ``main`` only handles IO. Idempotent: re-running on an already
+enriched overview reproduces the same result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Iterable, Optional
+
+DEPENDS_REL = "depends"
+
+
+def _leaf(label: str) -> str:
+    return label.rsplit("/", 1)[-1]
+
+
+def longest_prefix_dir(root: str, labels: list[str]) -> Optional[int]:
+    """Index of the directory whose label is the longest path-prefix of ``root``.
+
+    NX project roots (``apps/kbve/axum-kbve``) are finer-grained than Graphify's
+    directory bubbles (``apps/kbve``); a project attaches to the deepest bubble
+    that contains it.
+    """
+    best_i: Optional[int] = None
+    best_len = -1
+    for i, label in enumerate(labels):
+        if root == label or root.startswith(label + "/"):
+            if len(label) > best_len:
+                best_len, best_i = len(label), i
+    return best_i
+
+
+def _slug_index(slugs: Iterable[str]) -> dict[str, str]:
+    """Map a lowercased last-segment → full slug, preferring ``application/*``."""
+    index: dict[str, str] = {}
+    for slug in slugs:
+        leaf = slug.rsplit("/", 1)[-1].lower()
+        if not leaf:
+            continue
+        prefer = slug.startswith("application/")
+        if leaf not in index or (prefer and not index[leaf].startswith("application/")):
+            index[leaf] = slug
+    return index
+
+
+def doc_ref_for(candidates: Iterable[str], slug_index: dict[str, str]) -> Optional[str]:
+    for cand in candidates:
+        slug = slug_index.get(cand.lower())
+        if slug:
+            return f"/{slug}/"
+    return None
+
+
+def enrich(overview: dict, nx_graph: dict, doc_slugs: Iterable[str]) -> dict:
+    """Return ``overview`` enriched with NX identity/edges and doc refs.
+
+    Mutates and returns the passed overview for convenience; callers that need
+    the original untouched should deep-copy first.
+    """
+    dirs = overview.get("dirs", [])
+    labels = [d["label"] for d in dirs]
+    slug_index = _slug_index(doc_slugs)
+
+    graph = nx_graph.get("graph", {})
+    nodes = graph.get("nodes", {})
+    deps = graph.get("dependencies", {})
+
+    # NX project identity → the directory bubble that contains it.
+    project_dir: dict[str, int] = {}
+    for name, node in nodes.items():
+        root = (node.get("data") or {}).get("root")
+        if not root:
+            continue
+        idx = longest_prefix_dir(root, labels)
+        if idx is None:
+            continue
+        project_dir[name] = idx
+        bucket = dirs[idx].setdefault("nx", {"projects": []})
+        bucket["projects"].append({"name": name, "type": node.get("type")})
+
+    # Project→project deps collapsed to dir→dir "depends" edges (deduped).
+    depends: dict[tuple[int, int], int] = {}
+    for src, edges in deps.items():
+        si = project_dir.get(src)
+        if si is None:
+            continue
+        for e in edges or []:
+            ti = project_dir.get(e.get("target"))
+            if ti is None or ti == si:
+                continue
+            key = (si, ti)
+            depends[key] = depends.get(key, 0) + 1
+
+    relations = overview.setdefault("meta", {}).setdefault(
+        "relations", ["imports", "calls", "references",
+                      "contains", "extends", "other"]
+    )
+    if DEPENDS_REL not in relations:
+        relations.append(DEPENDS_REL)
+    depends_rel = relations.index(DEPENDS_REL)
+
+    dir_edges = overview.setdefault("dirEdges", [])
+    # Drop any prior depends edges so re-runs stay idempotent.
+    dir_edges[:] = [e for e in dir_edges if e[3] != depends_rel]
+    for (si, ti), weight in sorted(depends.items()):
+        dir_edges.append([si, ti, weight, depends_rel])
+
+    # Doc references: dir leaf + any NX project names on the node.
+    for d in dirs:
+        candidates = [_leaf(d["label"])]
+        for p in (d.get("nx") or {}).get("projects", []):
+            candidates.append(p["name"])
+        ref = doc_ref_for(candidates, slug_index)
+        if ref:
+            d["ref"] = ref
+        elif "ref" in d:
+            del d["ref"]
+
+    overview["meta"]["nxEdges"] = len(depends)
+    overview["meta"]["nxProjects"] = len(project_dir)
+    overview["meta"]["docRefs"] = sum(1 for d in dirs if "ref" in d)
+    return overview
+
+
+def _walk_slugs(docs_root: str) -> list[str]:
+    slugs: list[str] = []
+    for base, _dirs, files in os.walk(docs_root):
+        for f in files:
+            if not (f.endswith(".md") or f.endswith(".mdx")):
+                continue
+            rel = os.path.relpath(os.path.join(base, f), docs_root)
+            slug = rel[: rel.rfind(".")].replace(os.sep, "/")
+            if slug.endswith("/index"):
+                slug = slug[: -len("/index")]
+            slugs.append(slug)
+    return slugs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("overview", help="tiered overview.json to enrich in place")
+    ap.add_argument("--nx-graph", required=True, help="nx-graph.json path")
+    ap.add_argument("--docs-root", required=True, help="content/docs root")
+    ap.add_argument("--out", help="output path (default: overwrite overview)")
+    args = ap.parse_args()
+
+    with open(args.overview) as fh:
+        overview = json.load(fh)
+    with open(args.nx_graph) as fh:
+        nx_graph = json.load(fh)
+    doc_slugs = _walk_slugs(args.docs_root)
+
+    enrich(overview, nx_graph, doc_slugs)
+
+    out = args.out or args.overview
+    with open(out, "w") as fh:
+        json.dump(overview, fh, separators=(",", ":"))
+    meta = overview["meta"]
+    print(
+        f"enriched {out}: {meta['nxProjects']} nx projects, "
+        f"{meta['nxEdges']} depends-edges, {meta['docRefs']} doc refs"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/data/graphify/scripts/test_enrich_unified.py
+++ b/packages/data/graphify/scripts/test_enrich_unified.py
@@ -1,0 +1,106 @@
+"""Unit tests for the unified-graph enrichment (no graphify binary needed)."""
+
+from __future__ import annotations
+
+import copy
+
+from enrich_unified import (
+    doc_ref_for,
+    enrich,
+    longest_prefix_dir,
+    _slug_index,
+)
+
+
+def overview():
+    return {
+        "meta": {
+            "relations": [
+                "imports",
+                "calls",
+                "references",
+                "contains",
+                "extends",
+                "other",
+            ],
+        },
+        "dirs": [
+            {"id": "apps__kbve", "label": "apps/kbve", "n": 10, "files": 3},
+            {"id": "packages__rust", "label": "packages/rust", "n": 20, "files": 5},
+            {"id": "docs", "label": "docs", "n": 1, "files": 1},
+        ],
+        "dirEdges": [[0, 1, 1, 0]],
+    }
+
+
+def nx_graph():
+    return {
+        "graph": {
+            "nodes": {
+                "axum-kbve": {"type": "app", "data": {"root": "apps/kbve/axum-kbve"}},
+                "jedi": {"type": "lib", "data": {"root": "packages/rust/jedi"}},
+                "kbve": {"type": "lib", "data": {"root": "packages/rust/kbve"}},
+            },
+            "dependencies": {
+                "axum-kbve": [{"target": "jedi"}, {"target": "kbve"}],
+                "kbve": [{"target": "jedi"}],  # same dir -> no cross edge
+                "jedi": [],
+            },
+        }
+    }
+
+
+DOCS = ["application/rust", "application/docker", "guides/unrelated", "index"]
+
+
+def test_longest_prefix_dir_picks_deepest_container():
+    labels = ["apps", "apps/kbve", "packages/rust"]
+    assert longest_prefix_dir("apps/kbve/axum-kbve", labels) == 1
+    assert longest_prefix_dir("packages/rust/jedi", labels) == 2
+    assert longest_prefix_dir("nowhere/x", labels) is None
+
+
+def test_slug_index_prefers_application_namespace():
+    idx = _slug_index(["guides/rust", "application/rust"])
+    assert idx["rust"] == "application/rust"
+
+
+def test_doc_ref_matches_first_candidate():
+    idx = _slug_index(DOCS)
+    assert doc_ref_for(["rust", "jedi"], idx) == "/application/rust/"
+    assert doc_ref_for(["nomatch"], idx) is None
+
+
+def test_enrich_attaches_nx_projects_to_containing_dir():
+    o = enrich(overview(), nx_graph(), DOCS)
+    kbve_dir = o["dirs"][0]
+    rust_dir = o["dirs"][1]
+    assert {p["name"] for p in kbve_dir["nx"]["projects"]} == {"axum-kbve"}
+    assert {p["name"] for p in rust_dir["nx"]["projects"]} == {"jedi", "kbve"}
+
+
+def test_enrich_adds_cross_dir_depends_edges_only():
+    o = enrich(overview(), nx_graph(), DOCS)
+    rel = o["meta"]["relations"]
+    assert rel[-1] == "depends"
+    di = rel.index("depends")
+    depends_edges = [e for e in o["dirEdges"] if e[3] == di]
+    # axum-kbve(dir0) -> jedi(dir1) and -> kbve(dir1): both collapse to (0,1) w=2
+    assert depends_edges == [[0, 1, 2, di]]
+    # kbve->jedi is intra-dir (both dir1) -> excluded
+    assert o["meta"]["nxEdges"] == 1
+
+
+def test_enrich_sets_doc_refs_by_leaf_then_project():
+    o = enrich(overview(), nx_graph(), DOCS)
+    assert o["dirs"][1]["ref"] == "/application/rust/"  # leaf "rust"
+    assert "ref" not in o["dirs"][0]  # no application/kbve or axum-kbve doc
+    assert o["meta"]["docRefs"] == 1
+
+
+def test_enrich_is_idempotent():
+    once = enrich(overview(), nx_graph(), DOCS)
+    twice = enrich(copy.deepcopy(once), nx_graph(), DOCS)
+    assert twice["dirEdges"] == once["dirEdges"]
+    assert twice["meta"]["relations"] == once["meta"]["relations"]
+    assert twice["meta"]["nxEdges"] == once["meta"]["nxEdges"]


### PR DESCRIPTION
## What

`/graph/` was a confusing multi-scope hub (search + scopes + facet cards + neighborhood). This makes it **one explorable graph** for the average user, and moves the fusion into the **graphify-wrapper (Python) pipeline** so a single enriched tiered graph is what ships — "digested at the wrapper level".

## The unified model (all at the directory tier)

- **Graphify** — the substrate (dir → file → symbol code analysis), unchanged.
- **NX** — overlay: project identity on directory nodes (`nx.projects`) + project→project deps collapsed to dir→dir edges under a **new `depends` relation** (violet).
- **Docs** — **references**, not nodes: each code node carries a `ref` URL (`packages/rust` → `/application/rust`). No doc-node flood — a reference hangs off the code node.

## Changes

| File | Role |
|------|------|
| `packages/data/graphify/scripts/enrich_unified.py` | **build-tiered step 4**: pure, idempotent fusion of NX + doc refs into `overview.json`. **7 vitest-style pytest cases**, runs without the graphify binary. |
| `build-tiered-graph.sh` | Runs enrich as step 4; `overview.json` regenerated in the pipeline. |
| `graphExplorer/*` | `depends` edge color; node-pick panel now shows the dir's **NX projects** + a **"Read the docs"** reference link. |
| `content/docs/graph.mdx` | `/graph/` renders the unified explorer (reuses `AstroGraphExplorer`). |
| `content/docs/graph/list.mdx` | The earlier search/cards hub, **kept as a fallback** at `/graph/list/` — nothing deleted. |

## Verify

- `pytest test_enrich_unified.py` — 7/7 (nx mapping, cross-dir depends edges, doc-ref precedence, idempotency).
- `vitest buildGraphIndex` — 8/8 (hub fallback still green).
- `nx run astro-kbve:build` — green. Enriched `overview.json` ships: `relations` gains `depends`, **140 nx projects, 27 dep edges, 23 doc refs**. `/graph/` = explorer, `/graph/list/` = fallback.

## Notes

- Enriched `overview.json` is committed so `/graph/` works this build; the weekly `build-tiered` run regenerates it (step 4).
- The existing `/dashboard/graph-explorer/` shares this `overview.json`, so it gains the NX edges + doc refs too — consistent.