### PR TITLE
fix(reel): stop transcode restarts, stabilize VPN swarm, harden status poll

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -208,8 +208,17 @@ export async function refreshReelList(): Promise<void> {
 		});
 		$reelListError.set(null);
 	} catch (e) {
+		// While polling (we already have a snapshot), a transient auth gap
+		// (401 during a token refresh) or an upstream blip (502/503 while the
+		// reel pod rolls) shouldn't wipe the view or flash an error — keep the
+		// last good data and let the next tick recover.
+		const status = e instanceof ApiError ? e.status : 0;
+		const transient = status === 401 || status === 502 || status === 503;
+		if (transient && $reelList.get().length > 0) {
+			return;
+		}
 		$reelListError.set(
-			e instanceof ApiError && e.status === 401
+			status === 401
 				? 'sign in as staff to manage reels'
 				: e instanceof Error
 					? e.message

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.13"
+version: "0.1.14"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -38,6 +38,7 @@ spec:
             - { name: FIREWALL, value: "on" }
             - { name: FIREWALL_INPUT_PORTS, value: "8080" }
             - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.0.0.0/8,172.16.0.0/12" }
+            - { name: WIREGUARD_MTU, value: "1320" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel
@@ -53,6 +54,7 @@ spec:
             - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
             - { name: REEL_BT_PORT_FILE, value: "/tmp/gluetun/forwarded_port" }
+            - { name: REEL_ENCODE_THREADS, value: "1" }
           envFrom:
             - secretRef: { name: reel-api }
           ports:
@@ -61,10 +63,14 @@ spec:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           livenessProbe:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 10
             periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests: { cpu: 100m, memory: 128Mi }
             limits: { cpu: "2", memory: 2Gi }

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -924,7 +924,7 @@ mod tests {
     }
 
     fn transcoder_with(store: StateStore) -> transcode::Transcoder {
-        transcode::Transcoder::new(store, 1, 1, "ffmpeg".into(), "ffprobe".into(), true)
+        transcode::Transcoder::new(store, 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1)
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub transcode_enabled: bool,
     pub remux_concurrency: usize,
     pub encode_concurrency: usize,
+    pub encode_threads: usize,
     pub ffmpeg_bin: String,
     pub ffprobe_bin: String,
     pub stream_enabled: bool,
@@ -181,6 +182,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         transcode_enabled: env_bool("REEL_TRANSCODE_ENABLED", true),
         remux_concurrency: env_u64("REEL_REMUX_CONCURRENCY", 3)? as usize,
         encode_concurrency: env_u64("REEL_ENCODE_CONCURRENCY", 1)? as usize,
+        encode_threads: env_u64("REEL_ENCODE_THREADS", 1)? as usize,
         ffmpeg_bin: env_or("REEL_FFMPEG_BIN", "ffmpeg"),
         ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
         stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
@@ -206,7 +208,7 @@ mod tests {
                   "REEL_STALL_TIMEOUT_SECS","REEL_STALL_CHECK_SECS",
                   "REEL_TRACKERS","REEL_TRACKERS_URLS","REEL_TRACKERS_CACHE","REEL_TRACKERS_REFRESH_SECS",
                   "REEL_STATE_FLUSH_MS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
-                  "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY",
+                  "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY","REEL_ENCODE_THREADS",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
                   "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS",
                   "REEL_BT_PORT_FILE","REEL_BT_PORT_WAIT_SECS"] {
@@ -360,6 +362,7 @@ mod tests {
         assert!(c.transcode_enabled);
         assert_eq!(c.remux_concurrency, 3);
         assert_eq!(c.encode_concurrency, 1);
+        assert_eq!(c.encode_threads, 1);
         assert_eq!(c.ffmpeg_bin, "ffmpeg");
         std::env::set_var("REEL_TRANSCODE_ENABLED", "false");
         std::env::set_var("REEL_ENCODE_CONCURRENCY", "2");

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -63,18 +63,17 @@ pub async fn vpn_status(urls: &[String]) -> VpnStatus {
     VpnStatus::Unverified
 }
 
-pub fn decide_vpn(status: VpnStatus, prev_ok: bool, streak: u32, threshold: u32) -> (bool, u32) {
+pub fn decide_vpn(status: VpnStatus, prev_ok: bool, streak: u32, _threshold: u32) -> (bool, u32) {
     match status {
         VpnStatus::Confirmed(_) => (true, 0),
         VpnStatus::Leak(_) => (false, 0),
-        VpnStatus::Unverified => {
-            let s = streak.saturating_add(1);
-            if s >= threshold.max(1) {
-                (false, s)
-            } else {
-                (prev_ok, s)
-            }
-        }
+        // Unverified means the check endpoints were unreachable — NOT that the
+        // tunnel leaked. Under heavy download the probes compete for tunnel
+        // bandwidth and time out, so pausing here would falsely drop every peer
+        // and thrash the swarm. Hold the previous state and lean on the gluetun
+        // killswitch (which blocks all non-tunnel egress) as the real barrier;
+        // only a Confirmed leak (a real non-VPN egress IP) forces a pause.
+        VpnStatus::Unverified => (prev_ok, streak.saturating_add(1)),
     }
 }
 
@@ -1090,8 +1089,15 @@ mod tests {
         let (ok2, s2) = decide_vpn(VpnStatus::Unverified, ok1, s1, 3);
         assert_eq!((ok2, s2), (true, 2), "2nd flake still holds");
         let (ok3, s3) = decide_vpn(VpnStatus::Unverified, ok2, s2, 3);
-        assert_eq!((ok3, s3), (false, 3), "3rd flake trips the pause");
+        assert_eq!((ok3, s3), (true, 3), "unverified never pauses — killswitch is the barrier");
+        let (ok4, s4) = decide_vpn(VpnStatus::Unverified, ok3, s3, 3);
+        assert_eq!((ok4, s4), (true, 4), "still holds past threshold");
 
+        assert_eq!(
+            decide_vpn(VpnStatus::Leak(ip), true, 9, 3),
+            (false, 0),
+            "a confirmed leak still pauses immediately"
+        );
         assert_eq!(
             decide_vpn(VpnStatus::Confirmed(ip), false, 3, 3),
             (true, 0),

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -99,6 +99,7 @@ pub struct HlsManager {
     ffmpeg_bin: String,
     segment_secs: u32,
     enabled: bool,
+    encode_threads: usize,
     children: Arc<Mutex<HashMap<String, Child>>>,
     delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
 }
@@ -110,6 +111,7 @@ impl HlsManager {
         ffmpeg_bin: String,
         segment_secs: u32,
         enabled: bool,
+        encode_threads: usize,
     ) -> Self {
         let this = Self {
             store,
@@ -117,6 +119,7 @@ impl HlsManager {
             ffmpeg_bin,
             segment_secs,
             enabled,
+            encode_threads,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
         };
@@ -254,6 +257,10 @@ impl HlsManager {
                 args.push("libx264".into());
                 args.push("-preset".into());
                 args.push("veryfast".into());
+                if self.encode_threads > 0 {
+                    args.push("-threads".into());
+                    args.push(self.encode_threads.to_string());
+                }
                 args.push("-c:a".into());
                 args.push("aac".into());
             }
@@ -418,7 +425,7 @@ mod mgr_tests {
     async fn abort_unknown_is_noop() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true, 1);
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
     }
@@ -427,7 +434,7 @@ mod mgr_tests {
     fn cached_delivery_none_then_some() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-cache-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true, 1);
         assert_eq!(mgr.cached_delivery("1"), None);
         mgr.cache_delivery("1", Delivery::RemuxHls);
         assert_eq!(mgr.cached_delivery("1"), Some(Delivery::RemuxHls));

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.ffmpeg_bin.clone(),
         cfg.ffprobe_bin.clone(),
         cfg.transcode_enabled,
+        cfg.encode_threads,
     );
 
     let hls = reel::hls::HlsManager::new(
@@ -35,6 +36,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.ffmpeg_bin.clone(),
         cfg.hls_segment_secs as u32,
         cfg.hls_enabled,
+        cfg.encode_threads,
     );
 
     tokio::spawn(reaper::reap_loop(

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -220,6 +220,7 @@ pub struct Transcoder {
     ffmpeg_bin: String,
     ffprobe_bin: String,
     enabled: bool,
+    encode_threads: usize,
     children: Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::process::Child>>>,
 }
 
@@ -231,6 +232,7 @@ impl Transcoder {
         ffmpeg_bin: String,
         ffprobe_bin: String,
         enabled: bool,
+        encode_threads: usize,
     ) -> Self {
         let this = Self {
             store,
@@ -239,6 +241,7 @@ impl Transcoder {
             ffmpeg_bin,
             ffprobe_bin,
             enabled,
+            encode_threads,
             children: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         };
         for m in this.store.list() {
@@ -397,13 +400,14 @@ impl Transcoder {
             }
             Route::Encode => {
                 let _permit = self.encode_sem.acquire().await?;
-                self.run_tracked(
-                    id,
-                    &["-c:v", "libx264", "-c:a", "aac", "-movflags", "+faststart"],
-                    &primary,
-                    &dest,
-                )
-                .await?;
+                let threads = self.encode_threads.to_string();
+                let mut args: Vec<&str> = vec!["-c:v", "libx264"];
+                if self.encode_threads > 0 {
+                    args.push("-threads");
+                    args.push(&threads);
+                }
+                args.extend_from_slice(&["-c:a", "aac", "-movflags", "+faststart"]);
+                self.run_tracked(id, &args, &primary, &dest).await?;
             }
         }
 
@@ -596,7 +600,7 @@ mod transcoder_tests {
         store.upsert(meta("none", TranscodeStatus::None)).unwrap();
 
         let _transcoder =
-            Transcoder::new(store.clone(), 1, 1, "ffmpeg".into(), "ffprobe".into(), true);
+            Transcoder::new(store.clone(), 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1);
 
         let pending = store.get("pending").unwrap();
         assert_eq!(pending.transcode, TranscodeStatus::Failed);

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -48,7 +48,7 @@ async fn hls_transcode_integration() {
     };
     store.upsert(entry).unwrap();
 
-    let mgr = reel::hls::HlsManager::new(store.clone(), 1, "ffmpeg".into(), 4, true);
+    let mgr = reel::hls::HlsManager::new(store.clone(), 1, "ffmpeg".into(), 4, true, 1);
     let outcome = mgr
         .request("test-hls", reel::transcode::Delivery::TranscodeHls)
         .await;


### PR DESCRIPTION
Three issues seen on the live pod.

## #1 — transcode fails with "interrupted by restart"
That message is only set on **startup reconcile**, so the pod was **restarting mid-transcode**. Root cause: the libx264 **encode** path saturates both CPU cores (limit `"2"`), starving the async runtime → `/healthz` misses the default **1s** probe timeout. Readiness flaps (pod pulled from the Service → upstream **502s**) and liveness kills the container → the in-flight transcode is marked "interrupted by restart" on the next pod. Remux (`-c copy`) is cheap, so only encode-path files (hevc, non-aac, …) trip it — matching "some files".

- **Cap ffmpeg encode threads** — `REEL_ENCODE_THREADS` (default 1), applied to both transcode and HLS-transcode, so a core stays free for the runtime/`/healthz`.
- **Relax both probes** — `timeoutSeconds: 5`, `failureThreshold: 6`, so transient load can't restart or de-register the pod.

## #2 — peers dropping + swarm restarting mid-download
- **`decide_vpn` no longer pauses on `Unverified`.** When the download saturates the tunnel, the VPN check endpoints (ipify, etc.) time out → `Unverified`. The old debounce tripped a *pause* after 3, which dropped **every peer**, then resumed — thrashing the swarm on a loop. `Unverified` ≠ leak; only a **Confirmed** non-VPN egress IP pauses now. The gluetun killswitch stays the real barrier.
- **`WIREGUARD_MTU=1320`** — BitTorrent saturating the tunnel with default MTU (1420) hits PMTU black holes that reset peer connections. 1320 is a safe WG-over-anything value.

## #3 — intermittent 502 / "missing auth header" on /status
Mostly a symptom of #1 (upstream down while the pod restarts) — fixed there. Also hardened the console: while **polling** (a snapshot already exists), a transient 401 (token-refresh gap) or 502/503 (pod rolling) now keeps the last good data instead of wiping the view and flashing an error; the next 4s tick recovers.

## Testing
- `cargo test -p reel` → 123 passed, 4 ignored (updated `decide_vpn` + `encode_threads` assertions).
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel (21 repo-wide = pre-existing generated-proto).
- reel.yaml validated as YAML.

reel 0.1.13 → 0.1.14.

Kube manifest: apps/kube/reel/manifest/reel.yaml