### PR TITLE
feat(reel-web): one-click play for the reel player

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -166,6 +166,12 @@ import ReactReelConsole from '@/components/media/ReactReelConsole';
 		color: #fca5a5;
 	}
 
+	:global(.reel-console__btn--active) {
+		border-color: #10b981;
+		background: #064e3b;
+		color: #6ee7b7;
+	}
+
 	:global(.reel-console__refresh:disabled),
 	:global(.reel-console__add button:disabled),
 	:global(.reel-console__btn:disabled),

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -7,6 +7,8 @@ import {
 	$reelListLoading,
 	$reelLive,
 	$reelHealth,
+	$reelSelectedId,
+	selectReel,
 	addTorrent,
 	deleteTorrent,
 	startTranscode,
@@ -161,6 +163,7 @@ export default function ReactReelConsole() {
 	const loading = useStore($reelListLoading);
 	const live = useStore($reelLive);
 	const health = useStore($reelHealth);
+	const selectedId = useStore($reelSelectedId);
 	const isStaff = useStore(homeService.$isStaff);
 
 	const [source, setSource] = useState('');
@@ -356,16 +359,17 @@ export default function ReactReelConsole() {
 								)}
 							</div>
 							<div className="reel-console__actions">
-								<a
-									className="reel-console__btn"
-									aria-disabled={!playable}
-									href={
-										playable
-											? `?id=${encodeURIComponent(t.id)}`
-											: undefined
-									}>
-									Play
-								</a>
+								<button
+									type="button"
+									className={`reel-console__btn${
+										selectedId === t.id
+											? ' reel-console__btn--active'
+											: ''
+									}`}
+									disabled={!playable}
+									onClick={() => selectReel(t.id)}>
+									{selectedId === t.id ? 'Playing' : 'Play'}
+								</button>
 								<button
 									type="button"
 									className="reel-console__btn"

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
@@ -5,6 +5,7 @@ import {
 	$reelError,
 	$reelName,
 	$reelNotice,
+	$reelSelectedId,
 	ReelPlayer,
 } from './reelService';
 
@@ -27,9 +28,16 @@ export default function ReactReelPlayer() {
 	const error = useStore($reelError);
 	const name = useStore($reelName);
 	const notice = useStore($reelNotice);
+	const selectedId = useStore($reelSelectedId);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [player] = useState(() => new ReelPlayer());
-	const [id] = useState(() => readId());
+
+	// Seed the selection from the URL so a shared /media/reel/?id=… link binds
+	// the player on first load (playback still needs a tap there — no gesture).
+	useEffect(() => {
+		const urlId = readId();
+		if (urlId) $reelSelectedId.set(urlId);
+	}, []);
 
 	useEffect(() => {
 		return () => {
@@ -37,9 +45,18 @@ export default function ReactReelPlayer() {
 		};
 	}, [player]);
 
+	// Autoplay whenever a reel is selected. In-page Play clicks carry the user
+	// gesture through, so playback starts immediately; a cold URL load may be
+	// blocked by the browser and falls back to the Play button below.
+	useEffect(() => {
+		if (!selectedId || !videoRef.current) return;
+		void player.start(videoRef.current, selectedId);
+		videoRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	}, [selectedId, player]);
+
 	const play = () => {
-		if (videoRef.current && id) {
-			void player.start(videoRef.current, id);
+		if (videoRef.current && selectedId) {
+			void player.start(videoRef.current, selectedId);
 		}
 	};
 
@@ -62,29 +79,25 @@ export default function ReactReelPlayer() {
 						{state === 'error' && error && (
 							<p className="reel-player__error">{error}</p>
 						)}
-						{!id && (
-							<p className="reel-player__error">
-								No torrent selected — add ?id=&lt;id&gt; to the URL.
+						{!selectedId && (
+							<p className="reel-player__meta">
+								Pick a reel below to start watching.
 							</p>
 						)}
 					</div>
 				)}
 			</div>
 			{notice && <p className="reel-player__notice">{notice}</p>}
-			<div className="reel-player__controls">
-				{state === 'error' ? (
-					<button type="button" disabled={!id} onClick={play}>
-						Retry
-					</button>
-				) : (
+			{(state === 'error' || (selectedId && !playing && !busy)) && (
+				<div className="reel-player__controls">
 					<button
 						type="button"
-						disabled={busy || playing || !id}
+						disabled={!selectedId}
 						onClick={play}>
-						{busy ? 'Preparing…' : 'Play'}
+						{state === 'error' ? 'Retry' : 'Play'}
 					</button>
-				)}
-			</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -9,6 +9,21 @@ export const $reelError = atom<string | null>(null);
 export const $reelName = atom<string | null>(null);
 export const $reelNotice = atom<string | null>(null);
 
+// The reel the player is currently bound to. Clicking Play in the console sets
+// this; the player island reacts and starts playback in place — no navigation,
+// no second click.
+export const $reelSelectedId = atom<string | null>(null);
+
+export function selectReel(id: string): void {
+	$reelSelectedId.set(id);
+	if (typeof window !== 'undefined') {
+		const url = new URL(window.location.href);
+		url.searchParams.set('id', id);
+		// Keep the URL shareable/refresh-safe without reloading the page.
+		window.history.replaceState(null, '', url);
+	}
+}
+
 export interface ReelDetail {
 	id?: string;
 	name?: string;


### PR DESCRIPTION
## What

Makes the reel player **just start playing**. Before: the console **Play** control was an `<a href=\"?id=…\">` that **reloaded the whole page**, after which the player showed a **second Play button** you had to click. Two clicks + a reload to watch anything.

## Now

Click **Play** → the reel binds and starts **in place**. One click, no reload.

- **reelService** — `$reelSelectedId` atom + `selectReel(id)`; updates the URL via `history.replaceState` so `/media/reel/?id=…` links stay shareable and refresh-safe, without navigating.
- **console** — Play is a `<button>` calling `selectReel`; the bound reel shows **Playing** with an active (green) style.
- **player** — autoplays on selection and scrolls into view; seeds the selection from `?id=` on load. Keeps a **Play/Retry** button for cold URL loads (autoplay-with-sound needs a user gesture there) and for errors.

## Notes

- Frontend-only (astro-kbve); no reel service change, no version bump. Pairs with the popcorn live-stream PR (#14942) but is independent — works for seeding entries too.
- In-page Play carries the user gesture through, so playback starts with sound immediately; a shared cold link falls back to the single Play button.

[Generated with KBVE Code](https://kbve.com/)