### PR TITLE
feat(palforge): !signtrace — capture the sign concrete-model via OnSetConcreteModel (v0.0.22)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -118,6 +118,7 @@ local function on_chat(_, a, b)
         pcall(spike.spawn, sender, text, pos_emit, pos.player_location)
         pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.signinspect, sender, text, pos_emit)
+        pcall(spike.signtrace, sender, text, pos_emit)
         pcall(spike.httptest, sender, text, pos_emit)
         pcall(spike.curltest, sender, text, pos_emit)
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -285,9 +285,16 @@ local MODEL_CLASSES = {
     "PalMapObjectConcreteModelBase",
 }
 
+local function full_name(obj)
+    local fn = nil
+    pcall(function() fn = tostring(obj:GetFullName()) end)
+    return fn
+end
+
 local function is_tracked(actor)
+    local target = full_name(actor)
     for _, a in ipairs(spawned) do
-        if a == actor then
+        if a == actor or (target and full_name(a) == target) then
             return true
         end
     end
@@ -332,9 +339,13 @@ function M.signinspect(sender, msg, emit, find_first, find_all)
         boards = {}
     end
     for _, a in ipairs(spawned) do
+        local afull = full_name(a)
         local seen = false
         for _, b in ipairs(boards) do
-            if b == a then seen = true break end
+            if b == a or (afull and full_name(b) == afull) then
+                seen = true
+                break
+            end
         end
         if not seen then
             boards[#boards + 1] = a
@@ -357,6 +368,63 @@ function M.signinspect(sender, msg, emit, find_first, find_all)
     end
 
     emit("signinspect: done (populated model/mesh props on PLACED = what bare spawn lacks)")
+    return true
+end
+
+local SIGNBOARD_ONSETMODEL_CANDS = {
+    "/Game/Pal/Blueprint/MapObject/BuildObject/BP_BuildObject_Signboard.BP_BuildObject_Signboard_C:OnSetConcreteModel",
+    "BP_BuildObject_Signboard_C:OnSetConcreteModel",
+}
+local trace_registered = false
+
+function M.signtrace(sender, msg, emit, deps)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signtrace" then
+        return false
+    end
+    deps = deps or {}
+    local register = deps.register or RegisterHook
+    local load_asset = deps.load_asset or LoadAsset
+
+    if trace_registered then
+        emit("signtrace: already armed — place a signboard and watch for TRACE")
+        return true
+    end
+
+    emit("signtrace: arming OnSetConcreteModel hook (force-load class first)")
+    pcall(load_asset, SIGNBOARD_CLASS)
+
+    local function cb(ctx, model_param)
+        pcall(function()
+            local actor = ctx and ctx:get()
+            local afull = "?"
+            pcall(function() afull = tostring(actor:GetFullName()) end)
+            emit("TRACE OnSetConcreteModel actor=" .. afull)
+
+            local model = model_param and model_param:get()
+            if not model then
+                emit("TRACE   model = nil")
+                return
+            end
+            local mfull, mcls = "?", "?"
+            pcall(function() mfull = tostring(model:GetFullName()) end)
+            pcall(function() mcls = tostring(model:GetClass():GetFullName()) end)
+            emit("TRACE   model class = " .. mcls)
+            emit("TRACE   model full  = " .. mfull)
+            pcall(function()
+                emit("TRACE   model outer = " .. tostring(model:GetOuter():GetFullName()))
+            end)
+        end)
+    end
+
+    for _, fn in ipairs(SIGNBOARD_ONSETMODEL_CANDS) do
+        local ok = pcall(register, fn, cb)
+        emit("signtrace hook " .. fn .. " -> " .. (ok and "registered" or "FAILED"))
+        if ok then
+            trace_registered = true
+            break
+        end
+    end
+    emit("signtrace: armed=" .. tostring(trace_registered) .. " — now MANUALLY place a signboard")
     return true
 end
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -174,6 +174,26 @@ local signinspect_ok = si1 == true
     and emitted(si_emits, "instances -> 1")
     and emitted(si_emits, "signinspect: done")
 
+_print("=== spike.signtrace command ===")
+local st_emits = {}
+local function st_emit(m)
+    st_emits[#st_emits + 1] = m
+    _print("  trace: " .. m)
+end
+local st_deps = {
+    register = function() return true end,
+    load_asset = function() return true end,
+}
+local st1 = spike.signtrace("Al", "!signtrace", st_emit, st_deps)
+local st2 = spike.signtrace("Al", "nope", st_emit, st_deps)
+local st3 = spike.signtrace("Al", "!signtrace", st_emit, st_deps)
+local signtrace_ok = st1 == true
+    and st2 == false
+    and st3 == true
+    and emitted(st_emits, "signtrace: arming")
+    and emitted(st_emits, "armed=true")
+    and emitted(st_emits, "already armed")
+
 _print("=== spike.curltest command ===")
 local ct_emits = {}
 local function ct_emit(m)
@@ -214,6 +234,7 @@ local ok = calls.pending == 1
     and spawn_ok
     and clear_ok
     and signinspect_ok
+    and signtrace_ok
     and curltest_ok
     and httptest_ok
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.21"
+version: "0.0.22"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

`!signtrace` — hooks the signboard's `OnSetConcreteModel` so a **manual** sign placement reveals the real concrete-model class + object graph. This is the definitive unlock for a **server-scope-persistent, visible** sign.

## Why (the architecture, from the header dump)

DrRak72's `CXXHeaderDump/BP_BuildObject_Signboard.hpp` shows the actor exposes:

```cpp
void OnSetConcreteModel(class UPalMapObjectConcreteModelBase* Model);
class UStaticMeshComponent* StaticMesh;
class UWidgetComponent* WidgetComponent;   // 3D text
class UPalMapObjectSignboardParameterComponent* PalMapObjectSignboardParameter;
```

Native placement flow is the **inverse** of what our `!signspawn` did:

1. `PalMapObjectManager` creates an **ownerless, saved `ConcreteModel`** (the persistent data — this is what the save system serializes, and what has no owner so it can't decay).
2. The model spawns its actor and the manager calls `actor:OnSetConcreteModel(model)` → mesh + widget render.

Our raw `SpawnActor` makes only the actor shell → no model → **invisible, unsaved, and (if owned) decay-prone** — the exact opposite of the forge's goal of server-authored objects that persist outside player scope.

## How signtrace helps

Force-loads the signboard class, then `RegisterHook`s `OnSetConcreteModel` (same proven path as the chat hook). Place one sign manually → the hook logs the **real model class, full name, and outer (manager)** — the object graph we must reproduce to create a server-owned sign. No more blind guessing across deploy cycles.

## Also

Fixes `is_tracked` / FindAllOf-fallback dedup to compare by `GetFullName` — UE4SS wraps the same UObject in distinct Lua userdata, so `==` was double-counting our spawn as both `PLACED?` and `SPAWNED(bare)`.

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**, new `signtrace_ok` case.

## Version

`0.0.22` (dev is `0.0.21`). version.toml + gameserver.yaml → ci-manifest-sync.

## Next

Deploy → `!signtrace` → place one sign → read the `TRACE` model class → reproduce the create+register+OnSetConcreteModel to spawn an ownerless, saved, visible sign.