### PR TITLE
chore(deps): remove unused react-helmet-async

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,6 @@
 		"phaser": "^4.2.0",
 		"pngjs": "^7.0.0",
 		"postprocessing": "^6.39.2",
-		"react-helmet-async": "^2.0.5",
 		"react-hook-form": "^7.53.1",
 		"react-is": "19.2.4",
 		"react-native": "0.85.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,9 +283,6 @@ importers:
       postprocessing:
         specifier: ^6.39.2
         version: 6.39.2(three@0.184.0)
-      react-helmet-async:
-        specifier: ^2.0.5
-        version: 2.0.5(react@19.2.3)
       react-hook-form:
         specifier: ^7.53.1
         version: 7.55.0(react@19.2.3)
@@ -13803,11 +13800,6 @@ packages:
     peerDependencies:
       react: 19.2.3
       react-dom: 19.2.3
-
-  react-helmet-async@2.0.5:
-    resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
-    peerDependencies:
-      react: 19.2.3
 
   react-hook-form@7.55.0:
     resolution: {integrity: sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==}
@@ -33907,7 +33899,8 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
-  react-fast-compare@3.2.2: {}
+  react-fast-compare@3.2.2:
+    optional: true
 
   react-freeze@1.0.4(react@19.2.3):
     dependencies:
@@ -33924,13 +33917,6 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
     optional: true
-
-  react-helmet-async@2.0.5(react@19.2.3):
-    dependencies:
-      invariant: 2.2.4
-      react: 19.2.3
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
 
   react-hook-form@7.55.0(react@19.2.3):
     dependencies:
@@ -35051,7 +35037,8 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  shallowequal@1.1.0: {}
+  shallowequal@1.1.0:
+    optional: true
 
   sharp@0.34.5:
     dependencies:


### PR DESCRIPTION
Removes the unused `react-helmet-async` direct dependency.

## Why
- No source file imports `react-helmet-async` (`<Helmet>`/`<HelmetProvider>`) anywhere in `apps/` or `packages/`.
- SEO/head handling already uses React 19 native `<title>`/`<meta>` hoisting — see [apps/jobboard/web/src/lib/seo.tsx](apps/jobboard/web/src/lib/seo.tsx) (comment explicitly avoids react-helmet).
- Root `react` is 19.2.3; the removed `^2.0.5` peers React 18 anyway.

## Relation to #14724
Dependabot opened #14724 to bump 2.0.5 → 3.0.0. Since the package is dead weight, removing it is cleaner than upgrading. Close #14724 after this merges.

Note: `react-helmet-async@1.3.0` remains in the lockfile as a transitive dep of `expo-router` — untouched and expected.