### PR TITLE
fix(reel): make torrent add idempotent — stops duplicate-watcher deletes

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.20"
+version: "0.1.21"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -233,6 +233,18 @@ by a failed delete, an interrupted move, or lost state. Actively tracked downloa
 currently-streaming item is never swept mid-use. File deletions that fail are now
 logged rather than silently swallowed, so a leaked file is visible and gets cleaned
 on the next sweep instead of accumulating forever.
+
+Adding a torrent is idempotent. A torrent is keyed by its info_hash, so submitting
+the same magnet or `.torrent` while it is already leeching or seeding returns the
+existing id instead of registering it again. Without this guard, a repeated submit
+(a double-click, or a client that retries) spawned a second completion watcher for
+the same info_hash; the duplicate watcher tracked an empty handle, reported zero
+progress and zero peers, and — once its stall timer elapsed — marked the torrent
+failed and deleted it from the session **with its files**, killing the healthy
+download the first watcher was still driving. That presented as the swarm
+"resetting to zero" mid-download and as finished files disappearing. The dedupe
+check removes the duplicate watcher entirely; a genuinely failed torrent can still
+be re-added to retry.
 
 </BentoProse>
 

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -378,6 +378,10 @@ impl Engine {
         now_ok
     }
 
+    fn already_active(&self, id: &str) -> bool {
+        is_active_state(self.store.get(id).map(|m| m.state))
+    }
+
     pub async fn add(&self, source: &str) -> anyhow::Result<String> {
         if !self.vpn_ok() {
             anyhow::bail!("vpn egress unavailable; refusing to add torrent");
@@ -400,6 +404,10 @@ impl Engine {
             .and_then(|m| m.as_id20().map(|h| (h.as_string(), m.name.clone())))
         {
             let name = name.unwrap_or_else(|| id.clone());
+            if self.already_active(&id) {
+                tracing::info!(id = %id, "add ignored: torrent already active (idempotent)");
+                return Ok(id);
+            }
             self.store
                 .upsert(leeching_meta(&id, &name, &out_dir))?;
             crate::telemetry::torrent_added(&id, "magnet");
@@ -428,6 +436,11 @@ impl Engine {
             .into_handle()
             .ok_or_else(|| anyhow::anyhow!("torrent is list-only, no handle"))?;
         let id = handle.info_hash().as_string();
+        if self.already_active(&id) {
+            let _ = std::fs::remove_dir_all(&out_dir);
+            tracing::info!(id = %id, "add ignored: torrent already active (idempotent)");
+            return Ok(id);
+        }
         let name = handle.name().unwrap_or_else(|| id.clone());
         self.store.upsert(leeching_meta(&id, &name, &out_dir))?;
         crate::telemetry::torrent_added(&id, "url");
@@ -1023,6 +1036,13 @@ pub async fn tracker_refresh_loop(
     }
 }
 
+pub fn is_active_state(state: Option<state::TorrentState>) -> bool {
+    matches!(
+        state,
+        Some(state::TorrentState::Leeching | state::TorrentState::Seeding)
+    )
+}
+
 pub fn remove_entry_files(path: &str, transcode_path: Option<&str>) {
     for p in std::iter::once(path).chain(transcode_path) {
         let pb = std::path::Path::new(p);
@@ -1055,6 +1075,15 @@ mod tests {
         remove_entry_files(&src.display().to_string(), Some(&tc.display().to_string()));
         assert!(!src.exists());
         assert!(!tc.exists());
+    }
+
+    #[test]
+    fn is_active_state_matches_leeching_and_seeding_only() {
+        use state::TorrentState::*;
+        assert!(is_active_state(Some(Leeching)));
+        assert!(is_active_state(Some(Seeding)));
+        assert!(!is_active_state(Some(Failed)));
+        assert!(!is_active_state(None));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause (caught live)

Watched a real download: the same magnet was submitted **6 times** in one session (repeated download click while it looked dead). \`add()\` isn't idempotent → each submit spawned another completion watcher for the same info_hash.

- The **real** download was fine: climbing past **3.8 GB at 60+ Mbps**.
- The **duplicate** watchers tracked an empty handle → \`progress=0 peers=0\`. Their heartbeats interleaved with the real one → status flapped between the true swarm and zero = the **"peers reset to 0"** symptom.
- Worse: each zombie runs the stall timer. At \`REEL_STALL_TIMEOUT_SECS\` with no progress it marks the torrent **Failed** and calls \`delete_from_session(id, delete_files=true)\`. Same info_hash → **that deletes the healthy download and its files** → completed items vanish, streaming 404s.

Not VPN / DNS / MTU — an app-level idempotency bug.

## Fix

\`add()\` checks the info_hash before registering. If a torrent with that id is already **Leeching or Seeding**, return the existing id with no second upsert/watcher (magnet path returns early; url path also removes the unused out_dir it created). A **Failed** torrent can still be re-added to retry. Pure \`is_active_state()\` helper, unit-tested.

140 tests, clippy clean. mdx 0.1.20→0.1.21.

## Follow-up (separate)

Worth checking why the client submitted the same magnet 6×; server idempotency is the correct fix regardless, but the frontend may be re-posting.