### PR TITLE
feat(media): /media console hub + pin reel image to MDX version tag

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/media/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/media/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Media
+description: KBVE media console — stream ephemeral legal torrents, manage transcodes, and monitor the reel pipeline.
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+prev: false
+sidebar:
+    label: Media
+    order: 6
+    attrs:
+        data-auth-visibility: staff
+unsplash: 1478720568477-152d9b164e26
+img: https://images.unsplash.com/photo-1478720568477-152d9b164e26?fit=crop&w=1400&h=700&q=75
+tags:
+    - media
+    - reel
+    - streaming
+    - staff
+---
+
+import { Card, CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution" title="Staff only">
+	Media tools stream and transcode ephemeral legal torrents behind the VPN fail-safe. Access is limited to staff accounts.
+</Aside>
+
+The media console is the home for KBVE's streaming pipeline — fetch, transcode, and play ephemeral legal media on demand.
+
+<CardGrid>
+	<LinkCard
+		title="Reel Player"
+		href="/media/reel/"
+		description="Stream a legal torrent as progressive MP4 or live HLS, straight in the browser."
+	/>
+	<Card title="Transcode Queue" icon="setting">
+		Remux and encode status for in-flight media. Coming soon.
+	</Card>
+	<Card title="Library" icon="open-book">
+		Browse completed media before it is reaped. Coming soon.
+	</Card>
+	<Card title="VPN Health" icon="shield">
+		Fail-safe egress checks that gate every fetch. Coming soon.
+	</Card>
+</CardGrid>


### PR DESCRIPTION
## What

**1. `/media` console hub** — new `content/docs/media/index.mdx` → the `/media` route: central staff media landing.
- Reel Player LinkCard → existing `/media/reel` (unchanged, not moved).
- Placeholder cards: Transcode Queue, Library, VPN Health — future sub-pages.
- Splash template, staff-gated sidebar, matching reel frontmatter.

**2. Reel image pinning** — stop tracking `:latest`, use MDX-driven version tags.
- Add `deployment_yaml: apps/kube/reel/manifest/reel.yaml` to `reel.mdx` frontmatter + `ci-dispatch-manifest.json`, so `utils-post-publish.yml` sed-bumps the deployment image tag on every `version:` bump (same as jobboard/discordsh/metrics).
- Pin `reel.yaml` → `ghcr.io/kbve/reel:0.1.1` (current published version). Controlled, reproducible rollouts; implicit `imagePullPolicy` becomes `IfNotPresent` for the immutable tag.

## Why

`/media` had no parent hub — reel floated at `/media/reel`. And the deployment tracked mutable `:latest` with no controlled rollout. Both are "make media operational" prep.

## Notes

- Kept hub under `/media` (not `/dashboard/media`) per direction — reel URL unchanged, no redirect.
- `ci-dispatch-manifest.json` hand-edited to match the generator (no node_modules in worktree); `ci-manifest-guard` verifies regen parity in CI.