### PR TITLE
fix(reel): non-blocking media scan + header auth for hls.js

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -142,11 +142,6 @@ export function mediaUrl(id: string, suffix: string, token: string | null): stri
 	return `${base}${sep}access_token=${encodeURIComponent(token)}`;
 }
 
-export function withToken(url: string, token: string): string {
-	if (url.includes('access_token=')) return url;
-	const sep = url.includes('?') ? '&' : '?';
-	return `${url}${sep}access_token=${encodeURIComponent(token)}`;
-}
 
 export async function listTorrents(): Promise<ReelTorrent[]> {
 	return authedApiFetch<ReelTorrent[]>(`${REEL_PATH}/torrents`);
@@ -327,10 +322,12 @@ export class ReelPlayer {
 		gen: number,
 	): Promise<void> {
 		if (this.generation !== gen) return;
-		const manifestUrl = mediaUrl(id, '/manifest.m3u8', token);
 		let status: number;
 		try {
-			const resp = await fetch(manifestUrl, { cache: 'no-store' });
+			const resp = await fetch(mediaUrl(id, '/manifest.m3u8', null), {
+				cache: 'no-store',
+				headers: { Authorization: `Bearer ${token}` },
+			});
 			status = resp.status;
 		} catch {
 			if (this.generation !== gen) return;
@@ -347,7 +344,7 @@ export class ReelPlayer {
 				this.playRaw(video, id, token, true, gen);
 				return;
 			case 'hls':
-				await this.playHls(video, manifestUrl, token, gen);
+				await this.playHls(video, id, token, gen);
 				return;
 			case 'poll':
 				if (attempt >= MAX_POLLS) {
@@ -394,14 +391,16 @@ export class ReelPlayer {
 
 	private async playHls(
 		video: HTMLVideoElement,
-		manifestUrl: string,
+		id: string,
 		token: string,
 		gen: number,
 	): Promise<void> {
 		if (this.generation !== gen) return;
 		if (video.canPlayType(MANIFEST_MIME)) {
+			// A <video> element can't send headers, so the native-HLS path
+			// still carries the short-lived scoped token in the query string.
 			this.attachVideoError(video, gen);
-			video.src = manifestUrl;
+			video.src = mediaUrl(id, '/manifest.m3u8', token);
 			$reelState.set('hls');
 			void video.play().catch(() => undefined);
 			return;
@@ -412,16 +411,19 @@ export class ReelPlayer {
 			this.fail('HLS is not supported in this browser');
 			return;
 		}
+		// hls.js drives its own XHRs, so the token rides in the Authorization
+		// header — never in the manifest/segment URLs (no Referer/log leak).
 		const hls = new Hls({
 			xhrSetup: (xhr: XMLHttpRequest, url: string) => {
-				xhr.open('GET', withToken(url, token), true);
+				xhr.open('GET', url, true);
+				xhr.setRequestHeader('Authorization', `Bearer ${token}`);
 			},
 		});
 		this.hls = hls;
 		hls.on(Hls.Events.ERROR, (_evt, data) => {
 			if (data.fatal) this.fail(`HLS error: ${data.type}`);
 		});
-		hls.loadSource(manifestUrl);
+		hls.loadSource(mediaUrl(id, '/manifest.m3u8', null));
 		hls.attachMedia(video);
 		$reelState.set('hls');
 		void video.play().catch(() => undefined);

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.12"
+version: "0.1.13"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -154,6 +154,11 @@ back to a random port (no inbound peers) rather than failing to start.
 librqbit announces), `forwarded_port` (what gluetun currently forwards), and
 `inbound_ready` (true only when the two match). The staff console shows this as
 `● inbound :PORT` vs `○ outbound-only`.
+
+Request-path media scans (`pick_primary_file`) run on a blocking thread pool so a
+large library tree can't stall the async runtime, and the hls.js player carries
+its scoped token in the `Authorization` header rather than the URL query — the
+token never lands in a manifest/segment request URL or a `Referer`.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -333,7 +333,7 @@ async fn manifest(
     let delivery = match st.hls.cached_delivery(&id) {
         Some(d) => d,
         None => {
-            let primary = match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
+            let primary = match transcode::pick_primary_file_async(std::path::PathBuf::from(&meta.path)).await {
                 Ok(p) => p,
                 Err(e) => {
                     tracing::warn!(id = %id, path = %meta.path, error = %e, "manifest: no primary media file");
@@ -506,7 +506,7 @@ pub(crate) async fn stream_core<S: engine::MediaSource>(
             };
             let path = match path {
                 Some(p) => p,
-                None => match transcode::pick_primary_file(std::path::Path::new(&meta.path)) {
+                None => match transcode::pick_primary_file_async(std::path::PathBuf::from(&meta.path)).await {
                     Ok(p) => p,
                     Err(e) => {
                         tracing::warn!(id = %id, path = %meta.path, error = %e, "stream: no primary media file");

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -50,6 +50,12 @@ pub fn decide_delivery(p: &ProbeResult) -> Delivery {
     }
 }
 
+pub async fn pick_primary_file_async(dir: PathBuf) -> anyhow::Result<PathBuf> {
+    tokio::task::spawn_blocking(move || pick_primary_file(&dir))
+        .await
+        .map_err(|e| anyhow::anyhow!("pick_primary_file task failed: {e}"))?
+}
+
 pub fn pick_primary_file(dir: &Path) -> anyhow::Result<PathBuf> {
     if dir.is_file() {
         return Ok(dir.to_path_buf());


### PR DESCRIPTION
Closes the two remaining reel survey gaps.

## #5 — non-blocking media scan
`pick_primary_file` does a recursive `std::fs` tree-walk. It ran **inline on the async runtime** inside the manifest + stream request handlers, so a large library directory could stall Tokio worker threads and block unrelated requests. Added `pick_primary_file_async` (wraps it in `spawn_blocking`); both request-path call sites now await it. Background callers (transcode/hls spawn tasks) keep the sync path — they're already off the request path.

## #11 — token out of media URLs
The hls.js player set the scoped media token in the URL query (`?access_token=`) on **every manifest + segment XHR**, so the token leaked into request URLs and `Referer`. It now rides in the `Authorization: Bearer` header instead (the reel proxy already prefers the header — `extract_auth_token`). The native-HLS `<video>` path keeps the query token, since a media element can't set headers (single short-lived scoped token, acceptable). Removed the now-unused `withToken` helper.

## Testing
- `cargo test -p reel` → 123 passed, 4 ignored.
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel files (21 repo-wide = pre-existing generated-proto, codegen not run in worktree).

reel.mdx updated; version 0.1.12 → 0.1.13.

Kube manifest: apps/kube/reel/manifest/reel.yaml