### PR TITLE
fix(reel): multi-transport tracker defaults (HTTP+HTTPS+UDP)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.8"
+version: "0.1.9"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -33,23 +33,24 @@ pub struct Config {
 }
 
 pub const DEFAULT_TRACKERS_URLS: &[&str] = &[
+    "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_all_https.txt",
+    "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_all_http.txt",
     "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt",
-    "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best_ip.txt",
 ];
 
 const DEFAULT_TRACKERS: &[&str] = &[
+    "https://tracker.tamersunion.org:443/announce",
+    "https://tracker.gbitt.info:443/announce",
+    "https://tracker.renfei.net:443/announce",
+    "http://tracker.opentrackr.org:1337/announce",
+    "http://tracker.openbittorrent.com:80/announce",
+    "http://open.tracker.cl:1337/announce",
     "udp://tracker.opentrackr.org:1337/announce",
-    "udp://open.tracker.cl:1337/announce",
     "udp://open.demonii.com:1337/announce",
-    "udp://tracker.torrent.eu.org:451/announce",
     "udp://exodus.desync.com:6969/announce",
     "udp://explodie.org:6969/announce",
     "udp://tracker.openbittorrent.com:6969/announce",
-    "udp://opentracker.i2p.rocks:6969/announce",
-    "udp://tracker.dler.org:6969/announce",
-    "udp://tracker.tiny-vps.com:6969/announce",
-    "https://tracker.tamersunion.org:443/announce",
-    "udp://tracker.moeking.me:6969/announce",
+    "udp://tracker.torrent.eu.org:451/announce",
 ];
 
 pub fn parse_trackers(text: &str) -> Vec<String> {


### PR DESCRIPTION
## What

Public **UDP** trackers return no response to the shared gluetun VPN exit IP, but the same trackers answer over **HTTP/HTTPS** through the tunnel. Old `trackers_best` defaults were UDP-dominant → UDP-only magnets found 0 peers.

- `DEFAULT_TRACKERS_URLS` → ngosang `trackers_all_https` + `trackers_all_http` + `trackers_best` (UDP bonus)
- static fallback reordered https/http-first
- `parse_trackers` already accepts udp/http/https → magnets announce over all transports

## Why

Re-applies the tracker fix that was orphaned when #14755 merged only its first commit (live-stats). dev still had UDP-dominant defaults.

## Verified live (kubectl from gluetun)

| test | result |
|---|---|
| ubuntu-26.04 magnet (https tracker) | Seeding, full 6.5 GB |
| opentrackr **HTTP** :1337 announce | returned a peer |
| opentrackr/openbittorrent/demonii **UDP** | silent |
| UDP DNS 1.1.1.1:53 | works (generic UDP fine) |

118 tests pass. mdx 0.1.8→0.1.9.

Docs: apps/kube/reel/manifest/reel.yaml