### PR TITLE
fix(reel): disable VPN port forwarding to stop peer-wipe churn

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -39,6 +39,7 @@ spec:
             - { name: FIREWALL_INPUT_PORTS, value: "8080" }
             - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.244.0.0/16,10.96.0.0/12" }
             - { name: WIREGUARD_MTU, value: "1320" }
+            - { name: VPN_PORT_FORWARDING, value: "off" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel
@@ -53,9 +54,6 @@ spec:
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
             - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
-            - { name: REEL_BT_PORT_FILE, value: "/tmp/gluetun/forwarded_port" }
-            - { name: REEL_BT_PORT_STABLE_SECS, value: "45" }
-            - { name: REEL_BT_PORT_WATCH_SECS, value: "86400" }
             - { name: REEL_ENCODE_THREADS, value: "1" }
           envFrom:
             - secretRef: { name: reel-api }


### PR DESCRIPTION
## Problem

Download speed sawtooths — `peers_live` collapses to **0 every ~60-90s** then rebuilds, repeatedly (0 → 40 Mbps → 0). Not WireGuard, not librqbit.

## Root cause (from live logs)

ProtonVPN on the current exit does **not honor NAT-PMP mapping renewal**. gluetun renews the previously-assigned port and Proton hands back a fresh random port each cycle:

```
[port forwarding] refreshing port mapping ... requested as 39032 but received 35644
[firewall] removing allowed port 39032...   → full port-forwarding restart → rebuild iptables
```

The iptables rebuild has a brief killswitch-DROP window that flushes conntrack → **every live peer dies**. librqbit then reconnects from scratch. One wipe per renewal cycle = the sawtooth.

Inbound was already dead anyway: librqbit can't rebind its listener without a session restart, so it stayed pinned to the first forwarded port (39032) while the real port rotated away within a minute.

## Fix

- Override `VPN_PORT_FORWARDING=off` via explicit container env (wins over the `reel-gluetun` secret's `on` — **no reseal**). No port mapping → no renewal → no firewall rebuild loop → tunnel + swarm stay steady.
- Drop `REEL_BT_PORT_FILE` (and the now-moot stable/watch secs) so reel binds a random listen port immediately instead of waiting on a port file that never gets written.

## Trade-off

No inbound peers on this exit (already broken). Stable outbound download beats a sawtooth. Restoring inbound needs a Proton server that honors PF renewal — separate follow-up.

Kube-only; no image/version bump.