### PR TITLE
feat(palworld): enable predator boss pals

### DIFF
--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -79,6 +79,8 @@ spec:
                         value: '0.500000'
                       - name: ENABLE_PREDATOR_BOSS_PAL
                         value: 'True'
+                      - name: BASE_CAMP_WORKER_MAX_NUM
+                        value: '35'
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -77,6 +77,8 @@ spec:
                         value: '60'
                       - name: ITEM_WEIGHT_RATE
                         value: '0.500000'
+                      - name: ENABLE_PREDATOR_BOSS_PAL
+                        value: 'True'
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER


### PR DESCRIPTION
Enable predator (field alpha) boss pals.

| Setting | Env var | Value |
|---------|---------|-------|
| Predator boss pals | `ENABLE_PREDATOR_BOSS_PAL` | **True** |

Env var name verified against thijsvanloef `scripts/compile-settings.sh` (base-image settings generator).

**Apply:** `SERVER_SETTINGS_MODE=auto` regenerates `PalWorldSettings.ini` on boot — takes effect after GameServer recreate.