### PR TITLE
feat(reel): cancel in-flight ffmpeg on delete, reap, and shutdown

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -152,6 +152,7 @@ async fn remove(
         return StatusCode::UNAUTHORIZED.into_response();
     }
     st.hls.abort(&id).await;
+    st.transcoder.abort(&id).await;
     match st.engine.delete(&id).await {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => StatusCode::NOT_FOUND.into_response(),

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -168,6 +168,16 @@ impl HlsManager {
         }
     }
 
+    pub async fn abort_all(&self) {
+        let children: Vec<Child> = {
+            let mut g = self.children.lock().unwrap();
+            g.drain().map(|(_, c)| c).collect()
+        };
+        for mut child in children {
+            let _ = child.kill().await;
+        }
+    }
+
     fn take_child(&self, id: &str) -> Option<Child> {
         let mut g = self.children.lock().unwrap();
         g.remove(id)

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -39,6 +39,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(reaper::reap_loop(
         eng.clone(),
         hls.clone(),
+        transcoder.clone(),
         cfg.ttl_secs,
         cfg.reap_interval_secs,
     ));
@@ -58,6 +59,8 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(state::persist_loop(store.clone(), cfg.state_flush_ms));
 
     let store_for_flush = store.clone();
+    let transcoder_for_shutdown = transcoder.clone();
+    let hls_for_shutdown = hls.clone();
     let app = api::router(api::AppState {
         engine: eng,
         store,
@@ -72,7 +75,9 @@ async fn main() -> anyhow::Result<()> {
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await?;
-    tracing::info!("shutdown signal received; flushing state");
+    tracing::info!("shutdown signal received; killing ffmpeg children and flushing state");
+    transcoder_for_shutdown.abort_all().await;
+    hls_for_shutdown.abort_all().await;
     if let Err(e) = store_for_flush.flush() {
         tracing::warn!(error = %e, "state flush on shutdown failed");
     }

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -30,6 +30,7 @@ use crate::util::now_secs;
 pub async fn reap_loop(
     engine: crate::engine::Engine,
     hls: crate::hls::HlsManager,
+    transcoder: crate::transcode::Transcoder,
     ttl_secs: u64,
     interval_secs: u64,
 ) {
@@ -40,6 +41,7 @@ pub async fn reap_loop(
             Ok(reaped) => {
                 for id in reaped {
                     hls.abort(&id).await;
+                    transcoder.abort(&id).await;
                 }
             }
             Err(e) => tracing::error!(error = %e, "reap cycle failed"),

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -214,6 +214,7 @@ pub struct Transcoder {
     ffmpeg_bin: String,
     ffprobe_bin: String,
     enabled: bool,
+    children: Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::process::Child>>>,
 }
 
 impl Transcoder {
@@ -232,6 +233,7 @@ impl Transcoder {
             ffmpeg_bin,
             ffprobe_bin,
             enabled,
+            children: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         };
         for m in this.store.list() {
             let in_flight = matches!(
@@ -294,6 +296,67 @@ impl Transcoder {
         });
     }
 
+    async fn run_tracked(
+        &self,
+        id: &str,
+        args: &[&str],
+        src: &std::path::Path,
+        dest: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        use tokio::io::AsyncReadExt;
+        let mut cmd = Command::new(&self.ffmpeg_bin);
+        cmd.arg("-y")
+            .arg("-nostats")
+            .arg("-loglevel")
+            .arg("error")
+            .arg("-i")
+            .arg(src)
+            .args(args)
+            .arg(dest)
+            .stderr(std::process::Stdio::piped());
+        let mut child = cmd.spawn()?;
+        let mut stderr = child.stderr.take();
+        self.children
+            .lock()
+            .unwrap()
+            .insert(id.to_string(), child);
+
+        let mut errbuf = String::new();
+        if let Some(e) = stderr.as_mut() {
+            let _ = e.read_to_string(&mut errbuf).await;
+        }
+
+        let mut child = match self.take_child(id) {
+            Some(c) => c,
+            None => anyhow::bail!("transcode aborted"),
+        };
+        let status = child.wait().await?;
+        if !status.success() {
+            anyhow::bail!("ffmpeg failed: {errbuf}");
+        }
+        Ok(())
+    }
+
+    fn take_child(&self, id: &str) -> Option<tokio::process::Child> {
+        self.children.lock().unwrap().remove(id)
+    }
+
+    pub async fn abort(&self, id: &str) {
+        if let Some(mut child) = self.take_child(id) {
+            let _ = child.kill().await;
+        }
+    }
+
+    pub async fn abort_all(&self) {
+        let children: Vec<tokio::process::Child> = {
+            let mut g = self.children.lock().unwrap();
+            g.drain().map(|(_, c)| c).collect()
+        };
+        for mut child in children {
+            let _ = child.kill().await;
+        }
+    }
+
     async fn run_job(&self, id: &str, meta: &crate::state::Metadata) -> anyhow::Result<()> {
         let src_dir = std::path::PathBuf::from(&meta.path);
         let primary = pick_primary_file(&src_dir)?;
@@ -316,11 +379,18 @@ impl Transcoder {
         match route {
             Route::Remux => {
                 let _permit = self.remux_sem.acquire().await?;
-                remux(&self.ffmpeg_bin, &primary, &dest).await?;
+                self.run_tracked(id, &["-c", "copy", "-movflags", "+faststart"], &primary, &dest)
+                    .await?;
             }
             Route::Encode => {
                 let _permit = self.encode_sem.acquire().await?;
-                encode(&self.ffmpeg_bin, &primary, &dest).await?;
+                self.run_tracked(
+                    id,
+                    &["-c:v", "libx264", "-c:a", "aac", "-movflags", "+faststart"],
+                    &primary,
+                    &dest,
+                )
+                .await?;
             }
         }
 


### PR DESCRIPTION
Closes the transcode-cancellation gap (survey #3/#7).

## Problem
Transcode ran ffmpeg via `Command::output()` and never kept the child handle. Deleting or reaping an entry mid-transcode (`api::remove`, `reaper`) left the ffmpeg process running to completion — burning CPU and re-writing `<stem>.reel.mp4` into the library directory `remove_entry_files` had just deleted, leaving an orphan file. On SIGTERM the same processes were orphaned and could race the next boot's `hls/` dir reset. HLS already tracked its children and killed them; transcode didn't.

## Fix
- `Transcoder` now holds a `children` map. `run_tracked` spawns ffmpeg, registers the child, reads stderr to EOF, then reaps exit status; an aborted job (child already taken) bails cleanly instead of writing output.
- `abort(id)` / `abort_all()` on both `Transcoder` and `HlsManager` kill tracked processes.
- `api::remove` and the reaper abort the transcoder alongside HLS.
- Graceful shutdown kills all HLS + transcode children before flushing state.

## Verify
`cargo test -p reel`: 115 passed; clean build, no warnings.

Bumps reel.mdx → 0.1.5 (stacks after #14704's 0.1.4; version line will need a trivial rebase on whichever merges second).
