### PR TITLE
fix(reel): stop forwarded-port restart-loop on a rotating NAT-PMP exit

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -164,14 +164,22 @@ librqbit announces), `forwarded_port` (what gluetun currently forwards), and
 `● inbound :PORT` vs `○ outbound-only`.
 
 The forwarded port is **dynamic** — NAT-PMP settles on a port a few seconds after
-the tunnel comes up (the first value written can differ from the final one), and it
-rotates on every VPN reconnect. So reel doesn't trust a single early read: at startup
-it waits for the value to hold steady (`REEL_BT_PORT_STABLE_SECS`) before binding
-librqbit's listener, and a watcher (`REEL_BT_PORT_WATCH_SECS`) then compares the
-live `forwarded_port` against the bound `bt_listen_port` — on a durable mismatch it
-logs `vpn_forwarded_port_changed` and exits for a clean restart, so restart-resume
-rebinds the listener to the new port with no torrent loss. Without this the announced
-port silently drifts from the real forwarded port and inbound peers hit a dead port.
+the tunnel comes up (the first value written can differ from the final one). So reel
+doesn't trust a single early read: at startup it waits for the value to hold steady
+(`REEL_BT_PORT_STABLE_SECS`) before binding librqbit's listener, and a watcher
+(`REEL_BT_PORT_WATCH_SECS`) compares the live `forwarded_port` against the bound
+`bt_listen_port` — on a durable mismatch it logs `vpn_forwarded_port_changed` and
+exits for a clean restart so restart-resume rebinds with no torrent loss.
+
+That rebind only makes sense when the port is otherwise **stable**. On the current
+provider exit it isn't — gluetun's NAT-PMP renewal returns a *new* external port
+roughly every 90s (`requested as N but received M`), so the forwarded port rotates
+continuously and can never match a pinned socket. Chasing it would restart-loop, so
+`REEL_BT_PORT_WATCH_SECS` is set very high to disable the rebind: reel binds its
+startup port once and stays put. The service runs **outbound-only** (fine for
+well-seeded torrents; peer stability comes from the VPN watchdog + MTU + encode-cap
+fixes, not inbound PF). If a future exit holds the port, lowering the interval
+re-enables live rebind.
 
 Port forwarding uses NAT-PMP against the WireGuard gateway (`10.2.0.1`), so
 `FIREWALL_OUTBOUND_SUBNETS` must **not** cover the tunnel gateway — a broad

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -55,7 +55,7 @@ spec:
             - { name: REEL_LOG_JSON, value: "true" }
             - { name: REEL_BT_PORT_FILE, value: "/tmp/gluetun/forwarded_port" }
             - { name: REEL_BT_PORT_STABLE_SECS, value: "45" }
-            - { name: REEL_BT_PORT_WATCH_SECS, value: "30" }
+            - { name: REEL_BT_PORT_WATCH_SECS, value: "86400" }
             - { name: REEL_ENCODE_THREADS, value: "1" }
           envFrom:
             - secretRef: { name: reel-api }


### PR DESCRIPTION
## Problem

Port-forwarding is mechanically working now, but the **forwarded port rotates continuously** on this ProtonVPN exit — gluetun's NAT-PMP renewal returns a *new* external port roughly every 90s:

```
13:05:53  port forwarded is 39523
13:06:54  refreshing ... requested as 39523 but received 53554  → port forwarded is 65319
13:08:26  refreshing ... requested as 65319 but received 62557  → port forwarded is 34943
13:09:19  refreshing ... requested as 34943 but received 48852  → ...
```

librqbit binds one socket, so a port that moves every 90s can never stay matched. The rebind-on-change watcher shipped in 0.1.17 (#14838) then **restart-loops** chasing it (`reel_restarts` climbing).

This is a gluetun↔ProtonVPN NAT-PMP behavior (renewal not sticky), not a reel bug and not the VPN tunnel — the WireGuard tunnel itself is stable. gluetun is already on `latest`, so it's not a version issue.

## Fix

Set `REEL_BT_PORT_WATCH_SECS` very high (86400) to **disable the rebind**: reel binds its startup port once and stays put — no restart-loop. The service runs **outbound-only**, which is fine for well-seeded torrents. Peer stability (the original "peers dropping mid-download" complaint) comes from the VPN watchdog + `WIREGUARD_MTU` + encode-thread-cap fixes (live since 0.1.16), **not** inbound PF.

Startup stabilization (`REEL_BT_PORT_STABLE_SECS`) stays on. If a future exit holds the port, lowering `REEL_BT_PORT_WATCH_SECS` re-enables live rebind — no code change needed.

Kube + doc only, no image change → no version bump.

## After this
- reel stops restart-looping → stable single pod.
- `/status` may show `outbound-only` (or brief `inbound` right after a bind); that's expected on a rotating exit.

Docs: apps/kube/reel/manifest/
