### PR TITLE
feat(reel): surface inbound port-forward status + evict HLS delivery cache

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -185,6 +185,16 @@ export default function ReactReelConsole() {
 						{health.vpn_ok ? '● VPN ok' : '● VPN down'}
 					</span>
 					<span>{health.trackers} trackers</span>
+					<span
+						className={
+							health.inbound_ready
+								? 'reel-console__health-ok'
+								: undefined
+						}>
+						{health.inbound_ready
+							? `● inbound :${health.forwarded_port}`
+							: '○ outbound-only'}
+					</span>
 					<span>
 						{health.counts.seeding} seeding · {health.counts.leeching}{' '}
 						leeching · {health.counts.failed} failed

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -81,6 +81,9 @@ export interface ReelStatusTorrent extends ReelTorrent {
 export interface ReelStatusReport {
 	vpn_ok: boolean;
 	trackers: number;
+	bt_listen_port?: number;
+	forwarded_port?: number;
+	inbound_ready: boolean;
 	counts: ReelCounts;
 	torrents: ReelStatusTorrent[];
 }
@@ -88,6 +91,9 @@ export interface ReelStatusReport {
 export interface ReelHealth {
 	vpn_ok: boolean;
 	trackers: number;
+	bt_listen_port?: number;
+	forwarded_port?: number;
+	inbound_ready: boolean;
 	counts: ReelCounts;
 }
 
@@ -200,6 +206,9 @@ export async function refreshReelList(): Promise<void> {
 		$reelHealth.set({
 			vpn_ok: report.vpn_ok,
 			trackers: report.trackers,
+			bt_listen_port: report.bt_listen_port,
+			forwarded_port: report.forwarded_port,
+			inbound_ready: report.inbound_ready,
 			counts: report.counts,
 		});
 		$reelListError.set(null);

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.11"
+version: "0.1.12"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -149,6 +149,11 @@ sealed via `apps/kube/reel/seal-gluetun-secret.sh`), layered over the shared
 `vpn-wireguard` secret so kasm/firecracker are untouched — and so the provider
 name stays out of the repo. If the forwarded-port file never appears, reel falls
 back to a random port (no inbound peers) rather than failing to start.
+
+`GET /status` reports whether it's actually working: `bt_listen_port` (the port
+librqbit announces), `forwarded_port` (what gluetun currently forwards), and
+`inbound_ready` (true only when the two match). The staff console shows this as
+`● inbound :PORT` vs `○ outbound-only`.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -87,8 +87,17 @@ struct Counts {
 struct StatusReport {
     vpn_ok: bool,
     trackers: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bt_listen_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    forwarded_port: Option<u16>,
+    inbound_ready: bool,
     counts: Counts,
     torrents: Vec<TorrentView>,
+}
+
+fn inbound_ready(listen: Option<u16>, forwarded: Option<u16>) -> bool {
+    matches!((listen, forwarded), (Some(l), Some(f)) if l == f)
 }
 
 fn served_bytes(range: Option<&str>, total: u64) -> u64 {
@@ -170,9 +179,14 @@ async fn status(State(st): State<AppState>, headers: HeaderMap) -> impl IntoResp
         let l = live.remove(&meta.id);
         torrents.push(TorrentView::build(meta, l));
     }
+    let bt_listen_port = st.engine.bt_listen_port();
+    let forwarded_port = st.engine.forwarded_port();
     Json(StatusReport {
         vpn_ok: st.engine.vpn_ok(),
         trackers: st.engine.tracker_count(),
+        bt_listen_port,
+        forwarded_port,
+        inbound_ready: inbound_ready(bt_listen_port, forwarded_port),
         counts,
         torrents,
     })
@@ -827,6 +841,15 @@ mod tests {
         m.transcode = TranscodeStatus::None;
         m.hls = HlsStatus::Live;
         assert_eq!(derive_phase(&m, None), "streaming-hls");
+    }
+
+    #[test]
+    fn inbound_ready_requires_matching_ports() {
+        assert!(inbound_ready(Some(51820), Some(51820)));
+        assert!(!inbound_ready(Some(51820), Some(6881)));
+        assert!(!inbound_ready(Some(51820), None));
+        assert!(!inbound_ready(None, Some(51820)));
+        assert!(!inbound_ready(None, None));
     }
 
     #[test]

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -161,6 +161,7 @@ pub struct Engine {
     stall_timeout: Duration,
     stall_check: Duration,
     trackers: Arc<Mutex<Arc<Vec<String>>>>,
+    bt_port_file: Option<PathBuf>,
 }
 
 const LEECH_DRAIN_CAP: Duration = Duration::from_secs(6 * 3600);
@@ -278,6 +279,7 @@ impl Engine {
                 &cfg.trackers_cache,
                 &cfg.extra_trackers,
             )))),
+            bt_port_file: cfg.bt_port_file.clone(),
         };
         engine.resume_on_start();
         Ok(engine)
@@ -893,6 +895,15 @@ impl Engine {
 
     pub fn tracker_count(&self) -> usize {
         self.trackers.lock().unwrap().len()
+    }
+
+    pub fn bt_listen_port(&self) -> Option<u16> {
+        self.session.tcp_listen_port()
+    }
+
+    pub fn forwarded_port(&self) -> Option<u16> {
+        let path = self.bt_port_file.as_ref()?;
+        parse_forwarded_port(&std::fs::read_to_string(path).ok()?)
     }
 }
 

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -181,6 +181,7 @@ impl HlsManager {
     }
 
     pub async fn abort(&self, id: &str) {
+        self.delivery_cache.lock().unwrap().remove(id);
         let child = self.take_child(id);
         if let Some(mut child) = child {
             let _ = child.kill().await;


### PR DESCRIPTION
Follow-up to the VPN port-forwarding PR — lets you confirm inbound is actually working once it deploys, plus a small cache-leak fix.

## Inbound status on GET /status
- `bt_listen_port` — the port librqbit is announcing to trackers (`session.tcp_listen_port()`).
- `forwarded_port` — what gluetun currently forwards, read live from `/tmp/gluetun/forwarded_port`.
- `inbound_ready` — `true` only when the two match (gluetun forwarded a port **and** librqbit pinned its listener to it → peers can reach us).

Staff console health line renders it: **● inbound :PORT** when ready, **○ outbound-only** otherwise. So after the PF secret lands you can see at a glance whether inbound peers are live, without shelling into the pod.

## HLS delivery cache eviction (survey #10)
`HlsManager.delivery_cache` was never pruned — it grew unbounded as torrents came and went. Now evicted in `abort()` (called on delete + reap), so it can't leak.

## Testing
- `cargo test -p reel` → 123 passed, 4 ignored (added `inbound_ready` unit test).
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel files (21 repo-wide = pre-existing generated-proto, codegen not run in worktree).

reel.mdx updated; version 0.1.11 → 0.1.12.

Kube manifest: apps/kube/reel/manifest/reel.yaml