### PR TITLE
fix(palforge): use !pos not /pos (Palworld eats slash commands)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -117,5 +117,5 @@ local function schedule()
     end
 end
 
-log("loaded (spawn/setter pending Phase 0 spike; /pos command active)")
+log("loaded (spawn/setter pending Phase 0 spike; !pos command active)")
 schedule()

--- a/apps/agones/palworld/mods/PalForge/scripts/pos.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/pos.lua
@@ -43,16 +43,16 @@ function M.player_location(sender, finder)
 end
 
 function M.handle(sender, msg, emit, finder)
-    if type(msg) ~= "string" or trim(msg):lower() ~= "/pos" then
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!pos" then
         return false
     end
     local loc = M.player_location(sender, finder)
     if loc then
         emit(string.format(
-            "/pos %s -> X=%.1f Y=%.1f Z=%.1f",
+            "!pos %s -> X=%.1f Y=%.1f Z=%.1f",
             tostring(sender), loc.x, loc.y, loc.z))
     else
-        emit("/pos " .. tostring(sender) .. " -> location unresolved")
+        emit("!pos " .. tostring(sender) .. " -> location unresolved")
     end
     return true
 end

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -64,20 +64,20 @@ local function finder_with(name, x, y, z)
     end
 end
 
-local h1 = pos.handle("Al", "/pos", emit, finder_with("Al", 100, 200, 300))
+local h1 = pos.handle("Al", "!pos", emit, finder_with("Al", 100, 200, 300))
 local n_after_h1 = #pos_emits
-local h2 = pos.handle("Al", "hello world", emit, finder_with("Al", 1, 2, 3))
+local h2 = pos.handle("Al", "/pos", emit, finder_with("Al", 1, 2, 3))
 local n_after_h2 = #pos_emits
-local h3 = pos.handle("Al", "  /POS ", emit, finder_with("Al", 5, 6, 7))
-local h4 = pos.handle("Bob", "/pos", emit, function(_) return {} end)
+local h3 = pos.handle("Al", "  !POS ", emit, finder_with("Al", 5, 6, 7))
+local h4 = pos.handle("Bob", "!pos", emit, function(_) return {} end)
 
 local pos_ok = h1 == true
     and h2 == false
     and n_after_h2 == n_after_h1
     and h3 == true
     and h4 == true
-    and pos_emits[1] == "/pos Al -> X=100.0 Y=200.0 Z=300.0"
-    and pos_emits[2] == "/pos Al -> X=5.0 Y=6.0 Z=7.0"
+    and pos_emits[1] == "!pos Al -> X=100.0 Y=200.0 Z=300.0"
+    and pos_emits[2] == "!pos Al -> X=5.0 Y=6.0 Z=7.0"
     and pos_emits[3]:find("location unresolved", 1, true) ~= nil
 
 _print("=== results ===")

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.12"
+version: "0.0.13"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Bug

Live test of `/pos` returned **'unknown command'**. Root cause: Palworld's own command parser intercepts any chat message starting with `/` and returns 'unknown command' **before** broadcasting it — so our `PalGameStateInGame:BroadcastChatMessage` hook never sees `/pos`. Confirmed on the live 0.0.12 pod: **zero** PalForge `/pos` activity in `UE4SS.log`.

## Fix

Switch the trigger from `/pos` → **`!pos`**. A `!` prefix isn't a Palworld command, so it travels as normal chat and reaches the hook.

- `pos.lua` — `handle()` now matches trimmed/case-insensitive `!pos`, emits `!pos …`
- `main.lua` — load log updated
- `harness.lua` — `!pos` cases, plus asserts `/pos` (slash) is now **ignored** (`h2 == false`)
- MDX **0.0.12 → 0.0.13**, bumped **in the same commit** so the squash-merge can't orphan the lever (as happened with 0.0.12).

## Verified

```
nx test agones-palworld  ->  HARNESS PASS
```