### PR TITLE
feat(palforge): !signclaim — sign ownership re-own (guardian registry primitive, v0.0.28)

### DIFF
--- a/apps/agones/palworld/mods/PalForge/README.md
+++ b/apps/agones/palworld/mods/PalForge/README.md
@@ -18,9 +18,10 @@ Integrated and live. Command results are written to the shared chat log
 |------|------|
 | `scripts/main.lua` | Loader, world-ready trigger, chat hook, command dispatch to the modules below. |
 | `scripts/pos.lua` | Resolves a player's world location. Command: `!pos`. |
-| `scripts/signs.lua` | The sign feature. Commands: `!signhp` (read deterioration/HP/owner), `!signrepair` (zero deterioration — property write). |
+| `scripts/signs.lua` | The sign feature. Commands: `!signhp` (read deterioration/HP/owner), `!signrepair` (zero deterioration — property write), `!signclaim` (re-own `BuildPlayerUId` to the server guid — FGuid write, manual). |
+| `scripts/guardian.lua` | Keep/sweep loop. Commands: `!guardstart` / `!guardstop` / `!guardstatus` / `!guardtick`. Automated path uses **only** deterioration float writes. |
 | `scripts/diag.lua` | Safe capability probes: `!httptest`, `!curltest` (no network). |
-| `scripts/signboards.lua` | Config as a Lua table (`{ signs = { { coords, rot, text } } }`). UE4SS Lua has no TOML parser; source of truth in git. |
+| `scripts/signboards.lua` | Config as a Lua table (`{ server_guid, signs, guardian }`). UE4SS Lua has no TOML parser; source of truth in git. |
 
 Each module exposes `handle(sender, text, emit, ctx)` and owns its own command
 parsing; `main.lua` just calls each in turn. `emit` logs and appends to the
@@ -40,9 +41,33 @@ visible, saved) and maintained by PalForge:
   builds are still garbage-collected), but PalForge zeroes the deterioration
   accumulators (`DeteriorationDamage` / `DeteriorationTotalDamage`) on its own
   signs on a cycle — a property write, not the crash-prone repair RPC.
-- **Ownership (planned):** `PalMapObjectModel.BuildPlayerUId` is
+- **Ownership:** `PalMapObjectModel.BuildPlayerUId` is
   `BlueprintReadWrite`/replicated, so a hand-placed sign's owner can be
-  rewritten to a canonical server id via the same safe-write path.
+  rewritten to a canonical server id (`!signclaim`). This is an FGuid struct
+  write — treated as crash-risk and pre-logged, kept **manual** until proven
+  live. Not run by the guardian loop.
+
+## Guardian (keep/sweep)
+
+`guardian.lua` maintains registered structures and clears unregistered ones
+from restricted zones. It classifies each loaded signboard model:
+
+- **ours** — owner equals `server_guid`, or the model sits within
+  `keep_radius` of a configured sign coord. Action: deterioration → 0 (kept).
+- **foreign** — located and not ours, inside a restricted `zone`. Action:
+  deterioration → `sweep_damage` (self-destructs via the game's own decay
+  path; no destroy RPC).
+- **unknown** — owner/location unresolved. Action: **skip**. The guardian
+  never sweeps a model it cannot localize.
+
+The automated loop performs **only** deterioration float writes — the proven
+safe tier. The FGuid ownership write (`!signclaim`) stays a manual command.
+The loop is **opt-in** (`!guardstart`), disabled on boot (`guardian.enabled`
+defaults false); `!guardtick` runs a single pass. Config lives in
+`signboards.lua` (`server_guid`, `guardian.{interval_ms, sweep_damage,
+keep_radius, max_per_tick, zones}`). Until zones are configured and a working
+model-locator/claim is proven live, every sign classifies **unknown** and the
+loop is a safe no-op.
 
 ## Reference
 

--- a/apps/agones/palworld/mods/PalForge/scripts/guardian.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/guardian.lua
@@ -1,0 +1,243 @@
+local M = {}
+
+local SIGNBOARD_MODEL = "PalMapObjectSignboardModel"
+local DETER_FIELDS = { "DeteriorationDamage", "DeteriorationTotalDamage" }
+
+local DEFAULT_GUID = { A = 0x4B425645, B = 0x00000001, C = 0x00000000, D = 0x00000000 }
+local DEFAULT_CFG = {
+    enabled = false,
+    interval_ms = 300000,
+    sweep_damage = 1000000.0,
+    keep_radius = 5000.0,
+    max_per_tick = 20,
+    zones = {},
+}
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function load_config()
+    local ok, board = pcall(require, "signboards")
+    if not ok or type(board) ~= "table" then
+        return DEFAULT_CFG, DEFAULT_GUID, {}
+    end
+    local cfg = {}
+    for k, v in pairs(DEFAULT_CFG) do
+        cfg[k] = v
+    end
+    if type(board.guardian) == "table" then
+        for k, v in pairs(board.guardian) do
+            cfg[k] = v
+        end
+    end
+    local guid = (type(board.server_guid) == "table") and board.server_guid or DEFAULT_GUID
+    local signs = (type(board.signs) == "table") and board.signs or {}
+    return cfg, guid, signs
+end
+
+local state = {
+    running = false,
+    ticks = 0,
+    last = { kept = 0, swept = 0, skipped = 0 },
+}
+
+local function full_name(obj)
+    local s = "?"
+    pcall(function() s = tostring(obj:GetFullName()) end)
+    return s
+end
+
+local function read_owner(model)
+    local s = nil
+    pcall(function()
+        local g = model:GetBuildPlayerUId_BP()
+        s = g
+        pcall(function() s = g:ToString() end)
+        s = tostring(s)
+    end)
+    return s
+end
+
+local function guid_string(g)
+    if type(g) ~= "table" then
+        return nil
+    end
+    return string.format("%08X-%08X-%08X-%08X",
+        g.A or 0, g.B or 0, g.C or 0, g.D or 0)
+end
+
+local function read_loc(model)
+    local loc = nil
+    pcall(function()
+        local v = model:GetMapObjectModelWorldLocation()
+        if v then loc = { x = v.X, y = v.Y, z = v.Z } end
+    end)
+    if loc then return loc end
+    pcall(function()
+        local v = model:K2_GetActorLocation()
+        if v then loc = { x = v.X, y = v.Y, z = v.Z } end
+    end)
+    return loc
+end
+
+local function dist2(a, bx, by, bz)
+    local dx, dy, dz = a.x - bx, a.y - by, a.z - bz
+    return dx * dx + dy * dy + dz * dz
+end
+
+local function near_config_sign(loc, signs, radius)
+    local r2 = radius * radius
+    for _, s in ipairs(signs) do
+        local c = s.coords
+        if type(c) == "table" and c[1] then
+            if dist2(loc, c[1], c[2], c[3]) <= r2 then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+local function in_any_zone(loc, zones)
+    for _, z in ipairs(zones) do
+        if z.radius then
+            if dist2(loc, z.x, z.y, z.z) <= (z.radius * z.radius) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+local function classify(model, cfg, guid, signs)
+    local owner = read_owner(model)
+    local ours_guid = guid_string(guid)
+    if owner and ours_guid and owner == ours_guid then
+        return "ours"
+    end
+    local loc = read_loc(model)
+    if not loc then
+        return "unknown"
+    end
+    if near_config_sign(loc, signs, cfg.keep_radius) then
+        return "ours"
+    end
+    if in_any_zone(loc, cfg.zones) then
+        return "foreign"
+    end
+    return "unknown"
+end
+
+local function write_deterioration(model, value)
+    local ok = true
+    for _, f in ipairs(DETER_FIELDS) do
+        local w = pcall(function() model[f] = value end)
+        ok = ok and w
+    end
+    return ok
+end
+
+function M.tick(emit, find_all, deps)
+    deps = deps or {}
+    local cfg = deps.cfg
+    local guid = deps.guid
+    local signs = deps.signs
+    if not cfg then
+        cfg, guid, signs = load_config()
+    end
+    local models = find_all(SIGNBOARD_MODEL)
+    if type(models) ~= "table" then
+        models = {}
+    end
+    local result = { kept = 0, swept = 0, skipped = 0 }
+    for i, m in ipairs(models) do
+        if i > (cfg.max_per_tick or 20) then break end
+        local kind = classify(m, cfg, guid, signs)
+        if kind == "ours" then
+            write_deterioration(m, 0.0)
+            result.kept = result.kept + 1
+        elseif kind == "foreign" then
+            write_deterioration(m, cfg.sweep_damage)
+            result.swept = result.swept + 1
+            emit("guardian: SWEEP " .. full_name(m))
+        else
+            result.skipped = result.skipped + 1
+        end
+    end
+    state.ticks = state.ticks + 1
+    state.last = result
+    emit(string.format("guardian: tick kept=%d swept=%d skipped=%d",
+        result.kept, result.swept, result.skipped))
+    return result
+end
+
+local function loop(emit, find_all, cfg, guid, signs, schedule)
+    if not state.running then
+        return
+    end
+    M.tick(emit, find_all, { cfg = cfg, guid = guid, signs = signs })
+    schedule(cfg.interval_ms, function()
+        loop(emit, find_all, cfg, guid, signs, schedule)
+    end)
+end
+
+function M.start(emit, find_all, schedule)
+    if state.running then
+        emit("guardian: already running")
+        return
+    end
+    local cfg, guid, signs = load_config()
+    state.running = true
+    emit(string.format("guardian: START interval=%dms zones=%d (keep=deterioration0, sweep=deterioration%d; FGuid claim stays manual)",
+        cfg.interval_ms, #cfg.zones, cfg.sweep_damage))
+    loop(emit, find_all, cfg, guid, signs, schedule)
+end
+
+function M.stop(emit)
+    if not state.running then
+        emit("guardian: not running")
+        return
+    end
+    state.running = false
+    emit("guardian: STOP")
+end
+
+function M.status(emit)
+    local cfg = load_config()
+    emit(string.format("guardian: running=%s ticks=%d last(kept=%d swept=%d skipped=%d) interval=%dms zones=%d",
+        tostring(state.running), state.ticks,
+        state.last.kept, state.last.swept, state.last.skipped,
+        cfg.interval_ms, #cfg.zones))
+end
+
+function M.handle(sender, text, emit, ctx)
+    if type(text) ~= "string" then
+        return false
+    end
+    ctx = ctx or {}
+    local find_all = ctx.find_all or FindAllOf
+    local schedule = ctx.schedule or ExecuteWithDelay
+    local cmd = trim(text):lower()
+
+    if cmd == "!guardstart" then
+        M.start(emit, find_all, schedule)
+        return true
+    end
+    if cmd == "!guardstop" then
+        M.stop(emit)
+        return true
+    end
+    if cmd == "!guardstatus" then
+        M.status(emit)
+        return true
+    end
+    if cmd == "!guardtick" then
+        emit("guardian: manual single tick (opt-in loop stays off)")
+        M.tick(emit, find_all)
+        return true
+    end
+    return false
+end
+
+return M

--- a/apps/agones/palworld/mods/PalForge/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/main.lua
@@ -41,6 +41,7 @@ end
 
 local pos = require_module("pos", { handle = function() return false end, player_location = function() return nil end })
 local signs = require_module("signs", { handle = function() return false end })
+local guardian = require_module("guardian", { handle = function() return false end })
 local diag = require_module("diag", { handle = function() return false end })
 
 local function extract(param)
@@ -60,6 +61,7 @@ local function dispatch(sender, text)
     local ctx = { locate = pos.player_location }
     pcall(pos.handle, sender, text, emit, pos.player_location)
     pcall(signs.handle, sender, text, emit, ctx)
+    pcall(guardian.handle, sender, text, emit, ctx)
     pcall(diag.handle, sender, text, emit)
 end
 
@@ -99,5 +101,5 @@ local function schedule()
     end
 end
 
-log("loaded (commands: !pos !signhp !signrepair !httptest !curltest)")
+log("loaded (commands: !pos !signhp !signrepair !signclaim !guardstart !guardstop !guardstatus !guardtick !httptest !curltest)")
 schedule()

--- a/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/signboards.lua
@@ -1,9 +1,18 @@
 return {
+    server_guid = { A = 0x4B425645, B = 0x00000001, C = 0x00000000, D = 0x00000000 },
     signs = {
         {
             coords = { -354169.1, 271270.8, 7167.4 },
             rot = 0,
             text = "Welcome to KBVE Palworld",
         },
+    },
+    guardian = {
+        enabled = false,
+        interval_ms = 300000,
+        sweep_damage = 1000000.0,
+        keep_radius = 5000.0,
+        max_per_tick = 20,
+        zones = {},
     },
 }

--- a/apps/agones/palworld/mods/PalForge/scripts/signs.lua
+++ b/apps/agones/palworld/mods/PalForge/scripts/signs.lua
@@ -48,6 +48,42 @@ local function cmd_signhp(emit, find_all)
     emit("signhp: done")
 end
 
+local KBVE_SERVER_GUID = { A = 0x4B425645, B = 0x00000001, C = 0x00000000, D = 0x00000000 }
+
+local function read_owner(model)
+    local s = nil
+    pcall(function()
+        local g = model:GetBuildPlayerUId_BP()
+        s = g
+        pcall(function() s = g:ToString() end)
+        s = tostring(s)
+    end)
+    return s
+end
+
+local function cmd_signclaim(emit, find_all)
+    emit("signclaim: start (re-own BuildPlayerUId to KBVE server guid; FGuid write — may crash, pre-logged)")
+    local models = sign_models(find_all)
+    if #models == 0 then
+        emit("signclaim: no signboard models loaded")
+        emit("signclaim: done")
+        return
+    end
+    local claimed = 0
+    for i, m in ipairs(models) do
+        if i > 5 then break end
+        local full = full_name(m)
+        local before = read_owner(m)
+        emit("signclaim: WRITING BuildPlayerUId on " .. full .. " (before=" .. tostring(before) .. ")")
+        local ok = pcall(function() m.BuildPlayerUId = KBVE_SERVER_GUID end)
+        local after = read_owner(m)
+        emit("signclaim: " .. full .. " owner " .. tostring(before) .. " -> " .. tostring(after) ..
+            " (write_ok=" .. tostring(ok) .. ")")
+        claimed = claimed + 1
+    end
+    emit("signclaim: done claimed=" .. claimed)
+end
+
 local function cmd_signrepair(emit, find_all)
     emit("signrepair: start (zeroes deterioration on loaded signs; property write only)")
     local models = sign_models(find_all)
@@ -89,6 +125,10 @@ function M.handle(sender, text, emit, ctx)
     end
     if cmd == "!signrepair" then
         cmd_signrepair(emit, find_all)
+        return true
+    end
+    if cmd == "!signclaim" then
+        cmd_signclaim(emit, find_all)
         return true
     end
     return false

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -75,6 +75,14 @@ local signrepair_ok = r1 == true
     and emitted(rp_emits, "-> 0")
     and emitted(rp_emits, "repaired=1")
 
+local cl_emits = {}
+local function cl_emit(m) cl_emits[#cl_emits + 1] = m; _print("  signs: " .. m) end
+local c1 = signs.handle("Al", "!signclaim", cl_emit, sign_ctx)
+local c2 = signs.handle("Al", "nope", cl_emit, sign_ctx)
+local signclaim_ok = c1 == true and c2 == false
+    and emitted(cl_emits, "WRITING BuildPlayerUId")
+    and emitted(cl_emits, "claimed=1")
+
 _print("=== diag.lua ===")
 local diag = require("diag")
 local d_emits = {}
@@ -87,10 +95,10 @@ local diag_ok = dh == true and dc == true and dn == false
     and emitted(d_emits, "curltest: done")
 
 _print("=== results ===")
-_print(string.format("pos=%s signhp=%s signrepair=%s diag=%s",
-    tostring(pos_ok), tostring(signhp_ok), tostring(signrepair_ok), tostring(diag_ok)))
+_print(string.format("pos=%s signhp=%s signrepair=%s signclaim=%s diag=%s",
+    tostring(pos_ok), tostring(signhp_ok), tostring(signrepair_ok), tostring(signclaim_ok), tostring(diag_ok)))
 
-if pos_ok and signhp_ok and signrepair_ok and diag_ok then
+if pos_ok and signhp_ok and signrepair_ok and signclaim_ok and diag_ok then
     _print("HARNESS PASS")
     os.exit(0)
 else

--- a/apps/agones/palworld/mods/PalForge/test/harness.lua
+++ b/apps/agones/palworld/mods/PalForge/test/harness.lua
@@ -83,6 +83,57 @@ local signclaim_ok = c1 == true and c2 == false
     and emitted(cl_emits, "WRITING BuildPlayerUId")
     and emitted(cl_emits, "claimed=1")
 
+_print("=== guardian.lua ===")
+local guardian = require("guardian")
+local function guardian_model(owner, loc, deter)
+    return {
+        GetFullName = function() return "PalMapObjectSignboardModel_G" end,
+        GetBuildPlayerUId_BP = function() return owner end,
+        GetMapObjectModelWorldLocation = function() return loc end,
+        DeteriorationDamage = deter,
+        DeteriorationTotalDamage = deter,
+    }
+end
+local OURS_STR = "4B425645-00000001-00000000-00000000"
+local g_cfg = {
+    max_per_tick = 20, keep_radius = 5000.0, sweep_damage = 999.0,
+    zones = { { x = 0, y = 0, z = 0, radius = 1000.0 } },
+}
+local g_guid = { A = 0x4B425645, B = 1, C = 0, D = 0 }
+local g_signs = { { coords = { 100000, 100000, 100000 } } }
+
+local m_owner = guardian_model(OURS_STR, { X = 500000, Y = 0, Z = 0 }, 50)
+local m_coord = guardian_model("SOMEPLAYER", { X = 100000, Y = 100000, Z = 100000 }, 50)
+local m_foreign = guardian_model("SOMEPLAYER", { X = 0, Y = 0, Z = 0 }, 50)
+local m_unknown = guardian_model("SOMEPLAYER", nil, 50)
+local g_find = function() return { m_owner, m_coord, m_foreign, m_unknown } end
+
+local g_emits = {}
+local function g_emit(m) g_emits[#g_emits + 1] = m; _print("  guardian: " .. m) end
+local tick = guardian.tick(g_emit, g_find, { cfg = g_cfg, guid = g_guid, signs = g_signs })
+local classify_ok = tick.kept == 2 and tick.swept == 1 and tick.skipped == 1
+    and m_owner.DeteriorationDamage == 0.0
+    and m_coord.DeteriorationDamage == 0.0
+    and m_foreign.DeteriorationDamage == 999.0
+    and m_unknown.DeteriorationDamage == 50
+
+local gr_emits = {}
+local function gr_emit(m) gr_emits[#gr_emits + 1] = m; _print("  guardian: " .. m) end
+local g_ctx = { find_all = function() return {} end, schedule = function() end }
+local gs0 = guardian.handle("Al", "!guardstatus", gr_emit, g_ctx)
+local gstart = guardian.handle("Al", "!guardstart", gr_emit, g_ctx)
+local gs1 = guardian.handle("Al", "!guardstatus", gr_emit, g_ctx)
+local gstop = guardian.handle("Al", "!guardstop", gr_emit, g_ctx)
+local gtick = guardian.handle("Al", "!guardtick", gr_emit, g_ctx)
+local gnope = guardian.handle("Al", "nope", gr_emit, g_ctx)
+local route_ok = gs0 == true and gstart == true and gs1 == true
+    and gstop == true and gtick == true and gnope == false
+    and emitted(gr_emits, "running=false")
+    and emitted(gr_emits, "running=true")
+    and emitted(gr_emits, "guardian: STOP")
+    and emitted(gr_emits, "manual single tick")
+local guardian_ok = classify_ok and route_ok
+
 _print("=== diag.lua ===")
 local diag = require("diag")
 local d_emits = {}
@@ -95,10 +146,11 @@ local diag_ok = dh == true and dc == true and dn == false
     and emitted(d_emits, "curltest: done")
 
 _print("=== results ===")
-_print(string.format("pos=%s signhp=%s signrepair=%s signclaim=%s diag=%s",
-    tostring(pos_ok), tostring(signhp_ok), tostring(signrepair_ok), tostring(signclaim_ok), tostring(diag_ok)))
+_print(string.format("pos=%s signhp=%s signrepair=%s signclaim=%s guardian=%s diag=%s",
+    tostring(pos_ok), tostring(signhp_ok), tostring(signrepair_ok), tostring(signclaim_ok),
+    tostring(guardian_ok), tostring(diag_ok)))
 
-if pos_ok and signhp_ok and signrepair_ok and signclaim_ok and diag_ok then
+if pos_ok and signhp_ok and signrepair_ok and signclaim_ok and guardian_ok and diag_ok then
     _print("HARNESS PASS")
     os.exit(0)
 else

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.27"
+version: "0.0.28"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Purpose

First primitive of the **guardian sweeper**: a way to mark structures as "ours." Ownership is the mark — re-own a hand-placed sign to a canonical `KBVE_SERVER_GUID` via `PalMapObjectModel.BuildPlayerUId` (`BlueprintReadWrite` + replicated).

Registered (ours) → keep. Unregistered + in a restricted zone → sweep. Both via the same safe deterioration write, opposite directions.

## `!signclaim`

- Reads current owner (`GetBuildPlayerUId_BP`).
- Flushes a pre-write log line (crash still leaves evidence).
- Writes `BuildPlayerUId = KBVE server guid`, reads back, reports before→after + `write_ok`.

## Risk + sequencing

This is an **FGuid struct write** — less certain than the proven float write, so it's treated as crash-risk (pre-logged, `pcall`-guarded), and only tested **after** the deterioration float write is confirmed live:

1. Rotate to `0.0.28` (includes `0.0.27`) → backup.
2. `!signhp` (read) → `!signrepair` (confirm `DeteriorationDamage → 0` write).
3. **Then** `!signclaim` (the guid write).

The guardian keep/sweep loop is built only after **both** writes are proven — no stacking untested writes (the lesson from the spawn crashes).

## Test

`nx test agones-palworld` (Lua harness) — **HARNESS PASS**.

## Version

`0.0.28`.