### PR TITLE
feat(palworld): pawn cull perf, palbox transfer policy, invaders

### DIFF
--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -87,6 +87,8 @@ spec:
                         value: 'True'
                       - name: ALLOW_GLOBAL_PALBOX_IMPORT
                         value: 'False'
+                      - name: ENABLE_INVADER_ENEMY
+                        value: 'True'
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -81,6 +81,12 @@ spec:
                         value: 'True'
                       - name: BASE_CAMP_WORKER_MAXNUM
                         value: '35'
+                      - name: SERVER_REPLICATE_PAWN_CULL_DISTANCE
+                        value: '10000.000000'
+                      - name: ALLOW_GLOBAL_PALBOX_EXPORT
+                        value: 'True'
+                      - name: ALLOW_GLOBAL_PALBOX_IMPORT
+                        value: 'False'
                       - name: MULTITHREAD_ENABLED
                         value: 'true'
                       - name: COMMUNITY_SERVER


### PR DESCRIPTION
Perf + gameplay policy tuning (env-only, no image rebuild).

| Setting | Env var | Value |
|---------|---------|-------|
| Pawn replication cull | `SERVER_REPLICATE_PAWN_CULL_DISTANCE` | 15000 → **10000** |
| Global palbox export | `ALLOW_GLOBAL_PALBOX_EXPORT` | **True** |
| Global palbox import | `ALLOW_GLOBAL_PALBOX_IMPORT` | **False** |
| Invader enemies | `ENABLE_INVADER_ENEMY` | **True** |

**Verification:**
- All 4 env var names confirmed present in the live ripps818 base image `/includes/config.sh` OptionSettings assembly (not just README).
- Image tag unchanged (`0.0.21` = currently-running = published version.toml) — env-only change, no rebuild / no ImagePullBackOff risk.
- Values match float/bool format the live server already runs.

**Apply:** `SERVER_SETTINGS_MODE=auto` regenerates `PalWorldSettings.ini` on boot — takes effect after GameServer recreate.