### PR TITLE
fix(reel): sweep orphaned library/active files independent of state

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.19"
+version: "0.1.20"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -222,6 +222,17 @@ erroring. ffprobe also ignores **attached-picture** streams (embedded cover art,
 reported as an mjpeg/png "video") when detecting the codec, so an h264 file with a
 poster frame routes as h264 rather than being mistaken for an image and sent to a
 full re-encode.
+
+The cache is swept at two levels so nothing is left to sit on disk. The state-aware
+reaper removes tracked entries once they pass their idle TTL (deleting both the state
+record and the files). On top of that, a filesystem sweeper runs every reap cycle and
+deletes anything in the active or library directories that is **not** referenced by
+any state entry and is older than the TTL by modification time — orphans left behind
+by a failed delete, an interrupted move, or lost state. Actively tracked downloads
+(and the librqbit `.session` directory) are always skipped, so an in-progress or
+currently-streaming item is never swept mid-use. File deletions that fail are now
+logged rather than silently swallowed, so a leaked file is visible and gets cleaned
+on the next sweep instead of accumulating forever.
 
 </BentoProse>
 

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -668,6 +668,25 @@ impl Engine {
         }
         Ok(reaped)
     }
+
+    pub fn sweep_orphans(&self, ttl_secs: u64, now: u64) -> usize {
+        let mut known = std::collections::HashSet::new();
+        for m in self.store.list() {
+            known.insert(m.path.clone());
+            if let Some(p) = m.transcode_path {
+                known.insert(p);
+            }
+            if let Some(p) = m.hls_dir {
+                known.insert(p);
+            }
+        }
+        crate::sweeper::sweep_orphans(
+            &[self.library_dir.clone(), self.active_dir.clone()],
+            &known,
+            ttl_secs,
+            now,
+        )
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1007,10 +1026,15 @@ pub async fn tracker_refresh_loop(
 pub fn remove_entry_files(path: &str, transcode_path: Option<&str>) {
     for p in std::iter::once(path).chain(transcode_path) {
         let pb = std::path::Path::new(p);
-        if pb.is_dir() {
-            let _ = std::fs::remove_dir_all(pb);
+        let res = if pb.is_dir() {
+            std::fs::remove_dir_all(pb)
         } else if pb.exists() {
-            let _ = std::fs::remove_file(pb);
+            std::fs::remove_file(pb)
+        } else {
+            Ok(())
+        };
+        if let Err(e) = res {
+            tracing::warn!(path = %p, error = %e, "failed to remove entry files; leaving orphan for sweeper");
         }
     }
 }

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -6,6 +6,7 @@ pub mod mover;
 pub mod reaper;
 pub mod state;
 pub mod stream;
+pub mod sweeper;
 pub mod telemetry;
 pub mod transcode;
 pub mod util;

--- a/apps/media/reel/src/reaper.rs
+++ b/apps/media/reel/src/reaper.rs
@@ -37,7 +37,8 @@ pub async fn reap_loop(
     let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
     loop {
         ticker.tick().await;
-        match engine.reap_expired(ttl_secs, now_secs()).await {
+        let now = now_secs();
+        match engine.reap_expired(ttl_secs, now).await {
             Ok(reaped) => {
                 for id in reaped {
                     hls.abort(&id).await;
@@ -45,6 +46,10 @@ pub async fn reap_loop(
                 }
             }
             Err(e) => tracing::error!(error = %e, "reap cycle failed"),
+        }
+        let swept = engine.sweep_orphans(ttl_secs, now);
+        if swept > 0 {
+            tracing::info!(count = swept, "swept orphaned files not tracked in state");
         }
     }
 }

--- a/apps/media/reel/src/sweeper.rs
+++ b/apps/media/reel/src/sweeper.rs
@@ -1,0 +1,147 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub fn expired_orphans(
+    entries: &[(String, u64)],
+    known: &HashSet<String>,
+    ttl_secs: u64,
+    now: u64,
+) -> Vec<String> {
+    entries
+        .iter()
+        .filter(|(path, mtime)| !known.contains(path) && now.saturating_sub(*mtime) > ttl_secs)
+        .map(|(path, _)| path.clone())
+        .collect()
+}
+
+fn scan_dir(dir: &Path) -> Vec<(String, u64)> {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in rd.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let mtime = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        out.push((path.to_string_lossy().into_owned(), mtime));
+    }
+    out
+}
+
+fn delete_path(path: &str) -> std::io::Result<()> {
+    let pb = Path::new(path);
+    if pb.is_dir() {
+        std::fs::remove_dir_all(pb)
+    } else if pb.exists() {
+        std::fs::remove_file(pb)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn sweep_orphans(
+    dirs: &[PathBuf],
+    known: &HashSet<String>,
+    ttl_secs: u64,
+    now: u64,
+) -> usize {
+    let mut entries = Vec::new();
+    for dir in dirs {
+        entries.extend(scan_dir(dir));
+    }
+    let mut removed = 0usize;
+    for path in expired_orphans(&entries, known, ttl_secs, now) {
+        match delete_path(&path) {
+            Ok(()) => {
+                crate::telemetry::swept(&path);
+                removed += 1;
+            }
+            Err(e) => tracing::warn!(path = %path, error = %e, "sweep: orphan delete failed"),
+        }
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn keeps_known_paths() {
+        let entries = vec![("/lib/a".to_string(), 0)];
+        let known = set(&["/lib/a"]);
+        assert!(expired_orphans(&entries, &known, 50, 1000).is_empty());
+    }
+
+    #[test]
+    fn keeps_fresh_orphans() {
+        let entries = vec![("/lib/a".to_string(), 990)];
+        let known = set(&[]);
+        assert!(expired_orphans(&entries, &known, 50, 1000).is_empty());
+    }
+
+    #[test]
+    fn removes_old_orphans() {
+        let entries = vec![("/lib/a".to_string(), 100), ("/lib/b".to_string(), 990)];
+        let known = set(&[]);
+        assert_eq!(
+            expired_orphans(&entries, &known, 50, 1000),
+            vec!["/lib/a".to_string()]
+        );
+    }
+
+    #[test]
+    fn known_takes_priority_over_age() {
+        let entries = vec![("/lib/a".to_string(), 0)];
+        let known = set(&["/lib/a"]);
+        assert!(expired_orphans(&entries, &known, 50, 10_000_000).is_empty());
+    }
+
+    #[test]
+    fn scan_skips_hidden_and_reports_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".session")).unwrap();
+        std::fs::write(dir.path().join("movie.mp4"), b"data").unwrap();
+        let entries = scan_dir(dir.path());
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].0.ends_with("movie.mp4"));
+    }
+
+    #[test]
+    fn sweep_deletes_old_orphan_dir_keeps_known_and_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = dir.path().join("library");
+        let active = dir.path().join("active");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::create_dir(active.join(".session")).unwrap();
+
+        let orphan = lib.join("old-orphan");
+        std::fs::create_dir(&orphan).unwrap();
+        std::fs::write(orphan.join("f.mp4"), b"x").unwrap();
+        let tracked = lib.join("tracked");
+        std::fs::create_dir(&tracked).unwrap();
+
+        let known = set(&[tracked.to_string_lossy().as_ref()]);
+        // now far in the future so every mtime is "old"
+        let removed = sweep_orphans(&[lib.clone(), active.clone()], &known, 10, 10_000_000_000);
+        assert_eq!(removed, 1);
+        assert!(!orphan.exists(), "old orphan removed");
+        assert!(tracked.exists(), "known path kept");
+        assert!(active.join(".session").exists(), "session dir protected");
+    }
+}

--- a/apps/media/reel/src/telemetry.rs
+++ b/apps/media/reel/src/telemetry.rs
@@ -19,6 +19,10 @@ pub fn reaped(id: &str, name: &str, size: u64) {
     tracing::info!(event = "reaped", id, name, size, "reaped");
 }
 
+pub fn swept(path: &str) {
+    tracing::info!(event = "swept", path, "orphan file removed by sweeper");
+}
+
 pub fn reconcile_failed(id: &str, name: &str) {
     tracing::warn!(
         event = "reconcile_failed",


### PR DESCRIPTION
## Root cause of "streaming doesn't work"

Exec'd into the live pod: **`reel-state.json` is `{}` (empty)** while `/data/library` holds two fully-downloaded items — **Big Buck Bunny.mp4 (276 MB, playable)** + a 6.1 GB ISO.

State is the *only* index of the library, so an empty state makes every completed download invisible:
- `list` → nothing (UI shows empty library)
- `/stream/{id}` → 404 → **Play has nothing to play**

The media is on disk, just unreachable. Not a VPN or librqbit problem — a reel lifecycle bug.

## Why the files were orphaned

`delete()` removes the state entry (persisting empty state), then calls `remove_entry_files` with `let _ = remove_dir_all(...)` — **swallowing any failure**. State vanishes, files leak, nothing logs it. The state-aware reaper only knows what's in state, so once an entry is lost the files sit forever (the 6.1 GB leak).

## Fix — sweep by filesystem, independent of state

- **New `sweeper` module.** Each reap cycle, scan `active` + `library` and delete any top-level entry **not** referenced by a state entry (`path`/`transcode_path`/`hls_dir`) **and** older than the TTL by mtime. Hidden entries (librqbit `.session`) and actively tracked downloads are skipped → in-progress / currently-streaming items are never swept. Cleans orphans from failed deletes, interrupted moves, or lost state — *"too old → gone, regardless of state."*
- **`remove_entry_files` now logs delete failures** instead of swallowing them → leaks are visible and get cleaned on the next sweep.

## Tests

139 pass (6 new sweeper tests incl. "old orphan removed, known path kept, .session protected"), clippy clean.

## Note

This cleans orphans + prevents the leak, keeping the ephemeral model you asked for. Once deployed, the real end-to-end test is a **fresh** download → Play; the stream path itself (native librqbit `FileStream` + byte-range) audits clean, so I expect it to work — and if not, we'll finally have live `/stream` logs to debug from.