### PR TITLE
fix(reel): isolate each prepared entry to a single playable file

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.22"
+version: "0.1.23"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -256,6 +256,13 @@ mp4 and the original source is deleted, so a 4 GB MKV does not sit on disk next 
 one is ready, so a completed item plays directly instead of being routed back through
 the original (which, for a container like MKV, the browser cannot decode). The result
 is a single playable file per download and a Play button that just works.
+
+Once a download is prepared, its entry is isolated down to exactly the one playable
+file — the original source, subtitle sidecars, artwork, and any stray files or
+directories beside it are removed. Nothing lingers: an already-playable file keeps
+only itself, and a transcoded file keeps only its `.reel.mp4`. The idle-TTL reaper and
+the filesystem sweeper still apply on top, but the per-entry directory never holds more
+than the single file needed to play.
 
 </BentoProse>
 

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -519,6 +519,7 @@ impl Transcoder {
                 m.transcode_error = None;
                 ((), true)
             });
+            isolate_dir(&src_dir, &primary);
             crate::telemetry::transcode_ready(id, &primary.display().to_string());
             return Ok(());
         }
@@ -595,14 +596,35 @@ impl Transcoder {
         });
         crate::telemetry::transcode_ready(id, &dest.display().to_string());
 
-        // Single-file policy: the transcoded .reel.mp4 is now the playable
-        // copy, so drop the original source instead of storing both.
-        if primary != dest {
-            if let Err(e) = std::fs::remove_file(&primary) {
-                tracing::warn!(id = %id, path = %primary.display(), error = %e, "failed to remove source after transcode");
-            }
-        }
+        // Single-file policy: the transcoded .reel.mp4 is the only thing worth
+        // keeping, so strip the entry down to it — source, subtitles, artwork
+        // and any stray files or dirs all go.
+        isolate_dir(&src_dir, &dest);
         Ok(())
+    }
+}
+
+/// Reduce an entry directory to a single kept file, deleting every other file
+/// or subdirectory beside it. Failures are logged, not fatal — the sweeper is
+/// the backstop. `keep` is expected to live directly inside `dir`.
+pub fn isolate_dir(dir: &std::path::Path, keep: &std::path::Path) {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p == keep {
+            continue;
+        }
+        let res = if p.is_dir() {
+            std::fs::remove_dir_all(&p)
+        } else {
+            std::fs::remove_file(&p)
+        };
+        if let Err(e) = res {
+            tracing::warn!(path = %p.display(), error = %e, "isolate: failed to remove leftover");
+        }
     }
 }
 
@@ -825,6 +847,29 @@ mod transcoder_tests {
             hls_dir: None,
             hls_error: None,
         }
+    }
+
+    #[test]
+    fn isolate_dir_keeps_only_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        let keep = d.join("movie.reel.mp4");
+        std::fs::write(&keep, b"keep").unwrap();
+        std::fs::write(d.join("movie.mkv"), b"src").unwrap();
+        std::fs::write(d.join("movie.srt"), b"subs").unwrap();
+        std::fs::write(d.join("poster.jpg"), b"art").unwrap();
+        std::fs::create_dir(d.join("hls")).unwrap();
+        std::fs::write(d.join("hls").join("0.ts"), b"seg").unwrap();
+
+        isolate_dir(d, &keep);
+
+        assert!(keep.exists(), "kept file survives");
+        assert!(!d.join("movie.mkv").exists());
+        assert!(!d.join("movie.srt").exists());
+        assert!(!d.join("poster.jpg").exists());
+        assert!(!d.join("hls").exists(), "stray dir removed");
+        let remaining = std::fs::read_dir(d).unwrap().flatten().count();
+        assert_eq!(remaining, 1, "only the kept file remains");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #14925. That PR deleted the source after transcode, but left subtitle sidecars, poster artwork, and any stray files / on-disk `hls/` dir behind. This isolates every prepared entry to **exactly the one playable file**:

- **Transcoded:** keep only `.reel.mp4`, delete everything else (source, subs, artwork, stray dirs).
- **Already-playable** (h264+aac+mp4, no transcode): keep only that original, delete the rest.

New `isolate_dir(dir, keep)` walks the entry dir and removes every file/subdir except the kept file; failures logged, not fatal (the sweeper is the backstop). Unit-tested with a mixed dir (source + subs + poster + nested `hls/`) asserting only the kept file survives.

Nothing lingers — the per-entry directory never holds more than the single file needed to play. 143 tests, clippy clean. mdx 0.1.22→0.1.23.