### PR TITLE
fix(palforge): dispatch signtry spawn via ExecuteInGameThread (v0.0.26)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/scripts/spike.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/spike.lua
@@ -555,19 +555,34 @@ function M.signtry(sender, msg, emit, loc_fn, deps)
     local location = { X = loc.x, Y = loc.y, Z = loc.z }
     local rotation = { Pitch = 0.0, Yaw = 0.0, Roll = 0.0 }
 
-    emit(string.format(
-        "signtry: CALLING RequestSpawnMapObject_Server id='%s' loc=%.1f,%.1f,%.1f (may crash — pre-logged)",
-        id, loc.x, loc.y, loc.z))
+    local in_thread = deps.in_thread or ExecuteInGameThread
+    emit("signtry: ExecuteInGameThread -> " .. type(in_thread))
 
-    local ok, res = pcall(function()
-        return mgr:RequestSpawnMapObject_Server(id, location, rotation)
-    end)
-
-    emit("signtry: RETURNED ok=" .. tostring(ok) .. " res=" .. tostring(res))
-    if ok and res == true then
-        emit("signtry: SUCCESS — LOOK for the object")
+    local function do_spawn()
+        emit(string.format(
+            "signtry: CALLING RequestSpawnMapObject_Server id='%s' loc=%.1f,%.1f,%.1f",
+            id, loc.x, loc.y, loc.z))
+        local ok, res = pcall(function()
+            return mgr:RequestSpawnMapObject_Server(id, location, rotation)
+        end)
+        emit("signtry: RETURNED ok=" .. tostring(ok) .. " res=" .. tostring(res))
+        if ok and res == true then
+            emit("signtry: SUCCESS — LOOK for the object")
+        end
+        emit("signtry: done")
     end
-    emit("signtry: done")
+
+    if type(in_thread) == "function" then
+        emit("signtry: dispatching spawn on game thread (may crash — pre-logged)")
+        local disp_ok = pcall(in_thread, do_spawn)
+        if not disp_ok then
+            emit("signtry: ExecuteInGameThread dispatch ERR — falling back to direct")
+            do_spawn()
+        end
+    else
+        emit("signtry: no ExecuteInGameThread — direct call (may crash — pre-logged)")
+        do_spawn()
+    end
     return true
 end
 

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -197,7 +197,7 @@ local mapids_ok = mi1 == true
 
 local sy_emits = {}
 local function sy_emit(m) sy_emits[#sy_emits + 1] = m; _print("  signtry: " .. m) end
-local sy_deps = { find_all = dbg_find_all, find_first = dbg_find_first }
+local sy_deps = { find_all = dbg_find_all, find_first = dbg_find_first, in_thread = function(fn) fn() end }
 local sy_ok_call = spike.signtry("Al", "!signtry Signboard", sy_emit, mock_loc, sy_deps)
 local sy_refuse = spike.signtry("Al", "!signtry Bogus", sy_emit, mock_loc, sy_deps)
 local sy_usage = spike.signtry("Al", "!signtry", sy_emit, mock_loc, sy_deps)
@@ -207,6 +207,7 @@ local signtry_ok = sy_ok_call == true
     and sy_usage == true
     and sy_pass == false
     and emitted(sy_emits, "id validated")
+    and emitted(sy_emits, "dispatching spawn on game thread")
     and emitted(sy_emits, "CALLING RequestSpawnMapObject_Server")
     and emitted(sy_emits, "SUCCESS")
     and emitted(sy_emits, "REFUSED")

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.25"
+version: "0.0.26"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Evidence

`!signtry Signboard` — with a **valid** id (`!mapids` confirmed `Signboard` is a real live model id) — still crashed the server (exitCode 3). That **rejects the bad-id hypothesis**: the native call itself aborts, regardless of id.

## Root cause (matched to a known UE4SS bug)

UE4SS crashes on `UWorld::SpawnActor()` / UFunction calls with struct params — a **null `memcpy` in `UObject::execLocalVariable`** — when the engine call runs **outside a guarded game-thread context**. UE4SS added a lock-guard inside `ExecuteInGameThread` specifically for this. Our `signtry` called `RequestSpawnMapObject_Server` **directly inside the `BroadcastChatMessage` hook callback** — no game-thread dispatch. Exact match.

Refs: [RE-UE4SS #527](https://github.com/UE4SS-RE/RE-UE4SS/issues/527), [ExecuteInGameThread docs](https://docs.ue4ss.com/dev/lua-api/global-functions/executeingamethread.html).

## Fix

Wrap the spawn in `ExecuteInGameThread(...)`. `signtry` now:
- logs whether `ExecuteInGameThread` exists,
- dispatches the spawn onto the game thread,
- keeps the pre-call flush (crash still leaves the exact call recorded),
- falls back to a direct call only if `ExecuteInGameThread` is absent.

Everything else (id validation against live models, refuse-on-bad-id) unchanged.

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**.

## Version

`0.0.26`.

## Next

Recover current pod, rotate to 0.0.26, re-run `!signtry Signboard`:
- **Succeeds + sign renders** → game-thread dispatch was the fix → build the safe `mapobject.spawn` primitive on top.
- **Still crashes** → thread wasn't it → next: construct real `FVector`/`FRotator` structs instead of Lua tables.