### PR TITLE
chore(reel): bump CPU + encode threads for faster transcoding

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -56,7 +56,7 @@ spec:
             - { name: REEL_UPLOAD_LIMIT_BPS, value: "2097152" }
             - { name: RUST_LOG, value: "reel=debug,warn,librqbit::torrent_state::live=error" }
             - { name: REEL_LOG_JSON, value: "true" }
-            - { name: REEL_ENCODE_THREADS, value: "1" }
+            - { name: REEL_ENCODE_THREADS, value: "16" }
           envFrom:
             - secretRef: { name: reel-api }
           ports:
@@ -74,8 +74,8 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 6
           resources:
-            requests: { cpu: 100m, memory: 128Mi }
-            limits: { cpu: "2", memory: 2Gi }
+            requests: { cpu: "4", memory: 1Gi }
+            limits: { cpu: "16", memory: 8Gi }
           volumeMounts:
             - { name: data, mountPath: /data }
             - { name: gluetun-run, mountPath: /tmp/gluetun, readOnly: true }


### PR DESCRIPTION
## Why

Transcodes and live encodes were starved. The container had `cpu: request 100m / limit 2` and `REEL_ENCODE_THREADS=1`, so libx264 ran **single-threaded** and the pod had almost no guaranteed CPU. The node has **64 cores / ~566 Gi free**, so there's plenty of headroom to spend.

## Change (kube-only, no version bump)

- **resources**: requests `cpu 100m→4`, `memory 128Mi→1Gi`; limits `cpu 2→16`, `memory 2Gi→8Gi`.
- **`REEL_ENCODE_THREADS` 1 → 16** so libx264 actually uses the cores — much faster VOD transcode, and the live (popcorn) encode path keeps up with realtime far more easily (fewer buffering stalls on non-h264 sources).

Encode concurrency stays 1 (one job at a time, now with many threads). Applies on the next Argo sync via a normal rollout.

[Generated for KBVE Media](https://kbve.com/media/)