### PR TITLE
chore(reel): bump to 0.1.2 (stall-timeout + tracker injection)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.1"
+version: "0.1.2"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml


### PR DESCRIPTION
Release bump for the reel work merged in #14661.

Bumps `project/reel.mdx` version `0.1.1` → `0.1.2` (MDX is the CI source of truth). `version.toml`, `Cargo.toml`, and `ci-dispatch-manifest.json` are synced by the manifest-sync automation.

Ships:
- fail-with-reason on unresolvable torrents (metadata + stall timeouts)
- public tracker list injection + auto-refresh from ngosang/trackerslist
- multi-list merge + static PVC tracker cache
