### PR TITLE
fix(reel): auto-transcode to a single playable file so Play just works

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.21"
+version: "0.1.22"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -245,6 +245,17 @@ download the first watcher was still driving. That presented as the swarm
 "resetting to zero" mid-download and as finished files disappearing. The dedupe
 check removes the duplicate watcher entirely; a genuinely failed torrent can still
 be re-added to retry.
+
+Playback is meant to be effortless: download a file and it becomes watchable on its
+own, with no manual transcode step and without keeping two copies. When a download
+finishes, an auto-transcode worker wakes and processes it. If the file is already
+directly playable in the browser — h264 video, aac audio, in an mp4 container — it is
+left untouched and served as-is. Otherwise it is transcoded once to a browser-ready
+mp4 and the original source is deleted, so a 4 GB MKV does not sit on disk next to a
+4 GB mp4. The manifest and the raw stream both resolve to the finished transcode when
+one is ready, so a completed item plays directly instead of being routed back through
+the original (which, for a container like MKV, the browser cannot decode). The result
+is a single playable file per download and a Play button that just works.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -323,6 +323,17 @@ async fn stream_file(
     .await
 }
 
+/// The file delivery should probe/serve: the finished transcode when it is
+/// Ready, otherwise None (caller falls back to the largest source file). Keeps
+/// manifest routing consistent with what `/stream` actually serves.
+pub(crate) fn delivery_source(meta: &state::Metadata) -> Option<std::path::PathBuf> {
+    if meta.transcode == state::TranscodeStatus::Ready {
+        meta.transcode_path.clone().map(std::path::PathBuf::from)
+    } else {
+        None
+    }
+}
+
 async fn manifest(
     State(st): State<AppState>,
     headers: HeaderMap,
@@ -346,16 +357,19 @@ async fn manifest(
     let delivery = match st.hls.cached_delivery(&id) {
         Some(d) => d,
         None => {
-            let primary = match transcode::pick_primary_file_async(std::path::PathBuf::from(&meta.path)).await {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::warn!(id = %id, path = %meta.path, error = %e, "manifest: no primary media file");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({"error": e.to_string()})),
-                    )
-                        .into_response();
-                }
+            let primary = match delivery_source(&meta) {
+                Some(p) => p,
+                None => match transcode::pick_primary_file_async(std::path::PathBuf::from(&meta.path)).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::warn!(id = %id, path = %meta.path, error = %e, "manifest: no primary media file");
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({"error": e.to_string()})),
+                        )
+                            .into_response();
+                    }
+                },
             };
             let probe = match transcode::probe(&st.ffprobe_bin, &primary).await {
                 Ok(p) => p,
@@ -821,6 +835,21 @@ mod tests {
             hls_dir: None,
             hls_error: None,
         }
+    }
+
+    #[test]
+    fn delivery_source_prefers_ready_transcode() {
+        let mut m = meta_for(TorrentState::Seeding);
+        assert_eq!(delivery_source(&m), None, "no transcode -> fall back to source");
+        m.transcode = TranscodeStatus::Ready;
+        m.transcode_path = Some("/lib/m/x.reel.mp4".into());
+        assert_eq!(
+            delivery_source(&m),
+            Some(std::path::PathBuf::from("/lib/m/x.reel.mp4"))
+        );
+        m.transcode = TranscodeStatus::Ready;
+        m.transcode_path = None;
+        assert_eq!(delivery_source(&m), None, "ready but no path -> fall back");
     }
 
     fn live_for(progress: u64, total: u64, finished: bool) -> crate::engine::TorrentLive {

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -213,6 +213,7 @@ pub struct Engine {
     stall_check: Duration,
     trackers: Arc<Mutex<Arc<Vec<String>>>>,
     bt_port_file: Option<PathBuf>,
+    transcode_wake: Arc<Notify>,
 }
 
 const LEECH_DRAIN_CAP: Duration = Duration::from_secs(6 * 3600);
@@ -331,6 +332,7 @@ impl Engine {
                 &cfg.extra_trackers,
             )))),
             bt_port_file: cfg.bt_port_file.clone(),
+            transcode_wake: Arc::new(Notify::new()),
         };
         engine.resume_on_start();
         Ok(engine)
@@ -338,6 +340,13 @@ impl Engine {
 
     pub fn vpn_ok(&self) -> bool {
         self.vpn_ok.load(Ordering::Relaxed)
+    }
+
+    /// Notified whenever a torrent finishes and becomes Seeding, so an
+    /// auto-transcode worker can turn it into a playable file without the user
+    /// asking. Also fire once at startup to catch resumed Seeding items.
+    pub fn transcode_wake(&self) -> Arc<Notify> {
+        self.transcode_wake.clone()
     }
 
     fn all_handles(&self) -> Vec<Arc<ManagedTorrent>> {
@@ -498,6 +507,7 @@ impl Engine {
         let session = self.session.clone();
         let active_leech = self.active_leech.clone();
         let drain = self.drain.clone();
+        let transcode_wake = self.transcode_wake.clone();
         let metadata_timeout = self.metadata_timeout;
         let stall_timeout = self.stall_timeout;
         let stall_check = self.stall_check;
@@ -608,6 +618,7 @@ impl Engine {
                         hls_error: None,
                     });
                     crate::telemetry::torrent_completed(&id, moved.size);
+                    transcode_wake.notify_one();
                     wait_leech_drained(&active_leech, &drain, &id).await;
                     delete_from_session(&session, &id, false).await;
                 }

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -59,6 +59,12 @@ async fn main() -> anyhow::Result<()> {
         ));
     }
 
+    tokio::spawn(reel::transcode::auto_transcode_loop(
+        transcoder.clone(),
+        store.clone(),
+        eng.transcode_wake(),
+    ));
+
     tokio::spawn(state::persist_loop(store.clone(), cfg.state_flush_ms));
 
     let restart = std::sync::Arc::new(tokio::sync::Notify::new());

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -509,6 +509,20 @@ impl Transcoder {
         let src_dir = std::path::PathBuf::from(&meta.path);
         let primary = pick_primary_file(&src_dir)?;
         let probe = probe(&self.ffprobe_bin, &primary).await?;
+
+        // Already directly playable in the browser (h264 + aac + mp4): no
+        // transcode, no second copy — serve the original as-is.
+        if decide_delivery(&probe) == Delivery::RawProgressive {
+            let _ = self.store.update(id, |m| {
+                m.transcode = TranscodeStatus::Ready;
+                m.transcode_path = None;
+                m.transcode_error = None;
+                ((), true)
+            });
+            crate::telemetry::transcode_ready(id, &primary.display().to_string());
+            return Ok(());
+        }
+
         let route = decide_route(&probe);
         crate::telemetry::transcode_started(
             id,
@@ -580,7 +594,40 @@ impl Transcoder {
             ((), true)
         });
         crate::telemetry::transcode_ready(id, &dest.display().to_string());
+
+        // Single-file policy: the transcoded .reel.mp4 is now the playable
+        // copy, so drop the original source instead of storing both.
+        if primary != dest {
+            if let Err(e) = std::fs::remove_file(&primary) {
+                tracing::warn!(id = %id, path = %primary.display(), error = %e, "failed to remove source after transcode");
+            }
+        }
         Ok(())
+    }
+}
+
+/// A finished download that has not been made playable yet. Failed transcodes
+/// are left alone (no auto-retry loop); the user can retry manually.
+pub fn should_auto_transcode(m: &crate::state::Metadata) -> bool {
+    m.state == crate::state::TorrentState::Seeding && m.transcode == TranscodeStatus::None
+}
+
+/// Makes every completed download playable on its own — no manual transcode
+/// step. Wakes on completion (and once at startup for resumed items), then asks
+/// the transcoder to process anything Seeding-but-untranscoded. request() is
+/// idempotent, so re-scans never double-start a job.
+pub async fn auto_transcode_loop(
+    transcoder: Transcoder,
+    store: StateStore,
+    wake: std::sync::Arc<tokio::sync::Notify>,
+) {
+    loop {
+        for m in store.list() {
+            if should_auto_transcode(&m) {
+                let _ = transcoder.request(&m.id).await;
+            }
+        }
+        wake.notified().await;
     }
 }
 
@@ -778,6 +825,17 @@ mod transcoder_tests {
             hls_dir: None,
             hls_error: None,
         }
+    }
+
+    #[test]
+    fn auto_transcode_only_untranscoded_seeding() {
+        assert!(should_auto_transcode(&meta("a", TranscodeStatus::None)));
+        assert!(!should_auto_transcode(&meta("b", TranscodeStatus::Ready)));
+        assert!(!should_auto_transcode(&meta("c", TranscodeStatus::Pending)));
+        assert!(!should_auto_transcode(&meta("d", TranscodeStatus::Failed)));
+        let mut leech = meta("e", TranscodeStatus::None);
+        leech.state = TorrentState::Leeching;
+        assert!(!should_auto_transcode(&leech));
     }
 
     #[test]


### PR DESCRIPTION
## Live-test findings (MKV: h264 + eac3 + subs)

Watched a real download end-to-end. Download + peer stability + transcode all worked (0.1.21). But **Play** failed with "browser can't decode, try HLS" — three bugs behind it:

### 1. Manifest probed the wrong file
`/stream` serves the finished transcode when Ready, but `manifest` always probed `pick_primary_file` = the **largest** file. After remux, both the 4.1 GB source **MKV** and the 4.0 GB `.reel.mp4` are in the dir → it probed the MKV (matroska/eac3) → routed to HLS-from-MKV / raw MKV, which browsers can't decode. State confirmed `transcode:Ready, transcode_path:…reel.mp4` while the probe logged `audio:eac3 container:matroska`.
**Fix:** `delivery_source()` — when transcode is Ready, probe/serve the `transcode_path`, matching `/stream`.

### 2. Transcode was manual
Now `auto_transcode_loop` wakes on completion (engine fires `transcode_wake` after a torrent becomes Seeding; also scans once at startup for resumed items) and calls `Transcoder::request` for anything Seeding-but-untranscoded. `request()` is idempotent → re-scans never double-start.

### 3. Stored twice
`run_job` now **skips** entirely when the source is already directly playable (h264 + aac + mp4), and when it does transcode, **deletes the original** afterward. One playable file per download (no 4 GB MKV next to a 4 GB mp4).

## Net effect
download → becomes playable automatically → **Play just works**, no manual step, no double storage. Matches the "scoped to be easy" goal.

Pure helpers `delivery_source()` + `should_auto_transcode()` unit-tested. 142 tests, clippy clean. mdx 0.1.21→0.1.22.