### PR TITLE
fix(reel): robust stream mapping + cover-art handling for MKV/AVI/edge files

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.18"
+version: "0.1.19"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -211,6 +211,17 @@ or container, instead of kicking off a full re-encode. A true video re-encode
 (`-c:v libx264`) is reserved for genuinely incompatible video — hevc/av1/mpeg2 —
 where there's no way around it. h264+aac in an mp4 still streams raw with no ffmpeg
 at all.
+
+Container edge cases are handled explicitly so odd files don't wedge ffmpeg. Every
+ffmpeg invocation maps exactly the first real video stream and (optionally) the first
+audio stream — `-map 0:V:0 -map 0:a:0?` — which drops subtitle, data, and attachment
+streams. Without that, an MKV or AVI carrying subtitle tracks makes a `-c copy`
+remux fail outright (subrip/ass can't be muxed into MPEG-TS or MP4). The optional
+audio map (`?`) means a video with no audio track transcodes cleanly instead of
+erroring. ffprobe also ignores **attached-picture** streams (embedded cover art,
+reported as an mjpeg/png "video") when detecting the codec, so an h264 file with a
+poster frame routes as h264 rather than being mistaken for an image and sent to a
+full re-encode.
 
 </BentoProse>
 

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -248,6 +248,11 @@ impl HlsManager {
             "-i".into(),
             primary.display().to_string(),
         ];
+        args.extend(
+            crate::transcode::MAP_VIDEO_AUDIO
+                .iter()
+                .map(|s| s.to_string()),
+        );
         match delivery {
             Delivery::RemuxHls => {
                 args.push("-c".into());

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use tokio::process::Command;
 use tokio::sync::Semaphore;
 
+pub(crate) const MAP_VIDEO_AUDIO: &[&str] = &["-map", "0:V:0", "-map", "0:a:0?"];
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProbeResult {
     pub video_codec: Option<String>,
@@ -78,7 +80,8 @@ pub fn decide_delivery(p: &ProbeResult) -> Delivery {
     if p.video_codec.as_deref() != Some("h264") {
         return Delivery::TranscodeHls;
     }
-    if p.audio_codec.as_deref() != Some("aac") {
+    let audio_ok = p.audio_codec.is_none() || p.audio_codec.as_deref() == Some("aac");
+    if !audio_ok {
         return Delivery::CopyVideoHls;
     }
     let is_mp4 = p
@@ -156,6 +159,10 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
         anyhow::bail!("ffprobe failed: {}", String::from_utf8_lossy(&out.stderr));
     }
     let json: serde_json::Value = serde_json::from_slice(&out.stdout)?;
+    Ok(parse_probe_json(&json))
+}
+
+pub fn parse_probe_json(json: &serde_json::Value) -> ProbeResult {
     let mut video = None;
     let mut audio = None;
     if let Some(streams) = json.get("streams").and_then(|s| s.as_array()) {
@@ -165,8 +172,14 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
                 .get("codec_name")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let is_cover = s
+                .get("disposition")
+                .and_then(|d| d.get("attached_pic"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0)
+                == 1;
             match kind {
-                Some("video") if video.is_none() => video = codec,
+                Some("video") if video.is_none() && !is_cover => video = codec,
                 Some("audio") if audio.is_none() => audio = codec,
                 _ => {}
             }
@@ -182,12 +195,12 @@ pub async fn probe(ffprobe_bin: &str, path: &Path) -> anyhow::Result<ProbeResult
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<f64>().ok())
         .filter(|d| *d > 0.0);
-    Ok(ProbeResult {
+    ProbeResult {
         video_codec: video,
         audio_codec: audio,
         container,
         duration_secs,
-    })
+    }
 }
 
 async fn run_ffmpeg(
@@ -532,7 +545,8 @@ impl Transcoder {
                 Route::Remux => {
                     let _permit = self.remux_sem.acquire().await?;
                     let audio_aac = probe.audio_codec.as_deref() == Some("aac");
-                    let mut args: Vec<&str> = vec!["-c:v", "copy"];
+                    let mut args: Vec<&str> = MAP_VIDEO_AUDIO.to_vec();
+                    args.extend_from_slice(&["-c:v", "copy"]);
                     if audio_aac {
                         args.extend_from_slice(&["-c:a", "copy"]);
                     } else {
@@ -544,7 +558,8 @@ impl Transcoder {
                 Route::Encode => {
                     let _permit = self.encode_sem.acquire().await?;
                     let threads = self.encode_threads.to_string();
-                    let mut args: Vec<&str> = vec!["-c:v", "libx264"];
+                    let mut args: Vec<&str> = MAP_VIDEO_AUDIO.to_vec();
+                    args.extend_from_slice(&["-c:v", "libx264"]);
                     if self.encode_threads > 0 {
                         args.push("-threads");
                         args.push(&threads);
@@ -686,6 +701,37 @@ mod tests {
             decide_delivery(&pr(None, None, None)),
             Delivery::TranscodeHls
         );
+    }
+    #[test]
+    fn probe_skips_cover_art_video_stream() {
+        let json = serde_json::json!({
+            "streams": [
+                {"codec_type": "video", "codec_name": "mjpeg", "disposition": {"attached_pic": 1}},
+                {"codec_type": "video", "codec_name": "h264"},
+                {"codec_type": "audio", "codec_name": "aac"}
+            ],
+            "format": {"format_name": "mov,mp4,m4a", "duration": "12.5"}
+        });
+        let p = parse_probe_json(&json);
+        assert_eq!(p.video_codec.as_deref(), Some("h264"), "cover art skipped");
+        assert_eq!(p.audio_codec.as_deref(), Some("aac"));
+        assert_eq!(p.duration_secs, Some(12.5));
+        assert_eq!(decide_route(&p), Route::Remux, "not misrouted to encode");
+    }
+    #[test]
+    fn probe_handles_no_audio_stream() {
+        let json = serde_json::json!({
+            "streams": [{"codec_type": "video", "codec_name": "h264"}],
+            "format": {"format_name": "avi"}
+        });
+        let p = parse_probe_json(&json);
+        assert_eq!(p.video_codec.as_deref(), Some("h264"));
+        assert_eq!(p.audio_codec, None);
+        assert_eq!(decide_delivery(&p), Delivery::RemuxHls, "h264 no-audio remuxes");
+    }
+    #[test]
+    fn map_selects_real_video_and_optional_audio() {
+        assert_eq!(MAP_VIDEO_AUDIO, &["-map", "0:V:0", "-map", "0:a:0?"]);
     }
     #[test]
     fn picks_largest_file() {


### PR DESCRIPTION
Follow-up to #14853 — hardening the transcode/stream routing for real-world containers (MKV, AVI, and odd files), so edge cases don't silently wedge ffmpeg.

## What breaks today

- **MKV/AVI with subtitle or data tracks** → the `-c copy` remux (and copy paths) try to mux subtitles into MPEG-TS/MP4 and **ffmpeg fails** (`subrip`/`ass` aren't valid TS/MP4 codecs). The file just errors instead of playing.
- **MP4 with embedded cover art** → ffprobe reports the poster frame as an mjpeg/png "video" stream; if it's listed first, the file is detected as *not h264* and sent to a **full re-encode** even though the real video is h264.
- **Video with no audio track** → routed as if audio needed transcoding.

## Fix

- **Explicit stream mapping** on every ffmpeg call: `-map 0:V:0 -map 0:a:0?`
  - `0:V:0` — the first *real* video stream (capital `V` excludes attached-picture/cover-art streams).
  - `0:a:0?` — the first audio stream, optional (`?`), so no-audio videos transcode cleanly.
  - Drops subtitles/data/attachments → no more remux failures on MKV/AVI-with-subs.
  - Applied to `run_job` (remux + encode) and all HLS deliveries (remux / copy-video / transcode).
- **ffprobe ignores attached-picture streams** when detecting the video codec (`disposition.attached_pic == 1`), so an h264 file with a poster frame routes as h264, not as an image.
- `decide_delivery` treats a **missing audio track** as compatible → `RawProgressive`/`RemuxHls` instead of `CopyVideoHls`.
- Extracted `parse_probe_json` (pure) so the probe logic is unit-tested.

## Coverage after this

| File | Result |
|------|--------|
| MKV, h264 + ac3 + subs | copy video, transcode audio, **subs dropped** (was: ffmpeg error) |
| AVI, mpeg4/xvid + mp3 | full transcode (unavoidable) |
| MP4, h264 + aac + cover art | raw stream (was: full re-encode) |
| h264, no audio | raw / remux (was: audio path) |

## Tests
133 tests — added: cover-art stream skipped, no-audio h264 remuxes, map constant. clippy clean (only pre-existing `stream.rs:13`). mdx 0.1.18 → 0.1.19.

Docs: apps/kube/reel/manifest/
