### PR TITLE
feat(reel): subtitles in the live stream (0.1.27)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -493,6 +493,14 @@ export class ReelPlayer {
 		hls.on(Hls.Events.ERROR, (_evt, data) => {
 			if (data.fatal) this.fail(`HLS error: ${data.type}`);
 		});
+		// Auto-enable the first subtitle rendition (the live stream marks it
+		// DEFAULT=YES) so provided subs show without the viewer hunting for a menu.
+		hls.on(Hls.Events.SUBTITLE_TRACKS_UPDATED, (_evt, data) => {
+			if (data.subtitleTracks.length > 0) {
+				hls.subtitleDisplay = true;
+				hls.subtitleTrack = 0;
+			}
+		});
 		hls.loadSource(mediaUrl(id, '/manifest.m3u8', null));
 		hls.attachMedia(video);
 		$reelState.set('hls');

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.26"
+version: "0.1.27"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -110,6 +110,14 @@ downloaded-ahead lead. Because the copy path muxes as fast as pieces arrive, the
 segment head stays ahead of the playhead whenever download rate beats the video
 bitrate — so after the initial prime, buffering only happens on a genuinely slow
 swarm.
+
+**Subtitles.** When the primary file carries a text subtitle track (SubRip/ASS/
+mov_text — image subs like PGS/VobSub are skipped), the live job emits a WebVTT
+subtitle rendition alongside the video: ffmpeg produces a master playlist with an
+`EXT-X-MEDIA` subtitle group (`-c:s webvtt`, `-var_stream_map`), the player marks
+it `DEFAULT=YES`, and hls.js auto-enables it. The manifest served at
+`…/manifest.m3u8` rewrites child-playlist and segment references under `hls/` so
+they resolve against the segment route, while the child playlists are served raw.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -440,15 +440,62 @@ async fn live_manifest(
 
 async fn serve_manifest_file(dir: &str) -> axum::response::Response {
     let path = std::path::Path::new(dir).join("index.m3u8");
-    let file = match tokio::fs::File::open(&path).await {
-        Ok(f) => f,
+    let body = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
-    let total = match file.metadata().await {
-        Ok(m) => m.len(),
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    };
-    crate::stream::serve_range(file, total, None, "application/vnd.apple.mpegurl", false).await
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/vnd.apple.mpegurl",
+        )],
+        rewrite_manifest_paths(&body),
+    )
+        .into_response()
+}
+
+/// ffmpeg writes segment / child-playlist references as bare basenames, but the
+/// top-level manifest is served from `…/torrents/{id}/manifest.m3u8` while the
+/// files live under `…/torrents/{id}/hls/`. Prefix every resource reference
+/// (segment lines, variant playlists, and `URI="…"` group attributes) with
+/// `hls/` so the player resolves them against the segment route. Child
+/// playlists are served raw — their basenames already resolve under `hls/`.
+fn rewrite_manifest_paths(body: &str) -> String {
+    fn needs_prefix(s: &str) -> bool {
+        !s.is_empty() && !s.starts_with("hls/") && !s.contains("://") && !s.starts_with('/')
+    }
+    let mut out = String::with_capacity(body.len() + 64);
+    for line in body.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            out.push('\n');
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            // Rewrite a URI="…" attribute (subtitle/audio group refs) if present.
+            if let Some(start) = rest.find("URI=\"") {
+                let uri_start = "#".len() + start + "URI=\"".len();
+                if let Some(end_rel) = trimmed[uri_start..].find('"') {
+                    let uri = &trimmed[uri_start..uri_start + end_rel];
+                    if needs_prefix(uri) {
+                        out.push_str(&trimmed[..uri_start]);
+                        out.push_str("hls/");
+                        out.push_str(&trimmed[uri_start..]);
+                        out.push('\n');
+                        continue;
+                    }
+                }
+            }
+            out.push_str(trimmed);
+        } else if needs_prefix(trimmed) {
+            out.push_str("hls/");
+            out.push_str(trimmed);
+        } else {
+            out.push_str(trimmed);
+        }
+        out.push('\n');
+    }
+    out
 }
 
 async fn hls_segment(
@@ -755,6 +802,8 @@ pub(crate) async fn hls_segment_core(
     let range = headers.get("range").and_then(|h| h.to_str().ok());
     let ct = if segment.ends_with(".ts") {
         "video/mp2t"
+    } else if segment.ends_with(".vtt") {
+        "text/vtt"
     } else {
         "application/vnd.apple.mpegurl"
     };
@@ -876,6 +925,24 @@ mod tests {
             hls_dir: None,
             hls_error: None,
         }
+    }
+
+    #[test]
+    fn rewrite_manifest_prefixes_media_playlist_segments() {
+        let src = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:4.0,\nseg00001.ts\nhls/seg00002.ts\n";
+        let out = rewrite_manifest_paths(src);
+        assert!(out.contains("\nhls/seg00001.ts\n"), "bare segment prefixed");
+        assert!(!out.contains("hls/hls/"), "already-prefixed left alone");
+        assert!(out.contains("#EXTINF:4.0,"), "tags untouched");
+    }
+
+    #[test]
+    fn rewrite_manifest_prefixes_master_variants_and_subs() {
+        let src = "#EXTM3U\n#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"subs\",NAME=\"s\",DEFAULT=YES,URI=\"stream_0_vtt.m3u8\"\n#EXT-X-STREAM-INF:BANDWIDTH=1,SUBTITLES=\"subs\"\nstream_0.m3u8\n";
+        let out = rewrite_manifest_paths(src);
+        assert!(out.contains("URI=\"hls/stream_0_vtt.m3u8\""), "sub URI prefixed");
+        assert!(out.contains("\nhls/stream_0.m3u8\n"), "variant playlist prefixed");
+        assert!(out.contains("GROUP-ID=\"subs\""), "other attrs preserved");
     }
 
     #[test]
@@ -1385,7 +1452,7 @@ mod tests {
     #[tokio::test]
     async fn hls_segment_rejects_bad_name_is_400() {
         let res = hls_segment_core(
-            &HeaderMap::new(), None, &None, &store_with_one(), "1", "seg.ts", &Method::GET,
+            &HeaderMap::new(), None, &None, &store_with_one(), "1", "seg-1.mp4", &Method::GET,
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -7,16 +7,18 @@ use tokio::process::{Child, Command};
 use tokio::sync::Semaphore;
 
 pub fn valid_segment_name(name: &str) -> bool {
-    if name == "index.m3u8" {
-        return true;
-    }
-    let stem = match name.strip_suffix(".ts") {
-        Some(s) => s,
+    // Accept only ffmpeg-generated HLS artifacts: playlists (index.m3u8,
+    // stream_0.m3u8, stream_0_vtt.m3u8), TS segments (seg00001.ts,
+    // seg_0_00001.ts) and WebVTT subtitle segments (stream_00.vtt). The stem is
+    // restricted to [A-Za-z0-9_] so no path separator or `..` can appear.
+    let (stem, ext) = match name.rsplit_once('.') {
+        Some(pair) => pair,
         None => return false,
     };
-    stem.strip_prefix("seg")
-        .map(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
-        .unwrap_or(false)
+    if !matches!(ext, "ts" | "m3u8" | "vtt") {
+        return false;
+    }
+    !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
 #[cfg(test)]
@@ -26,6 +28,11 @@ mod tests {
     fn accepts_segment_and_manifest() {
         assert!(valid_segment_name("seg00001.ts"));
         assert!(valid_segment_name("index.m3u8"));
+        // multi-variant (subtitle) artifacts
+        assert!(valid_segment_name("seg_0_00001.ts"));
+        assert!(valid_segment_name("stream_0.m3u8"));
+        assert!(valid_segment_name("stream_0_vtt.m3u8"));
+        assert!(valid_segment_name("stream_00.vtt"));
     }
     #[test]
     fn rejects_traversal() {
@@ -34,9 +41,10 @@ mod tests {
             ".../x",
             "a/b",
             "/etc/passwd",
-            "seg.ts",
             "index.m3u",
             "seg01.ts..",
+            "seg-1.ts",
+            "..",
         ] {
             assert!(!valid_segment_name(n), "{n}");
         }
@@ -542,7 +550,17 @@ impl HlsManager {
             }
             prefix.extend_from_slice(&buf[..n]);
         }
-        let video_copy = self.probe_prefix_is_h264(&prefix).await;
+        let probe = self.probe_prefix(&prefix).await;
+        let video_copy = probe
+            .as_ref()
+            .map(|p| p.video_codec.as_deref() == Some("h264"))
+            .unwrap_or(false);
+        // Only text subtitles can become WebVTT; image subs (PGS/VobSub) are
+        // skipped so ffmpeg never fails on `-c:s webvtt`.
+        let with_subs = probe
+            .as_ref()
+            .map(|p| crate::transcode::subtitle_is_text(p.subtitle_codec.as_deref()))
+            .unwrap_or(false);
 
         // h264 is stream-copied (cheap, realtime); anything else is encoded and
         // must hold an encode permit. Audio is always downmixed to stereo aac.
@@ -565,6 +583,10 @@ impl HlsManager {
                 .iter()
                 .map(|s| s.to_string()),
         );
+        if with_subs {
+            args.push("-map".into());
+            args.push("0:s:0?".into());
+        }
         if video_copy {
             args.push("-c:v".into());
             args.push("copy".into());
@@ -582,6 +604,10 @@ impl HlsManager {
         args.push("aac".into());
         args.push("-ac".into());
         args.push("2".into());
+        if with_subs {
+            args.push("-c:s".into());
+            args.push("webvtt".into());
+        }
         args.push("-f".into());
         args.push("hls".into());
         args.push("-hls_time".into());
@@ -590,9 +616,21 @@ impl HlsManager {
         args.push("event".into());
         args.push("-hls_flags".into());
         args.push("append_list".into());
-        args.push("-hls_segment_filename".into());
-        args.push(hls_dir.join("seg%05d.ts").display().to_string());
-        args.push(hls_dir.join("index.m3u8").display().to_string());
+        if with_subs {
+            // Multi-variant output: a master index.m3u8 referencing the video
+            // variant plus a WebVTT subtitle group the player can toggle.
+            args.push("-master_pl_name".into());
+            args.push("index.m3u8".into());
+            args.push("-var_stream_map".into());
+            args.push("v:0,a:0,s:0,sgroup:subs".into());
+            args.push("-hls_segment_filename".into());
+            args.push(hls_dir.join("seg_%v_%05d.ts").display().to_string());
+            args.push(hls_dir.join("stream_%v.m3u8").display().to_string());
+        } else {
+            args.push("-hls_segment_filename".into());
+            args.push(hls_dir.join("seg%05d.ts").display().to_string());
+            args.push(hls_dir.join("index.m3u8").display().to_string());
+        }
 
         let mut cmd = Command::new(&self.ffmpeg_bin);
         cmd.args(&args)
@@ -625,7 +663,15 @@ impl HlsManager {
             });
         }
 
-        crate::telemetry::hls_started(id, if video_copy { "live_copy" } else { "live_transcode" });
+        crate::telemetry::hls_started(
+            id,
+            match (video_copy, with_subs) {
+                (true, true) => "live_copy_subs",
+                (true, false) => "live_copy",
+                (false, true) => "live_transcode_subs",
+                (false, false) => "live_transcode",
+            },
+        );
         {
             let mut g = self.children.lock().unwrap();
             g.insert(id.to_string(), child);
@@ -642,22 +688,22 @@ impl HlsManager {
         Ok(())
     }
 
-    /// Best-effort: write the download prefix to a temp file and ask ffprobe
-    /// whether the video stream is h264. Any failure (partial header, unknown
-    /// codec) returns false, so the caller falls back to a safe re-encode.
-    async fn probe_prefix_is_h264(&self, prefix: &[u8]) -> bool {
+    /// Best-effort: write the download prefix to a temp file and ffprobe it for
+    /// the video/subtitle codecs. Any failure (partial header) returns None, so
+    /// the caller falls back to a safe re-encode with no subtitles.
+    async fn probe_prefix(&self, prefix: &[u8]) -> Option<crate::transcode::ProbeResult> {
         if prefix.is_empty() {
-            return false;
+            return None;
         }
         static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tmp = std::env::temp_dir().join(format!("reel-live-probe-{}-{n}.bin", std::process::id()));
         if tokio::fs::write(&tmp, prefix).await.is_err() {
-            return false;
+            return None;
         }
         let res = crate::transcode::probe(&self.ffprobe_bin, &tmp).await;
         let _ = tokio::fs::remove_file(&tmp).await;
-        matches!(res, Ok(p) if p.video_codec.as_deref() == Some("h264"))
+        res.ok()
     }
 }
 

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -11,8 +11,32 @@ pub struct ProbeResult {
     pub video_codec: Option<String>,
     pub audio_codec: Option<String>,
     pub audio_channels: Option<i64>,
+    pub subtitle_codec: Option<String>,
     pub container: Option<String>,
     pub duration_secs: Option<f64>,
+}
+
+/// Text-based subtitle codecs that ffmpeg can convert to WebVTT for HLS.
+/// Image subtitles (PGS/VobSub/DVB) cannot and are left out of the live stream.
+pub fn subtitle_is_text(codec: Option<&str>) -> bool {
+    matches!(
+        codec,
+        Some(
+            "subrip"
+                | "srt"
+                | "ass"
+                | "ssa"
+                | "mov_text"
+                | "webvtt"
+                | "text"
+                | "subviewer"
+                | "subviewer1"
+                | "microdvd"
+                | "mpl2"
+                | "vplayer"
+                | "pjs"
+        )
+    )
 }
 
 pub fn progress_pct(out_time_us: u64, duration_secs: f64) -> u8 {
@@ -175,6 +199,7 @@ pub fn parse_probe_json(json: &serde_json::Value) -> ProbeResult {
     let mut video = None;
     let mut audio = None;
     let mut audio_channels = None;
+    let mut subtitle = None;
     if let Some(streams) = json.get("streams").and_then(|s| s.as_array()) {
         for s in streams {
             let kind = s.get("codec_type").and_then(|v| v.as_str());
@@ -194,6 +219,7 @@ pub fn parse_probe_json(json: &serde_json::Value) -> ProbeResult {
                     audio = codec;
                     audio_channels = s.get("channels").and_then(|v| v.as_i64());
                 }
+                Some("subtitle") if subtitle.is_none() => subtitle = codec,
                 _ => {}
             }
         }
@@ -212,6 +238,7 @@ pub fn parse_probe_json(json: &serde_json::Value) -> ProbeResult {
         video_codec: video,
         audio_codec: audio,
         audio_channels,
+        subtitle_codec: subtitle,
         container,
         duration_secs,
     }
@@ -686,9 +713,36 @@ mod tests {
             video_codec: v.map(String::from),
             audio_codec: a.map(String::from),
             audio_channels: None,
+            subtitle_codec: None,
             container: c.map(String::from),
             duration_secs: None,
         }
+    }
+
+    #[test]
+    fn subtitle_is_text_allows_text_rejects_image() {
+        assert!(subtitle_is_text(Some("subrip")));
+        assert!(subtitle_is_text(Some("ass")));
+        assert!(subtitle_is_text(Some("mov_text")));
+        assert!(!subtitle_is_text(Some("hdmv_pgs_subtitle")));
+        assert!(!subtitle_is_text(Some("dvd_subtitle")));
+        assert!(!subtitle_is_text(None));
+    }
+
+    #[test]
+    fn parse_probe_reads_first_subtitle_codec() {
+        let json = serde_json::json!({
+            "streams": [
+                {"codec_type": "video", "codec_name": "h264"},
+                {"codec_type": "audio", "codec_name": "aac", "channels": 2},
+                {"codec_type": "subtitle", "codec_name": "subrip"},
+                {"codec_type": "subtitle", "codec_name": "hdmv_pgs_subtitle"}
+            ],
+            "format": {"format_name": "matroska,webm"}
+        });
+        let p = parse_probe_json(&json);
+        assert_eq!(p.subtitle_codec.as_deref(), Some("subrip"));
+        assert!(subtitle_is_text(p.subtitle_codec.as_deref()));
     }
 
     #[test]


### PR DESCRIPTION
## What

Includes **subtitles in the live (popcorn) stream** when the file provides them. When the primary file carries a **text** subtitle track (SubRip/ASS/mov_text — image subs like PGS/VobSub are skipped), the live HLS job emits a WebVTT subtitle rendition the player shows automatically.

## How

- **probe** — parse the first subtitle codec; `subtitle_is_text()` gates on text-based codecs so ffmpeg never fails on `-c:s webvtt` for image subs.
- **run_live** — when a text sub is present, emit a **master playlist** with a WebVTT subtitle group (`-c:s webvtt`, `-master_pl_name index.m3u8`, `-var_stream_map "v:0,a:0,s:0,sgroup:subs"`); otherwise the existing single media playlist. The exact ffmpeg command was **validated locally end-to-end** (master → video variant + `stream_0_vtt.m3u8` → WebVTT cues).
- **serve_manifest_file** — the top-level manifest is served from `…/torrents/{id}/manifest.m3u8` but files live under `…/hls/`, so child-playlist / segment / `URI="…"` references are rewritten with an `hls/` prefix to resolve against the `/hls/{segment}` route. Child playlists are served raw. *(This also fixes segment-URL resolution for the plain seeding playlist, which pointed at the wrong path.)*
- **valid_segment_name** — broadened to accept multi-variant artifacts (`stream_0.m3u8`, `seg_0_00001.ts`, `stream_00.vtt`) while keeping path-traversal safety (stem restricted to `[A-Za-z0-9_]`). `.vtt` served as `text/vtt`.
- **frontend** — hls.js auto-enables the `DEFAULT=YES` subtitle track.

## Notes

- **Stacks on #14954 (buffer, 0.1.26) — merge that first.** This PR is 0.1.27; if merged out of order, resolve the one-line version conflict.
- Only the primary video file's **embedded** text subs are used for live (sidecar `.srt` files aren't in the piped stream); completion still keeps sidecars per the earlier fix.
- 151 tests pass, clippy clean (only the pre-existing `stream.rs:13` warning).

[KBVE Media](https://kbve.com/media/)