### PR TITLE
fix(reel): scope gluetun FIREWALL_OUTBOUND_SUBNETS so NAT-PMP reaches the VPN gateway

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -163,6 +163,13 @@ librqbit announces), `forwarded_port` (what gluetun currently forwards), and
 `inbound_ready` (true only when the two match). The staff console shows this as
 `● inbound :PORT` vs `○ outbound-only`.
 
+Port forwarding uses NAT-PMP against the WireGuard gateway (`10.2.0.1`), so
+`FIREWALL_OUTBOUND_SUBNETS` must **not** cover the tunnel gateway — a broad
+`10.0.0.0/8` swallows it and gluetun routes the NAT-PMP request outside the tunnel
+(`getting external IPv4 address … i/o timeout`, no forwarded port). It's scoped to
+the cluster pod + service CIDRs (`10.244.0.0/16`, `10.96.0.0/12`) instead, which
+excludes `10.2.0.0/16` while still letting reel answer in-cluster health probes.
+
 Request-path media scans (`pick_primary_file`) run on a blocking thread pool so a
 large library tree can't stall the async runtime, and the hls.js player carries
 its scoped token in the `Authorization` header rather than the URL query — the

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -37,7 +37,7 @@ spec:
           env:
             - { name: FIREWALL, value: "on" }
             - { name: FIREWALL_INPUT_PORTS, value: "8080" }
-            - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.0.0.0/8,172.16.0.0/12" }
+            - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.244.0.0/16,10.96.0.0/12" }
             - { name: WIREGUARD_MTU, value: "1320" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }


### PR DESCRIPTION
## Problem

With the crashloop fixed (#14834) the reel pod runs `0.1.16` and the VPN comes up through the provider — but **port forwarding fails**:

```
[port forwarding] starting
ERROR [vpn] starting port forwarding service: getting external IPv4 address:
  ... read udp 10.244.0.209:39474->10.2.0.1:5351: i/o timeout (tries 1..9)
  - make sure FIREWALL_OUTBOUND_SUBNETS does not conflict with the VPN gateway ip address 10.2.0.1
```

NAT-PMP asks the **WireGuard gateway `10.2.0.1`** for a forwarded port. But `FIREWALL_OUTBOUND_SUBNETS` was `10.0.0.0/8,172.16.0.0/12`, and `10.2.0.1` falls **inside `10.0.0.0/8`** — so gluetun routes the NAT-PMP request *outside* the tunnel (toward the pod LAN) → timeout → no forwarded port → `/status` stays `outbound-only`.

## Fix

Scope `FIREWALL_OUTBOUND_SUBNETS` to the **actual cluster CIDRs**:
- `10.244.0.0/16` (pod CIDR)
- `10.96.0.0/12` (service CIDR)

Both exclude the `10.2.0.0/16` tunnel range, so NAT-PMP stays inside the tunnel and reaches `10.2.0.1` → real forwarded port → **inbound peers + DHT**. reel still reaches pod/service networks to answer in-cluster health probes (the only outbound-bypass it needs; peers/trackers already go through the tunnel).

CIDRs verified against `apps/kube/talos-worker.yaml` (`serviceSubnets` / `podSubnets`) and live nodes.

## Deploy state
Stability fixes are already live (`0.1.16` serving after #14834). This is purely the inbound-peer lever. Kube-only, no image change → no version bump.

Docs: apps/kube/reel/manifest/
