### PR TITLE
feat(reel-web): theater mode for the player

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -48,6 +48,45 @@ import ReactReelConsole from '@/components/media/ReactReelConsole';
 		object-fit: contain;
 	}
 
+	:global(.reel-player__theater-toggle) {
+		position: absolute;
+		top: 0.6rem;
+		right: 0.6rem;
+		z-index: 2;
+		padding: 0.35rem 0.7rem;
+		border-radius: 0.4rem;
+		border: 1px solid rgba(255, 255, 255, 0.25);
+		background: rgba(0, 0, 0, 0.55);
+		color: #e5e7eb;
+		font-size: 0.75rem;
+		cursor: pointer;
+		opacity: 0.75;
+		transition: opacity 0.15s ease;
+	}
+
+	:global(.reel-player__theater-toggle:hover),
+	:global(.reel-player__theater-toggle:focus-visible) {
+		opacity: 1;
+	}
+
+	/* Theater mode: fill the window without going native fullscreen. */
+	:global(.reel-player--theater) {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		background: #000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	:global(.reel-player--theater .reel-player__stage) {
+		width: 100%;
+		height: 100%;
+		aspect-ratio: auto;
+		border-radius: 0;
+	}
+
 	:global(.reel-player__overlay) {
 		position: absolute;
 		inset: 0;

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
@@ -31,6 +31,7 @@ export default function ReactReelPlayer() {
 	const selectedId = useStore($reelSelectedId);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [player] = useState(() => new ReelPlayer());
+	const [theater, setTheater] = useState(false);
 
 	// Seed the selection from the URL so a shared /media/reel/?id=… link binds
 	// the player on first load (playback still needs a tap there — no gesture).
@@ -54,6 +55,23 @@ export default function ReactReelPlayer() {
 		videoRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}, [selectedId, player]);
 
+	// Theater mode blows the stage up to fill the window (not native fullscreen),
+	// so it's easy to watch without leaving the page. Esc exits, and the page
+	// behind it is scroll-locked while active.
+	useEffect(() => {
+		if (!theater) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') setTheater(false);
+		};
+		const prevOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		window.addEventListener('keydown', onKey);
+		return () => {
+			window.removeEventListener('keydown', onKey);
+			document.body.style.overflow = prevOverflow;
+		};
+	}, [theater]);
+
 	const play = () => {
 		if (videoRef.current && selectedId) {
 			void player.start(videoRef.current, selectedId);
@@ -64,7 +82,7 @@ export default function ReactReelPlayer() {
 	const playing = state === 'raw' || state === 'hls';
 
 	return (
-		<div className="reel-player">
+		<div className={`reel-player${theater ? ' reel-player--theater' : ''}`}>
 			<div className="reel-player__stage">
 				<video
 					ref={videoRef}
@@ -72,6 +90,16 @@ export default function ReactReelPlayer() {
 					playsInline
 					className="reel-player__video"
 				/>
+				{selectedId && (
+					<button
+						type="button"
+						className="reel-player__theater-toggle"
+						aria-pressed={theater}
+						title={theater ? 'Exit theater (Esc)' : 'Theater mode'}
+						onClick={() => setTheater((v) => !v)}>
+						{theater ? '✕ Exit' : '⛶ Theater'}
+					</button>
+				)}
 				{!playing && (
 					<div className="reel-player__overlay">
 						<p>{STATE_LABEL[state] ?? state}</p>


### PR DESCRIPTION
## What

Adds a **Theater** button to the reel player that expands the video to fill the window — easier to watch without going into native fullscreen.

- Toggle overlaid top-right of the stage, visible whenever a reel is bound (so it's reachable during playback).
- Theater applies a fixed, full-viewport overlay (`position: fixed; inset: 0`), not the Fullscreen API — stays in-page, browser chrome remains.
- **Esc** exits; the page behind is scroll-locked while active.

## Notes

- Frontend-only (astro-kbve) — no reel service change, no version bump.
- Independent of the live-subtitles PR (#14956); no file overlap.

[KBVE OSRS](https://kbve.com/osrs)