### PR TITLE
feat(reel): live transcode progress % + wider input format detection

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -250,7 +250,14 @@ export default function ReactReelConsole() {
 									</span>
 									<span>{progressLine(t, live[t.id])}</span>
 									{t.transcode !== 'None' && (
-										<span>transcode: {t.transcode}</span>
+										<span>
+											transcode: {t.transcode}
+											{t.transcode_progress != null &&
+											(t.transcode === 'Remuxing' ||
+												t.transcode === 'Encoding')
+												? ` ${t.transcode_progress}%`
+												: ''}
+										</span>
 									)}
 									{t.hls !== 'None' && (
 										<span>hls: {t.hls}</span>

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -50,6 +50,7 @@ export interface ReelTorrent {
 	error?: string | null;
 	transcode: ReelTranscodeStatus;
 	transcode_error?: string | null;
+	transcode_progress?: number | null;
 	hls: ReelHlsStatus;
 	hls_error?: string | null;
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.14"
+version: "0.1.15"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -159,6 +159,13 @@ Request-path media scans (`pick_primary_file`) run on a blocking thread pool so 
 large library tree can't stall the async runtime, and the hls.js player carries
 its scoped token in the `Authorization` header rather than the URL query — the
 token never lands in a manifest/segment request URL or a `Referer`.
+
+Transcode jobs report **live progress**: ffprobe reads the source duration, ffmpeg
+streams `-progress`, and reel derives a percent (0–100) held in memory (never
+persisted). `GET /status` surfaces it as `transcode_progress` and the console
+shows `transcode: Encoding 42%`. Input coverage is whatever the bundled ffmpeg
+supports — h264+aac passes through (remux), everything else re-encodes to h264/aac
+MP4.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -66,12 +66,23 @@ struct TorrentView {
     phase: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     live: Option<engine::TorrentLive>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcode_progress: Option<u8>,
 }
 
 impl TorrentView {
-    fn build(meta: state::Metadata, live: Option<engine::TorrentLive>) -> Self {
+    fn build(
+        meta: state::Metadata,
+        live: Option<engine::TorrentLive>,
+        transcode_progress: Option<u8>,
+    ) -> Self {
         let phase = derive_phase(&meta, live.as_ref());
-        Self { meta, phase, live }
+        Self {
+            meta,
+            phase,
+            live,
+            transcode_progress,
+        }
     }
 }
 
@@ -177,7 +188,8 @@ async fn status(State(st): State<AppState>, headers: HeaderMap) -> impl IntoResp
             state::TorrentState::Reaped => {}
         }
         let l = live.remove(&meta.id);
-        torrents.push(TorrentView::build(meta, l));
+        let progress = st.transcoder.progress_of(&meta.id);
+        torrents.push(TorrentView::build(meta, l, progress));
     }
     let bt_listen_port = st.engine.bt_listen_port();
     let forwarded_port = st.engine.forwarded_port();
@@ -206,7 +218,8 @@ async fn status_one(
         None => return StatusCode::NOT_FOUND.into_response(),
     };
     let live = st.engine.live_stats_map().remove(&id);
-    Json(TorrentView::build(meta, live)).into_response()
+    let progress = st.transcoder.progress_of(&id);
+    Json(TorrentView::build(meta, live, progress)).into_response()
 }
 
 async fn get_one(

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -627,9 +627,12 @@ pub struct FileEntry {
 
 fn is_media_name(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    [".mp4", ".mkv", ".webm", ".avi", ".mov", ".m4v", ".ts"]
-        .iter()
-        .any(|ext| lower.ends_with(ext))
+    [
+        ".mp4", ".mkv", ".webm", ".avi", ".mov", ".m4v", ".ts", ".m2ts", ".mts", ".flv", ".wmv",
+        ".mpg", ".mpeg", ".3gp", ".ogv",
+    ]
+    .iter()
+    .any(|ext| lower.ends_with(ext))
 }
 
 pub fn primary_file_index(files: &[FileEntry]) -> Option<usize> {

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -9,6 +9,20 @@ pub struct ProbeResult {
     pub video_codec: Option<String>,
     pub audio_codec: Option<String>,
     pub container: Option<String>,
+    pub duration_secs: Option<f64>,
+}
+
+pub fn progress_pct(out_time_us: u64, duration_secs: f64) -> u8 {
+    if duration_secs <= 0.0 {
+        return 0;
+    }
+    let pct = (out_time_us as f64 / 1_000_000.0) / duration_secs * 100.0;
+    pct.clamp(0.0, 100.0) as u8
+}
+
+pub fn parse_progress_line(line: &str) -> Option<(&str, &str)> {
+    let (k, v) = line.split_once('=')?;
+    Some((k.trim(), v.trim()))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -129,15 +143,21 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
             }
         }
     }
-    let container = json
-        .get("format")
+    let format = json.get("format");
+    let container = format
         .and_then(|f| f.get("format_name"))
         .and_then(|v| v.as_str())
         .map(String::from);
+    let duration_secs = format
+        .and_then(|f| f.get("duration"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|d| *d > 0.0);
     Ok(ProbeResult {
         video_codec: video,
         audio_codec: audio,
         container,
+        duration_secs,
     })
 }
 
@@ -222,6 +242,7 @@ pub struct Transcoder {
     enabled: bool,
     encode_threads: usize,
     children: Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::process::Child>>>,
+    progress: Arc<std::sync::Mutex<std::collections::HashMap<String, u8>>>,
 }
 
 impl Transcoder {
@@ -243,6 +264,7 @@ impl Transcoder {
             enabled,
             encode_threads,
             children: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            progress: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         };
         for m in this.store.list() {
             let in_flight = matches!(
@@ -311,24 +333,57 @@ impl Transcoder {
         args: &[&str],
         src: &std::path::Path,
         dest: &std::path::Path,
+        duration_secs: Option<f64>,
     ) -> anyhow::Result<()> {
         use tokio::io::AsyncReadExt;
         let mut cmd = Command::new(&self.ffmpeg_bin);
-        cmd.arg("-y")
-            .arg("-nostats")
-            .arg("-loglevel")
+        cmd.arg("-y").arg("-nostats");
+        if duration_secs.is_some() {
+            cmd.arg("-progress")
+                .arg("pipe:1")
+                .arg("-stats_period")
+                .arg("1");
+        }
+        cmd.arg("-loglevel")
             .arg("error")
             .arg("-i")
             .arg(src)
             .args(args)
             .arg(dest)
             .stderr(std::process::Stdio::piped());
+        if duration_secs.is_some() {
+            cmd.stdout(std::process::Stdio::piped());
+        }
         let mut child = cmd.spawn()?;
+        let stdout = child.stdout.take();
         let mut stderr = child.stderr.take();
         self.children
             .lock()
             .unwrap()
             .insert(id.to_string(), child);
+
+        if let (Some(stdout), Some(dur)) = (stdout, duration_secs) {
+            use tokio::io::AsyncBufReadExt;
+            let this = self.clone();
+            let id = id.to_string();
+            tokio::spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stdout).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if let Some((k, v)) = parse_progress_line(&line) {
+                        match k {
+                            // ffmpeg reports both keys in microseconds
+                            "out_time_us" | "out_time_ms" => {
+                                if let Ok(us) = v.parse::<u64>() {
+                                    this.set_progress(&id, progress_pct(us, dur));
+                                }
+                            }
+                            "progress" if v == "end" => this.set_progress(&id, 100),
+                            _ => {}
+                        }
+                    }
+                }
+            });
+        }
 
         let mut errbuf = String::new();
         if let Some(e) = stderr.as_mut() {
@@ -348,6 +403,18 @@ impl Transcoder {
 
     fn take_child(&self, id: &str) -> Option<tokio::process::Child> {
         self.children.lock().unwrap().remove(id)
+    }
+
+    fn set_progress(&self, id: &str, pct: u8) {
+        self.progress.lock().unwrap().insert(id.to_string(), pct);
+    }
+
+    fn clear_progress(&self, id: &str) {
+        self.progress.lock().unwrap().remove(id);
+    }
+
+    pub fn progress_of(&self, id: &str) -> Option<u8> {
+        self.progress.lock().unwrap().get(id).copied()
     }
 
     pub async fn abort(&self, id: &str) {
@@ -391,25 +458,38 @@ impl Transcoder {
             };
             ((), true)
         });
+        self.set_progress(id, 0);
+        let duration = probe.duration_secs;
 
-        match route {
-            Route::Remux => {
-                let _permit = self.remux_sem.acquire().await?;
-                self.run_tracked(id, &["-c", "copy", "-movflags", "+faststart"], &primary, &dest)
-                    .await?;
-            }
-            Route::Encode => {
-                let _permit = self.encode_sem.acquire().await?;
-                let threads = self.encode_threads.to_string();
-                let mut args: Vec<&str> = vec!["-c:v", "libx264"];
-                if self.encode_threads > 0 {
-                    args.push("-threads");
-                    args.push(&threads);
+        let result = async {
+            match route {
+                Route::Remux => {
+                    let _permit = self.remux_sem.acquire().await?;
+                    self.run_tracked(
+                        id,
+                        &["-c", "copy", "-movflags", "+faststart"],
+                        &primary,
+                        &dest,
+                        duration,
+                    )
+                    .await
                 }
-                args.extend_from_slice(&["-c:a", "aac", "-movflags", "+faststart"]);
-                self.run_tracked(id, &args, &primary, &dest).await?;
+                Route::Encode => {
+                    let _permit = self.encode_sem.acquire().await?;
+                    let threads = self.encode_threads.to_string();
+                    let mut args: Vec<&str> = vec!["-c:v", "libx264"];
+                    if self.encode_threads > 0 {
+                        args.push("-threads");
+                        args.push(&threads);
+                    }
+                    args.extend_from_slice(&["-c:a", "aac", "-movflags", "+faststart"]);
+                    self.run_tracked(id, &args, &primary, &dest, duration).await
+                }
             }
         }
+        .await;
+        self.clear_progress(id);
+        result?;
 
         let _ = self.store.update(id, |m| {
             m.transcode = TranscodeStatus::Ready;
@@ -430,7 +510,24 @@ mod tests {
             video_codec: v.map(String::from),
             audio_codec: a.map(String::from),
             container: c.map(String::from),
+            duration_secs: None,
         }
+    }
+
+    #[test]
+    fn progress_pct_computes_and_clamps() {
+        assert_eq!(progress_pct(0, 100.0), 0);
+        assert_eq!(progress_pct(50_000_000, 100.0), 50);
+        assert_eq!(progress_pct(100_000_000, 100.0), 100);
+        assert_eq!(progress_pct(200_000_000, 100.0), 100, "clamps over 100");
+        assert_eq!(progress_pct(50_000_000, 0.0), 0, "no duration → 0");
+    }
+
+    #[test]
+    fn parse_progress_line_splits_key_value() {
+        assert_eq!(parse_progress_line("out_time_us=4560000"), Some(("out_time_us", "4560000")));
+        assert_eq!(parse_progress_line("progress=end"), Some(("progress", "end")));
+        assert_eq!(parse_progress_line("garbage"), None);
     }
     #[test]
     fn h264_aac_remuxes() {


### PR DESCRIPTION
Answers "does transcoding give a % we can forward to the user?" — now yes.

## Live progress %
- `ffprobe` captures the source **duration** (`-show_format`).
- ffmpeg runs with `-progress pipe:1 -stats_period 1`; a reader task parses `out_time_us` → percent (`progress_pct`, clamped 0–100), and `progress=end` → 100.
- The percent lives in an **in-memory map on the Transcoder**, not in `Metadata` — it's ephemeral, so it's **never persisted** (avoids the state-file write amplification the old `touch` path suffered). Set to 0 on start, updated ~1/s, cleared on completion/failure.
- `GET /status` and `/torrents/{id}/status` expose `transcode_progress`; the staff console renders **`transcode: Encoding 42%`**.

## Input formats
Transcode input coverage is whatever the bundled ffmpeg (full Debian build) supports — mp4/mkv/webm/avi/mov/flv/wmv/mpeg/ts/… with h264/hevc/vp9/av1/…; h264+aac passes through (remux/raw), everything else re-encodes to h264/aac MP4. Also widened `is_media_name` (m2ts/mts/flv/wmv/mpg/mpeg/3gp/ogv) so more containers are picked as the primary file for **leech-time** streaming.

## Notes
- Percent needs a known duration; a source ffprobe can't get a duration for falls back to no percent (status still shows the phase).
- Remux (`-c copy`) is near-instant, so its bar mostly jumps 0→100; the encode path is where the live % matters.

## Testing
- `cargo test -p reel` → 125 passed, 4 ignored (added `progress_pct` + `parse_progress_line`).
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel (21 repo-wide = pre-existing generated-proto).

reel 0.1.14 → 0.1.15.

Kube manifest: apps/kube/reel/manifest/reel.yaml