### PR TITLE
feat(palforge): !httptest — safe HTTP-capability probe (no network/exec)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -116,6 +116,7 @@ local function on_chat(_, a, b)
         pcall(pos.handle, sender, text, pos_emit)
         pcall(spike.handle, sender, text, pos_emit, pos.player_location)
         pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
+        pcall(spike.httptest, sender, text, pos_emit)
     end
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -189,4 +189,35 @@ function M.spawn(sender, msg, emit, loc_fn, deps)
     return true
 end
 
+local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
+local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
+
+function M.httptest(sender, msg, emit)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!httptest" then
+        return false
+    end
+
+    emit("httptest: start (capability detection only; NO network, NO exec)")
+
+    emit("httptest package -> " .. type(package))
+    if type(package) == "table" then
+        emit("httptest package.loadlib -> " .. type(package.loadlib))
+        emit("httptest package.cpath -> " .. tostring(package.cpath))
+    end
+    emit("httptest os.execute -> " .. type(os.execute))
+    emit("httptest io.popen -> " .. type(io.popen))
+
+    for _, g in ipairs(HTTP_GLOBALS) do
+        emit("httptest global " .. g .. " -> " .. type(_G[g]))
+    end
+
+    for _, name in ipairs(HTTP_MODULES) do
+        local ok, mod = pcall(require, name)
+        emit("httptest require " .. name .. " -> " .. (ok and type(mod) or "absent"))
+    end
+
+    emit("httptest: done (nothing loaded, nothing sent)")
+    return true
+end
+
 return M

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -135,6 +135,19 @@ local spawn_ok = w1 == true
     and emitted(sw_emits, "spawn setter SetText -> OK")
     and sw_emits[#sw_emits]:find("signspawn: done", 1, true) ~= nil
 
+_print("=== spike.httptest command ===")
+local ht_emits = {}
+local function ht_emit(m)
+    ht_emits[#ht_emits + 1] = m
+    _print("  http: " .. m)
+end
+local ht1 = spike.httptest("Al", "!httptest", ht_emit)
+local ht2 = spike.httptest("Al", "nope", ht_emit)
+local httptest_ok = ht1 == true
+    and ht2 == false
+    and ht_emits[1]:find("httptest: start", 1, true) ~= nil
+    and ht_emits[#ht_emits]:find("httptest: done", 1, true) ~= nil
+
 _print("=== results ===")
 _print(string.format(
     "placed=%d pending=%d setter_callable=%d setter_absent=%d pos_ok=%s",
@@ -147,6 +160,7 @@ local ok = calls.pending == 1
     and pos_ok
     and spike_ok
     and spawn_ok
+    and httptest_ok
 
 if ok then
     _print("HARNESS PASS")

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.16"
+version: "0.0.17"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

A `!httptest` chat command that detects whether a Lua-side HTTP path is even possible in our UE4SS build — **without touching the network or spawning any process**. Pure capability detection, all `pcall`-guarded.

Reports:
- `type(package.loadlib)` + `package.cpath` — can we load C modules, and where a `.dll` would go
- `os.execute` / `io.popen` availability (curl-fallback viability)
- presence of `http`/`socket`/`curl`/`https`/`ssl` globals (any modpack-provided client)
- `pcall(require, ...)` of `socket`/`socket.http`/`ssl`/`http`/... — which resolve

## Safety

**No network calls. No process spawns. Nothing loaded.** It only introspects and attempts  (which fails gracefully via ). Zero ecosystem impact — the whole point.

## Why

Decides the HTTP question from facts: if C-module loading works → LuaSocket/lua-curl is viable; if /curl exists → a shell fallback; if neither → keep the Rust relay bridge. 

MDX 0.0.16 → 0.0.17. Verified: nx test agones-palworld → HARNESS PASS.