### PR TITLE
perf(reel): reuse completed live HLS, skip re-encode (0.1.30)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.28"
+version: "0.1.30"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -118,6 +118,15 @@ subtitle rendition alongside the video: ffmpeg produces a master playlist with a
 it `DEFAULT=YES`, and hls.js auto-enables it. The manifest served at
 `…/manifest.m3u8` rewrites child-playlist and segment references under `hls/` so
 they resolve against the segment route, while the child playlists are served raw.
+
+**Reusing the live stream.** If a live (popcorn) HLS job was watched to
+completion during the download, ffmpeg has already produced a full, playable HLS
+of the whole file — so on completion reel **adopts that HLS as the deliverable
+and skips the VOD re-encode entirely** (a huge win for non-h264 sources that
+would otherwise take hours). The completion watcher waits for the live job to
+finalize (`#EXT-X-ENDLIST`), relocates the directory, marks the entry Ready with
+its HLS, and drops the source video (keeping subtitles/poster). If no live job
+ran, or it didn't finish cleanly, the normal transcode runs as before.
 
 Once a download **completes**, its transcoded `.reel.mp4` no longer carries the
 subtitle streams, so the embedded text subs extracted to sidecar `.srt` files are

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -597,28 +597,73 @@ impl Engine {
                 delete_from_session(&session, &id, true).await;
                 return;
             }
+            // If a live (popcorn) HLS job was serving this download, let it
+            // finalize before we relocate the directory — a completed HLS can be
+            // reused as the deliverable instead of re-encoding the whole file.
+            let had_live = matches!(
+                store.get(&id).map(|m| m.hls),
+                Some(state::HlsStatus::Starting | state::HlsStatus::Live)
+            );
+            if had_live {
+                wait_hls_settle(&store, &id, LEECH_DRAIN_CAP).await;
+            }
             match mover::move_completed(&out_dir, &library_dir) {
                 Ok(moved) => {
                     let now = now_secs();
-                    let _ = store.upsert(state::Metadata {
-                        id: id.clone(),
-                        name,
-                        path: moved.dest.display().to_string(),
-                        size: moved.size,
-                        completed_at: Some(now),
-                        last_access: now,
-                        state: state::TorrentState::Seeding,
-                        error: None,
-                        active_path: None,
-                        transcode: state::TranscodeStatus::None,
-                        transcode_path: None,
-                        transcode_error: None,
-                        hls: state::HlsStatus::None,
-                        hls_dir: None,
-                        hls_error: None,
-                    });
                     crate::telemetry::torrent_completed(&id, moved.size);
-                    transcode_wake.notify_one();
+                    let hls_dir = moved.dest.join("hls");
+                    let adopt = had_live
+                        && matches!(
+                            store.get(&id).map(|m| m.hls),
+                            Some(state::HlsStatus::Ready)
+                        )
+                        && live_hls_complete(&hls_dir);
+                    if adopt {
+                        // Reuse the HLS produced during download; drop the source
+                        // video (HLS is the deliverable) but keep subtitles/poster.
+                        if let Ok(src) = crate::transcode::pick_primary_file(&moved.dest) {
+                            if let Err(e) = std::fs::remove_file(&src) {
+                                tracing::warn!(id = %id, path = %src.display(), error = %e, "adopt: source remove failed");
+                            }
+                        }
+                        let _ = store.upsert(state::Metadata {
+                            id: id.clone(),
+                            name,
+                            path: moved.dest.display().to_string(),
+                            size: moved.size,
+                            completed_at: Some(now),
+                            last_access: now,
+                            state: state::TorrentState::Seeding,
+                            error: None,
+                            active_path: None,
+                            transcode: state::TranscodeStatus::Ready,
+                            transcode_path: None,
+                            transcode_error: None,
+                            hls: state::HlsStatus::Ready,
+                            hls_dir: Some(hls_dir.display().to_string()),
+                            hls_error: None,
+                        });
+                        crate::telemetry::live_hls_adopted(&id, &hls_dir.display().to_string());
+                    } else {
+                        let _ = store.upsert(state::Metadata {
+                            id: id.clone(),
+                            name,
+                            path: moved.dest.display().to_string(),
+                            size: moved.size,
+                            completed_at: Some(now),
+                            last_access: now,
+                            state: state::TorrentState::Seeding,
+                            error: None,
+                            active_path: None,
+                            transcode: state::TranscodeStatus::None,
+                            transcode_path: None,
+                            transcode_error: None,
+                            hls: state::HlsStatus::None,
+                            hls_dir: None,
+                            hls_error: None,
+                        });
+                        transcode_wake.notify_one();
+                    }
                     wait_leech_drained(&active_leech, &drain, &id).await;
                     delete_from_session(&session, &id, false).await;
                 }
@@ -858,6 +903,49 @@ impl<R: AsyncSeek + Unpin> AsyncSeek for GuardedReader<R> {
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<u64>> {
         Pin::new(&mut self.inner).poll_complete(cx)
     }
+}
+
+/// Wait until a live HLS job leaves a transient state (Starting/Live), i.e. the
+/// ffmpeg process has exited and its output is stable, so the directory can be
+/// safely relocated. Bounded by `cap`.
+async fn wait_hls_settle(store: &state::StateStore, id: &str, cap: Duration) {
+    let step = Duration::from_secs(1);
+    let mut waited = Duration::ZERO;
+    loop {
+        match store.get(id).map(|m| m.hls) {
+            Some(state::HlsStatus::Starting) | Some(state::HlsStatus::Live) => {}
+            _ => return,
+        }
+        if waited >= cap {
+            tracing::warn!(id = %id, "live hls did not finalize before timeout; proceeding");
+            return;
+        }
+        tokio::time::sleep(step).await;
+        waited = waited.saturating_add(step);
+    }
+}
+
+/// A live HLS directory is complete when its manifest exists and at least one
+/// playlist carries `#EXT-X-ENDLIST` (ffmpeg finished writing it end to end).
+pub fn live_hls_complete(hls_dir: &std::path::Path) -> bool {
+    if !hls_dir.join("index.m3u8").exists() {
+        return false;
+    }
+    let rd = match std::fs::read_dir(hls_dir) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|x| x.to_str()) == Some("m3u8") {
+            if let Ok(s) = std::fs::read_to_string(&p) {
+                if s.contains("#EXT-X-ENDLIST") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 async fn wait_leech_drained(
@@ -1122,6 +1210,22 @@ mod tests {
         remove_entry_files(&src.display().to_string(), Some(&tc.display().to_string()));
         assert!(!src.exists());
         assert!(!tc.exists());
+    }
+
+    #[test]
+    fn live_hls_complete_requires_manifest_and_endlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = dir.path();
+        assert!(!live_hls_complete(h), "no manifest");
+        std::fs::write(h.join("index.m3u8"), b"#EXTM3U\nstream_0.m3u8\n").unwrap();
+        std::fs::write(h.join("stream_0.m3u8"), b"#EXTM3U\n#EXTINF:4,\nseg_0_00000.ts\n").unwrap();
+        assert!(!live_hls_complete(h), "no ENDLIST yet (still live)");
+        std::fs::write(
+            h.join("stream_0.m3u8"),
+            b"#EXTM3U\n#EXTINF:4,\nseg_0_00000.ts\n#EXT-X-ENDLIST\n",
+        )
+        .unwrap();
+        assert!(live_hls_complete(h), "manifest + ENDLIST -> complete");
     }
 
     #[test]

--- a/apps/media/reel/src/telemetry.rs
+++ b/apps/media/reel/src/telemetry.rs
@@ -52,6 +52,15 @@ pub fn transcode_ready(id: &str, path: &str) {
     tracing::info!(event = "transcode_ready", id, path, "transcode ready");
 }
 
+pub fn live_hls_adopted(id: &str, path: &str) {
+    tracing::info!(
+        event = "live_hls_adopted",
+        id,
+        path,
+        "reused completed live hls as deliverable; skipped re-encode"
+    );
+}
+
 pub fn transcode_failed(id: &str, reason: &str) {
     tracing::error!(event = "transcode_failed", id, reason, "transcode failed");
 }


### PR DESCRIPTION
## Idea

If you **watched the live (popcorn) stream during the download**, ffmpeg already transcoded the whole file into a complete HLS. Re-encoding it again to `.reel.mp4` on completion is pure double work — for a 4K/HEVC source that's the hours-long pass. This **adopts the finished live HLS as the deliverable and skips the VOD encode**.

## How

- **Completion watcher**: if a live HLS job was active (`Starting`/`Live`) when the download finished, wait for it to **finalize** (`wait_hls_settle` — polls until it leaves the transient state, so ffmpeg's output is stable) *before* relocating the directory. This avoids the mid-write move that would corrupt it.
- After the move, if the relocated `hls/` dir is **complete** (`index.m3u8` + a playlist with `#EXT-X-ENDLIST`) and the job ended `Ready`, **adopt**: mark `transcode=Ready` + `hls=Ready`, point `hls_dir` at the moved output, **drop the source video** (keep subtitles/poster), and don't wake the transcoder.
- **Fallback**: no live job, or it didn't finish cleanly → the normal transcode runs exactly as before. Any doubt defaults to re-encoding, so this can't leave an entry unplayable.
- `live_hls_adopted` telemetry event.

## Effect

- Non-h264 played during download → **completion is instant** (no re-encode), 4K quality preserved (no downscale).
- Single stored copy (source dropped; HLS kept). Delete still nukes the whole dir.
- h264 (already fast remux) and un-watched downloads are unchanged.

## Notes

- **Stacks after #14975** (veryfast preset) — this is `0.1.30`; resolve the one-line version conflict if merged out of order.
- 158 tests pass, clippy clean.

[KBVE Palworld](https://kbve.com/palworld/)