### PR TITLE
feat(reel): transcode/download ETA + animated progress bars

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -201,6 +201,88 @@ import ReactReelConsole from '@/components/media/ReactReelConsole';
 		font-weight: 600;
 	}
 
+	:global(.reel-console__idle) {
+		color: #9ca3af;
+		font-size: 0.72rem;
+	}
+
+	:global(.reel-bar) {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		margin-top: 0.15rem;
+		min-width: 0;
+	}
+
+	:global(.reel-bar__track) {
+		position: relative;
+		height: 6px;
+		border-radius: 999px;
+		background: #27272a;
+		overflow: hidden;
+	}
+
+	:global(.reel-bar__fill) {
+		height: 100%;
+		border-radius: 999px;
+		transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	:global(.reel-bar--download .reel-bar__fill) {
+		background: linear-gradient(90deg, #34d399, #10b981);
+	}
+
+	:global(.reel-bar--transcode .reel-bar__fill) {
+		background: linear-gradient(90deg, #fbbf24, #f59e0b);
+	}
+
+	:global(.reel-bar--hls .reel-bar__fill) {
+		background: linear-gradient(90deg, #60a5fa, #3b82f6);
+	}
+
+	:global(.reel-bar__track--indeterminate .reel-bar__fill) {
+		width: 35%;
+		animation: reel-indet 1.2s ease-in-out infinite;
+	}
+
+	@keyframes reel-indet {
+		0% {
+			margin-left: -35%;
+		}
+		100% {
+			margin-left: 100%;
+		}
+	}
+
+	:global(.reel-bar__meta) {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem 0.75rem;
+		justify-content: space-between;
+		font-size: 0.7rem;
+	}
+
+	:global(.reel-bar__primary) {
+		color: #d4d4d8;
+		font-variant-numeric: tabular-nums;
+	}
+
+	:global(.reel-bar__secondary) {
+		color: #9ca3af;
+		font-variant-numeric: tabular-nums;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(.reel-bar__fill) {
+			transition: none;
+		}
+		:global(.reel-bar__track--indeterminate .reel-bar__fill) {
+			animation: none;
+			width: 100%;
+			opacity: 0.4;
+		}
+	}
+
 	:global(.reel-console__list) {
 		list-style: none;
 		margin: 0;

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -11,6 +11,9 @@ import {
 	deleteTorrent,
 	startTranscode,
 	refreshReelList,
+	formatEta,
+	formatSpeed,
+	downloadEtaSecs,
 	type ReelTorrent,
 	type ReelLive,
 } from './reelService';
@@ -46,27 +49,110 @@ function fmtSize(bytes: number): string {
 	return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
-function progressLine(t: ReelTorrent, live: ReelLive | undefined): string {
+interface BarModel {
+	variant: 'download' | 'transcode' | 'hls';
+	pct: number | null; // null → indeterminate
+	primary: string;
+	secondary?: string;
+}
+
+function joinDot(parts: (string | null | undefined)[]): string | undefined {
+	const kept = parts.filter((p): p is string => !!p);
+	return kept.length ? kept.join(' · ') : undefined;
+}
+
+function rowProgress(t: ReelTorrent, live: ReelLive | undefined): BarModel | null {
 	if (t.state === 'Leeching') {
-		if (!live || live.total_bytes === 0) {
-			const seen = live?.peers_seen ?? 0;
-			return seen > 0
-				? `resolving metadata • ${seen} peer${seen === 1 ? '' : 's'} seen`
-				: 'searching for peers…';
+		if (live && live.total_bytes > 0) {
+			const pct = Math.min(
+				100,
+				Math.floor((live.progress_bytes / live.total_bytes) * 100),
+			);
+			const eta = downloadEtaSecs(
+				live.progress_bytes,
+				live.total_bytes,
+				live.download_mbps,
+			);
+			return {
+				variant: 'download',
+				pct,
+				primary: `${pct}% · ${fmtSize(live.progress_bytes)} / ${fmtSize(live.total_bytes)}`,
+				secondary: joinDot([
+					live.download_mbps
+						? `${live.download_mbps.toFixed(1)} MiB/s`
+						: null,
+					`${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`,
+					eta != null ? formatEta(eta) : null,
+				]),
+			};
 		}
-		const pct = Math.min(
-			100,
-			Math.floor((live.progress_bytes / live.total_bytes) * 100),
-		);
-		const speed = live.download_mbps
-			? ` • ${live.download_mbps.toFixed(1)} MB/s`
-			: '';
-		return `${pct}% of ${fmtSize(live.total_bytes)}${speed} • ${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`;
+		const seen = live?.peers_seen ?? 0;
+		return {
+			variant: 'download',
+			pct: null,
+			primary: seen > 0 ? 'resolving metadata' : 'searching for peers…',
+			secondary: seen > 0 ? `${seen} seen` : undefined,
+		};
 	}
+	if (t.state === 'Seeding') {
+		if (t.transcode === 'Remuxing' || t.transcode === 'Encoding') {
+			const p = t.transcode_progress;
+			const pct = p?.pct ?? 0;
+			return {
+				variant: 'transcode',
+				pct,
+				primary: `transcoding ${pct}%`,
+				secondary: joinDot([
+					formatSpeed(p?.speed),
+					p?.eta_secs != null ? formatEta(p.eta_secs) : null,
+				]),
+			};
+		}
+		if (t.hls === 'Starting') {
+			return { variant: 'hls', pct: null, primary: 'preparing HLS…' };
+		}
+	}
+	return null;
+}
+
+function idleText(t: ReelTorrent, live: ReelLive | undefined): string {
 	if (t.state === 'Seeding' && live && live.upload_mbps) {
-		return `seeding • ↑ ${live.upload_mbps.toFixed(1)} MB/s • ${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`;
+		return `seeding · ↑ ${live.upload_mbps.toFixed(1)} MiB/s · ${live.peers_live} peer${live.peers_live === 1 ? '' : 's'}`;
 	}
+	if (t.state === 'Seeding') return `ready · ${fmtSize(t.size)}`;
 	return fmtSize(t.size);
+}
+
+function ProgressBar({ model }: { model: BarModel }) {
+	const indeterminate = model.pct == null;
+	return (
+		<div className={`reel-bar reel-bar--${model.variant}`}>
+			<div
+				className={`reel-bar__track${indeterminate ? ' reel-bar__track--indeterminate' : ''}`}
+				role="progressbar"
+				aria-label={model.primary}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				{...(indeterminate
+					? {}
+					: { 'aria-valuenow': model.pct as number })}>
+				<div
+					className="reel-bar__fill"
+					style={
+						indeterminate ? undefined : { width: `${model.pct}%` }
+					}
+				/>
+			</div>
+			<div className="reel-bar__meta">
+				<span className="reel-bar__primary">{model.primary}</span>
+				{model.secondary && (
+					<span className="reel-bar__secondary">
+						{model.secondary}
+					</span>
+				)}
+			</div>
+		</div>
+	);
 }
 
 export default function ReactReelConsole() {
@@ -248,21 +334,17 @@ export default function ReactReelConsole() {
 											? (PHASE_LABEL[t.phase] ?? t.phase)
 											: t.state}
 									</span>
-									<span>{progressLine(t, live[t.id])}</span>
-									{t.transcode !== 'None' && (
-										<span>
-											transcode: {t.transcode}
-											{t.transcode_progress != null &&
-											(t.transcode === 'Remuxing' ||
-												t.transcode === 'Encoding')
-												? ` ${t.transcode_progress}%`
-												: ''}
-										</span>
-									)}
-									{t.hls !== 'None' && (
-										<span>hls: {t.hls}</span>
-									)}
 								</span>
+								{(() => {
+									const model = rowProgress(t, live[t.id]);
+									return model ? (
+										<ProgressBar model={model} />
+									) : (
+										<span className="reel-console__idle">
+											{idleText(t, live[t.id])}
+										</span>
+									);
+								})()}
 								{(t.error ||
 									t.transcode_error ||
 									t.hls_error) && (

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -50,9 +50,15 @@ export interface ReelTorrent {
 	error?: string | null;
 	transcode: ReelTranscodeStatus;
 	transcode_error?: string | null;
-	transcode_progress?: number | null;
+	transcode_progress?: ReelTranscodeProgress | null;
 	hls: ReelHlsStatus;
 	hls_error?: string | null;
+}
+
+export interface ReelTranscodeProgress {
+	pct: number;
+	speed: number;
+	eta_secs?: number | null;
 }
 
 export interface ReelLive {
@@ -134,6 +140,37 @@ async function mediaToken(): Promise<string | null> {
 		mediaTokenCache = null;
 		return null;
 	}
+}
+
+export function formatEta(secs: number | null | undefined): string {
+	if (secs == null || !Number.isFinite(secs) || secs < 0) return '';
+	if (secs < 1) return 'almost done';
+	if (secs < 60) return `~${Math.round(secs)}s left`;
+	if (secs < 3600) {
+		const m = Math.floor(secs / 60);
+		const s = Math.round(secs % 60);
+		return s > 0 ? `~${m}m ${s}s left` : `~${m}m left`;
+	}
+	const h = Math.floor(secs / 3600);
+	const m = Math.round((secs % 3600) / 60);
+	return m > 0 ? `~${h}h ${m}m left` : `~${h}h left`;
+}
+
+export function formatSpeed(x: number | null | undefined): string {
+	if (x == null || !Number.isFinite(x) || x <= 0) return '';
+	return `${x.toFixed(x < 10 ? 1 : 0)}×`;
+}
+
+// librqbit reports speed in MiB/s
+export function downloadEtaSecs(
+	progressBytes: number,
+	totalBytes: number,
+	mibps: number,
+): number | null {
+	const remaining = totalBytes - progressBytes;
+	const bytesPerSec = mibps * 1024 * 1024;
+	if (remaining <= 0 || bytesPerSec <= 0) return null;
+	return remaining / bytesPerSec;
 }
 
 export function mediaUrl(id: string, suffix: string, token: string | null): string {

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.15"
+version: "0.1.16"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -160,12 +160,15 @@ large library tree can't stall the async runtime, and the hls.js player carries
 its scoped token in the `Authorization` header rather than the URL query — the
 token never lands in a manifest/segment request URL or a `Referer`.
 
-Transcode jobs report **live progress**: ffprobe reads the source duration, ffmpeg
-streams `-progress`, and reel derives a percent (0–100) held in memory (never
-persisted). `GET /status` surfaces it as `transcode_progress` and the console
-shows `transcode: Encoding 42%`. Input coverage is whatever the bundled ffmpeg
-supports — h264+aac passes through (remux), everything else re-encodes to h264/aac
-MP4.
+Transcode jobs report **live progress with an ETA**: ffprobe reads the source
+duration, ffmpeg streams `-progress`, and reel derives `{pct, speed, eta_secs}`
+held in memory (never persisted). `GET /status` surfaces it as
+`transcode_progress`. The staff console renders animated determinate bars for
+both **download** (percent, throughput, peers, ETA) and **transcode** (percent,
+encode speed ×, ETA), plus an indeterminate shimmer while resolving metadata or
+preparing HLS — all theme-aware and reduced-motion friendly. Input coverage is
+whatever the bundled ffmpeg supports — h264+aac passes through (remux),
+everything else re-encodes to h264/aac MP4.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -67,14 +67,14 @@ struct TorrentView {
     #[serde(skip_serializing_if = "Option::is_none")]
     live: Option<engine::TorrentLive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transcode_progress: Option<u8>,
+    transcode_progress: Option<transcode::TranscodeProgress>,
 }
 
 impl TorrentView {
     fn build(
         meta: state::Metadata,
         live: Option<engine::TorrentLive>,
-        transcode_progress: Option<u8>,
+        transcode_progress: Option<transcode::TranscodeProgress>,
     ) -> Self {
         let phase = derive_phase(&meta, live.as_ref());
         Self {

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -25,6 +25,33 @@ pub fn parse_progress_line(line: &str) -> Option<(&str, &str)> {
     Some((k.trim(), v.trim()))
 }
 
+pub fn parse_speed(v: &str) -> Option<f32> {
+    let v = v.trim().trim_end_matches('x').trim();
+    if v.eq_ignore_ascii_case("n/a") {
+        return None;
+    }
+    v.parse::<f32>().ok().filter(|s| *s > 0.0)
+}
+
+pub fn eta_secs(duration_secs: f64, out_time_us: u64, speed: f32) -> Option<u32> {
+    if speed <= 0.05 || duration_secs <= 0.0 {
+        return None;
+    }
+    let remaining = duration_secs - (out_time_us as f64 / 1_000_000.0);
+    if remaining <= 0.0 {
+        return Some(0);
+    }
+    Some((remaining / speed as f64).round().max(0.0) as u32)
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+pub struct TranscodeProgress {
+    pub pct: u8,
+    pub speed: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta_secs: Option<u32>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Route {
     Remux,
@@ -242,7 +269,7 @@ pub struct Transcoder {
     enabled: bool,
     encode_threads: usize,
     children: Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::process::Child>>>,
-    progress: Arc<std::sync::Mutex<std::collections::HashMap<String, u8>>>,
+    progress: Arc<std::sync::Mutex<std::collections::HashMap<String, TranscodeProgress>>>,
 }
 
 impl Transcoder {
@@ -368,16 +395,46 @@ impl Transcoder {
             let id = id.to_string();
             tokio::spawn(async move {
                 let mut lines = tokio::io::BufReader::new(stdout).lines();
+                let mut last_us = 0u64;
+                let mut last_speed = 0.0f32;
                 while let Ok(Some(line)) = lines.next_line().await {
                     if let Some((k, v)) = parse_progress_line(&line) {
                         match k {
                             // ffmpeg reports both keys in microseconds
                             "out_time_us" | "out_time_ms" => {
                                 if let Ok(us) = v.parse::<u64>() {
-                                    this.set_progress(&id, progress_pct(us, dur));
+                                    last_us = us;
+                                    this.set_progress(
+                                        &id,
+                                        TranscodeProgress {
+                                            pct: progress_pct(last_us, dur),
+                                            speed: last_speed,
+                                            eta_secs: eta_secs(dur, last_us, last_speed),
+                                        },
+                                    );
                                 }
                             }
-                            "progress" if v == "end" => this.set_progress(&id, 100),
+                            "speed" => {
+                                if let Some(s) = parse_speed(v) {
+                                    last_speed = s;
+                                    this.set_progress(
+                                        &id,
+                                        TranscodeProgress {
+                                            pct: progress_pct(last_us, dur),
+                                            speed: last_speed,
+                                            eta_secs: eta_secs(dur, last_us, last_speed),
+                                        },
+                                    );
+                                }
+                            }
+                            "progress" if v == "end" => this.set_progress(
+                                &id,
+                                TranscodeProgress {
+                                    pct: 100,
+                                    speed: last_speed,
+                                    eta_secs: Some(0),
+                                },
+                            ),
                             _ => {}
                         }
                     }
@@ -405,15 +462,15 @@ impl Transcoder {
         self.children.lock().unwrap().remove(id)
     }
 
-    fn set_progress(&self, id: &str, pct: u8) {
-        self.progress.lock().unwrap().insert(id.to_string(), pct);
+    fn set_progress(&self, id: &str, p: TranscodeProgress) {
+        self.progress.lock().unwrap().insert(id.to_string(), p);
     }
 
     fn clear_progress(&self, id: &str) {
         self.progress.lock().unwrap().remove(id);
     }
 
-    pub fn progress_of(&self, id: &str) -> Option<u8> {
+    pub fn progress_of(&self, id: &str) -> Option<TranscodeProgress> {
         self.progress.lock().unwrap().get(id).copied()
     }
 
@@ -458,7 +515,14 @@ impl Transcoder {
             };
             ((), true)
         });
-        self.set_progress(id, 0);
+        self.set_progress(
+            id,
+            TranscodeProgress {
+                pct: 0,
+                speed: 0.0,
+                eta_secs: None,
+            },
+        );
         let duration = probe.duration_secs;
 
         let result = async {
@@ -528,6 +592,24 @@ mod tests {
         assert_eq!(parse_progress_line("out_time_us=4560000"), Some(("out_time_us", "4560000")));
         assert_eq!(parse_progress_line("progress=end"), Some(("progress", "end")));
         assert_eq!(parse_progress_line("garbage"), None);
+    }
+
+    #[test]
+    fn parse_speed_strips_x_and_rejects_na() {
+        assert_eq!(parse_speed("1.85x"), Some(1.85));
+        assert_eq!(parse_speed(" 2x "), Some(2.0));
+        assert_eq!(parse_speed("N/A"), None);
+        assert_eq!(parse_speed("0x"), None);
+        assert_eq!(parse_speed("junk"), None);
+    }
+
+    #[test]
+    fn eta_secs_from_remaining_over_speed() {
+        // 100s total, 40s done, 2x → 30s remaining wall-clock
+        assert_eq!(eta_secs(100.0, 40_000_000, 2.0), Some(30));
+        assert_eq!(eta_secs(100.0, 100_000_000, 2.0), Some(0), "done → 0");
+        assert_eq!(eta_secs(100.0, 40_000_000, 0.0), None, "no speed → none");
+        assert_eq!(eta_secs(0.0, 0, 2.0), None, "no duration → none");
     }
     #[test]
     fn h264_aac_remuxes() {


### PR DESCRIPTION
Follows up the transcode-% PR with the "best UI/UX" pass.

## Backend
- Transcode progress is now `{pct, speed, eta_secs}`. The `-progress` reader parses ffmpeg's `speed=Nx` alongside `out_time` and computes an **ETA** (`remaining_secs / speed`). Still in-memory only, never persisted.
- `GET /status` exposes `transcode_progress` as that object.

## Frontend (staff console)
- **Animated determinate bars**:
  - **Download** — `42% · 230 MB / 549 MB` + `1.8 MiB/s · 7 peers · ~3m left`
  - **Transcode** — `transcoding 42%` + `1.8× · ~2m 10s left`
- **Indeterminate shimmer** while resolving metadata / searching for peers / preparing HLS.
- Download ETA from remaining bytes over the live rate (librqbit reports **MiB/s** — confirmed in its `Speed` Display).
- Colour-coded per variant (download=emerald, transcode=amber, hls=blue), tabular-nums so numbers don't jitter, `role="progressbar"` + `aria-valuenow`, and **reduced-motion aware** (transition + shimmer disabled under `prefers-reduced-motion`).
- Pure helpers `formatEta` / `formatSpeed` / `downloadEtaSecs`.

## Notes
- Transcode ETA needs a probe-able duration + a live speed; before the first `speed=` line it shows just the percent.
- Remux is near-instant (bar jumps 0→100); the ETA is meaningful on the encode path.

## Testing
- `cargo test -p reel` → 127 passed, 4 ignored (added `parse_speed` + `eta_secs`).
- `cargo clippy -p reel` clean (one pre-existing stream.rs warning untouched).
- `astro check` → 0 errors in media/reel (21 repo-wide = pre-existing generated-proto).

reel 0.1.15 → 0.1.16.

Kube manifest: apps/kube/reel/manifest/reel.yaml