### PR TITLE
fix(palworld): prune fabricated chat-hook candidates from PalChatRelay

### DIFF
--- a/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
@@ -3,13 +3,10 @@ local RETRY_MS = 15000
 
 local CANDIDATES = {
     "/Script/Pal.PalGameStateInGame:BroadcastChatMessage",
-    "/Script/Pal.PalNetworkChatManager:BroadcastChat",
-    "/Script/Pal.PalNetworkChatManager:BroadcastChatMessage",
 }
 
 local CLASS_PROBES = {
     "/Script/Pal.PalGameStateInGame",
-    "/Script/Pal.PalNetworkChatManager",
 }
 
 local function log(msg)

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.10"
+version: "0.0.11"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Removes two dead chat-hook candidates from `PalChatRelay/scripts/main.lua` that reference `/Script/Pal.PalNetworkChatManager` — a class that **does not exist in Palworld** (0 hits in the [SDK reference dump](https://github.com/DrRak72/Palworld-Modding-Reference)). They never resolved at runtime; the live-verified hook is `PalGameStateInGame:BroadcastChatMessage`, which is kept.

- Prune fake `PalNetworkChatManager:BroadcastChat` + `:BroadcastChatMessage` candidates
- Prune fake `PalNetworkChatManager` class probe
- Keep retry-forever + probe machinery (hook can't register until the class loads at warmup)

## Why

Dead weight + misleading. The relay works today on the single real hook.

## Deploy

MDX-only bump `agones-palworld` 0.0.10 → 0.0.11 (the mod bakes into the game image). deployment yaml + version.toml sync automatically post-publish.