### PR TITLE
feat(palworld): searchable crossplay community server

### DIFF
--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -53,8 +53,14 @@ spec:
                         value: 'auto'
                       - name: SERVER_NAME
                         value: 'KBVE Palworld'
+                      - name: SERVER_DESCRIPTION
+                        value: 'KBVE community server — crossplay Steam/Xbox/PS5. Search: kbve'
+                      - name: PUBLIC_IP
+                        value: '142.132.206.74'
                       - name: PUBLIC_PORT
                         value: '8211'
+                      - name: CROSSPLAY_PLATFORMS
+                        value: '(Steam,Xbox,PS5,Mac)'
                       - name: MAX_PLAYERS
                         value: '16'
                       - name: RCON_ENABLED
@@ -68,7 +74,7 @@ spec:
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER
-                        value: 'false'
+                        value: 'true'
                       - name: BACKUP_ENABLED
                         value: 'true'
                       - name: RESTART_ENABLED


### PR DESCRIPTION
## What
Make the `apps/agones/palworld` GameServer a **public community server** joinable/searchable by console players.

## Changes (`apps/kube/agones/palworld/manifests/gameserver.yaml`)
- `COMMUNITY_SERVER` `false → true` — lists in Palworld Community Servers browser (`bIsPublic=True`)
- `CROSSPLAY_PLATFORMS=(Steam,Xbox,PS5,Mac)` — PS5/Xbox clients can join
- `PUBLIC_IP=142.132.206.74` — node hosting the Static hostPort; required for community registration to resolve
- `SERVER_DESCRIPTION` added
- Searchable by **"kbve"** via existing `SERVER_NAME='KBVE Palworld'`

## Notes
- Mods (PalChatRelay / PalForge) are server-side Lua only → consoles join without any client mod.
- `SERVER_SETTINGS_MODE=auto` regenerates `PalWorldSettings.ini` from env on boot; GameServer must recreate to apply.
- `PUBLIC_IP` is pinned to the current Static-hostPort node. If the pod reschedules to a different node, update this value.
- Server is open (no `SERVER_PASSWORD`).