### PR TITLE
fix(kong): make a kong-config edit actually reach the running proxy

### DIFF
--- a/.github/workflows/ci-kong-config-guard.yml
+++ b/.github/workflows/ci-kong-config-guard.yml
@@ -1,0 +1,80 @@
+name: CI - Kong Config Guard
+
+# Kong is DB-less: the proxy renders KONG_DECLARATIVE_CONFIG from the kong-config
+# ConfigMap through an envsubst init container into an emptyDir, once, at pod
+# start. Editing the ConfigMap therefore changes nothing in the running proxy
+# until the pods roll — which is how `preserve_host: true` (#14465) sat correct
+# in git and absent from the live proxy for weeks.
+#
+# The pod template's `config-hash` annotation is what makes the restart fall out
+# of an ArgoCD sync. This guard fails any PR that edits the ConfigMap without
+# bumping it, so the config change and the restart it needs stay in one commit.
+
+on:
+    pull_request:
+        branches:
+            - main
+            - dev
+        paths:
+            - 'apps/kube/kong/manifests/kong-config.yaml'
+            - 'apps/kube/kong/manifests/kong-deployment.yaml'
+            - 'scripts/kong-config-hash.sh'
+            - '.github/workflows/ci-kong-config-guard.yml'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    verify:
+        name: Verify kong config-hash is up to date
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v7
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: '3.13'
+
+            - run: pip install --disable-pip-version-check pyyaml
+
+            - name: config-hash matches kong-config.yaml
+              run: ./scripts/kong-config-hash.sh --check
+
+            # A config edit that never reaches the proxy is the failure mode this
+            # guard exists for; a config edit that cannot be parsed takes the whole
+            # supabase.kbve.com host down on sync. Check both.
+            - name: Inner kong.yml parses
+              run: |
+                  python3 - <<'PY'
+                  import sys, yaml
+
+                  with open('apps/kube/kong/manifests/kong-config.yaml') as fh:
+                      cm = next(
+                          d for d in yaml.safe_load_all(fh)
+                          if d and d.get('kind') == 'ConfigMap'
+                          and d['metadata']['name'] == 'kong-config'
+                      )
+
+                  raw = cm['data']['kong.yml']
+                  try:
+                      inner = yaml.safe_load(raw)
+                  except yaml.YAMLError as e:
+                      sys.exit(f'kong.yml is not parseable YAML — this would break the whole host:\n{e}')
+
+                  if not isinstance(inner, dict):
+                      sys.exit(f'kong.yml did not parse to a mapping, got {type(inner).__name__}')
+
+                  services = inner.get('services') or []
+                  routes = sum(len(s.get('routes') or []) for s in services)
+                  print(f'kong.yml OK — {len(services)} services, {routes} routes')
+
+                  missing = [s.get('name', '<unnamed>') for s in services if not s.get('url')]
+                  if missing:
+                      sys.exit(f'services with no upstream url: {missing}')
+                  PY

--- a/apps/kube/kong/application.yaml
+++ b/apps/kube/kong/application.yaml
@@ -37,3 +37,17 @@ spec:
                 duration: 5s
                 factor: 2
                 maxDuration: 3m
+    # Reloader runs with reloadStrategy=env-vars, so restarting kong-kong means
+    # injecting a STAKATER_*_CONFIGMAP / _SECRET env var into the pod template.
+    # This app syncs with selfHeal + Replace + Force, which would revert that
+    # injection, and Reloader would re-apply it on the next ConfigMap change —
+    # a slow fight over the proxy that fronts the whole supabase.kbve.com host.
+    # Ignoring the injected vars lets Reloader own them and ArgoCD own the rest.
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          name: kong-kong
+          namespace: kilobase
+          jqPathExpressions:
+              - '.spec.template.spec.containers[]?.env[]? | select(.name | startswith("STAKATER_"))'
+              - '.spec.template.spec.initContainers[]?.env[]? | select(.name | startswith("STAKATER_"))'

--- a/apps/kube/kong/manifests/kong-deployment.yaml
+++ b/apps/kube/kong/manifests/kong-deployment.yaml
@@ -12,6 +12,8 @@ metadata:
         kbve.com/category: networking
         kbve.com/stack: core
         kbve.com/managed-by: argocd
+    annotations:
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 2
     selector:
@@ -30,7 +32,7 @@ spec:
                 app.kubernetes.io/version: '3.9'
                 version: '3.9'
             annotations:
-                config-hash: abe86a1b6665e4b135829be4ef256287
+                config-hash: 8def9c20346cdd082231e084b3ee36c5
                 kuma.io/gateway: enabled
                 traffic.sidecar.istio.io/includeInboundPorts: ''
         spec:

--- a/scripts/kong-config-hash.sh
+++ b/scripts/kong-config-hash.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Keep the kong-kong pod template's `config-hash` annotation in step with the
+# contents of the kong-config ConfigMap.
+#
+# Kong runs DB-less: KONG_DECLARATIVE_CONFIG points at a file that an envsubst
+# init container renders from the ConfigMap into an emptyDir at pod start. The
+# rendered copy is never refreshed, so editing the ConfigMap changes nothing in
+# the running proxy until the pods restart. Nothing in ArgoCD restarts a pod for
+# a ConfigMap change on its own, which is how `preserve_host: true` (PR #14465)
+# sat correct in git and absent from the live proxy for weeks.
+#
+# Folding a hash of the ConfigMap data into the pod template makes the restart
+# fall out of the sync: the config edit and its hash land in the same commit, so
+# applying that commit changes the Deployment and the pods roll. Deterministic
+# from main, and independent of Reloader being healthy.
+#
+#   kong-config-hash.sh --check   verify the annotation matches (exit 1 if not)
+#   kong-config-hash.sh --write   rewrite the annotation in place
+#
+# Hashes only the ConfigMap's `data` block, so relabelling the ConfigMap does
+# not needlessly restart the proxy.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+config_file="${repo_root}/apps/kube/kong/manifests/kong-config.yaml"
+deployment_file="${repo_root}/apps/kube/kong/manifests/kong-deployment.yaml"
+
+mode="${1:---check}"
+case "$mode" in
+--check | --write) ;;
+*)
+    echo "Usage: $(basename "$0") [--check|--write]" >&2
+    exit 2
+    ;;
+esac
+
+for f in "$config_file" "$deployment_file"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: not found: $f" >&2
+        exit 2
+    fi
+done
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo "ERROR: python3 with PyYAML is required (pip install pyyaml)." >&2
+    exit 2
+fi
+
+expected=$(python3 - "$config_file" <<'PY'
+import hashlib, json, sys, yaml
+
+with open(sys.argv[1]) as fh:
+    docs = [d for d in yaml.safe_load_all(fh) if d]
+
+cms = [d for d in docs if d.get("kind") == "ConfigMap" and d["metadata"]["name"] == "kong-config"]
+if len(cms) != 1:
+    sys.exit(f"expected exactly one kong-config ConfigMap, found {len(cms)}")
+
+# Canonical JSON so trivial YAML reflow (line wrapping, quoting style) does not
+# move the hash — only a real content change does.
+payload = json.dumps(cms[0].get("data", {}), sort_keys=True, separators=(",", ":"))
+print(hashlib.sha256(payload.encode()).hexdigest()[:32])
+PY
+)
+
+actual=$(python3 - "$deployment_file" <<'PY'
+import sys, yaml
+
+with open(sys.argv[1]) as fh:
+    docs = [d for d in yaml.safe_load_all(fh) if d]
+
+deps = [d for d in docs if d.get("kind") == "Deployment" and d["metadata"]["name"] == "kong-kong"]
+if len(deps) != 1:
+    sys.exit(f"expected exactly one kong-kong Deployment, found {len(deps)}")
+
+anns = deps[0]["spec"]["template"]["metadata"].get("annotations", {})
+print(anns.get("config-hash", ""))
+PY
+)
+
+if [ "$mode" = "--check" ]; then
+    if [ "$expected" = "$actual" ]; then
+        echo "config-hash up to date: $expected"
+        exit 0
+    fi
+    cat >&2 <<EOF
+ERROR: kong-kong config-hash is stale.
+
+  expected (from kong-config.yaml): $expected
+  found (in kong-deployment.yaml):  ${actual:-<missing>}
+
+The Kong proxy renders its declarative config once at pod start, so a
+kong-config.yaml change does not reach the running proxy until the pods roll.
+Bump the annotation in the same commit:
+
+  ./scripts/kong-config-hash.sh --write
+EOF
+    exit 1
+fi
+
+if [ "$expected" = "$actual" ]; then
+    echo "config-hash already $expected — nothing to do."
+    exit 0
+fi
+
+python3 - "$deployment_file" "$expected" <<'PY'
+import re, sys
+
+path, new_hash = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    text = fh.read()
+
+pattern = re.compile(r"^(?P<indent>[ \t]*)config-hash:[ \t]*\S+[ \t]*$", re.MULTILINE)
+text, n = pattern.subn(lambda m: f"{m.group('indent')}config-hash: {new_hash}", text)
+if n != 1:
+    sys.exit(f"expected exactly one config-hash line to rewrite, matched {n}")
+
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+
+echo "config-hash -> $expected"


### PR DESCRIPTION
Follow-up to #14920, which fixed the symptom. This fixes the reason the symptom lasted weeks.

## The gap

Kong runs DB-less. `kong-config` is mounted as a **template**, rendered once by a `dibi/envsubst` init container into an emptyDir, and read from there by the proxy at pod start — [kong-deployment.yaml:67-105](apps/kube/kong/manifests/kong-deployment.yaml#L67-L105).

That makes the usual reasoning wrong in two ways:

1. Even when kubelet refreshes a mounted ConfigMap in place, the **rendered** copy is only ever written at pod start. A restart is genuinely mandatory, not just convenient.
2. Nothing in an ArgoCD sync restarts a pod for a ConfigMap change.

So `preserve_host: true` (#14465) was correct in git and absent from the live proxy for weeks, and every `supabase.kbve.com` login bounce came back with `redirect_to=http://studio-gate:5678/...`. Nobody had reason to doubt the config — it was right there in `main`.

The same gap covers **secrets**: that init container reads `anon-key`, `service-key`, and `secret` from `supabase-jwt`. Rotating any of them silently no-ops today too.

## The mechanism was already there, as a lie

The pod template carried `config-hash: abe86a1b6665e4b135829be4ef256287` — a leftover from when this was a Helm chart, frozen at whatever the config looked like when the chart was last rendered. Nothing regenerated it. It was the vestige of exactly the right pattern.

Making it truthful turns the restart into a property of the sync: the config edit and its hash land in one commit, ArgoCD applies both from `main`, the pods roll. No controller in the path, nothing to remember, reproducible from `main` alone.

## Changes

**`scripts/kong-config-hash.sh --check | --write`** hashes the ConfigMap's `data` block as canonical JSON, so YAML reflow (line wrapping, quoting style) does not move the hash — only real content changes do. Verified: round-tripping the ConfigMap through `yaml.safe_dump(width=40)` leaves the hash identical.

**`.github/workflows/ci-kong-config-guard.yml`** fails any PR that edits the ConfigMap without bumping the hash. It also asserts the **inner** `kong.yml` still parses and that every service has an upstream `url` — `kong-config.yaml` is a hard-wrapped quoted scalar, and a malformed inner document takes down the entire `supabase.kbve.com` host on sync. Currently reports `16 services, 16 routes`.

**`reloader.stakater.com/auto: 'true'`** on the Deployment. Reloader is already installed cluster-wide (`watchGlobally: true`, chart 2.2.11) and ~20 manifests use it; Kong had no annotation at all. This is the half that also covers `supabase-jwt` rotation.

**Narrow `ignoreDifferences` on the Application.** Reloader runs `reloadStrategy: env-vars`, so restarting `kong-kong` means injecting a `STAKATER_*` env var into the pod template — and this app syncs with `selfHeal` + `Replace` + `Force`, which would revert it, leaving ArgoCD and Reloader fighting over the proxy that fronts the whole host. The two `jqPathExpressions` hand those vars to Reloader and nothing else.

## Verification

- guard fails on a config edit with a stale hash (simulated `_format_version` bump: `expected 3d50f721 / found 8def9c20`, exit 1), passes once bumped
- hash is reflow-immune (confirmed by YAML round-trip)
- inner `kong.yml` parse + service-url assertions run green against the real file
- both `jqPathExpressions` tested through `jq` against the real Deployment JSON, including the absent-`initContainers` case — `[]?` on **both** levels, since `.initContainers[]` alone raises `Cannot iterate over null`
- every touched YAML re-parsed after prettier; `bash -n` clean

## Heads-up on merge

The hash bump in this PR is itself a live config change: it **rolls the two `kong-kong` pods once** on sync. Rolling update, `replicas: 2`. That restart is the point — it is what finally makes the running proxy match what `main` has said for weeks.

## Also worth knowing

#14920 is live and verified in prod — `redirect_to` now comes back as `https://supabase.kbve.com/project/default/sql?schema=public`, correct origin with the query preserved. Studio is unlocked.

One consequence: because `GATE_EXTERNAL_BASE` bypasses `Host` and `X-Forwarded-Proto` entirely, that probe can no longer tell you anything about Kong's config state. The gate emits the right origin whether or not Kong ever reloaded. Losing the outside-in signal is part of why this guard belongs in CI.

Separately, `./kbve.sh -worktree-prune --merged` cannot detect merged work in this repo: its gate is `git merge-base --is-ancestor HEAD origin/dev` ([kbve.sh:664](kbve.sh#L664)), and squash-merged branches are never ancestors of `dev`. Every merged branch fails it, and the failure is printed as `Skipped (real uncommitted work)` — the opposite of the truth. Not touched here; happy to fix in its own PR.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)