### PR TITLE
feat(palforge): !signplace — native server spawn of a persistent sign (v0.0.23)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -119,6 +119,7 @@ local function on_chat(_, a, b)
         pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.signinspect, sender, text, pos_emit)
         pcall(spike.signtrace, sender, text, pos_emit)
+        pcall(spike.signplace, sender, text, pos_emit, pos.player_location)
         pcall(spike.httptest, sender, text, pos_emit)
         pcall(spike.curltest, sender, text, pos_emit)
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -428,6 +428,65 @@ function M.signtrace(sender, msg, emit, deps)
     return true
 end
 
+local MAPOBJ_ID_CANDIDATES = {
+    "Signboard",
+    "SignBoard",
+    "Sign",
+    "Signboard_Wood",
+    "Signboard01",
+    "BuildObject_Signboard",
+}
+
+function M.signplace(sender, msg, emit, loc_fn, deps)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!signplace" then
+        return false
+    end
+    deps = deps or {}
+    local find_first = deps.find_first or FindFirstOf
+
+    emit("signplace: start (native server spawn = ownerless + saved + no-decay)")
+
+    local mgr = find_first("PalMapObjectManager")
+    if not is_valid(mgr) then
+        emit("signplace: abort — PalMapObjectManager not found")
+        return true
+    end
+
+    local loc = loc_fn and loc_fn(sender) or nil
+    if not loc then
+        emit("signplace: abort — no location")
+        return true
+    end
+    emit(string.format("signplace at X=%.1f Y=%.1f Z=%.1f", loc.x, loc.y, loc.z))
+
+    local location = { X = loc.x, Y = loc.y, Z = loc.z }
+    local rotation = { Pitch = 0.0, Yaw = 0.0, Roll = 0.0 }
+
+    local placed_id = nil
+    for _, id in ipairs(MAPOBJ_ID_CANDIDATES) do
+        local ok, res = pcall(function()
+            return mgr:RequestSpawnMapObject_Server(id, location, rotation)
+        end)
+        if not ok then
+            emit("signplace id=" .. id .. " -> ERR " .. tostring(res))
+        else
+            emit("signplace id=" .. id .. " -> " .. tostring(res))
+            if res == true then
+                placed_id = id
+                break
+            end
+        end
+    end
+
+    if placed_id then
+        emit("signplace: SUCCESS via MapObjectId '" .. placed_id .. "' — LOOK for the sign")
+    else
+        emit("signplace: no candidate id returned true (need correct MapObjectId)")
+    end
+    emit("signplace: done")
+    return true
+end
+
 local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
 local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -174,6 +174,30 @@ local signinspect_ok = si1 == true
     and emitted(si_emits, "instances -> 1")
     and emitted(si_emits, "signinspect: done")
 
+_print("=== spike.signplace command ===")
+local pl_emits = {}
+local function pl_emit(m)
+    pl_emits[#pl_emits + 1] = m
+    _print("  place: " .. m)
+end
+local pl_deps = {
+    find_first = function()
+        return {
+            IsValid = function() return true end,
+            RequestSpawnMapObject_Server = function(_, id)
+                return id == "Signboard"
+            end,
+        }
+    end,
+}
+local pl1 = spike.signplace("Al", "!signplace", pl_emit, mock_loc, pl_deps)
+local pl2 = spike.signplace("Al", "nope", pl_emit, mock_loc, pl_deps)
+local signplace_ok = pl1 == true
+    and pl2 == false
+    and emitted(pl_emits, "signplace: start")
+    and emitted(pl_emits, "SUCCESS via MapObjectId 'Signboard'")
+    and emitted(pl_emits, "signplace: done")
+
 _print("=== spike.signtrace command ===")
 local st_emits = {}
 local function st_emit(m)
@@ -234,6 +258,7 @@ local ok = calls.pending == 1
     and spawn_ok
     and clear_ok
     and signinspect_ok
+    and signplace_ok
     and signtrace_ok
     and curltest_ok
     and httptest_ok

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.22"
+version: "0.0.23"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

`!signplace` — the payoff. Spawns a signboard through Palworld's **own** server-authoritative map-object API, so it's visible, saved, ownerless, and decay-proof.

## How we got the API

`!signtrace` (0.0.22) hooked `OnSetConcreteModel` and a manual placement revealed:
- model class = `/Script/Pal.PalMapObjectSignboardModel`
- model **Outer** = `BP_PalMapObjectManager_C` → the manager owns the model (that's what makes it saved + ownerless)

`localcc/PalworldModdingKit`'s `PalMapObjectManager.h` then gave the spawn API:

```cpp
bool RequestSpawnMapObject_Server(FName MapObjectId, FVector Location, FRotator Rotation);
bool RequestSpawnMapObjectByPlayer_Server(FName MapObjectId, FVector, FRotator, FGuid RequestPlayerUId);  // player-owned, decays — NOT this
```

## What it does

Finds `PalMapObjectManager`, then calls **`RequestSpawnMapObject_Server`** (no player UId → **server-scope, no decay**) at the caller's location. It runs the whole native flow — create+register concrete model, spawn actor, `OnSetConcreteModel`, replicate, persist — the exact thing our raw `SpawnActor` couldn't.

The `FName MapObjectId` isn't in any dump, so it tries signboard-name candidates (`Signboard`, `SignBoard`, …) and **breaks on the first `bool=true`**. Invalid ids just return false — no junk spawned — and it reports which id worked so we lock the FName.

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**, new `signplace_ok` case.

## Version

`0.0.23` (dev is `0.0.22`).

## Next

Deploy → `!signplace` → **look**. If a real sign renders and survives reboot → the forge's core capability works; lock the winning MapObjectId, then wire config coords→spawn + `OnUpdateText` for server-authored text.