### PR TITLE
feat(kubectl): restart-gameserver for config-only GameServer restarts

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -417,7 +417,7 @@
 		{
 			"key": "kubectl",
 			"app_name": "kbve-kubectl",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/vm/kubectl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx",
 			"version_target": "apps/vm/kubectl/Cargo.toml",
@@ -432,6 +432,8 @@
 				"apps/kube/kubevirt/runner/scaled-job.yaml",
 				"apps/kube/kubevirt/keda/scaled-jobs.yaml",
 				"apps/kube/agones/factorio/manifests/rotation-deployment.yaml",
+				"apps/kube/agones/palworld/manifests/rotation-deployment.yaml",
+				"apps/kube/agones/palworld/jobs/config-restart-job.yaml",
 				"apps/kube/namespace/manifests/pod-gc-cronjob.yaml",
 				"apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml",
 				"apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -16,12 +16,12 @@ jsonld:
         - question: What is the KBVE kubectl image?
           answer: It is an Alpine-based kubectl image with a static musl Rust CLI wrapper for KubeVirt VM management. It replaces the distroless registry.k8s.io/kubectl image, which lacks /bin/sh and breaks Kubernetes Job scripts.
         - question: What can the kbve-kubectl CLI do?
-          answer: The Rust CLI offers info to print versions and check tools, run to execute shell scripts, guest-exec to run commands inside a KubeVirt VM via the QEMU Guest Agent, and rotate-gameserver to roll an Agones GameServer when its desired image drifts from the running pod.
+          answer: The Rust CLI offers info to print versions and check tools, run to execute shell scripts, guest-exec to run commands inside a KubeVirt VM via the QEMU Guest Agent, rotate-gameserver to roll an Agones GameServer when its desired image drifts from the running pod, and restart-gameserver to unconditionally restart a GameServer (backup, delete, wait for Ready) for config or env changes that leave the image tag unchanged.
         - question: How is the kubectl image kept in sync across manifests?
           answer: The image tag is pinned across every manifest listed in the deployment_yamls frontmatter field, and all of them auto-bump on each publish via the post-publish version sync.
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.8"
+version: "0.1.9"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml
@@ -34,6 +34,8 @@ deployment_yamls:
     - apps/kube/kubevirt/runner/scaled-job.yaml
     - apps/kube/kubevirt/keda/scaled-jobs.yaml
     - apps/kube/agones/factorio/manifests/rotation-deployment.yaml
+    - apps/kube/agones/palworld/manifests/rotation-deployment.yaml
+    - apps/kube/agones/palworld/jobs/config-restart-job.yaml
     - apps/kube/namespace/manifests/pod-gc-cronjob.yaml
     - apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
     - apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml

--- a/apps/kube/agones/palworld/jobs/config-restart-job.yaml
+++ b/apps/kube/agones/palworld/jobs/config-restart-job.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: palworld-config-restart
+    namespace: palworld
+    labels:
+        app.kubernetes.io/part-of: palworld
+        app.kubernetes.io/component: config-restart
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+spec:
+    ttlSecondsAfterFinished: 3600
+    backoffLimit: 0
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/part-of: palworld
+                app.kubernetes.io/component: config-restart
+        spec:
+            serviceAccountName: palworld-rotator
+            automountServiceAccountToken: true
+            restartPolicy: Never
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: restart
+                  image: ghcr.io/kbve/kubectl:0.1.9
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - restart-gameserver
+                      - --namespace=palworld
+                      - --gameserver=palworld
+                      - --container=palworld
+                      - --delete-timeout=180
+                      - --ready-timeout=600
+                      - --backup
+                      - --save-path=/palworld/Pal/Saved
+                      - --backup-dir=/palworld/backups
+                      - --backup-keep=5
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  resources:
+                      requests:
+                          cpu: 25m
+                          memory: 64Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi

--- a/apps/vm/kubectl/src/main.rs
+++ b/apps/vm/kubectl/src/main.rs
@@ -88,6 +88,30 @@ enum Commands {
         #[arg(long, default_value = "5")]
         backup_keep: u32,
     },
+    /// Restart an Agones GameServer unconditionally (for config/env changes that
+    /// leave the image tag unchanged, which rotate-gameserver deliberately skips)
+    RestartGameserver {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        gameserver: String,
+        #[arg(long, default_value = "palworld")]
+        container: String,
+        #[arg(long, default_value = "180")]
+        delete_timeout: u64,
+        #[arg(long, default_value = "600")]
+        ready_timeout: u64,
+        #[arg(long)]
+        backup: bool,
+        #[arg(long, default_value = "")]
+        world: String,
+        #[arg(long, default_value = "/palworld/Pal/Saved")]
+        save_path: String,
+        #[arg(long, default_value = "/palworld/backups")]
+        backup_dir: String,
+        #[arg(long, default_value = "5")]
+        backup_keep: u32,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -701,6 +725,95 @@ async fn cmd_rotate_gameserver(
     }
 }
 
+async fn gs_state(namespace: &str, gameserver: &str) -> String {
+    kubectl_output(&[
+        "-n",
+        namespace,
+        "get",
+        &format!("gs/{gameserver}"),
+        "-o",
+        "jsonpath={.status.state}",
+    ])
+    .await
+    .unwrap_or_default()
+}
+
+async fn wait_for_ready(namespace: &str, gameserver: &str, ready_timeout: u64) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(ready_timeout);
+    let mut ticker = tokio::time::interval(Duration::from_secs(10));
+    loop {
+        ticker.tick().await;
+        let state = gs_state(namespace, gameserver).await;
+        tracing::info!("waiting for Ready: state={state}");
+        if state == "Ready" || state == "Allocated" {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "timed out after {ready_timeout}s waiting for {gameserver} Ready (state={state})"
+            ));
+        }
+    }
+}
+
+/// Unconditional restart: backup, delete the GameServer (ArgoCD selfHeal
+/// recreates it from the desired spec, picking up env/config changes), then wait
+/// for it to come back Ready. Unlike rotate-gameserver this does NOT gate on
+/// image drift — it exists for config-only changes where the image tag is
+/// unchanged.
+async fn cmd_restart_gameserver(
+    namespace: &str,
+    gameserver: &str,
+    container: &str,
+    delete_timeout: u64,
+    ready_timeout: u64,
+    backup: &BackupOpts,
+) -> ExitCode {
+    let state = gs_state(namespace, gameserver).await;
+    if state.is_empty() {
+        tracing::error!("gameserver {gameserver} not found in {namespace}");
+        return ExitCode::FAILURE;
+    }
+    tracing::info!("restart requested: gs={gameserver} ns={namespace} state={state}");
+
+    if backup.enabled {
+        match backup_before_rotate(namespace, gameserver, container, backup).await {
+            Ok(name) => tracing::info!("pre-restart backup created: {name}"),
+            Err(e) => {
+                tracing::error!("pre-restart backup FAILED, aborting restart: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let timeout_arg = format!("--timeout={delete_timeout}s");
+    let wrapper_timeout = Duration::from_secs(delete_timeout.saturating_add(30));
+    let delete_args = [
+        "-n",
+        namespace,
+        "delete",
+        &format!("gs/{gameserver}"),
+        &timeout_arg,
+        "--ignore-not-found",
+    ];
+    tracing::warn!("deleting gs {gameserver}; ArgoCD selfHeal will recreate from desired spec");
+    if let Err(e) = kubectl_output_with_timeout(&delete_args, wrapper_timeout).await {
+        tracing::error!("restart delete failed: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    match wait_for_ready(namespace, gameserver, ready_timeout).await {
+        Ok(()) => {
+            tracing::info!("restart complete: {gameserver} is Ready");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            tracing::error!("{e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -747,6 +860,35 @@ async fn main() -> ExitCode {
                 delete_timeout,
                 watch,
                 interval,
+                &backup_opts,
+            )
+            .await
+        }
+        Commands::RestartGameserver {
+            namespace,
+            gameserver,
+            container,
+            delete_timeout,
+            ready_timeout,
+            backup,
+            world,
+            save_path,
+            backup_dir,
+            backup_keep,
+        } => {
+            let backup_opts = BackupOpts {
+                enabled: backup,
+                world,
+                save_path,
+                backup_dir,
+                keep: backup_keep,
+            };
+            cmd_restart_gameserver(
+                &namespace,
+                &gameserver,
+                &container,
+                delete_timeout,
+                ready_timeout,
                 &backup_opts,
             )
             .await


### PR DESCRIPTION
## Why

`rotate-gameserver` (the watchdog) deliberately only rotates on **image-tag drift** — this prevents delete loops. But env/config-only changes to a GameServer (same image tag) have **no** trigger, so they never auto-apply. Applying them means hand-recreating the pod, which is where the standalone-GS `Unhealthy` deadlock bites (REST shutdown respawns in-place; only a `kubectl delete gs` + ArgoCD selfHeal recreates cleanly).

Concretely hit while applying palworld guild-size / death-penalty env changes.

## What

- **`restart-gameserver` subcommand** in the `kbve-kubectl` Rust CLI: unconditional `backup → delete gs → wait until Ready`. No image-drift gate. Reuses the existing backup/delete helpers.
- **On-demand `config-restart-job.yaml`** under `apps/kube/agones/palworld/jobs/` (outside the ArgoCD-synced `manifests/` path — run only when you mean to). Uses the `palworld-rotator` ServiceAccount RBAC, backups enabled.
- Register palworld `rotation-deployment.yaml` + the new job in the kubectl image `deployment_yamls` so their image tags stay in post-publish sync (palworld rotator was previously not tracked).
- MDX bump `0.1.8 → 0.1.9`; CI dispatch manifest regenerated.

The image-drift watchdog is unchanged — this is purely the config-change path.

## Usage (after image lands in prod)

```
kubectl create -f apps/kube/agones/palworld/jobs/config-restart-job.yaml
```

## Verification

- `cargo build` / `cargo clippy` clean; 13 unit tests pass; `--help` parses.
- Manual dry-run of the exact sequence against live palworld (announce → 12M backup → `delete gs` → selfHeal recreate → Ready) succeeded with no player disruption.

Kube manifests: https://kbve.com/application/kubernetes/