### PR TITLE
chore(reel): pin deployment to versioned tag + wire post-publish auto-bump

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -542,6 +542,7 @@
 			"source_path": "apps/media/reel",
 			"runner": "ubuntu-latest",
 			"image": "kbve/reel",
+			"deployment_yaml": "apps/kube/reel/manifest/reel.yaml",
 			"has_test": false
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -19,6 +19,7 @@ version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
 runner: ubuntu-latest
 image: kbve/reel
+deployment_yaml: apps/kube/reel/manifest/reel.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -38,7 +38,7 @@ spec:
             - { name: FIREWALL_INPUT_PORTS, value: "8080" }
             - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.0.0.0/8,172.16.0.0/12" }
         - name: reel
-          image: ghcr.io/kbve/reel:latest
+          image: ghcr.io/kbve/reel:0.1.6
           env:
             - { name: REEL_API_ADDR, value: "0.0.0.0:8080" }
             - { name: REEL_ACTIVE_DIR, value: "/data/active" }


### PR DESCRIPTION
## Why
reel.yaml tracked `ghcr.io/kbve/reel:latest`. A new image reuses the same tag, so the manifest never changes and ArgoCD never rolls it out — every reel release (including the 0.1.6 VPN false-leak fix) sat built-but-undeployed until a manual `kubectl rollout restart`. Pinned peers (metrics, axum-rentearth) don't have this problem because the post-publish chore bumps their versioned tag.

## Fix
The post-publish workflow (`utils-post-publish.yml`) seds `image: <name>:<ver>` in a `deployment_yaml` it reads from the app's manifest entry — which comes from mdx frontmatter. reel's entry was missing it.

- **reel.mdx**: add `deployment_yaml: apps/kube/reel/manifest/reel.yaml` (mirrors `metrics.mdx`).
- **ci-dispatch-manifest.json**: regenerated via `nx run astro-kbve:gen:ci-manifest` — reel entry now carries `deployment_yaml` (one-line diff).
- **reel.yaml**: pin `:latest` → `:0.1.6`.

## Effect
- This PR's reel.yaml change makes ArgoCD roll out **0.1.6** — deploying the VPN fix via GitOps (no manual restart).
- Every future `reel.mdx` version bump now auto-pins reel.yaml through post-publish, so releases roll out on their own.

No code change; no version bump (0.1.6 already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)