### PR TITLE
feat(palforge): !signprobe probes existing signboard setter (R2)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -4,6 +4,15 @@ local SIGNBOARD_CLASS =
     "/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C"
 
 local WORLD_CANDIDATES = { "PalGameWorld", "World" }
+local SIGNBOARD_SHORT = "BP_BuildObject_Signboard_C"
+local SETTER_CANDIDATES = {
+    "SetSignboardText",
+    "SetText",
+    "SetMessage",
+    "UpdateText",
+    "OnUpdateText",
+}
+local PROBE_TEXT = "PalForge R2 probe"
 
 local function trim(s)
     return (s:gsub("^%s+", ""):gsub("%s+$", ""))
@@ -19,14 +28,15 @@ local function try(emit, label, fn)
     return nil
 end
 
-function M.handle(sender, msg, emit, loc_fn, static_find, find_first)
+function M.handle(sender, msg, emit, loc_fn, static_find, find_first, find_all)
     if type(msg) ~= "string" or trim(msg):lower() ~= "!signprobe" then
         return false
     end
     static_find = static_find or StaticFindObject
     find_first = find_first or FindFirstOf
+    find_all = find_all or FindAllOf
 
-    emit("signprobe: start (read-only recon)")
+    emit("signprobe: start (recon)")
 
     local cls = try(emit, "class", function()
         return static_find(SIGNBOARD_CLASS)
@@ -47,6 +57,25 @@ function M.handle(sender, msg, emit, loc_fn, static_find, find_first)
         end
     end
 
+    local boards = try(emit, "FindAllOf(signboard)", function()
+        return find_all(SIGNBOARD_SHORT)
+    end)
+    if type(boards) == "table" and #boards > 0 then
+        emit("signprobe instances -> " .. #boards)
+        local b = boards[1]
+        try(emit, "getter GetSignboardText", function()
+            return tostring(b:GetSignboardText():ToString())
+        end)
+        for _, s in ipairs(SETTER_CANDIDATES) do
+            try(emit, "setter " .. s, function()
+                b[s](b, PROBE_TEXT)
+                return "called"
+            end)
+        end
+    else
+        emit("signprobe instances -> 0 (place a signboard to probe the setter)")
+    end
+
     local loc = loc_fn and loc_fn(sender) or nil
     if loc then
         emit(string.format("signprobe target %s -> X=%.1f Y=%.1f Z=%.1f",
@@ -55,7 +84,7 @@ function M.handle(sender, msg, emit, loc_fn, static_find, find_first)
         emit("signprobe target " .. tostring(sender) .. " -> unresolved")
     end
 
-    emit("signprobe: done (inspect UE4SS.log; no spawn attempted)")
+    emit("signprobe: done (inspect UE4SS.log; a working setter changes an existing sign's text)")
     return true
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -13,6 +13,15 @@ local SETTER_CANDIDATES = {
     "OnUpdateText",
 }
 local PROBE_TEXT = "PalForge R2 probe"
+local LOAD_CANDIDATES = { "StaticLoadObject", "LoadObject", "LoadAsset" }
+
+local function is_valid(obj)
+    if not obj then
+        return false
+    end
+    local ok, v = pcall(function() return obj:IsValid() end)
+    return ok and v
+end
 
 local function trim(s)
     return (s:gsub("^%s+", ""):gsub("%s+$", ""))
@@ -38,11 +47,31 @@ function M.handle(sender, msg, emit, loc_fn, static_find, find_first, find_all)
 
     emit("signprobe: start (recon)")
 
-    local cls = try(emit, "class", function()
+    local cls = try(emit, "class find", function()
         return static_find(SIGNBOARD_CLASS)
     end)
-    if cls then
-        try(emit, "class:IsValid", function() return cls:IsValid() end)
+    local cls_valid = is_valid(cls)
+    emit("signprobe class find:IsValid -> " .. tostring(cls_valid))
+    if not cls_valid then
+        emit("signprobe class not loaded; trying load candidates")
+        for _, name in ipairs(LOAD_CANDIDATES) do
+            local loader = _G[name]
+            if type(loader) ~= "function" then
+                emit("signprobe load " .. name .. " -> global absent")
+            else
+                local loaded = try(emit, "load " .. name, function()
+                    return loader(SIGNBOARD_CLASS)
+                end)
+                if is_valid(loaded) then
+                    emit("signprobe load " .. name .. " -> VALID class")
+                    cls = loaded
+                    cls_valid = true
+                    break
+                end
+            end
+        end
+    end
+    if cls_valid then
         try(emit, "class:GetFullName", function() return cls:GetFullName() end)
     end
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.14"
+version: "0.0.15"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Context

Live `!signprobe` confirmed the signboard `UClass` **lazy-loads** — `IsValid` was `false` until a signboard was placed in-world, then flipped `true` with a real `BlueprintGeneratedClass`. World handle + location already resolve. So R1's remaining piece is the **text setter (R2)**.

## Change

`!signprobe` now also:
- `FindAllOf("BP_BuildObject_Signboard_C")` → logs instance count
- on the first instance: reads `GetSignboardText` (getter), then tries setter candidates `SetSignboardText / SetText / SetMessage / UpdateText / OnUpdateText`

A working setter **visibly changes the placed sign's text in-world** → instant confirmation of which call sets signboard text. All `pcall`-guarded + logged to UE4SS.log + PAL.

## Test

Place a signboard, run `!signprobe`, watch which setter logs OK **and** whether the sign's text changes on screen.

MDX 0.0.14 → 0.0.15. Verified: nx test agones-palworld → HARNESS PASS.