### PR TITLE
feat(reel): graceful shutdown + flush; silence librqbit chunk-log spam

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -47,7 +47,7 @@ spec:
             - { name: REEL_STATE_FILE, value: "/data/reel-state.json" }
             - { name: REEL_TTL_SECS, value: "21600" }
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
-            - { name: RUST_LOG, value: "reel=info,warn" }
+            - { name: RUST_LOG, value: "reel=info,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
           envFrom:
             - secretRef: { name: reel-api }

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(state::persist_loop(store.clone(), cfg.state_flush_ms));
 
+    let store_for_flush = store.clone();
     let app = api::router(api::AppState {
         engine: eng,
         store,
@@ -68,6 +69,34 @@ async fn main() -> anyhow::Result<()> {
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    tracing::info!("shutdown signal received; flushing state");
+    if let Err(e) = store_for_flush.flush() {
+        tracing::warn!(error = %e, "state flush on shutdown failed");
+    }
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to install SIGTERM handler"),
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
 }


### PR DESCRIPTION
Two robustness/ops improvements on reel.

## Graceful shutdown + state flush
`axum::serve` was awaited bare — on pod SIGTERM, in-flight streams were cut and the debounced state persister could drop up to ~1s of `last_access` updates. Now serves `with_graceful_shutdown` (SIGTERM + ctrl_c), draining in-flight requests, then calls `store.flush()` before exit. (Closes the documented persister follow-up.)

## Log-noise fix
librqbit logs *"we already requested ChunkInfo … previously"* at WARN under `librqbit::torrent_state::live`, at high volume — observed flooding the pod logs, which Vector ships to ClickHouse. `RUST_LOG` now scopes that target to `error` while keeping `reel=info` and other crates' warnings. Deploy-only (inline env → pod rolls on apply).

## Release
Bumps `reel.mdx` 0.1.2 → 0.1.3.

Verify: `cargo test -p reel` 115 passed; clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)