### PR TITLE
fix(reel): keep BitTorrent listener locked to the dynamic VPN forwarded port

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.16"
+version: "0.1.17"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -162,6 +162,16 @@ peers) rather than failing to start.
 librqbit announces), `forwarded_port` (what gluetun currently forwards), and
 `inbound_ready` (true only when the two match). The staff console shows this as
 `● inbound :PORT` vs `○ outbound-only`.
+
+The forwarded port is **dynamic** — NAT-PMP settles on a port a few seconds after
+the tunnel comes up (the first value written can differ from the final one), and it
+rotates on every VPN reconnect. So reel doesn't trust a single early read: at startup
+it waits for the value to hold steady (`REEL_BT_PORT_STABLE_SECS`) before binding
+librqbit's listener, and a watcher (`REEL_BT_PORT_WATCH_SECS`) then compares the
+live `forwarded_port` against the bound `bt_listen_port` — on a durable mismatch it
+logs `vpn_forwarded_port_changed` and exits for a clean restart, so restart-resume
+rebinds the listener to the new port with no torrent loss. Without this the announced
+port silently drifts from the real forwarded port and inbound peers hit a dead port.
 
 Port forwarding uses NAT-PMP against the WireGuard gateway (`10.2.0.1`), so
 `FIREWALL_OUTBOUND_SUBNETS` must **not** cover the tunnel gateway — a broad

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -54,6 +54,8 @@ spec:
             - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
             - { name: REEL_BT_PORT_FILE, value: "/tmp/gluetun/forwarded_port" }
+            - { name: REEL_BT_PORT_STABLE_SECS, value: "45" }
+            - { name: REEL_BT_PORT_WATCH_SECS, value: "30" }
             - { name: REEL_ENCODE_THREADS, value: "1" }
           envFrom:
             - secretRef: { name: reel-api }
@@ -61,13 +63,13 @@ spec:
             - containerPort: 8080
           readinessProbe:
             httpGet: { path: /healthz, port: 8080 }
-            initialDelaySeconds: 5
+            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
           livenessProbe:
             httpGet: { path: /healthz, port: 8080 }
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 6

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub hls_segment_secs: u64,
     pub bt_port_file: Option<PathBuf>,
     pub bt_port_wait_secs: u64,
+    pub bt_port_stable_secs: u64,
+    pub bt_port_watch_secs: u64,
 }
 
 pub const DEFAULT_TRACKERS_URLS: &[&str] = &[
@@ -193,6 +195,8 @@ pub fn load_from_env() -> anyhow::Result<Config> {
             _ => None,
         },
         bt_port_wait_secs: env_u64("REEL_BT_PORT_WAIT_SECS", 20)?,
+        bt_port_stable_secs: env_u64("REEL_BT_PORT_STABLE_SECS", 45)?,
+        bt_port_watch_secs: env_u64("REEL_BT_PORT_WATCH_SECS", 30)?,
     })
 }
 
@@ -244,6 +248,8 @@ mod tests {
         assert!(c.api_token.is_none());
         assert!(c.bt_port_file.is_none());
         assert_eq!(c.bt_port_wait_secs, 20);
+        assert_eq!(c.bt_port_stable_secs, 45);
+        assert_eq!(c.bt_port_watch_secs, 30);
     }
 
     #[test]

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -84,12 +84,12 @@ pub fn parse_forwarded_port(raw: &str) -> Option<u16> {
     }
 }
 
-async fn await_forwarded_port(path: &std::path::Path, wait_secs: u64) -> Option<u16> {
+async fn await_forwarded_port(path: &std::path::Path, wait_secs: u64, stable_secs: u64) -> Option<u16> {
     let mut waited = 0u64;
-    loop {
+    let mut current = loop {
         if let Ok(raw) = std::fs::read_to_string(path) {
             if let Some(port) = parse_forwarded_port(&raw) {
-                return Some(port);
+                break port;
             }
         }
         if waited >= wait_secs {
@@ -97,6 +97,58 @@ async fn await_forwarded_port(path: &std::path::Path, wait_secs: u64) -> Option<
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
         waited += 1;
+    };
+    let mut steady = 0u64;
+    let cap = stable_secs.saturating_mul(2);
+    let mut elapsed = 0u64;
+    while steady < stable_secs && elapsed < cap {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        elapsed += 1;
+        match std::fs::read_to_string(path)
+            .ok()
+            .and_then(|r| parse_forwarded_port(&r))
+        {
+            Some(p) if p == current => steady += 1,
+            Some(p) => {
+                tracing::info!(from = current, to = p, "forwarded port changed during startup; re-stabilizing");
+                current = p;
+                steady = 0;
+            }
+            None => steady = 0,
+        }
+    }
+    Some(current)
+}
+
+pub async fn forwarded_port_watch_loop(engine: Engine, interval_secs: u64, restart: Arc<Notify>) {
+    if engine.bt_port_file.is_none() {
+        return;
+    }
+    let interval = Duration::from_secs(interval_secs.max(5));
+    let mut mismatches = 0u32;
+    loop {
+        tokio::time::sleep(interval).await;
+        match (engine.forwarded_port(), engine.bt_listen_port()) {
+            (Some(forwarded), Some(listen)) if forwarded != listen => {
+                mismatches += 1;
+                tracing::warn!(
+                    forwarded,
+                    listen,
+                    mismatches,
+                    "VPN forwarded port no longer matches BitTorrent listener"
+                );
+                if mismatches >= 2 {
+                    tracing::warn!(
+                        forwarded,
+                        listen,
+                        "vpn_forwarded_port_changed: restarting to rebind listener to the forwarded port"
+                    );
+                    restart.notify_one();
+                    return;
+                }
+            }
+            _ => mismatches = 0,
+        }
     }
 }
 
@@ -228,7 +280,7 @@ impl Engine {
         std::fs::create_dir_all(&cfg.library_dir)?;
         std::fs::create_dir_all(&cfg.session_dir)?;
         let listen_port_range = match &cfg.bt_port_file {
-            Some(path) => match await_forwarded_port(path, cfg.bt_port_wait_secs).await {
+            Some(path) => match await_forwarded_port(path, cfg.bt_port_wait_secs, cfg.bt_port_stable_secs).await {
                 Some(port) => {
                     tracing::info!(port, "using VPN forwarded port for BitTorrent listener");
                     Some(port..port.saturating_add(1))
@@ -989,6 +1041,30 @@ mod tests {
         assert_eq!(parse_forwarded_port(""), None);
         assert_eq!(parse_forwarded_port("notaport"), None);
         assert_eq!(parse_forwarded_port("70000"), None);
+    }
+
+    #[tokio::test]
+    async fn await_forwarded_port_returns_none_when_never_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("forwarded_port");
+        assert_eq!(await_forwarded_port(&path, 1, 1).await, None);
+    }
+
+    #[tokio::test]
+    async fn await_forwarded_port_adopts_late_settled_value() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("forwarded_port");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"33078")
+            .unwrap();
+        let p2 = path.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1200)).await;
+            std::fs::write(&p2, b"43287").unwrap();
+        });
+        assert_eq!(await_forwarded_port(&path, 2, 2).await, Some(43287));
     }
 
     #[test]

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -61,6 +61,13 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(state::persist_loop(store.clone(), cfg.state_flush_ms));
 
+    let restart = std::sync::Arc::new(tokio::sync::Notify::new());
+    tokio::spawn(engine::forwarded_port_watch_loop(
+        eng.clone(),
+        cfg.bt_port_watch_secs,
+        restart.clone(),
+    ));
+
     let store_for_flush = store.clone();
     let transcoder_for_shutdown = transcoder.clone();
     let hls_for_shutdown = hls.clone();
@@ -76,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(restart))
         .await?;
     tracing::info!("shutdown signal received; killing ffmpeg children and flushing state");
     transcoder_for_shutdown.abort_all().await;
@@ -87,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn shutdown_signal() {
+async fn shutdown_signal(restart: std::sync::Arc<tokio::sync::Notify>) {
     let ctrl_c = async {
         let _ = tokio::signal::ctrl_c().await;
     };
@@ -106,5 +113,8 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => {}
         _ = terminate => {}
+        _ = restart.notified() => {
+            tracing::warn!("restart requested by forwarded-port watcher");
+        }
     }
 }


### PR DESCRIPTION
## Problem

After the subnet fix (#14837) Proton **grants** a forwarded port — but reel still isn't reachable. The port is **dynamic** and reel treated it as static:

Observed on the live pod:
```
12:01:57  reel: using VPN forwarded port for BitTorrent listener  port=33078   <- read once, bound
12:02:46  gluetun: [port forwarding] port forwarded is 43287                    <- NAT-PMP settled elsewhere
          gluetun: writing port file /tmp/gluetun/forwarded_port                 <- file now 43287
```

reel read `/tmp/gluetun/forwarded_port` **once at startup** and pinned librqbit to `33078`, while gluetun actually forwards `43287`. So `bt_listen_port (33078) != forwarded_port (43287)` → **inbound peers hit a dead port** even though PF "works". Two dynamics cause this:
1. **Settle race** — NAT-PMP finalizes on a port a few seconds *after* the tunnel is up; the first value written can differ from the final one. reel read too early.
2. **Rotation** — on every VPN reconnect Proton hands out a new port; reel never re-reads.

## Fix

Keep librqbit's listener locked to whatever gluetun currently forwards:

- **Startup stabilization** — `await_forwarded_port` now waits for the value to hold steady for `REEL_BT_PORT_STABLE_SECS` (default 45, capped) before binding, absorbing the settle race.
- **Runtime watcher** — `forwarded_port_watch_loop` compares the live `forwarded_port` (file) against the bound `bt_listen_port` (session) every `REEL_BT_PORT_WATCH_SECS` (default 30). On a *durable* mismatch (2 consecutive checks, to ignore write races) it logs `vpn_forwarded_port_changed` and fires a graceful shutdown → k8s restarts → **restart-resume rebinds** the listener to the new port with no torrent loss.
- **Probes** — `livenessProbe.initialDelaySeconds` widened to 90 to cover the stabilization window before `/healthz` comes up; `readiness` to 15. Two tuning envs added.

## Test / verify
- 129 tests (added: `await_forwarded_port` returns None when never written; adopts a late-settled value after an in-flight change). clippy clean (only pre-existing `stream.rs:13`).
- Post-deploy, `/status` should show `bt_listen_port == forwarded_port` and `inbound_ready: true` (console `● inbound :PORT`), and stay matched across a gluetun PF refresh.

mdx 0.1.16 → 0.1.17.

Docs: apps/kube/reel/manifest/
