### PR TITLE
feat(reel): staff console — add/list/transcode/delete torrents

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -1,6 +1,7 @@
 ---
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactReelPlayer from '@/components/media/ReactReelPlayer';
+import ReactReelConsole from '@/components/media/ReactReelConsole';
 ---
 
 <BentoShell
@@ -10,6 +11,9 @@ import ReactReelPlayer from '@/components/media/ReactReelPlayer';
 	<div class="reel-dash not-content">
 		<div class="reel-dash__stream not-content">
 			<ReactReelPlayer client:only="react" />
+		</div>
+		<div class="reel-dash__console not-content">
+			<ReactReelConsole client:only="react" />
 		</div>
 	</div>
 </BentoShell>
@@ -92,5 +96,177 @@ import ReactReelPlayer from '@/components/media/ReactReelPlayer';
 	:global(.reel-player__controls button:disabled) {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.reel-dash__console {
+		margin-top: 2rem;
+	}
+
+	:global(.reel-console) {
+		border: 1px solid #27272a;
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+		background: #0c0c0e;
+	}
+
+	:global(.reel-console__header) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	:global(.reel-console__header h3) {
+		margin: 0;
+		font-size: 1rem;
+		color: #e5e7eb;
+	}
+
+	:global(.reel-console__gate) {
+		color: #9ca3af;
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	:global(.reel-console__add) {
+		display: flex;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+
+	:global(.reel-console__add input) {
+		flex: 1;
+		min-width: 0;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.5rem;
+		border: 1px solid #3f3f46;
+		background: #18181b;
+		color: #e5e7eb;
+		font-size: 0.875rem;
+	}
+
+	:global(.reel-console__refresh),
+	:global(.reel-console__add button),
+	:global(.reel-console__btn) {
+		padding: 0.5rem 1rem;
+		border-radius: 0.5rem;
+		border: 1px solid #3f3f46;
+		background: #18181b;
+		color: #e5e7eb;
+		cursor: pointer;
+		font-size: 0.8125rem;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+	}
+
+	:global(.reel-console__btn--danger) {
+		border-color: #7f1d1d;
+		color: #fca5a5;
+	}
+
+	:global(.reel-console__refresh:disabled),
+	:global(.reel-console__add button:disabled),
+	:global(.reel-console__btn:disabled),
+	:global(.reel-console__btn[aria-disabled='true']) {
+		opacity: 0.5;
+		cursor: not-allowed;
+		pointer-events: none;
+	}
+
+	:global(.reel-console__error) {
+		color: #f87171;
+		font-size: 0.8125rem;
+		margin: 0 0 0.75rem;
+	}
+
+	:global(.reel-console__list) {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	:global(.reel-console__empty) {
+		color: #71717a;
+		font-size: 0.875rem;
+		padding: 0.75rem 0;
+	}
+
+	:global(.reel-console__row) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.75rem;
+		border: 1px solid #27272a;
+		border-radius: 0.5rem;
+		background: #131316;
+		flex-wrap: wrap;
+	}
+
+	:global(.reel-console__meta) {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		min-width: 0;
+	}
+
+	:global(.reel-console__name) {
+		color: #e5e7eb;
+		font-size: 0.875rem;
+		font-weight: 600;
+		word-break: break-word;
+	}
+
+	:global(.reel-console__sub) {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		color: #9ca3af;
+		font-size: 0.75rem;
+	}
+
+	:global(.reel-console__rowerr) {
+		color: #f87171;
+		font-size: 0.75rem;
+	}
+
+	:global(.reel-console__badge) {
+		padding: 0.05rem 0.5rem;
+		border-radius: 999px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		background: #27272a;
+		color: #d4d4d8;
+	}
+
+	:global(.reel-console__badge--seeding) {
+		background: #064e3b;
+		color: #6ee7b7;
+	}
+
+	:global(.reel-console__badge--leeching) {
+		background: #78350f;
+		color: #fcd34d;
+	}
+
+	:global(.reel-console__badge--failed) {
+		background: #7f1d1d;
+		color: #fca5a5;
+	}
+
+	:global(.reel-console__badge--reaped) {
+		background: #3f3f46;
+		color: #a1a1aa;
+	}
+
+	:global(.reel-console__actions) {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { homeService } from '@/components/dashboard/homeService';
+import {
+	$reelList,
+	$reelListError,
+	$reelListLoading,
+	addTorrent,
+	deleteTorrent,
+	startTranscode,
+	refreshReelList,
+	type ReelTorrent,
+} from './reelService';
+
+const STATE_BADGE: Record<string, string> = {
+	Leeching: 'reel-console__badge--leeching',
+	Seeding: 'reel-console__badge--seeding',
+	Reaped: 'reel-console__badge--reaped',
+	Failed: 'reel-console__badge--failed',
+};
+
+function fmtSize(bytes: number): string {
+	if (!bytes) return '—';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	let v = bytes;
+	let i = 0;
+	while (v >= 1024 && i < units.length - 1) {
+		v /= 1024;
+		i++;
+	}
+	return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+export default function ReactReelConsole() {
+	const list = useStore($reelList);
+	const listError = useStore($reelListError);
+	const loading = useStore($reelListLoading);
+	const isStaff = useStore(homeService.$isStaff);
+
+	const [source, setSource] = useState('');
+	const [adding, setAdding] = useState(false);
+	const [busyId, setBusyId] = useState<string | null>(null);
+	const [actionError, setActionError] = useState<string | null>(null);
+
+	useEffect(() => {
+		void homeService.initAuth();
+	}, []);
+
+	useEffect(() => {
+		if (isStaff) void refreshReelList();
+	}, [isStaff]);
+
+	const add = useCallback(async () => {
+		const src = source.trim();
+		if (!src) return;
+		setAdding(true);
+		setActionError(null);
+		try {
+			await addTorrent(src);
+			setSource('');
+			await refreshReelList();
+		} catch (e) {
+			setActionError(e instanceof Error ? e.message : 'add failed');
+		} finally {
+			setAdding(false);
+		}
+	}, [source]);
+
+	const remove = useCallback(async (t: ReelTorrent) => {
+		if (!confirm(`Delete "${t.name || t.id}"? This purges its cache.`))
+			return;
+		setBusyId(t.id);
+		setActionError(null);
+		try {
+			await deleteTorrent(t.id);
+			await refreshReelList();
+		} catch (e) {
+			setActionError(e instanceof Error ? e.message : 'delete failed');
+		} finally {
+			setBusyId(null);
+		}
+	}, []);
+
+	const transcode = useCallback(async (t: ReelTorrent) => {
+		setBusyId(t.id);
+		setActionError(null);
+		try {
+			await startTranscode(t.id);
+			await refreshReelList();
+		} catch (e) {
+			setActionError(e instanceof Error ? e.message : 'transcode failed');
+		} finally {
+			setBusyId(null);
+		}
+	}, []);
+
+	if (!isStaff) {
+		return (
+			<div className="reel-console reel-console--gated">
+				<p className="reel-console__gate">
+					Reel management is restricted to KBVE staff. Sign in with a
+					staff account to add, transcode, or remove reels.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="reel-console">
+			<div className="reel-console__header">
+				<h3>Reel manager</h3>
+				<button
+					type="button"
+					className="reel-console__refresh"
+					disabled={loading}
+					onClick={() => void refreshReelList()}>
+					{loading ? 'Refreshing…' : 'Refresh'}
+				</button>
+			</div>
+
+			<form
+				className="reel-console__add"
+				onSubmit={(e) => {
+					e.preventDefault();
+					void add();
+				}}>
+				<input
+					type="text"
+					value={source}
+					placeholder="magnet:?xt=… or https://…/file.torrent"
+					onChange={(e) => setSource(e.target.value)}
+					disabled={adding}
+				/>
+				<button type="submit" disabled={adding || !source.trim()}>
+					{adding ? 'Adding…' : 'Add reel'}
+				</button>
+			</form>
+
+			{(actionError || listError) && (
+				<p className="reel-console__error">
+					{actionError ?? listError}
+				</p>
+			)}
+
+			<ul className="reel-console__list">
+				{list.length === 0 && !loading && (
+					<li className="reel-console__empty">No reels yet.</li>
+				)}
+				{list.map((t) => {
+					const playable =
+						t.state === 'Seeding' || t.state === 'Leeching';
+					return (
+						<li key={t.id} className="reel-console__row">
+							<div className="reel-console__meta">
+								<span className="reel-console__name">
+									{t.name || t.id}
+								</span>
+								<span className="reel-console__sub">
+									<span
+										className={`reel-console__badge ${
+											STATE_BADGE[t.state] ?? ''
+										}`}>
+										{t.state}
+									</span>
+									<span>{fmtSize(t.size)}</span>
+									{t.transcode !== 'None' && (
+										<span>transcode: {t.transcode}</span>
+									)}
+									{t.hls !== 'None' && (
+										<span>hls: {t.hls}</span>
+									)}
+								</span>
+								{(t.error ||
+									t.transcode_error ||
+									t.hls_error) && (
+									<span className="reel-console__rowerr">
+										{t.error ??
+											t.transcode_error ??
+											t.hls_error}
+									</span>
+								)}
+							</div>
+							<div className="reel-console__actions">
+								<a
+									className="reel-console__btn"
+									aria-disabled={!playable}
+									href={
+										playable
+											? `?id=${encodeURIComponent(t.id)}`
+											: undefined
+									}>
+									Play
+								</a>
+								<button
+									type="button"
+									className="reel-console__btn"
+									disabled={
+										busyId === t.id ||
+										t.transcode === 'Pending' ||
+										t.transcode === 'Remuxing' ||
+										t.transcode === 'Encoding'
+									}
+									onClick={() => void transcode(t)}>
+									Transcode
+								</button>
+								<button
+									type="button"
+									className="reel-console__btn reel-console__btn--danger"
+									disabled={busyId === t.id}
+									onClick={() => void remove(t)}>
+									Delete
+								</button>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -19,6 +19,34 @@ export interface ReelDetail {
 	[key: string]: unknown;
 }
 
+export type ReelTorrentState = 'Leeching' | 'Seeding' | 'Reaped' | 'Failed';
+export type ReelTranscodeStatus =
+	| 'None'
+	| 'Pending'
+	| 'Remuxing'
+	| 'Encoding'
+	| 'Ready'
+	| 'Failed';
+export type ReelHlsStatus = 'None' | 'Starting' | 'Live' | 'Ready' | 'Failed';
+
+export interface ReelTorrent {
+	id: string;
+	name: string;
+	size: number;
+	state: ReelTorrentState;
+	completed_at?: number | null;
+	last_access: number;
+	error?: string | null;
+	transcode: ReelTranscodeStatus;
+	transcode_error?: string | null;
+	hls: ReelHlsStatus;
+	hls_error?: string | null;
+}
+
+export const $reelList = atom<ReelTorrent[]>([]);
+export const $reelListError = atom<string | null>(null);
+export const $reelListLoading = atom<boolean>(false);
+
 const REEL_PATH: string =
 	(import.meta.env.PUBLIC_REEL_BASE as string | undefined) ?? '/api/v1/reel';
 const MEDIA_BASE = `${DASH_PROXY_BASE}${REEL_PATH}`;
@@ -45,6 +73,50 @@ export function withToken(url: string, token: string): string {
 	if (url.includes('access_token=')) return url;
 	const sep = url.includes('?') ? '&' : '?';
 	return `${url}${sep}access_token=${encodeURIComponent(token)}`;
+}
+
+export async function listTorrents(): Promise<ReelTorrent[]> {
+	return authedApiFetch<ReelTorrent[]>(`${REEL_PATH}/torrents`);
+}
+
+export async function addTorrent(source: string): Promise<string> {
+	const res = await authedApiFetch<{ id: string }>(`${REEL_PATH}/torrents`, {
+		method: 'POST',
+		body: JSON.stringify({ source }),
+	});
+	return res.id;
+}
+
+export async function deleteTorrent(id: string): Promise<void> {
+	await authedApiFetch<void>(
+		`${REEL_PATH}/torrents/${encodeURIComponent(id)}`,
+		{ method: 'DELETE' },
+	);
+}
+
+export async function startTranscode(id: string): Promise<void> {
+	await authedApiFetch<void>(
+		`${REEL_PATH}/torrents/${encodeURIComponent(id)}/transcode`,
+		{ method: 'POST' },
+	);
+}
+
+export async function refreshReelList(): Promise<void> {
+	$reelListLoading.set(true);
+	try {
+		$reelList.set(await listTorrents());
+		$reelListError.set(null);
+	} catch (e) {
+		$reelListError.set(
+			e instanceof ApiError && e.status === 401
+				? 'sign in as staff to manage reels'
+				: e instanceof Error
+					? e.message
+					: String(e),
+		);
+	} finally {
+		$reelListLoading.set(false);
+	}
 }
 
 export type ProbeAction = 'raw' | 'raw-leeching' | 'hls' | 'poll' | 'error';


### PR DESCRIPTION
## What

Wires the reel frontend to the backend CRUD it never called. Adds a staff-gated **Reel manager** console under the player on `/media/reel`.

- **Add** a reel by magnet URI or `.torrent` URL (`POST /torrents`)
- **Browse** the torrent list with state / transcode / HLS badges (`GET /torrents`)
- **Transcode** trigger (`POST /torrents/{id}/transcode`)
- **Delete** / purge cache (`DELETE /torrents/{id}`)
- **Play** links jump the on-page player via `?id=`

## Why

Backend (#14509–#14615) shipped full CRUD but the frontend only had a player that required manually pasting `?id=` into the URL. This closes the last reel frontend gap.

## Gating

UI gated on `homeService.$isStaff`; the `/api/v1/reel` proxy still enforces auth server-side.

## Test

- `tsc --noEmit`: 0 errors
- `astro check`: 0 errors in reel/media files (pre-existing generated-proto errors are worktree-codegen artifacts, unrelated)

Files: `ReactReelConsole.tsx` (new), `reelService.ts`, `AstroReelPlayer.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)