### PR TITLE
fix(reel): robust multi-endpoint VPN check with debounce (stop false leaks)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub state_file: PathBuf,
     pub api_addr: String,
     pub vpn_check_url: String,
+    pub vpn_check_urls: Vec<String>,
+    pub vpn_leak_threshold: u32,
     pub vpn_watchdog_secs: u64,
     pub metadata_timeout_secs: u64,
     pub stall_timeout_secs: u64,
@@ -71,6 +73,40 @@ pub fn merge_trackers<I: IntoIterator<Item = String>>(lists: I) -> Vec<String> {
     out
 }
 
+pub const DEFAULT_VPN_CHECK_URLS: &[&str] = &[
+    "https://api.ipify.org",
+    "https://ifconfig.me/ip",
+    "https://icanhazip.com",
+    "https://ipinfo.io/ip",
+];
+
+fn vpn_check_urls_from_env() -> Vec<String> {
+    if let Ok(v) = std::env::var("REEL_VPN_CHECK_URLS") {
+        let list: Vec<String> = v
+            .split([',', '\n'])
+            .map(str::trim)
+            .filter(|s| s.starts_with("http"))
+            .map(String::from)
+            .collect();
+        if !list.is_empty() {
+            return list;
+        }
+    }
+    let mut urls: Vec<String> = Vec::new();
+    if let Ok(u) = std::env::var("REEL_VPN_CHECK_URL") {
+        let u = u.trim();
+        if u.starts_with("http") {
+            urls.push(u.to_string());
+        }
+    }
+    for d in DEFAULT_VPN_CHECK_URLS {
+        if !urls.iter().any(|x| x == d) {
+            urls.push((*d).to_string());
+        }
+    }
+    urls
+}
+
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
 }
@@ -105,6 +141,8 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         state_file: PathBuf::from(env_or("REEL_STATE_FILE", "/data/reel-state.json")),
         api_addr: env_or("REEL_API_ADDR", "0.0.0.0:8080"),
         vpn_check_url: env_or("REEL_VPN_CHECK_URL", "https://api.ipify.org"),
+        vpn_check_urls: vpn_check_urls_from_env(),
+        vpn_leak_threshold: env_u64("REEL_VPN_LEAK_THRESHOLD", 3)?.max(1) as u32,
         vpn_watchdog_secs: env_u64("REEL_VPN_WATCHDOG_SECS", 60)?,
         metadata_timeout_secs: env_u64("REEL_METADATA_TIMEOUT_SECS", 120)?,
         stall_timeout_secs: env_u64("REEL_STALL_TIMEOUT_SECS", 300)?,
@@ -156,7 +194,7 @@ mod tests {
     fn clear() {
         for k in ["REEL_TTL_SECS","REEL_REAP_INTERVAL_SECS","REEL_ACTIVE_DIR",
                   "REEL_LIBRARY_DIR","REEL_SESSION_DIR","REEL_STATE_FILE","REEL_API_ADDR",
-                  "REEL_VPN_CHECK_URL","REEL_VPN_WATCHDOG_SECS","REEL_METADATA_TIMEOUT_SECS",
+                  "REEL_VPN_CHECK_URL","REEL_VPN_CHECK_URLS","REEL_VPN_LEAK_THRESHOLD","REEL_VPN_WATCHDOG_SECS","REEL_METADATA_TIMEOUT_SECS",
                   "REEL_STALL_TIMEOUT_SECS","REEL_STALL_CHECK_SECS",
                   "REEL_TRACKERS","REEL_TRACKERS_URLS","REEL_TRACKERS_CACHE","REEL_TRACKERS_REFRESH_SECS",
                   "REEL_STATE_FLUSH_MS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
@@ -175,6 +213,9 @@ mod tests {
         assert_eq!(c.ttl_secs, 21600);
         assert_eq!(c.reap_interval_secs, 300);
         assert_eq!(c.vpn_watchdog_secs, 60);
+        assert_eq!(c.vpn_leak_threshold, 3);
+        assert_eq!(c.vpn_check_urls.len(), DEFAULT_VPN_CHECK_URLS.len());
+        assert!(c.vpn_check_urls.iter().all(|u| u.starts_with("https://")));
         assert_eq!(c.metadata_timeout_secs, 120);
         assert_eq!(c.stall_timeout_secs, 300);
         assert_eq!(c.stall_check_secs, 15);
@@ -245,6 +286,23 @@ mod tests {
         std::env::set_var("REEL_TRACKERS", "udp://x:1/announce, wss://skip, https://y:2/announce");
         let c = load_from_env().unwrap();
         assert_eq!(c.extra_trackers, vec!["udp://x:1/announce", "https://y:2/announce"]);
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn vpn_check_urls_override_and_legacy_prepend() {
+        clear();
+        std::env::set_var("REEL_VPN_CHECK_URLS", "https://a/ip, https://b/ip");
+        assert_eq!(
+            load_from_env().unwrap().vpn_check_urls,
+            vec!["https://a/ip", "https://b/ip"]
+        );
+        std::env::remove_var("REEL_VPN_CHECK_URLS");
+        std::env::set_var("REEL_VPN_CHECK_URL", "https://custom/ip");
+        let urls = load_from_env().unwrap().vpn_check_urls;
+        assert_eq!(urls.first().map(String::as_str), Some("https://custom/ip"));
+        assert!(urls.len() > 1, "defaults appended as fallback");
         clear();
     }
 

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -38,16 +38,60 @@ fn http_client() -> &'static reqwest::Client {
     })
 }
 
-pub async fn vpn_preflight(check_url: &str) -> anyhow::Result<IpAddr> {
-    let body = http_client().get(check_url).send().await?.text().await?;
-    let ip: IpAddr = body
-        .trim()
-        .parse()
-        .map_err(|_| anyhow::anyhow!("vpn check returned non-ip: {body}"))?;
-    if !is_vpn_ip(ip) {
-        anyhow::bail!("egress ip {ip} is not a public/vpn address; refusing to start");
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum VpnStatus {
+    Confirmed(IpAddr),
+    Leak(IpAddr),
+    Unverified,
+}
+
+async fn probe_ip(url: &str) -> Option<IpAddr> {
+    let body = http_client().get(url).send().await.ok()?.text().await.ok()?;
+    body.trim().parse().ok()
+}
+
+pub async fn vpn_status(urls: &[String]) -> VpnStatus {
+    for url in urls {
+        if let Some(ip) = probe_ip(url).await {
+            return if is_vpn_ip(ip) {
+                VpnStatus::Confirmed(ip)
+            } else {
+                VpnStatus::Leak(ip)
+            };
+        }
     }
-    Ok(ip)
+    VpnStatus::Unverified
+}
+
+pub fn decide_vpn(status: VpnStatus, prev_ok: bool, streak: u32, threshold: u32) -> (bool, u32) {
+    match status {
+        VpnStatus::Confirmed(_) => (true, 0),
+        VpnStatus::Leak(_) => (false, 0),
+        VpnStatus::Unverified => {
+            let s = streak.saturating_add(1);
+            if s >= threshold.max(1) {
+                (false, s)
+            } else {
+                (prev_ok, s)
+            }
+        }
+    }
+}
+
+pub async fn vpn_preflight(urls: &[String]) -> anyhow::Result<IpAddr> {
+    for attempt in 0..5u32 {
+        match vpn_status(urls).await {
+            VpnStatus::Confirmed(ip) => return Ok(ip),
+            VpnStatus::Leak(ip) => {
+                anyhow::bail!("egress ip {ip} is not a public/vpn address; refusing to start")
+            }
+            VpnStatus::Unverified => {
+                tracing::warn!(attempt, "vpn preflight: no check endpoint reachable; retrying");
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+        }
+    }
+    anyhow::bail!("vpn preflight failed: no check endpoint reachable after retries")
 }
 
 use crate::util::now_secs;
@@ -84,8 +128,10 @@ pub struct Engine {
     store: state::StateStore,
     active_dir: PathBuf,
     library_dir: PathBuf,
-    vpn_check_url: String,
+    vpn_check_urls: Vec<String>,
+    vpn_leak_threshold: u32,
     vpn_ok: Arc<AtomicBool>,
+    vpn_fail_streak: Arc<AtomicU32>,
     active_leech: Arc<Mutex<HashMap<String, u32>>>,
     drain: Arc<Notify>,
     metadata_timeout: Duration,
@@ -102,7 +148,7 @@ pub fn is_stalled(prev_bytes: u64, cur_bytes: u64, idle_secs: u64, stall_timeout
 
 impl Engine {
     pub async fn start(cfg: &config::Config, store: state::StateStore) -> anyhow::Result<Self> {
-        let ip = vpn_preflight(&cfg.vpn_check_url).await?;
+        let ip = vpn_preflight(&cfg.vpn_check_urls).await?;
         tracing::info!(%ip, "vpn preflight ok");
         std::fs::create_dir_all(&cfg.active_dir)?;
         std::fs::create_dir_all(&cfg.library_dir)?;
@@ -127,8 +173,10 @@ impl Engine {
             store,
             active_dir: cfg.active_dir.clone(),
             library_dir: cfg.library_dir.clone(),
-            vpn_check_url: cfg.vpn_check_url.clone(),
+            vpn_check_urls: cfg.vpn_check_urls.clone(),
+            vpn_leak_threshold: cfg.vpn_leak_threshold,
             vpn_ok: Arc::new(AtomicBool::new(true)),
+            vpn_fail_streak: Arc::new(AtomicU32::new(0)),
             active_leech: Arc::new(Mutex::new(HashMap::new())),
             drain: Arc::new(Notify::new()),
             metadata_timeout: Duration::from_secs(cfg.metadata_timeout_secs),
@@ -153,8 +201,15 @@ impl Engine {
     }
 
     pub async fn vpn_recheck(&self) -> bool {
-        let now_ok = vpn_preflight(&self.vpn_check_url).await.is_ok();
+        let status = vpn_status(&self.vpn_check_urls).await;
         let prev_ok = self.vpn_ok.load(Ordering::Relaxed);
+        let streak = self.vpn_fail_streak.load(Ordering::Relaxed);
+        let (now_ok, new_streak) =
+            decide_vpn(status, prev_ok, streak, self.vpn_leak_threshold);
+        self.vpn_fail_streak.store(new_streak, Ordering::Relaxed);
+        if matches!(status, VpnStatus::Unverified) && !now_ok && prev_ok {
+            tracing::warn!(streak = new_streak, "vpn check unverified past threshold; pausing");
+        }
         match next_vpn_action(prev_ok, now_ok) {
             VpnAction::Pause => {
                 crate::telemetry::vpn_leak();
@@ -774,6 +829,26 @@ mod tests {
         assert_eq!(next_vpn_action(true, false), VpnAction::Pause);
         assert_eq!(next_vpn_action(false, true), VpnAction::Resume);
         assert_eq!(next_vpn_action(false, false), VpnAction::None);
+    }
+
+    #[test]
+    fn decide_vpn_debounces_transient_failures() {
+        let ip = "1.2.3.4".parse().unwrap();
+        assert_eq!(decide_vpn(VpnStatus::Confirmed(ip), false, 5, 3), (true, 0));
+        assert_eq!(decide_vpn(VpnStatus::Leak(ip), true, 0, 3), (false, 0));
+
+        let (ok1, s1) = decide_vpn(VpnStatus::Unverified, true, 0, 3);
+        assert_eq!((ok1, s1), (true, 1), "1st flake holds prev ok");
+        let (ok2, s2) = decide_vpn(VpnStatus::Unverified, ok1, s1, 3);
+        assert_eq!((ok2, s2), (true, 2), "2nd flake still holds");
+        let (ok3, s3) = decide_vpn(VpnStatus::Unverified, ok2, s2, 3);
+        assert_eq!((ok3, s3), (false, 3), "3rd flake trips the pause");
+
+        assert_eq!(
+            decide_vpn(VpnStatus::Confirmed(ip), false, 3, 3),
+            (true, 0),
+            "confirm resets streak and resumes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Live bug
Adding a magnet fails with **"vpn egress unavailable; refusing to add torrent"** even though the VPN is up. The VPN watchdog checked a single endpoint (`api.ipify.org`) and treated **any** failure as a leak. Diagnosed on the live pod: gluetun holds a stable public IP (217.138.216.99, Germany), but `api.ipify.org` intermittently times out through the tunnel (~1 in 5 requests). So reel flapped `vpn_leak` → `vpn_restored` every few minutes, pausing all torrents and rejecting `add` during each window.

## Fix
- **Multi-endpoint** `vpn_status()`: tries ipify, ifconfig.me, icanhazip, ipinfo in order; first reachable one decides. A reachable **non-VPN IP** is a real leak → pause immediately. **All unreachable** → `Unverified`, not a leak.
- **Debounce** `decide_vpn()`: an `Unverified` check holds the previous state and only pauses after `REEL_VPN_LEAK_THRESHOLD` (default 3) consecutive unverified cycles. A transient endpoint flake never pauses; a real outage still trips within a few minutes; a real IP leak pauses instantly.
- **Preflight** retries across endpoints before refusing to boot.
- Config: `REEL_VPN_CHECK_URLS` (comma list), `REEL_VPN_LEAK_THRESHOLD`; legacy `REEL_VPN_CHECK_URL` still honored (prepended to the default set).

## Verify
`cargo test -p reel`: 117 passed (+2: `decide_vpn_debounces_transient_failures`, `vpn_check_urls_override_and_legacy_prepend`); clean build, no warnings.

Bumps reel.mdx → 0.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)