### PR TITLE
feat(reel): buffer headroom for live streaming (0.1.26)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -475,7 +475,15 @@ export class ReelPlayer {
 		}
 		// hls.js drives its own XHRs, so the token rides in the Authorization
 		// header — never in the manifest/segment URLs (no Referer/log leak).
+		// Buffer generously: popcorn segments are produced ahead of the playhead
+		// as the download runs, so let the player hold minutes of that lead to
+		// ride out download dips instead of stalling at the live edge.
 		const hls = new Hls({
+			maxBufferLength: 120,
+			maxMaxBufferLength: 600,
+			backBufferLength: 90,
+			liveSyncDurationCount: 6,
+			lowLatencyMode: false,
 			xhrSetup: (xhr: XMLHttpRequest, url: string) => {
 				xhr.open('GET', url, true);
 				xhr.setRequestHeader('Authorization', `Bearer ${token}`);

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.25"
+version: "0.1.26"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -101,6 +101,15 @@ audio is always downmixed to stereo aac so it plays with sound. The player
 already polls `202 → 200` and switches to hls.js unchanged. Gated by
 `REEL_LIVE_HLS` (default on); when off, leeching falls back to raw progressive.
 Playback quality tracks download rate — a starved swarm buffers.
+
+To keep playback smooth, the live job holds back **going Live** until
+`REEL_LIVE_PREBUFFER_SEGMENTS` (default 3, ≈12s at 4s segments) are ready, so a
+brief download dip right after Play doesn't immediately re-buffer, and the player
+(hls.js) is tuned to hold a large forward buffer (up to ~10 min) of the
+downloaded-ahead lead. Because the copy path muxes as fast as pieces arrive, the
+segment head stays ahead of the playhead whenever download rate beats the video
+bitrate — so after the initial prime, buffering only happens on a genuinely slow
+swarm.
 
 </BentoProse>
 

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub stream_enabled: bool,
     pub hls_enabled: bool,
     pub live_hls_enabled: bool,
+    pub live_prebuffer_segments: usize,
     pub hls_segment_secs: u64,
     pub bt_port_file: Option<PathBuf>,
     pub bt_port_wait_secs: u64,
@@ -191,6 +192,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
         hls_enabled: env_bool("REEL_HLS_ENABLED", true),
         live_hls_enabled: env_bool("REEL_LIVE_HLS", true),
+        live_prebuffer_segments: env_u64("REEL_LIVE_PREBUFFER_SEGMENTS", 3)?.max(1) as usize,
         hls_segment_secs: env_u64("REEL_HLS_SEGMENT_SECS", 4)?,
         bt_port_file: match std::env::var("REEL_BT_PORT_FILE") {
             Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v.trim())),
@@ -216,7 +218,7 @@ mod tests {
                   "REEL_STATE_FLUSH_MS","REEL_UPLOAD_LIMIT_BPS","REEL_API_TOKEN","REEL_TRANSCODE_ENABLED",
                   "REEL_REMUX_CONCURRENCY","REEL_ENCODE_CONCURRENCY","REEL_ENCODE_THREADS",
                   "REEL_FFMPEG_BIN","REEL_FFPROBE_BIN","REEL_STREAM_ENABLED",
-                  "REEL_HLS_ENABLED","REEL_LIVE_HLS","REEL_HLS_SEGMENT_SECS",
+                  "REEL_HLS_ENABLED","REEL_LIVE_HLS","REEL_LIVE_PREBUFFER_SEGMENTS","REEL_HLS_SEGMENT_SECS",
                   "REEL_BT_PORT_FILE","REEL_BT_PORT_WAIT_SECS"] {
             std::env::remove_var(k);
         }
@@ -410,6 +412,7 @@ mod tests {
         let c = load_from_env().unwrap();
         assert!(c.hls_enabled);
         assert!(c.live_hls_enabled);
+        assert_eq!(c.live_prebuffer_segments, 3);
         assert_eq!(c.hls_segment_secs, 4);
         std::env::set_var("REEL_HLS_ENABLED", "false");
         std::env::set_var("REEL_LIVE_HLS", "false");

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -41,6 +41,28 @@ mod tests {
             assert!(!valid_segment_name(n), "{n}");
         }
     }
+
+    #[test]
+    fn count_ts_segments_counts_only_ts() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        assert_eq!(count_ts_segments(d), 0);
+        std::fs::write(d.join("seg00000.ts"), b"a").unwrap();
+        std::fs::write(d.join("seg00001.ts"), b"b").unwrap();
+        std::fs::write(d.join("index.m3u8"), b"m").unwrap();
+        assert_eq!(count_ts_segments(d), 2, "m3u8 not counted");
+        assert_eq!(count_ts_segments(&d.join("missing")), 0, "missing dir -> 0");
+    }
+}
+
+fn count_ts_segments(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.flatten()
+                .filter(|e| e.file_name().to_string_lossy().ends_with(".ts"))
+                .count()
+        })
+        .unwrap_or(0)
 }
 
 fn delivery_label(d: Delivery) -> &'static str {
@@ -118,6 +140,7 @@ pub struct HlsManager {
     segment_secs: u32,
     enabled: bool,
     live_enabled: bool,
+    live_prebuffer_segments: usize,
     encode_threads: usize,
     children: Arc<Mutex<HashMap<String, Child>>>,
     delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
@@ -133,6 +156,7 @@ impl HlsManager {
         segment_secs: u32,
         enabled: bool,
         live_enabled: bool,
+        live_prebuffer_segments: usize,
         encode_threads: usize,
     ) -> Self {
         let this = Self {
@@ -143,6 +167,7 @@ impl HlsManager {
             segment_secs,
             enabled,
             live_enabled,
+            live_prebuffer_segments: live_prebuffer_segments.max(1),
             encode_threads,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -345,7 +370,8 @@ impl HlsManager {
             g.insert(id.to_string(), child);
         }
 
-        self.spawn_output_watch(id.to_string(), hls_dir.join("index.m3u8"), errbuf, permit);
+        // Completed download: the file is whole, so one segment is enough.
+        self.spawn_output_watch(id.to_string(), hls_dir.join("index.m3u8"), 1, errbuf, permit);
 
         Ok(())
     }
@@ -358,29 +384,32 @@ impl HlsManager {
         &self,
         id: String,
         index_path: PathBuf,
+        min_segments: usize,
         errbuf: Arc<Mutex<String>>,
         permit: Option<tokio::sync::OwnedSemaphorePermit>,
     ) {
         let this = self.clone();
+        let hls_dir = index_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default();
         tokio::spawn(async move {
+            // Hold back going Live until enough segments exist to prime the
+            // player's buffer, so a brief download dip after start doesn't
+            // immediately re-buffer. Exit the loop as soon as ffmpeg dies.
             let mut went_live = false;
-            for _ in 0..100 {
-                if index_path.exists() {
+            let exit_result = loop {
+                if !went_live
+                    && index_path.exists()
+                    && count_ts_segments(&hls_dir) >= min_segments
+                {
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Live;
                         ((), true)
                     });
-                    tracing::info!(id = %id, "hls manifest live");
+                    tracing::info!(id = %id, min_segments, "hls manifest live");
                     went_live = true;
-                    break;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-            if !went_live {
-                tracing::warn!(id = %id, "hls manifest not produced within 10s; ffmpeg may still be starting");
-            }
-
-            let exit_result = loop {
                 match this.poll_child(&id) {
                     Some(Ok(Some(status))) => break Some(Ok(status)),
                     Some(Ok(None)) => {}
@@ -602,7 +631,14 @@ impl HlsManager {
             g.insert(id.to_string(), child);
         }
 
-        self.spawn_output_watch(id.to_string(), hls_dir.join("index.m3u8"), errbuf, permit);
+        // Live: prime a few segments of buffer before letting the player start.
+        self.spawn_output_watch(
+            id.to_string(),
+            hls_dir.join("index.m3u8"),
+            self.live_prebuffer_segments,
+            errbuf,
+            permit,
+        );
         Ok(())
     }
 
@@ -701,7 +737,7 @@ mod mgr_tests {
     async fn abort_unknown_is_noop() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 1);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 3, 1);
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
     }
@@ -710,7 +746,7 @@ mod mgr_tests {
     fn cached_delivery_none_then_some() {
         let dir = std::env::temp_dir().join(format!("reel-hls-test-cache-{}", std::process::id()));
         let store = StateStore::load(dir.join("state.json")).unwrap();
-        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 1);
+        let mgr = HlsManager::new(store, 1, "ffmpeg".into(), "ffprobe".into(), 4, true, true, 3, 1);
         assert_eq!(mgr.cached_delivery("1"), None);
         mgr.cache_delivery("1", Delivery::RemuxHls);
         assert_eq!(mgr.cached_delivery("1"), Some(Delivery::RemuxHls));

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.hls_segment_secs as u32,
         cfg.hls_enabled,
         cfg.live_hls_enabled,
+        cfg.live_prebuffer_segments,
         cfg.encode_threads,
     );
 

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -56,6 +56,7 @@ async fn hls_transcode_integration() {
         4,
         true,
         true,
+        3,
         1,
     );
     let outcome = mgr


### PR DESCRIPTION
## Why

Live (popcorn) playback could stutter right after **Play**: the manifest flipped `Live` on the *first* segment, so the player started with almost no buffer and re-buffered on the first download dip.

## What

**Server — prebuffer gate.** A live HLS job now stays `Starting` until `REEL_LIVE_PREBUFFER_SEGMENTS` (default **3**, ≈12s at 4s segments) segments exist before it goes `Live`. The frontend already polls `202 → 200`, so this just delays go-live until there's a cushion. The completed-download path is unaffected (goes Live on one segment).

`spawn_output_watch` is now a single loop that flips `Live` once `index.m3u8` + `≥ min_segments` are present and exits when ffmpeg dies — removing the old fixed 10s go-live cap that could otherwise strand a slow live stream at `202`.

**Frontend — hls.js buffer tuning.** `maxBufferLength: 120`, `maxMaxBufferLength: 600`, `backBufferLength: 90`, `lowLatencyMode: false`. Because the copy path muxes as fast as pieces arrive, the segment head runs ahead of the playhead whenever download rate beats the bitrate; this lets the player *hold* that downloaded-ahead lead (up to ~10 min) instead of sitting at the live edge.

## Net effect

After the initial prime, buffering only happens on a genuinely slow swarm — download rate is the real limiter, and we can't manufacture bytes, but we no longer stall on transient dips.

- New: `REEL_LIVE_PREBUFFER_SEGMENTS` (default 3).
- 148 tests pass, clippy clean (only the pre-existing `stream.rs:13` warning).

[KBVE Media ](https://kbve.com/media/)