### PR TITLE
feat(reel): scoped short-lived media token (stop leaking JWT in media URLs)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -1,5 +1,4 @@
 import { atom } from 'nanostores';
-import { getAccessToken } from '@kbve/astro';
 import { authedApiFetch, ApiError } from '@/lib/apiFetch';
 import { DASH_PROXY_BASE } from '@/components/rnweb/dashProxyBase';
 
@@ -56,10 +55,27 @@ const MAX_POLLS = 25;
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 5000;
 
+let mediaTokenCache: { token: string; expiresAtMs: number } | null = null;
+
 async function mediaToken(): Promise<string | null> {
 	const dev = import.meta.env.PUBLIC_REEL_TOKEN as string | undefined;
 	if (dev) return dev;
-	return getAccessToken();
+	if (mediaTokenCache && mediaTokenCache.expiresAtMs > Date.now()) {
+		return mediaTokenCache.token;
+	}
+	try {
+		const res = await authedApiFetch<{ token: string; exp: number }>(
+			`${REEL_PATH}/media-token`,
+		);
+		mediaTokenCache = {
+			token: res.token,
+			expiresAtMs: Date.now() + Math.max(0, res.exp - 30) * 1000,
+		};
+		return res.token;
+	} catch {
+		mediaTokenCache = null;
+		return null;
+	}
 }
 
 export function mediaUrl(id: string, suffix: string, token: string | null): string {

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -764,6 +764,10 @@ fn router(state: AppState) -> Router {
             any(super::proxy::vibeshine_webrtc_handler),
         )
         .route(
+            "/api/v1/reel/media-token",
+            axum::routing::get(super::proxy::reel_media_token_handler),
+        )
+        .route(
             "/api/v1/reel/{*rest}",
             any(super::proxy::reel_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/mod.rs
@@ -6,6 +6,7 @@ mod guacamole;
 mod kasm;
 mod kubevirt;
 mod reel;
+mod reel_token;
 mod simple;
 mod vibeshine;
 mod windmill;

--- a/apps/kbve/axum-kbve/src/transport/proxy/reel.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/reel.rs
@@ -11,6 +11,9 @@ use reqwest::Client;
 use serde_json::json;
 
 use super::core::*;
+use super::reel_token;
+use axum::http::HeaderMap;
+use axum::Json;
 
 static REEL: OnceLock<ServiceProxy> = OnceLock::new();
 
@@ -38,10 +41,48 @@ pub fn init_reel_proxy() -> bool {
     .is_ok()
 }
 
+async fn require_reel_access(headers: &HeaderMap, query: Option<&str>) -> Result<(), Response> {
+    if let Some(tok) = extract_auth_token(headers, query) {
+        if reel_token::is_media_token(tok) {
+            return match reel_token::verify_media_token(tok, reel_token::now_unix()) {
+                Some(_) => Ok(()),
+                None => Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": "Invalid or expired media token"})),
+                )
+                    .into_response()),
+            };
+        }
+    }
+    require_dashboard_view_with_query(headers, query, "Reel")
+        .await
+        .map(|_| ())
+}
+
+pub async fn reel_media_token_handler(req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let info = match require_dashboard_view_with_query(&headers, None, "Reel").await {
+        Ok(i) => i,
+        Err(resp) => return resp,
+    };
+    match reel_token::mint_media_token(
+        &info.user_id,
+        reel_token::DEFAULT_TTL_SECS,
+        reel_token::now_unix(),
+    ) {
+        Some(token) => Json(json!({"token": token, "exp": reel_token::DEFAULT_TTL_SECS})).into_response(),
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "media token signing not configured"})),
+        )
+            .into_response(),
+    }
+}
+
 pub async fn reel_proxy_handler(rest: Option<Path<String>>, req: Request<Body>) -> Response {
     let headers = req.headers().clone();
     let query = req.uri().query().map(str::to_owned);
-    if let Err(resp) = require_dashboard_view_with_query(&headers, query.as_deref(), "Reel").await {
+    if let Err(resp) = require_reel_access(&headers, query.as_deref()).await {
         return resp;
     }
 

--- a/apps/kbve/axum-kbve/src/transport/proxy/reel_token.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/reel_token.rs
@@ -1,0 +1,114 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const PREFIX: &str = "rmt";
+const SCOPE: &str = "reel";
+pub const DEFAULT_TTL_SECS: i64 = 300;
+
+fn secret() -> Option<&'static [u8]> {
+    static S: OnceLock<Option<Vec<u8>>> = OnceLock::new();
+    S.get_or_init(|| {
+        std::env::var("REEL_MEDIA_TOKEN_SECRET")
+            .or_else(|_| std::env::var("REEL_API_TOKEN"))
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(String::into_bytes)
+    })
+    .as_deref()
+}
+
+pub fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn message(exp: i64, uid: &str) -> String {
+    format!("{SCOPE}:{exp}:{uid}")
+}
+
+fn sign_with(secret: &[u8], exp: i64, uid: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).expect("hmac accepts any key length");
+    mac.update(message(exp, uid).as_bytes());
+    URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+}
+
+fn mint_with(secret: &[u8], exp: i64, uid: &str) -> String {
+    format!("{PREFIX}.{exp}.{uid}.{}", sign_with(secret, exp, uid))
+}
+
+fn verify_with(secret: &[u8], token: &str, now: i64) -> Option<String> {
+    let mut parts = token.split('.');
+    if parts.next()? != PREFIX {
+        return None;
+    }
+    let exp: i64 = parts.next()?.parse().ok()?;
+    let uid = parts.next()?;
+    let sig = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    if exp <= now {
+        return None;
+    }
+    let expected = URL_SAFE_NO_PAD.decode(sig).ok()?;
+    let mut mac = HmacSha256::new_from_slice(secret).expect("hmac accepts any key length");
+    mac.update(message(exp, uid).as_bytes());
+    mac.verify_slice(&expected).ok()?;
+    Some(uid.to_string())
+}
+
+pub fn mint_media_token(uid: &str, ttl_secs: i64, now: i64) -> Option<String> {
+    Some(mint_with(secret()?, now + ttl_secs, uid))
+}
+
+pub fn verify_media_token(token: &str, now: i64) -> Option<String> {
+    verify_with(secret()?, token, now)
+}
+
+pub fn is_media_token(token: &str) -> bool {
+    token.starts_with("rmt.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &[u8] = b"test-secret-key";
+
+    #[test]
+    fn mint_then_verify_roundtrips() {
+        let tok = mint_with(KEY, 1_000, "user-abc");
+        assert!(is_media_token(&tok));
+        assert_eq!(verify_with(KEY, &tok, 999).as_deref(), Some("user-abc"));
+    }
+
+    #[test]
+    fn expired_token_rejected() {
+        let tok = mint_with(KEY, 1_000, "user-abc");
+        assert_eq!(verify_with(KEY, &tok, 1_000), None);
+        assert_eq!(verify_with(KEY, &tok, 1_500), None);
+    }
+
+    #[test]
+    fn tampered_or_wrong_key_rejected() {
+        let tok = mint_with(KEY, 1_000, "user-abc");
+        assert_eq!(verify_with(b"other-key", &tok, 500), None);
+        let swapped = tok.replace("user-abc", "user-xyz");
+        assert_eq!(verify_with(KEY, &swapped, 500), None);
+    }
+
+    #[test]
+    fn malformed_tokens_rejected() {
+        assert_eq!(verify_with(KEY, "rmt.notanumber.u.sig", 0), None);
+        assert_eq!(verify_with(KEY, "jwt.1000.u.sig", 0), None);
+        assert_eq!(verify_with(KEY, "rmt.1000.u.sig.extra", 0), None);
+        assert_eq!(verify_with(KEY, "rmt.1000.u", 0), None);
+    }
+}


### PR DESCRIPTION
## Problem

Video and HLS-segment elements can't send an `Authorization` header, so the reel player put the **full Supabase JWT** in `?access_token=` on every media URL. That JWT then lands in the access logs of any ingress / CDN / proxy in front of axum-kbve — a long-lived, full-scope credential sitting in URL logs.

## Fix — scoped signed token (axum-kbve)

- `reel_token.rs`: HMAC-SHA256 mint/verify. Token is `rmt.<exp>.<uid>.<sig>`, 5-min TTL, `reel` scope, constant-time verify (`mac.verify_slice`). Pure fns + 4 unit tests (roundtrip, expiry, tamper/wrong-key, malformed).
- `GET /api/v1/reel/media-token` — gated by full JWT + `DASHBOARD_VIEW` (header-only), returns the signed token for the authenticated staff user.
- reel proxy guard (`require_reel_access`) fast-paths `rmt.` tokens (HMAC + exp) and falls back to the existing full-JWT path for detail/list requests.
- HMAC key = `REEL_MEDIA_TOKEN_SECRET`, falling back to the `REEL_API_TOKEN` axum-kbve already holds → **zero new config/secrets**.

## Fix — frontend (reelService.ts)

`mediaToken()` now mints + caches the scoped token (30s skew) and uses it for media `?access_token=`. Detail/list calls keep using the header JWT via `authedApiFetch`. Removed the raw-JWT-in-URL path and the now-orphaned `getAccessToken` import.

## Result

A leaked media token is short-lived, reel-only, and useless as a session credential. The full JWT never appears in a media URL.

## Verify

- `cargo test -p axum-kbve reel_token`: 4 passed
- `cargo check -p axum-kbve`: clean
- `tsc --noEmit`: 0 errors in reel/media files

Rides the kbve release train (axum-kbve + astro-kbve); no reel image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)