### PR TITLE
feat(palworld): tune egg hatch, supply drop, item weight

### DIFF
--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -71,10 +71,12 @@ spec:
                         value: 'true'
                       - name: RESTAPI_PORT
                         value: '8212'
-                      # Hours to hatch an egg. Base-image default is 72; halved
-                      # for faster breeding turnaround on the KBVE server.
                       - name: PAL_EGG_DEFAULT_HATCHING_TIME
-                        value: '36.000000'
+                        value: '12.000000'
+                      - name: SUPPLY_DROP_SPAN
+                        value: '60'
+                      - name: ITEM_WEIGHT_RATE
+                        value: '0.500000'
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER


### PR DESCRIPTION
Palworld server gameplay tuning.

| Setting | Env var | Old | New |
|---------|---------|-----|-----|
| Egg hatch time | `PAL_EGG_DEFAULT_HATCHING_TIME` | 36h | **12h** |
| Supply drop interval | `SUPPLY_DROP_SPAN` | (default 180) | **60 min** |
| Item weight rate | `ITEM_WEIGHT_RATE` | (default 1.0) | **0.5** |

Env var names + value formats verified against thijsvanloef `scripts/compile-settings.sh` (the base-image settings generator).

**Apply:** `SERVER_SETTINGS_MODE=auto` regenerates `PalWorldSettings.ini` on boot — takes effect only after GameServer recreate.