### PR TITLE
feat(palforge): !signspawn — force-load + World:SpawnActor + set text (R1)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -115,6 +115,7 @@ local function on_chat(_, a, b)
     if sender and text and #text > 0 then
         pcall(pos.handle, sender, text, pos_emit)
         pcall(spike.handle, sender, text, pos_emit, pos.player_location)
+        pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
     end
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -13,6 +13,7 @@ local SETTER_CANDIDATES = {
     "OnUpdateText",
 }
 local PROBE_TEXT = "PalForge R2 probe"
+local SPAWN_TEXT = "PalForge spawn test"
 local LOAD_CANDIDATES = { "StaticLoadObject", "LoadObject", "LoadAsset" }
 
 local function is_valid(obj)
@@ -30,10 +31,10 @@ end
 local function try(emit, label, fn)
     local ok, res = pcall(fn)
     if ok then
-        emit("signprobe " .. label .. " -> OK " .. tostring(res))
+        emit(label .. " -> OK " .. tostring(res))
         return res
     end
-    emit("signprobe " .. label .. " -> ERR " .. tostring(res))
+    emit(label .. " -> ERR " .. tostring(res))
     return nil
 end
 
@@ -114,6 +115,77 @@ function M.handle(sender, msg, emit, loc_fn, static_find, find_first, find_all)
     end
 
     emit("signprobe: done (inspect UE4SS.log; a working setter changes an existing sign's text)")
+    return true
+end
+
+local function resolve_class(emit, static_find, load_asset)
+    local c = static_find(SIGNBOARD_CLASS)
+    if is_valid(c) then
+        emit("signspawn class -> found (loaded)")
+        return c
+    end
+    if type(load_asset) == "function" then
+        local ok, loaded = pcall(load_asset, SIGNBOARD_CLASS)
+        if ok and is_valid(loaded) then
+            emit("signspawn class -> LoadAsset OK")
+            return loaded
+        end
+    end
+    emit("signspawn class -> unresolved")
+    return nil
+end
+
+function M.spawn(sender, msg, emit, loc_fn, deps)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signspawn" then
+        return false
+    end
+    deps = deps or {}
+    local static_find = deps.static_find or StaticFindObject
+    local find_first = deps.find_first or FindFirstOf
+    local load_asset = deps.load_asset or LoadAsset
+
+    emit("signspawn: start")
+
+    local cls = resolve_class(emit, static_find, load_asset)
+    if not cls then
+        emit("signspawn: abort — no class")
+        return true
+    end
+
+    local world = find_first("World")
+    if not is_valid(world) then
+        emit("signspawn: abort — no world")
+        return true
+    end
+
+    local loc = loc_fn and loc_fn(sender) or nil
+    if not loc then
+        emit("signspawn: abort — no location")
+        return true
+    end
+    emit(string.format("signspawn at X=%.1f Y=%.1f Z=%.1f", loc.x, loc.y, loc.z))
+
+    local location = { X = loc.x, Y = loc.y, Z = loc.z }
+    local rotation = { Pitch = 0.0, Yaw = 0.0, Roll = 0.0 }
+
+    local actor = try(emit, "world:SpawnActor", function()
+        return world:SpawnActor(cls, location, rotation)
+    end)
+
+    if is_valid(actor) then
+        emit("signspawn: ACTOR SPAWNED")
+        try(emit, "actor:GetFullName", function() return actor:GetFullName() end)
+        for _, s in ipairs(SETTER_CANDIDATES) do
+            try(emit, "spawn setter " .. s, function()
+                actor[s](actor, SPAWN_TEXT)
+                return "called"
+            end)
+        end
+    else
+        emit("signspawn: no actor from world:SpawnActor")
+    end
+
+    emit("signspawn: done")
     return true
 end
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -103,6 +103,38 @@ local spike_ok = s1 == true
     and sp_emits[1]:find("signprobe: start", 1, true) ~= nil
     and sp_emits[#sp_emits]:find("done", 1, true) ~= nil
 
+_print("=== spike.spawn command ===")
+local spawned = {
+    IsValid = function() return true end,
+    GetFullName = function() return "Signboard_spawned_1" end,
+    SetText = function() return true end,
+}
+local spawn_deps = {
+    static_find = function() return { IsValid = function() return false end } end,
+    load_asset = function() return { IsValid = function() return true end } end,
+    find_first = function()
+        return { IsValid = function() return true end, SpawnActor = function() return spawned end }
+    end,
+}
+local sw_emits = {}
+local function sw_emit(m)
+    sw_emits[#sw_emits + 1] = m
+    _print("  spawn: " .. m)
+end
+local w1 = spike.spawn("Al", "!signspawn", sw_emit, mock_loc, spawn_deps)
+local w2 = spike.spawn("Al", "nope", sw_emit, mock_loc, spawn_deps)
+local function emitted(list, needle)
+    for _, m in ipairs(list) do
+        if m:find(needle, 1, true) then return true end
+    end
+    return false
+end
+local spawn_ok = w1 == true
+    and w2 == false
+    and emitted(sw_emits, "ACTOR SPAWNED")
+    and emitted(sw_emits, "spawn setter SetText -> OK")
+    and sw_emits[#sw_emits]:find("signspawn: done", 1, true) ~= nil
+
 _print("=== results ===")
 _print(string.format(
     "placed=%d pending=%d setter_callable=%d setter_absent=%d pos_ok=%s",
@@ -114,6 +146,7 @@ local ok = calls.pending == 1
     and calls.setter_absent == 4
     and pos_ok
     and spike_ok
+    and spawn_ok
 
 if ok then
     _print("HARNESS PASS")

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.15"
+version: "0.0.16"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Context

Live `!signprobe` proved:
- `LoadAsset(path)` **force-loads** the signboard `UClass` cold — `StaticFindObject` returned invalid, `StaticLoadObject`/`LoadObject` absent, but `LoadAsset -> VALID class`. No placed sign needed.
- `FindFirstOf('World')` → valid `UWorld`; player location via `!pos`.

That's everything R1 needs.

## `!signspawn`

Admin types `!signspawn` → it:
1. resolves the class (`StaticFindObject`, else `LoadAsset`)
2. `FindFirstOf('World')`
3. caller location
4. `world:SpawnActor(class, location, rotation)`
5. on a valid actor: `GetFullName` + tries setter candidates (`SetSignboardText/SetText/SetMessage/UpdateText/OnUpdateText`) to set its text

All `pcall`-guarded + logged to UE4SS.log + PAL. First real attempt to place a sign from Lua — if `SpawnActor` isn't the right call/signature, the log says exactly how it failed and we iterate.

MDX 0.0.15 → 0.0.16. Verified: nx test agones-palworld → HARNESS PASS.