### PR TITLE
fix(reel): pin gluetun to Germany/Frankfurt for stable port forwarding

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -39,6 +39,8 @@ spec:
             - { name: FIREWALL_INPUT_PORTS, value: "8080" }
             - { name: FIREWALL_OUTBOUND_SUBNETS, value: "10.244.0.0/16,10.96.0.0/12" }
             - { name: WIREGUARD_MTU, value: "1320" }
+            - { name: SERVER_COUNTRIES, value: "Germany" }
+            - { name: SERVER_CITIES, value: "Frankfurt" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel


### PR DESCRIPTION
## The real problem (not WireGuard)

The peer-wipe sawtooth (`peers_live` → 0 every ~60-90s) is **one flaky server**. The pod ran **8h, 0 restarts** on a single German exit, yet gluetun logged a NAT-PMP renewal failure every cycle:

```
[port forwarding] refreshing port mapping ... requested as 39032 but received 35644
[firewall] removing allowed port 39032...   → full PF restart → iptables rebuild → conntrack flush → all peers die
```

gluetun had **no `SERVER_*` filter**, so it picked one German PF server at connect and stuck to it — and *that* server doesn't honor NAT-PMP renewal.

## Fix

Pin `SERVER_COUNTRIES=Germany` + `SERVER_CITIES=Frankfurt` so gluetun selects from the Frankfurt pool and lands a **renewal-honoring** server → forwarded port stays stable → inbound peers survive.

- PF stays **on**.
- Rebind watcher stays **disabled** this pass (`REEL_BT_PORT_WATCH_SECS`) so a still-flaky server can't restart-loop. Observe port stability first.

## Iteration path

1. Merge → watch gluetun logs. Port holds steady 5-10 min → **inbound restored**; re-enable watcher in a follow-up.
2. Still rotates → pin an exact `SERVER_HOSTNAMES`.
3. None hold → fall back to disabling PF (#14871).

**Supersedes #14871** if the port holds. #14871 stays open as the guaranteed-stable fallback.

Kube-only; no image/version bump.