### PR TITLE
feat(palworld): wire PalSchema data-table framework (v0.0.20)

### DIFF
--- a/apps/agones/palworld/Dockerfile
+++ b/apps/agones/palworld/Dockerfile
@@ -15,8 +15,25 @@ ENV INSTALL_UE4SS_EXPERIMENTAL=true \
     CUSTOM_SCRIPT_PATH=/opt/palchatrelay/overlay.sh \
     PALWORLD_CHAT_LOG=Z:/shared/chat/chat.log
 
+# PalSchema (Okaetsu) — JSON-driven data-table/blueprint framework, C++ UE4SS mod
+# (main.dll). Same author as the base image's UE4SS-Palworld fork. Pinned by
+# release + sha256 (verified against the GitHub API asset digest); bump both ARGs
+# to update. Downloaded at build (once), staged into ue4ss/Mods by overlay.sh.
+ARG PALSCHEMA_VERSION=0.6.1
+ARG PALSCHEMA_SHA256=d30f0ff7bed94bc4695468ff5dd4f6070efd1f89ce8c983eb814bb2960f5262b
+RUN set -eux \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends unzip curl ca-certificates \
+    && curl -fsSL -o /tmp/palschema.zip \
+        "https://github.com/Okaetsu/PalSchema/releases/download/${PALSCHEMA_VERSION}/PalSchema_${PALSCHEMA_VERSION}.zip" \
+    && echo "${PALSCHEMA_SHA256}  /tmp/palschema.zip" | sha256sum -c - \
+    && unzip -q /tmp/palschema.zip -d /opt/palchatrelay/ \
+    && rm -f /tmp/palschema.zip \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY apps/agones/palworld/mods/PalChatRelay /opt/palchatrelay/PalChatRelay
 COPY apps/agones/palworld/mods/PalForge /opt/palchatrelay/PalForge
+COPY apps/agones/palworld/mods/PalSchema /opt/palchatrelay/PalSchema-overlay
 COPY apps/agones/palworld/overlay.sh /opt/palchatrelay/overlay.sh
 COPY apps/agones/palworld/shim/agones-shim-prestop.sh /usr/local/bin/agones-shim-prestop
 RUN chmod +x /opt/palchatrelay/overlay.sh /usr/local/bin/agones-shim-prestop \

--- a/apps/agones/palworld/mods/PalSchema/README.md
+++ b/apps/agones/palworld/mods/PalSchema/README.md
@@ -1,0 +1,33 @@
+# PalSchema overlay (KBVE JSON mods)
+
+PalSchema (Okaetsu) is a JSON-driven data-table / blueprint framework for
+Palworld, running as a C++ UE4SS mod (`main.dll`). It is the clean path for
+**data-level content** — custom NPCs/characters, items, recipes, shop tables —
+versus PalForge's runtime Lua reflection.
+
+## How it's wired
+
+- The framework binary is **not vendored here**. `Dockerfile` downloads the
+  pinned release (`PALSCHEMA_VERSION` + `PALSCHEMA_SHA256`, verified against the
+  GitHub asset digest) and extracts it to `/opt/palchatrelay/PalSchema`
+  (`dlls/main.dll`, `enabled.txt`, `mods/`).
+- This directory (`mods/PalSchema/`) is the **KBVE overlay**: any JSON under
+  `mods/` here is copied into the framework's `Mods/PalSchema/mods/` at
+  container start by `overlay.sh`, then enabled via `mods.txt`.
+
+## Adding an NPC / content mod
+
+Drop a `*.json` PalSchema mod under [`mods/`](./mods/). See the PalSchema docs
+for the JSON schema (data-table blueprint edits, character definitions, spawn
+tables). Files here are layered on top of the pinned framework — no binary
+changes needed.
+
+## Updating the framework
+
+Bump `PALSCHEMA_VERSION` and `PALSCHEMA_SHA256` in `apps/agones/palworld/Dockerfile`.
+Get the digest from:
+
+```bash
+gh api repos/Okaetsu/PalSchema/releases/latest \
+  --jq '.assets[] | select(.name|endswith(".zip")) | {name, digest}'
+```

--- a/apps/agones/palworld/mods/mods.txt
+++ b/apps/agones/palworld/mods/mods.txt
@@ -1,2 +1,3 @@
 PalChatRelay : 1
 PalForge : 1
+PalSchema : 1

--- a/apps/agones/palworld/overlay.sh
+++ b/apps/agones/palworld/overlay.sh
@@ -47,6 +47,37 @@ if [[ -d "${FORGE_SRC}" ]]; then
     fi
 fi
 
+# PalSchema (Okaetsu) — C++ dll framework fetched (pinned+sha256) into
+# /opt/palchatrelay/PalSchema by the Dockerfile. Stage the whole mod folder
+# (dlls/main.dll + enabled.txt + mods/) into ue4ss/Mods, then layer our KBVE
+# JSON overlay (mods/PalSchema/mods/*) on top of the framework's mods/ dir.
+SCHEMA_SRC=/opt/palchatrelay/PalSchema
+if [[ -d "${SCHEMA_SRC}" ]]; then
+    echo "[palchatrelay-overlay] staging PalSchema into ${MODS_DIR}"
+    rm -rf "${MODS_DIR}/PalSchema"
+    cp -a "${SCHEMA_SRC}" "${MODS_DIR}/PalSchema"
+    mkdir -p "${MODS_DIR}/PalSchema/mods"
+
+    SCHEMA_OVERLAY=/opt/palchatrelay/PalSchema-overlay/mods
+    if [[ -d "${SCHEMA_OVERLAY}" ]]; then
+        shopt -s nullglob dotglob
+        overlay_files=("${SCHEMA_OVERLAY}"/*)
+        if (( ${#overlay_files[@]} )); then
+            echo "[palchatrelay-overlay] layering KBVE PalSchema JSON overlay"
+            cp -a "${SCHEMA_OVERLAY}"/. "${MODS_DIR}/PalSchema/mods/"
+        fi
+        shopt -u nullglob dotglob
+    fi
+
+    if grep -qiE '^[[:space:]]*PalSchema[[:space:]]*:' "${MODS_TXT}"; then
+        sed -i -E 's|^[[:space:]]*PalSchema[[:space:]]*:.*|PalSchema : 1|I' "${MODS_TXT}"
+    else
+        echo "PalSchema : 1" >> "${MODS_TXT}"
+    fi
+else
+    echo "[palchatrelay-overlay] WARN: PalSchema not found at ${SCHEMA_SRC} (Dockerfile fetch failed?)"
+fi
+
 # Headless server has no GPU: force the UE4SS GUI/OpenGL console off (it hangs
 # or crashes the game under Xvfb). Keep the text console on for logging.
 SETTINGS="${UE4SS_DIR}/UE4SS-settings.ini"

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.19"
+version: "0.0.20"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Wires **PalSchema** (Okaetsu) into the Agones Palworld image — a JSON-driven data-table / blueprint framework running as a C++ UE4SS mod (`main.dll`).

## Why

PalSchema is the clean path for **data-level content** — custom NPCs/characters, items, recipes, shop tables — versus PalForge's runtime Lua reflection (which stays for signs). Same author as the base image's `Okaetsu UE4SS-Palworld` fork, so it loads in our **Windows-UE4SS-under-Wine** setup (the `Z:\` cpath + cmd.exe behavior confirmed we're on Wine, not native Linux).

NPCs get placed by Palworld's own spawner systems once they're in the data tables — so unlike build-object signs, no runtime placement/model-attach hack is needed.

## Delivery — pinned, not Steam Workshop

- **Dockerfile** downloads release `0.6.1` and verifies `sha256` against the GitHub asset digest (`d30f0ff…5262b`) before extracting to `/opt/palchatrelay/PalSchema`. Bump `PALSCHEMA_VERSION` + `PALSCHEMA_SHA256` to update.
- **overlay.sh** stages the framework (`dlls/main.dll` + `enabled.txt` + `mods/`) into `ue4ss/Mods` at boot, layers any KBVE JSON from `mods/PalSchema/mods/` on top, and adds `PalSchema : 1` to `mods.txt`.
- **Not Workshop**: no Steam client on the dedicated server, the Workshop copy is delisted, and Workshop auto-update would break image reproducibility. We pin + bump deliberately like every other dep.

## Files

- `Dockerfile` — pinned+verified PalSchema fetch
- `overlay.sh` — stage framework + KBVE JSON overlay + mods.txt
- `mods/PalSchema/` — KBVE JSON overlay dir (empty; framework-only for now) + README
- `mods/mods.txt`, MDX `version: 0.0.20`

## Next

Author NPC JSON under `mods/PalSchema/mods/` per the PalSchema schema. version.toml + gameserver.yaml left to ci-manifest-sync.