### PR TITLE
chore(crates): syn 3 + publish holy 0.2.2 / embeddb-derive 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7060,7 +7060,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -9109,7 +9109,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand 0.10.2",
- "syn 2.0.119",
+ "syn 3.0.2",
  "trybuild",
 ]
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/embeddb-derive-crate.mdx
@@ -11,7 +11,7 @@ tags:
 key: embeddb_derive_crate
 pipeline: crates
 package_name: embeddb-derive
-version: "0.1.0"
+version: "0.1.1"
 source_path: packages/rust/embeddb-derive
 version_toml: packages/rust/embeddb-derive/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/holy-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/holy-crate.mdx
@@ -11,7 +11,7 @@ tags:
 key: holy_crate
 pipeline: crates
 package_name: holy
-version: "0.2.1"
+version: "0.2.2"
 source_path: packages/rust/holy
 version_toml: packages/rust/holy/version.toml
 author: h0lybyte

--- a/packages/rust/embeddb-derive/Cargo.toml
+++ b/packages/rust/embeddb-derive/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/embeddb-deriv
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"

--- a/packages/rust/holy/Cargo.toml
+++ b/packages/rust/holy/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 rust-version.workspace = true
 
 [dependencies]
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 quote = "1.0.44"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
Supersedes #14719 (dependabot syn 2→3 bump).

## What
- Includes dependabot's `syn` 2.0.119 → 3.0.2 bump (Cargo.toml + Cargo.lock) for `holy` + `embeddb-derive`.
- Patch-bumps both crates so the syn 3 build gets published to crates.io:
  - `holy` 0.2.1 → 0.2.2
  - `embeddb-derive` 0.1.0 → 0.1.1
- Versions bumped in the MDX source-of-truth (`docs/project/*-crate.mdx`); CI patches Cargo.toml on publish.

## Safety
Only these 2 proc-macro crates resolve syn 3 (rest of workspace stays on syn 2, dual-major). Both build clean and pass full test suites against syn 3:
- `holy` — 20 trybuild pass-cases + 8 fail-cases (macro output + error spans correct)
- `embeddb-derive` — compiles clean

syn 3 breaking changes (Modifiers structs, BareFn→FnPtr, Type attrs) don't touch either crate's API surface — both use only stable `DeriveInput`/`Data`/`Fields`/`Type`/`Error`/`Ident`.

Docs: https://kbve.com/application/rust/