### PR TITLE
fix(reel): revert DNS override to gluetun default (heal crashloop)

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -42,7 +42,6 @@ spec:
             - { name: SERVER_COUNTRIES, value: "Germany" }
             - { name: SERVER_CITIES, value: "Frankfurt" }
             - { name: VPN_PORT_FORWARDING, value: "off" }
-            - { name: DNS_UPSTREAM_RESOLVER_TYPE, value: "plain" }
           volumeMounts:
             - { name: gluetun-run, mountPath: /tmp/gluetun }
         - name: reel


### PR DESCRIPTION
Both `DOT=off` and `DNS_UPSTREAM_RESOLVER_TYPE=plain` crashloop gluetun latest (the latter needs `DNS_UPSTREAM_PLAIN_ADDRESSES` too). DNS isn't the peer-drop cause, so revert to gluetun's default resolver — boots clean, served for hours. Peer-drop investigation moves to MTU / WireGuard rekey. Kube-only.