### PR TITLE
fix(reel): copy h264 video instead of re-encoding it; only transcode audio

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.17"
+version: "0.1.18"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -199,9 +199,18 @@ held in memory (never persisted). `GET /status` surfaces it as
 `transcode_progress`. The staff console renders animated determinate bars for
 both **download** (percent, throughput, peers, ETA) and **transcode** (percent,
 encode speed ×, ETA), plus an indeterminate shimmer while resolving metadata or
-preparing HLS — all theme-aware and reduced-motion friendly. Input coverage is
-whatever the bundled ffmpeg supports — h264+aac passes through (remux),
-everything else re-encodes to h264/aac MP4.
+preparing HLS — all theme-aware and reduced-motion friendly.
+
+Routing keys on the **video** codec, not the whole codec pair. Re-encoding h264 with
+libx264 is the slow part (minutes-to-hours on a single core), and it's almost never
+needed: the browser plays h264 directly. So any file whose **video is already h264**
+copies the video stream untouched (`-c:v copy`) and only touches the audio —
+`-c:a copy` when it's already aac, `-c:a aac` when it isn't (ac3/eac3/dts/mp3/opus).
+That makes "hit Play on a finished h264" resolve in seconds regardless of its audio
+or container, instead of kicking off a full re-encode. A true video re-encode
+(`-c:v libx264`) is reserved for genuinely incompatible video — hevc/av1/mpeg2 —
+where there's no way around it. h264+aac in an mp4 still streams raw with no ffmpeg
+at all.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -377,6 +377,7 @@ async fn manifest(
                 match d {
                     transcode::Delivery::RawProgressive => "raw_progressive",
                     transcode::Delivery::RemuxHls => "remux_hls",
+                    transcode::Delivery::CopyVideoHls => "copy_video_hls",
                     transcode::Delivery::TranscodeHls => "transcode_hls",
                 },
             );

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -47,6 +47,7 @@ fn delivery_label(d: Delivery) -> &'static str {
     match d {
         Delivery::RawProgressive => "raw_progressive",
         Delivery::RemuxHls => "remux_hls",
+        Delivery::CopyVideoHls => "copy_video_hls",
         Delivery::TranscodeHls => "transcode_hls",
     }
 }
@@ -251,6 +252,12 @@ impl HlsManager {
             Delivery::RemuxHls => {
                 args.push("-c".into());
                 args.push("copy".into());
+            }
+            Delivery::CopyVideoHls => {
+                args.push("-c:v".into());
+                args.push("copy".into());
+                args.push("-c:a".into());
+                args.push("aac".into());
             }
             Delivery::TranscodeHls => {
                 args.push("-c:v".into());

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -62,11 +62,12 @@ pub enum Route {
 pub enum Delivery {
     RawProgressive,
     RemuxHls,
+    CopyVideoHls,
     TranscodeHls,
 }
 
 pub fn decide_route(p: &ProbeResult) -> Route {
-    if p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac") {
+    if p.video_codec.as_deref() == Some("h264") {
         Route::Remux
     } else {
         Route::Encode
@@ -74,10 +75,11 @@ pub fn decide_route(p: &ProbeResult) -> Route {
 }
 
 pub fn decide_delivery(p: &ProbeResult) -> Delivery {
-    let compat_codecs =
-        p.video_codec.as_deref() == Some("h264") && p.audio_codec.as_deref() == Some("aac");
-    if !compat_codecs {
+    if p.video_codec.as_deref() != Some("h264") {
         return Delivery::TranscodeHls;
+    }
+    if p.audio_codec.as_deref() != Some("aac") {
+        return Delivery::CopyVideoHls;
     }
     let is_mp4 = p
         .container
@@ -529,14 +531,15 @@ impl Transcoder {
             match route {
                 Route::Remux => {
                     let _permit = self.remux_sem.acquire().await?;
-                    self.run_tracked(
-                        id,
-                        &["-c", "copy", "-movflags", "+faststart"],
-                        &primary,
-                        &dest,
-                        duration,
-                    )
-                    .await
+                    let audio_aac = probe.audio_codec.as_deref() == Some("aac");
+                    let mut args: Vec<&str> = vec!["-c:v", "copy"];
+                    if audio_aac {
+                        args.extend_from_slice(&["-c:a", "copy"]);
+                    } else {
+                        args.extend_from_slice(&["-c:a", "aac"]);
+                    }
+                    args.extend_from_slice(&["-movflags", "+faststart"]);
+                    self.run_tracked(id, &args, &primary, &dest, duration).await
                 }
                 Route::Encode => {
                     let _permit = self.encode_sem.acquire().await?;
@@ -626,10 +629,11 @@ mod tests {
         );
     }
     #[test]
-    fn non_aac_audio_encodes() {
+    fn h264_non_aac_audio_still_remuxes() {
         assert_eq!(
             decide_route(&pr(Some("h264"), Some("ac3"), None)),
-            Route::Encode
+            Route::Remux,
+            "h264 video is copied; only audio is transcoded"
         );
     }
     #[test]
@@ -662,10 +666,18 @@ mod tests {
         );
     }
     #[test]
-    fn non_aac_is_transcode_hls() {
+    fn h264_non_aac_mp4_is_copy_video_hls() {
         assert_eq!(
             decide_delivery(&pr(Some("h264"), Some("ac3"), Some("mov,mp4,m4a"))),
-            Delivery::TranscodeHls
+            Delivery::CopyVideoHls,
+            "h264 video copied, audio transcoded to aac — no video re-encode"
+        );
+    }
+    #[test]
+    fn h264_non_aac_mkv_is_copy_video_hls() {
+        assert_eq!(
+            decide_delivery(&pr(Some("h264"), Some("eac3"), Some("matroska,webm"))),
+            Delivery::CopyVideoHls
         );
     }
     #[test]


### PR DESCRIPTION
## Problem

Hit Play on a finished **h264** file → nothing plays; the Transcode button then estimates **~3 hours**.

Root cause (traced live): routing only treated **exactly `h264+aac`** as "no re-encode". A file with h264 video + **non-aac audio** (ac3/eac3/dts/mp3/opus — extremely common in downloads) fell into `Delivery::TranscodeHls` / `Route::Encode`, which runs `-c:v libx264` — **re-encoding the video from scratch**. That's the multi-hour job. The browser plays h264 natively; only the *audio* ever needed converting.

`Play` itself works (auto-starts HLS and polls `/manifest`) — it just polled silently for hours behind the needless video encode, then timed out. "Nothing happened."

## Fix — route on the video codec

When the **video is already h264**, copy it and touch only the audio:

| Input | Before | After |
|-------|--------|-------|
| h264 + aac + mp4 | raw byte-range | raw byte-range (unchanged) |
| h264 + aac + mkv | remux `-c copy` | remux `-c copy` (unchanged) |
| **h264 + non-aac** | **full `-c:v libx264` (hours)** | **`-c:v copy -c:a aac` (seconds)** |
| hevc/av1/mpeg2 | full transcode | full transcode (unavoidable) |

- `decide_route`: `video==h264 → Remux` (copy video); else `Encode`.
- `run_job` remux: `-c:v copy` + `-c:a copy` when aac else `-c:a aac` (+faststart).
- `decide_delivery`: adds `Delivery::CopyVideoHls` (`-c:v copy -c:a aac`, cheap — does **not** take the `encode_sem` slot). Full `TranscodeHls` reserved for non-h264 video.

**Result:** "hit Play on a finished h264" resolves in **seconds** regardless of audio/container, matching the expected UX (Play = watch now).

## Notes
- Byte-range `/stream` (206/seeking) already correct in `stream.rs` — untouched.
- The dead standalone `remux()`/`encode()` helpers left as-is (not in the routing path).
- 130 tests (existing tests that encoded the old h264+ac3→Encode/TranscodeHls behavior flipped to Remux/CopyVideoHls; added mkv+non-aac case). clippy clean (only pre-existing `stream.rs:13`).

mdx 0.1.17 → 0.1.18.

Docs: apps/kube/reel/manifest/
