### PR TITLE
feat(reel): sidecar subtitles for completed reels (0.1.28)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -196,6 +196,22 @@ export function mediaUrl(id: string, suffix: string, token: string | null): stri
 }
 
 
+export interface ReelSubtitle {
+	index: number;
+	label: string;
+	lang: string;
+}
+
+export async function fetchSubtitles(id: string): Promise<ReelSubtitle[]> {
+	try {
+		return await authedApiFetch<ReelSubtitle[]>(
+			`${REEL_PATH}/torrents/${encodeURIComponent(id)}/subtitles`,
+		);
+	} catch {
+		return [];
+	}
+}
+
 export async function listTorrents(): Promise<ReelTorrent[]> {
 	return authedApiFetch<ReelTorrent[]>(`${REEL_PATH}/torrents`);
 }
@@ -441,7 +457,41 @@ export class ReelPlayer {
 		if (leeching) {
 			$reelNotice.set('still downloading — playing the available portion');
 		}
+		void this.addSubtitleTracks(video, id, token, gen);
 		void video.play().catch(() => undefined);
+	}
+
+	// Attach sidecar subtitles (kept beside a completed download) as WebVTT
+	// <track>s. The <track> element can't send headers, so the token rides the
+	// query string. Live HLS carries its own subtitle rendition, so leeching
+	// entries simply return an empty list here.
+	private async addSubtitleTracks(
+		video: HTMLVideoElement,
+		id: string,
+		token: string,
+		gen: number,
+	): Promise<void> {
+		this.removeSubtitleTracks(video);
+		const subs = await fetchSubtitles(id);
+		if (this.generation !== gen || !subs.length) return;
+		subs.forEach((s, i) => {
+			const track = document.createElement('track');
+			track.kind = 'subtitles';
+			track.label = s.label;
+			track.srclang = s.lang || 'und';
+			track.src = mediaUrl(id, `/subtitles/${s.index}`, token);
+			if (i === 0) track.default = true;
+			video.appendChild(track);
+		});
+		// Show the first track once its cues load.
+		const first = video.textTracks[0];
+		if (first) first.mode = 'showing';
+	}
+
+	private removeSubtitleTracks(video: HTMLVideoElement): void {
+		video
+			.querySelectorAll('track')
+			.forEach((t) => t.parentNode?.removeChild(t));
 	}
 
 	private attachVideoError(video: HTMLVideoElement, gen: number): void {
@@ -458,6 +508,9 @@ export class ReelPlayer {
 		gen: number,
 	): Promise<void> {
 		if (this.generation !== gen) return;
+		// Sidecar subs for a completed entry; live HLS returns an empty list and
+		// shows its own in-stream subtitle rendition instead.
+		void this.addSubtitleTracks(video, id, token, gen);
 		// Prefer hls.js wherever it's supported (desktop Safari included). Its
 		// XHRs carry the token in the Authorization header, so every request —
 		// master, child playlists, segments, subtitle VTTs — authenticates. The
@@ -519,6 +572,7 @@ export class ReelPlayer {
 		}
 		if (this.video) {
 			this.video.onerror = null;
+			this.removeSubtitleTracks(this.video);
 		}
 		if (this.hls) {
 			try {

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -118,6 +118,13 @@ subtitle rendition alongside the video: ffmpeg produces a master playlist with a
 it `DEFAULT=YES`, and hls.js auto-enables it. The manifest served at
 `…/manifest.m3u8` rewrites child-playlist and segment references under `hls/` so
 they resolve against the segment route, while the child playlists are served raw.
+
+Once a download **completes**, its transcoded `.reel.mp4` no longer carries the
+subtitle streams, so the embedded text subs extracted to sidecar `.srt` files are
+served separately: `GET /torrents/{id}/subtitles` lists them and
+`GET /torrents/{id}/subtitles/{n}` returns each converted to WebVTT on the fly.
+The player attaches them as `<track>` elements (token on the query string, since
+`<track>` can't send headers), so finished reels play with selectable subtitles.
 
 </BentoProse>
 

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -832,6 +832,55 @@ pub(crate) async fn hls_segment_core(
     crate::stream::serve_range(file, total, range, ct, head_only).await
 }
 
+async fn subtitles_list(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if !check_auth(&headers, &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let dir = std::path::PathBuf::from(&meta.path);
+    Json(crate::subtitles::tracks_for(&dir)).into_response()
+}
+
+async fn subtitle_vtt(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path((id, idx)): Path<(String, usize)>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
+) -> impl IntoResponse {
+    if !check_auth_q(&headers, query.as_deref(), &st.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let meta = match st.store.get(&id) {
+        Some(m) => m,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let dir = std::path::PathBuf::from(&meta.path);
+    let path = match crate::subtitles::list_sidecars(&dir).into_iter().nth(idx) {
+        Some(p) => p,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let srt = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(id = %id, path = %path.display(), error = %e, "subtitle read failed");
+            return StatusCode::NOT_FOUND.into_response();
+        }
+    };
+    let _ = st.store.touch(&id, now_secs());
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/vtt; charset=utf-8")],
+        crate::subtitles::srt_to_vtt(&srt),
+    )
+        .into_response()
+}
+
 fn store_scoped_router(state: AppStateStub) -> Router {
     Router::new()
         .route("/torrents", get(list))
@@ -855,6 +904,8 @@ pub fn router(state: AppState) -> Router {
             "/torrents/{id}/hls/{segment}",
             get(hls_segment).head(hls_segment),
         )
+        .route("/torrents/{id}/subtitles", get(subtitles_list))
+        .route("/torrents/{id}/subtitles/{idx}", get(subtitle_vtt))
         .with_state(state);
     Router::new()
         .route("/healthz", get(|| async { "ok" }))

--- a/apps/media/reel/src/lib.rs
+++ b/apps/media/reel/src/lib.rs
@@ -6,6 +6,7 @@ pub mod mover;
 pub mod reaper;
 pub mod state;
 pub mod stream;
+pub mod subtitles;
 pub mod sweeper;
 pub mod telemetry;
 pub mod transcode;

--- a/apps/media/reel/src/subtitles.rs
+++ b/apps/media/reel/src/subtitles.rs
@@ -1,0 +1,148 @@
+use std::path::{Path, PathBuf};
+
+/// A subtitle sidecar discovered next to a completed download.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SubtitleTrack {
+    pub index: usize,
+    pub label: String,
+    pub lang: String,
+}
+
+fn is_srt(name: &str) -> bool {
+    name.to_ascii_lowercase().ends_with(".srt")
+}
+
+/// Best-effort language guess from a sidecar filename, e.g.
+/// `movie.en.srt` / `movie.sub2.eng.srt` → a 2-letter code, else "und".
+fn guess_lang(stem: &str) -> String {
+    let lower = stem.to_ascii_lowercase();
+    for part in lower.rsplit(['.', '_', '-']) {
+        let p = part.trim();
+        let code = match p {
+            "en" | "eng" | "english" => "en",
+            "es" | "spa" | "spanish" => "es",
+            "fr" | "fra" | "fre" | "french" => "fr",
+            "de" | "ger" | "deu" | "german" => "de",
+            "it" | "ita" | "italian" => "it",
+            "pt" | "por" | "portuguese" => "pt",
+            "ru" | "rus" | "russian" => "ru",
+            "ja" | "jpn" | "japanese" => "ja",
+            "ko" | "kor" | "korean" => "ko",
+            "zh" | "chi" | "zho" | "chinese" => "zh",
+            _ => continue,
+        };
+        return code.to_string();
+    }
+    "und".to_string()
+}
+
+/// List `.srt` sidecars directly inside `dir`, sorted by filename so the order
+/// is stable across requests. `dir` is the entry's library directory; a file
+/// path (single-file entry) has no sidecars.
+pub fn list_sidecars(dir: &Path) -> Vec<PathBuf> {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+    let mut out: Vec<PathBuf> = rd
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(is_srt)
+                    .unwrap_or(false)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+pub fn tracks_for(dir: &Path) -> Vec<SubtitleTrack> {
+    list_sidecars(dir)
+        .into_iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            SubtitleTrack {
+                index,
+                label: format!("Subtitles {}", index + 1),
+                lang: guess_lang(&stem),
+            }
+        })
+        .collect()
+}
+
+/// Convert SubRip text to WebVTT. Only the timestamp line's `,` separators are
+/// rewritten to `.` — commas inside dialogue are left untouched. A leading BOM
+/// is stripped. Cue-index lines pass through (valid in WebVTT).
+pub fn srt_to_vtt(srt: &str) -> String {
+    let srt = srt.strip_prefix('\u{feff}').unwrap_or(srt);
+    let mut out = String::with_capacity(srt.len() + 16);
+    out.push_str("WEBVTT\n\n");
+    for line in srt.lines() {
+        if line.contains("-->") {
+            out.push_str(&line.replace(',', "."));
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn srt_to_vtt_rewrites_only_timestamp_commas() {
+        let srt = "1\n00:00:01,000 --> 00:00:04,500\nHello, world\n";
+        let vtt = srt_to_vtt(srt);
+        assert!(vtt.starts_with("WEBVTT\n\n"));
+        assert!(vtt.contains("00:00:01.000 --> 00:00:04.500"));
+        assert!(vtt.contains("Hello, world"), "dialogue comma preserved");
+    }
+
+    #[test]
+    fn srt_to_vtt_strips_bom() {
+        let vtt = srt_to_vtt("\u{feff}1\n00:00:00,000 --> 00:00:01,000\nhi\n");
+        assert!(vtt.starts_with("WEBVTT"));
+        assert!(!vtt.contains('\u{feff}'));
+    }
+
+    #[test]
+    fn guess_lang_reads_codes() {
+        assert_eq!(guess_lang("movie.en"), "en");
+        assert_eq!(guess_lang("movie.sub2.eng"), "en");
+        assert_eq!(guess_lang("movie.spanish"), "es");
+        assert_eq!(guess_lang("movie.sub0"), "und");
+    }
+
+    #[test]
+    fn list_and_tracks_sorted_srt_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        std::fs::write(d.join("m.sub1.srt"), b"x").unwrap();
+        std::fs::write(d.join("m.sub0.srt"), b"x").unwrap();
+        std::fs::write(d.join("m.mp4"), b"x").unwrap();
+        std::fs::write(d.join("poster.jpg"), b"x").unwrap();
+        let list = list_sidecars(d);
+        assert_eq!(list.len(), 2);
+        assert!(list[0].ends_with("m.sub0.srt"), "sorted");
+        let tracks = tracks_for(d);
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0].index, 0);
+        assert_eq!(tracks[0].label, "Subtitles 1");
+    }
+
+    #[test]
+    fn list_sidecars_missing_dir_is_empty() {
+        assert!(list_sidecars(Path::new("/no/such/dir/xyz")).is_empty());
+    }
+}


### PR DESCRIPTION
## Diagnosis (on the running pod)

Subtitles *do* work server-side during live streaming — the live HLS had 773/1465 WebVTT segments with cues, and completion produced real `.sub0.srt` (73 KB) + `.sub1.srt` (93 KB) sidecars. But the finished **`.reel.mp4` has no subtitle stream** (the transcode drops them), and the sidecars weren't wired to playback. So a **completed** reel plays with **zero subs** — that's the gap this fixes.

## Fix

- **subtitles module** — list `.srt` sidecars beside the entry (sorted, stable order), guess language from the filename, and convert **SubRip → WebVTT** on the fly. Only the timestamp line's commas are rewritten to dots — dialogue commas are preserved — and a leading BOM is stripped.
- **api** — `GET /torrents/{id}/subtitles` lists tracks (`{index, label, lang}`); `GET /torrents/{id}/subtitles/{n}` returns the converted WebVTT (`text/vtt`).
- **frontend** — fetch the list and attach `<track>` elements on playback; first one shows by default. The `<track>` element can't send headers, so the token rides the query string (the `reel_media_token` cookie from #14967 also covers it). Live HLS returns an empty list and keeps its in-stream rendition, so leeching entries are unaffected — no double subs.

## Notes

- Independent of the live-subtitle PR (#14956, the in-stream rendition) — this covers the **completed** path. Both can land.
- 157 tests pass, clippy clean. reel **0.1.27 → 0.1.28**.

[KBVE Code](https://kbve.com/)