### PR TITLE
fix(reel): VPN-aware stall watchdog, HTTP timeouts, 503 on vpn-down add

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -130,6 +130,13 @@ async fn add(
     if !check_auth(&headers, &st.token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
+    if !st.engine.vpn_ok() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "vpn egress unavailable; try again shortly",
+        )
+            .into_response();
+    }
     match st.engine.add(&req.source).await {
         Ok(id) => Json(serde_json::json!({ "id": id })).into_response(),
         Err(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -27,8 +27,19 @@ pub fn is_vpn_ip(ip: IpAddr) -> bool {
     }
 }
 
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
+            .build()
+            .unwrap_or_default()
+    })
+}
+
 pub async fn vpn_preflight(check_url: &str) -> anyhow::Result<IpAddr> {
-    let body = reqwest::get(check_url).await?.text().await?;
+    let body = http_client().get(check_url).send().await?.text().await?;
     let ip: IpAddr = body
         .trim()
         .parse()
@@ -226,6 +237,7 @@ impl Engine {
         let metadata_timeout = self.metadata_timeout;
         let stall_timeout = self.stall_timeout;
         let stall_check = self.stall_check;
+        let vpn_ok = self.vpn_ok.clone();
         tokio::spawn(async move {
             match tokio::time::timeout(metadata_timeout, handle.wait_until_initialized()).await {
                 Err(_) => {
@@ -267,6 +279,10 @@ impl Engine {
                         let s = handle.stats();
                         if s.finished {
                             break Ok(());
+                        }
+                        if !vpn_ok.load(Ordering::Relaxed) {
+                            idle_secs = 0;
+                            continue;
                         }
                         if s.progress_bytes > last_bytes {
                             last_bytes = s.progress_bytes;
@@ -594,7 +610,12 @@ impl Engine {
         let mut fetched: Vec<String> = Vec::new();
         let mut ok = 0usize;
         for url in urls {
-            match reqwest::get(url).await.and_then(|r| r.error_for_status()) {
+            match http_client()
+                .get(url)
+                .send()
+                .await
+                .and_then(|r| r.error_for_status())
+            {
                 Ok(resp) => match resp.text().await {
                     Ok(text) => {
                         fetched.extend(config::parse_trackers(&text));


### PR DESCRIPTION
Three backend robustness fixes surfaced by a code survey.

## 1. Data-loss: stall watchdog deletes healthy downloads during a VPN blip
`vpn_recheck` pauses every torrent when the VPN check fails, but the per-torrent stall watchdog kept accumulating `idle_secs` while paused. After `REEL_STALL_TIMEOUT_SECS` (default 300s) of VPN downtime it marked a still-valid leeching torrent `Failed` and `delete_from_session(..., true)` **deleted its partial files**. Now the watchdog resets its idle counter whenever `vpn_ok` is false — paused torrents are never reaped as stalled.

## 2. No HTTP timeouts → boot hang + watchdog stall
`vpn_preflight` (awaited before the server binds) and the tracker refresh used `reqwest::get` with no timeout. A slow/unreachable check URL (default `api.ipify.org`) hung the whole process at boot, and the same call inside the VPN watchdog could stall leak detection. Both now share a client with 5s connect / 15s request timeouts.

## 3. Wrong status code
`POST /torrents` mapped all errors to 400, including "vpn egress unavailable" — a transient server condition. Now returns **503** when `vpn_ok()` is false, so the console doesn't tell the user their input was bad.

## Verify
`cargo test -p reel`: 115 passed; clean build.

Bumps reel.mdx 0.1.3 → 0.1.4. Transcode-cancellation (orphaned ffmpeg on delete/reap/shutdown) and frontend UX gaps (console auto-refresh, swallowed play errors) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)