### PR TITLE
feat(palforge): !curltest — check if curl is reachable in the Wine env

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -118,6 +118,7 @@ local function on_chat(_, a, b)
         pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
         pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.httptest, sender, text, pos_emit)
+        pcall(spike.curltest, sender, text, pos_emit)
     end
 end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -251,6 +251,48 @@ end
 local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
 local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
 
+local CURL_CANDIDATES = { "curl --version", "curl.exe --version" }
+
+function M.curltest(sender, msg, emit)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!curltest" then
+        return false
+    end
+    emit("curltest: start (runs 'curl --version' only; NO network)")
+
+    local ok0 = pcall(function()
+        local h = io.popen("echo palforge_popen_ok")
+        if h then
+            local out = h:read("*l")
+            h:close()
+            emit("curltest popen echo -> " .. tostring(out))
+        else
+            emit("curltest popen echo -> no handle")
+        end
+    end)
+    if not ok0 then
+        emit("curltest popen echo -> ERR (io.popen blocked)")
+    end
+
+    for _, cmd in ipairs(CURL_CANDIDATES) do
+        local ok = pcall(function()
+            local h = io.popen(cmd .. " 2>&1")
+            if not h then
+                emit("curltest " .. cmd .. " -> no handle")
+                return
+            end
+            local out = h:read("*l")
+            h:close()
+            emit("curltest " .. cmd .. " -> " .. tostring(out))
+        end)
+        if not ok then
+            emit("curltest " .. cmd .. " -> ERR")
+        end
+    end
+
+    emit("curltest: done")
+    return true
+end
+
 function M.httptest(sender, msg, emit)
     if type(msg) ~= "string" or trim(msg):lower() ~= "!httptest" then
         return false

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -147,6 +147,19 @@ local clear_ok = c1 == true
     and emitted(cl_emits, "signclear: done")
     and spawned.destroyed == true
 
+_print("=== spike.curltest command ===")
+local ct_emits = {}
+local function ct_emit(m)
+    ct_emits[#ct_emits + 1] = m
+    _print("  curl: " .. m)
+end
+local ct1 = spike.curltest("Al", "!curltest", ct_emit)
+local ct2 = spike.curltest("Al", "nope", ct_emit)
+local curltest_ok = ct1 == true
+    and ct2 == false
+    and ct_emits[1]:find("curltest: start", 1, true) ~= nil
+    and ct_emits[#ct_emits]:find("curltest: done", 1, true) ~= nil
+
 _print("=== spike.httptest command ===")
 local ht_emits = {}
 local function ht_emit(m)
@@ -173,6 +186,7 @@ local ok = calls.pending == 1
     and spike_ok
     and spawn_ok
     and clear_ok
+    and curltest_ok
     and httptest_ok
 
 if ok then


### PR DESCRIPTION
## What

`!curltest` — the cheapest experiment to decide the Lua-HTTP path. `httptest` already confirmed `package.loadlib` is a function and `os.execute`/`io.popen` exist. This checks whether the **simplest** route (`io.popen("curl ...")`) actually works in the Windows-under-Wine environment:

- `io.popen("echo palforge_popen_ok")` — sanity: does io.popen spawn at all here
- `curl --version` / `curl.exe --version` — is curl reachable on Wine's PATH

Logs the first output line of each. **`--version` only — no network, no side effects.**

## Outcome

- curl prints a version → the `io.popen` route is trivial (no dll, no ABI). 
- not found → we either bake a `curl.exe` into the image, or go the LuaSocket `.dll` route (cpath already includes `PalForge/Scripts/?.dll`), or stick with the relay bridge.

**No MDX bump** — rides the still-unpublished 0.0.18. Verified: nx test agones-palworld → HARNESS PASS.