### PR TITLE
feat(palworld): 0.0.14 — prestop waittime + !cmd suppress + pos-to-PAL + !signprobe

### DIFF
--- a/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalChatRelay/scripts/main.lua
@@ -56,7 +56,8 @@ local function on_chat(self, a, b)
     if (not text or #text == 0) and b ~= nil then
         player, text = extract(b)
     end
-    if player and text and #text > 0 and player:upper() ~= "SYSTEM" then
+    if player and text and #text > 0 and player:upper() ~= "SYSTEM"
+        and text:sub(1, 1) ~= "!" then
         append(player, text)
     end
 end

--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -9,8 +9,29 @@ local SIGNBOARD_CLASS =
 local placed = false
 local chat_registered = false
 
+local CHAT_LOG = os.getenv("PALWORLD_CHAT_LOG") or "/shared/chat/chat.log"
+
 local function log(msg)
     print("[" .. MOD .. "] " .. msg)
+end
+
+local function now_ms()
+    return string.format("%d", os.time() * 1000)
+end
+
+local function chat_write(sender, text)
+    local f = io.open(CHAT_LOG, "a")
+    if not f then
+        return
+    end
+    local clean = text:gsub("[\t\r\n]", " ")
+    f:write(now_ms() .. "\t" .. sender .. "\t" .. clean .. "\n")
+    f:close()
+end
+
+local function pos_emit(msg)
+    log(msg)
+    chat_write(MOD, msg)
 end
 
 local ok_pos, pos = pcall(require, "pos")
@@ -86,7 +107,7 @@ local function on_chat(_, a, b)
         sender, text = extract(b)
     end
     if sender and text and #text > 0 then
-        pcall(pos.handle, sender, text, log)
+        pcall(pos.handle, sender, text, pos_emit)
     end
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -37,7 +37,13 @@ end
 local ok_pos, pos = pcall(require, "pos")
 if not ok_pos or type(pos) ~= "table" then
     log("pos module load failed: " .. tostring(pos))
-    pos = { handle = function() return false end }
+    pos = { handle = function() return false end, player_location = function() return nil end }
+end
+
+local ok_spike, spike = pcall(require, "spike")
+if not ok_spike or type(spike) ~= "table" then
+    log("spike module load failed: " .. tostring(spike))
+    spike = { handle = function() return false end }
 end
 
 local function load_signs()
@@ -108,6 +114,7 @@ local function on_chat(_, a, b)
     end
     if sender and text and #text > 0 then
         pcall(pos.handle, sender, text, pos_emit)
+        pcall(spike.handle, sender, text, pos_emit, pos.player_location)
     end
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
@@ -1,7 +1,7 @@
 return {
     signs = {
         {
-            coords = { 0, 0, 0 },
+            coords = { -354169.1, 271270.8, 7167.4 },
             rot = 0,
             text = "Welcome to KBVE Palworld",
         },

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -1,0 +1,62 @@
+local M = {}
+
+local SIGNBOARD_CLASS =
+    "/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C"
+
+local WORLD_CANDIDATES = { "PalGameWorld", "World" }
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function try(emit, label, fn)
+    local ok, res = pcall(fn)
+    if ok then
+        emit("signprobe " .. label .. " -> OK " .. tostring(res))
+        return res
+    end
+    emit("signprobe " .. label .. " -> ERR " .. tostring(res))
+    return nil
+end
+
+function M.handle(sender, msg, emit, loc_fn, static_find, find_first)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signprobe" then
+        return false
+    end
+    static_find = static_find or StaticFindObject
+    find_first = find_first or FindFirstOf
+
+    emit("signprobe: start (read-only recon)")
+
+    local cls = try(emit, "class", function()
+        return static_find(SIGNBOARD_CLASS)
+    end)
+    if cls then
+        try(emit, "class:IsValid", function() return cls:IsValid() end)
+        try(emit, "class:GetFullName", function() return cls:GetFullName() end)
+    end
+
+    for _, name in ipairs(WORLD_CANDIDATES) do
+        local w = try(emit, "world(" .. name .. ")", function()
+            return find_first(name)
+        end)
+        if w then
+            try(emit, "world(" .. name .. "):GetFullName", function()
+                return w:GetFullName()
+            end)
+        end
+    end
+
+    local loc = loc_fn and loc_fn(sender) or nil
+    if loc then
+        emit(string.format("signprobe target %s -> X=%.1f Y=%.1f Z=%.1f",
+            tostring(sender), loc.x, loc.y, loc.z))
+    else
+        emit("signprobe target " .. tostring(sender) .. " -> unresolved")
+    end
+
+    emit("signprobe: done (inspect UE4SS.log; no spawn attempted)")
+    return true
+end
+
+return M

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -80,6 +80,29 @@ local pos_ok = h1 == true
     and pos_emits[2] == "!pos Al -> X=5.0 Y=6.0 Z=7.0"
     and pos_emits[3]:find("location unresolved", 1, true) ~= nil
 
+_print("=== spike.lua command ===")
+local spike = require("spike")
+local sp_emits = {}
+local function sp_emit(m)
+    sp_emits[#sp_emits + 1] = m
+    _print("  spike: " .. m)
+end
+local mock_static = function()
+    return { IsValid = function() return true end, GetFullName = function() return "SignboardClass" end }
+end
+local mock_find = function()
+    return { GetFullName = function() return "PalGameWorld_0" end }
+end
+local mock_loc = function()
+    return { x = 1, y = 2, z = 3 }
+end
+local s1 = spike.handle("Al", "!signprobe", sp_emit, mock_loc, mock_static, mock_find)
+local s2 = spike.handle("Al", "nope", sp_emit, mock_loc, mock_static, mock_find)
+local spike_ok = s1 == true
+    and s2 == false
+    and sp_emits[1]:find("signprobe: start", 1, true) ~= nil
+    and sp_emits[#sp_emits]:find("done", 1, true) ~= nil
+
 _print("=== results ===")
 _print(string.format(
     "placed=%d pending=%d setter_callable=%d setter_absent=%d pos_ok=%s",
@@ -90,6 +113,7 @@ local ok = calls.pending == 1
     and calls.setter_callable == 1
     and calls.setter_absent == 4
     and pos_ok
+    and spike_ok
 
 if ok then
     _print("HARNESS PASS")

--- a/apps/agones/palworld/shim/agones-shim-prestop.sh
+++ b/apps/agones/palworld/shim/agones-shim-prestop.sh
@@ -19,14 +19,14 @@ curl -fsS -u "$auth" -X POST "$base/announce" \
     -H 'Content-Type: application/json' \
     -d "{\"message\":\"Server restarting in ${WARN_SECS}s — progress will be saved.\"}" >/dev/null 2>&1 || true
 
+echo "[prestop] requesting graceful shutdown (waittime=${WARN_SECS}s, save)"
+curl -fsS -u "$auth" -X POST "$base/shutdown" \
+    -H 'Content-Type: application/json' \
+    -d "{\"waittime\":${WARN_SECS},\"message\":\"Server restarting in ${WARN_SECS}s. See you in a minute.\"}" >/dev/null 2>&1 || true
+
 if [ "$WARN_SECS" -gt 0 ] 2>/dev/null; then
     sleep "$WARN_SECS"
 fi
-
-echo "[prestop] requesting graceful shutdown (save)"
-curl -fsS -u "$auth" -X POST "$base/shutdown" \
-    -H 'Content-Type: application/json' \
-    -d "{\"waittime\":1,\"message\":\"Restarting now. See you in a minute.\"}" >/dev/null 2>&1 || true
 
 sleep 3
 

--- a/apps/agones/palworld/shim/agones-shim-prestop.sh
+++ b/apps/agones/palworld/shim/agones-shim-prestop.sh
@@ -28,6 +28,11 @@ if [ "$WARN_SECS" -gt 0 ] 2>/dev/null; then
     sleep "$WARN_SECS"
 fi
 
+echo "[prestop] final shutdown (force save)"
+curl -fsS -u "$auth" -X POST "$base/shutdown" \
+    -H 'Content-Type: application/json' \
+    -d "{\"waittime\":1,\"message\":\"Restarting now. See you in a minute.\"}" >/dev/null 2>&1 || true
+
 sleep 3
 
 echo "[prestop] done"

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.13"
+version: "0.0.14"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
Bundles palworld image tweaks + the safe spawn-recon tool into one 0.0.14 rollout.

## 1. Prestop honors the 30s (waittime)
`/shutdown` now `waittime=${WARN_SECS}` (native countdown+save); flow: announce → shutdown waittime=30 → hold pod 30s → final shutdown waittime=1 (last-second forced save) → 3s buffer.

## 2. Don't forward ! commands to Discord
PalChatRelay skips `!`-prefixed chat — `!pos`/`!signprobe` no longer echo as `[PAL] player: !cmd`.

## 3. Echo !pos result to PAL
PalForge writes the `!pos` result to chat.log (sender `PalForge`) → relay → `[PAL] PalForge: !pos <player> -> X= Y= Z=`.

## 4. !signprobe — safe read-only spawn recon (R1 debug)
New `scripts/spike.lua`: an admin types `!signprobe` and it inspects — does `BP_BuildObject_Signboard_C` resolve, is the world findable (PalGameWorld/World), what is the caller's spawn-target location — all pcall-guarded, logged to UE4SS.log + PAL, **no spawn attempted**. Grounds the spawn implementation in live facts.

Also: sign coords set to a real captured spot (-354169,271270,7167) — still PENDING until spawn is implemented.

MDX 0.0.13 → 0.0.14. Verified: nx test agones-palworld → HARNESS PASS.