### PR TITLE
feat(kbve): drive palworld bento sidebar from starlight route data

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -25,6 +25,8 @@ import {
 	PALWORLD_ROOT,
 	buildPalworldBreadcrumb,
 } from '../palworld/palworldNav';
+import { adaptStarlightSidebar } from './starlightNav';
+import type { StarlightEntry } from './starlightNav';
 import { NPC_ROOT, buildNpcNav, buildNpcBreadcrumb } from '../npcdb/npcNav';
 import {
 	ITEM_ROOT,
@@ -65,6 +67,12 @@ const isGaming = pathname.startsWith('/gaming/') || isGamingRoot(pathname);
 const isOsrsItem = pathname.startsWith('/osrs/') && pathname !== '/osrs/';
 const isMc = pathname.startsWith('/mc/');
 const isPalworld = pathname.startsWith('/palworld/');
+
+const routeSidebar = (Astro.locals.starlightRoute?.sidebar ??
+	[]) as StarlightEntry[];
+const palShell = isPalworld
+	? adaptStarlightSidebar(routeSidebar, pathname)
+	: null;
 const isNpcdb = pathname.startsWith('/npcdb/');
 const isItemdb = pathname.startsWith('/itemdb/');
 const isMapdb = pathname.startsWith('/mapdb/');
@@ -146,17 +154,27 @@ const shell = isDashboard
 									withToc: true,
 								}
 							: isPalworld
-								? {
-										entries: PALWORLD_NAV,
-										root: PALWORLD_ROOT,
-										menuLabel: 'Palworld',
-										navLabel: 'Palworld',
-										crumbs: buildPalworldBreadcrumb(
-											pathname,
-										),
-										collapsible: true,
-										withToc: true,
-									}
+								? palShell
+									? {
+											entries: palShell.entries,
+											root: palShell.root,
+											menuLabel: palShell.navLabel,
+											navLabel: palShell.navLabel,
+											crumbs: palShell.crumbs,
+											collapsible: true,
+											withToc: true,
+										}
+									: {
+											entries: PALWORLD_NAV,
+											root: PALWORLD_ROOT,
+											menuLabel: 'Palworld',
+											navLabel: 'Palworld',
+											crumbs: buildPalworldBreadcrumb(
+												pathname,
+											),
+											collapsible: true,
+											withToc: true,
+										}
 								: isNpcdb
 									? {
 											entries: npcNav,

--- a/apps/kbve/astro-kbve/src/components/dashboard/starlightNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/starlightNav.ts
@@ -1,0 +1,159 @@
+import type {
+	BreadcrumbCrumb,
+	DashboardNavEntry,
+	DashboardNavGroup,
+	DashboardNavItem,
+} from './dashboardNav';
+
+export interface StarlightLink {
+	type: 'link';
+	label: string;
+	href: string;
+	isCurrent: boolean;
+}
+
+export interface StarlightGroup {
+	type: 'group';
+	label: string;
+	entries: StarlightEntry[];
+	collapsed?: boolean;
+}
+
+export type StarlightEntry = StarlightLink | StarlightGroup;
+
+export interface GutterShell {
+	entries: DashboardNavEntry[];
+	root: DashboardNavItem;
+	navLabel: string;
+	crumbs: BreadcrumbCrumb[];
+}
+
+const isGroup = (entry: StarlightEntry): entry is StarlightGroup =>
+	entry.type === 'group';
+
+const hasCurrent = (entry: StarlightEntry): boolean =>
+	isGroup(entry) ? entry.entries.some(hasCurrent) : entry.isCurrent;
+
+const firstLink = (entry: StarlightEntry): StarlightLink | undefined => {
+	if (!isGroup(entry)) return entry;
+	for (const child of entry.entries) {
+		const link = firstLink(child);
+		if (link) return link;
+	}
+	return undefined;
+};
+
+const landingHref = (group: StarlightGroup): string =>
+	firstLink(group)?.href ?? '/';
+
+const flattenLinks = (entry: StarlightEntry): StarlightLink[] =>
+	isGroup(entry) ? entry.entries.flatMap(flattenLinks) : [entry];
+
+const toItem = (link: StarlightLink): DashboardNavItem => ({
+	label: link.label,
+	href: link.href,
+});
+
+const toGroup = (group: StarlightGroup): DashboardNavGroup => ({
+	label: group.label,
+	href: landingHref(group),
+	items: flattenLinks(group).map(toItem),
+});
+
+const sectionEntries = (section: StarlightGroup): DashboardNavEntry[] => {
+	const entries: DashboardNavEntry[] = [];
+	const loose: DashboardNavItem[] = [];
+	for (const child of section.entries) {
+		if (isGroup(child)) entries.push(toGroup(child));
+		else loose.push(toItem(child));
+	}
+	if (loose.length) {
+		entries.unshift({
+			label: section.label,
+			href: landingHref(section),
+			items: loose,
+		});
+	}
+	return entries;
+};
+
+const currentPath = (section: StarlightGroup): StarlightGroup[] => {
+	const path: StarlightGroup[] = [];
+	const walk = (group: StarlightGroup): boolean => {
+		for (const child of group.entries) {
+			if (isGroup(child) && hasCurrent(child)) {
+				path.push(child);
+				walk(child);
+				return true;
+			}
+		}
+		return false;
+	};
+	walk(section);
+	return path;
+};
+
+const currentLink = (section: StarlightGroup): StarlightLink | undefined => {
+	const stack: StarlightEntry[] = [section];
+	while (stack.length) {
+		const entry = stack.pop()!;
+		if (isGroup(entry)) stack.push(...entry.entries);
+		else if (entry.isCurrent) return entry;
+	}
+	return undefined;
+};
+
+const normalize = (path: string): string => {
+	const trimmed = path.split('?')[0].split('#')[0];
+	return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+};
+
+/**
+ * Map a Starlight route sidebar (`Astro.locals.starlightRoute.sidebar`) onto the
+ * bento gutter's nav shape. Reads only Starlight's plain data — no Starlight
+ * markup, so the shell keeps full styling control. Returns null when the route
+ * has no active entry (caller falls back to a hand-authored nav module).
+ */
+export const adaptStarlightSidebar = (
+	sidebar: StarlightEntry[],
+	pathname: string,
+): GutterShell | null => {
+	const top = sidebar.find((entry) => isGroup(entry) && hasCurrent(entry)) as
+		| StarlightGroup
+		| undefined;
+	if (!top) return null;
+
+	const activeChild = top.entries.find(
+		(entry) => isGroup(entry) && hasCurrent(entry),
+	) as StarlightGroup | undefined;
+	const section = activeChild ?? top;
+
+	const root: DashboardNavItem = {
+		label: section.label,
+		href: landingHref(section),
+	};
+
+	const crumbs: BreadcrumbCrumb[] = [
+		{ label: top.label, href: landingHref(top) },
+	];
+	if (activeChild) {
+		crumbs.push({ label: section.label, href: landingHref(section) });
+	}
+	for (const group of currentPath(section)) {
+		crumbs.push({ label: group.label, href: landingHref(group) });
+	}
+	const leaf = currentLink(section);
+	if (
+		leaf &&
+		!crumbs.some((crumb) => normalize(crumb.href) === normalize(leaf.href))
+	) {
+		crumbs.push({ label: leaf.label, href: leaf.href });
+	}
+
+	return {
+		entries: sectionEntries(section),
+		root,
+		navLabel: section.label,
+		crumbs,
+	};
+};


### PR DESCRIPTION
## What
Adds `adaptStarlightSidebar` — maps Starlight's route sidebar data (`Astro.locals.starlightRoute.sidebar`) onto the bento gutter's `DashboardNavGroup` shape. Data-only mapping, **no Starlight markup**, so the custom shell keeps full styling control (none of the `sl-*` constraints that got the Starlight sidebar dropped originally).

`/palworld/` now derives its gutter nav + breadcrumb from the `astro.config` sidebar via the adapter, with the hand-authored `palworldNav` module as fallback.

## Why
Single source for section nav: adding a new game becomes `astro.config` sidebar group + one guard + adapter call — no bespoke nav module. Proven on palworld; mc/project/gaming can migrate in a follow-up.

## Verification
- Unit-tested the pure adapter (palworld, mc, mc/items) — entries + breadcrumb match hand module.
- Rendered on worktree dev — rail (PALWORLD → Overview active + TOC) and breadcrumb (Gaming › Palworld) identical to the hand-module output. Hero/stats/accent-heading untouched.

## Notes
- `palworldNav.ts` kept as fallback (adapter returns `null` → hand module).
- Requires the `astro.config` Palworld sidebar group (already on dev).