### PR TITLE
feat(reel): observability sweep — phases, status endpoints, error surfacing

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -181,6 +181,26 @@ import ReactReelConsole from '@/components/media/ReactReelConsole';
 		margin: 0 0 0.75rem;
 	}
 
+	:global(.reel-console__health) {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem 1rem;
+		align-items: center;
+		color: #9ca3af;
+		font-size: 0.75rem;
+		margin: 0 0 0.75rem;
+	}
+
+	:global(.reel-console__health-ok) {
+		color: #6ee7b7;
+		font-weight: 600;
+	}
+
+	:global(.reel-console__health-bad) {
+		color: #fca5a5;
+		font-weight: 600;
+	}
+
 	:global(.reel-console__list) {
 		list-style: none;
 		margin: 0;

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -6,6 +6,7 @@ import {
 	$reelListError,
 	$reelListLoading,
 	$reelLive,
+	$reelHealth,
 	addTorrent,
 	deleteTorrent,
 	startTranscode,
@@ -19,6 +20,18 @@ const STATE_BADGE: Record<string, string> = {
 	Seeding: 'reel-console__badge--seeding',
 	Reaped: 'reel-console__badge--reaped',
 	Failed: 'reel-console__badge--failed',
+};
+
+const PHASE_LABEL: Record<string, string> = {
+	'resolving-metadata': 'resolving metadata',
+	connecting: 'connecting to peers',
+	downloading: 'downloading',
+	moving: 'moving to library',
+	ready: 'ready',
+	transcoding: 'transcoding',
+	'streaming-hls': 'streaming (HLS)',
+	failed: 'failed',
+	reaped: 'reaped',
 };
 
 function fmtSize(bytes: number): string {
@@ -61,6 +74,7 @@ export default function ReactReelConsole() {
 	const listError = useStore($reelListError);
 	const loading = useStore($reelListLoading);
 	const live = useStore($reelLive);
+	const health = useStore($reelHealth);
 	const isStaff = useStore(homeService.$isStaff);
 
 	const [source, setSource] = useState('');
@@ -160,6 +174,24 @@ export default function ReactReelConsole() {
 				</button>
 			</div>
 
+			{health && (
+				<p className="reel-console__health">
+					<span
+						className={
+							health.vpn_ok
+								? 'reel-console__health-ok'
+								: 'reel-console__health-bad'
+						}>
+						{health.vpn_ok ? '● VPN ok' : '● VPN down'}
+					</span>
+					<span>{health.trackers} trackers</span>
+					<span>
+						{health.counts.seeding} seeding · {health.counts.leeching}{' '}
+						leeching · {health.counts.failed} failed
+					</span>
+				</p>
+			)}
+
 			<form
 				className="reel-console__add"
 				onSubmit={(e) => {
@@ -202,7 +234,9 @@ export default function ReactReelConsole() {
 										className={`reel-console__badge ${
 											STATE_BADGE[t.state] ?? ''
 										}`}>
-										{t.state}
+										{t.phase
+											? (PHASE_LABEL[t.phase] ?? t.phase)
+											: t.state}
 									</span>
 									<span>{progressLine(t, live[t.id])}</span>
 									{t.transcode !== 'None' && (

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -28,11 +28,23 @@ export type ReelTranscodeStatus =
 	| 'Failed';
 export type ReelHlsStatus = 'None' | 'Starting' | 'Live' | 'Ready' | 'Failed';
 
+export type ReelPhase =
+	| 'resolving-metadata'
+	| 'connecting'
+	| 'downloading'
+	| 'moving'
+	| 'ready'
+	| 'transcoding'
+	| 'streaming-hls'
+	| 'failed'
+	| 'reaped';
+
 export interface ReelTorrent {
 	id: string;
 	name: string;
 	size: number;
 	state: ReelTorrentState;
+	phase?: ReelPhase;
 	completed_at?: number | null;
 	last_access: number;
 	error?: string | null;
@@ -54,10 +66,36 @@ export interface ReelLive {
 	peers_connecting: number;
 }
 
+export interface ReelCounts {
+	total: number;
+	leeching: number;
+	seeding: number;
+	failed: number;
+}
+
+export interface ReelStatusTorrent extends ReelTorrent {
+	phase: ReelPhase;
+	live?: ReelLive;
+}
+
+export interface ReelStatusReport {
+	vpn_ok: boolean;
+	trackers: number;
+	counts: ReelCounts;
+	torrents: ReelStatusTorrent[];
+}
+
+export interface ReelHealth {
+	vpn_ok: boolean;
+	trackers: number;
+	counts: ReelCounts;
+}
+
 export const $reelList = atom<ReelTorrent[]>([]);
 export const $reelListError = atom<string | null>(null);
 export const $reelListLoading = atom<boolean>(false);
 export const $reelLive = atom<Record<string, ReelLive>>({});
+export const $reelHealth = atom<ReelHealth | null>(null);
 
 const REEL_PATH: string =
 	(import.meta.env.PUBLIC_REEL_BASE as string | undefined) ?? '/api/v1/reel';
@@ -143,11 +181,27 @@ export async function refreshLiveStats(): Promise<void> {
 	}
 }
 
+export async function fetchStatus(): Promise<ReelStatusReport> {
+	return authedApiFetch<ReelStatusReport>(`${REEL_PATH}/status`);
+}
+
 export async function refreshReelList(): Promise<void> {
 	$reelListLoading.set(true);
 	try {
-		const [list] = await Promise.all([listTorrents(), refreshLiveStats()]);
-		$reelList.set(list);
+		const report = await fetchStatus();
+		$reelList.set(report.torrents);
+		$reelLive.set(
+			Object.fromEntries(
+				report.torrents
+					.filter((t) => t.live)
+					.map((t) => [t.id, t.live as ReelLive]),
+			),
+		);
+		$reelHealth.set({
+			vpn_ok: report.vpn_ok,
+			trackers: report.trackers,
+			counts: report.counts,
+		});
 		$reelListError.set(null);
 	} catch (e) {
 		$reelListError.set(
@@ -181,6 +235,21 @@ export function nextFromManifestStatus(status: number): ProbeAction {
 
 export function backoffMs(attempt: number): number {
 	return Math.min(BACKOFF_BASE_MS * Math.pow(1.5, attempt), BACKOFF_CAP_MS);
+}
+
+export function mediaErrorMessage(err: MediaError | null | undefined): string {
+	switch (err?.code) {
+		case 1:
+			return 'playback aborted';
+		case 2:
+			return 'network error while streaming';
+		case 3:
+			return "browser can't decode this file — try Transcode to HLS";
+		case 4:
+			return "this container/codec isn't playable raw — try Transcode to HLS";
+		default:
+			return 'playback failed';
+	}
 }
 
 export class ReelPlayer {
@@ -298,12 +367,20 @@ export class ReelPlayer {
 		gen: number,
 	): void {
 		if (this.generation !== gen) return;
+		this.attachVideoError(video, gen);
 		video.src = mediaUrl(id, '/stream', token);
 		$reelState.set('raw');
 		if (leeching) {
 			$reelNotice.set('still downloading — playing the available portion');
 		}
 		void video.play().catch(() => undefined);
+	}
+
+	private attachVideoError(video: HTMLVideoElement, gen: number): void {
+		video.onerror = () => {
+			if (this.generation !== gen) return;
+			this.fail(mediaErrorMessage(video.error));
+		};
 	}
 
 	private async playHls(
@@ -314,6 +391,7 @@ export class ReelPlayer {
 	): Promise<void> {
 		if (this.generation !== gen) return;
 		if (video.canPlayType(MANIFEST_MIME)) {
+			this.attachVideoError(video, gen);
 			video.src = manifestUrl;
 			$reelState.set('hls');
 			void video.play().catch(() => undefined);
@@ -344,6 +422,9 @@ export class ReelPlayer {
 		if (this.pollTimer) {
 			clearTimeout(this.pollTimer);
 			this.pollTimer = null;
+		}
+		if (this.video) {
+			this.video.onerror = null;
 		}
 		if (this.hls) {
 			try {

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.9"
+version: "0.1.10"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -88,6 +88,50 @@ idle TTL, not a permanent library), and progressively delivers it to the browser
 - **Transcode** — ffprobe routes each file to remux (faststart MP4) or re-encode.
 - **Stream** — byte-range progressive MP4 while still downloading; HLS for containers/codecs the browser can't play raw.
 - **Player** — an astro-kbve hls.js island at `/media/reel/`, proxied same-origin through axum-kbve at `/api/v1/reel`, staff-gated.
+
+</BentoProse>
+
+<BentoProse id="observability" eyebrow="Operations" heading="Observability & diagnostics">
+
+Every torrent moves through an explicit **phase** so an operator can tell exactly
+where it is — and, when it stops, why.
+
+### Phases
+
+`resolving-metadata` → `connecting` → `downloading` → `moving` → `ready`, with
+`transcoding` / `streaming-hls` once seeding, and `failed` on any terminal error.
+The phase is derived from persisted state plus the live librqbit snapshot, so a
+torrent stuck at `connecting` (metadata resolved, zero bytes) is distinct from one
+still `resolving-metadata` (no peers responding at all).
+
+### Status endpoints
+
+- `GET /status` — one call for the whole service: `vpn_ok`, tracker count, counts
+  by state (`leeching`/`seeding`/`failed`), and every torrent as a merged view
+  (persisted metadata + derived `phase` + live peers/speed/progress).
+- `GET /torrents/{id}/status` — the same merged view for a single torrent.
+- `GET /stats` — raw librqbit live snapshot (peers seen/live/connecting, mbps).
+- `GET /torrents` · `GET /torrents/{id}` — persisted metadata only.
+
+### Error surfacing
+
+Failures no longer collapse to an opaque status code. A `failed` torrent returns
+its stored reason as a JSON body on `/stream` and `/manifest.m3u8`
+(`{"state":"failed","error":"…"}`), and the reason names the phase it died in —
+`could not resolve torrent metadata within Ns — no peers responded`,
+`no data received for Ns — no seeders`, `move failed`, `ffprobe failed`. HLS
+failures now capture the ffmpeg stderr tail instead of just the exit code.
+
+### Structured log events
+
+All lifecycle transitions emit a stable `event=` field (JSON on stdout, tailed by
+Vector into ClickHouse): `torrent_added`, `torrent_completed`, `torrent_failed`
+(with `phase` + `reason`), `probe_decided`, `transcode_started`,
+`transcode_ready`, `transcode_failed`, `hls_started`, `hls_ready`, `hls_failed`,
+`stream_served`, `vpn_leak`, `vpn_restored`, `reaped`. A per-torrent leech
+heartbeat logs progress + live peer count each stall-check tick. The default log
+filter is `info` (`reel=debug`) so the happy path is visible without setting
+`RUST_LOG`.
 
 </BentoProse>
 

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -47,7 +47,7 @@ spec:
             - { name: REEL_STATE_FILE, value: "/data/reel-state.json" }
             - { name: REEL_TTL_SECS, value: "21600" }
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
-            - { name: RUST_LOG, value: "reel=info,warn,librqbit::torrent_state::live=error" }
+            - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
           envFrom:
             - secretRef: { name: reel-api }

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -33,6 +33,64 @@ impl From<&AppState> for AppStateStub {
 
 use crate::util::now_secs;
 
+fn derive_phase(m: &state::Metadata, live: Option<&engine::TorrentLive>) -> &'static str {
+    use state::{HlsStatus, TorrentState, TranscodeStatus};
+    match m.state {
+        TorrentState::Failed => "failed",
+        TorrentState::Reaped => "reaped",
+        TorrentState::Leeching => match live {
+            Some(l) if l.finished => "moving",
+            Some(l) if l.total_bytes > 0 && l.progress_bytes > 0 => "downloading",
+            Some(l) if l.total_bytes > 0 => "connecting",
+            _ => "resolving-metadata",
+        },
+        TorrentState::Seeding => {
+            if matches!(m.hls, HlsStatus::Live) {
+                "streaming-hls"
+            } else if matches!(
+                m.transcode,
+                TranscodeStatus::Pending | TranscodeStatus::Remuxing | TranscodeStatus::Encoding
+            ) {
+                "transcoding"
+            } else {
+                "ready"
+            }
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct TorrentView {
+    #[serde(flatten)]
+    meta: state::Metadata,
+    phase: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    live: Option<engine::TorrentLive>,
+}
+
+impl TorrentView {
+    fn build(meta: state::Metadata, live: Option<engine::TorrentLive>) -> Self {
+        let phase = derive_phase(&meta, live.as_ref());
+        Self { meta, phase, live }
+    }
+}
+
+#[derive(serde::Serialize, Default)]
+struct Counts {
+    total: usize,
+    leeching: usize,
+    seeding: usize,
+    failed: usize,
+}
+
+#[derive(serde::Serialize)]
+struct StatusReport {
+    vpn_ok: bool,
+    trackers: usize,
+    counts: Counts,
+    torrents: Vec<TorrentView>,
+}
+
 fn served_bytes(range: Option<&str>, total: u64) -> u64 {
     match crate::stream::parse_range(range, total) {
         Ok(Some(r)) => r.end.saturating_sub(r.start) + 1,
@@ -92,6 +150,49 @@ async fn live_stats(State(st): State<AppState>, headers: HeaderMap) -> impl Into
         return StatusCode::UNAUTHORIZED.into_response();
     }
     Json(st.engine.live_stats()).into_response()
+}
+
+async fn status(State(st): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let mut live = st.engine.live_stats_map();
+    let mut counts = Counts::default();
+    let mut torrents = Vec::new();
+    for meta in st.store.list() {
+        counts.total += 1;
+        match meta.state {
+            state::TorrentState::Leeching => counts.leeching += 1,
+            state::TorrentState::Seeding => counts.seeding += 1,
+            state::TorrentState::Failed => counts.failed += 1,
+            state::TorrentState::Reaped => {}
+        }
+        let l = live.remove(&meta.id);
+        torrents.push(TorrentView::build(meta, l));
+    }
+    Json(StatusReport {
+        vpn_ok: st.engine.vpn_ok(),
+        trackers: st.engine.tracker_count(),
+        counts,
+        torrents,
+    })
+    .into_response()
+}
+
+async fn status_one(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let live = st.engine.live_stats_map().remove(&id);
+    Json(TorrentView::build(meta, live)).into_response()
 }
 
 async fn get_one(
@@ -220,13 +321,38 @@ async fn manifest(
         None => {
             let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
                 Ok(p) => p,
-                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, path = %meta.path, error = %e, "manifest: no primary media file");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": e.to_string()})),
+                    )
+                        .into_response();
+                }
             };
             let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
                 Ok(p) => p,
-                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, error = %e, "manifest: ffprobe failed");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": e.to_string()})),
+                    )
+                        .into_response();
+                }
             };
             let d = transcode::decide_delivery(&probe);
+            crate::telemetry::probe_decided(
+                &id,
+                probe.video_codec.as_deref().unwrap_or("none"),
+                probe.audio_codec.as_deref().unwrap_or("none"),
+                probe.container.as_deref().unwrap_or("none"),
+                match d {
+                    transcode::Delivery::RawProgressive => "raw_progressive",
+                    transcode::Delivery::RemuxHls => "remux_hls",
+                    transcode::Delivery::TranscodeHls => "transcode_hls",
+                },
+            );
             st.hls.cache_delivery(&id, d);
             d
         }
@@ -368,24 +494,36 @@ pub(crate) async fn stream_core<S: engine::MediaSource>(
                 Some(p) => p,
                 None => match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
                     Ok(p) => p,
-                    Err(_) => return StatusCode::CONFLICT.into_response(),
+                    Err(e) => {
+                        tracing::warn!(id = %id, path = %meta.path, error = %e, "stream: no primary media file");
+                        return StatusCode::CONFLICT.into_response();
+                    }
                 },
             };
             let ct = crate::stream::content_type_for(&path.to_string_lossy());
             if head_only {
                 let total = match tokio::fs::metadata(&path).await {
                     Ok(m) => m.len(),
-                    Err(_) => return StatusCode::NOT_FOUND.into_response(),
+                    Err(e) => {
+                        tracing::warn!(id = %id, path = %path.display(), error = %e, "stream: head stat failed");
+                        return StatusCode::NOT_FOUND.into_response();
+                    }
                 };
                 return crate::stream::head_response(total, range, ct);
             }
             let file = match tokio::fs::File::open(&path).await {
                 Ok(f) => f,
-                Err(_) => return StatusCode::NOT_FOUND.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, path = %path.display(), error = %e, "stream: file open failed");
+                    return StatusCode::NOT_FOUND.into_response();
+                }
             };
             let total = match file.metadata().await {
                 Ok(m) => m.len(),
-                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, error = %e, "stream: file stat failed");
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
             };
             crate::telemetry::stream_served(id, served_bytes(range, total), "progressive", range.is_some());
             crate::stream::serve_range(file, total, range, ct, head_only).await
@@ -394,11 +532,17 @@ pub(crate) async fn stream_core<S: engine::MediaSource>(
             let files = match source.entries(id) {
                 Ok(Some(f)) => f,
                 Ok(None) => return StatusCode::TOO_EARLY.into_response(),
-                Err(_) => return StatusCode::TOO_EARLY.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, error = %e, "stream: leech entries unavailable");
+                    return StatusCode::TOO_EARLY.into_response();
+                }
             };
             let idx = match engine::primary_file_index(&files) {
                 Some(i) => i,
-                None => return StatusCode::CONFLICT.into_response(),
+                None => {
+                    tracing::warn!(id = %id, "stream: no media file in leeching torrent");
+                    return StatusCode::CONFLICT.into_response();
+                }
             };
             let name = files
                 .iter()
@@ -416,11 +560,22 @@ pub(crate) async fn stream_core<S: engine::MediaSource>(
             }
             let stream = match source.open(id, idx) {
                 Ok(s) => s,
-                Err(_) => return StatusCode::TOO_EARLY.into_response(),
+                Err(e) => {
+                    tracing::warn!(id = %id, error = %e, "stream: leech open failed");
+                    return StatusCode::TOO_EARLY.into_response();
+                }
             };
             crate::telemetry::stream_served(id, served_bytes(range, total), "leeching", range.is_some());
             crate::stream::serve_range(stream, total, range, ct, head_only).await
         }
+        state::TorrentState::Failed => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "state": "failed",
+                "error": meta.error.unwrap_or_else(|| "torrent failed".into()),
+            })),
+        )
+            .into_response(),
         _ => StatusCode::CONFLICT.into_response(),
     }
 }
@@ -470,7 +625,18 @@ pub(crate) async fn manifest_status_core(
     }
 
     if meta.state != state::TorrentState::Seeding {
-        return ManifestStep::Done(StatusCode::TOO_EARLY.into_response());
+        let resp = match meta.state {
+            state::TorrentState::Failed => (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "state": "failed",
+                    "error": meta.error.clone().unwrap_or_else(|| "torrent failed".into()),
+                })),
+            )
+                .into_response(),
+            _ => StatusCode::TOO_EARLY.into_response(),
+        };
+        return ManifestStep::Done(resp);
     }
     ManifestStep::Proceed(meta)
 }
@@ -518,11 +684,17 @@ pub(crate) async fn hls_segment_core(
     }
     let file = match tokio::fs::File::open(&path).await {
         Ok(f) => f,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::warn!(id = %id, segment, path = %path.display(), error = %e, "hls segment open failed");
+            return StatusCode::NOT_FOUND.into_response();
+        }
     };
     let total = match file.metadata().await {
         Ok(m) => m.len(),
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::warn!(id = %id, segment, error = %e, "hls segment stat failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
     };
     crate::telemetry::stream_served(id, served_bytes(range, total), "hls", range.is_some());
     crate::stream::serve_range(file, total, range, ct, head_only).await
@@ -540,6 +712,8 @@ pub fn router(state: AppState) -> Router {
     let stub = AppStateStub::from(&state);
     let engine_router = Router::new()
         .route("/stats", get(live_stats))
+        .route("/status", get(status))
+        .route("/torrents/{id}/status", get(status_one))
         .route("/torrents", post(add))
         .route("/torrents/{id}", axum::routing::delete(remove))
         .route("/torrents/{id}/transcode", post(transcode_start))
@@ -599,6 +773,66 @@ mod tests {
         let mut h = HeaderMap::new();
         h.insert("Authorization", format!("Bearer {token}").parse().unwrap());
         h
+    }
+
+    fn meta_for(state: TorrentState) -> Metadata {
+        Metadata {
+            id: "1".into(),
+            name: "m".into(),
+            path: "/lib/m".into(),
+            size: 0,
+            completed_at: None,
+            last_access: 0,
+            state,
+            error: None,
+            active_path: None,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
+        }
+    }
+
+    fn live_for(progress: u64, total: u64, finished: bool) -> crate::engine::TorrentLive {
+        crate::engine::TorrentLive {
+            id: "1".into(),
+            progress_bytes: progress,
+            total_bytes: total,
+            finished,
+            download_mbps: 0.0,
+            upload_mbps: 0.0,
+            peers_live: 0,
+            peers_seen: 0,
+            peers_connecting: 0,
+        }
+    }
+
+    #[test]
+    fn phase_leeching_reflects_live_progress() {
+        let m = meta_for(TorrentState::Leeching);
+        assert_eq!(derive_phase(&m, None), "resolving-metadata");
+        assert_eq!(derive_phase(&m, Some(&live_for(0, 100, false))), "connecting");
+        assert_eq!(derive_phase(&m, Some(&live_for(50, 100, false))), "downloading");
+        assert_eq!(derive_phase(&m, Some(&live_for(100, 100, true))), "moving");
+    }
+
+    #[test]
+    fn phase_seeding_reflects_transcode_and_hls() {
+        let mut m = meta_for(TorrentState::Seeding);
+        assert_eq!(derive_phase(&m, None), "ready");
+        m.transcode = TranscodeStatus::Encoding;
+        assert_eq!(derive_phase(&m, None), "transcoding");
+        m.transcode = TranscodeStatus::None;
+        m.hls = HlsStatus::Live;
+        assert_eq!(derive_phase(&m, None), "streaming-hls");
+    }
+
+    #[test]
+    fn phase_failed_and_reaped() {
+        assert_eq!(derive_phase(&meta_for(TorrentState::Failed), None), "failed");
+        assert_eq!(derive_phase(&meta_for(TorrentState::Reaped), None), "reaped");
     }
 
     #[test]

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -434,6 +434,20 @@ impl Engine {
                     r = &mut completed => break r,
                     _ = tokio::time::sleep(stall_check) => {
                         let s = handle.stats();
+                        let (dl_mbps, peers_live) = s
+                            .live
+                            .as_ref()
+                            .map(|l| (l.download_speed.mbps, l.snapshot.peer_stats.live))
+                            .unwrap_or((0.0, 0));
+                        tracing::debug!(
+                            id = %id,
+                            progress_bytes = s.progress_bytes,
+                            total_bytes = s.total_bytes,
+                            peers_live,
+                            dl_mbps,
+                            idle_secs,
+                            "leech heartbeat"
+                        );
                         if s.finished {
                             break Ok(());
                         }
@@ -827,6 +841,13 @@ impl Engine {
             })
             .collect()
         })
+    }
+
+    pub fn live_stats_map(&self) -> HashMap<String, TorrentLive> {
+        self.live_stats()
+            .into_iter()
+            .map(|t| (t.id.clone(), t))
+            .collect()
     }
 
     pub fn tracker_count(&self) -> usize {

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -43,6 +43,25 @@ mod tests {
     }
 }
 
+fn delivery_label(d: Delivery) -> &'static str {
+    match d {
+        Delivery::RawProgressive => "raw_progressive",
+        Delivery::RemuxHls => "remux_hls",
+        Delivery::TranscodeHls => "transcode_hls",
+    }
+}
+
+fn ffmpeg_tail(buf: &Arc<Mutex<String>>) -> String {
+    let s = buf.lock().unwrap();
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return "no stderr captured".into();
+    }
+    let mut tail: Vec<char> = trimmed.chars().rev().take(500).collect();
+    tail.reverse();
+    tail.into_iter().collect::<String>().replace('\n', " ")
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum StartOutcome {
     Started,
@@ -258,8 +277,21 @@ impl HlsManager {
         };
 
         let mut cmd = Command::new(&self.ffmpeg_bin);
-        cmd.args(&args);
-        let child = cmd.spawn()?;
+        cmd.args(&args).stderr(std::process::Stdio::piped());
+        let mut child = cmd.spawn()?;
+
+        let errbuf = Arc::new(Mutex::new(String::new()));
+        if let Some(mut stderr) = child.stderr.take() {
+            let buf = errbuf.clone();
+            tokio::spawn(async move {
+                use tokio::io::AsyncReadExt;
+                let mut s = String::new();
+                let _ = stderr.read_to_string(&mut s).await;
+                *buf.lock().unwrap() = s;
+            });
+        }
+
+        crate::telemetry::hls_started(id, delivery_label(delivery));
 
         {
             let mut g = self.children.lock().unwrap();
@@ -270,15 +302,21 @@ impl HlsManager {
         let id = id.to_string();
         let index_path = hls_dir.join("index.m3u8");
         tokio::spawn(async move {
+            let mut went_live = false;
             for _ in 0..100 {
                 if index_path.exists() {
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Live;
                         ((), true)
                     });
+                    tracing::info!(id = %id, "hls manifest live");
+                    went_live = true;
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            if !went_live {
+                tracing::warn!(id = %id, "hls manifest not produced within 10s; ffmpeg may still be starting");
             }
 
             let exit_result = loop {
@@ -300,18 +338,23 @@ impl HlsManager {
                         m.hls_error = None;
                         ((), true)
                     });
+                    crate::telemetry::hls_ready(&id);
                 }
                 Some(Ok(status)) => {
+                    let reason = format!("ffmpeg exited: {status}: {}", ffmpeg_tail(&errbuf));
+                    crate::telemetry::hls_failed(&id, &reason);
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Failed;
-                        m.hls_error = Some(format!("ffmpeg exited: {status}"));
+                        m.hls_error = Some(reason.clone());
                         ((), true)
                     });
                 }
                 Some(Err(e)) => {
+                    let reason = e.to_string();
+                    crate::telemetry::hls_failed(&id, &reason);
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Failed;
-                        m.hls_error = Some(e.to_string());
+                        m.hls_error = Some(reason.clone());
                         ((), true)
                     });
                 }

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -5,7 +5,8 @@ async fn main() -> anyhow::Result<()> {
     let log_json = std::env::var("REEL_LOG_JSON")
         .map(|v| !(v.eq_ignore_ascii_case("false") || v == "0"))
         .unwrap_or(true);
-    let filter = tracing_subscriber::EnvFilter::from_default_env();
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,reel=debug"));
     if log_json {
         tracing_subscriber::fmt()
             .with_env_filter(filter)

--- a/apps/media/reel/src/telemetry.rs
+++ b/apps/media/reel/src/telemetry.rs
@@ -28,8 +28,36 @@ pub fn reconcile_failed(id: &str, name: &str) {
     );
 }
 
+pub fn probe_decided(id: &str, video: &str, audio: &str, container: &str, delivery: &str) {
+    tracing::info!(
+        event = "probe_decided",
+        id,
+        video,
+        audio,
+        container,
+        delivery,
+        "probe routed delivery"
+    );
+}
+
+pub fn transcode_started(id: &str, route: &str) {
+    tracing::info!(event = "transcode_started", id, route, "transcode started");
+}
+
+pub fn transcode_ready(id: &str, path: &str) {
+    tracing::info!(event = "transcode_ready", id, path, "transcode ready");
+}
+
 pub fn transcode_failed(id: &str, reason: &str) {
     tracing::error!(event = "transcode_failed", id, reason, "transcode failed");
+}
+
+pub fn hls_started(id: &str, delivery: &str) {
+    tracing::info!(event = "hls_started", id, delivery, "hls started");
+}
+
+pub fn hls_ready(id: &str) {
+    tracing::info!(event = "hls_ready", id, "hls ready");
 }
 
 pub fn hls_failed(id: &str, reason: &str) {

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -362,6 +362,13 @@ impl Transcoder {
         let primary = pick_primary_file(&src_dir)?;
         let probe = probe(&self.ffprobe_bin, &primary).await?;
         let route = decide_route(&probe);
+        crate::telemetry::transcode_started(
+            id,
+            match route {
+                Route::Remux => "remux",
+                Route::Encode => "encode",
+            },
+        );
         let stem = primary
             .file_stem()
             .map(|s| s.to_string_lossy().into_owned())
@@ -400,6 +407,7 @@ impl Transcoder {
             m.transcode_error = None;
             ((), true)
         });
+        crate::telemetry::transcode_ready(id, &dest.display().to_string());
         Ok(())
     }
 }


### PR DESCRIPTION
## What

Sweep through reel so an operator can tell **exactly where a torrent is and why it failed** — no more opaque codes / silent black screens. Backend + the staff console + deploy config, end to end.

### Phases
Every torrent has a derived `phase`, from persisted state + live librqbit snapshot:
`resolving-metadata` → `connecting` → `downloading` → `moving` → `ready`, plus `transcoding` / `streaming-hls` once seeding, and `failed`. `connecting` (metadata resolved, 0 bytes) is now distinct from `resolving-metadata` (no peers at all).

### Status endpoints
- `GET /status` — one call for the whole service: `vpn_ok`, tracker count, counts by state, every torrent as a merged view (metadata + `phase` + live peers/speed/progress).
- `GET /torrents/{id}/status` — same for one torrent.

### Error surfacing
- `failed` torrents return their stored reason as a JSON body (`{"state":"failed","error":"…"}`) on `/stream` and `/manifest.m3u8` instead of a bare 409/425.
- HLS ffmpeg now pipes stderr — failures record the stderr tail, not just the exit code.
- Previously opaque `Err(_) =>` handler arms now log `id` + cause.

### Logging
- New structured `event=` lines: `probe_decided`, `transcode_started`, `transcode_ready`, `hls_started`, `hls_ready`.
- Per-torrent leech heartbeat (progress + live peer count) each stall-check tick.
- Default filter `info` (`reel=debug`) when `RUST_LOG` unset; **reel.yaml bumped `reel=info` → `reel=debug`** so the heartbeat/debug events are actually visible in the running pod (prod sets RUST_LOG, overriding the default).

### Staff console (frontend)
- Consumes `GET /status`: a health line (VPN ok/down · N trackers · seeding/leeching/failed counts) + a human phase chip per torrent.
- Player attaches a `<video>` error listener on raw + native-HLS playback → undecodable container/codec shows "can't decode — try Transcode to HLS" instead of a silent black screen.

## Testing
- `cargo test -p reel` → 121 passed, 4 ignored (added phase-derivation unit tests).
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel files (21 repo-wide errors are pre-existing generated-proto, codegen not run in worktree).

Docs: reel.mdx gains an Observability section; version 0.1.9 → 0.1.10.

Kube manifest: apps/kube/reel/manifest/reel.yaml