### PR TITLE
chore(palworld): bump agones-palworld 0.0.11 -> 0.0.12 (ship /pos)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.11"
+version: "0.0.12"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Lands the **0.0.12 publish lever** for PalForge `/pos`.

## Why a separate PR

The `/pos` feature (#14643) squash-merged to dev, but my MDX version bump raced the squash and got left **orphaned on `palforge-pos`** — dev ended up with the `/pos` code at version **0.0.11**, so the image would never publish/deploy. This bump lands the lever on a clean branch off dev.

## Effect

MDX 0.0.11 → 0.0.12 → CI publishes `agones-palworld:0.0.12` (with `/pos` + PalForge already on dev) → rotator adopts → new GS runs `/pos`. version.toml + gameserver.yaml sync automatically post-publish.