### PR TITLE
perf(reel): veryfast x264 preset for VOD transcode (0.1.29)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.30"
+version: "0.1.31"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -1126,7 +1126,7 @@ mod tests {
     }
 
     fn transcoder_with(store: StateStore) -> transcode::Transcoder {
-        transcode::Transcoder::new(store, 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1)
+        transcode::Transcoder::new(store, 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1, "veryfast".into())
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub remux_concurrency: usize,
     pub encode_concurrency: usize,
     pub encode_threads: usize,
+    pub encode_preset: String,
     pub ffmpeg_bin: String,
     pub ffprobe_bin: String,
     pub stream_enabled: bool,
@@ -187,6 +188,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         remux_concurrency: env_u64("REEL_REMUX_CONCURRENCY", 3)? as usize,
         encode_concurrency: env_u64("REEL_ENCODE_CONCURRENCY", 1)? as usize,
         encode_threads: env_u64("REEL_ENCODE_THREADS", 1)? as usize,
+        encode_preset: env_or("REEL_ENCODE_PRESET", "veryfast"),
         ffmpeg_bin: env_or("REEL_FFMPEG_BIN", "ffmpeg"),
         ffprobe_bin: env_or("REEL_FFPROBE_BIN", "ffprobe"),
         stream_enabled: env_bool("REEL_STREAM_ENABLED", true),
@@ -373,6 +375,7 @@ mod tests {
         assert_eq!(c.remux_concurrency, 3);
         assert_eq!(c.encode_concurrency, 1);
         assert_eq!(c.encode_threads, 1);
+        assert_eq!(c.encode_preset, "veryfast");
         assert_eq!(c.ffmpeg_bin, "ffmpeg");
         std::env::set_var("REEL_TRANSCODE_ENABLED", "false");
         std::env::set_var("REEL_ENCODE_CONCURRENCY", "2");

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -28,6 +28,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.ffprobe_bin.clone(),
         cfg.transcode_enabled,
         cfg.encode_threads,
+        cfg.encode_preset.clone(),
     );
 
     let hls = reel::hls::HlsManager::new(

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -324,11 +324,13 @@ pub struct Transcoder {
     ffprobe_bin: String,
     enabled: bool,
     encode_threads: usize,
+    encode_preset: String,
     children: Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::process::Child>>>,
     progress: Arc<std::sync::Mutex<std::collections::HashMap<String, TranscodeProgress>>>,
 }
 
 impl Transcoder {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         store: StateStore,
         remux_conc: usize,
@@ -337,6 +339,7 @@ impl Transcoder {
         ffprobe_bin: String,
         enabled: bool,
         encode_threads: usize,
+        encode_preset: String,
     ) -> Self {
         let this = Self {
             store,
@@ -346,6 +349,7 @@ impl Transcoder {
             ffprobe_bin,
             enabled,
             encode_threads,
+            encode_preset,
             children: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             progress: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         };
@@ -618,7 +622,7 @@ impl Transcoder {
                     let _permit = self.encode_sem.acquire().await?;
                     let threads = self.encode_threads.to_string();
                     let mut args: Vec<&str> = MAP_VIDEO_AUDIO.to_vec();
-                    args.extend_from_slice(&["-c:v", "libx264"]);
+                    args.extend_from_slice(&["-c:v", "libx264", "-preset", &self.encode_preset]);
                     if self.encode_threads > 0 {
                         args.push("-threads");
                         args.push(&threads);
@@ -1021,7 +1025,7 @@ mod transcoder_tests {
         store.upsert(meta("none", TranscodeStatus::None)).unwrap();
 
         let _transcoder =
-            Transcoder::new(store.clone(), 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1);
+            Transcoder::new(store.clone(), 1, 1, "ffmpeg".into(), "ffprobe".into(), true, 1, "veryfast".into());
 
         let pending = store.get("pending").unwrap();
         assert_eq!(pending.transcode, TranscodeStatus::Failed);


### PR DESCRIPTION
## Why it took hours

The completed-download **Encode route** (non-h264 sources — x265/HEVC, common in 1080p releases) ran `libx264` with **no `-preset`**, so it used the default **`medium`**. Combined with the old single-thread limit, re-encoding a full movie took hours. (h264 sources take the Remux route = `-c:v copy`, already fast — so this only bit non-h264.)

## Change

Set the preset on the VOD encode, configurable via **`REEL_ENCODE_PRESET`** (default **`veryfast`**). ~3–5× faster encode at negligible quality cost for an ephemeral streaming cache. The live (popcorn) path already used `veryfast`.

Stacks with the CPU/thread bump (#14974): 16 threads × veryfast turns an hours-long medium/1-thread encode into minutes for typical 1080p.

## Further levers (not in this PR)

- **`REEL_ENCODE_PRESET=ultrafast`** — even faster, larger files; flip via env if needed, no redeploy of code.
- **Downscale >1080p → 1080p** on the encode route — cuts 4K encode time a lot; worth adding as an option if 4K sources are common.
- **Reuse the completed live-HLS output** as the persistent deliverable instead of re-encoding to `.reel.mp4` — would eliminate the second full encode entirely for non-h264. Bigger refactor.
- **GPU/NVENC** — only if the node has an NVIDIA GPU (talos node here is CPU-only).

157 tests pass, clippy clean. reel **0.1.28 → 0.1.29**.
[Generated for KBVE Media](https://kbve.com/media/)