### PR TITLE
fix(store): digital products no longer demand a shipping address

### DIFF
--- a/apps/kbve/astro-kbve/src/components/store/StoreCatalog.tsx
+++ b/apps/kbve/astro-kbve/src/components/store/StoreCatalog.tsx
@@ -40,7 +40,7 @@ export function StoreCatalog() {
 						<span>
 							{p.price} {p.currency}
 						</span>
-						{p.fulfillment === 'digital' ? (
+						{p.fulfillment !== 'physical' && p.fulfillment !== 'both' ? (
 							<a
 								className="kbve-store-card__buy"
 								href={`/store/`}>

--- a/apps/kbve/axum-kbve/src/transport/store.rs
+++ b/apps/kbve/axum-kbve/src/transport/store.rs
@@ -60,7 +60,12 @@ pub(crate) struct StoreProductDto {
     pub description: Option<String>,
     pub price: i64,
     pub currency: String,
+    /// 'digital' | 'physical' | 'both'. Clients route the buy path on this:
+    /// digital mints straight from credits, physical/both needs a variant +
+    /// shipping address. Omitting it made every product look physical.
+    pub fulfillment: String,
     pub asset_ref: serde_json::Value,
+    pub variant_count: i64,
     pub created_at: String,
 }
 
@@ -101,21 +106,7 @@ pub(crate) async fn list_products() -> Response {
         None => return service_unavailable(),
     };
     match client.store_catalog().await {
-        Ok(rows) => Json(
-            rows.into_iter()
-                .map(|r| StoreProductDto {
-                    product_id: r.product_id,
-                    slug: r.slug,
-                    title: r.title,
-                    description: r.description,
-                    price: r.price,
-                    currency: r.currency.as_pg().to_string(),
-                    asset_ref: r.asset_ref,
-                    created_at: r.created_at.to_rfc3339(),
-                })
-                .collect::<Vec<_>>(),
-        )
-        .into_response(),
+        Ok(rows) => Json(rows.into_iter().map(map_product_dto).collect::<Vec<_>>()).into_response(),
         Err(e) => wallet_error_response(e),
     }
 }
@@ -421,7 +412,9 @@ fn map_product_dto(p: kbve::wallet::StoreProductRow) -> StoreProductDto {
         description: p.description,
         price: p.price,
         currency: p.currency.as_pg().to_string(),
+        fulfillment: p.fulfillment,
         asset_ref: p.asset_ref,
+        variant_count: p.variant_count,
         created_at: p.created_at.to_rfc3339(),
     }
 }

--- a/packages/npm/rn/src/markets/store/BuyCredits.tsx
+++ b/packages/npm/rn/src/markets/store/BuyCredits.tsx
@@ -5,6 +5,7 @@ import { Surface } from '../../ui/primitives/Surface';
 import { Text } from '../../ui/primitives/Text';
 import type { StoreApi } from './api';
 import { CREDIT_PACKS } from './types';
+import { ProgressBar } from '../../ui/feedback/ProgressBar';
 import { StoreApiError } from './errors';
 import { openCheckout } from './openCheckout';
 
@@ -44,6 +45,12 @@ export function BuyCredits({ api, authenticated }: BuyCreditsProps) {
 					<Text variant="caption" tone="danger">
 						{error}
 					</Text>
+				) : null}
+				{busy ? (
+					<ProgressBar
+						indeterminate
+						label="Opening the secure Stripe checkout…"
+					/>
 				) : null}
 				<Stack direction="row" gap="sm">
 					{CREDIT_PACKS.map((p) => (

--- a/packages/npm/rn/src/markets/store/CheckoutModal.tsx
+++ b/packages/npm/rn/src/markets/store/CheckoutModal.tsx
@@ -7,21 +7,33 @@ import { Surface } from '../../ui/primitives/Surface';
 import { Text } from '../../ui/primitives/Text';
 import type { StoreApi } from './api';
 import type { ShippingAddress, StoreVariant } from './types';
+import { ProgressBar } from '../../ui/feedback/ProgressBar';
 import { StoreApiError } from './errors';
 import { notifyWalletRefresh } from './walletSync';
+import { PurchaseProgress, type PurchaseStatus } from './PurchaseProgress';
 
 const EMPTY_ADDR: ShippingAddress = {
 	name: '', line1: '', line2: '', city: '', region: '', postal_code: '', country: '',
 };
 
-const ADDR_FIELDS: [keyof ShippingAddress, string][] = [
-	['name', 'Full name'],
-	['line1', 'Address line 1'],
-	['line2', 'Address line 2'],
-	['city', 'City'],
-	['region', 'State / region'],
-	['postal_code', 'Postal code'],
-	['country', 'Country'],
+const ADDR_FIELDS: [keyof ShippingAddress, string, boolean][] = [
+	['name', 'Full name', true],
+	['line1', 'Address line 1', true],
+	['line2', 'Address line 2', false],
+	['city', 'City', true],
+	['region', 'State / region', false],
+	['postal_code', 'Postal code', true],
+	['country', 'Country', true],
+];
+
+const REQUIRED: (keyof ShippingAddress)[] = ADDR_FIELDS.filter(
+	([, , req]) => req,
+).map(([k]) => k);
+
+const ORDER_STEPS = [
+	'Reserving stock and charging credits',
+	'Refreshing your orders',
+	'Order placed',
 ];
 
 export interface CheckoutModalProps {
@@ -37,8 +49,15 @@ export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModal
 	const [qty, setQty] = useState('1');
 	const [addr, setAddr] = useState<ShippingAddress>(EMPTY_ADDR);
 	const [busy, setBusy] = useState(false);
+	const [loaded, setLoaded] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [done, setDone] = useState<number | null>(null);
+	const [touched, setTouched] = useState<Partial<Record<keyof ShippingAddress, boolean>>>({});
+	const [phase, setPhase] = useState<{
+		activeIndex: number;
+		status: PurchaseStatus;
+		error?: string | null;
+	} | null>(null);
 
 	useEffect(() => {
 		void api
@@ -46,6 +65,7 @@ export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModal
 			.then((d) => {
 				setVariants(d.variants);
 				if (d.variants[0]) setVariantId(d.variants[0].variant_id);
+				setLoaded(true);
 			})
 			.catch((e) => setError(e instanceof Error ? e.message : 'load failed'));
 	}, [api, slug]);
@@ -53,33 +73,42 @@ export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModal
 	const submit = async () => {
 		setBusy(true);
 		setError(null);
+		setPhase({ activeIndex: 0, status: 'running' });
 		try {
 			const res = await api.buyPhysical(variantId, {
 				qty: Math.max(1, Number(qty) || 1),
 				shipping_address: addr,
 			});
+			setPhase({ activeIndex: 1, status: 'running' });
 			notifyWalletRefresh();
 			setDone(res.order_id);
 			onPurchased?.(res.order_id);
+			setPhase({ activeIndex: 2, status: 'done' });
 		} catch (e) {
+			let msg: string;
 			if (e instanceof StoreApiError) {
-				if (e.status === 402) setError('Not enough credits.');
+				if (e.status === 402) msg = 'Not enough credits.';
 				else if (e.code === 'P1020' || e.status === 409)
-					setError('Out of stock or duplicate. Try again.');
-				else if (e.status === 401) setError('Sign in to buy.');
-				else setError(e.message || 'purchase failed');
-			} else setError(e instanceof Error ? e.message : 'purchase failed');
+					msg = 'Out of stock or duplicate. Try again.';
+				else if (e.status === 401) msg = 'Sign in to buy.';
+				else msg = e.message || 'purchase failed';
+			} else msg = e instanceof Error ? e.message : 'purchase failed';
+			setError(msg);
+			setPhase({ activeIndex: 0, status: 'error', error: msg });
 		} finally {
 			setBusy(false);
 		}
 	};
 
-	const set = (k: keyof ShippingAddress) => (v: string) =>
+	const set = (k: keyof ShippingAddress) => (v: string) => {
 		setAddr((a) => ({ ...a, [k]: v }));
+		setTouched((t) => (t[k] ? t : { ...t, [k]: true }));
+	};
 
-	const invalid =
-		busy || !variantId || !addr.name || !addr.line1 || !addr.city ||
-		!addr.postal_code || !addr.country;
+	const missing = REQUIRED.filter((k) => !addr[k]?.trim());
+	const filled = REQUIRED.length - missing.length;
+	const ready = variantId !== '' && missing.length === 0;
+	const invalid = busy || !ready;
 
 	return (
 		<Surface>
@@ -89,14 +118,41 @@ export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModal
 					<Button title="Close" variant="ghost" onPress={onClose} accessibilityLabel="Close" />
 				</Stack>
 				{done ? (
+					<Stack gap="sm">
+						{phase ? (
+							<PurchaseProgress
+								steps={ORDER_STEPS}
+								activeIndex={phase.activeIndex}
+								status={phase.status}
+								error={phase.error}
+							/>
+						) : null}
+						<Text variant="caption" tone="muted">
+							Paid in credits. Track it in your order history.
+						</Text>
+					</Stack>
+				) : loaded && variants.length === 0 ? (
 					<Text variant="caption" tone="muted">
-						Paid in credits. Track it in your order history.
+						No shippable variant is listed for this product yet — nothing to
+						check out.
 					</Text>
 				) : (
 					<>
-						{error ? (
+						{!loaded ? (
+							<ProgressBar indeterminate label="Loading variants…" />
+						) : null}
+						{error && !busy ? (
 							<Text variant="caption" tone="danger">{error}</Text>
 						) : null}
+						<ProgressBar
+							value={filled / REQUIRED.length}
+							tone={ready ? 'success' : 'primary'}
+							label={
+								ready
+									? 'Shipping details complete'
+									: `Shipping details — ${filled} of ${REQUIRED.length} required fields`
+							}
+						/>
 						<Select
 							value={variantId}
 							onValueChange={setVariantId}
@@ -109,22 +165,48 @@ export function CheckoutModal({ api, slug, onClose, onPurchased }: CheckoutModal
 							label="Qty"
 							keyboardType="number-pad"
 							value={qty}
+							editable={!busy}
 							onChangeText={setQty}
 						/>
-						{ADDR_FIELDS.map(([k, label]) => (
+						{ADDR_FIELDS.map(([k, label, required]) => (
 							<FormField
 								key={k}
-								label={label}
+								label={required ? `${label} *` : label}
 								value={addr[k] ?? ''}
+								editable={!busy}
+								error={
+									required && touched[k] && !addr[k]?.trim()
+										? `${label} is required`
+										: null
+								}
 								onChangeText={set(k)}
 							/>
 						))}
+						{phase ? (
+							<PurchaseProgress
+								steps={ORDER_STEPS}
+								activeIndex={phase.activeIndex}
+								status={phase.status}
+								error={phase.error}
+							/>
+						) : null}
 						<Button
-							title={busy ? 'Placing…' : 'Buy with credits'}
+							title={busy ? 'Placing your order…' : 'Buy with credits'}
 							variant="primary"
 							disabled={invalid}
 							onPress={() => void submit()}
 						/>
+						{missing.length > 0 && !busy ? (
+							<Text variant="caption" tone="faint">
+								{`Still needed: ${missing
+									.map(
+										(k) =>
+											ADDR_FIELDS.find(([key]) => key === k)?.[1] ??
+											k,
+									)
+									.join(', ')}`}
+							</Text>
+						) : null}
 					</>
 				)}
 			</Stack>

--- a/packages/npm/rn/src/markets/store/ProductCard.tsx
+++ b/packages/npm/rn/src/markets/store/ProductCard.tsx
@@ -3,6 +3,7 @@ import { Button } from '../../ui/primitives/Button';
 import { Stack } from '../../ui/primitives/Stack';
 import { Surface } from '../../ui/primitives/Surface';
 import { Text } from '../../ui/primitives/Text';
+import { needsShipping } from './types';
 import type { StoreProduct } from './types';
 
 export interface ProductCardProps {
@@ -23,13 +24,13 @@ export function ProductCard({
 	onBuyPhysical,
 }: ProductCardProps) {
 	const price = `${product.price.toLocaleString()} ${product.currency}`;
-	const physical = product.fulfillment !== 'digital';
+	const physical = needsShipping(product.fulfillment);
 	return (
 		<Surface>
 			<Stack gap="xs">
 				<Stack direction="row" justify="space-between" align="center">
 					<Text variant="subtitle">{product.title}</Text>
-					<Badge tone="neutral" label={product.fulfillment} />
+					<Badge tone="neutral" label={product.fulfillment ?? 'digital'} />
 				</Stack>
 				<Text variant="caption" tone="muted">
 					{owned ? 'Unlocked. You own this.' : (product.description ?? '')}

--- a/packages/npm/rn/src/markets/store/PurchaseProgress.tsx
+++ b/packages/npm/rn/src/markets/store/PurchaseProgress.tsx
@@ -1,0 +1,121 @@
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { Stack } from '../../ui/primitives/Stack';
+import { Text } from '../../ui/primitives/Text';
+import { ProgressBar } from '../../ui/feedback/ProgressBar';
+import { tokens } from '../../ui/theme';
+
+export type PurchaseStatus = 'running' | 'done' | 'error';
+
+export interface PurchaseProgressProps {
+	steps: string[];
+	activeIndex: number;
+	status: PurchaseStatus;
+	error?: string | null;
+}
+
+function glyph(state: 'done' | 'active' | 'pending' | 'failed'): string {
+	if (state === 'done') return '✓';
+	if (state === 'failed') return '✕';
+	if (state === 'active') return '›';
+	return '·';
+}
+
+export function PurchaseProgress({
+	steps,
+	activeIndex,
+	status,
+	error,
+}: PurchaseProgressProps) {
+	const total = Math.max(1, steps.length);
+	const completed = status === 'done' ? total : Math.max(0, activeIndex);
+	const tone =
+		status === 'error' ? 'danger' : status === 'done' ? 'success' : 'primary';
+	const headline =
+		status === 'error'
+			? (error ?? 'Purchase failed')
+			: status === 'done'
+				? 'Purchase complete'
+				: (steps[activeIndex] ?? 'Working…');
+
+	return (
+		<View
+			accessibilityLiveRegion="polite"
+			accessibilityLabel={headline}
+			style={styles.wrap}>
+			<Stack gap="sm">
+				<Stack direction="row" align="center" gap="sm">
+					{status === 'running' ? (
+						<ActivityIndicator
+							size="small"
+							color={tokens.color.primary}
+						/>
+					) : null}
+					<Text
+						variant="label"
+						tone={
+							status === 'error'
+								? 'danger'
+								: status === 'done'
+									? 'success'
+									: 'default'
+						}>
+						{headline}
+					</Text>
+				</Stack>
+				<ProgressBar
+					value={completed / total}
+					tone={tone}
+					label={`Step ${Math.min(completed + (status === 'done' ? 0 : 1), total)} of ${total}`}
+				/>
+				<Stack gap="xs">
+					{steps.map((label, i) => {
+						const state =
+							status === 'error' && i === activeIndex
+								? 'failed'
+								: i < completed
+									? 'done'
+									: i === activeIndex && status === 'running'
+										? 'active'
+										: 'pending';
+						return (
+							<Stack
+								key={label}
+								direction="row"
+								align="center"
+								gap="sm">
+								<Text
+									variant="caption"
+									tone={
+										state === 'failed'
+											? 'danger'
+											: state === 'done'
+												? 'success'
+												: 'muted'
+									}>
+									{glyph(state)}
+								</Text>
+								<Text
+									variant="caption"
+									tone={state === 'pending' ? 'muted' : 'default'}>
+									{label}
+								</Text>
+							</Stack>
+						);
+					})}
+				</Stack>
+			</Stack>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	wrap: {
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		borderRadius: tokens.radius.md,
+		backgroundColor: tokens.color.bgSubtle,
+		padding: tokens.space.md,
+	},
+});
+
+export default PurchaseProgress;

--- a/packages/npm/rn/src/markets/store/StoreView.tsx
+++ b/packages/npm/rn/src/markets/store/StoreView.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Stack } from '../../ui/primitives/Stack';
 import { Text } from '../../ui/primitives/Text';
+import { EmptyState } from '../../ui/feedback/EmptyState';
+import { Skeleton, SkeletonGroup } from '../../ui/feedback/Skeleton';
 import { tokens } from '../../ui/theme';
 import { createStoreApi } from './api';
 import { BuyCredits } from './BuyCredits';
@@ -40,6 +42,7 @@ export function StoreView({
 	const [entitlements, setEntitlements] = useState<StoreEntitlement[]>([]);
 	const [orders, setOrders] = useState<StoreOrder[]>([]);
 	const [error, setError] = useState<string | null>(null);
+	const [loaded, setLoaded] = useState(false);
 	const [busySlug, setBusySlug] = useState<string | null>(null);
 	const [checkoutSlug, setCheckoutSlug] = useState<string | null>(null);
 	const [progress, setProgress] = useState<{
@@ -55,6 +58,8 @@ export function StoreView({
 			setError(null);
 		} catch (e) {
 			setError(e instanceof Error ? e.message : 'load failed');
+		} finally {
+			setLoaded(true);
 		}
 		if (authenticated) {
 			const [ents, ords] = await Promise.all([
@@ -154,7 +159,23 @@ export function StoreView({
 					{progressFor(featured.slug)}
 				</Stack>
 			) : null}
-			<Text variant="subtitle">All products</Text>
+			{!loaded ? (
+				<Stack gap="sm">
+					<Skeleton height={22} width="40%" />
+					<SkeletonGroup rows={3} />
+				</Stack>
+			) : products.length === 0 ? (
+				<EmptyState
+					title="The shelves are empty"
+					message="No products are listed right now. Check back after the next drop."
+				/>
+			) : rest.length === 0 ? (
+				<Text variant="caption" tone="muted">
+					This is the only drop live right now — more are on the way.
+				</Text>
+			) : (
+				<Text variant="subtitle">All products</Text>
+			)}
 			<View style={styles.grid}>
 				{rest.map((p) => (
 					<View key={p.product_id} style={styles.cell}>

--- a/packages/npm/rn/src/markets/store/StoreView.tsx
+++ b/packages/npm/rn/src/markets/store/StoreView.tsx
@@ -9,10 +9,17 @@ import { ProductCard } from './ProductCard';
 import { IdiotCard } from './IdiotCard';
 import { CheckoutModal } from './CheckoutModal';
 import { OrderHistory } from './OrderHistory';
+import { PurchaseProgress, type PurchaseStatus } from './PurchaseProgress';
 import { StoreApiError } from './errors';
 import { notifyWalletRefresh } from './walletSync';
 import { FEATURED_SLUG } from './types';
 import type { StoreEntitlement, StoreOrder, StoreProduct } from './types';
+
+const DIGITAL_STEPS = [
+	'Charging credits and minting your item',
+	'Syncing wallet and inventory',
+	'Unlocked — it is yours',
+];
 
 export interface StoreViewProps {
 	getToken: () => Promise<string | null>;
@@ -35,6 +42,12 @@ export function StoreView({
 	const [error, setError] = useState<string | null>(null);
 	const [busySlug, setBusySlug] = useState<string | null>(null);
 	const [checkoutSlug, setCheckoutSlug] = useState<string | null>(null);
+	const [progress, setProgress] = useState<{
+		slug: string;
+		activeIndex: number;
+		status: PurchaseStatus;
+		error?: string | null;
+	} | null>(null);
 
 	const load = useCallback(async () => {
 		try {
@@ -68,21 +81,35 @@ export function StoreView({
 	const buyDigital = useCallback(
 		async (slug: string) => {
 			setBusySlug(slug);
-			try {
-				await api.buyProduct(slug);
+			setError(null);
+			setProgress({ slug, activeIndex: 0, status: 'running' });
+			const sync = async () => {
+				setProgress({ slug, activeIndex: 1, status: 'running' });
 				notifyWalletRefresh();
 				setEntitlements(
 					await api.myEntitlements().catch(() => entitlements),
 				);
+				setProgress({ slug, activeIndex: 2, status: 'done' });
+			};
+			try {
+				await api.buyProduct(slug);
+				await sync();
 			} catch (e) {
 				if (e instanceof StoreApiError && e.status === 409) {
-					notifyWalletRefresh();
-					setEntitlements(
-						await api.myEntitlements().catch(() => entitlements),
-					);
+					await sync();
 				} else {
-					setError(
-						e instanceof Error ? e.message : 'purchase failed',
+					const msg =
+						e instanceof StoreApiError && e.status === 402
+							? 'Not enough credits. Top up above and try again.'
+							: e instanceof StoreApiError && e.status === 401
+								? 'Sign in to buy.'
+								: e instanceof Error
+									? e.message
+									: 'purchase failed';
+					setProgress((p) =>
+						p && p.slug === slug
+							? { ...p, status: 'error', error: msg }
+							: p,
 					);
 				}
 			} finally {
@@ -94,6 +121,16 @@ export function StoreView({
 
 	const featured = products.find((p) => p.slug === FEATURED_SLUG);
 	const rest = products.filter((p) => p.slug !== FEATURED_SLUG);
+
+	const progressFor = (slug: string) =>
+		progress && progress.slug === slug ? (
+			<PurchaseProgress
+				steps={DIGITAL_STEPS}
+				activeIndex={progress.activeIndex}
+				status={progress.status}
+				error={progress.error}
+			/>
+		) : null;
 
 	return (
 		<Stack gap="lg">
@@ -114,20 +151,24 @@ export function StoreView({
 						onBuyDigital={(s) => void buyDigital(s)}
 						onBuyPhysical={setCheckoutSlug}
 					/>
+					{progressFor(featured.slug)}
 				</Stack>
 			) : null}
 			<Text variant="subtitle">All products</Text>
 			<View style={styles.grid}>
 				{rest.map((p) => (
 					<View key={p.product_id} style={styles.cell}>
-						<ProductCard
-							product={p}
-							owned={owns(p.slug)}
-							authenticated={authenticated}
-							busy={busySlug === p.slug}
-							onBuyDigital={(s) => void buyDigital(s)}
-							onBuyPhysical={setCheckoutSlug}
-						/>
+						<Stack gap="sm">
+							<ProductCard
+								product={p}
+								owned={owns(p.slug)}
+								authenticated={authenticated}
+								busy={busySlug === p.slug}
+								onBuyDigital={(s) => void buyDigital(s)}
+								onBuyPhysical={setCheckoutSlug}
+							/>
+							{progressFor(p.slug)}
+						</Stack>
 					</View>
 				))}
 			</View>

--- a/packages/npm/rn/src/markets/store/__tests__/ProductCard.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/ProductCard.test.tsx
@@ -28,4 +28,32 @@ describe('ProductCard', () => {
 		fireEvent.click(getByText(/Buy/));
 		expect(onBuyDigital).toHaveBeenCalledWith('coin');
 	});
+
+	it('treats a missing fulfillment as digital, not physical', () => {
+		const onBuyDigital = vi.fn();
+		const onBuyPhysical = vi.fn();
+		const legacy = { ...digital } as StoreProduct;
+		delete (legacy as Partial<StoreProduct>).fulfillment;
+		const { getByText } = render(
+			<ProductCard product={legacy} owned={false} authenticated busy={false}
+				onBuyDigital={onBuyDigital} onBuyPhysical={onBuyPhysical} />,
+		);
+		fireEvent.click(getByText(/Buy/));
+		expect(onBuyPhysical).not.toHaveBeenCalled();
+		expect(onBuyDigital).toHaveBeenCalledWith('coin');
+	});
+
+	it('routes physical and both to the shipping checkout', () => {
+		for (const fulfillment of ['physical', 'both'] as const) {
+			const onBuyPhysical = vi.fn();
+			const { getByText, unmount } = render(
+				<ProductCard product={{ ...digital, fulfillment }} owned={false}
+					authenticated busy={false}
+					onBuyDigital={vi.fn()} onBuyPhysical={onBuyPhysical} />,
+			);
+			fireEvent.click(getByText(/Buy/));
+			expect(onBuyPhysical).toHaveBeenCalledWith('coin');
+			unmount();
+		}
+	});
 });

--- a/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 
 vi.mock('../IdiotCard', () => ({
 	IdiotCard: () => null,
@@ -65,5 +65,39 @@ describe('StoreView', () => {
 			/>,
 		);
 		expect(await findByText('Buy credits')).toBeTruthy();
+	});
+
+	it('walks the digital purchase through its progress steps', async () => {
+		const { findByText, getByText } = render(
+			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		await findByText('Idiot');
+		fireEvent.click(getByText('Buy · 100 credits'));
+		expect(await findByText('Purchase complete')).toBeTruthy();
+		expect(getByText('Unlocked — it is yours')).toBeTruthy();
+	});
+
+	it('surfaces a failed purchase in the progress panel', async () => {
+		global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+			const buying = init?.method === 'POST';
+			return {
+				ok: !buying,
+				status: buying ? 402 : 200,
+				text: async () =>
+					buying
+						? JSON.stringify({ error: 'P1010', message: 'insufficient' })
+						: url.includes('/products')
+							? JSON.stringify(PRODUCTS)
+							: JSON.stringify([]),
+			};
+		}) as any;
+		const { findByText, getByText } = render(
+			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		await findByText('Idiot');
+		fireEvent.click(getByText('Buy · 100 credits'));
+		expect(
+			await findByText('Not enough credits. Top up above and try again.'),
+		).toBeTruthy();
 	});
 });

--- a/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
+++ b/packages/npm/rn/src/markets/store/__tests__/StoreView.test.tsx
@@ -67,6 +67,38 @@ describe('StoreView', () => {
 		expect(await findByText('Buy credits')).toBeTruthy();
 	});
 
+	it('hides the All products heading when the featured drop is the only listing', async () => {
+		global.fetch = vi.fn(async (url: string) => ({
+			ok: true,
+			status: 200,
+			text: async () =>
+				url.includes('/products')
+					? JSON.stringify([PRODUCTS[0]])
+					: JSON.stringify([]),
+		})) as any;
+		const { findByText, queryByText } = render(
+			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		await findByText('Idiot');
+		expect(queryByText('All products')).toBeNull();
+		expect(
+			await findByText(/only drop live right now/),
+		).toBeTruthy();
+	});
+
+	it('shows an empty state when the catalog has no products', async () => {
+		global.fetch = vi.fn(async () => ({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify([]),
+		})) as any;
+		const { findByText, queryByText } = render(
+			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,
+		);
+		expect(await findByText('The shelves are empty')).toBeTruthy();
+		expect(queryByText('All products')).toBeNull();
+	});
+
 	it('walks the digital purchase through its progress steps', async () => {
 		const { findByText, getByText } = render(
 			<StoreView getToken={async () => 'tok'} baseUrl="" authenticated />,

--- a/packages/npm/rn/src/markets/store/index.ts
+++ b/packages/npm/rn/src/markets/store/index.ts
@@ -10,6 +10,8 @@ export { ProductCard } from './ProductCard';
 export { IdiotCard } from './IdiotCard';
 export type { IdiotCardProps } from './IdiotCard';
 export { CheckoutModal } from './CheckoutModal';
+export { PurchaseProgress } from './PurchaseProgress';
+export type { PurchaseProgressProps, PurchaseStatus } from './PurchaseProgress';
 export { OrderHistory } from './OrderHistory';
 export { StoreView } from './StoreView';
 export type { StoreViewProps } from './StoreView';

--- a/packages/npm/rn/src/markets/store/types.ts
+++ b/packages/npm/rn/src/markets/store/types.ts
@@ -84,6 +84,10 @@ export const CREDIT_PACKS: CreditPack[] = [
 
 export const FEATURED_SLUG = 'i-am-an-idiot';
 
+export function needsShipping(fulfillment?: Fulfillment | string | null): boolean {
+	return fulfillment === 'physical' || fulfillment === 'both';
+}
+
 export interface StaffProductBody {
 	slug: string;
 	title: string;

--- a/packages/npm/rn/src/ui/feedback/ProgressBar.tsx
+++ b/packages/npm/rn/src/ui/feedback/ProgressBar.tsx
@@ -1,0 +1,117 @@
+import { memo, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { ViewStyle } from 'react-native';
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+	withRepeat,
+	withTiming,
+} from 'react-native-reanimated';
+import { tokens } from '../theme';
+import { Text } from '../primitives/Text';
+
+export type ProgressTone = 'primary' | 'success' | 'danger';
+
+export interface ProgressBarProps {
+	value?: number;
+	indeterminate?: boolean;
+	tone?: ProgressTone;
+	height?: number;
+	label?: string;
+	style?: ViewStyle;
+}
+
+const TONE_COLOR: Record<ProgressTone, string> = {
+	primary: tokens.color.primary,
+	success: tokens.color.success,
+	danger: tokens.color.danger,
+};
+
+export const ProgressBar = memo(function ProgressBar({
+	value = 0,
+	indeterminate = false,
+	tone = 'primary',
+	height = 6,
+	label,
+	style,
+}: ProgressBarProps) {
+	const clamped = Math.max(0, Math.min(1, value));
+	const pct = useSharedValue(clamped);
+	const slide = useSharedValue(0);
+
+	useEffect(() => {
+		pct.value = withTiming(clamped, { duration: 260 });
+	}, [clamped]);
+
+	useEffect(() => {
+		if (!indeterminate) {
+			slide.value = 0;
+			return;
+		}
+		slide.value = 0;
+		slide.value = withRepeat(withTiming(1, { duration: 1100 }), -1, false);
+	}, [indeterminate]);
+
+	const fill = useAnimatedStyle(() =>
+		indeterminate
+			? {
+					width: '35%',
+					left: `${slide.value * 100 - 35}%`,
+				}
+			: { width: `${pct.value * 100}%`, left: 0 },
+	);
+
+	const percentLabel = indeterminate ? null : `${Math.round(clamped * 100)}%`;
+
+	return (
+		<View style={style}>
+			{label || percentLabel ? (
+				<View style={styles.head}>
+					{label ? (
+						<Text variant="caption" tone="muted">
+							{label}
+						</Text>
+					) : null}
+					{percentLabel ? (
+						<Text variant="caption" tone="muted">
+							{percentLabel}
+						</Text>
+					) : null}
+				</View>
+			) : null}
+			<View
+				accessibilityRole="progressbar"
+				accessibilityValue={
+					indeterminate
+						? undefined
+						: { min: 0, max: 100, now: Math.round(clamped * 100) }
+				}
+				style={[styles.track, { height, borderRadius: height }]}>
+				<Animated.View
+					style={[
+						styles.fill,
+						{ backgroundColor: TONE_COLOR[tone], borderRadius: height },
+						fill,
+					]}
+				/>
+			</View>
+		</View>
+	);
+});
+
+const styles = StyleSheet.create({
+	head: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		marginBottom: tokens.space.xs,
+	},
+	track: {
+		backgroundColor: tokens.color.surfaceAlt,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+		overflow: 'hidden',
+	},
+	fill: { position: 'absolute', top: 0, bottom: 0 },
+});
+
+export default ProgressBar;

--- a/packages/npm/rn/src/ui/index.ts
+++ b/packages/npm/rn/src/ui/index.ts
@@ -41,6 +41,7 @@ export * from './feedback/EmptyState';
 export * from './feedback/LoadingState';
 export * from './feedback/ErrorState';
 export * from './feedback/Skeleton';
+export * from './feedback/ProgressBar';
 
 export * from './state/store';
 export * from './state/overlayStore';

--- a/packages/npm/rn/src/ui/index.web.ts
+++ b/packages/npm/rn/src/ui/index.web.ts
@@ -51,6 +51,7 @@ export * from './feedback/EmptyState';
 export * from './feedback/LoadingState';
 export * from './feedback/ErrorState';
 export * from './feedback/Skeleton';
+export * from './feedback/ProgressBar';
 
 export * from './state/store';
 export * from './state/overlayStore';


### PR DESCRIPTION
## Problem

Buying the featured `i-am-an-idiot` card on https://kbve.com/store/ opened the **physical** checkout: it asked for a full shipping address for a digital collectible, and the submit button could never enable — the card was unbuyable.

Live API confirmed the cause — `fulfillment` was absent from the response:

```json
{"product_id":"83456e39-...","slug":"i-am-an-idiot","price":10,"currency":"credits","asset_ref":{"kind":"webgl_card"},"created_at":"..."}
```

Chain:
1. `StoreProductDto` (apps/kbve/axum-kbve/src/transport/store.rs) never serialized `fulfillment` / `variant_count`, though `StoreProductRow` carries both.
2. Client saw `fulfillment: undefined`; `ProductCard` routed on `product.fulfillment !== 'digital'` → truthy → physical path → shipping address form.
3. Digital products have no variants → `variantId` stayed `''` → "Buy with credits" permanently disabled.

## Fix

- `StoreProductDto` gains `fulfillment` and `variant_count`; `list_products` reuses `map_product_dto` so catalog and detail can't drift apart again.
- New `needsShipping()` helper: only `physical` / `both` collect an address, so a missing or unknown value degrades to digital instead of demanding shipping.
- Empty-variant checkout shows "nothing to check out" instead of a dead disabled form.
- Legacy `astro-kbve/src/components/store/StoreCatalog.tsx` gets the same guard.

## Purchase feedback (UI/UX)

- New `ProgressBar` primitive (determinate + indeterminate, themed, `accessibilityRole="progressbar"`).
- New `PurchaseProgress` panel: step list with per-step state, driven by the **real** request phases — digital: charge/mint → sync wallet+inventory → unlocked; order: reserve/charge → refresh orders → placed. Failures mark the step that broke and show the mapped reason (402 → "Not enough credits. Top up above and try again.").
- Checkout form: completion meter (`N of 5 required fields`), `*` on required labels, per-field required errors after touch, a "Still needed: …" summary, and inputs locked while submitting.
- Stripe top-up shows an indeterminate bar while the redirect opens.

## Verification

- `nx lint axum-kbve` — clean (only the pre-existing `needless_borrow` warning in `rcon/handler.rs`).
- `nx test rn` — 43 files, 184 tests pass, including 4 new: missing `fulfillment` routes digital, `physical`/`both` route to checkout, digital purchase walks its progress steps, failed purchase surfaces in the panel.
- `nx lint rn` — no new warnings.

## Notes

- Needs an `axum-kbve` rollout. The frontend guard alone makes the card buyable; catalog badges stay wrong until the API ships the field.
- `packages/data/openapi/openapi.json` is stale (v1.0.227 vs current 1.0.256). Regenerating swept in ~3k lines of unrelated drift, so it is left out of this PR — separate cleanup.
- `nx typecheck rn` fails on `tsconfig.lib.json` (`error TS5103: Invalid value for '--ignoreDeprecations'`), pre-existing and unrelated.