### PR TITLE
fix(reel): disable gluetun DoT — DNS storm collapses the peer swarm

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -42,6 +42,7 @@ spec:
             - { name: SERVER_COUNTRIES, value: "Germany" }
             - { name: SERVER_CITIES, value: "Frankfurt" }
             - { name: VPN_PORT_FORWARDING, value: "off" }
+            - { name: DOT, value: "off" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel


### PR DESCRIPTION
## The real peer-drop cause (after PF was already off)

Peers still cliff **13 → 0**, but the tunnel is stable the whole time: one WireGuard connect at startup, no reconnect, no healthcheck restart, no reel restart, no VPN pause. So it's not the tunnel and not PF churn (already fixed). It's **DNS**.

gluetun defaults to **DNS-over-TLS** (`DOT=on`) over a single connection to `1.1.1.1:853`. librqbit resolves ~93 trackers (A **and** AAAA each, plus DHT/peer lookups) → floods that one DoT connection → gluetun logs a burst of:

```
WARN [dns] running TLS handshake with 1.1.1.1:853: read: connection reset by peer
```

Cloudflare resets the flood → tracker announces fail en masse → the swarm can't be replenished → live peers decay to zero. BitTorrent's DNS volume is more than a single DoT link can carry (well-known gluetun-under-torrent issue).

## Fix

`DOT=off` → gluetun uses ProtonVPN's plain DNS resolver **over the tunnel**. DNS still goes through the VPN (killswitch blocks non-tunnel egress → no leak), but plain UDP DNS absorbs the query volume without TLS-handshake resets.

Kube-only; no image/version bump. Verify after roll: gluetun DNS `connection reset by peer` warnings gone, `peers_live` holds instead of cliffing to 0.