### PR TITLE
feat(reel): live download stats in console + tracker cache optimization

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -5,11 +5,13 @@ import {
 	$reelList,
 	$reelListError,
 	$reelListLoading,
+	$reelLive,
 	addTorrent,
 	deleteTorrent,
 	startTranscode,
 	refreshReelList,
 	type ReelTorrent,
+	type ReelLive,
 } from './reelService';
 
 const STATE_BADGE: Record<string, string> = {
@@ -31,10 +33,34 @@ function fmtSize(bytes: number): string {
 	return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
+function progressLine(t: ReelTorrent, live: ReelLive | undefined): string {
+	if (t.state === 'Leeching') {
+		if (!live || live.total_bytes === 0) {
+			const seen = live?.peers_seen ?? 0;
+			return seen > 0
+				? `resolving metadata • ${seen} peer${seen === 1 ? '' : 's'} seen`
+				: 'searching for peers…';
+		}
+		const pct = Math.min(
+			100,
+			Math.floor((live.progress_bytes / live.total_bytes) * 100),
+		);
+		const speed = live.download_mbps
+			? ` • ${live.download_mbps.toFixed(1)} MB/s`
+			: '';
+		return `${pct}% of ${fmtSize(live.total_bytes)}${speed} • ${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`;
+	}
+	if (t.state === 'Seeding' && live && live.upload_mbps) {
+		return `seeding • ↑ ${live.upload_mbps.toFixed(1)} MB/s • ${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`;
+	}
+	return fmtSize(t.size);
+}
+
 export default function ReactReelConsole() {
 	const list = useStore($reelList);
 	const listError = useStore($reelListError);
 	const loading = useStore($reelListLoading);
+	const live = useStore($reelLive);
 	const isStaff = useStore(homeService.$isStaff);
 
 	const [source, setSource] = useState('');
@@ -178,7 +204,7 @@ export default function ReactReelConsole() {
 										}`}>
 										{t.state}
 									</span>
-									<span>{fmtSize(t.size)}</span>
+									<span>{progressLine(t, live[t.id])}</span>
 									{t.transcode !== 'None' && (
 										<span>transcode: {t.transcode}</span>
 									)}

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -42,9 +42,22 @@ export interface ReelTorrent {
 	hls_error?: string | null;
 }
 
+export interface ReelLive {
+	id: string;
+	progress_bytes: number;
+	total_bytes: number;
+	finished: boolean;
+	download_mbps: number;
+	upload_mbps: number;
+	peers_live: number;
+	peers_seen: number;
+	peers_connecting: number;
+}
+
 export const $reelList = atom<ReelTorrent[]>([]);
 export const $reelListError = atom<string | null>(null);
 export const $reelListLoading = atom<boolean>(false);
+export const $reelLive = atom<Record<string, ReelLive>>({});
 
 const REEL_PATH: string =
 	(import.meta.env.PUBLIC_REEL_BASE as string | undefined) ?? '/api/v1/reel';
@@ -117,10 +130,24 @@ export async function startTranscode(id: string): Promise<void> {
 	);
 }
 
+export async function fetchLiveStats(): Promise<ReelLive[]> {
+	return authedApiFetch<ReelLive[]>(`${REEL_PATH}/stats`);
+}
+
+export async function refreshLiveStats(): Promise<void> {
+	try {
+		const stats = await fetchLiveStats();
+		$reelLive.set(Object.fromEntries(stats.map((s) => [s.id, s])));
+	} catch {
+		/* stats are best-effort; keep the last snapshot */
+	}
+}
+
 export async function refreshReelList(): Promise<void> {
 	$reelListLoading.set(true);
 	try {
-		$reelList.set(await listTorrents());
+		const [list] = await Promise.all([listTorrents(), refreshLiveStats()]);
+		$reelList.set(list);
 		$reelListError.set(null);
 	} catch (e) {
 		$reelListError.set(

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.7"
+version: "0.1.8"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -87,6 +87,13 @@ async fn list(State(st): State<AppStateStub>, headers: HeaderMap) -> impl IntoRe
     Json(st.store.list()).into_response()
 }
 
+async fn live_stats(State(st): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    Json(st.engine.live_stats()).into_response()
+}
+
 async fn get_one(
     State(st): State<AppStateStub>,
     headers: HeaderMap,
@@ -532,6 +539,7 @@ fn store_scoped_router(state: AppStateStub) -> Router {
 pub fn router(state: AppState) -> Router {
     let stub = AppStateStub::from(&state);
     let engine_router = Router::new()
+        .route("/stats", get(live_stats))
         .route("/torrents", post(add))
         .route("/torrents/{id}", axum::routing::delete(remove))
         .route("/torrents/{id}/transcode", post(transcode_start))

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -146,6 +146,19 @@ pub fn is_stalled(prev_bytes: u64, cur_bytes: u64, idle_secs: u64, stall_timeout
     cur_bytes <= prev_bytes && idle_secs >= stall_timeout_secs
 }
 
+#[derive(serde::Serialize)]
+pub struct TorrentLive {
+    pub id: String,
+    pub progress_bytes: u64,
+    pub total_bytes: u64,
+    pub finished: bool,
+    pub download_mbps: f64,
+    pub upload_mbps: f64,
+    pub peers_live: usize,
+    pub peers_seen: usize,
+    pub peers_connecting: usize,
+}
+
 fn magnet_with_trackers(source: &str, trackers: &[String]) -> String {
     if trackers.is_empty() {
         return source.to_string();
@@ -774,12 +787,46 @@ impl Engine {
             anyhow::bail!("all {} tracker sources failed", urls.len());
         }
         let merged = config::merge_trackers(embedded.iter().cloned().chain(fetched));
+        let current = self.trackers.lock().unwrap().clone();
+        if merged == *current {
+            return Ok(merged.len());
+        }
         if let Err(e) = write_cache(cache, &merged) {
             tracing::warn!(error = %e, cache = %cache.display(), "tracker cache write failed");
         }
         let n = merged.len();
         *self.trackers.lock().unwrap() = Arc::new(merged);
         Ok(n)
+    }
+
+    pub fn live_stats(&self) -> Vec<TorrentLive> {
+        self.session.with_torrents(|it| {
+            it.map(|(_, h)| {
+                let s = h.stats();
+                let (down, up, live, seen, connecting) = match s.live.as_ref() {
+                    Some(l) => (
+                        l.download_speed.mbps,
+                        l.upload_speed.mbps,
+                        l.snapshot.peer_stats.live,
+                        l.snapshot.peer_stats.seen,
+                        l.snapshot.peer_stats.connecting,
+                    ),
+                    None => (0.0, 0.0, 0, 0, 0),
+                };
+                TorrentLive {
+                    id: h.info_hash().as_string(),
+                    progress_bytes: s.progress_bytes,
+                    total_bytes: s.total_bytes,
+                    finished: s.finished,
+                    download_mbps: down,
+                    upload_mbps: up,
+                    peers_live: live,
+                    peers_seen: seen,
+                    peers_connecting: connecting,
+                }
+            })
+            .collect()
+        })
     }
 
     pub fn tracker_count(&self) -> usize {
@@ -793,6 +840,15 @@ fn write_cache(cache: &std::path::Path, list: &[String]) -> std::io::Result<()> 
     std::fs::rename(&tmp, cache)
 }
 
+fn cache_is_fresh(cache: &std::path::Path, max_age_secs: u64) -> bool {
+    std::fs::metadata(cache)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .map(|age| age.as_secs() < max_age_secs)
+        .unwrap_or(false)
+}
+
 pub async fn tracker_refresh_loop(
     engine: Engine,
     urls: Vec<String>,
@@ -800,10 +856,14 @@ pub async fn tracker_refresh_loop(
     embedded: Vec<String>,
     interval_secs: u64,
 ) {
-    match engine.refresh_trackers(&urls, &cache, &embedded).await {
-        Ok(n) => tracing::info!(count = n, sources = urls.len(), "tracker list loaded"),
-        Err(e) => {
-            tracing::warn!(error = %e, "tracker fetch failed; using cache/embedded seed")
+    if cache_is_fresh(&cache, interval_secs.max(60)) {
+        tracing::info!("tracker cache is fresh; deferring initial fetch to first interval");
+    } else {
+        match engine.refresh_trackers(&urls, &cache, &embedded).await {
+            Ok(n) => tracing::info!(count = n, sources = urls.len(), "tracker list loaded"),
+            Err(e) => {
+                tracing::warn!(error = %e, "tracker fetch failed; using cache/embedded seed")
+            }
         }
     }
     let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs.max(60)));


### PR DESCRIPTION
## Progress feedback (the 'Leeching —' problem)
The console had no download feedback because reel's persisted `Metadata` carries no live progress. New **`GET /stats`** returns librqbit's live per-torrent stats (progress/total bytes, down/up MB/s, live/seen/connecting peer counts). The staff console fetches it alongside the list each 4s poll and renders a real status line:
- downloading → `42% of 549 MB · 1.2 MB/s · 6 peers`
- resolving → `resolving metadata · N peers seen` / `searching for peers…` (a stuck add now shows **why** — 0 peers seen)
- seeding → `seeding · ↑ 0.4 MB/s · 3 peers`

This also gives us the diagnostic for the Tears of Steel no-download: the console (and `/stats`) will show whether it's finding **0 peers** (discovery problem) vs peers-but-no-data.

## Tracker cache optimization
- **Write/swap on change only**: refresh writes the cache file + swaps the in-memory `Arc` *only when the merged list actually changed* — no 6-hourly disk churn or reader-`Arc` churn on an identical 48-line list.
- **Skip fresh boot fetch**: the refresh loop skips its initial GitHub fetch when the on-disk cache is younger than the refresh interval, so a pod restart reuses the fresh cache instead of re-downloading.

(Skipped ETag conditional-GET on purpose: it conflicts with the merge-from-scratch model and would risk dropping cached trackers on a 304.)

## Verify
- `cargo test -p reel`: 118 passed; clean build.
- `tsc --noEmit`: 0 errors in reel/media files.

Bumps reel.mdx → 0.1.8 (auto-deploys via the post-publish pin now wired in #14745).
