### PR TITLE
fix(kbve-gate): GATE_EXTERNAL_BASE so supabase studio mints a public redirect_to

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -385,7 +385,7 @@
 		{
 			"key": "kbve_gate",
 			"app_name": "kbve-gate",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/kbve/kbve-gate/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
 			"version_target": "apps/kbve/kbve-gate/Cargo.toml",

--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -393,7 +393,6 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/kbve-gate",
 			"deployment_yamls": [
-				"apps/kube/n8n/manifest/n8n-deployment.yaml",
 				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml",
 				"apps/kube/argocd/manifests/argocd-gate-deployment.yaml",
 				"apps/kube/storage/manifests/longhorn-gate-deployment.yaml",

--- a/apps/kbve/astro-kbve/src/components/auth/gateBounce.test.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/gateBounce.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readGateRedirect } from './gateBounce';
+
+const q = (value: string) => `?redirect_to=${encodeURIComponent(value)}`;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('readGateRedirect', () => {
+	it('accepts an https target on a kbve.com subdomain', () => {
+		expect(
+			readGateRedirect(q('https://supabase.kbve.com/project/default')),
+		).toBe('https://supabase.kbve.com/project/default');
+	});
+
+	it('accepts the apex host', () => {
+		expect(readGateRedirect(q('https://kbve.com/x'))).toBe(
+			'https://kbve.com/x',
+		);
+	});
+
+	it('preserves the query on a deep-link target', () => {
+		expect(
+			readGateRedirect(
+				q(
+					'https://supabase.kbve.com/project/default/sql?schema=public',
+				),
+			),
+		).toBe('https://supabase.kbve.com/project/default/sql?schema=public');
+	});
+
+	it('returns null when the param is absent', () => {
+		expect(readGateRedirect('')).toBeNull();
+		expect(readGateRedirect('?other=1')).toBeNull();
+	});
+
+	it.each([
+		['plain http', 'http://supabase.kbve.com/project/default'],
+		['an internal service host', 'http://studio-gate:5678/project/default'],
+		['a foreign origin', 'https://evil.com/steal'],
+		['a suffix lookalike', 'https://notkbve.com/steal'],
+		['a prefix lookalike', 'https://kbve.com.evil.com/steal'],
+		['a path-only value', '/project/default'],
+		['a javascript scheme', 'javascript:alert(1)'],
+		['garbage', 'not a url'],
+	])('rejects %s', (_label, value) => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		expect(readGateRedirect(q(value))).toBeNull();
+		expect(warn).toHaveBeenCalledOnce();
+	});
+
+	it('warns with the rejected value so the cause is visible', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		readGateRedirect(q('http://studio-gate:5678/project/default'));
+		expect(warn.mock.calls[0][0]).toContain('http://studio-gate:5678');
+		expect(warn.mock.calls[0][0]).toContain('not https');
+	});
+
+	it('does not warn when there is nothing to redirect to', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		readGateRedirect('');
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/auth/gateBounce.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/gateBounce.ts
@@ -14,16 +14,30 @@ export function readGateRedirect(
 		? window.location.search
 		: '',
 ): string | null {
+	const raw = new URLSearchParams(search).get(GATE_REDIRECT_PARAM);
+	if (!raw) return null;
 	try {
-		const raw = new URLSearchParams(search).get(GATE_REDIRECT_PARAM);
-		if (!raw) return null;
 		const url = new URL(raw);
-		if (url.protocol !== 'https:') return null;
-		if (!isTrustedGateHost(url.hostname)) return null;
+		if (url.protocol !== 'https:') return reject(raw, 'not https');
+		if (!isTrustedGateHost(url.hostname))
+			return reject(raw, 'host is not kbve.com or a subdomain');
 		return url.toString();
 	} catch {
-		return null;
+		return reject(raw, 'not a parseable absolute URL');
 	}
+}
+
+/**
+ * A rejected `redirect_to` silently drops the user on the login origin instead
+ * of the gated host they asked for, which reads as a broken login rather than a
+ * blocked redirect. Say so — the usual cause is a gate behind a second proxy
+ * emitting an internal `http://svc:port` target, fixed with GATE_EXTERNAL_BASE.
+ */
+function reject(raw: string, reason: string): null {
+	console.warn(
+		`Ignoring untrusted ${GATE_REDIRECT_PARAM} (${reason}): ${raw}`,
+	);
+	return null;
 }
 
 /**

--- a/apps/kbve/astro-kbve/src/components/auth/gateBounce.unit.test.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/gateBounce.unit.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bounceToGate } from './gateBounce';
+
+let replace: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	replace = vi.fn();
+	Object.defineProperty(window, 'location', {
+		configurable: true,
+		value: { ...window.location, replace },
+	});
+});
+
+describe('bounceToGate', () => {
+	it('appends the access token and navigates', () => {
+		expect(
+			bounceToGate('https://supabase.kbve.com/project/default', 'jwt123'),
+		).toBe(true);
+		expect(replace).toHaveBeenCalledWith(
+			'https://supabase.kbve.com/project/default?access_token=jwt123',
+		);
+	});
+
+	it('keeps an existing deep-link query alongside the token', () => {
+		bounceToGate(
+			'https://supabase.kbve.com/project/default/sql?schema=public',
+			'jwt123',
+		);
+		expect(replace).toHaveBeenCalledWith(
+			'https://supabase.kbve.com/project/default/sql?schema=public&access_token=jwt123',
+		);
+	});
+
+	it('overwrites a token already present rather than duplicating it', () => {
+		bounceToGate('https://supabase.kbve.com/x?access_token=stale', 'fresh');
+		expect(replace).toHaveBeenCalledWith(
+			'https://supabase.kbve.com/x?access_token=fresh',
+		);
+	});
+
+	it.each([
+		['a foreign origin', 'https://evil.com/steal'],
+		['a prefix lookalike', 'https://kbve.com.evil.com/steal'],
+		['garbage', 'not a url'],
+	])('refuses to hand the token to %s', (_label, target) => {
+		expect(bounceToGate(target, 'jwt123')).toBe(false);
+		expect(replace).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op without a target or a token', () => {
+		expect(bounceToGate('', 'jwt123')).toBe(false);
+		expect(bounceToGate('https://supabase.kbve.com/x', '')).toBe(false);
+		expect(replace).not.toHaveBeenCalled();
+	});
+});

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -12,7 +12,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.8"
+version: "0.1.9"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml
@@ -146,6 +146,7 @@ After the JWT validates it applies an authz policy:
 | `GATE_FORWARD_USER_HEADER` / `GATE_FORWARD_USER_VALUE` | — | trusted identity header injected downstream (Grafana auth-proxy) |
 | `GATE_LOGIN_REDIRECT` | — | 302 target for unauthed browser navigations |
 | `GATE_COOKIE_DOMAIN` | — | domain scope for the minted session cookie (e.g. `.kbve.com`) |
+| `GATE_EXTERNAL_BASE` | — | public origin for `redirect_to` (e.g. `https://supabase.kbve.com`); required behind a proxy that rewrites `Host` or drops `X-Forwarded-Proto` |
 | `SUPABASE_JWT_SECRET` | — | required |
 | `SUPABASE_URL` | — | required for `is_staff` (direct PostgREST) |
 
@@ -170,6 +171,14 @@ navigation carries no token. The gate completes auth with a bounce:
 
 The login page only honours `redirect_to` targets on `*.kbve.com` over https,
 so the token can never be handed to a foreign origin.
+
+`redirect_to` is normally derived from `Host` + `X-Forwarded-Proto`. A gate
+behind a second reverse proxy can see neither: Supabase Studio sits behind Kong,
+which without `preserve_host` sends `Host: studio-gate:5678` and stamps
+`X-Forwarded-Proto: http` for its own plaintext listener. The gate then emits
+`http://studio-gate:5678/...`, the login page rejects it, and the user lands on
+the homepage instead of the gated host. Set `GATE_EXTERNAL_BASE` on any gate
+that is not directly addressed by its public hostname.
 
 </BentoProse>
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -19,7 +19,6 @@ version_target: apps/kbve/kbve-gate/Cargo.toml
 runner: ubuntu-latest
 image: kbve/kbve-gate
 deployment_yamls:
-    - apps/kube/n8n/manifest/n8n-deployment.yaml
     - apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
     - apps/kube/argocd/manifests/argocd-gate-deployment.yaml
     - apps/kube/storage/manifests/longhorn-gate-deployment.yaml
@@ -172,13 +171,25 @@ navigation carries no token. The gate completes auth with a bounce:
 The login page only honours `redirect_to` targets on `*.kbve.com` over https,
 so the token can never be handed to a foreign origin.
 
-`redirect_to` is normally derived from `Host` + `X-Forwarded-Proto`. A gate
+`redirect_to` carries the full path **and query**, so a deep link
+(`/project/default/sql?schema=public`) survives the round trip. Any
+`access_token` already in the query is dropped rather than echoed back.
+
+`redirect_to` is otherwise derived from `Host` + `X-Forwarded-Proto`. A gate
 behind a second reverse proxy can see neither: Supabase Studio sits behind Kong,
 which without `preserve_host` sends `Host: studio-gate:5678` and stamps
 `X-Forwarded-Proto: http` for its own plaintext listener. The gate then emits
 `http://studio-gate:5678/...`, the login page rejects it, and the user lands on
-the homepage instead of the gated host. Set `GATE_EXTERNAL_BASE` on any gate
-that is not directly addressed by its public hostname.
+the homepage instead of the gated host.
+
+`GATE_EXTERNAL_BASE` pins the public origin and bypasses both headers. It is set
+on studio, grafana, argo, longhorn, and windmill so no future proxy change can
+break the bounce. A bad value fails at boot rather than at login. **Forgejo
+deliberately leaves it unset** — it serves `forgejo.kbve.com`, `git.kbve.com`,
+and the DNS-only `direct.git.kbve.com` from one route, so pinning one origin
+would bounce every login away from the other two. When the value is unset and
+the derived target is not https on a public hostname, the gate logs a warning
+naming this env var.
 
 </BentoProse>
 

--- a/apps/kube/argocd/manifests/argocd-gate-deployment.yaml
+++ b/apps/kube/argocd/manifests/argocd-gate-deployment.yaml
@@ -54,6 +54,8 @@ spec:
                         value: forum
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
+                      - name: GATE_EXTERNAL_BASE
+                        value: https://argo.kbve.com
                       - name: GATE_COOKIE_DOMAIN
                         value: .kbve.com
                       - name: SUPABASE_URL

--- a/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
+++ b/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
@@ -53,6 +53,8 @@ spec:
                         value: forum
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
+                      - name: GATE_EXTERNAL_BASE
+                        value: https://grafana.kbve.com
                       - name: GATE_COOKIE_DOMAIN
                         value: .kbve.com
                       - name: SUPABASE_URL

--- a/apps/kube/storage/manifests/longhorn-gate-deployment.yaml
+++ b/apps/kube/storage/manifests/longhorn-gate-deployment.yaml
@@ -47,6 +47,8 @@ spec:
                         value: forum
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
+                      - name: GATE_EXTERNAL_BASE
+                        value: https://longhorn.kbve.com
                       - name: GATE_COOKIE_DOMAIN
                         value: .kbve.com
                       - name: SUPABASE_URL

--- a/apps/kube/studio/manifests/studio-gate-deployment.yaml
+++ b/apps/kube/studio/manifests/studio-gate-deployment.yaml
@@ -61,6 +61,8 @@ spec:
                         value: is_superadmin
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
+                      - name: GATE_EXTERNAL_BASE
+                        value: https://supabase.kbve.com
                       - name: GATE_COOKIE_DOMAIN
                         value: .kbve.com
                       - name: SUPABASE_URL

--- a/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
+++ b/apps/kube/windmill/manifest/windmill-gate-deployment.yaml
@@ -53,6 +53,8 @@ spec:
                         value: forum
                       - name: GATE_LOGIN_REDIRECT
                         value: https://kbve.com/login
+                      - name: GATE_EXTERNAL_BASE
+                        value: https://windmill.kbve.com
                       - name: GATE_COOKIE_DOMAIN
                         value: .kbve.com
                       - name: SUPABASE_URL

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -79,6 +79,9 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         .ok()
         .map(|s| s.trim().trim_end_matches('/').to_string())
         .filter(|s| !s.is_empty());
+    if let Some(base) = &external_base {
+        validate_external_base(base)?;
+    }
     let upstream_ca_cert_path = std::env::var("GATE_UPSTREAM_CA_CERT_PATH")
         .ok()
         .filter(|s| !s.is_empty());
@@ -167,6 +170,34 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         verifier,
         windmill,
     })
+}
+
+/// Reject a `GATE_EXTERNAL_BASE` that cannot produce a working bounce target, so
+/// a typo fails at boot instead of silently stranding every login. A path
+/// component is refused because the request path is appended verbatim and would
+/// be doubled up.
+#[cfg(feature = "gate")]
+fn validate_external_base(base: &str) -> Result<(), String> {
+    let url = url::Url::parse(base)
+        .map_err(|e| format!("GATE_EXTERNAL_BASE must be an absolute origin URL: {e}"))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| format!("GATE_EXTERNAL_BASE has no host: {base}"))?;
+    if !url.path().is_empty() && url.path() != "/" {
+        return Err(format!(
+            "GATE_EXTERNAL_BASE must be an origin without a path, got path '{}'",
+            url.path()
+        ));
+    }
+    let local = host == "localhost" || host == "127.0.0.1" || host == "::1";
+    if url.scheme() != "https" && !local {
+        tracing::warn!(
+            %base,
+            "GATE_EXTERNAL_BASE is not https — the login page only honours https targets, \
+             so every login bounce will be rejected"
+        );
+    }
+    Ok(())
 }
 
 /// Bind `GATE_LISTEN` (default `0.0.0.0:5678`) and serve the gate forever.

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -35,6 +35,9 @@ use std::net::SocketAddr;
 /// - `GATE_UPSTREAM_BASIC`  optional `Basic <b64>` injected upstream
 /// - `GATE_LOGIN_REDIRECT`  optional 302 target for unauthed navigations
 /// - `GATE_COOKIE_DOMAIN`   optional domain scope for the session cookie
+/// - `GATE_EXTERNAL_BASE`   public origin (`https://host`) for the
+///   `redirect_to` bounce target; set it when a fronting proxy rewrites `Host`
+///   or drops `X-Forwarded-Proto`
 /// - `GATE_STAFF_TTL_SECS`  is_staff cache TTL (default 30)
 /// - `GATE_STAFF_SCHEMA`    PostgREST schema for the RPC (default `forum`)
 /// - `GATE_STAFF_RPC`       PostgREST RPC name (default `is_staff`); e.g.
@@ -71,6 +74,10 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         .filter(|s| !s.is_empty());
     let cookie_domain = std::env::var("GATE_COOKIE_DOMAIN")
         .ok()
+        .filter(|s| !s.is_empty());
+    let external_base = std::env::var("GATE_EXTERNAL_BASE")
+        .ok()
+        .map(|s| s.trim().trim_end_matches('/').to_string())
         .filter(|s| !s.is_empty());
     let upstream_ca_cert_path = std::env::var("GATE_UPSTREAM_CA_CERT_PATH")
         .ok()
@@ -151,6 +158,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         upstream_basic,
         login_redirect,
         cookie_domain,
+        external_base,
         staff,
         upstream_ca_cert_path,
         upstream_bearer,

--- a/packages/rust/kbve/src/gate/proxy.rs
+++ b/packages/rust/kbve/src/gate/proxy.rs
@@ -39,6 +39,13 @@ pub struct GateConfig {
     /// so every subdomain behind the gate shares it. When unset the cookie is
     /// host-only.
     pub cookie_domain: Option<String>,
+    /// Authoritative public origin (`https://host[:port]`) used to build the
+    /// `redirect_to` bounce target, overriding `Host` + `X-Forwarded-Proto`.
+    /// Required when another reverse proxy rewrites `Host` to the gate's
+    /// internal service name (Kong `preserve_host: false`) or terminates TLS
+    /// without forwarding the client scheme — both yield an internal
+    /// `http://svc:port` target the login page rejects.
+    pub external_base: Option<String>,
     /// Staff RPC gate. Required when `authz` is `IsStaff`.
     pub staff: Option<StaffGate>,
     /// PEM CA bundle trusted for the upstream TLS connection. Lets the gate
@@ -146,7 +153,11 @@ fn redirect(location: &str, set_cookie: Option<&str>) -> Response {
 
 /// Reconstruct the externally-visible URL (sans query) from proxy headers, used
 /// as the `redirect_to` target so the login page can return the browser here.
-fn external_url(headers: &HeaderMap, uri: &Uri) -> String {
+/// `base` wins when set — see [`GateConfig::external_base`].
+fn external_url(base: Option<&str>, headers: &HeaderMap, uri: &Uri) -> String {
+    if let Some(base) = base {
+        return format!("{}{}", base.trim_end_matches('/'), uri.path());
+    }
     let host = headers
         .get(header::HOST)
         .and_then(|v| v.to_str().ok())
@@ -424,7 +435,7 @@ async fn authorize(
 async fn gate_handler(State(state): State<Arc<GateState>>, req: Request<Body>) -> Response {
     let headers = req.headers().clone();
     let query = req.uri().query().map(|q| q.to_string());
-    let ext_url = external_url(&headers, req.uri());
+    let ext_url = external_url(state.cfg.external_base.as_deref(), &headers, req.uri());
     let bounced = query.as_deref().and_then(access_token_in_query).is_some();
 
     let (exp, user, email) =
@@ -822,4 +833,54 @@ async fn pump_ws(
         _ = upstream_to_browser => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(host: &str, proto: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::HOST, HeaderValue::from_str(host).unwrap());
+        if let Some(p) = proto {
+            h.insert("x-forwarded-proto", HeaderValue::from_str(p).unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn external_url_from_headers() {
+        let uri: Uri = "/project/default".parse().unwrap();
+        assert_eq!(
+            external_url(None, &headers("grafana.kbve.com", None), &uri),
+            "https://grafana.kbve.com/project/default"
+        );
+    }
+
+    #[test]
+    fn external_base_overrides_proxy_rewritten_host_and_scheme() {
+        let uri: Uri = "/project/default".parse().unwrap();
+        let h = headers("studio-gate:5678", Some("http"));
+        assert_eq!(
+            external_url(None, &h, &uri),
+            "http://studio-gate:5678/project/default"
+        );
+        assert_eq!(
+            external_url(Some("https://supabase.kbve.com"), &h, &uri),
+            "https://supabase.kbve.com/project/default"
+        );
+    }
+
+    #[test]
+    fn external_base_trailing_slash_does_not_double() {
+        let uri: Uri = "/".parse().unwrap();
+        assert_eq!(
+            external_url(
+                Some("https://supabase.kbve.com/"),
+                &headers("studio-gate:5678", Some("http")),
+                &uri
+            ),
+            "https://supabase.kbve.com/"
+        );
+    }
 }

--- a/packages/rust/kbve/src/gate/proxy.rs
+++ b/packages/rust/kbve/src/gate/proxy.rs
@@ -151,22 +151,66 @@ fn redirect(location: &str, set_cookie: Option<&str>) -> Response {
         .into_response()
 }
 
-/// Reconstruct the externally-visible URL (sans query) from proxy headers, used
-/// as the `redirect_to` target so the login page can return the browser here.
-/// `base` wins when set — see [`GateConfig::external_base`].
+/// Reconstruct the externally-visible URL from proxy headers, used as the
+/// `redirect_to` target so the login page can return the browser exactly here —
+/// query included, so a deep link (`/project/default/sql?schema=public`) survives
+/// the round trip. Any `access_token` is dropped: the login page appends its own,
+/// and a stale one must never be echoed back into a redirect.
+/// `base` wins over the headers when set — see [`GateConfig::external_base`].
 fn external_url(base: Option<&str>, headers: &HeaderMap, uri: &Uri) -> String {
-    if let Some(base) = base {
-        return format!("{}{}", base.trim_end_matches('/'), uri.path());
+    let mut out = match base {
+        Some(base) => format!("{}{}", base.trim_end_matches('/'), uri.path()),
+        None => {
+            let host = headers
+                .get(header::HOST)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            let scheme = headers
+                .get("x-forwarded-proto")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("https");
+            format!("{scheme}://{host}{}", uri.path())
+        }
+    };
+    if let Some(query) = uri.query() {
+        let cleaned = strip_access_token(query);
+        if !cleaned.is_empty() {
+            out.push('?');
+            out.push_str(&cleaned);
+        }
     }
-    let host = headers
-        .get(header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let scheme = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("https");
-    format!("{scheme}://{host}{}", uri.path())
+    out
+}
+
+/// True when the login page will accept this URL as a `redirect_to` target: https
+/// on a real hostname. A gate whose `Host` has been rewritten to an internal
+/// service name (`studio-gate:5678`) or whose scheme arrives as plain http fails
+/// here, and every login bounce silently strands the user on the login origin.
+fn is_bounceable(url: &str) -> bool {
+    match url::Url::parse(url) {
+        Ok(u) => {
+            u.scheme() == "https"
+                && u.host_str()
+                    .map(|h| h.contains('.') && !h.ends_with(".local"))
+                    .unwrap_or(false)
+        }
+        Err(_) => false,
+    }
+}
+
+/// One-shot loud warning for the misconfiguration above. Fires on the first
+/// unbounceable deny rather than at boot, because it needs a real request's
+/// headers to know what the fronting proxy actually sends.
+fn warn_unbounceable(ext_url: &str) {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        warn!(
+            redirect_to = %ext_url,
+            "gate login bounce target is not https on a public hostname — the login page \
+             will reject it and strand the user. A fronting proxy is rewriting Host or \
+             dropping X-Forwarded-Proto; set GATE_EXTERNAL_BASE to this gate's public origin."
+        );
+    });
 }
 
 /// Drop the `access_token` pair from a query string, preserving the rest.
@@ -272,6 +316,9 @@ fn deny(
         }
         if let Some(target) = &state.cfg.login_redirect {
             if is_navigation(headers) {
+                if !is_bounceable(ext_url) {
+                    warn_unbounceable(ext_url);
+                }
                 let enc: String =
                     url::form_urlencoded::byte_serialize(ext_url.as_bytes()).collect();
                 let sep = if target.contains('?') { '&' } else { '?' };
@@ -882,5 +929,52 @@ mod tests {
             ),
             "https://supabase.kbve.com/"
         );
+    }
+
+    #[test]
+    fn external_url_preserves_query() {
+        let uri: Uri = "/project/default/sql?schema=public&tab=new"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            external_url(Some("https://supabase.kbve.com"), &HeaderMap::new(), &uri),
+            "https://supabase.kbve.com/project/default/sql?schema=public&tab=new"
+        );
+        assert_eq!(
+            external_url(None, &headers("grafana.kbve.com", None), &uri),
+            "https://grafana.kbve.com/project/default/sql?schema=public&tab=new"
+        );
+    }
+
+    #[test]
+    fn external_url_drops_access_token_from_query() {
+        let uri: Uri = "/d/abc?from=now-6h&access_token=leaked&to=now"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            external_url(None, &headers("grafana.kbve.com", None), &uri),
+            "https://grafana.kbve.com/d/abc?from=now-6h&to=now"
+        );
+    }
+
+    #[test]
+    fn external_url_omits_empty_query() {
+        let uri: Uri = "/d/abc?access_token=leaked".parse().unwrap();
+        assert_eq!(
+            external_url(None, &headers("grafana.kbve.com", None), &uri),
+            "https://grafana.kbve.com/d/abc"
+        );
+    }
+
+    #[test]
+    fn bounceable_only_for_https_public_hosts() {
+        assert!(is_bounceable("https://supabase.kbve.com/project/default"));
+        assert!(is_bounceable("https://grafana.kbve.com/?a=b"));
+        assert!(!is_bounceable("http://studio-gate:5678/project/default"));
+        assert!(!is_bounceable("https://studio-gate/project/default"));
+        assert!(!is_bounceable("https://studio-gate.svc.local/x"));
+        assert!(!is_bounceable("http://supabase.kbve.com/x"));
+        assert!(!is_bounceable("https:///x"));
+        assert!(!is_bounceable("not a url"));
     }
 }


### PR DESCRIPTION
## Problem

`supabase.kbve.com` locks out every user. The gate's login bounce emits an **internal** target:

```
GET https://supabase.kbve.com/project/default
302 location: https://kbve.com/login?redirect_to=http%3A%2F%2Fstudio-gate%3A5678%2Fproject%2Fdefault
```

`readGateRedirect` only honours `https:` on `*.kbve.com` (open-redirect token-exfil guard), so it returns `null`, the login flow has no gate target, and `ReactAuthCallback` falls through to `window.location.href = '/'` — the user lands on the kbve.com homepage instead of Studio.

Working gates for comparison:

```
grafana.kbve.com  -> redirect_to=https%3A%2F%2Fgrafana.kbve.com%2F
forgejo.kbve.com  -> redirect_to=https%3A%2F%2Fforgejo.kbve.com%2F
```

## Cause

`external_url()` built `redirect_to` from `Host` + `X-Forwarded-Proto`. studio-gate is the only gate that sits **behind a second reverse proxy** — the others are addressed directly by their public hostname through Envoy. Kong sends `Host: studio-gate:5678` and stamps `X-Forwarded-Proto: http` for its own plaintext listener, so both inputs are internal.

`preserve_host: true` on the `dashboard-all` route (#14465) is present in `kong-config.yaml` on `main`, but Kong runs DB-less from `KONG_DECLARATIVE_CONFIG` and a ConfigMap edit does not hot-reload — the live proxy never picked it up. Even after a reload it would emit `http://supabase.kbve.com/...`, still rejected: there is no `KONG_TRUSTED_IPS`, so Kong ignores Envoy's `X-Forwarded-Proto: https`.

## Fix

`GATE_EXTERNAL_BASE` sets the authoritative public origin and bypasses both proxy headers. Unset keeps the existing header-derived behaviour.

- `packages/rust/kbve/src/gate` — `external_base` config + `GATE_EXTERNAL_BASE` env
- `studio-gate-deployment.yaml` — `GATE_EXTERNAL_BASE=https://supabase.kbve.com`
- kbve-gate `0.1.8` -> `0.1.9` (MDX only), `ci-dispatch-manifest.json` regenerated

Chosen over the Kong-side fix (`KONG_TRUSTED_IPS` + pod restart) because it is independent of proxy header behaviour and does not touch `kong-config.yaml` — that file is a hard-wrapped quoted scalar where one bad edit takes down the whole `supabase.kbve.com` host. `preserve_host` is left in place.

## Hardening — so this class of failure cannot recur silently

**`redirect_to` now carries the query, not just the path.** A deep link (`/project/default/sql?schema=public`, `/d/abc?from=now-6h`) previously lost its params on every login bounce, on every gate. Any `access_token` in the query is stripped rather than echoed back into a redirect.

**Bad config fails at boot.** `GATE_EXTERNAL_BASE` that is not absolute, has no host, or carries a path exits 2; non-https warns. A path is refused because the request path is appended verbatim and would be doubled.

**The broken case now names its own fix.** The first bounce target that is not https-on-a-public-hostname logs a one-shot warning pointing at `GATE_EXTERNAL_BASE`. The original lockout *was* logged — as an ordinary deny line, indistinguishable from any 401.

**`GATE_EXTERNAL_BASE` pinned on grafana / argo / longhorn / windmill**, so no future proxy insertion can break them. **Forgejo deliberately excluded** — [httproute.yaml](apps/kube/forgejo/manifest/httproute.yaml) serves `forgejo.kbve.com`, `git.kbve.com`, and the DNS-only `direct.git.kbve.com` (grey-cloud, for LFS pushes over CF's body cap) from one route; pinning one origin would bounce every login away from the other two. That is also why the header path stays the default rather than the env becoming mandatory.

**`gateBounce.ts` had zero tests** despite being the open-redirect / token-exfil guard, and a rejected target vanished with no signal. Now 21 tests (reject matrix: http, internal host, foreign origin, suffix/prefix lookalikes, path-only, `javascript:`, garbage) plus a `console.warn` on rejection. The jsdom half is `.unit.test.tsx` — `.unit.test.ts` gets picked up by *both* vitest configs and fails under `environment: 'node'`.

**Dead entry removed** — `deployment_yamls` listed `apps/kube/n8n/manifest/n8n-deployment.yaml`; `apps/kube/n8n/` no longer exists (decommissioned for Windmill). Was a silent CI warning at publish time.

## Verification

- `kbve:test --features gate` — 57 passed, incl. 7 `gate::proxy::tests`
- `astro-kbve:test` — 323 passed (14 new); `astro-kbve:test:unit` — 28 passed (7 new)
- `kbve:lint --features gate` clean; `kbve-gate:build` clean
- manifest regenerated from a fresh `--skip-nx-cache` astro build; only the version line and the dead n8n path moved
- `astro-kbve:check` is red on `main` already (d3 typings, recharts formatter types under `components/dashboard/`) — zero errors in `components/auth`

## Not in scope

The reason #14465 silently did nothing is worth its own issue: Kong runs DB-less from `KONG_DECLARATIVE_CONFIG`, so **any** `kong-config.yaml` edit no-ops until the pod restarts, and `preserve_host` sat correct-in-git / wrong-in-cluster for weeks. Fixing it means a ConfigMap-hash annotation on the pod template or a kustomize `configMapGenerator` — changes against the file where one bad edit takes down the whole host.

## Rollout

Reaches the cluster after the dev -> main release sync and the `atom-post-publish-kbve-gate-v0.1.9` image-tag PR.

Interim unlock for a SUPERADMIN, no deploy needed:

```
https://kbve.com/login?redirect_to=https%3A%2F%2Fsupabase.kbve.com%2Fproject%2Fdefault
```

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)