### PR TITLE
feat(palforge): add /pos chat command for authoring sign coords

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -2,13 +2,21 @@ local MOD = "PalForge"
 local RETRY_MS = 15000
 
 local GAMESTATE = "/Script/Pal.PalGameStateInGame"
+local CHAT_FN = "/Script/Pal.PalGameStateInGame:BroadcastChatMessage"
 local SIGNBOARD_CLASS =
     "/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C"
 
 local placed = false
+local chat_registered = false
 
 local function log(msg)
     print("[" .. MOD .. "] " .. msg)
+end
+
+local ok_pos, pos = pcall(require, "pos")
+if not ok_pos or type(pos) ~= "table" then
+    log("pos module load failed: " .. tostring(pos))
+    pos = { handle = function() return false end }
 end
 
 local function load_signs()
@@ -59,6 +67,39 @@ local function place_all()
     end
 end
 
+local function extract(param)
+    local ok, sender, text = pcall(function()
+        local p = param:get()
+        local name = (p.Sender and tostring(p.Sender:ToString())) or "?"
+        local msg = (p.Message and tostring(p.Message:ToString())) or ""
+        return name, msg
+    end)
+    if ok then
+        return sender, text
+    end
+    return nil, nil
+end
+
+local function on_chat(_, a, b)
+    local sender, text = extract(a)
+    if (not text or #text == 0) and b ~= nil then
+        sender, text = extract(b)
+    end
+    if sender and text and #text > 0 then
+        pcall(pos.handle, sender, text, log)
+    end
+end
+
+local function register_chat()
+    if chat_registered then
+        return
+    end
+    if pcall(RegisterHook, CHAT_FN, on_chat) then
+        chat_registered = true
+        log("chat command hook registered on " .. CHAT_FN)
+    end
+end
+
 local function world_ready()
     local ok, obj = pcall(StaticFindObject, GAMESTATE)
     return ok and obj and obj:IsValid()
@@ -67,11 +108,14 @@ end
 local function schedule()
     if world_ready() then
         place_all()
-        return
+        register_chat()
+    else
+        log("world not ready; retry in " .. (RETRY_MS / 1000) .. "s")
     end
-    log("world not ready; retry in " .. (RETRY_MS / 1000) .. "s")
-    pcall(ExecuteWithDelay, RETRY_MS, schedule)
+    if not chat_registered then
+        pcall(ExecuteWithDelay, RETRY_MS, schedule)
+    end
 end
 
-log("loaded (spawn/setter pending Phase 0 spike)")
+log("loaded (spawn/setter pending Phase 0 spike; /pos command active)")
 schedule()

--- a/apps/agones/palworld/mods/PalForge/scripts/pos.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/pos.lua
@@ -1,0 +1,60 @@
+local M = {}
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+function M.player_location(sender, finder)
+    finder = finder or FindAllOf
+    local ok, loc = pcall(function()
+        local pcs = finder("PalPlayerController")
+        if type(pcs) ~= "table" then
+            return nil
+        end
+        for _, pc in ipairs(pcs) do
+            local name
+            pcall(function()
+                name = pc.PlayerState.PlayerNamePrivate:ToString()
+            end)
+            if not name then
+                pcall(function()
+                    name = pc.PlayerState.PlayerName:ToString()
+                end)
+            end
+            if name == sender then
+                local pawn = pc.Pawn
+                if not pawn and pc.K2_GetPawn then
+                    pcall(function()
+                        pawn = pc:K2_GetPawn()
+                    end)
+                end
+                if pawn then
+                    local v = pawn:K2_GetActorLocation()
+                    return { x = v.X, y = v.Y, z = v.Z }
+                end
+            end
+        end
+        return nil
+    end)
+    if ok then
+        return loc
+    end
+    return nil
+end
+
+function M.handle(sender, msg, emit, finder)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "/pos" then
+        return false
+    end
+    local loc = M.player_location(sender, finder)
+    if loc then
+        emit(string.format(
+            "/pos %s -> X=%.1f Y=%.1f Z=%.1f",
+            tostring(sender), loc.x, loc.y, loc.z))
+    else
+        emit("/pos " .. tostring(sender) .. " -> location unresolved")
+    end
+    return true
+end
+
+return M

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -25,6 +25,10 @@ end
 
 function ExecuteWithDelay(_, _) end
 
+function RegisterHook(_, _)
+    return true
+end
+
 function FindAllOf(_)
     local board = {
         GetSignboardText = function()
@@ -41,15 +45,51 @@ dofile(SCRIPTS .. "/main.lua")
 _print("=== load probe.lua ===")
 dofile(SCRIPTS .. "/probe.lua")
 
+_print("=== pos.lua command ===")
+local pos = require("pos")
+
+local pos_emits = {}
+local function emit(m)
+    pos_emits[#pos_emits + 1] = m
+    _print("  emit: " .. m)
+end
+
+local function finder_with(name, x, y, z)
+    local pc = {
+        PlayerState = { PlayerNamePrivate = { ToString = function() return name end } },
+        Pawn = { K2_GetActorLocation = function() return { X = x, Y = y, Z = z } end },
+    }
+    return function(_)
+        return { pc }
+    end
+end
+
+local h1 = pos.handle("Al", "/pos", emit, finder_with("Al", 100, 200, 300))
+local n_after_h1 = #pos_emits
+local h2 = pos.handle("Al", "hello world", emit, finder_with("Al", 1, 2, 3))
+local n_after_h2 = #pos_emits
+local h3 = pos.handle("Al", "  /POS ", emit, finder_with("Al", 5, 6, 7))
+local h4 = pos.handle("Bob", "/pos", emit, function(_) return {} end)
+
+local pos_ok = h1 == true
+    and h2 == false
+    and n_after_h2 == n_after_h1
+    and h3 == true
+    and h4 == true
+    and pos_emits[1] == "/pos Al -> X=100.0 Y=200.0 Z=300.0"
+    and pos_emits[2] == "/pos Al -> X=5.0 Y=6.0 Z=7.0"
+    and pos_emits[3]:find("location unresolved", 1, true) ~= nil
+
 _print("=== results ===")
 _print(string.format(
-    "placed=%d pending=%d setter_callable=%d setter_absent=%d",
-    calls.placed, calls.pending, calls.setter_callable, calls.setter_absent))
+    "placed=%d pending=%d setter_callable=%d setter_absent=%d pos_ok=%s",
+    calls.placed, calls.pending, calls.setter_callable, calls.setter_absent, tostring(pos_ok)))
 
 local ok = calls.pending == 1
     and calls.placed == 0
     and calls.setter_callable == 1
     and calls.setter_absent == 4
+    and pos_ok
 
 if ok then
     _print("HARNESS PASS")


### PR DESCRIPTION
## What

Adds a **`/pos`** chat command to PalForge. A player types `/pos`, their world location is logged — so admins can harvest real coordinates for `signboards.lua` instead of the `0,0,0` placeholder.

## How

- **`scripts/pos.lua`** — command module.
  - `player_location(sender, finder)` resolves sender → `PalPlayerController` → pawn → `K2_GetActorLocation`. Defensive: candidate name fields (`PlayerNamePrivate`/`PlayerName`), everything `pcall`-guarded, `finder` injectable for tests.
  - `handle(sender, msg, emit, finder)` matches a trimmed/case-insensitive `/pos` → emits `X= Y= Z=` or an unresolved fallback.
- **`main.lua`** — registers a chat hook on `PalGameStateInGame:BroadcastChatMessage` (retry-forever, same pattern as the loader), extracts sender+text, routes to `pos.handle`. Module load is `pcall`-guarded with a no-op fallback so a missing module can't break boot.
- **`harness.lua`** — `/pos` cases: match→coords, non-command ignored, trim/case, unresolved.

## Safety / scope

- **Read-only** — no spawn, no writes to the world. Safe to run live.
- The sender→pawn→location API is a **runtime unknown**, resolved defensively; real output is verified on the cluster with a live player. **Load** is gated by e2e.
- **No MDX bump → does not deploy.**

## Verified

```
nx test agones-palworld  ->  HARNESS PASS  (pos_ok=true)
```

Related: #14628 (scaffold), #14640 (harness target), #14641 (image integration + e2e load gate).