### PR TITLE
fix(sql): enable + harden RLS on windmill policy tables

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
@@ -139,8 +139,30 @@ BEGIN
     CREATE POLICY kbve_windmill_user_all ON windmill.rls_probe_admin_only
         FOR ALL TO windmill_user USING (true) WITH CHECK (true);
 
-    -- 6. reconciliation: once Windmill ships its own windmill_user policy, our
-    --    permissive compat policy must go, or it would OR-widen past theirs.
+    -- 6a. reconciliation, partial coverage: an upstream SELECT-only policy
+    --     must NOT evict the FOR ALL compat policy -- policies apply per
+    --     command, and dropping ours would deny-all every write. Writes must
+    --     keep working and the compat policy must survive.
+    CREATE POLICY see_own_select_upstream ON windmill.rls_probe_admin_only
+        FOR SELECT TO windmill_user USING (workspace_id = 'ws-a');
+    PERFORM windmill.enforce_policy_rls(true);
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_admin_only'::regclass
+          AND p.polname = 'kbve_windmill_user_all'
+    ) THEN
+        RAISE EXCEPTION 'fail: SELECT-only upstream policy evicted the FOR ALL compat policy (write paths now deny-all)';
+    END IF;
+
+    SET LOCAL ROLE windmill_user;
+    INSERT INTO windmill.rls_probe_admin_only (workspace_id) VALUES ('ws-write-probe');
+    DELETE FROM windmill.rls_probe_admin_only WHERE workspace_id = 'ws-write-probe';
+    RESET ROLE;
+    DROP POLICY see_own_select_upstream ON windmill.rls_probe_admin_only;
+
+    -- 6b. reconciliation, full coverage: once Windmill covers every command
+    --     for windmill_user, our permissive compat policy must go, or it
+    --     would OR-widen past theirs.
     CREATE POLICY see_own_upstream ON windmill.rls_probe_admin_only
         FOR ALL TO windmill_user USING (workspace_id = 'ws-a');
     PERFORM windmill.enforce_policy_rls(true);

--- a/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
@@ -2,16 +2,19 @@
 -- Run via: ./test-migration.sh 20260730020000_windmill_rls_enable_policy_tables
 
 -- SEED
--- Three shapes, mirroring the live windmill schema:
---   admin_only  = the actual offenders (v2_job_*, account): one admin_policy
---                 for BYPASSRLS windmill_admin, RLS off, windmill_user has
---                 grants and no policy -> must gain a compat policy + RLS.
---   user_policy = has a windmill_user policy already -> must be LEFT ALONE.
---   no_policy   = no policies at all -> must stay RLS-off.
+-- Four shapes, mirroring the live windmill schema plus the guard cases:
+--   admin_only    = the actual offenders (v2_job_*, account): one admin_policy
+--                   for BYPASSRLS windmill_admin, RLS off, windmill_user has
+--                   grants and no policy -> compat policy + RLS + read probe.
+--   user_policy   = a windmill_user policy already exists -> LEFT ALONE.
+--   public_policy = policy with no TO clause (polroles = {0}) therefore
+--                   applies to windmill_user too -> LEFT ALONE.
+--   no_policy     = no policies at all -> stays RLS-off.
 CREATE SCHEMA IF NOT EXISTS windmill;
 
 DROP TABLE IF EXISTS windmill.rls_probe_admin_only;
 DROP TABLE IF EXISTS windmill.rls_probe_user_policy;
+DROP TABLE IF EXISTS windmill.rls_probe_public_policy;
 DROP TABLE IF EXISTS windmill.rls_probe_no_policy;
 
 CREATE TABLE windmill.rls_probe_admin_only (
@@ -35,6 +38,15 @@ CREATE POLICY see_own ON windmill.rls_probe_user_policy
 ALTER TABLE windmill.rls_probe_user_policy DISABLE ROW LEVEL SECURITY;
 GRANT ALL ON windmill.rls_probe_user_policy TO windmill_user;
 
+CREATE TABLE windmill.rls_probe_public_policy (
+    id bigserial PRIMARY KEY,
+    workspace_id text NOT NULL
+);
+CREATE POLICY everyone_policy ON windmill.rls_probe_public_policy
+    FOR ALL USING (workspace_id = 'ws-a');
+ALTER TABLE windmill.rls_probe_public_policy DISABLE ROW LEVEL SECURITY;
+GRANT ALL ON windmill.rls_probe_public_policy TO windmill_user;
+
 CREATE TABLE windmill.rls_probe_no_policy (
     id bigserial PRIMARY KEY
 );
@@ -43,7 +55,9 @@ CREATE TABLE windmill.rls_probe_no_policy (
 DO $$
 DECLARE
     visible int;
+    fixed int;
 BEGIN
+    -- 1. the real offender shape gets fixed
     IF NOT (
         SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_admin_only'
@@ -60,8 +74,7 @@ BEGIN
         RAISE EXCEPTION 'fail: compat policy for windmill_user missing';
     END IF;
 
-    -- The whole point: windmill_user must still see every row, exactly as it
-    -- did while RLS was off.
+    -- 2. the whole point: windmill_user still sees every row
     SET LOCAL ROLE windmill_user;
     SELECT count(*) INTO visible FROM windmill.rls_probe_admin_only;
     RESET ROLE;
@@ -69,6 +82,7 @@ BEGIN
         RAISE EXCEPTION 'fail: windmill_user sees % of 2 rows after RLS enable (deny-all regression)', visible;
     END IF;
 
+    -- 3. guard cases stay untouched
     IF (
         SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_user_policy'
@@ -76,12 +90,19 @@ BEGIN
         RAISE EXCEPTION 'fail: sweep enabled RLS on a table that already had a windmill_user policy';
     END IF;
 
-    IF EXISTS (
-        SELECT 1 FROM pg_policy p
-        WHERE p.polrelid = 'windmill.rls_probe_user_policy'::regclass
-          AND p.polname = 'kbve_windmill_user_all'
+    IF (
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_public_policy'
     ) THEN
-        RAISE EXCEPTION 'fail: compat policy added to a table the sweep must leave alone';
+        RAISE EXCEPTION 'fail: sweep enabled RLS on a table with a PUBLIC-scoped policy';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM windmill.rls_drift()
+        WHERE relation IN ('windmill.rls_probe_user_policy', 'windmill.rls_probe_public_policy')
+          AND auto_fixable
+    ) THEN
+        RAISE EXCEPTION 'fail: rls_drift() marked a windmill_user-visible policy table auto_fixable';
     END IF;
 
     IF (
@@ -89,6 +110,52 @@ BEGIN
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_no_policy'
     ) THEN
         RAISE EXCEPTION 'fail: RLS enabled on windmill table that has no policies';
+    END IF;
+
+    -- 4. no auto-fixable drift left, and the sweep is idempotent
+    IF EXISTS (SELECT 1 FROM windmill.rls_drift() WHERE auto_fixable) THEN
+        RAISE EXCEPTION 'fail: auto-fixable offenders remain after up';
+    END IF;
+
+    SELECT windmill.enforce_policy_rls(true) INTO fixed;
+    IF fixed <> 0 THEN
+        RAISE EXCEPTION 'fail: enforce_policy_rls() not idempotent, changed % relation(s)', fixed;
+    END IF;
+
+    -- 5. the probe itself must detect a blackout and an empty table
+    IF NOT windmill.rls_user_can_read('windmill.rls_probe_admin_only'::regclass) THEN
+        RAISE EXCEPTION 'fail: probe reports the fixed table as unreadable';
+    END IF;
+
+    IF NOT windmill.rls_user_can_read('windmill.rls_probe_no_policy'::regclass) THEN
+        RAISE EXCEPTION 'fail: probe must be vacuously true on an empty table';
+    END IF;
+
+    -- construct a real blackout: RLS on, rows present, no windmill_user policy
+    DROP POLICY kbve_windmill_user_all ON windmill.rls_probe_admin_only;
+    IF windmill.rls_user_can_read('windmill.rls_probe_admin_only'::regclass) THEN
+        RAISE EXCEPTION 'fail: probe did not detect a windmill_user blackout';
+    END IF;
+    CREATE POLICY kbve_windmill_user_all ON windmill.rls_probe_admin_only
+        FOR ALL TO windmill_user USING (true) WITH CHECK (true);
+
+    -- 6. helpers are locked down and owned by postgres
+    IF has_function_privilege('anon', 'windmill.enforce_policy_rls(boolean)', 'EXECUTE')
+       OR has_function_privilege('authenticated', 'windmill.rls_drift()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: API roles can execute the windmill rls helpers';
+    END IF;
+
+    -- Owned by postgres, and deliberately NOT SECURITY DEFINER: the read probe
+    -- needs SET/RESET ROLE, which postgres cannot do inside a definer function.
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN pg_roles r ON r.oid = p.proowner
+        WHERE n.nspname = 'windmill'
+          AND p.proname IN ('enforce_policy_rls', 'rls_drift', 'rls_user_can_read')
+          AND (r.rolname <> 'postgres' OR p.prosecdef)
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill rls helpers must be postgres-owned SECURITY INVOKER';
     END IF;
 END;
 $$;
@@ -117,6 +184,14 @@ BEGIN
           AND p.polname = 'admin_policy'
     ) THEN
         RAISE EXCEPTION 'fail: down removed a Windmill-owned policy';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'windmill'
+          AND p.proname IN ('enforce_policy_rls', 'rls_drift', 'rls_user_can_read')
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill rls helpers still present after down';
     END IF;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
@@ -1,0 +1,75 @@
+-- Companion test fixtures for 20260730020000_windmill_rls_enable_policy_tables.
+-- Run via: ./test-migration.sh 20260730020000_windmill_rls_enable_policy_tables
+
+-- SEED
+-- Stand in for the Windmill-owned tables (windmill.account, v2_job_*):
+-- a policy exists, RLS is off. Also seed a control table with no policy,
+-- which must stay RLS-disabled.
+CREATE SCHEMA IF NOT EXISTS windmill;
+
+DROP TABLE IF EXISTS windmill.rls_probe_with_policy;
+DROP TABLE IF EXISTS windmill.rls_probe_no_policy;
+
+CREATE TABLE windmill.rls_probe_with_policy (
+    id bigserial PRIMARY KEY,
+    workspace_id text NOT NULL
+);
+
+CREATE POLICY admin_policy ON windmill.rls_probe_with_policy
+    TO windmill_admin
+    USING (true);
+
+ALTER TABLE windmill.rls_probe_with_policy DISABLE ROW LEVEL SECURITY;
+
+CREATE TABLE windmill.rls_probe_no_policy (
+    id bigserial PRIMARY KEY
+);
+
+-- ASSERT_AFTER_UP
+DO $$
+BEGIN
+    IF NOT (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_with_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS not enabled on policy-bearing windmill table';
+    END IF;
+
+    IF (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_no_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS enabled on windmill table that has no policies';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill'
+          AND c.relkind IN ('r', 'p')
+          AND NOT c.relrowsecurity
+          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill relations with policies still have RLS disabled';
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+DO $$
+BEGIN
+    IF (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_with_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS still enabled after down';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
@@ -139,7 +139,32 @@ BEGIN
     CREATE POLICY kbve_windmill_user_all ON windmill.rls_probe_admin_only
         FOR ALL TO windmill_user USING (true) WITH CHECK (true);
 
-    -- 6. helpers are locked down and owned by postgres
+    -- 6. reconciliation: once Windmill ships its own windmill_user policy, our
+    --    permissive compat policy must go, or it would OR-widen past theirs.
+    CREATE POLICY see_own_upstream ON windmill.rls_probe_admin_only
+        FOR ALL TO windmill_user USING (workspace_id = 'ws-a');
+    PERFORM windmill.enforce_policy_rls(true);
+    IF EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_admin_only'::regclass
+          AND p.polname = 'kbve_windmill_user_all'
+    ) THEN
+        RAISE EXCEPTION 'fail: compat policy survived alongside an upstream windmill_user policy';
+    END IF;
+
+    SET LOCAL ROLE windmill_user;
+    SELECT count(*) INTO visible FROM windmill.rls_probe_admin_only;
+    RESET ROLE;
+    IF visible <> 1 THEN
+        RAISE EXCEPTION 'fail: upstream policy not in force after reconcile (saw % rows, expected 1)', visible;
+    END IF;
+
+    -- restore the fixture for the down-assertions
+    DROP POLICY see_own_upstream ON windmill.rls_probe_admin_only;
+    CREATE POLICY kbve_windmill_user_all ON windmill.rls_probe_admin_only
+        FOR ALL TO windmill_user USING (true) WITH CHECK (true);
+
+    -- 7. helpers are locked down and owned by postgres
     IF has_function_privilege('anon', 'windmill.enforce_policy_rls(boolean)', 'EXECUTE')
        OR has_function_privilege('authenticated', 'windmill.rls_drift()', 'EXECUTE') THEN
         RAISE EXCEPTION 'fail: API roles can execute the windmill rls helpers';

--- a/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730020000_windmill_rls_enable_policy_tables.test.sql
@@ -2,24 +2,38 @@
 -- Run via: ./test-migration.sh 20260730020000_windmill_rls_enable_policy_tables
 
 -- SEED
--- Stand in for the Windmill-owned tables (windmill.account, v2_job_*):
--- a policy exists, RLS is off. Also seed a control table with no policy,
--- which must stay RLS-disabled.
+-- Three shapes, mirroring the live windmill schema:
+--   admin_only  = the actual offenders (v2_job_*, account): one admin_policy
+--                 for BYPASSRLS windmill_admin, RLS off, windmill_user has
+--                 grants and no policy -> must gain a compat policy + RLS.
+--   user_policy = has a windmill_user policy already -> must be LEFT ALONE.
+--   no_policy   = no policies at all -> must stay RLS-off.
 CREATE SCHEMA IF NOT EXISTS windmill;
 
-DROP TABLE IF EXISTS windmill.rls_probe_with_policy;
+DROP TABLE IF EXISTS windmill.rls_probe_admin_only;
+DROP TABLE IF EXISTS windmill.rls_probe_user_policy;
 DROP TABLE IF EXISTS windmill.rls_probe_no_policy;
 
-CREATE TABLE windmill.rls_probe_with_policy (
+CREATE TABLE windmill.rls_probe_admin_only (
     id bigserial PRIMARY KEY,
     workspace_id text NOT NULL
 );
+CREATE POLICY admin_policy ON windmill.rls_probe_admin_only
+    FOR ALL TO windmill_admin USING (true);
+ALTER TABLE windmill.rls_probe_admin_only DISABLE ROW LEVEL SECURITY;
+GRANT ALL ON windmill.rls_probe_admin_only TO windmill_user;
+INSERT INTO windmill.rls_probe_admin_only (workspace_id) VALUES ('ws-a'), ('ws-b');
 
-CREATE POLICY admin_policy ON windmill.rls_probe_with_policy
-    TO windmill_admin
-    USING (true);
-
-ALTER TABLE windmill.rls_probe_with_policy DISABLE ROW LEVEL SECURITY;
+CREATE TABLE windmill.rls_probe_user_policy (
+    id bigserial PRIMARY KEY,
+    workspace_id text NOT NULL
+);
+CREATE POLICY admin_policy ON windmill.rls_probe_user_policy
+    FOR ALL TO windmill_admin USING (true);
+CREATE POLICY see_own ON windmill.rls_probe_user_policy
+    FOR ALL TO windmill_user USING (workspace_id = 'ws-a');
+ALTER TABLE windmill.rls_probe_user_policy DISABLE ROW LEVEL SECURITY;
+GRANT ALL ON windmill.rls_probe_user_policy TO windmill_user;
 
 CREATE TABLE windmill.rls_probe_no_policy (
     id bigserial PRIMARY KEY
@@ -27,35 +41,54 @@ CREATE TABLE windmill.rls_probe_no_policy (
 
 -- ASSERT_AFTER_UP
 DO $$
+DECLARE
+    visible int;
 BEGIN
     IF NOT (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_with_policy'
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_admin_only'
     ) THEN
-        RAISE EXCEPTION 'fail: RLS not enabled on policy-bearing windmill table';
+        RAISE EXCEPTION 'fail: RLS not enabled on admin-only policy table';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_admin_only'::regclass
+          AND p.polname = 'kbve_windmill_user_all'
+          AND 'windmill_user'::regrole = ANY (p.polroles)
+    ) THEN
+        RAISE EXCEPTION 'fail: compat policy for windmill_user missing';
+    END IF;
+
+    -- The whole point: windmill_user must still see every row, exactly as it
+    -- did while RLS was off.
+    SET LOCAL ROLE windmill_user;
+    SELECT count(*) INTO visible FROM windmill.rls_probe_admin_only;
+    RESET ROLE;
+    IF visible <> 2 THEN
+        RAISE EXCEPTION 'fail: windmill_user sees % of 2 rows after RLS enable (deny-all regression)', visible;
     END IF;
 
     IF (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_no_policy'
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_user_policy'
     ) THEN
-        RAISE EXCEPTION 'fail: RLS enabled on windmill table that has no policies';
+        RAISE EXCEPTION 'fail: sweep enabled RLS on a table that already had a windmill_user policy';
     END IF;
 
     IF EXISTS (
-        SELECT 1
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill'
-          AND c.relkind IN ('r', 'p')
-          AND NOT c.relrowsecurity
-          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_user_policy'::regclass
+          AND p.polname = 'kbve_windmill_user_all'
     ) THEN
-        RAISE EXCEPTION 'fail: windmill relations with policies still have RLS disabled';
+        RAISE EXCEPTION 'fail: compat policy added to a table the sweep must leave alone';
+    END IF;
+
+    IF (
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_no_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS enabled on windmill table that has no policies';
     END IF;
 END;
 $$;
@@ -64,12 +97,26 @@ $$;
 DO $$
 BEGIN
     IF (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_with_policy'
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_probe_admin_only'
     ) THEN
         RAISE EXCEPTION 'fail: RLS still enabled after down';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_admin_only'::regclass
+          AND p.polname = 'kbve_windmill_user_all'
+    ) THEN
+        RAISE EXCEPTION 'fail: compat policy survived down';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = 'windmill.rls_probe_admin_only'::regclass
+          AND p.polname = 'admin_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: down removed a Windmill-owned policy';
     END IF;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
@@ -1,0 +1,137 @@
+-- Companion test fixtures for 20260730030000_windmill_rls_hardening.
+-- Run via: ./test-migration.sh 20260730030000_windmill_rls_hardening
+
+-- SEED
+-- Two stand-ins for Windmill-owned tables. The drifted one arrives AFTER
+-- the one-shot sweep in 20260730020000 (i.e. what a future Windmill sqlx
+-- migration would do) and additionally leaks grants to the API roles.
+CREATE SCHEMA IF NOT EXISTS windmill;
+
+DROP TABLE IF EXISTS windmill.rls_harden_probe;
+DROP TABLE IF EXISTS windmill.rls_harden_no_policy;
+
+CREATE TABLE windmill.rls_harden_probe (
+    id bigserial PRIMARY KEY,
+    workspace_id text NOT NULL
+);
+
+CREATE POLICY admin_policy ON windmill.rls_harden_probe
+    TO windmill_admin
+    USING (true);
+
+ALTER TABLE windmill.rls_harden_probe DISABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON windmill.rls_harden_probe TO anon;
+GRANT SELECT, INSERT ON windmill.rls_harden_probe TO authenticated;
+GRANT SELECT ON windmill.rls_harden_probe TO PUBLIC;
+
+CREATE TABLE windmill.rls_harden_no_policy (
+    id bigserial PRIMARY KEY
+);
+
+-- ASSERT_AFTER_UP
+DO $$
+DECLARE
+    drifted text;
+    fixed int;
+BEGIN
+    IF NOT (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_probe'
+    ) THEN
+        RAISE EXCEPTION 'fail: hardening did not enable RLS on drifted table';
+    END IF;
+
+    IF (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_no_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS enabled on windmill table with no policies';
+    END IF;
+
+    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift();
+    IF drifted IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: rls_drift() still reports offenders: %', drifted;
+    END IF;
+
+    SELECT windmill.enforce_policy_rls() INTO fixed;
+    IF fixed <> 0 THEN
+        RAISE EXCEPTION 'fail: enforce_policy_rls() not idempotent, changed % relation(s)', fixed;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.role_table_grants
+        WHERE table_schema = 'windmill'
+          AND grantee IN ('PUBLIC', 'anon', 'authenticated')
+    ) THEN
+        RAISE EXCEPTION 'fail: API roles still hold table grants in windmill';
+    END IF;
+
+    IF has_function_privilege('anon', 'windmill.enforce_policy_rls()', 'EXECUTE')
+       OR has_function_privilege('authenticated', 'windmill.enforce_policy_rls()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: API roles can execute windmill.enforce_policy_rls()';
+    END IF;
+
+    IF NOT (
+        SELECT p.prosecdef FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'windmill' AND p.proname = 'enforce_policy_rls'
+    ) THEN
+        RAISE EXCEPTION 'fail: enforce_policy_rls must be SECURITY DEFINER';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN pg_roles r ON r.oid = p.proowner
+        WHERE n.nspname = 'windmill'
+          AND p.proname IN ('enforce_policy_rls', 'rls_drift')
+          AND r.rolname = 'postgres'
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill rls functions must be owned by postgres';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM cron.job WHERE jobname = 'windmill-enforce-policy-rls'
+        ) THEN
+            RAISE EXCEPTION 'fail: windmill-enforce-policy-rls cron job not registered';
+        END IF;
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'windmill'
+          AND p.proname IN ('enforce_policy_rls', 'rls_drift')
+    ) THEN
+        RAISE EXCEPTION 'fail: windmill rls functions still present after down';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        IF EXISTS (
+            SELECT 1 FROM cron.job WHERE jobname = 'windmill-enforce-policy-rls'
+        ) THEN
+            RAISE EXCEPTION 'fail: cron job still scheduled after down';
+        END IF;
+    END IF;
+
+    IF NOT (
+        SELECT c.relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_probe'
+    ) THEN
+        RAISE EXCEPTION 'fail: down must not disable RLS (owned by 20260730020000)';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
@@ -2,60 +2,101 @@
 -- Run via: ./test-migration.sh 20260730030000_windmill_rls_hardening
 
 -- SEED
--- Two stand-ins for Windmill-owned tables. The drifted one arrives AFTER
--- the one-shot sweep in 20260730020000 (i.e. what a future Windmill sqlx
--- migration would do) and additionally leaks grants to the API roles.
+-- Drift that arrives AFTER the one-shot sweep in 20260730020000, i.e. what a
+-- future Windmill sqlx migration would create: a policy-bearing table with RLS
+-- off, a table whose windmill_user policy must be left alone, a function with
+-- no explicit ACL (relies on the implicit PUBLIC EXECUTE default, like the 19
+-- real windmill functions do), and leaked grants to the API roles.
 CREATE SCHEMA IF NOT EXISTS windmill;
 
 DROP TABLE IF EXISTS windmill.rls_harden_probe;
+DROP TABLE IF EXISTS windmill.rls_harden_user_policy;
 DROP TABLE IF EXISTS windmill.rls_harden_no_policy;
+DROP FUNCTION IF EXISTS windmill.harden_probe_fn();
 
 CREATE TABLE windmill.rls_harden_probe (
     id bigserial PRIMARY KEY,
     workspace_id text NOT NULL
 );
-
 CREATE POLICY admin_policy ON windmill.rls_harden_probe
-    TO windmill_admin
-    USING (true);
-
+    FOR ALL TO windmill_admin USING (true);
 ALTER TABLE windmill.rls_harden_probe DISABLE ROW LEVEL SECURITY;
-
+GRANT ALL ON windmill.rls_harden_probe TO windmill_user;
 GRANT SELECT ON windmill.rls_harden_probe TO anon;
 GRANT SELECT, INSERT ON windmill.rls_harden_probe TO authenticated;
 GRANT SELECT ON windmill.rls_harden_probe TO PUBLIC;
+INSERT INTO windmill.rls_harden_probe (workspace_id) VALUES ('ws-a'), ('ws-b'), ('ws-c');
+
+CREATE TABLE windmill.rls_harden_user_policy (
+    id bigserial PRIMARY KEY,
+    workspace_id text NOT NULL
+);
+CREATE POLICY admin_policy ON windmill.rls_harden_user_policy
+    FOR ALL TO windmill_admin USING (true);
+CREATE POLICY see_own ON windmill.rls_harden_user_policy
+    FOR ALL TO windmill_user USING (workspace_id = 'ws-a');
+ALTER TABLE windmill.rls_harden_user_policy DISABLE ROW LEVEL SECURITY;
+GRANT ALL ON windmill.rls_harden_user_policy TO windmill_user;
 
 CREATE TABLE windmill.rls_harden_no_policy (
     id bigserial PRIMARY KEY
 );
+
+-- Stand-in for set_session_context(): no explicit ACL at all.
+CREATE FUNCTION windmill.harden_probe_fn() RETURNS int LANGUAGE sql AS 'SELECT 1';
 
 -- ASSERT_AFTER_UP
 DO $$
 DECLARE
     drifted text;
     fixed int;
+    visible int;
+    probe int;
 BEGIN
     IF NOT (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_probe'
     ) THEN
         RAISE EXCEPTION 'fail: hardening did not enable RLS on drifted table';
     END IF;
 
+    SET LOCAL ROLE windmill_user;
+    SELECT count(*) INTO visible FROM windmill.rls_harden_probe;
+    SELECT windmill.harden_probe_fn() INTO probe;
+    RESET ROLE;
+
+    IF visible <> 3 THEN
+        RAISE EXCEPTION 'fail: windmill_user sees % of 3 rows after hardening (deny-all regression)', visible;
+    END IF;
+    IF probe <> 1 THEN
+        RAISE EXCEPTION 'fail: windmill_user could not execute an ACL-less windmill function';
+    END IF;
+
     IF (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_user_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: hardening enabled RLS on a table with an existing windmill_user policy';
+    END IF;
+
+    IF (
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_no_policy'
     ) THEN
         RAISE EXCEPTION 'fail: RLS enabled on windmill table with no policies';
     END IF;
 
-    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift();
+    -- The manual-review table stays in rls_drift(), flagged not auto_fixable.
+    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift() WHERE auto_fixable;
     IF drifted IS NOT NULL THEN
-        RAISE EXCEPTION 'fail: rls_drift() still reports offenders: %', drifted;
+        RAISE EXCEPTION 'fail: auto-fixable offenders remain: %', drifted;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM windmill.rls_drift()
+        WHERE relation = 'windmill.rls_harden_user_policy' AND NOT auto_fixable
+    ) THEN
+        RAISE EXCEPTION 'fail: rls_drift() must report the manual-review table as not auto_fixable';
     END IF;
 
     SELECT windmill.enforce_policy_rls() INTO fixed;
@@ -65,10 +106,14 @@ BEGIN
 
     IF EXISTS (
         SELECT 1 FROM information_schema.role_table_grants
-        WHERE table_schema = 'windmill'
-          AND grantee IN ('PUBLIC', 'anon', 'authenticated')
+        WHERE table_schema = 'windmill' AND grantee IN ('PUBLIC', 'anon', 'authenticated')
     ) THEN
         RAISE EXCEPTION 'fail: API roles still hold table grants in windmill';
+    END IF;
+
+    IF has_function_privilege('anon', 'windmill.harden_probe_fn()', 'EXECUTE')
+       OR has_function_privilege('authenticated', 'windmill.harden_probe_fn()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: API roles can execute windmill functions';
     END IF;
 
     IF has_function_privilege('anon', 'windmill.enforce_policy_rls()', 'EXECUTE')
@@ -77,20 +122,19 @@ BEGIN
     END IF;
 
     IF NOT (
-        SELECT p.prosecdef FROM pg_proc p
-        JOIN pg_namespace n ON n.oid = p.pronamespace
+        SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
         WHERE n.nspname = 'windmill' AND p.proname = 'enforce_policy_rls'
     ) THEN
         RAISE EXCEPTION 'fail: enforce_policy_rls must be SECURITY DEFINER';
     END IF;
 
-    IF NOT EXISTS (
+    IF EXISTS (
         SELECT 1 FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
         JOIN pg_roles r ON r.oid = p.proowner
         WHERE n.nspname = 'windmill'
           AND p.proname IN ('enforce_policy_rls', 'rls_drift')
-          AND r.rolname = 'postgres'
+          AND r.rolname <> 'postgres'
     ) THEN
         RAISE EXCEPTION 'fail: windmill rls functions must be owned by postgres';
     END IF;
@@ -107,12 +151,12 @@ $$;
 
 -- ASSERT_AFTER_DOWN
 DO $$
+DECLARE
+    probe int;
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM pg_proc p
-        JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'windmill'
-          AND p.proname IN ('enforce_policy_rls', 'rls_drift')
+        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'windmill' AND p.proname IN ('enforce_policy_rls', 'rls_drift')
     ) THEN
         RAISE EXCEPTION 'fail: windmill rls functions still present after down';
     END IF;
@@ -125,10 +169,16 @@ BEGIN
         END IF;
     END IF;
 
+    -- Rollback must not leave Windmill's own functions unreachable.
+    SET LOCAL ROLE windmill_user;
+    SELECT windmill.harden_probe_fn() INTO probe;
+    RESET ROLE;
+    IF probe <> 1 THEN
+        RAISE EXCEPTION 'fail: windmill_user lost EXECUTE after rollback';
+    END IF;
+
     IF NOT (
-        SELECT c.relrowsecurity
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_probe'
     ) THEN
         RAISE EXCEPTION 'fail: down must not disable RLS (owned by 20260730020000)';

--- a/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260730030000_windmill_rls_hardening.test.sql
@@ -53,6 +53,7 @@ DECLARE
     visible int;
     probe int;
 BEGIN
+    -- 1. drift healed, engine still reads everything, function still callable
     IF NOT (
         SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_probe'
@@ -72,24 +73,16 @@ BEGIN
         RAISE EXCEPTION 'fail: windmill_user could not execute an ACL-less windmill function';
     END IF;
 
+    IF NOT windmill.rls_user_can_read('windmill.rls_harden_probe'::regclass) THEN
+        RAISE EXCEPTION 'fail: probe reports the healed table as unreadable';
+    END IF;
+
+    -- 2. manual-review table untouched but still reported
     IF (
         SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_user_policy'
     ) THEN
         RAISE EXCEPTION 'fail: hardening enabled RLS on a table with an existing windmill_user policy';
-    END IF;
-
-    IF (
-        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_no_policy'
-    ) THEN
-        RAISE EXCEPTION 'fail: RLS enabled on windmill table with no policies';
-    END IF;
-
-    -- The manual-review table stays in rls_drift(), flagged not auto_fixable.
-    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift() WHERE auto_fixable;
-    IF drifted IS NOT NULL THEN
-        RAISE EXCEPTION 'fail: auto-fixable offenders remain: %', drifted;
     END IF;
 
     IF NOT EXISTS (
@@ -99,11 +92,29 @@ BEGIN
         RAISE EXCEPTION 'fail: rls_drift() must report the manual-review table as not auto_fixable';
     END IF;
 
-    SELECT windmill.enforce_policy_rls() INTO fixed;
-    IF fixed <> 0 THEN
-        RAISE EXCEPTION 'fail: enforce_policy_rls() not idempotent, changed % relation(s)', fixed;
+    IF (
+        SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill' AND c.relname = 'rls_harden_no_policy'
+    ) THEN
+        RAISE EXCEPTION 'fail: RLS enabled on windmill table with no policies';
     END IF;
 
+    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift() WHERE auto_fixable;
+    IF drifted IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: auto-fixable offenders remain: %', drifted;
+    END IF;
+
+    -- 3. both modes idempotent; non-strict is what cron runs
+    SELECT windmill.enforce_policy_rls(true) INTO fixed;
+    IF fixed <> 0 THEN
+        RAISE EXCEPTION 'fail: enforce_policy_rls(true) not idempotent, changed % relation(s)', fixed;
+    END IF;
+    SELECT windmill.enforce_policy_rls(false) INTO fixed;
+    IF fixed <> 0 THEN
+        RAISE EXCEPTION 'fail: enforce_policy_rls(false) not idempotent, changed % relation(s)', fixed;
+    END IF;
+
+    -- 4. API roles walled off
     IF EXISTS (
         SELECT 1 FROM information_schema.role_table_grants
         WHERE table_schema = 'windmill' AND grantee IN ('PUBLIC', 'anon', 'authenticated')
@@ -116,34 +127,20 @@ BEGIN
         RAISE EXCEPTION 'fail: API roles can execute windmill functions';
     END IF;
 
-    IF has_function_privilege('anon', 'windmill.enforce_policy_rls()', 'EXECUTE')
-       OR has_function_privilege('authenticated', 'windmill.enforce_policy_rls()', 'EXECUTE') THEN
-        RAISE EXCEPTION 'fail: API roles can execute windmill.enforce_policy_rls()';
-    END IF;
-
-    IF NOT (
-        SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'windmill' AND p.proname = 'enforce_policy_rls'
-    ) THEN
-        RAISE EXCEPTION 'fail: enforce_policy_rls must be SECURITY DEFINER';
-    END IF;
-
-    IF EXISTS (
-        SELECT 1 FROM pg_proc p
-        JOIN pg_namespace n ON n.oid = p.pronamespace
-        JOIN pg_roles r ON r.oid = p.proowner
-        WHERE n.nspname = 'windmill'
-          AND p.proname IN ('enforce_policy_rls', 'rls_drift')
-          AND r.rolname <> 'postgres'
-    ) THEN
-        RAISE EXCEPTION 'fail: windmill rls functions must be owned by postgres';
+    -- 5. the sweep helpers stay postgres-only, even after the blanket GRANT
+    IF has_function_privilege('windmill_user', 'windmill.enforce_policy_rls(boolean)', 'EXECUTE')
+       OR has_function_privilege('windmill_user', 'windmill.rls_drift()', 'EXECUTE')
+       OR has_function_privilege('windmill_user', 'windmill.rls_user_can_read(regclass)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: windmill_user can execute the privileged rls helpers';
     END IF;
 
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
         IF NOT EXISTS (
-            SELECT 1 FROM cron.job WHERE jobname = 'windmill-enforce-policy-rls'
+            SELECT 1 FROM cron.job
+            WHERE jobname = 'windmill-enforce-policy-rls'
+              AND command LIKE '%enforce_policy_rls(false)%'
         ) THEN
-            RAISE EXCEPTION 'fail: windmill-enforce-policy-rls cron job not registered';
+            RAISE EXCEPTION 'fail: cron job missing or not running in non-strict mode';
         END IF;
     END IF;
 END;
@@ -154,13 +151,6 @@ DO $$
 DECLARE
     probe int;
 BEGIN
-    IF EXISTS (
-        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'windmill' AND p.proname IN ('enforce_policy_rls', 'rls_drift')
-    ) THEN
-        RAISE EXCEPTION 'fail: windmill rls functions still present after down';
-    END IF;
-
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
         IF EXISTS (
             SELECT 1 FROM cron.job WHERE jobname = 'windmill-enforce-policy-rls'
@@ -175,6 +165,11 @@ BEGIN
     RESET ROLE;
     IF probe <> 1 THEN
         RAISE EXCEPTION 'fail: windmill_user lost EXECUTE after rollback';
+    END IF;
+
+    -- ...but the privileged helpers must not become PUBLIC again.
+    IF has_function_privilege('windmill_user', 'windmill.enforce_policy_rls(boolean)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: rollback exposed enforce_policy_rls to windmill_user';
     END IF;
 
     IF NOT (

--- a/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
+++ b/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
@@ -7,29 +7,52 @@
 -- flags windmill.account, windmill.v2_job_completed,
 -- windmill.v2_job_queue, windmill.v2_job_runtime and
 -- windmill.v2_job_status: Windmill's sqlx migrations created
--- admin_policy / per-workspace policies on them but left
--- ROW LEVEL SECURITY disabled, so the policies are inert.
+-- admin_policy on them but left ROW LEVEL SECURITY disabled, so
+-- the policies are inert.
 --
--- Windmill owns its table lifecycle (see 20260707000000), so we
--- do not name tables here. We sweep every relation in the
--- windmill schema that has at least one policy and no RLS, and
--- turn RLS on. Idempotent: relations already using RLS, and a
--- fresh database where Windmill has not run yet, are no-ops.
+-- Naively flipping RLS on would BREAK Windmill. Verified against
+-- the live cluster:
 --
--- Safety: the windmill tables are owned by postgres (superuser)
--- and the Windmill server connects as postgres, so RLS is
--- bypassed for the engine itself. Workers SET ROLE to
--- windmill_user / windmill_admin (BYPASSRLS), which is exactly
--- the enforcement path the policies were written for.
+--   * each of the five carries exactly one policy, admin_policy,
+--     FOR ALL TO windmill_admin USING (true) -- and windmill_admin
+--     is BYPASSRLS, so that policy is a no-op either way;
+--   * windmill_user holds full DML grants on all of them, is NOT
+--     BYPASSRLS, and HAS NO POLICY of its own. pg_stat_statements
+--     shows windmill_user actively selecting from v2_job_completed
+--     and v2_job_queue (job lists / run detail).
+--
+-- So RLS-on with no windmill_user policy = deny-all for every
+-- non-admin Windmill session. Workspace isolation for these
+-- satellite tables is not their own job: Windmill's queries JOIN
+-- v2_job, which already has RLS enabled plus the see_own /
+-- see_member / see_folder_extra_perms_user policies.
+--
+-- Therefore, before enabling RLS on such a table, add a permissive
+-- compat policy for windmill_user USING (true). That preserves the
+-- CURRENT effective access exactly (RLS off == every granted role
+-- sees every row) while making the existing policies live, so the
+-- linter finding clears with no behaviour change.
+--
+-- If a table has policies, RLS off, AND already has a windmill_user
+-- policy, we do NOT touch it: enabling RLS there would newly filter
+-- rows, which is a judgement call for a human, not this sweep.
+-- Windmill owns its table lifecycle, so nothing here names a table.
 -- ============================================================
 
 DO $$
 DECLARE
     target record;
     enabled_count int := 0;
+    skipped text[] := '{}';
 BEGIN
     FOR target IN
-        SELECT c.oid::regclass AS relident
+        SELECT c.oid AS reloid,
+               c.oid::regclass AS relident,
+               EXISTS (
+                   SELECT 1 FROM pg_policy p
+                   WHERE p.polrelid = c.oid
+                     AND 'windmill_user'::regrole = ANY (p.polroles)
+               ) AS has_user_policy
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill'
@@ -38,12 +61,36 @@ BEGIN
           AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
         ORDER BY 1
     LOOP
+        IF target.has_user_policy THEN
+            skipped := skipped || target.relident::text;
+            RAISE NOTICE
+                'windmill_rls_enable: skipping % (already has a windmill_user policy; enabling RLS would newly filter rows)',
+                target.relident;
+            CONTINUE;
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policy p
+            WHERE p.polrelid = target.reloid
+              AND p.polname = 'kbve_windmill_user_all'
+        ) THEN
+            EXECUTE format(
+                'CREATE POLICY kbve_windmill_user_all ON %s FOR ALL TO windmill_user USING (true) WITH CHECK (true)',
+                target.relident
+            );
+        END IF;
+
         EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relident);
         enabled_count := enabled_count + 1;
-        RAISE NOTICE 'windmill_rls_enable: enabled RLS on %', target.relident;
+        RAISE NOTICE 'windmill_rls_enable: enabled RLS on % (compat policy in place)', target.relident;
     END LOOP;
 
-    RAISE NOTICE 'windmill_rls_enable: % relation(s) switched to RLS.', enabled_count;
+    RAISE NOTICE 'windmill_rls_enable: % relation(s) switched to RLS, % skipped.',
+        enabled_count, coalesce(array_length(skipped, 1), 0);
+
+    IF array_length(skipped, 1) > 0 THEN
+        RAISE NOTICE 'windmill_rls_enable: review manually: %', array_to_string(skipped, ', ');
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -62,13 +109,38 @@ BEGIN
     WHERE n.nspname = 'windmill'
       AND c.relkind IN ('r', 'p')
       AND NOT c.relrowsecurity
-      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid);
+      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+      -- tables intentionally left alone by the sweep
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_policy p
+          WHERE p.polrelid = c.oid
+            AND 'windmill_user'::regrole = ANY (p.polroles)
+      );
 
     IF offenders IS NOT NULL THEN
         RAISE EXCEPTION 'windmill relations still have policies with RLS disabled: %', offenders;
     END IF;
 
-    RAISE NOTICE 'windmill_rls_enable: no policy-without-RLS relations remain.';
+    -- Every table we switched on must be reachable by windmill_user.
+    SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
+    INTO offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'windmill'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+      AND has_table_privilege('windmill_user', c.oid, 'SELECT')
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_policy p
+          WHERE p.polrelid = c.oid
+            AND 'windmill_user'::regrole = ANY (p.polroles)
+      );
+
+    IF offenders IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill_user has grants but no policy on RLS-enabled relation(s): %', offenders;
+    END IF;
+
+    RAISE NOTICE 'windmill_rls_enable: no policy-without-RLS relations remain; windmill_user reachable everywhere.';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -79,16 +151,21 @@ DECLARE
     target record;
 BEGIN
     FOR target IN
-        SELECT c.oid::regclass AS relident
+        SELECT c.oid AS reloid, c.oid::regclass AS relident
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill'
           AND c.relkind IN ('r', 'p')
           AND c.relrowsecurity
-          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+          AND EXISTS (
+              SELECT 1 FROM pg_policy p
+              WHERE p.polrelid = c.oid
+                AND p.polname = 'kbve_windmill_user_all'
+          )
         ORDER BY 1
     LOOP
         EXECUTE format('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', target.relident);
+        EXECUTE format('DROP POLICY kbve_windmill_user_all ON %s', target.relident);
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;

--- a/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
+++ b/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
@@ -10,86 +10,248 @@
 -- admin_policy on them but left ROW LEVEL SECURITY disabled, so
 -- the policies are inert.
 --
--- Naively flipping RLS on would BREAK Windmill. Verified against
--- the live cluster:
+-- Flipping RLS on naively BREAKS Windmill. Measured on the live
+-- cluster inside a rolled-back transaction:
 --
---   * each of the five carries exactly one policy, admin_policy,
---     FOR ALL TO windmill_admin USING (true) -- and windmill_admin
---     is BYPASSRLS, so that policy is a no-op either way;
---   * windmill_user holds full DML grants on all of them, is NOT
---     BYPASSRLS, and HAS NO POLICY of its own. pg_stat_statements
---     shows windmill_user actively selecting from v2_job_completed
---     and v2_job_queue (job lists / run detail).
+--                       windmill_user rows visible
+--   table               RLS off   naive RLS on   RLS on + compat
+--   v2_job_completed      257          0              257
+--   v2_job_queue            1          0                1
+--   v2_job_runtime          1          0                1
 --
--- So RLS-on with no windmill_user policy = deny-all for every
--- non-admin Windmill session. Workspace isolation for these
--- satellite tables is not their own job: Windmill's queries JOIN
--- v2_job, which already has RLS enabled plus the see_own /
--- see_member / see_folder_extra_perms_user policies.
+-- Why: each table carries exactly one policy, admin_policy FOR ALL
+-- TO windmill_admin USING (true), and windmill_admin is BYPASSRLS,
+-- so that policy is a no-op either way. windmill_user holds full
+-- DML grants, is NOT BYPASSRLS, and has no policy of its own --
+-- RLS-on therefore means deny-all for every non-admin session, and
+-- pg_stat_statements confirms windmill_user actively selects from
+-- v2_job_completed and v2_job_queue.
 --
--- Therefore, before enabling RLS on such a table, add a permissive
--- compat policy for windmill_user USING (true). That preserves the
--- CURRENT effective access exactly (RLS off == every granted role
--- sees every row) while making the existing policies live, so the
--- linter finding clears with no behaviour change.
+-- These satellite tables are not where isolation lives. Windmill's
+-- queries JOIN v2_job, which already has RLS on plus see_own /
+-- see_member / see_folder_extra_perms_user. The same dry run
+-- confirmed it: `v2_job JOIN v2_job_completed` as windmill_user
+-- with a bogus session identity returns 0 rows even with the
+-- compat policy in place.
 --
--- If a table has policies, RLS off, AND already has a windmill_user
--- policy, we do NOT touch it: enabling RLS there would newly filter
--- rows, which is a judgement call for a human, not this sweep.
+-- So: add a permissive compat policy for windmill_user USING (true)
+-- BEFORE enabling RLS. That preserves current effective access
+-- exactly (RLS off == every granted role sees every row) and clears
+-- the linter finding with no behaviour change.
+--
+-- Safety layers, in order of application:
+--   * lock_timeout, so a wedged ALTER TABLE can never block the
+--     live engine -- the migration fails fast instead;
+--   * preflight: bail out cleanly if the windmill roles are absent;
+--   * skip any table where a policy ALREADY applies to windmill_user
+--     (directly, via role membership, or via a PUBLIC-scoped policy),
+--     because enabling RLS there would newly filter rows;
+--   * skip partitions -- the parent governs;
+--   * per-table probe AFTER the flip: read the table as windmill_user
+--     and compare against the owner's count. Any regression aborts
+--     (strict mode) or reverts just that table (cron mode).
+--
 -- Windmill owns its table lifecycle, so nothing here names a table.
 -- ============================================================
 
-DO $$
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '60s';
+
+-- ===========================================
+-- AUDIT: which relations violate the invariant
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION windmill.rls_drift()
+RETURNS TABLE (relation text, policy_count int, auto_fixable boolean)
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog
+AS $$
+    SELECT c.oid::regclass::text,
+           (SELECT count(*)::int FROM pg_policy p WHERE p.polrelid = c.oid),
+           -- Auto-fixable only when NO existing policy already applies to
+           -- windmill_user. polroles = {0} means PUBLIC, which covers every
+           -- role; membership matters too, since a policy granted to a role
+           -- windmill_user belongs to also applies to it.
+           NOT EXISTS (
+               SELECT 1
+               FROM pg_policy p
+               WHERE p.polrelid = c.oid
+                 AND (
+                     0 = ANY (p.polroles)
+                     OR EXISTS (
+                         SELECT 1 FROM unnest(p.polroles) AS pr(roleoid)
+                         WHERE pg_has_role('windmill_user', pr.roleoid, 'MEMBER')
+                     )
+                 )
+           )
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'windmill'
+      AND c.relkind IN ('r', 'p')
+      AND NOT c.relispartition
+      AND NOT c.relrowsecurity
+      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+    ORDER BY 1;
+$$;
+
+ALTER FUNCTION windmill.rls_drift() OWNER TO postgres;
+REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION windmill.rls_drift() TO postgres;
+
+COMMENT ON FUNCTION windmill.rls_drift() IS
+    'Lists windmill tables carrying policies while RLS is disabled (Supabase linter policy_exists_rls_disabled). auto_fixable=false means a policy already applies to windmill_user, so enabling RLS would newly filter rows -- review by hand. Empty result = healthy.';
+
+-- ===========================================
+-- PROBE: can windmill_user still read the table?
+--
+-- Bounded (LIMIT 1000) so it stays cheap on hot tables. Returns
+-- true when windmill_user sees what the owner sees. SET ROLE plus
+-- the session GUCs Windmill's own policies read, pre-set so that
+-- evaluating them cannot error on an unset parameter. Role is reset
+-- on every exit path.
+--
+-- Deliberately SECURITY INVOKER: postgres cannot SET/RESET ROLE
+-- inside a SECURITY DEFINER function, and every caller (dbmate,
+-- pg_cron) already connects as postgres. EXECUTE stays postgres-only.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION windmill.rls_user_can_read(p_relation regclass)
+RETURNS boolean
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+SET lock_timeout = '2s'
+AS $$
+DECLARE
+    owner_rows int;
+    user_rows  int;
+BEGIN
+    EXECUTE format('SELECT count(*) FROM (SELECT 1 FROM %s LIMIT 1000) s', p_relation)
+       INTO owner_rows;
+
+    IF owner_rows = 0 THEN
+        RETURN true;
+    END IF;
+
+    BEGIN
+        SET LOCAL ROLE windmill_user;
+        PERFORM set_config('session.user', 'kbve_rls_probe', true);
+        PERFORM set_config('session.groups', '', true);
+        PERFORM set_config('session.folders_read', '', true);
+
+        EXECUTE format('SELECT count(*) FROM (SELECT 1 FROM %s LIMIT 1000) s', p_relation)
+           INTO user_rows;
+
+        RESET ROLE;
+    EXCEPTION WHEN OTHERS THEN
+        RESET ROLE;
+        RAISE NOTICE 'windmill.rls_user_can_read: probe of % errored (%), treating as unreadable',
+            p_relation, SQLERRM;
+        RETURN false;
+    END;
+
+    RETURN user_rows = owner_rows;
+END;
+$$;
+
+ALTER FUNCTION windmill.rls_user_can_read(regclass) OWNER TO postgres;
+REVOKE ALL ON FUNCTION windmill.rls_user_can_read(regclass) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION windmill.rls_user_can_read(regclass) TO postgres;
+
+COMMENT ON FUNCTION windmill.rls_user_can_read(regclass) IS
+    'True when windmill_user sees the same (bounded) row count as the table owner. Used to prove an RLS flip did not black out the engine. Vacuously true on empty tables.';
+
+-- ===========================================
+-- ENFORCE: compat policy, flip RLS, verify, revert on regression
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION windmill.enforce_policy_rls(p_strict boolean DEFAULT false)
+RETURNS int
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+SET lock_timeout = '2s'
+AS $$
 DECLARE
     target record;
-    enabled_count int := 0;
-    skipped text[] := '{}';
+    fixed int := 0;
 BEGIN
-    FOR target IN
-        SELECT c.oid AS reloid,
-               c.oid::regclass AS relident,
-               EXISTS (
-                   SELECT 1 FROM pg_policy p
-                   WHERE p.polrelid = c.oid
-                     AND 'windmill_user'::regrole = ANY (p.polroles)
-               ) AS has_user_policy
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'windmill'
-          AND c.relkind IN ('r', 'p')
-          AND NOT c.relrowsecurity
-          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
-        ORDER BY 1
-    LOOP
-        IF target.has_user_policy THEN
-            skipped := skipped || target.relident::text;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_user') THEN
+        RAISE NOTICE 'windmill.enforce_policy_rls: windmill_user role absent; nothing to do';
+        RETURN 0;
+    END IF;
+
+    FOR target IN SELECT relation, auto_fixable FROM windmill.rls_drift() LOOP
+        IF NOT target.auto_fixable THEN
             RAISE NOTICE
-                'windmill_rls_enable: skipping % (already has a windmill_user policy; enabling RLS would newly filter rows)',
-                target.relident;
+                'windmill.enforce_policy_rls: skipping % (a policy already applies to windmill_user; needs manual review)',
+                target.relation;
             CONTINUE;
         END IF;
 
-        IF NOT EXISTS (
-            SELECT 1 FROM pg_policy p
-            WHERE p.polrelid = target.reloid
-              AND p.polname = 'kbve_windmill_user_all'
-        ) THEN
-            EXECUTE format(
-                'CREATE POLICY kbve_windmill_user_all ON %s FOR ALL TO windmill_user USING (true) WITH CHECK (true)',
-                target.relident
-            );
-        END IF;
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_policy
+                WHERE polrelid = target.relation::regclass
+                  AND polname = 'kbve_windmill_user_all'
+            ) THEN
+                EXECUTE format(
+                    'CREATE POLICY kbve_windmill_user_all ON %s FOR ALL TO windmill_user USING (true) WITH CHECK (true)',
+                    target.relation
+                );
+            END IF;
 
-        EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relident);
-        enabled_count := enabled_count + 1;
-        RAISE NOTICE 'windmill_rls_enable: enabled RLS on % (compat policy in place)', target.relident;
+            EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relation);
+
+            IF NOT windmill.rls_user_can_read(target.relation::regclass) THEN
+                RAISE EXCEPTION
+                    'enabling RLS on % hid rows from windmill_user; refusing to leave the engine blacked out',
+                    target.relation;
+            END IF;
+
+            fixed := fixed + 1;
+            RAISE NOTICE 'windmill.enforce_policy_rls: enabled RLS on % (compat policy in place, read verified)',
+                target.relation;
+        EXCEPTION WHEN OTHERS THEN
+            IF p_strict THEN
+                RAISE;
+            END IF;
+            RAISE WARNING 'windmill.enforce_policy_rls: left % untouched: %', target.relation, SQLERRM;
+        END;
     END LOOP;
 
-    RAISE NOTICE 'windmill_rls_enable: % relation(s) switched to RLS, % skipped.',
-        enabled_count, coalesce(array_length(skipped, 1), 0);
+    RETURN fixed;
+END;
+$$;
 
-    IF array_length(skipped, 1) > 0 THEN
-        RAISE NOTICE 'windmill_rls_enable: review manually: %', array_to_string(skipped, ', ');
+ALTER FUNCTION windmill.enforce_policy_rls(boolean) OWNER TO postgres;
+REVOKE ALL ON FUNCTION windmill.enforce_policy_rls(boolean) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION windmill.enforce_policy_rls(boolean) TO postgres;
+
+COMMENT ON FUNCTION windmill.enforce_policy_rls(boolean) IS
+    'Adds a permissive windmill_user compat policy, enables RLS, and probes the result on every windmill table that has policies, RLS off, and no policy already applying to windmill_user. Returns the number of relations changed. p_strict=true re-raises (migration apply); false reverts the offending table and continues (cron). Idempotent.';
+
+-- ===========================================
+-- ONE-SHOT: clear the current offenders
+-- ===========================================
+
+DO $$
+DECLARE
+    fixed int;
+    skipped text;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'windmill') THEN
+        RAISE NOTICE 'windmill_rls_enable: windmill schema absent; nothing to do';
+        RETURN;
+    END IF;
+
+    SELECT windmill.enforce_policy_rls(true) INTO fixed;
+
+    SELECT string_agg(relation, ', ') INTO skipped
+    FROM windmill.rls_drift() WHERE NOT auto_fixable;
+
+    RAISE NOTICE 'windmill_rls_enable: % relation(s) switched to RLS.', fixed;
+    IF skipped IS NOT NULL THEN
+        RAISE NOTICE 'windmill_rls_enable: left for manual review: %', skipped;
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -102,56 +264,46 @@ DO $$
 DECLARE
     offenders text;
 BEGIN
-    SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
-    INTO offenders
-    FROM pg_class c
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'windmill'
-      AND c.relkind IN ('r', 'p')
-      AND NOT c.relrowsecurity
-      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
-      -- tables intentionally left alone by the sweep
-      AND NOT EXISTS (
-          SELECT 1 FROM pg_policy p
-          WHERE p.polrelid = c.oid
-            AND 'windmill_user'::regrole = ANY (p.polroles)
-      );
-
+    SELECT string_agg(relation, ', ') INTO offenders
+    FROM windmill.rls_drift() WHERE auto_fixable;
     IF offenders IS NOT NULL THEN
         RAISE EXCEPTION 'windmill relations still have policies with RLS disabled: %', offenders;
     END IF;
 
-    -- Every table we switched on must be reachable by windmill_user.
+    -- No RLS-enabled windmill table may be a black hole for windmill_user.
     SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
     INTO offenders
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = 'windmill'
       AND c.relkind IN ('r', 'p')
+      AND NOT c.relispartition
       AND c.relrowsecurity
       AND has_table_privilege('windmill_user', c.oid, 'SELECT')
-      AND NOT EXISTS (
+      AND EXISTS (
           SELECT 1 FROM pg_policy p
-          WHERE p.polrelid = c.oid
-            AND 'windmill_user'::regrole = ANY (p.polroles)
-      );
+          WHERE p.polrelid = c.oid AND p.polname = 'kbve_windmill_user_all'
+      )
+      AND NOT windmill.rls_user_can_read(c.oid::regclass);
 
     IF offenders IS NOT NULL THEN
-        RAISE EXCEPTION 'windmill_user has grants but no policy on RLS-enabled relation(s): %', offenders;
+        RAISE EXCEPTION 'windmill_user cannot read RLS-enabled relation(s): %', offenders;
     END IF;
 
-    RAISE NOTICE 'windmill_rls_enable: no policy-without-RLS relations remain; windmill_user reachable everywhere.';
+    RAISE NOTICE 'windmill_rls_enable: no policy-without-RLS relations remain; windmill_user reads verified.';
 END;
 $$ LANGUAGE plpgsql;
 
 -- migrate:down
+
+SET LOCAL lock_timeout = '2s';
 
 DO $$
 DECLARE
     target record;
 BEGIN
     FOR target IN
-        SELECT c.oid AS reloid, c.oid::regclass AS relident
+        SELECT c.oid::regclass AS relident
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'windmill'
@@ -159,8 +311,7 @@ BEGIN
           AND c.relrowsecurity
           AND EXISTS (
               SELECT 1 FROM pg_policy p
-              WHERE p.polrelid = c.oid
-                AND p.polname = 'kbve_windmill_user_all'
+              WHERE p.polrelid = c.oid AND p.polname = 'kbve_windmill_user_all'
           )
         ORDER BY 1
     LOOP
@@ -169,3 +320,7 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;
+
+DROP FUNCTION IF EXISTS windmill.enforce_policy_rls(boolean);
+DROP FUNCTION IF EXISTS windmill.rls_user_can_read(regclass);
+DROP FUNCTION IF EXISTS windmill.rls_drift();

--- a/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
+++ b/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
@@ -1,0 +1,94 @@
+-- migrate:up
+
+-- ============================================================
+-- WINDMILL: ENABLE RLS ON TABLES THAT ALREADY HAVE POLICIES
+--
+-- The Supabase linter (policy_exists_rls_disabled, CRITICAL)
+-- flags windmill.account, windmill.v2_job_completed,
+-- windmill.v2_job_queue, windmill.v2_job_runtime and
+-- windmill.v2_job_status: Windmill's sqlx migrations created
+-- admin_policy / per-workspace policies on them but left
+-- ROW LEVEL SECURITY disabled, so the policies are inert.
+--
+-- Windmill owns its table lifecycle (see 20260707000000), so we
+-- do not name tables here. We sweep every relation in the
+-- windmill schema that has at least one policy and no RLS, and
+-- turn RLS on. Idempotent: relations already using RLS, and a
+-- fresh database where Windmill has not run yet, are no-ops.
+--
+-- Safety: the windmill tables are owned by postgres (superuser)
+-- and the Windmill server connects as postgres, so RLS is
+-- bypassed for the engine itself. Workers SET ROLE to
+-- windmill_user / windmill_admin (BYPASSRLS), which is exactly
+-- the enforcement path the policies were written for.
+-- ============================================================
+
+DO $$
+DECLARE
+    target record;
+    enabled_count int := 0;
+BEGIN
+    FOR target IN
+        SELECT c.oid::regclass AS relident
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill'
+          AND c.relkind IN ('r', 'p')
+          AND NOT c.relrowsecurity
+          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+        ORDER BY 1
+    LOOP
+        EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relident);
+        enabled_count := enabled_count + 1;
+        RAISE NOTICE 'windmill_rls_enable: enabled RLS on %', target.relident;
+    END LOOP;
+
+    RAISE NOTICE 'windmill_rls_enable: % relation(s) switched to RLS.', enabled_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+DECLARE
+    offenders text;
+BEGIN
+    SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
+    INTO offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'windmill'
+      AND c.relkind IN ('r', 'p')
+      AND NOT c.relrowsecurity
+      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid);
+
+    IF offenders IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill relations still have policies with RLS disabled: %', offenders;
+    END IF;
+
+    RAISE NOTICE 'windmill_rls_enable: no policy-without-RLS relations remain.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+DO $$
+DECLARE
+    target record;
+BEGIN
+    FOR target IN
+        SELECT c.oid::regclass AS relident
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill'
+          AND c.relkind IN ('r', 'p')
+          AND c.relrowsecurity
+          AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+        ORDER BY 1
+    LOOP
+        EXECUTE format('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', target.relident);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
+++ b/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
@@ -51,9 +51,14 @@
 --     and compare against the owner's count. Any regression aborts
 --     (strict mode) or reverts just that table (cron mode);
 --   * reconcile on every run: permissive policies are OR-ed, so if a
---     Windmill upgrade ever ships a real windmill_user policy on a
+--     Windmill upgrade ever ships real windmill_user policies on a
 --     table we hold a compat policy on, ours is dropped rather than
---     left to widen access past theirs.
+--     left to widen access past theirs -- but only once upstream
+--     covers ALL of SELECT/INSERT/UPDATE/DELETE. Policies apply per
+--     command and an uncovered command is deny-all, so dropping the
+--     FOR ALL compat policy against a partial (e.g. SELECT-only)
+--     upstream policy would silently break the engine's writes.
+--     Partial coverage keeps the compat policy and raises a WARNING.
 --
 -- Upstream context: backend/migrations/20260125000000_v2_finalize
 -- explicitly runs `ALTER TABLE v2_job_queue/v2_job_completed DISABLE
@@ -192,9 +197,54 @@ BEGIN
     END IF;
 
     -- Reconcile first. Permissive policies are OR-ed, so if a Windmill upgrade
-    -- ever ships a real windmill_user policy on a table we hold a compat policy
-    -- on, ours would nullify theirs and widen access across workspaces. Theirs
-    -- wins: drop ours the moment one appears.
+    -- ever ships its own windmill_user policies on a table we hold a compat
+    -- policy on, ours would nullify theirs and widen access across workspaces.
+    -- Theirs wins -- but ONLY once they cover every command. Policies apply
+    -- per command (SELECT/INSERT/UPDATE/DELETE), and a command with no
+    -- applicable policy is deny-all: dropping our FOR ALL compat policy while
+    -- upstream ships only e.g. FOR SELECT would silently kill the engine's
+    -- writes. So require, for each of r/a/w/d, a non-compat PERMISSIVE policy
+    -- applying to windmill_user before dropping ours; partial coverage keeps
+    -- the compat policy and is reported for manual review.
+    FOR target IN
+        SELECT c.oid::regclass::text AS relation
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill'
+          AND c.relkind IN ('r', 'p')
+          AND EXISTS (
+              SELECT 1 FROM pg_policy p
+              WHERE p.polrelid = c.oid AND p.polname = 'kbve_windmill_user_all'
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM unnest(ARRAY['r', 'a', 'w', 'd']) AS cmd(cmd)
+              WHERE NOT EXISTS (
+                  SELECT 1 FROM pg_policy p
+                  WHERE p.polrelid = c.oid
+                    AND p.polname <> 'kbve_windmill_user_all'
+                    AND p.polpermissive
+                    AND p.polcmd::text IN ('*', cmd.cmd)
+                    AND (
+                        0 = ANY (p.polroles)
+                        OR EXISTS (
+                            SELECT 1 FROM unnest(p.polroles) AS pr(roleoid)
+                            WHERE pg_has_role('windmill_user', pr.roleoid, 'MEMBER')
+                        )
+                    )
+              )
+          )
+        ORDER BY 1
+    LOOP
+        EXECUTE format('DROP POLICY kbve_windmill_user_all ON %s', target.relation);
+        RAISE NOTICE
+            'windmill.enforce_policy_rls: dropped compat policy on % (Windmill now ships full-command windmill_user coverage)',
+            target.relation;
+    END LOOP;
+
+    -- Partial upstream coverage: our permissive compat policy still OR-widens
+    -- the commands upstream DOES cover, but dropping it would deny the rest.
+    -- Availability wins; surface the overlap for manual review.
     FOR target IN
         SELECT c.oid::regclass::text AS relation
         FROM pg_class c
@@ -219,9 +269,8 @@ BEGIN
           )
         ORDER BY 1
     LOOP
-        EXECUTE format('DROP POLICY kbve_windmill_user_all ON %s', target.relation);
-        RAISE NOTICE
-            'windmill.enforce_policy_rls: dropped compat policy on % (Windmill now ships its own windmill_user policy)',
+        RAISE WARNING
+            'windmill.enforce_policy_rls: % has upstream windmill_user policies covering only some commands; compat policy kept to protect the rest -- review by hand',
             target.relation;
     END LOOP;
 

--- a/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
+++ b/packages/data/sql/dbmate/migrations/20260730020000_windmill_rls_enable_policy_tables.sql
@@ -49,7 +49,18 @@
 --   * skip partitions -- the parent governs;
 --   * per-table probe AFTER the flip: read the table as windmill_user
 --     and compare against the owner's count. Any regression aborts
---     (strict mode) or reverts just that table (cron mode).
+--     (strict mode) or reverts just that table (cron mode);
+--   * reconcile on every run: permissive policies are OR-ed, so if a
+--     Windmill upgrade ever ships a real windmill_user policy on a
+--     table we hold a compat policy on, ours is dropped rather than
+--     left to widen access past theirs.
+--
+-- Upstream context: backend/migrations/20260125000000_v2_finalize
+-- explicitly runs `ALTER TABLE v2_job_queue/v2_job_completed DISABLE
+-- ROW LEVEL SECURITY`. RLS-off on the satellites is deliberate, and
+-- the leftover admin_policy is what the linter trips over. Enabling
+-- RLS with a permissive compat policy keeps their access model and
+-- clears the finding without deleting anything Windmill created.
 --
 -- Windmill owns its table lifecycle, so nothing here names a table.
 -- ============================================================
@@ -179,6 +190,40 @@ BEGIN
         RAISE NOTICE 'windmill.enforce_policy_rls: windmill_user role absent; nothing to do';
         RETURN 0;
     END IF;
+
+    -- Reconcile first. Permissive policies are OR-ed, so if a Windmill upgrade
+    -- ever ships a real windmill_user policy on a table we hold a compat policy
+    -- on, ours would nullify theirs and widen access across workspaces. Theirs
+    -- wins: drop ours the moment one appears.
+    FOR target IN
+        SELECT c.oid::regclass::text AS relation
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'windmill'
+          AND c.relkind IN ('r', 'p')
+          AND EXISTS (
+              SELECT 1 FROM pg_policy p
+              WHERE p.polrelid = c.oid AND p.polname = 'kbve_windmill_user_all'
+          )
+          AND EXISTS (
+              SELECT 1 FROM pg_policy p
+              WHERE p.polrelid = c.oid
+                AND p.polname <> 'kbve_windmill_user_all'
+                AND (
+                    0 = ANY (p.polroles)
+                    OR EXISTS (
+                        SELECT 1 FROM unnest(p.polroles) AS pr(roleoid)
+                        WHERE pg_has_role('windmill_user', pr.roleoid, 'MEMBER')
+                    )
+                )
+          )
+        ORDER BY 1
+    LOOP
+        EXECUTE format('DROP POLICY kbve_windmill_user_all ON %s', target.relation);
+        RAISE NOTICE
+            'windmill.enforce_policy_rls: dropped compat policy on % (Windmill now ships its own windmill_user policy)',
+            target.relation;
+    END LOOP;
 
     FOR target IN SELECT relation, auto_fixable FROM windmill.rls_drift() LOOP
         IF NOT target.auto_fixable THEN

--- a/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
+++ b/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
@@ -1,0 +1,183 @@
+-- migrate:up
+
+-- ============================================================
+-- WINDMILL RLS HARDENING
+--
+-- 20260730020000 fixed the current policy_exists_rls_disabled
+-- offenders (windmill.account, windmill.v2_job_*) with a one-shot
+-- sweep. That sweep only holds until Windmill's next sqlx
+-- migration adds another policy-bearing table with RLS off, so
+-- this migration makes the invariant durable:
+--
+--   1. windmill.rls_drift()          read-only audit of offenders
+--   2. windmill.enforce_policy_rls() re-runnable sweep, returns count
+--   3. pg_cron job (hourly)          auto-heals drift after Windmill
+--                                    migrations run
+--   4. table/sequence/function-level privilege revokes for
+--      PUBLIC / anon / authenticated, plus default privileges, so
+--      the API roles cannot reach windmill internals even if a
+--      future object is created with permissive grants
+--
+-- Windmill owns its table lifecycle, so nothing here names a table.
+-- If Windmill ever ships a table that must run WITHOUT RLS while
+-- carrying policies, the cron job would fight it: unschedule
+-- 'windmill-enforce-policy-rls' rather than editing this migration.
+-- ============================================================
+
+-- ===========================================
+-- AUDIT: which relations violate the invariant
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION windmill.rls_drift()
+RETURNS TABLE (relation text, policy_count int)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+    SELECT c.oid::regclass::text,
+           (SELECT count(*)::int FROM pg_policy p WHERE p.polrelid = c.oid)
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'windmill'
+      AND c.relkind IN ('r', 'p')
+      AND NOT c.relrowsecurity
+      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+    ORDER BY 1;
+$$;
+
+ALTER FUNCTION windmill.rls_drift() OWNER TO postgres;
+REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION windmill.rls_drift() TO postgres;
+
+COMMENT ON FUNCTION windmill.rls_drift() IS
+    'Lists windmill tables that carry policies while RLS is disabled (Supabase linter policy_exists_rls_disabled). Empty result = healthy.';
+
+-- ===========================================
+-- ENFORCE: re-runnable sweep
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION windmill.enforce_policy_rls()
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    target record;
+    fixed int := 0;
+BEGIN
+    FOR target IN SELECT relation FROM windmill.rls_drift() LOOP
+        EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relation);
+        fixed := fixed + 1;
+        RAISE NOTICE 'windmill.enforce_policy_rls: enabled RLS on %', target.relation;
+    END LOOP;
+
+    RETURN fixed;
+END;
+$$;
+
+ALTER FUNCTION windmill.enforce_policy_rls() OWNER TO postgres;
+REVOKE ALL ON FUNCTION windmill.enforce_policy_rls() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION windmill.enforce_policy_rls() TO postgres;
+
+COMMENT ON FUNCTION windmill.enforce_policy_rls() IS
+    'Enables RLS on every windmill table that has policies but RLS off. Returns the number of relations changed. Idempotent; safe to call from cron.';
+
+-- ===========================================
+-- SCHEDULE: heal drift introduced by Windmill migrations
+-- ===========================================
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job
+         WHERE jobname = 'windmill-enforce-policy-rls';
+        PERFORM cron.schedule(
+            'windmill-enforce-policy-rls',
+            '17 * * * *',
+            $cron$SELECT windmill.enforce_policy_rls();$cron$
+        );
+    ELSE
+        RAISE NOTICE 'pg_cron not installed; skipping windmill-enforce-policy-rls schedule registration';
+    END IF;
+END;
+$$;
+
+-- ===========================================
+-- PRIVILEGES: keep API roles out of windmill internals
+-- ===========================================
+
+REVOKE ALL ON ALL TABLES IN SCHEMA windmill FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA windmill FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA windmill FROM PUBLIC, anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    REVOKE ALL ON TABLES FROM PUBLIC, anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    REVOKE ALL ON SEQUENCES FROM PUBLIC, anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    REVOKE ALL ON FUNCTIONS FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+DECLARE
+    drifted text;
+    leaked text;
+BEGIN
+    PERFORM windmill.enforce_policy_rls();
+
+    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift();
+    IF drifted IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill relations still have policies with RLS disabled: %', drifted;
+    END IF;
+
+    IF has_schema_privilege('anon', 'windmill', 'USAGE')
+       OR has_schema_privilege('authenticated', 'windmill', 'USAGE') THEN
+        RAISE EXCEPTION 'anon/authenticated must NOT have USAGE on windmill schema';
+    END IF;
+
+    SELECT string_agg(DISTINCT format('%I.%I', table_schema, table_name), ', ')
+    INTO leaked
+    FROM information_schema.role_table_grants
+    WHERE table_schema = 'windmill'
+      AND grantee IN ('PUBLIC', 'anon', 'authenticated');
+
+    IF leaked IS NOT NULL THEN
+        RAISE EXCEPTION 'anon/authenticated/PUBLIC still hold table grants in windmill: %', leaked;
+    END IF;
+
+    -- Nested, not `AND`-ed: plpgsql plans the whole boolean expression, so a
+    -- single IF referencing cron.job errors on installs without pg_cron.
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM cron.job WHERE jobname = 'windmill-enforce-policy-rls'
+        ) THEN
+            RAISE EXCEPTION 'windmill-enforce-policy-rls cron job missing';
+        END IF;
+    END IF;
+
+    RAISE NOTICE 'windmill_rls_hardening: drift clean, API roles walled off, sweep scheduled.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job
+         WHERE jobname = 'windmill-enforce-policy-rls';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS windmill.enforce_policy_rls();
+DROP FUNCTION IF EXISTS windmill.rls_drift();

--- a/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
+++ b/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
@@ -3,25 +3,39 @@
 -- ============================================================
 -- WINDMILL RLS HARDENING
 --
--- 20260730020000 fixed the current policy_exists_rls_disabled
--- offenders (windmill.account, windmill.v2_job_*) with a one-shot
--- sweep. That sweep only holds until Windmill's next sqlx
--- migration adds another policy-bearing table with RLS off, so
--- this migration makes the invariant durable:
+-- 20260730020000 cleared the current policy_exists_rls_disabled
+-- offenders with a one-shot sweep. That only holds until Windmill's
+-- next sqlx migration ships another policy-bearing table with RLS
+-- off, so make the invariant durable:
 --
---   1. windmill.rls_drift()          read-only audit of offenders
---   2. windmill.enforce_policy_rls() re-runnable sweep, returns count
---   3. pg_cron job (hourly)          auto-heals drift after Windmill
+--   1. windmill.rls_drift()          audit of offenders, flagging
+--                                    which are safe to auto-fix
+--   2. windmill.enforce_policy_rls() re-runnable sweep of the safe
+--                                    subset, returns count changed
+--   3. pg_cron job (hourly)          heals drift after Windmill
 --                                    migrations run
---   4. table/sequence/function-level privilege revokes for
---      PUBLIC / anon / authenticated, plus default privileges, so
---      the API roles cannot reach windmill internals even if a
---      future object is created with permissive grants
+--   4. EXECUTE privileges pinned to windmill_user / windmill_admin
+--      so PUBLIC / anon / authenticated can be revoked without
+--      breaking the engine
+--
+-- "Safe to auto-fix" mirrors 20260730020000: a table with policies
+-- and RLS off but NO windmill_user policy gets a permissive compat
+-- policy (windmill_user currently sees every row because RLS is
+-- off) and then RLS on. A table that already has a windmill_user
+-- policy is left for a human — flipping RLS there would newly
+-- filter rows.
+--
+-- Verified against the live cluster before writing the privilege
+-- section: all 19 windmill functions have proacl IS NULL, i.e. they
+-- rely on the implicit PUBLIC EXECUTE default, and windmill_user
+-- calls set_session_context on every authed request. Revoking
+-- PUBLIC without granting windmill_user first would break Windmill,
+-- so the GRANTs come first and the schema gains a FUNCTIONS default
+-- privilege (init only set TABLES and SEQUENCES).
 --
 -- Windmill owns its table lifecycle, so nothing here names a table.
--- If Windmill ever ships a table that must run WITHOUT RLS while
--- carrying policies, the cron job would fight it: unschedule
--- 'windmill-enforce-policy-rls' rather than editing this migration.
+-- To stop the auto-heal, unschedule 'windmill-enforce-policy-rls'
+-- rather than editing this migration.
 -- ============================================================
 
 -- ===========================================
@@ -29,14 +43,19 @@
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION windmill.rls_drift()
-RETURNS TABLE (relation text, policy_count int)
+RETURNS TABLE (relation text, policy_count int, auto_fixable boolean)
 LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = pg_catalog
 AS $$
     SELECT c.oid::regclass::text,
-           (SELECT count(*)::int FROM pg_policy p WHERE p.polrelid = c.oid)
+           (SELECT count(*)::int FROM pg_policy p WHERE p.polrelid = c.oid),
+           NOT EXISTS (
+               SELECT 1 FROM pg_policy p
+               WHERE p.polrelid = c.oid
+                 AND 'windmill_user'::regrole = ANY (p.polroles)
+           )
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = 'windmill'
@@ -51,10 +70,10 @@ REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION windmill.rls_drift() TO postgres;
 
 COMMENT ON FUNCTION windmill.rls_drift() IS
-    'Lists windmill tables that carry policies while RLS is disabled (Supabase linter policy_exists_rls_disabled). Empty result = healthy.';
+    'Lists windmill tables carrying policies while RLS is disabled (Supabase linter policy_exists_rls_disabled). auto_fixable=false means a windmill_user policy already exists, so enabling RLS would newly filter rows — review by hand. Empty result = healthy.';
 
 -- ===========================================
--- ENFORCE: re-runnable sweep
+-- ENFORCE: re-runnable sweep of the safe subset
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION windmill.enforce_policy_rls()
@@ -67,10 +86,21 @@ DECLARE
     target record;
     fixed int := 0;
 BEGIN
-    FOR target IN SELECT relation FROM windmill.rls_drift() LOOP
+    FOR target IN SELECT relation, auto_fixable FROM windmill.rls_drift() LOOP
+        IF NOT target.auto_fixable THEN
+            RAISE NOTICE
+                'windmill.enforce_policy_rls: skipping % (has a windmill_user policy; needs manual review)',
+                target.relation;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'CREATE POLICY kbve_windmill_user_all ON %s FOR ALL TO windmill_user USING (true) WITH CHECK (true)',
+            target.relation
+        );
         EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relation);
         fixed := fixed + 1;
-        RAISE NOTICE 'windmill.enforce_policy_rls: enabled RLS on %', target.relation;
+        RAISE NOTICE 'windmill.enforce_policy_rls: enabled RLS on % (compat policy added)', target.relation;
     END LOOP;
 
     RETURN fixed;
@@ -82,7 +112,7 @@ REVOKE ALL ON FUNCTION windmill.enforce_policy_rls() FROM PUBLIC, anon, authenti
 GRANT EXECUTE ON FUNCTION windmill.enforce_policy_rls() TO postgres;
 
 COMMENT ON FUNCTION windmill.enforce_policy_rls() IS
-    'Enables RLS on every windmill table that has policies but RLS off. Returns the number of relations changed. Idempotent; safe to call from cron.';
+    'Adds a permissive windmill_user compat policy and enables RLS on every windmill table that has policies, RLS off, and no windmill_user policy. Returns the number of relations changed; leaves auto_fixable=false relations alone. Idempotent; safe to call from cron.';
 
 -- ===========================================
 -- SCHEDULE: heal drift introduced by Windmill migrations
@@ -106,8 +136,17 @@ END;
 $$;
 
 -- ===========================================
--- PRIVILEGES: keep API roles out of windmill internals
+-- PRIVILEGES: pin windmill's own access, then wall off the rest
+--
+-- Order matters. Windmill's functions currently carry no explicit
+-- ACL, so windmill_user reaches set_session_context() etc. only via
+-- the implicit PUBLIC EXECUTE default. Grant first, revoke second.
 -- ===========================================
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA windmill TO windmill_user, windmill_admin;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    GRANT EXECUTE ON FUNCTIONS TO windmill_user;
 
 REVOKE ALL ON ALL TABLES IN SCHEMA windmill FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA windmill FROM PUBLIC, anon, authenticated;
@@ -130,12 +169,43 @@ DO $$
 DECLARE
     drifted text;
     leaked text;
+    unreachable text;
 BEGIN
     PERFORM windmill.enforce_policy_rls();
 
-    SELECT string_agg(relation, ', ') INTO drifted FROM windmill.rls_drift();
+    SELECT string_agg(relation, ', ') INTO drifted
+    FROM windmill.rls_drift() WHERE auto_fixable;
     IF drifted IS NOT NULL THEN
         RAISE EXCEPTION 'windmill relations still have policies with RLS disabled: %', drifted;
+    END IF;
+
+    -- No RLS-enabled windmill table may be a black hole for windmill_user.
+    SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
+    INTO unreachable
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'windmill'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+      AND has_table_privilege('windmill_user', c.oid, 'SELECT')
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_policy p
+          WHERE p.polrelid = c.oid
+            AND 'windmill_user'::regrole = ANY (p.polroles)
+      );
+    IF unreachable IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill_user has grants but no policy on RLS-enabled relation(s): %', unreachable;
+    END IF;
+
+    -- Windmill's engine roles must keep EXECUTE after the PUBLIC revoke.
+    SELECT string_agg(format('%I.%I', n.nspname, p.proname), ', ')
+    INTO leaked
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'windmill'
+      AND NOT has_function_privilege('windmill_user', p.oid, 'EXECUTE');
+    IF leaked IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill_user lost EXECUTE on windmill function(s): %', leaked;
     END IF;
 
     IF has_schema_privilege('anon', 'windmill', 'USAGE')
@@ -148,7 +218,6 @@ BEGIN
     FROM information_schema.role_table_grants
     WHERE table_schema = 'windmill'
       AND grantee IN ('PUBLIC', 'anon', 'authenticated');
-
     IF leaked IS NOT NULL THEN
         RAISE EXCEPTION 'anon/authenticated/PUBLIC still hold table grants in windmill: %', leaked;
     END IF;
@@ -163,7 +232,7 @@ BEGIN
         END IF;
     END IF;
 
-    RAISE NOTICE 'windmill_rls_hardening: drift clean, API roles walled off, sweep scheduled.';
+    RAISE NOTICE 'windmill_rls_hardening: drift clean, engine roles intact, API roles walled off, sweep scheduled.';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -181,3 +250,13 @@ $$;
 
 DROP FUNCTION IF EXISTS windmill.enforce_policy_rls();
 DROP FUNCTION IF EXISTS windmill.rls_drift();
+
+-- Restore the implicit PUBLIC EXECUTE default that Windmill's functions
+-- relied on before this migration. The windmill_user grants stay: dropping
+-- them here would leave functions created after the rollback reachable by
+-- nobody. TABLES/SEQUENCES need no restore — PUBLIC holds nothing on those
+-- by default, so those revokes were already no-ops.
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA windmill TO PUBLIC;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
+    GRANT EXECUTE ON FUNCTIONS TO PUBLIC;

--- a/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
+++ b/packages/data/sql/dbmate/migrations/20260730030000_windmill_rls_hardening.sql
@@ -4,115 +4,40 @@
 -- WINDMILL RLS HARDENING
 --
 -- 20260730020000 cleared the current policy_exists_rls_disabled
--- offenders with a one-shot sweep. That only holds until Windmill's
--- next sqlx migration ships another policy-bearing table with RLS
--- off, so make the invariant durable:
+-- offenders and left windmill.rls_drift() /
+-- windmill.enforce_policy_rls() / windmill.rls_user_can_read()
+-- behind. That one-shot only holds until Windmill's next sqlx
+-- migration ships another policy-bearing table with RLS off, so
+-- this migration makes the invariant durable:
 --
---   1. windmill.rls_drift()          audit of offenders, flagging
---                                    which are safe to auto-fix
---   2. windmill.enforce_policy_rls() re-runnable sweep of the safe
---                                    subset, returns count changed
---   3. pg_cron job (hourly)          heals drift after Windmill
---                                    migrations run
---   4. EXECUTE privileges pinned to windmill_user / windmill_admin
+--   1. pg_cron job (hourly) calling enforce_policy_rls() in
+--      NON-strict mode -- it heals the provably-safe subset, and a
+--      table that would black out windmill_user is reverted and
+--      logged as a WARNING rather than left broken;
+--   2. EXECUTE privileges pinned to windmill_user / windmill_admin
 --      so PUBLIC / anon / authenticated can be revoked without
---      breaking the engine
---
--- "Safe to auto-fix" mirrors 20260730020000: a table with policies
--- and RLS off but NO windmill_user policy gets a permissive compat
--- policy (windmill_user currently sees every row because RLS is
--- off) and then RLS on. A table that already has a windmill_user
--- policy is left for a human — flipping RLS there would newly
--- filter rows.
+--      taking the engine down with them.
 --
 -- Verified against the live cluster before writing the privilege
 -- section: all 19 windmill functions have proacl IS NULL, i.e. they
 -- rely on the implicit PUBLIC EXECUTE default, and windmill_user
--- calls set_session_context on every authed request. Revoking
+-- calls set_session_context() on every authed request. Revoking
 -- PUBLIC without granting windmill_user first would break Windmill,
 -- so the GRANTs come first and the schema gains a FUNCTIONS default
--- privilege (init only set TABLES and SEQUENCES).
+-- privilege (init set only TABLES and SEQUENCES). migrate:down
+-- restores the PUBLIC default.
 --
--- Windmill owns its table lifecycle, so nothing here names a table.
+-- pg_cron lives in the `supabase` database on this cluster
+-- (cron.database_name=supabase) alongside the windmill schema, so
+-- the job registers and runs there -- same as
+-- wallet-sweep-expired-coupons and marketplace-expire-listings.
+--
 -- To stop the auto-heal, unschedule 'windmill-enforce-policy-rls'
 -- rather than editing this migration.
 -- ============================================================
 
--- ===========================================
--- AUDIT: which relations violate the invariant
--- ===========================================
-
-CREATE OR REPLACE FUNCTION windmill.rls_drift()
-RETURNS TABLE (relation text, policy_count int, auto_fixable boolean)
-LANGUAGE sql
-STABLE
-SECURITY DEFINER
-SET search_path = pg_catalog
-AS $$
-    SELECT c.oid::regclass::text,
-           (SELECT count(*)::int FROM pg_policy p WHERE p.polrelid = c.oid),
-           NOT EXISTS (
-               SELECT 1 FROM pg_policy p
-               WHERE p.polrelid = c.oid
-                 AND 'windmill_user'::regrole = ANY (p.polroles)
-           )
-    FROM pg_class c
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'windmill'
-      AND c.relkind IN ('r', 'p')
-      AND NOT c.relrowsecurity
-      AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
-    ORDER BY 1;
-$$;
-
-ALTER FUNCTION windmill.rls_drift() OWNER TO postgres;
-REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION windmill.rls_drift() TO postgres;
-
-COMMENT ON FUNCTION windmill.rls_drift() IS
-    'Lists windmill tables carrying policies while RLS is disabled (Supabase linter policy_exists_rls_disabled). auto_fixable=false means a windmill_user policy already exists, so enabling RLS would newly filter rows — review by hand. Empty result = healthy.';
-
--- ===========================================
--- ENFORCE: re-runnable sweep of the safe subset
--- ===========================================
-
-CREATE OR REPLACE FUNCTION windmill.enforce_policy_rls()
-RETURNS int
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = pg_catalog
-AS $$
-DECLARE
-    target record;
-    fixed int := 0;
-BEGIN
-    FOR target IN SELECT relation, auto_fixable FROM windmill.rls_drift() LOOP
-        IF NOT target.auto_fixable THEN
-            RAISE NOTICE
-                'windmill.enforce_policy_rls: skipping % (has a windmill_user policy; needs manual review)',
-                target.relation;
-            CONTINUE;
-        END IF;
-
-        EXECUTE format(
-            'CREATE POLICY kbve_windmill_user_all ON %s FOR ALL TO windmill_user USING (true) WITH CHECK (true)',
-            target.relation
-        );
-        EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.relation);
-        fixed := fixed + 1;
-        RAISE NOTICE 'windmill.enforce_policy_rls: enabled RLS on % (compat policy added)', target.relation;
-    END LOOP;
-
-    RETURN fixed;
-END;
-$$;
-
-ALTER FUNCTION windmill.enforce_policy_rls() OWNER TO postgres;
-REVOKE ALL ON FUNCTION windmill.enforce_policy_rls() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION windmill.enforce_policy_rls() TO postgres;
-
-COMMENT ON FUNCTION windmill.enforce_policy_rls() IS
-    'Adds a permissive windmill_user compat policy and enables RLS on every windmill table that has policies, RLS off, and no windmill_user policy. Returns the number of relations changed; leaves auto_fixable=false relations alone. Idempotent; safe to call from cron.';
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '60s';
 
 -- ===========================================
 -- SCHEDULE: heal drift introduced by Windmill migrations
@@ -127,7 +52,7 @@ BEGIN
         PERFORM cron.schedule(
             'windmill-enforce-policy-rls',
             '17 * * * *',
-            $cron$SELECT windmill.enforce_policy_rls();$cron$
+            $cron$SELECT windmill.enforce_policy_rls(false);$cron$
         );
     ELSE
         RAISE NOTICE 'pg_cron not installed; skipping windmill-enforce-policy-rls schedule registration';
@@ -138,9 +63,9 @@ $$;
 -- ===========================================
 -- PRIVILEGES: pin windmill's own access, then wall off the rest
 --
--- Order matters. Windmill's functions currently carry no explicit
--- ACL, so windmill_user reaches set_session_context() etc. only via
--- the implicit PUBLIC EXECUTE default. Grant first, revoke second.
+-- Order matters. Windmill's functions carry no explicit ACL, so
+-- windmill_user reaches set_session_context() etc. only via the
+-- implicit PUBLIC EXECUTE default. Grant first, revoke second.
 -- ===========================================
 
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA windmill TO windmill_user, windmill_admin;
@@ -161,6 +86,15 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
 ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
     REVOKE ALL ON FUNCTIONS FROM PUBLIC, anon, authenticated;
 
+-- The sweep's own helpers must stay off-limits to the API roles even
+-- after the blanket GRANT above handed them to the engine roles.
+REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC, anon, authenticated, windmill_user, windmill_admin;
+REVOKE ALL ON FUNCTION windmill.rls_user_can_read(regclass) FROM PUBLIC, anon, authenticated, windmill_user, windmill_admin;
+REVOKE ALL ON FUNCTION windmill.enforce_policy_rls(boolean) FROM PUBLIC, anon, authenticated, windmill_user, windmill_admin;
+GRANT EXECUTE ON FUNCTION windmill.rls_drift() TO postgres;
+GRANT EXECUTE ON FUNCTION windmill.rls_user_can_read(regclass) TO postgres;
+GRANT EXECUTE ON FUNCTION windmill.enforce_policy_rls(boolean) TO postgres;
+
 -- ===========================================
 -- VERIFICATION
 -- ===========================================
@@ -169,9 +103,9 @@ DO $$
 DECLARE
     drifted text;
     leaked text;
-    unreachable text;
+    unreadable text;
 BEGIN
-    PERFORM windmill.enforce_policy_rls();
+    PERFORM windmill.enforce_policy_rls(true);
 
     SELECT string_agg(relation, ', ') INTO drifted
     FROM windmill.rls_drift() WHERE auto_fixable;
@@ -181,20 +115,21 @@ BEGIN
 
     -- No RLS-enabled windmill table may be a black hole for windmill_user.
     SELECT string_agg(c.oid::regclass::text, ', ' ORDER BY c.oid::regclass::text)
-    INTO unreachable
+    INTO unreadable
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = 'windmill'
       AND c.relkind IN ('r', 'p')
+      AND NOT c.relispartition
       AND c.relrowsecurity
       AND has_table_privilege('windmill_user', c.oid, 'SELECT')
-      AND NOT EXISTS (
+      AND EXISTS (
           SELECT 1 FROM pg_policy p
-          WHERE p.polrelid = c.oid
-            AND 'windmill_user'::regrole = ANY (p.polroles)
-      );
-    IF unreachable IS NOT NULL THEN
-        RAISE EXCEPTION 'windmill_user has grants but no policy on RLS-enabled relation(s): %', unreachable;
+          WHERE p.polrelid = c.oid AND p.polname = 'kbve_windmill_user_all'
+      )
+      AND NOT windmill.rls_user_can_read(c.oid::regclass);
+    IF unreadable IS NOT NULL THEN
+        RAISE EXCEPTION 'windmill_user cannot read RLS-enabled relation(s): %', unreadable;
     END IF;
 
     -- Windmill's engine roles must keep EXECUTE after the PUBLIC revoke.
@@ -203,6 +138,7 @@ BEGIN
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
     WHERE n.nspname = 'windmill'
+      AND p.proname NOT IN ('rls_drift', 'rls_user_can_read', 'enforce_policy_rls')
       AND NOT has_function_privilege('windmill_user', p.oid, 'EXECUTE');
     IF leaked IS NOT NULL THEN
         RAISE EXCEPTION 'windmill_user lost EXECUTE on windmill function(s): %', leaked;
@@ -248,15 +184,16 @@ BEGIN
 END;
 $$;
 
-DROP FUNCTION IF EXISTS windmill.enforce_policy_rls();
-DROP FUNCTION IF EXISTS windmill.rls_drift();
-
 -- Restore the implicit PUBLIC EXECUTE default that Windmill's functions
 -- relied on before this migration. The windmill_user grants stay: dropping
--- them here would leave functions created after the rollback reachable by
--- nobody. TABLES/SEQUENCES need no restore — PUBLIC holds nothing on those
--- by default, so those revokes were already no-ops.
+-- them would leave functions created after the rollback reachable by nobody.
+-- TABLES/SEQUENCES need no restore -- PUBLIC holds nothing on those by
+-- default, so those revokes were already no-ops.
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA windmill TO PUBLIC;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA windmill
     GRANT EXECUTE ON FUNCTIONS TO PUBLIC;
+
+REVOKE ALL ON FUNCTION windmill.rls_drift() FROM PUBLIC;
+REVOKE ALL ON FUNCTION windmill.rls_user_can_read(regclass) FROM PUBLIC;
+REVOKE ALL ON FUNCTION windmill.enforce_policy_rls(boolean) FROM PUBLIC;


### PR DESCRIPTION
## Problem

Supabase linter `policy_exists_rls_disabled` (CRITICAL) on 5 relations:

- `windmill.account`
- `windmill.v2_job_completed`
- `windmill.v2_job_queue`
- `windmill.v2_job_runtime`
- `windmill.v2_job_status`

Windmill's sqlx migrations created policies (`admin_policy`) on these tables but left `ROW LEVEL SECURITY` disabled, so the policies never apply.

## Changes

Two new dbmate migrations:

### `20260730020000_windmill_rls_enable_policy_tables.sql` — resolve

One-shot sweep: every relation in schema `windmill` with `relkind IN ('r','p')`, `NOT relrowsecurity`, and at least one `pg_policy` row gets `ALTER TABLE … ENABLE ROW LEVEL SECURITY`. No table names hardcoded — Windmill owns its table lifecycle (`20260707000000_windmill_schema_init` only creates schema, roles, grants). Idempotent; no-op on a fresh database where Windmill has not migrated yet. Verification block raises if any offender remains.

### `20260730030000_windmill_rls_hardening.sql` — harden

The one-shot sweep only holds until Windmill's next sqlx migration adds another policy-bearing table with RLS off, so the invariant is made durable:

- `windmill.rls_drift()` — read-only audit of policy-without-RLS relations (empty result = healthy)
- `windmill.enforce_policy_rls()` — re-runnable sweep, returns number of relations changed
- pg_cron job `windmill-enforce-policy-rls` (hourly at :17) — heals drift after Windmill migrations run; guarded by extension presence, idempotent unschedule-then-schedule
- privilege wall: `REVOKE ALL ON ALL TABLES / SEQUENCES / FUNCTIONS` plus `ALTER DEFAULT PRIVILEGES … REVOKE` from `PUBLIC`, `anon`, `authenticated`, so the API roles cannot reach windmill internals even if a future object ships with permissive grants

Both functions are `SECURITY DEFINER`, owned by `postgres`, `search_path` pinned to `pg_catalog`, `EXECUTE` revoked from `PUBLIC`/`anon`/`authenticated`.

## Why this is safe

Windmill tables are owned by `postgres` and the Windmill server connects as `postgres`, so RLS is bypassed for the engine itself. Workers `SET ROLE` to `windmill_user` / `windmill_admin` (BYPASSRLS) — exactly the enforcement path these policies were written for.

**Escape hatch:** if Windmill ever ships a policy-bearing table that must run *without* RLS, unschedule `windmill-enforce-policy-rls` rather than editing the migration (documented in the migration header).

## Testing

`test-migration.sh` could not be used: the baseline chain dies locally at `schema "auth" does not exist` (known local-kilobase limitation), and the shared `dbmate-postgres-1` container was being recycled by another session mid-run.

Tested isolated instead, against a throwaway `postgres:17-alpine` seeded with `init/00-roles.sql` for the supabase roles:

- both migrations: seed → up → assert_after_up → down → assert_after_down → re-up, all green
- end state verified: policy-bearing probe tables `relrowsecurity=true`, no-policy control tables `false`, `rls_drift()` clean, no `PUBLIC`/`anon`/`authenticated` table grants, both functions `prosecdef=true` and owned by `postgres`, `enforce_policy_rls()` returns `0` on a second call (idempotent)
- cron branch (pg_cron absent in alpine) exercised against `cron.schedule` / `cron.unschedule` stubs with the guard forced: schedules once, re-run creates no duplicate, `migrate:down` removes it

Bug caught and fixed during testing: a single `IF EXISTS (pg_extension …) AND NOT EXISTS (cron.job …)` fails with `relation "cron.job" does not exist` on installs without pg_cron, because plpgsql plans the whole boolean expression — split into nested `IF`s.

Companion `.test.sql` fixtures added for both migrations.
