### PR TITLE
feat(palforge): !signinspect — find why spawned signs are invisible (v0.0.19)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -117,6 +117,7 @@ local function on_chat(_, a, b)
         pcall(spike.handle, sender, text, pos_emit, pos.player_location)
         pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
         pcall(spike.clear, sender, text, pos_emit)
+        pcall(spike.signinspect, sender, text, pos_emit)
         pcall(spike.httptest, sender, text, pos_emit)
         pcall(spike.curltest, sender, text, pos_emit)
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -248,6 +248,102 @@ function M.clear(sender, msg, emit)
     return true
 end
 
+local SUBSYSTEM_CANDIDATES = {
+    "PalMapObjectSubsystem",
+    "PalMapObjectConcreteModelBase",
+    "PalBuildInternalManager",
+    "PalBuildObjectManager",
+    "PalBuildObjectInterface",
+    "PalWorldMapObjectManager",
+}
+
+local INSPECT_HINTS = {
+    "mesh", "model", "component", "root", "concrete", "sign",
+    "widget", "static", "instance", "collision", "text",
+}
+
+local function hint_match(name)
+    local low = name:lower()
+    for _, h in ipairs(INSPECT_HINTS) do
+        if low:find(h, 1, true) then
+            return true
+        end
+    end
+    return false
+end
+
+local function is_tracked(actor)
+    for _, a in ipairs(spawned) do
+        if a == actor then
+            return true
+        end
+    end
+    return false
+end
+
+function M.signinspect(sender, msg, emit, find_first, find_all)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signinspect" then
+        return false
+    end
+    find_first = find_first or FindFirstOf
+    find_all = find_all or FindAllOf
+
+    emit("signinspect: start (read-only; compares placed sign vs bare spawn)")
+
+    for _, name in ipairs(SUBSYSTEM_CANDIDATES) do
+        local s = find_first(name)
+        emit("subsystem " .. name .. " -> " .. (is_valid(s) and "VALID" or "absent"))
+    end
+
+    local boards = try(emit, "FindAllOf(signboard)", function()
+        return find_all(SIGNBOARD_SHORT)
+    end)
+    if type(boards) ~= "table" or #boards == 0 then
+        emit("signinspect: no signboard instances (place one first)")
+        emit("signinspect: done")
+        return true
+    end
+    emit("signinspect instances -> " .. #boards)
+
+    for i, b in ipairs(boards) do
+        local tag = is_tracked(b) and "SPAWNED(bare)" or "PLACED?"
+        local full = "?"
+        pcall(function() full = tostring(b:GetFullName()) end)
+        emit(string.format("--- instance %d [%s] %s", i, tag, full))
+
+        local hits = 0
+        pcall(function()
+            b:ForEachProperty(function(prop)
+                local pname = tostring(prop:GetName())
+                if not hint_match(pname) then
+                    return
+                end
+                local vdesc = "nil/unread"
+                pcall(function()
+                    local v = b[pname]
+                    if v == nil then
+                        vdesc = "nil"
+                    elseif type(v) == "userdata" then
+                        local fn = "?"
+                        pcall(function() fn = tostring(v:GetFullName()) end)
+                        vdesc = "obj " .. fn
+                    else
+                        vdesc = type(v) .. " " .. tostring(v)
+                    end
+                end)
+                hits = hits + 1
+                if hits <= 30 then
+                    emit("  prop " .. pname .. " = " .. vdesc)
+                end
+            end)
+        end)
+        emit(string.format("  instance %d relevant props = %d", i, hits))
+    end
+
+    emit("signinspect: done (populated model/mesh props on PLACED = what bare spawn lacks)")
+    return true
+end
+
 local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
 local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -147,6 +147,33 @@ local clear_ok = c1 == true
     and emitted(cl_emits, "signclear: done")
     and spawned.destroyed == true
 
+_print("=== spike.signinspect command ===")
+local si_emits = {}
+local function si_emit(m)
+    si_emits[#si_emits + 1] = m
+    _print("  inspect: " .. m)
+end
+local function si_board(full)
+    return {
+        GetFullName = function() return full end,
+        ForEachProperty = function(_, cb)
+            cb({ GetName = function() return "StaticMeshComponent" end })
+            cb({ GetName = function() return "UnrelatedFlag" end })
+        end,
+    }
+end
+local si_find_first = function() return { IsValid = function() return true end } end
+local si_find_all = function() return { si_board("Signboard_placed_A") } end
+local si1 = spike.signinspect("Al", "!signinspect", si_emit, si_find_first, si_find_all)
+local si2 = spike.signinspect("Al", "nope", si_emit, si_find_first, si_find_all)
+local si_empty = spike.signinspect("Al", "!signinspect", si_emit, si_find_first, function() return {} end)
+local signinspect_ok = si1 == true
+    and si2 == false
+    and si_empty == true
+    and emitted(si_emits, "signinspect: start")
+    and emitted(si_emits, "instances -> 1")
+    and emitted(si_emits, "signinspect: done")
+
 _print("=== spike.curltest command ===")
 local ct_emits = {}
 local function ct_emit(m)
@@ -186,6 +213,7 @@ local ok = calls.pending == 1
     and spike_ok
     and spawn_ok
     and clear_ok
+    and signinspect_ok
     and curltest_ok
     and httptest_ok
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.18"
+version: "0.0.19"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Adds \`!signinspect\` — a read-only recon command to solve the invisible-sign problem.

## Why

\`!signspawn\` (v0.0.18) confirmed: raw \`world:SpawnActor(BP_BuildObject_Signboard_C)\` creates a real, replicated, persistent actor — but \`relevant props = 0\`. The bare actor has **no mesh/concrete-model component populated**, so there is nothing to render. Native placement (a player building a sign) attaches a \`PalMapObjectConcreteModel\` + mesh after spawn; raw SpawnActor skips that step.

## What it does (safe / read-only)

- Probes for the native build/map-object managers (\`PalMapObjectSubsystem\`, \`PalBuildInternalManager\`, \`PalBuildObjectManager\`, …) — reports which actually exist on the live server.
- \`FindAllOf\` signboard instances, tags each **SPAWNED(bare)** (our tracked spawn) vs **PLACED?** (real), and dumps its populated model/mesh/component/text props via \`ForEachProperty\`.
- The diff between a PLACED sign's props and our bare spawn = exactly what we must attach to make it visible.

No mutation, no network — just reads properties.

## Test

\`nx test agones-palworld\` (Lua harness in \`nickblah/lua:5.4\`) — **HARNESS PASS**, new \`signinspect_ok\` case added.

## Version

MDX bumped to \`0.0.19\` in this same commit (0.0.18 already published/deployed). version.toml + gameserver.yaml left to ci-manifest-sync.

## Next

Run \`!signinspect\` in-game near a placed sign → read UE4SS.log/\`[PAL]\` → wire the real concrete-model attach.