### PR TITLE
feat(reel): live (popcorn) HLS streaming while downloading (0.1.25)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -86,8 +86,21 @@ idle TTL, not a permanent library), and progressively delivers it to the browser
 
 - **Fetch** — librqbit leeches and seeds behind a Gluetun killswitch; a reaper deletes idle entries.
 - **Transcode** — ffprobe routes each file to remux (faststart MP4) or re-encode.
-- **Stream** — byte-range progressive MP4 while still downloading; HLS for containers/codecs the browser can't play raw.
+- **Stream** — live HLS while still downloading (popcorn); byte-range progressive MP4 for already-playable files; HLS for containers/codecs the browser can't play raw.
 - **Player** — an astro-kbve hls.js island at `/media/reel/`, proxied same-origin through axum-kbve at `/api/v1/reel`, staff-gated.
+
+### Live (popcorn) streaming
+
+Hitting **Play** on a still-downloading torrent no longer waits for the fetch to
+finish. `GET /manifest.m3u8` on a `Leeching` entry starts a **live HLS** job that
+reads directly from librqbit's sequential-priority stream and pipes it through
+ffmpeg (`pipe:0` → `-f hls`, event playlist), so the front of the file is
+watchable within seconds while the tail keeps downloading. h264 video is
+stream-copied (realtime); anything else is re-encoded `libx264 -preset veryfast`;
+audio is always downmixed to stereo aac so it plays with sound. The player
+already polls `202 → 200` and switches to hls.js unchanged. Gated by
+`REEL_LIVE_HLS` (default on); when off, leeching falls back to raw progressive.
+Playback quality tracks download rate — a starved swarm buffers.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -345,6 +345,7 @@ async fn manifest(
         query.as_deref(),
         &st.token,
         st.hls.enabled(),
+        st.hls.live_enabled(),
         &st.store,
         &id,
     )
@@ -352,6 +353,7 @@ async fn manifest(
     {
         ManifestStep::Done(resp) => return resp,
         ManifestStep::Proceed(m) => m,
+        ManifestStep::ProceedLive(m) => return live_manifest(&st, &id, m).await,
     };
 
     let delivery = match st.hls.cached_delivery(&id) {
@@ -407,33 +409,32 @@ async fn manifest(
             .into_response();
     }
 
-    match st.hls.request(&id, delivery).await {
-        hls::StartOutcome::Ready(dir) => serve_manifest_file(&dir).await,
-        hls::StartOutcome::InProgress(status) => {
-            if matches!(status, state::HlsStatus::Ready | state::HlsStatus::Live) {
-                if let Some(dir) = st.store.get(&id).and_then(|m| m.hls_dir) {
-                    return serve_manifest_file(&dir).await;
-                }
-            }
-            (
-                StatusCode::ACCEPTED,
-                Json(serde_json::json!({"status": format!("{status:?}")})),
-            )
-                .into_response()
-        }
-        hls::StartOutcome::Started => (
+    let outcome = st.hls.request(&id, delivery).await;
+    hls_outcome_response(&st.store, &id, outcome).await
+}
+
+/// Popcorn manifest: begin (or join) a live HLS job for a still-downloading
+/// torrent, transcoding from its in-flight librqbit stream.
+async fn live_manifest(
+    st: &AppState,
+    id: &str,
+    meta: state::Metadata,
+) -> axum::response::Response {
+    let out_dir = match meta.active_path {
+        Some(d) => std::path::PathBuf::from(d),
+        None => return StatusCode::TOO_EARLY.into_response(),
+    };
+    match st.engine.primary_stream(id) {
+        engine::LeechStream::NotReady => (
             StatusCode::ACCEPTED,
-            Json(serde_json::json!({"status": "started"})),
+            Json(serde_json::json!({"status": "resolving"})),
         )
             .into_response(),
-        hls::StartOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
-        hls::StartOutcome::NotCompleted => StatusCode::TOO_EARLY.into_response(),
-        hls::StartOutcome::RawProgressive => (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({"delivery": "raw_progressive"})),
-        )
-            .into_response(),
-        hls::StartOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        engine::LeechStream::NoMedia => StatusCode::CONFLICT.into_response(),
+        engine::LeechStream::Ready { reader, .. } => {
+            let outcome = st.hls.request_live(id, reader, out_dir).await;
+            hls_outcome_response(&st.store, id, outcome).await
+        }
     }
 }
 
@@ -625,6 +626,7 @@ pub(crate) async fn stream_core<S: engine::MediaSource>(
 pub(crate) enum ManifestStep {
     Done(axum::response::Response),
     Proceed(state::Metadata),
+    ProceedLive(state::Metadata),
 }
 
 pub(crate) async fn manifest_status_core(
@@ -632,6 +634,7 @@ pub(crate) async fn manifest_status_core(
     query: Option<&str>,
     token: &Option<String>,
     hls_enabled: bool,
+    live_enabled: bool,
     store: &state::StateStore,
     id: &str,
 ) -> ManifestStep {
@@ -666,9 +669,12 @@ pub(crate) async fn manifest_status_core(
         state::HlsStatus::None | state::HlsStatus::Failed => {}
     }
 
-    if meta.state != state::TorrentState::Seeding {
-        let resp = match meta.state {
-            state::TorrentState::Failed => (
+    match meta.state {
+        state::TorrentState::Seeding => ManifestStep::Proceed(meta),
+        // Popcorn path: play while the download is still in flight.
+        state::TorrentState::Leeching if live_enabled => ManifestStep::ProceedLive(meta),
+        state::TorrentState::Failed => ManifestStep::Done(
+            (
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
                     "state": "failed",
@@ -676,11 +682,46 @@ pub(crate) async fn manifest_status_core(
                 })),
             )
                 .into_response(),
-            _ => StatusCode::TOO_EARLY.into_response(),
-        };
-        return ManifestStep::Done(resp);
+        ),
+        _ => ManifestStep::Done(StatusCode::TOO_EARLY.into_response()),
     }
-    ManifestStep::Proceed(meta)
+}
+
+/// Map an HLS start outcome to an HTTP response, serving the manifest when the
+/// job is already Ready/Live. Shared by the completed and live manifest paths.
+async fn hls_outcome_response(
+    store: &state::StateStore,
+    id: &str,
+    outcome: hls::StartOutcome,
+) -> axum::response::Response {
+    match outcome {
+        hls::StartOutcome::Ready(dir) => serve_manifest_file(&dir).await,
+        hls::StartOutcome::InProgress(status) => {
+            if matches!(status, state::HlsStatus::Ready | state::HlsStatus::Live) {
+                if let Some(dir) = store.get(id).and_then(|m| m.hls_dir) {
+                    return serve_manifest_file(&dir).await;
+                }
+            }
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": format!("{status:?}")})),
+            )
+                .into_response()
+        }
+        hls::StartOutcome::Started => (
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({"status": "started"})),
+        )
+            .into_response(),
+        hls::StartOutcome::NotFound => StatusCode::NOT_FOUND.into_response(),
+        hls::StartOutcome::NotCompleted => StatusCode::TOO_EARLY.into_response(),
+        hls::StartOutcome::RawProgressive => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"delivery": "raw_progressive"})),
+        )
+            .into_response(),
+        hls::StartOutcome::Disabled => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
 }
 
 pub(crate) async fn hls_segment_core(
@@ -1212,13 +1253,14 @@ mod tests {
         match step {
             ManifestStep::Done(r) => r,
             ManifestStep::Proceed(_) => panic!("expected Done, got Proceed"),
+            ManifestStep::ProceedLive(_) => panic!("expected Done, got ProceedLive"),
         }
     }
 
     #[tokio::test]
     async fn manifest_missing_id_is_404() {
         let res = manifest_done(
-            manifest_status_core(&HeaderMap::new(), None, &None, true, &store_with_one(), "999").await,
+            manifest_status_core(&HeaderMap::new(), None, &None, true, false, &store_with_one(), "999").await,
         );
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
@@ -1226,7 +1268,7 @@ mod tests {
     #[tokio::test]
     async fn manifest_hls_disabled_is_503() {
         let res = manifest_done(
-            manifest_status_core(&HeaderMap::new(), None, &None, false, &store_with_one(), "1").await,
+            manifest_status_core(&HeaderMap::new(), None, &None, false, false, &store_with_one(), "1").await,
         );
         assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
@@ -1235,7 +1277,7 @@ mod tests {
     async fn manifest_requires_auth_when_token_set() {
         let res = manifest_done(
             manifest_status_core(
-                &HeaderMap::new(), None, &Some("secret".into()), true, &store_with_one(), "1",
+                &HeaderMap::new(), None, &Some("secret".into()), true, false, &store_with_one(), "1",
             )
             .await,
         );
@@ -1244,7 +1286,7 @@ mod tests {
 
     #[tokio::test]
     async fn manifest_seeding_none_proceeds_to_delivery() {
-        let res = manifest_status_core(&HeaderMap::new(), None, &None, true, &store_with_one(), "1").await;
+        let res = manifest_status_core(&HeaderMap::new(), None, &None, true, false, &store_with_one(), "1").await;
         assert!(matches!(res, ManifestStep::Proceed(_)));
     }
 
@@ -1272,9 +1314,36 @@ mod tests {
         })
         .unwrap();
         let res = manifest_done(
-            manifest_status_core(&HeaderMap::new(), None, &None, true, &s, "1").await,
+            manifest_status_core(&HeaderMap::new(), None, &None, true, false, &s, "1").await,
         );
         assert_eq!(res.status(), StatusCode::TOO_EARLY);
+    }
+
+    #[tokio::test]
+    async fn manifest_leeching_with_live_proceeds_live() {
+        let dir = tempdir().unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        std::mem::forget(dir);
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: String::new(),
+            size: 0,
+            completed_at: None,
+            last_access: 10,
+            state: TorrentState::Leeching,
+            error: None,
+            active_path: Some("/data/active/1".into()),
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::None,
+            hls_dir: None,
+            hls_error: None,
+        })
+        .unwrap();
+        let step = manifest_status_core(&HeaderMap::new(), None, &None, true, true, &s, "1").await;
+        assert!(matches!(step, ManifestStep::ProceedLive(_)));
     }
 
     #[tokio::test]
@@ -1304,7 +1373,7 @@ mod tests {
         .unwrap();
         std::mem::forget(dir);
         let res = manifest_done(
-            manifest_status_core(&HeaderMap::new(), None, &None, true, &s, "1").await,
+            manifest_status_core(&HeaderMap::new(), None, &None, true, false, &s, "1").await,
         );
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub ffprobe_bin: String,
     pub stream_enabled: bool,
     pub hls_enabled: bool,
+    pub live_hls_enabled: bool,
     pub hls_segment_secs: u64,
     pub bt_port_file: Option<PathBuf>,
     pub bt_port_wait_secs: u64,
@@ -189,6 +190,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
         stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
         hls_enabled: env_bool("REEL_HLS_ENABLED", true),
+        live_hls_enabled: env_bool("REEL_LIVE_HLS", true),
         hls_segment_secs: env_u64("REEL_HLS_SEGMENT_SECS", 4)?,
         bt_port_file: match std::env::var("REEL_BT_PORT_FILE") {
             Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v.trim())),
@@ -214,7 +216,7 @@ mod tests {
                   "REEL_STATE_FLUSH_MS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY","REEL_ENCODE_THREADS",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
-                  "REEL_HLS_ENABLED","REEL_HLS_SEGMENT_SECS",
+                  "REEL_HLS_ENABLED","REEL_LIVE_HLS","REEL_HLS_SEGMENT_SECS",
                   "REEL_BT_PORT_FILE","REEL_BT_PORT_WAIT_SECS"] {
             std::env::remove_var(k);
         }
@@ -407,11 +409,14 @@ mod tests {
         clear();
         let c = load_from_env().unwrap();
         assert!(c.hls_enabled);
+        assert!(c.live_hls_enabled);
         assert_eq!(c.hls_segment_secs, 4);
         std::env::set_var("REEL_HLS_ENABLED", "false");
+        std::env::set_var("REEL_LIVE_HLS", "false");
         std::env::set_var("REEL_HLS_SEGMENT_SECS", "8");
         let c2 = load_from_env().unwrap();
         assert!(!c2.hls_enabled);
+        assert!(!c2.live_hls_enabled);
         assert_eq!(c2.hls_segment_secs, 8);
         clear();
     }

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -777,6 +777,29 @@ impl Engine {
         handle.stream(file_id)
     }
 
+    /// Open a sequential-priority stream over the largest media file of a
+    /// leeching torrent, for live playback while the download is still in
+    /// flight. The returned reader carries a leech guard, so the completion
+    /// watcher will not tear the torrent down until the reader is dropped.
+    pub fn primary_stream(&self, id: &str) -> LeechStream {
+        let files = match self.list_files(id) {
+            Ok(Some(f)) => f,
+            _ => return LeechStream::NotReady,
+        };
+        let idx = match primary_file_index(&files) {
+            Some(i) => i,
+            None => return LeechStream::NoMedia,
+        };
+        let (name, len) = match files.iter().find(|f| f.index == idx) {
+            Some(e) => (e.name.clone(), e.len),
+            None => return LeechStream::NoMedia,
+        };
+        match self.open(id, idx) {
+            Ok(reader) => LeechStream::Ready { reader, name, len },
+            Err(_) => LeechStream::NotReady,
+        }
+    }
+
     fn leech_enter(&self, id: &str) -> LeechGuard {
         *self
             .active_leech
@@ -860,6 +883,19 @@ async fn wait_leech_drained(
 
 pub trait ReadSeek: AsyncRead + AsyncSeek + Send + Unpin {}
 impl<T: AsyncRead + AsyncSeek + Send + Unpin> ReadSeek for T {}
+
+/// Result of opening a leeching torrent's primary media file for live playback.
+pub enum LeechStream {
+    /// Metadata not resolved yet, or the file handle is not available.
+    NotReady,
+    /// The torrent has no playable media file.
+    NoMedia,
+    Ready {
+        reader: Box<dyn ReadSeek>,
+        name: String,
+        len: u64,
+    },
+}
 
 pub trait MediaSource: Send + Sync {
     fn entries(&self, id: &str) -> anyhow::Result<Option<Vec<FileEntry>>>;

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -93,33 +93,56 @@ pub fn next_hls(current: &HlsStatus, state: &TorrentState, enabled: bool) -> Hls
     }
 }
 
+/// Live (popcorn) HLS runs while the torrent is still Leeching, transcoding
+/// from the in-flight download stream. Only one job per torrent — an existing
+/// Starting/Live/Ready job is left to run.
+pub fn next_hls_live(current: &HlsStatus, state: &TorrentState, live_enabled: bool) -> HlsDecision {
+    if !live_enabled {
+        return HlsDecision::Reject(StartOutcome::Disabled);
+    }
+    if *state != TorrentState::Leeching {
+        return HlsDecision::Reject(StartOutcome::NotCompleted);
+    }
+    match current {
+        HlsStatus::None | HlsStatus::Failed => HlsDecision::Start,
+        other => HlsDecision::Reject(StartOutcome::InProgress(other.clone())),
+    }
+}
+
 #[derive(Clone)]
 pub struct HlsManager {
     store: StateStore,
     encode_sem: Arc<Semaphore>,
     ffmpeg_bin: String,
+    ffprobe_bin: String,
     segment_secs: u32,
     enabled: bool,
+    live_enabled: bool,
     encode_threads: usize,
     children: Arc<Mutex<HashMap<String, Child>>>,
     delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
 }
 
 impl HlsManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         store: StateStore,
         encode_conc: usize,
         ffmpeg_bin: String,
+        ffprobe_bin: String,
         segment_secs: u32,
         enabled: bool,
+        live_enabled: bool,
         encode_threads: usize,
     ) -> Self {
         let this = Self {
             store,
             encode_sem: Arc::new(Semaphore::new(encode_conc.max(1))),
             ffmpeg_bin,
+            ffprobe_bin,
             segment_secs,
             enabled,
+            live_enabled,
             encode_threads,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -148,6 +171,10 @@ impl HlsManager {
 
     pub fn enabled(&self) -> bool {
         self.enabled
+    }
+
+    pub fn live_enabled(&self) -> bool {
+        self.live_enabled
     }
 
     pub async fn request(&self, id: &str, delivery: Delivery) -> StartOutcome {
@@ -318,9 +345,23 @@ impl HlsManager {
             g.insert(id.to_string(), child);
         }
 
+        self.spawn_output_watch(id.to_string(), hls_dir.join("index.m3u8"), errbuf, permit);
+
+        Ok(())
+    }
+
+    /// Watch an already-spawned HLS ffmpeg child: flip the entry to Live once
+    /// the manifest appears, then to Ready or Failed when ffmpeg exits. Shared
+    /// by the completed-download path (`run_hls`) and the live path
+    /// (`run_live`).
+    fn spawn_output_watch(
+        &self,
+        id: String,
+        index_path: PathBuf,
+        errbuf: Arc<Mutex<String>>,
+        permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    ) {
         let this = self.clone();
-        let id = id.to_string();
-        let index_path = hls_dir.join("index.m3u8");
         tokio::spawn(async move {
             let mut went_live = false;
             for _ in 0..100 {
@@ -388,8 +429,199 @@ impl HlsManager {
             }
             drop(permit);
         });
+    }
 
+    /// Start (or join) a live HLS job for a still-downloading torrent, reading
+    /// from its in-flight librqbit stream. Idempotent: a job already Starting,
+    /// Live or Ready is returned as-is and the passed reader is dropped.
+    pub async fn request_live(
+        &self,
+        id: &str,
+        reader: Box<dyn crate::engine::ReadSeek>,
+        out_dir: PathBuf,
+    ) -> StartOutcome {
+        let result = self
+            .store
+            .update(id, |m| match next_hls_live(&m.hls, &m.state, self.live_enabled) {
+                HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Ready)) => {
+                    let outcome = match &m.hls_dir {
+                        Some(dir) => StartOutcome::Ready(dir.clone()),
+                        None => StartOutcome::InProgress(HlsStatus::Ready),
+                    };
+                    (outcome, false)
+                }
+                HlsDecision::Reject(outcome) => (outcome, false),
+                HlsDecision::Start => {
+                    m.hls = HlsStatus::Starting;
+                    m.hls_error = None;
+                    (StartOutcome::Started, true)
+                }
+            });
+        match result {
+            Ok(Some(StartOutcome::Started)) => {
+                self.spawn_live_job(id.to_string(), reader, out_dir);
+                StartOutcome::Started
+            }
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => StartOutcome::NotFound,
+            Err(_) => StartOutcome::NotFound,
+        }
+    }
+
+    fn spawn_live_job(&self, id: String, reader: Box<dyn crate::engine::ReadSeek>, out_dir: PathBuf) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.run_live(&id, reader, out_dir).await {
+                crate::telemetry::hls_failed(&id, &e.to_string());
+                let _ = this.store.update(&id, |m| {
+                    m.hls = HlsStatus::Failed;
+                    m.hls_error = Some(e.to_string());
+                    ((), true)
+                });
+            }
+        });
+    }
+
+    async fn run_live(
+        &self,
+        id: &str,
+        mut reader: Box<dyn crate::engine::ReadSeek>,
+        out_dir: PathBuf,
+    ) -> anyhow::Result<()> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let hls_dir = out_dir.join("hls");
+        if hls_dir.exists() {
+            let _ = std::fs::remove_dir_all(&hls_dir);
+        }
+        std::fs::create_dir_all(&hls_dir)?;
+        let hls_dir_str = hls_dir.display().to_string();
+        let _ = self.store.update(id, |m| {
+            m.hls_dir = Some(hls_dir_str.clone());
+            ((), true)
+        });
+
+        // Read a prefix off the front of the download to detect the video
+        // codec, then replay it into ffmpeg so no bytes are lost.
+        const PREFIX_MAX: usize = 8 * 1024 * 1024;
+        let mut prefix = Vec::with_capacity(256 * 1024);
+        let mut buf = vec![0u8; 256 * 1024];
+        while prefix.len() < PREFIX_MAX {
+            let n = reader.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            prefix.extend_from_slice(&buf[..n]);
+        }
+        let video_copy = self.probe_prefix_is_h264(&prefix).await;
+
+        // h264 is stream-copied (cheap, realtime); anything else is encoded and
+        // must hold an encode permit. Audio is always downmixed to stereo aac.
+        let permit = if video_copy {
+            None
+        } else {
+            Some(self.encode_sem.clone().acquire_owned().await?)
+        };
+
+        let mut args: Vec<String> = vec![
+            "-y".into(),
+            "-nostats".into(),
+            "-loglevel".into(),
+            "error".into(),
+            "-i".into(),
+            "pipe:0".into(),
+        ];
+        args.extend(
+            crate::transcode::MAP_VIDEO_AUDIO
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        if video_copy {
+            args.push("-c:v".into());
+            args.push("copy".into());
+        } else {
+            args.push("-c:v".into());
+            args.push("libx264".into());
+            args.push("-preset".into());
+            args.push("veryfast".into());
+            if self.encode_threads > 0 {
+                args.push("-threads".into());
+                args.push(self.encode_threads.to_string());
+            }
+        }
+        args.push("-c:a".into());
+        args.push("aac".into());
+        args.push("-ac".into());
+        args.push("2".into());
+        args.push("-f".into());
+        args.push("hls".into());
+        args.push("-hls_time".into());
+        args.push(self.segment_secs.to_string());
+        args.push("-hls_playlist_type".into());
+        args.push("event".into());
+        args.push("-hls_flags".into());
+        args.push("append_list".into());
+        args.push("-hls_segment_filename".into());
+        args.push(hls_dir.join("seg%05d.ts").display().to_string());
+        args.push(hls_dir.join("index.m3u8").display().to_string());
+
+        let mut cmd = Command::new(&self.ffmpeg_bin);
+        cmd.args(&args)
+            .stdin(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut child = cmd.spawn()?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("no ffmpeg stdin"))?;
+
+        // Feed the prefix, then pump the rest of the download into ffmpeg.
+        // When the download completes the reader hits EOF, stdin closes and
+        // ffmpeg finalizes the playlist; dropping the reader releases the
+        // leech guard so the completion watcher can move the files.
+        tokio::spawn(async move {
+            if stdin.write_all(&prefix).await.is_ok() {
+                let _ = tokio::io::copy(&mut reader, &mut stdin).await;
+            }
+            let _ = stdin.shutdown().await;
+        });
+
+        let errbuf = Arc::new(Mutex::new(String::new()));
+        if let Some(mut stderr) = child.stderr.take() {
+            let buf = errbuf.clone();
+            tokio::spawn(async move {
+                let mut s = String::new();
+                let _ = stderr.read_to_string(&mut s).await;
+                *buf.lock().unwrap() = s;
+            });
+        }
+
+        crate::telemetry::hls_started(id, if video_copy { "live_copy" } else { "live_transcode" });
+        {
+            let mut g = self.children.lock().unwrap();
+            g.insert(id.to_string(), child);
+        }
+
+        self.spawn_output_watch(id.to_string(), hls_dir.join("index.m3u8"), errbuf, permit);
         Ok(())
+    }
+
+    /// Best-effort: write the download prefix to a temp file and ask ffprobe
+    /// whether the video stream is h264. Any failure (partial header, unknown
+    /// codec) returns false, so the caller falls back to a safe re-encode.
+    async fn probe_prefix_is_h264(&self, prefix: &[u8]) -> bool {
+        if prefix.is_empty() {
+            return false;
+        }
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("reel-live-probe-{}-{n}.bin", std::process::id()));
+        if tokio::fs::write(&tmp, prefix).await.is_err() {
+            return false;
+        }
+        let res = crate::transcode::probe(&self.ffprobe_bin, &tmp).await;
+        let _ = tokio::fs::remove_file(&tmp).await;
+        matches!(res, Ok(p) if p.video_codec.as_deref() == Some("h264"))
     }
 }
 
@@ -433,11 +665,43 @@ mod mgr_tests {
         );
     }
 
+    #[test]
+    fn live_starts_only_while_leeching() {
+        assert_eq!(
+            next_hls_live(&HlsStatus::None, &TorrentState::Leeching, true),
+            HlsDecision::Start
+        );
+        assert_eq!(
+            next_hls_live(&HlsStatus::Failed, &TorrentState::Leeching, true),
+            HlsDecision::Start
+        );
+        assert_eq!(
+            next_hls_live(&HlsStatus::None, &TorrentState::Seeding, true),
+            HlsDecision::Reject(StartOutcome::NotCompleted)
+        );
+    }
+
+    #[test]
+    fn live_disabled_and_in_progress_rejected() {
+        assert_eq!(
+            next_hls_live(&HlsStatus::None, &TorrentState::Leeching, false),
+            HlsDecision::Reject(StartOutcome::Disabled)
+        );
+        assert_eq!(
+            next_hls_live(&HlsStatus::Live, &TorrentState::Leeching, true),
+            HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Live))
+        );
+        assert_eq!(
+            next_hls_live(&HlsStatus::Starting, &TorrentState::Leeching, true),
+            HlsDecision::Reject(StartOutcome::InProgress(HlsStatus::Starting))
+        );
+    }
+
     #[tokio::test]
     async fn abort_unknown_is_noop() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true, 1);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 1);
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
     }
@@ -446,7 +710,7 @@ mod mgr_tests {
     fn cached_delivery_none_then_some() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-cache-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), 4, true, 1);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 1);
         assert_eq!(mgr.cached_delivery("1"), None);
         mgr.cache_delivery("1", Delivery::RemuxHls);
         assert_eq!(mgr.cached_delivery("1"), Some(Delivery::RemuxHls));

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -34,8 +34,10 @@ async fn main() -> anyhow::Result<()> {
         store.clone(),
         cfg.encode_concurrency,
         cfg.ffmpeg_bin.clone(),
+        cfg.ffprobe_bin.clone(),
         cfg.hls_segment_secs as u32,
         cfg.hls_enabled,
+        cfg.live_hls_enabled,
         cfg.encode_threads,
     );
 

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -48,7 +48,16 @@ async fn hls_transcode_integration() {
     };
     store.upsert(entry).unwrap();
 
-    let mgr = reel::hls::HlsManager::new(store.clone(), 1, "ffmpeg".into(), 4, true, 1);
+    let mgr = reel::hls::HlsManager::new(
+        store.clone(),
+        1,
+        "ffmpeg".into(),
+        "ffprobe".into(),
+        4,
+        true,
+        true,
+        1,
+    );
     let outcome = mgr
         .request("test-hls", reel::transcode::Delivery::TranscodeHls)
         .await;


### PR DESCRIPTION
## What

Play on a still-downloading torrent no longer waits for the fetch to finish. `GET /manifest.m3u8` on a `Leeching` entry starts a **live HLS** job that reads directly from librqbit's sequential-priority stream and pipes it through ffmpeg (`pipe:0` → `-f hls`, event playlist) — the front of the file is watchable within seconds while the tail keeps downloading (popcorn-time style).

## How

- **engine** — `primary_stream(id)` opens the largest media file of a leeching torrent as a guarded reader; the existing leech-drain gate keeps the completion watcher from tearing the torrent down until the reader drops.
- **hls** — `request_live()` / `run_live()`: read an 8 MB prefix, ffprobe it for the video codec, then `-c:v copy` for h264 (realtime) or `libx264 -preset veryfast` otherwise; audio is always `-c:a aac -ac 2` (stereo downmix, so it plays with sound). The prefix is replayed into ffmpeg's stdin, then the rest of the download is pumped in. Shares the ffmpeg output watcher with the completed-download path.
- **api** — `manifest.m3u8` on a `Leeching` entry drives the live path (`ProceedLive`) instead of `425`. Returns `202` while starting, `200` once segments exist. **Frontend is unchanged** — it already polls `202 → 200` and switches to hls.js.
- **config** — `REEL_LIVE_HLS` (default on). When off, leeching falls back to raw progressive as before.

## Lifecycle

The live HLS dir is `<active>/hls` (same name the seeding path uses, so `pick_primary_file` skips it). On completion the entry moves to Seeding, `hls` resets to `None`, and the normal single-file transcode produces the persistent artifact; the frontend re-probes and gets the seeding delivery. Deleting the entry still removes everything.

## Notes

- Playback quality tracks download rate — a starved swarm buffers. Peer-drop hardening is a separate follow-up.
- 147 tests pass, clippy clean (only the pre-existing `stream.rs:13` warning).

