### PR TITLE
fix(reel): disable VPN port forwarding — rotates port on every renewal

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -41,6 +41,7 @@ spec:
             - { name: WIREGUARD_MTU, value: "1320" }
             - { name: SERVER_COUNTRIES, value: "Germany" }
             - { name: SERVER_CITIES, value: "Frankfurt" }
+            - { name: VPN_PORT_FORWARDING, value: "off" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel
@@ -55,9 +56,6 @@ spec:
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
             - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
-            - { name: REEL_BT_PORT_FILE, value: "/tmp/gluetun/forwarded_port" }
-            - { name: REEL_BT_PORT_STABLE_SECS, value: "45" }
-            - { name: REEL_BT_PORT_WATCH_SECS, value: "86400" }
             - { name: REEL_ENCODE_THREADS, value: "1" }
           envFrom:
             - secretRef: { name: reel-api }


### PR DESCRIPTION
## Result of the Frankfurt-pin experiment (#14872)

Server pinning **did not** fix the peer-wipe sawtooth. Live logs on the pinned Frankfurt exit (159.26.104.63, endpoint 79.127.141.53) show the same NAT-PMP renewal failure every ~45-90s as the previous German server:

```
requested as 64916 but received 45089  → restart → forwarded 64194
requested as 64194 but received 61910  → restart → forwarded 63157
```

**Two different servers, identical behavior.** VPN's NAT-PMP hands back a fresh external port on every renewal instead of honoring the held mapping — universalgluetun behavior, not a bad server. Each renewal restart rebuilds iptables + flushes conntrack → every live peer dies.

librqbit can't hot-rebind its listen socket, so a continuously rotating port makes inbound unachievable without a full session restart every cycle.

## Fix

- `VPN_PORT_FORWARDING=off` → no mapping, no renewal, no firewall rebuild loop. Tunnel + outbound swarm stay steady.
- Keep the Frankfurt pin (consistent exit region, harmless).
- Drop `REEL_BT_PORT_FILE` → reel binds a random listen port immediately.

## Trade-off

No inbound peers (fundamentally unavailable right now). Stable outbound beats a sawtooth. Restoring inbound needs a provider with a **static** forwarded port (e.g. AirVPN) — separate follow-up.

Kube-only; no image/version bump.