### PR TITLE
feat(palforge): !mapids + !signtry — instrumented crash-repro to fix the spawn bug (v0.0.25)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -119,6 +119,8 @@ local function on_chat(_, a, b)
         pcall(spike.clear, sender, text, pos_emit)
         pcall(spike.signinspect, sender, text, pos_emit)
         pcall(spike.signtrace, sender, text, pos_emit)
+        pcall(spike.mapids, sender, text, pos_emit)
+        pcall(spike.signtry, sender, text, pos_emit, pos.player_location)
         pcall(spike.httptest, sender, text, pos_emit)
         pcall(spike.curltest, sender, text, pos_emit)
     end

--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -448,6 +448,129 @@ function M.signtrace(sender, msg, emit, deps)
     return true
 end
 
+local ID_MODEL_CLASSES = { "PalMapObjectConcreteModelBase" }
+
+local function read_id(model)
+    local s = nil
+    pcall(function()
+        local id = model:TryGetMapObjectId()
+        s = id
+        pcall(function() s = id:ToString() end)
+        s = tostring(s)
+    end)
+    if s == nil or s == "" or s == "nil" then
+        return nil
+    end
+    return s
+end
+
+local function collect_ids(find_all)
+    local set = {}
+    for _, cname in ipairs(ID_MODEL_CLASSES) do
+        local models = find_all(cname)
+        if type(models) == "table" then
+            for _, m in ipairs(models) do
+                local s = read_id(m)
+                if s then
+                    set[s] = (set[s] or 0) + 1
+                end
+            end
+        end
+    end
+    return set
+end
+
+function M.mapids(sender, msg, emit, deps)
+    if type(msg) ~= "string" or trim(msg):lower() ~= "!mapids" then
+        return false
+    end
+    deps = deps or {}
+    local find_all = deps.find_all or FindAllOf
+
+    emit("mapids: start (read-only; live model MapObjectIds)")
+    local set = collect_ids(find_all)
+
+    local total, shown = 0, 0
+    local signs = {}
+    for id, n in pairs(set) do
+        total = total + 1
+        if id:lower():find("sign", 1, true) then
+            signs[#signs + 1] = id .. " (x" .. n .. ")"
+        end
+        if shown < 25 then
+            emit("mapid " .. id .. " x" .. n)
+            shown = shown + 1
+        end
+    end
+    emit("mapids: unique ids = " .. total .. " (showed " .. shown .. ")")
+    if #signs > 0 then
+        emit("mapids SIGN matches -> " .. table.concat(signs, " | "))
+    else
+        emit("mapids: no id containing 'sign' among live models")
+    end
+    emit("mapids: done")
+    return true
+end
+
+function M.signtry(sender, msg, emit, loc_fn, deps)
+    if type(msg) ~= "string" then
+        return false
+    end
+    local body = trim(msg)
+    local id = body:match("^[!]signtry%s+(.+)$")
+    if not id then
+        if body:lower() == "!signtry" then
+            emit("signtry: usage !signtry <MapObjectId> (id must exist among live models)")
+            return true
+        end
+        return false
+    end
+    id = trim(id)
+
+    deps = deps or {}
+    local find_first = deps.find_first or FindFirstOf
+    local find_all = deps.find_all or FindAllOf
+
+    emit("signtry: request id='" .. id .. "'")
+
+    local known = collect_ids(find_all)
+    if not known[id] then
+        emit("signtry: REFUSED — id '" .. id .. "' not found among live models (avoid null-row crash). Run !mapids.")
+        return true
+    end
+    emit("signtry: id validated (x" .. known[id] .. " live)")
+
+    local mgr = find_first("PalMapObjectManager")
+    if not is_valid(mgr) then
+        emit("signtry: abort — PalMapObjectManager not found")
+        return true
+    end
+
+    local loc = loc_fn and loc_fn(sender) or nil
+    if not loc then
+        emit("signtry: abort — no location")
+        return true
+    end
+
+    local location = { X = loc.x, Y = loc.y, Z = loc.z }
+    local rotation = { Pitch = 0.0, Yaw = 0.0, Roll = 0.0 }
+
+    emit(string.format(
+        "signtry: CALLING RequestSpawnMapObject_Server id='%s' loc=%.1f,%.1f,%.1f (may crash — pre-logged)",
+        id, loc.x, loc.y, loc.z))
+
+    local ok, res = pcall(function()
+        return mgr:RequestSpawnMapObject_Server(id, location, rotation)
+    end)
+
+    emit("signtry: RETURNED ok=" .. tostring(ok) .. " res=" .. tostring(res))
+    if ok and res == true then
+        emit("signtry: SUCCESS — LOOK for the object")
+    end
+    emit("signtry: done")
+    return true
+end
+
 local HTTP_GLOBALS = { "http", "socket", "curl", "https", "ssl" }
 local HTTP_MODULES = { "socket", "socket.http", "ssl", "ssl.https", "http", "http.request" }
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -174,6 +174,43 @@ local signinspect_ok = si1 == true
     and emitted(si_emits, "instances -> 1")
     and emitted(si_emits, "signinspect: done")
 
+_print("=== spike.mapids + signtry commands ===")
+local function id_model(id)
+    return { TryGetMapObjectId = function() return { ToString = function() return id end } end }
+end
+local dbg_find_all = function() return { id_model("Signboard"), id_model("CampFire"), id_model("Signboard") } end
+local dbg_find_first = function()
+    return {
+        IsValid = function() return true end,
+        RequestSpawnMapObject_Server = function(_, id) return id == "Signboard" end,
+    }
+end
+local mi_emits = {}
+local function mi_emit(m) mi_emits[#mi_emits + 1] = m; _print("  mapids: " .. m) end
+local mi1 = spike.mapids("Al", "!mapids", mi_emit, { find_all = dbg_find_all })
+local mi2 = spike.mapids("Al", "nope", mi_emit, { find_all = dbg_find_all })
+local mapids_ok = mi1 == true
+    and mi2 == false
+    and emitted(mi_emits, "mapids: start")
+    and emitted(mi_emits, "SIGN matches")
+    and emitted(mi_emits, "mapids: done")
+
+local sy_emits = {}
+local function sy_emit(m) sy_emits[#sy_emits + 1] = m; _print("  signtry: " .. m) end
+local sy_deps = { find_all = dbg_find_all, find_first = dbg_find_first }
+local sy_ok_call = spike.signtry("Al", "!signtry Signboard", sy_emit, mock_loc, sy_deps)
+local sy_refuse = spike.signtry("Al", "!signtry Bogus", sy_emit, mock_loc, sy_deps)
+local sy_usage = spike.signtry("Al", "!signtry", sy_emit, mock_loc, sy_deps)
+local sy_pass = spike.signtry("Al", "nope", sy_emit, mock_loc, sy_deps)
+local signtry_ok = sy_ok_call == true
+    and sy_refuse == true
+    and sy_usage == true
+    and sy_pass == false
+    and emitted(sy_emits, "id validated")
+    and emitted(sy_emits, "CALLING RequestSpawnMapObject_Server")
+    and emitted(sy_emits, "SUCCESS")
+    and emitted(sy_emits, "REFUSED")
+
 _print("=== spike.signtrace command ===")
 local st_emits = {}
 local function st_emit(m)
@@ -234,6 +271,8 @@ local ok = calls.pending == 1
     and spawn_ok
     and clear_ok
     and signinspect_ok
+    and mapids_ok
+    and signtry_ok
     and signtrace_ok
     and curltest_ok
     and httptest_ok

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.24"
+version: "0.0.25"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Purpose

Diagnostic build to **resolve** the `!signplace` crash (not just avoid it). Authorized: no players online, backup taken before testing.

## Hypothesis under test

`RequestSpawnMapObject_Server` is `BlueprintCallable` (not an RPC), and the manager validates ids against a `MapObjectData` table. Leading theory: signplace **guessed** ids → an id with no data-table row → the function derefs a null row → native abort (exitCode 3). With a **real** id it should be safe.

## Instruments

- **`!mapids`** (read-only) — enumerates live `PalMapObjectConcreteModelBase` models, reads each `TryGetMapObjectId()`, dumps the unique set + any `sign` matches. Gives the **real signboard MapObjectId** with zero spawn.
- **`!signtry <id>`** — spawns **one explicit id**, but only if it's in the live-model id set (bad id / typo → **REFUSED**, no crash). Flushes a `CALLING …` line to `chat.log` **before** the native call, so a crash still leaves the exact call recorded. Reports `ok`/`res` on return.

## Experiment

1. `!mapids` → read the real signboard id.
2. `!signtry <real id>` at your feet.
   - **Succeeds** → the bug was the bad id. Resolution: the safe primitive always validates against the live/data-table id set.
   - **Still crashes** with a known-valid id → hypothesis rejected → next variable (FVector/FRotator marshalling, or spawn context). The pre-flushed log pins the exact call.

## Safety

- `!signtry` refuses any id not present on a live model → can't repro the original bad-id crash by accident.
- Pre-call log is flushed (`f:close`) so evidence survives a crash.
- No players; fresh backup before the run; save proven to recover cleanly (restarts=0 on last recovery).

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**.

## Version

`0.0.25`.