### PR TITLE
feat(palworld): scaffold PalForge world-objects mod (not integrated)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/README.md
+++ b/apps/agones/palworld/mods/PalForge/README.md
@@ -1,0 +1,58 @@
+# PalForge
+
+Server-authored persistent world objects for the Agones Palworld server.
+UE4SS Lua mod, sibling to `PalChatRelay`. Drives Palworld's own native build
+objects from a git-versioned config — no custom meshes, no custom text
+rendering.
+
+**Feature #1:** readable signposts (a physical post players walk up to and
+read). Later object types (protected structures, landmarks, spawn decor) reuse
+the same place-from-config loop.
+
+## Status
+
+**Skeleton — NOT integrated into the server yet.** `mods.txt`, `overlay.sh`,
+and the `agones-palworld` MDX are intentionally untouched. Placement is stubbed
+pending the Phase 0 live spike (see below).
+
+## Layout
+
+| File | Role |
+|------|------|
+| `scripts/main.lua` | Loader, world-ready trigger, place-from-config loop. `spawn_signboard` / `set_sign_text` are stubs until the spike resolves them. |
+| `scripts/signboards.lua` | Config as a Lua table (`{ signs = { { coords, rot, text } } }`). Zero-dependency; UE4SS Lua has no TOML parser. Source of truth in git. |
+| `scripts/probe.lua` | Phase 0 spike tool. Finds existing signboards, confirms `GetSignboardText`, tries candidate text setters. Run manually on the live server; do not ship. |
+
+## The native signboard
+
+From the DrRak72/Palworld-Modding-Reference SDK dump:
+
+- `ABP_BuildObject_Signboard_C : APalBuildObject` — spawnable, replicated,
+  save-persisted. Path
+  `/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C`.
+- Text lives on native `PalMapObjectSignboardModel` (getter `GetSignboardText`,
+  delegate `UpdateSignboardTextDelegate`). Actor refresh `OnUpdateText(FString)`.
+  3D render widget `WBP_Ingame_Signboard_3DText.UpdateText`.
+
+## Open unknowns (Phase 0 spike)
+
+- **R1 — spawn.** Can Lua spawn `BP_BuildObject_Signboard_C` at a coordinate
+  with a valid concrete model? Bare `SpawnActor` may need the build system
+  (foundation / guild / owner) path.
+- **R2 — text setter.** Native setter name on `PalMapObjectSignboardModel`
+  (only the getter is dumped). `probe.lua` tries candidates against a live
+  signboard.
+
+Fallback if both fail: proximity-chat signs (invisible trigger → send text via
+the known-working `BroadcastChatMessage` path).
+
+## Integration (later, once the spike resolves R1/R2)
+
+1. Fill `spawn_signboard` / `set_sign_text` in `main.lua` with the confirmed
+   mechanism.
+2. Add `PalForge:1` to `apps/agones/palworld/mods/mods.txt`.
+3. Stage `PalForge/scripts` in `overlay.sh` (same pattern as `PalChatRelay`).
+4. Bump the `agones-palworld` MDX version (deploy lever).
+
+See `docs/superpowers/specs/2026-07-24-palforge-design.md` and the
+`project_palworld_agones` memory.

--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -1,0 +1,77 @@
+local MOD = "PalForge"
+local RETRY_MS = 15000
+
+local GAMESTATE = "/Script/Pal.PalGameStateInGame"
+local SIGNBOARD_CLASS =
+    "/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C"
+
+local placed = false
+
+local function log(msg)
+    print("[" .. MOD .. "] " .. msg)
+end
+
+local function load_signs()
+    local ok, cfg = pcall(require, "signboards")
+    if not ok or type(cfg) ~= "table" then
+        log("config load failed: " .. tostring(cfg))
+        return {}
+    end
+    return cfg.signs or {}
+end
+
+local function coord_str(coords)
+    if type(coords) ~= "table" then
+        return "?"
+    end
+    return table.concat(coords, ",")
+end
+
+local function spawn_signboard(coords, rot)
+    local _ = SIGNBOARD_CLASS
+    local _ = coords
+    local _ = rot
+    return nil
+end
+
+local function set_sign_text(actor, text)
+    local _ = actor
+    local _ = text
+    return false
+end
+
+local function place_all()
+    if placed then
+        return
+    end
+    placed = true
+
+    local signs = load_signs()
+    log("placing " .. #signs .. " sign(s)")
+
+    for _, s in ipairs(signs) do
+        local actor = spawn_signboard(s.coords, s.rot)
+        if actor and set_sign_text(actor, s.text) then
+            log("placed sign @ " .. coord_str(s.coords) .. " : " .. tostring(s.text))
+        else
+            log("PENDING spawn/setter unresolved (Phase 0 spike) @ " .. coord_str(s.coords))
+        end
+    end
+end
+
+local function world_ready()
+    local ok, obj = pcall(StaticFindObject, GAMESTATE)
+    return ok and obj and obj:IsValid()
+end
+
+local function schedule()
+    if world_ready() then
+        place_all()
+        return
+    end
+    log("world not ready; retry in " .. (RETRY_MS / 1000) .. "s")
+    pcall(ExecuteWithDelay, RETRY_MS, schedule)
+end
+
+log("loaded (skeleton; not yet integrated into server)")
+schedule()

--- a/apps/agones/palworld/mods/PalForge/scripts/probe.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/probe.lua
@@ -1,0 +1,88 @@
+local MOD = "PalForge/probe"
+local RETRY_MS = 15000
+
+local GAMESTATE = "/Script/Pal.PalGameStateInGame"
+local SIGNBOARD_SHORT = "BP_BuildObject_Signboard_C"
+
+local SETTER_CANDIDATES = {
+    "SetSignboardText",
+    "SetText",
+    "UpdateText",
+    "SetMessage",
+    "OnUpdateText",
+}
+
+local ran = false
+
+local function log(msg)
+    print("[" .. MOD .. "] " .. msg)
+end
+
+local function world_ready()
+    local ok, obj = pcall(StaticFindObject, GAMESTATE)
+    return ok and obj and obj:IsValid()
+end
+
+local function find_existing_signboards()
+    local ok, list = pcall(FindAllOf, SIGNBOARD_SHORT)
+    if not ok or type(list) ~= "table" then
+        return {}
+    end
+    return list
+end
+
+local function probe_getter(actor)
+    local ok, val = pcall(function()
+        return tostring(actor:GetSignboardText():ToString())
+    end)
+    if ok then
+        log("R2 getter GetSignboardText() -> " .. val)
+    else
+        log("R2 getter GetSignboardText() failed: " .. tostring(val))
+    end
+end
+
+local function probe_setters(actor)
+    for _, name in ipairs(SETTER_CANDIDATES) do
+        local ok = pcall(function()
+            actor[name](actor, "PalForge probe text")
+        end)
+        log("R2 setter " .. name .. " -> " .. (ok and "CALLABLE" or "absent/threw"))
+    end
+end
+
+local function probe_r2()
+    local boards = find_existing_signboards()
+    log("R2: found " .. #boards .. " existing signboard(s)")
+    if #boards == 0 then
+        log("R2: no existing signboards to probe; place one in-game then rerun")
+        return
+    end
+    local actor = boards[1]
+    probe_getter(actor)
+    probe_setters(actor)
+end
+
+local function probe_r1()
+    log("R1: spawn probe is manual for now — attempt SpawnActor of "
+        .. SIGNBOARD_SHORT .. " via UE4SS Live View / world SpawnActor and log result")
+end
+
+local function run()
+    if ran then
+        return
+    end
+    if not world_ready() then
+        log("world not ready; retry in " .. (RETRY_MS / 1000) .. "s")
+        pcall(ExecuteWithDelay, RETRY_MS, run)
+        return
+    end
+    ran = true
+    log("world ready; running Phase 0 probes")
+    probe_r2()
+    probe_r1()
+    log("probe complete")
+end
+
+log("loaded probe (Phase 0 spike; run manually, do not ship)")
+run()

--- a/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
@@ -1,0 +1,9 @@
+return {
+    signs = {
+        {
+            coords = { 0, 0, 0 },
+            rot = 0,
+            text = "Welcome to KBVE Palworld",
+        },
+    },
+}

--- a/docs/superpowers/specs/2026-07-24-palforge-design.md
+++ b/docs/superpowers/specs/2026-07-24-palforge-design.md
@@ -1,0 +1,128 @@
+# PalForge — Server-Authored World Objects Mod
+
+**Date:** 2026-07-24
+**Status:** Design approved; Phase 0 spike pending
+**Owner:** h0lybyte
+
+## Goal
+
+A UE4SS Lua mod that lets the server place persistent, config-defined world
+objects into the Palworld map. Feature #1: readable signposts (a physical
+post players can walk up to and read). Later object types (protected
+structures, landmarks, spawn decor) layer onto the same mechanism.
+
+## Why
+
+Vanilla Palworld has no server-authored placed objects. Admins cannot pin a
+"Welcome to Spawn" sign, a rules board, or a landmark that survives restarts
+and cannot be griefed. PalForge fills that gap by driving Palworld's own
+native build objects from a git-versioned config — no custom meshes, no
+custom text rendering.
+
+## Key Discovery — drive the native signboard, don't build one
+
+From the DrRak72/Palworld-Modding-Reference SDK dump:
+
+- `ABP_BuildObject_Signboard_C : APalBuildObject` — real, spawnable,
+  replicated, save-persisted. Path:
+  `/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C`.
+  MapObjectId `"Signboard"`.
+- Text lives on native `PalMapObjectSignboardModel` (getter
+  `GetSignboardText`, refresh delegate `UpdateSignboardTextDelegate`).
+- Actor `OnUpdateText(FString)` pushes model text → 3D widget
+  `WBP_Ingame_Signboard_3DText.UpdateText`.
+- Players already type text on these via `WBP_Ingame_Signboard_TextInput`.
+
+So a signboard already renders + replicates 3D text natively. PalForge's job
+is only to **place them from config and stamp the text.**
+
+## Architecture
+
+Sibling to `PalChatRelay`, same UE4SS loader pattern (retry-forever hook
+registration, `ExecuteWithDelay`, `pcall`, `StaticFindObject`, `RegisterHook`).
+
+```
+apps/agones/palworld/mods/PalForge/
+  scripts/main.lua          loader + world-load trigger + place loop
+  objects/signboards.toml   [[sign]] coords, rot, text   (git = source of truth)
+```
+
+- **Trigger:** on world-load (delayed schedule, mirroring PalChatRelay's boot
+  retry), read config.
+- **Place loop:** for each configured object → spawn the native build object
+  at coords/rotation → set its model text → call `OnUpdateText()` to refresh.
+- **Config = source of truth. Spawn transient + respawn each world-load** —
+  no dedupe against the save, no writable PVC state, edits ship by redeploying
+  the image. DRY.
+- **Packaging:** bakes into the `agones-palworld` game image via `overlay.sh`
+  (same staging path as PalChatRelay). `mods.txt` gains `PalForge:1`.
+- **Deploy lever:** bump `agones-palworld` MDX version only; deployment yaml
+  and version.toml sync automatically post-publish. Never hand-edit those.
+
+## Open Unknowns (resolved by Phase 0 spike)
+
+Both are only answerable on the live server via a UE4SS runtime dump — they
+are NOT in any static reference (the reference dumps Blueprint classes +
+JsonProperties; native manager/model setters are absent, the same gap that
+hid the chat function until it was proved live).
+
+- **R1 — spawn.** Can Lua spawn `BP_BuildObject_Signboard_C` at a coordinate
+  and get a valid concrete model? A bare `SpawnActor` may not register with
+  save/persistence or may lack a valid `PalMapObjectSignboardModel`; the real
+  path may require the build system (foundation / guild / owner).
+- **R2 — text setter.** The native setter name on
+  `PalMapObjectSignboardModel` (only `GetSignboardText` is dumped). Dump the
+  model's functions live to find it. `OnUpdateText` alone may be visual-only,
+  not persisted/replicated.
+
+**Fallback if R1/R2 fail:** proximity-chat signs — invisible trigger at
+coords; walking near sends the sign's text to the player via the known-working
+`BroadcastChatMessage` path (per-player if resolvable, else whole-server with
+a per-player cooldown). Reuses existing chat render, zero spawn/replication
+risk. Documented here so a spike failure has a landing spot.
+
+## Phases
+
+### Phase 0 — Live spike (de-risk before real build)
+
+Throwaway `probe.lua` deployed to the live server that:
+1. Attempts to spawn one `BP_BuildObject_Signboard_C` at a test coordinate.
+2. Dumps the spawned actor's `PalMapObjectSignboardParameter` /
+   `PalMapObjectSignboardModel` functions (via `ForEachFunction` / Live View)
+   to find the text setter.
+3. Attempts to set text + `OnUpdateText()` and reports whether the sign
+   renders client-side.
+
+Deliverable: probe results (spawn works Y/N, setter name, renders Y/N).
+Outcome selects the Phase-1 mechanism (native placement vs. fallback).
+
+### Phase 1 — Config-driven signboards (after spike)
+
+- `objects/signboards.toml` schema: `[[sign]]` with `coords = [x,y,z]`,
+  `rot = yaw`, `text = "..."`.
+- `scripts/main.lua`: loader, world-load trigger, config parse, place loop
+  using the mechanism the spike confirmed.
+- `mods.txt` += `PalForge:1`; `overlay.sh` stages `PalForge/scripts` +
+  `objects`.
+- MDX bump on `agones-palworld`.
+
+### Phase 2+ — Additional object types
+
+- Indestructible flag (protect placed + optionally player objects).
+- Further object types (landmarks, protected structures, spawn decor) reusing
+  the place-from-config loop.
+
+## Testing
+
+- Phase 0: manual live verification (join server, read UE4SS.log for probe
+  output, look for the test sign in-world).
+- Phase 1: config a known sign near spawn → redeploy → join → confirm the
+  post is present and the text renders for a second client.
+
+## References
+
+- Native signboard classes — DrRak72/Palworld-Modding-Reference (SDK dump).
+- Sibling mod — `apps/agones/palworld/mods/PalChatRelay/scripts/main.lua`.
+- UE4SS API confirmed in prod: `StaticFindObject`, `RegisterHook`,
+  `FindAllOf`, `ExecuteWithDelay`, `ForEachName`, `ForEachProperty`.
+- Image + deploy — see [[project_palworld_agones]] memory.


### PR DESCRIPTION
## What

Scaffolds **PalForge** — a new UE4SS Lua mod for server-authored persistent world objects, sibling to `PalChatRelay`. Feature #1 = readable signposts that drive Palworld's **native** `BP_BuildObject_Signboard_C` from a git-versioned config (no custom meshes, no custom text rendering).

## Scope — scaffold only, does NOT deploy

Intentionally **not** wired into the server:
- `mods.txt` — untouched (no `PalForge:1` entry)
- `overlay.sh` — untouched (mod not staged into the image)
- `agones-palworld` MDX — untouched (no version bump → no publish)

The mod sits in the tree unused. If ever loaded it logs `PENDING spawn/setter unresolved (Phase 0 spike)` and does nothing — `spawn_signboard` / `set_sign_text` are stubs.

## Files

| File | Role |
|------|------|
| `scripts/main.lua` | Loader + world-ready trigger + place-from-config loop (spawn/setter stubbed) |
| `scripts/probe.lua` | Phase 0 spike tool — find existing signboard, confirm `GetSignboardText`, try candidate setters. Run manually on live; do not ship. |
| `scripts/signboards.lua` | Config table (Lua, zero-dep — UE4SS has no TOML parser) |
| `README.md` | Mod overview + integration steps |
| `docs/superpowers/specs/2026-07-24-palforge-design.md` | Design spec |

## Open (Phase 0 live spike, deferred)

- **R1** — can Lua spawn `BP_BuildObject_Signboard_C` with a valid concrete model?
- **R2** — native text setter name on `PalMapObjectSignboardModel` (only `GetSignboardText` is dumped).

Fallback documented if both fail: proximity-chat signs via the known-working `BroadcastChatMessage` path.

Native signboard classes sourced from the [DrRak72/Palworld-Modding-Reference](https://github.com/DrRak72/Palworld-Modding-Reference) SDK dump.