### PR TITLE
fix(palforge): remove crashing !signplace + capture real MapObjectId via signtrace (v0.0.24)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -119,7 +119,6 @@ local function on_chat(_, a, b)
         pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.signinspect, sender, text, pos_emit)
         pcall(spike.signtrace, sender, text, pos_emit)
-        pcall(spike.signplace, sender, text, pos_emit, pos.player_location)
         pcall(spike.httptest, sender, text, pos_emit)
         pcall(spike.curltest, sender, text, pos_emit)
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -413,6 +413,26 @@ function M.signtrace(sender, msg, emit, deps)
             pcall(function()
                 emit("TRACE   model outer = " .. tostring(model:GetOuter():GetFullName()))
             end)
+
+            local id_read = false
+            pcall(function()
+                local id = model:TryGetMapObjectId()
+                local s = id
+                pcall(function() s = id:ToString() end)
+                emit("TRACE   MapObjectId (TryGetMapObjectId) = " .. tostring(s))
+                id_read = true
+            end)
+            if not id_read then
+                emit("TRACE   MapObjectId -> TryGetMapObjectId unavailable")
+            end
+            for _, field in ipairs({ "MapObjectMasterDataId", "BuildObjectId" }) do
+                pcall(function()
+                    local v = model[field]
+                    local s = v
+                    pcall(function() s = v:ToString() end)
+                    emit("TRACE   " .. field .. " = " .. tostring(s))
+                end)
+            end
         end)
     end
 

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -428,65 +428,6 @@ function M.signtrace(sender, msg, emit, deps)
     return true
 end
 
-local MAPOBJ_ID_CANDIDATES = {
-    "Signboard",
-    "SignBoard",
-    "Sign",
-    "Signboard_Wood",
-    "Signboard01",
-    "BuildObject_Signboard",
-}
-
-function M.signplace(sender, msg, emit, loc_fn, deps)
-    if type(msg) ~= "string" or trim(msg):lower() ~= "!signplace" then
-        return false
-    end
-    deps = deps or {}
-    local find_first = deps.find_first or FindFirstOf
-
-    emit("signplace: start (native server spawn = ownerless + saved + no-decay)")
-
-    local mgr = find_first("PalMapObjectManager")
-    if not is_valid(mgr) then
-        emit("signplace: abort — PalMapObjectManager not found")
-        return true
-    end
-
-    local loc = loc_fn and loc_fn(sender) or nil
-    if not loc then
-        emit("signplace: abort — no location")
-        return true
-    end
-    emit(string.format("signplace at X=%.1f Y=%.1f Z=%.1f", loc.x, loc.y, loc.z))
-
-    local location = { X = loc.x, Y = loc.y, Z = loc.z }
-    local rotation = { Pitch = 0.0, Yaw = 0.0, Roll = 0.0 }
-
-    local placed_id = nil
-    for _, id in ipairs(MAPOBJ_ID_CANDIDATES) do
-        local ok, res = pcall(function()
-            return mgr:RequestSpawnMapObject_Server(id, location, rotation)
-        end)
-        if not ok then
-            emit("signplace id=" .. id .. " -> ERR " .. tostring(res))
-        else
-            emit("signplace id=" .. id .. " -> " .. tostring(res))
-            if res == true then
-                placed_id = id
-                break
-            end
-        end
-    end
-
-    if placed_id then
-        emit("signplace: SUCCESS via MapObjectId '" .. placed_id .. "' — LOOK for the sign")
-    else
-        emit("signplace: no candidate id returned true (need correct MapObjectId)")
-    end
-    emit("signplace: done")
-    return true
-end
-
 local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
 local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -174,30 +174,6 @@ local signinspect_ok = si1 == true
     and emitted(si_emits, "instances -> 1")
     and emitted(si_emits, "signinspect: done")
 
-_print("=== spike.signplace command ===")
-local pl_emits = {}
-local function pl_emit(m)
-    pl_emits[#pl_emits + 1] = m
-    _print("  place: " .. m)
-end
-local pl_deps = {
-    find_first = function()
-        return {
-            IsValid = function() return true end,
-            RequestSpawnMapObject_Server = function(_, id)
-                return id == "Signboard"
-            end,
-        }
-    end,
-}
-local pl1 = spike.signplace("Al", "!signplace", pl_emit, mock_loc, pl_deps)
-local pl2 = spike.signplace("Al", "nope", pl_emit, mock_loc, pl_deps)
-local signplace_ok = pl1 == true
-    and pl2 == false
-    and emitted(pl_emits, "signplace: start")
-    and emitted(pl_emits, "SUCCESS via MapObjectId 'Signboard'")
-    and emitted(pl_emits, "signplace: done")
-
 _print("=== spike.signtrace command ===")
 local st_emits = {}
 local function st_emit(m)
@@ -258,7 +234,6 @@ local ok = calls.pending == 1
     and spawn_ok
     and clear_ok
     and signinspect_ok
-    and signplace_ok
     and signtrace_ok
     and curltest_ok
     and httptest_ok

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.23"
+version: "0.0.24"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Incident + fix

`!signplace` (v0.0.23, #14768) called `RequestSpawnMapObject_Server` and **aborted the native PalServer (exitCode 3)** in prod — game container `Error`, players dropped, GameServer recreated (clean, save intact, restarts=0).

This PR:
1. **Removes `!signplace`** — the crash can no longer be triggered.
2. **Adds read-only MapObjectId capture** to `!signtrace` — a safe step toward eventually making signs work.

## Why it crashed (revised)

The manager funcs are plain `UFUNCTION(BlueprintCallable)`, **not** Server RPCs. So `_Server` is just Palworld naming. The likely cause is a **wrong `MapObjectId`**: signplace *guessed* ids (`Signboard`, `SignBoard`, …); a name with no `MapObjectData` row makes `RequestSpawnMapObject_Server` deref a null row → native abort. With the **correct** id it likely wouldn't crash.

## The safe path added

`PalMapObjectConcreteModelBase` exposes `FName TryGetMapObjectId() const` (read-only), and the model carries `MapObjectMasterDataId` / `BuildObjectId`. `!signtrace` already hooks `OnSetConcreteModel` and holds the model, so it now logs the **real MapObjectId**. Placing one sign → we get the exact FName. No spawn, no crash.

## Next (deliberate, not ad-hoc)

With the real id in hand, a spawn retry becomes low-risk — but still only in a maintenance window, fresh backup seconds before, one attempt, restore on any crash.

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**.

## Version

`0.0.24`.