### PR TITLE
feat(palforge): signspawn v2 — replicate + property scan + tracked !signclear cleanup

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -116,6 +116,7 @@ local function on_chat(_, a, b)
         pcall(pos.handle, sender, text, pos_emit)
         pcall(spike.handle, sender, text, pos_emit, pos.player_location)
         pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
+        pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.httptest, sender, text, pos_emit)
     end
 end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -175,12 +175,31 @@ function M.spawn(sender, msg, emit, loc_fn, deps)
     if is_valid(actor) then
         emit("signspawn: ACTOR SPAWNED")
         try(emit, "actor:GetFullName", function() return actor:GetFullName() end)
-        for _, s in ipairs(SETTER_CANDIDATES) do
-            try(emit, "spawn setter " .. s, function()
-                actor[s](actor, SPAWN_TEXT)
-                return "called"
+
+        try(emit, "SetReplicates(true)", function() actor:SetReplicates(true) return "ok" end)
+        try(emit, "SetReplicateMovement(true)", function() actor:SetReplicateMovement(true) return "ok" end)
+        try(emit, "ForceNetUpdate", function() actor:ForceNetUpdate() return "ok" end)
+        try(emit, "SetActorHiddenInGame(false)", function() actor:SetActorHiddenInGame(false) return "ok" end)
+        try(emit, "SetActorEnableCollision(true)", function() actor:SetActorEnableCollision(true) return "ok" end)
+        try(emit, "OnUpdateText", function() actor:OnUpdateText(SPAWN_TEXT) return "ok" end)
+
+        emit("signspawn: scanning actor properties")
+        local hits = 0
+        pcall(function()
+            actor:ForEachProperty(function(prop)
+                local name = tostring(prop:GetName())
+                local low = name:lower()
+                if low:find("mesh") or low:find("model") or low:find("widget")
+                    or low:find("param") or low:find("sign") or low:find("concrete")
+                    or low:find("root") then
+                    hits = hits + 1
+                    if hits <= 20 then
+                        emit("prop " .. name)
+                    end
+                end
             end)
-        end
+        end)
+        emit("signspawn: relevant props = " .. hits)
     else
         emit("signspawn: no actor from world:SpawnActor")
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -16,12 +16,26 @@ local PROBE_TEXT = "PalForge R2 probe"
 local SPAWN_TEXT = "PalForge spawn test"
 local LOAD_CANDIDATES = { "StaticLoadObject", "LoadObject", "LoadAsset" }
 
+local DESTROY_CANDIDATES = { "K2_DestroyActor", "DestroyActor", "Destroy" }
+
+local spawned = {}
+
 local function is_valid(obj)
     if not obj then
         return false
     end
     local ok, v = pcall(function() return obj:IsValid() end)
     return ok and v
+end
+
+local function destroy_actor(a)
+    for _, m in ipairs(DESTROY_CANDIDATES) do
+        pcall(function() a[m](a) end)
+        if not is_valid(a) then
+            return m
+        end
+    end
+    return nil
 end
 
 local function trim(s)
@@ -173,7 +187,8 @@ function M.spawn(sender, msg, emit, loc_fn, deps)
     end)
 
     if is_valid(actor) then
-        emit("signspawn: ACTOR SPAWNED")
+        spawned[#spawned + 1] = actor
+        emit("signspawn: ACTOR SPAWNED (tracked " .. #spawned .. " this session)")
         try(emit, "actor:GetFullName", function() return actor:GetFullName() end)
 
         try(emit, "SetReplicates(true)", function() actor:SetReplicates(true) return "ok" end)
@@ -205,6 +220,31 @@ function M.spawn(sender, msg, emit, loc_fn, deps)
     end
 
     emit("signspawn: done")
+    return true
+end
+
+function M.clear(sender, msg, emit)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signclear" then
+        return false
+    end
+    emit("signclear: start (" .. #spawned .. " tracked this session)")
+    local destroyed, stale = 0, 0
+    for i = #spawned, 1, -1 do
+        local a = spawned[i]
+        if is_valid(a) then
+            local m = destroy_actor(a)
+            if m then
+                destroyed = destroyed + 1
+                emit("signclear destroyed via " .. m)
+            else
+                emit("signclear FAILED to destroy index " .. i)
+            end
+        else
+            stale = stale + 1
+        end
+        spawned[i] = nil
+    end
+    emit("signclear: done destroyed=" .. destroyed .. " stale=" .. stale)
     return true
 end
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -132,7 +132,6 @@ end
 local spawn_ok = w1 == true
     and w2 == false
     and emitted(sw_emits, "ACTOR SPAWNED")
-    and emitted(sw_emits, "spawn setter SetText -> OK")
     and sw_emits[#sw_emits]:find("signspawn: done", 1, true) ~= nil
 
 _print("=== spike.httptest command ===")

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -104,11 +104,10 @@ local spike_ok = s1 == true
     and sp_emits[#sp_emits]:find("done", 1, true) ~= nil
 
 _print("=== spike.spawn command ===")
-local spawned = {
-    IsValid = function() return true end,
-    GetFullName = function() return "Signboard_spawned_1" end,
-    SetText = function() return true end,
-}
+local spawned = { destroyed = false }
+spawned.IsValid = function() return not spawned.destroyed end
+spawned.GetFullName = function() return "Signboard_spawned_1" end
+spawned.K2_DestroyActor = function() spawned.destroyed = true end
 local spawn_deps = {
     static_find = function() return { IsValid = function() return false end } end,
     load_asset = function() return { IsValid = function() return true end } end,
@@ -133,6 +132,20 @@ local spawn_ok = w1 == true
     and w2 == false
     and emitted(sw_emits, "ACTOR SPAWNED")
     and sw_emits[#sw_emits]:find("signspawn: done", 1, true) ~= nil
+
+_print("=== spike.clear command ===")
+local cl_emits = {}
+local function cl_emit(m)
+    cl_emits[#cl_emits + 1] = m
+    _print("  clear: " .. m)
+end
+local c1 = spike.clear("Al", "!signclear", cl_emit)
+local c2 = spike.clear("Al", "nope", cl_emit)
+local clear_ok = c1 == true
+    and c2 == false
+    and emitted(cl_emits, "destroyed=1")
+    and emitted(cl_emits, "signclear: done")
+    and spawned.destroyed == true
 
 _print("=== spike.httptest command ===")
 local ht_emits = {}
@@ -159,6 +172,7 @@ local ok = calls.pending == 1
     and pos_ok
     and spike_ok
     and spawn_ok
+    and clear_ok
     and httptest_ok
 
 if ok then

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.17"
+version: "0.0.18"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Where we are

`!signspawn` **works server-side**: `LoadAsset` loads the class, `world:SpawnActor` returns a real `BP_BuildObject_Signboard_C` in `PersistentLevel`, `OnUpdateText` is callable. **But it's invisible client-side** — raw `SpawnActor` produces a bare server actor with **no replication** and **no concrete model** (Palworld signs get their mesh from a concrete model the build-system attaches; raw spawn skips it).

## This iteration (diagnose, don't guess)

After a successful spawn:
- force **replication/visibility**: `SetReplicates(true)`, `SetReplicateMovement(true)`, `ForceNetUpdate`, `SetActorHiddenInGame(false)`, `SetActorEnableCollision(true)`
- `OnUpdateText` (the callable text method — `SetSignboardText`/`SetText` are `TrivialObject` properties, not functions)
- **`ForEachProperty` scan** filtered to `mesh/model/widget/param/sign/concrete/root` (capped 20) → reveals which component/model fields the raw-spawned actor is missing vs a properly-built sign

All `pcall`-guarded. This tells us whether replication alone makes it appear, and exactly what the build-system attaches that we still need (likely the concrete model).

MDX 0.0.17 → 0.0.18. Verified: nx test agones-palworld → HARNESS PASS.