### PR TITLE
feat(palworld): expand Village shop to 70 items (foods, cakes, arrows)

### DIFF
--- a/apps/agones/palworld/mods/PalSchema/mods/KBVEShops/raw/kbve-shops.json
+++ b/apps/agones/palworld/mods/PalSchema/mods/KBVEShops/raw/kbve-shops.json
@@ -59,6 +59,440 @@
                         "OverridePrice": 1000,
                         "ProductNum": 1,
                         "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Potion_Low",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 80,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Opium",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 150,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_ChickenPal",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 60,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_SheepBall",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 80,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_Boar",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 100,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "ChickenSaute",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 150,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "GrilledSheepHerbs",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 180,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Egg",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 30,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Berries",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 20,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Wheat",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 25,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Wool",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Leather",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 60,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Milk",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 35,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "BerrySeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 50,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "WheatSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 60,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Bone",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 30,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Horn",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 50,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "PalFluid",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "ElectricOrgan",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 120,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Venom",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 100,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "FireOrgan",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 120,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "IceOrgan",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 120,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Arrow",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 10,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Arrow_Poison",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Arrow_Fire",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Accessory_Nonkilling",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 500,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head003_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head004_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head011_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head012_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head013_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head015_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Head016_5",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "HeadEquip028",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_CowPal",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 120,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_BerryGoat",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 90,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Meat_Deer",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 110,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Chowder",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 200,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "DeerStew",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 280,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "DeerLocoMoco",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 300,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Eaglestew",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 260,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "StewedIceDeer",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 300,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "MushroomJuice",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 90,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Cake",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 1500,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Cake02",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 2500,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Cake03",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 3000,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Cake04",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 5000,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Cake05",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 50000,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Honey",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 80,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Sweet",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 60,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Flour",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Mushroom",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 30,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Carrot",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 20,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Lettuce",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 25,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Tomato",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 25,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Onion",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 20,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "Potato",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 20,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "CarrotSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "LettuceSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 45,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "TomatoSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 45,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "OnionSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
+                    },
+                    {
+                        "StaticItemId": "PotatoSeeds",
+                        "ProductType": "EPalItemShopProductType::Normal",
+                        "OverridePrice": 40,
+                        "ProductNum": 1,
+                        "Stock": 0
                     }
                 ]
             }

--- a/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
@@ -20,11 +20,74 @@ palshop:
         - { id: Herbs, type: Normal, price: 50, num: 1, stock: 0 }
         - { id: Medicines, type: Normal, price: 200, num: 1, stock: 0 }
         - { id: LuxuryMedicines, type: Normal, price: 1000, num: 1, stock: 0 }
+        - { id: Potion_Low, type: Normal, price: 80, num: 1, stock: 0 }
+        - { id: Opium, type: Normal, price: 150, num: 1, stock: 0 }
+        - { id: Meat_ChickenPal, type: Normal, price: 60, num: 1, stock: 0 }
+        - { id: Meat_SheepBall, type: Normal, price: 80, num: 1, stock: 0 }
+        - { id: Meat_Boar, type: Normal, price: 100, num: 1, stock: 0 }
+        - { id: ChickenSaute, type: Normal, price: 150, num: 1, stock: 0 }
+        - { id: GrilledSheepHerbs, type: Normal, price: 180, num: 1, stock: 0 }
+        - { id: Egg, type: Normal, price: 30, num: 1, stock: 0 }
+        - { id: Berries, type: Normal, price: 20, num: 1, stock: 0 }
+        - { id: Wheat, type: Normal, price: 25, num: 1, stock: 0 }
+        - { id: Wool, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: Leather, type: Normal, price: 60, num: 1, stock: 0 }
+        - { id: Milk, type: Normal, price: 35, num: 1, stock: 0 }
+        - { id: BerrySeeds, type: Normal, price: 50, num: 1, stock: 0 }
+        - { id: WheatSeeds, type: Normal, price: 60, num: 1, stock: 0 }
+        - { id: Bone, type: Normal, price: 30, num: 1, stock: 0 }
+        - { id: Horn, type: Normal, price: 50, num: 1, stock: 0 }
+        - { id: PalFluid, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: ElectricOrgan, type: Normal, price: 120, num: 1, stock: 0 }
+        - { id: Venom, type: Normal, price: 100, num: 1, stock: 0 }
+        - { id: FireOrgan, type: Normal, price: 120, num: 1, stock: 0 }
+        - { id: IceOrgan, type: Normal, price: 120, num: 1, stock: 0 }
+        - { id: Arrow, type: Normal, price: 10, num: 1, stock: 0 }
+        - { id: Arrow_Poison, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: Arrow_Fire, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: Accessory_Nonkilling, type: Normal, price: 500, num: 1, stock: 0 }
+        - { id: Head003_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head004_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head011_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head012_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head013_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head015_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Head016_5, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: HeadEquip028, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: Meat_CowPal, type: Normal, price: 120, num: 1, stock: 0 }
+        - { id: Meat_BerryGoat, type: Normal, price: 90, num: 1, stock: 0 }
+        - { id: Meat_Deer, type: Normal, price: 110, num: 1, stock: 0 }
+        - { id: Chowder, type: Normal, price: 200, num: 1, stock: 0 }
+        - { id: DeerStew, type: Normal, price: 280, num: 1, stock: 0 }
+        - { id: DeerLocoMoco, type: Normal, price: 300, num: 1, stock: 0 }
+        - { id: Eaglestew, type: Normal, price: 260, num: 1, stock: 0 }
+        - { id: StewedIceDeer, type: Normal, price: 300, num: 1, stock: 0 }
+        - { id: MushroomJuice, type: Normal, price: 90, num: 1, stock: 0 }
+        - { id: Cake, type: Normal, price: 1500, num: 1, stock: 0 }
+        - { id: Cake02, type: Normal, price: 2500, num: 1, stock: 0 }
+        - { id: Cake03, type: Normal, price: 3000, num: 1, stock: 0 }
+        - { id: Cake04, type: Normal, price: 5000, num: 1, stock: 0 }
+        - { id: Cake05, type: Normal, price: 50000, num: 1, stock: 0 }
+        - { id: Honey, type: Normal, price: 80, num: 1, stock: 0 }
+        - { id: Sweet, type: Normal, price: 60, num: 1, stock: 0 }
+        - { id: Flour, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: Mushroom, type: Normal, price: 30, num: 1, stock: 0 }
+        - { id: Carrot, type: Normal, price: 20, num: 1, stock: 0 }
+        - { id: Lettuce, type: Normal, price: 25, num: 1, stock: 0 }
+        - { id: Tomato, type: Normal, price: 25, num: 1, stock: 0 }
+        - { id: Onion, type: Normal, price: 20, num: 1, stock: 0 }
+        - { id: Potato, type: Normal, price: 20, num: 1, stock: 0 }
+        - { id: CarrotSeeds, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: LettuceSeeds, type: Normal, price: 45, num: 1, stock: 0 }
+        - { id: TomatoSeeds, type: Normal, price: 45, num: 1, stock: 0 }
+        - { id: OnionSeeds, type: Normal, price: 40, num: 1, stock: 0 }
+        - { id: PotatoSeeds, type: Normal, price: 40, num: 1, stock: 0 }
 ---
 
 import PalShopTable from '@/components/palworld/PalShopTable.astro';
 
-The **Village Shop** stocks starter gear for new arrivals — capture spheres,
-climate armor, and healing supplies at fixed prices.
+The **Village Shop** is the main general store — capture spheres, climate
+armor, healing supplies, food and cooked meals, farm goods and seeds, Pal
+materials, and cosmetics, all at fixed prices.
 
 <PalShopTable shop={frontmatter.palshop} />

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.29"
+version: "0.0.30"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
Follow-up to the merged Phase 1 (#14839). Expands `Village_Shop_1` from the 8-item starter set to a full **70-item** general store.

## Contents

- Full 40-item Hex-reference set: spheres, armor/shield, meds, meat + cooked meals, farm goods, seeds, Pal materials (Bone/Horn/organs), Arrow, Accessory, cosmetic heads.
- Verified foods/produce: Chowder, DeerStew, DeerLocoMoco, Eaglestew, StewedIceDeer, MushroomJuice, Honey, Sweet, Flour, Mushroom, Carrot/Lettuce/Tomato/Onion/Potato + their seeds, extra meats (CowPal/BerryGoat/Deer).
- **Cake tiers** Cake/02/03/04/05 @ 1500/2500/3000/5000/50000.
- **Arrow_Poison, Arrow_Fire** @ 40.

## Verification

Every `StaticItemId` cross-checked against the Hex working-shop pool (303 ids) + DrRak `DT_ItemIconDataTable`. Generated `kbve-shops.json` regenerated from `village.mdx` and `gen:palworld-shops:check` reports **in sync**. Pipeline tests still 13/13.

Diff is 3 files: `village.mdx` (source), `kbve-shops.json` (generated overlay), and the `0.0.29 → 0.0.30` version bump to publish the new image.

## Deploy (after merge)

Image rebuild → recreate the GameServer (`kubectl delete gameserver palworld -n palworld`) → confirm PalSchema apply log lists KBVEShops + Village stock. The `Cake0x` ids are per in-game report; any that don't resolve just omit that row (no crash) — a one-line fix.