### PR TITLE
fix(palworld): metrics decode uptime field + kill relay log spam

### DIFF
--- a/apps/agones/palworld/relay/src/chat_tail.rs
+++ b/apps/agones/palworld/relay/src/chat_tail.rs
@@ -77,6 +77,7 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
 
     let mut pos: u64 = 0;
     let mut dedup = Dedup::new(DEDUP_WINDOW);
+    let mut missing = false;
     let mut ticker = time::interval(Duration::from_millis(500));
     ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
@@ -84,9 +85,18 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
         ticker.tick().await;
 
         let file = match tokio::fs::File::open(&path).await {
-            Ok(f) => f,
+            Ok(f) => {
+                if missing {
+                    info!(path = %path, "chat_tail: chat log now present");
+                    missing = false;
+                }
+                f
+            }
             Err(e) => {
-                debug!(error = %e, "chat_tail: chat log not open yet");
+                if !missing {
+                    debug!(error = %e, "chat_tail: chat log not open yet (suppressing until present)");
+                    missing = true;
+                }
                 continue;
             }
         };

--- a/apps/agones/palworld/relay/src/rest_client.rs
+++ b/apps/agones/palworld/relay/src/rest_client.rs
@@ -13,9 +13,13 @@ pub struct InfoResp {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct MetricsResp {
+    #[serde(default)]
     pub serverfps: i64,
+    #[serde(default)]
     pub currentplayernum: i64,
+    #[serde(rename = "uptime", alias = "serveruptime", default)]
     pub serveruptime: i64,
+    #[serde(default)]
     pub serverframetime: f64,
 }
 
@@ -61,15 +65,21 @@ impl RestClient {
     }
 
     async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let resp = self
+        let body = self
             .http
             .get(self.url(path))
             .basic_auth("admin", Some(&self.admin_password))
             .send()
             .await
             .with_context(|| format!("GET {path} failed"))?
-            .error_for_status()?;
-        Ok(resp.json::<T>().await?)
+            .error_for_status()?
+            .text()
+            .await
+            .with_context(|| format!("GET {path}: read body failed"))?;
+        serde_json::from_str::<T>(&body).with_context(|| {
+            let snippet: String = body.chars().take(240).collect();
+            format!("GET {path}: decode failed, body={snippet}")
+        })
     }
 
     pub async fn info(&self) -> Result<InfoResp> {
@@ -113,11 +123,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_metrics() {
-        let j = r#"{"serverfps":58,"currentplayernum":3,"serveruptime":1200,"serverframetime":16.9,"maxplayernum":32}"#;
+    fn parse_metrics_real_uptime_field() {
+        let j = r#"{"serverfps":58,"currentplayernum":3,"serverframetime":16.9,"maxplayernum":32,"uptime":1200}"#;
         let m: MetricsResp = serde_json::from_str(j).unwrap();
         assert_eq!(m.currentplayernum, 3);
         assert_eq!(m.serverfps, 58);
+        assert_eq!(m.serveruptime, 1200);
+    }
+
+    #[test]
+    fn parse_metrics_legacy_alias_and_missing_fields() {
+        let m: MetricsResp = serde_json::from_str(r#"{"serveruptime":42}"#).unwrap();
+        assert_eq!(m.serveruptime, 42);
+        assert_eq!(m.serverfps, 0);
+        let empty: MetricsResp = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty.serveruptime, 0);
     }
 
     #[test]

--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -4,8 +4,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-07-17T00:00:00Z'
-        kbve.sh/config-version: v9-webhook-auth
+        kbve.sh/last-updated: '2026-07-27T00:00:00Z'
+        kbve.sh/config-version: v10-tracing-level-fix
     labels:
         kbve.com/category: observability
         kbve.com/stack: core
@@ -136,7 +136,7 @@ data:
         \       string(.metadata.parsed.error_severity) ??\n               \"\"\n\n  \
         \    # If no metadata level, parse from raw message\n      if .level == \"\" {\n\
         \          msg = string(.event_message) ?? \"\"\n          # ClickHouse: <Error>,\
-        \ <Warning>, <Fatal>, <Critical>\n          if match(msg, r'<(Fatal|Error|Critical)>')\
+        \ <Warning>, <Fatal>, <Critical>\n          # Rust tracing fmt: \"<ISO8601> LEVEL target: ...\" — leading level wins over error= fields\n          tp, terr = parse_regex(msg, r'^\\S+\\s+(?P<lvl>TRACE|DEBUG|INFO|WARN|ERROR)\\s')\n          if terr == null {\n              .level = downcase(string(tp.lvl) ?? \"info\")\n          } else if match(msg, r'<(Fatal|Error|Critical)>')\
         \ {\n              .level = \"error\"\n          } else if match(msg, r'<Warning>')\
         \ {\n              .level = \"warn\"\n          } else if match(msg, r'<Debug>')\
         \ || match(msg, r'<Trace>') {\n              .level = \"debug\"\n          # kube-system:\


### PR DESCRIPTION
## Problem
ClickHouse (\`observability.logs_distributed\`) showed **390,788 \"errors\"** for \`palworld-relay\` over 5 days. 100% were misclassified: actually 53,748 DEBUG + 8,524 WARN. Two source-level causes plus one ingestion-level cause.

## Root causes
1. **Metrics decode fails every poll (~8.5k WARN, telemetry dead).** Palworld REST \`/v1/api/metrics\` returns \`uptime\`, but \`MetricsResp\` required \`serveruptime\` with no default → decode error on every poll → no snapshots ever written. \`players()\` survived only because its fields are all \`#[serde(default)]\`. The unit test hard-coded the wrong field name so it never caught it.
2. **chat_tail DEBUG spam (~53k).** \"chat log not open yet\" logged every 500ms while the file is absent.
3. **Vector level misclassification (all rust services).** \`ch_normalize\` had no branch for Rust \`tracing\` format, so the generic \`\\b(ERROR|...)\\b\` match fired on the \`error=\` structured field, tagging DEBUG/WARN as \`error\`.

## Fixes
- \`MetricsResp\`: \`#[serde(rename=\"uptime\", alias=\"serveruptime\", default)]\` + \`default\` on all fields. Restores telemetry.
- \`rest_client.get_json\`: capture raw body on decode failure — errors now show \`body=…\` instead of blind \"error decoding response body\".
- \`chat_tail\`: log the missing→present transition once instead of every tick.
- \`vector-config\` \`ch_normalize\`: leading \`TIMESTAMP LEVEL\` branch so the real level wins over \`error=\` fields, cluster-wide.

## Verification
- \`nx test agones-palworld-relay\`: 25 passed (new tests lock the \`uptime\` field + alias + missing-field defaults).
- \`nx lint agones-palworld-relay\`: clean.
- Vector VRL regex tested against real DEBUG/WARN/ERROR/INFO samples; YAML validated.

## Note
Vector DaemonSet needs a restart (or a config reloader) to pick up the new ConfigMap.

📖 [kube docs](https://kbve.com/application/kubernetes/)