### PR TITLE
fix(reel): correct gluetun plain-DNS env (DOT=off crashed the pod)

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -42,7 +42,7 @@ spec:
             - { name: SERVER_COUNTRIES, value: "Germany" }
             - { name: SERVER_CITIES, value: "Frankfurt" }
             - { name: VPN_PORT_FORWARDING, value: "off" }
-            - { name: DOT, value: "off" }
+            - { name: DNS_UPSTREAM_RESOLVER_TYPE, value: "plain" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel


### PR DESCRIPTION
## Fixes the crashloop from #14892

`DOT=off` is invalid on **gluetun latest** and hard-crashes:

```
ERROR dns settings: upstream type dot must be plain if the built-in DNS server is disabled
```

reel then crashloops (DNS never comes up → vpn preflight can't resolve → exit). RollingUpdate kept the old pod serving, so prod stayed up on the previous DoT config (which is why peer drops persisted in testing — the fix pod never went live).

## Correct env

gluetun latest replaced the `DOT` toggle with `DNS_UPSTREAM_RESOLVER_TYPE` (`dot`|`doh`|`plain`). Set `plain` → plain UDP DNS upstream instead of a single DoT connection. Still egresses through the tunnel (killswitch → no leak), but absorbs BitTorrent's tracker-DNS volume without the TLS-handshake resets.

## Honesty on scope

This fixes my crashloop mistake and removes the DoT storm. I am **not** confident it fixes the 15→0 peer cliff — established TCP peer connections don't drop from DNS/announce failures, and an instant total drop looks more like an MTU or WireGuard-rekey issue. Deploying the correct DNS config removes the storm as a confounder so the cliff can be diagnosed cleanly next.

Kube-only; no image/version bump.