### PR TITLE
fix(palworld): render game chat as [PAL] <player> on Discord

### DIFF
--- a/apps/agones/palworld/relay/src/irc_bridge.rs
+++ b/apps/agones/palworld/relay/src/irc_bridge.rs
@@ -215,8 +215,8 @@ fn format_for_irc(ev: &GameEvent, last_players: &mut Option<u64>) -> Option<Stri
                 .map(sanitize_irc)
                 .filter(|p| !p.is_empty());
             match player {
-                Some(player) => Some(format!("<{player}> {text}")),
-                None => Some(text),
+                Some(player) => Some(format!("[CHAT] {player}@palworld: {text}")),
+                None => Some(format!("[CHAT] server@palworld: {text}")),
             }
         }
         GameEventKind::Join
@@ -256,7 +256,7 @@ mod tests {
     fn chat_is_relayed() {
         let mut lp = None;
         let out = format_for_irc(&ev(GameEventKind::Chat, Some("Alice"), "hi"), &mut lp);
-        assert_eq!(out, Some("<Alice> hi".to_string()));
+        assert_eq!(out, Some("[CHAT] Alice@palworld: hi".to_string()));
     }
 
     #[test]
@@ -292,7 +292,7 @@ mod tests {
             &ev(GameEventKind::Chat, Some("A\x02li\x03ce"), "he\x03llo\x0f"),
             &mut lp,
         );
-        assert_eq!(out, Some("<Alice> hello".to_string()));
+        assert_eq!(out, Some("[CHAT] Alice@palworld: hello".to_string()));
     }
 
     #[test]
@@ -305,11 +305,11 @@ mod tests {
     }
 
     #[test]
-    fn control_only_player_drops_prefix() {
+    fn control_only_player_falls_back_to_server() {
         let mut lp = None;
         assert_eq!(
             format_for_irc(&ev(GameEventKind::Chat, Some("\x02\x03"), "hi"), &mut lp),
-            Some("hi".to_string())
+            Some("[CHAT] server@palworld: hi".to_string())
         );
     }
 
@@ -318,8 +318,7 @@ mod tests {
         let mut lp = None;
         let long = "x".repeat(600);
         let out = format_for_irc(&ev(GameEventKind::Chat, Some("Al"), &long), &mut lp).unwrap();
-        // "<Al> " + 400 chars
-        assert_eq!(out, format!("<Al> {}", "x".repeat(400)));
+        assert_eq!(out, format!("[CHAT] Al@palworld: {}", "x".repeat(400)));
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/relay.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/relay.rs
@@ -125,6 +125,7 @@ fn platform_tag(platform: &str) -> String {
         "isometric" => "I".to_owned(),
         "rareicon" => "R".to_owned(),
         "minecraft" => "M".to_owned(),
+        "palworld" => "PAL".to_owned(),
         "system" => "SYS".to_owned(),
         "irc" => "IRC".to_owned(),
         other => other

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_palworld_relay
 pipeline: docker
 app_name: agones-palworld-relay
-version: "0.0.6"
+version: "0.0.7"
 source_path: apps/agones/palworld/relay
 version_toml: apps/agones/palworld/relay/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.28"
+version: "0.1.29"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## Palworld chat renders as `[PAL] <player>` on Discord (not `[IRC] palworld-bot: <player>`)

### Problem
In-game chat reaches Discord, but as `**[IRC] palworld-bot**: <[KBVE.com] h0lybyte☠> hmm` — the relay bot's IRC nick shows as the sender and the real player is buried inside `<…>`.

### Root cause
Every KBVE game relay posts to IRC using a structured wire format — `[CHAT] <sender>@<platform>: <content>` — which the discordsh-bot chat parser (`ChatMessage::from_irc_privmsg`) decodes to recover the platform + real player. Factorio does this (`[CHAT] player@factorio: …`).

The Palworld relay was the exception: it posted old-style `<player> text`. The parser fails to match → falls back to `platform=irc, sender=<IRC nick>` (`palworld-bot`) → the whole line becomes content.

### Fix (2 files + 2 version bumps)
1. **`apps/agones/palworld/relay/src/irc_bridge.rs`** — `format_for_irc` now emits `[CHAT] {player}@palworld: {text}` (matches factorio). Tests updated.
2. **`apps/discordsh/discordsh-bot/src/discord/relay.rs`** — add `"palworld" => "PAL"` to `platform_tag` (else it renders the first-letter fallback `[P]`).

Result: `**[PAL] <player>**: text`.

### Verification
- Relay: `cargo test` 24/24.
- discordsh-bot: `cargo check` clean (pre-existing dead-code warnings only).

### Versions
MDX bumps only (deployment yaml + version.toml auto-synced by pipeline): `agones-palworld-relay` → `0.0.7`, `discordsh-bot` → `0.1.29`.

Note: keeps the full in-game display name (guild tag / symbols) for now — matches factorio. Stripping to a bare player name can be a follow-up.
