### PR TITLE
feat(reel): cookie auth for native HLS (iOS Safari)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -195,6 +195,18 @@ export function mediaUrl(id: string, suffix: string, token: string | null): stri
 	return `${base}${sep}access_token=${encodeURIComponent(token)}`;
 }
 
+// Native <video> HLS (iOS Safari) can't send an Authorization header, and the
+// relative child-playlist/segment URLs drop the query-string token — so scope
+// the media token into a cookie the browser sends with every media subrequest.
+function setMediaCookie(token: string): void {
+	if (typeof document === 'undefined') return;
+	const maxAge = mediaTokenCache
+		? Math.max(0, Math.floor((mediaTokenCache.expiresAtMs - Date.now()) / 1000))
+		: 300;
+	const secure = location.protocol === 'https:' ? '; Secure' : '';
+	document.cookie = `reel_media_token=${token}; Path=${MEDIA_BASE}; Max-Age=${maxAge}; SameSite=Lax${secure}`;
+}
+
 
 export async function listTorrents(): Promise<ReelTorrent[]> {
 	return authedApiFetch<ReelTorrent[]>(`${REEL_PATH}/torrents`);
@@ -500,9 +512,11 @@ export class ReelPlayer {
 			return;
 		}
 		if (video.canPlayType(MANIFEST_MIME)) {
-			// Last resort (iOS Safari, no MSE): native HLS with the token on the
-			// query string. Reliable for single-file HLS; multi-variant/live
-			// streams may fail here because relative child URLs lose the token.
+			// Last resort (iOS Safari, no MSE): native HLS. The element can't send
+			// headers and relative child/segment URLs drop the query token, so
+			// scope the token into a cookie the browser sends with every request;
+			// the query token on the master covers the very first request.
+			setMediaCookie(token);
 			this.attachVideoError(video, gen);
 			video.src = mediaUrl(id, '/manifest.m3u8', token);
 			$reelState.set('hls');

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.259"
+version: "1.0.260"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml

--- a/apps/kbve/axum-kbve/src/transport/proxy/reel.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/reel.rs
@@ -41,8 +41,25 @@ pub fn init_reel_proxy() -> bool {
     .is_ok()
 }
 
+/// Pull a media token out of the `reel_media_token` cookie. Native `<video>`
+/// HLS (iOS Safari — no MSE, so hls.js can't run) can't send an Authorization
+/// header, and relative child-playlist/segment URLs drop the query-string
+/// token, so the browser-sent cookie is the only credential those requests
+/// carry.
+fn media_token_cookie(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
+    raw.split(';').find_map(|pair| {
+        pair.trim()
+            .strip_prefix("reel_media_token=")
+            .filter(|v| !v.is_empty())
+    })
+}
+
 async fn require_reel_access(headers: &HeaderMap, query: Option<&str>) -> Result<(), Response> {
-    if let Some(tok) = extract_auth_token(headers, query) {
+    let media_tok = extract_auth_token(headers, query)
+        .filter(|t| reel_token::is_media_token(t))
+        .or_else(|| media_token_cookie(headers));
+    if let Some(tok) = media_tok {
         if reel_token::is_media_token(tok) {
             return match reel_token::verify_media_token(tok, reel_token::now_unix()) {
                 Some(_) => Ok(()),
@@ -93,5 +110,38 @@ pub async fn reel_proxy_handler(rest: Option<Path<String>>, req: Request<Body>) 
             axum::Json(json!({"error": "Reel proxy not configured"})),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header::COOKIE;
+
+    fn with_cookie(v: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(COOKIE, v.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn media_token_cookie_extracts_value() {
+        assert_eq!(
+            media_token_cookie(&with_cookie("reel_media_token=abc.def.ghi")),
+            Some("abc.def.ghi")
+        );
+        assert_eq!(
+            media_token_cookie(&with_cookie(
+                "dashboard_session=x; reel_media_token=tok123; other=y"
+            )),
+            Some("tok123")
+        );
+    }
+
+    #[test]
+    fn media_token_cookie_none_when_absent_or_empty() {
+        assert_eq!(media_token_cookie(&with_cookie("dashboard_session=x")), None);
+        assert_eq!(media_token_cookie(&with_cookie("reel_media_token=")), None);
+        assert_eq!(media_token_cookie(&HeaderMap::new()), None);
     }
 }


### PR DESCRIPTION
## Why

iOS Safari has **no MSE**, so hls.js can't run and the player falls back to native `<video>` HLS. A native element **can't send the `Authorization` header**, and relative child-playlist/segment URLs drop the `?access_token` query — so every child request **401s at the proxy** and playback fails. (Desktop is already fixed by preferring hls.js, #14965 — this covers the engines that can't use it.)

## Fix

Scope the media token into a **`reel_media_token` cookie** the browser sends automatically with every same-origin media subrequest.

- **axum-kbve proxy** — `require_reel_access` accepts the media token from the `reel_media_token` cookie in addition to header/query (`media_token_cookie` helper). Read literally, matching how header/query tokens are handled.
- **astro-kbve** — set the cookie (`Path=`media base, `Max-Age=`token TTL, `SameSite=Lax`, `Secure` on https) right before the native `<video>` src; the query token on the master still covers the first request.

## Notes

- Desktop stays on hls.js (header auth) — the cookie is only set on the native fallback path, so no token-in-URL leak and no behavior change for MSE browsers.
- `playsInline` is already set on the video element (iOS inline playback); Play is a tap (gesture) so autoplay-with-sound is allowed.
- axum-kbve **1.0.259 → 1.0.260** (proxy change ships in the axum-kbve container).
- Possible iOS follow-up: the live master omits a `CODECS` attribute (ffmpeg `-c:v copy`), which strict native HLS can dislike — revisit only if iOS still balks after this.
- reel proxy tests pass; frontend validated by CI (worktrees have no node_modules).

 [KBVE OSRS](https://kbve.com/osrs/)