### PR TITLE
feat(palworld): live player positions on the map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ name = "agones-palworld-relay"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "axum 0.8.9",
  "chrono",
  "futures",
  "jedi",

--- a/apps/agones/palworld/relay/Cargo.toml
+++ b/apps/agones/palworld/relay/Cargo.toml
@@ -8,6 +8,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
+axum = { version = "0.8", default-features = false, features = [
+    "http1",
+    "json",
+    "tokio",
+] }
 thiserror = "2"
 tokio = { version = "1.0", features = [
     "macros",

--- a/apps/agones/palworld/relay/src/config.rs
+++ b/apps/agones/palworld/relay/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub agones_initial_ready_delay_secs: u64,
     pub poll_interval_secs: u64,
     pub chat_log_path: Option<String>,
+    pub live_api_port: u16,
 }
 
 impl Config {
@@ -61,6 +62,7 @@ impl Config {
             )?,
             poll_interval_secs: parse_env_u64("PALWORLD_POLL_INTERVAL_SECS", 10)?,
             chat_log_path: std::env::var("CHAT_LOG_PATH").ok(),
+            live_api_port: parse_env_u16("LIVE_API_PORT", 8300)?,
         })
     }
 }

--- a/apps/agones/palworld/relay/src/live_api.rs
+++ b/apps/agones/palworld/relay/src/live_api.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::{
+    Json, Router,
+    extract::State,
+    http::header,
+    response::IntoResponse,
+    routing::get,
+};
+use serde::Serialize;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::config::Config;
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct LivePlayer {
+    pub name: String,
+    pub level: i64,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct LiveSnapshot {
+    pub ts: i64,
+    pub fps: i64,
+    pub uptime_s: i64,
+    pub player_count: i64,
+    pub players: Vec<LivePlayer>,
+}
+
+pub type SharedLive = Arc<RwLock<LiveSnapshot>>;
+
+async fn players(State(live): State<SharedLive>) -> impl IntoResponse {
+    let snap = live.read().await.clone();
+    (
+        [
+            (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        Json(snap),
+    )
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+pub async fn run(cfg: Config, live: SharedLive) -> Result<()> {
+    let app = Router::new()
+        .route("/live/players", get(players))
+        .route("/live/healthz", get(healthz))
+        .with_state(live);
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", cfg.live_api_port)).await?;
+    info!(port = cfg.live_api_port, "live_api listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/apps/agones/palworld/relay/src/main.rs
+++ b/apps/agones/palworld/relay/src/main.rs
@@ -4,6 +4,7 @@ mod chat_tail;
 mod config;
 mod event;
 mod irc_bridge;
+mod live_api;
 mod poller;
 mod rcon_client;
 mod rcon_pool;
@@ -47,11 +48,14 @@ async fn main() -> Result<()> {
         Duration::from_secs(5),
     )?);
 
-    let poller_handle = tokio::spawn(poller::run(cfg.clone(), game_tx.clone()));
+    let live = live_api::SharedLive::default();
+
+    let poller_handle = tokio::spawn(poller::run(cfg.clone(), game_tx.clone(), live.clone()));
     let chat_handle = tokio::spawn(chat_tail::run(cfg.clone(), game_tx.clone()));
     let irc_handle = tokio::spawn(irc_bridge::run(cfg.clone(), game_tx.subscribe(), rest.clone()));
     let ch_handle = tokio::spawn(ch_writer::run(cfg.clone(), game_tx.subscribe()));
     let agones_handle = tokio::spawn(agones_health::run(cfg.clone()));
+    let live_handle = tokio::spawn(live_api::run(cfg.clone(), live));
 
     drop(game_tx);
 
@@ -61,6 +65,7 @@ async fn main() -> Result<()> {
         r = irc_handle => r??,
         r = ch_handle => r??,
         r = agones_handle => r??,
+        r = live_handle => r??,
         _ = tokio::signal::ctrl_c() => { info!("ctrl_c received, shutting down"); }
     }
     Ok(())

--- a/apps/agones/palworld/relay/src/poller.rs
+++ b/apps/agones/palworld/relay/src/poller.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 
 use crate::config::Config;
 use crate::event::{GameEvent, GameEventKind};
+use crate::live_api::{LivePlayer, LiveSnapshot, SharedLive};
 use crate::rest_client::RestClient;
 
 pub fn diff_players(prev: &HashSet<String>, curr: &HashSet<String>) -> (Vec<String>, Vec<String>) {
@@ -32,7 +33,7 @@ fn stats_event(kind: &str, fields: HashMap<String, String>) -> GameEvent {
     }
 }
 
-pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
+pub async fn run(cfg: Config, tx: Sender<GameEvent>, live: SharedLive) -> Result<()> {
     let client = RestClient::new(
         cfg.rest_addr.clone(),
         cfg.admin_password.clone(),
@@ -89,7 +90,7 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
         }
         prev = curr;
 
-        match client.metrics().await {
+        let metrics = match client.metrics().await {
             Ok(m) => {
                 let mut f = HashMap::new();
                 f.insert("players".into(), m.currentplayernum.to_string());
@@ -97,9 +98,31 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
                 f.insert("uptime".into(), m.serveruptime.to_string());
                 f.insert("frametime".into(), format!("{:.3}", m.serverframetime));
                 let _ = tx.send(stats_event("snapshot", f));
+                Some(m)
             }
-            Err(e) => warn!(error = %e, "poller: metrics fetch failed"),
-        }
+            Err(e) => {
+                warn!(error = %e, "poller: metrics fetch failed");
+                None
+            }
+        };
+
+        let snap = LiveSnapshot {
+            ts: chrono::Utc::now().timestamp_millis(),
+            fps: metrics.as_ref().map(|m| m.serverfps).unwrap_or(0),
+            uptime_s: metrics.as_ref().map(|m| m.serveruptime).unwrap_or(0),
+            player_count: players.players.len() as i64,
+            players: players
+                .players
+                .iter()
+                .map(|p| LivePlayer {
+                    name: p.name.clone(),
+                    level: p.level,
+                    x: p.location_x,
+                    y: p.location_y,
+                })
+                .collect(),
+        };
+        *live.write().await = snap;
     }
 }
 

--- a/apps/agones/palworld/relay/src/rest_client.rs
+++ b/apps/agones/palworld/relay/src/rest_client.rs
@@ -36,6 +36,10 @@ pub struct Player {
     pub ping: f64,
     #[serde(default)]
     pub level: i64,
+    #[serde(default)]
+    pub location_x: f64,
+    #[serde(default)]
+    pub location_y: f64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/apps/agones/palworld/relay/version.toml
+++ b/apps/agones/palworld/relay/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.7"
+version = "0.0.8"

--- a/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import {
 	KIND,
 	KIND_META,
+	RESPAWN_MINUTES,
 	Kind,
 	Pos,
 	createMarkerWorld,
@@ -11,18 +12,39 @@ import {
 	labels,
 	iconKeys,
 	gameToUnits,
+	syncPlayers,
+	lerpFrom,
+	lerpStart,
 	type KindName,
+	type LivePlayer,
 } from './markerEcs';
 
 const MAX_ZOOM = 8;
 const PAL_TILE_BASE = '/palworld/tiles';
 const PAL_MAX_NATIVE_ZOOM = 6;
 const WT_TILE_BASE = '/palworld/wt-overlay';
+const LIVE_URL_DEFAULT = 'https://palworld.kbve.com/live/players';
+const LIVE_POLL_MS = 5000;
+const LERP_MS = 4000;
+const TIMERS_KEY = 'palworld-map-timers';
+
+const KIND_NAMES = Object.keys(KIND) as KindName[];
 
 export function gameToLatLng(gx: number, gy: number): L.LatLngTuple {
 	const [x, yd] = gameToUnits(gx, gy);
 	return [-yd, x];
 }
+
+const loadTimers = (): Record<string, number> => {
+	try {
+		return JSON.parse(localStorage.getItem(TIMERS_KEY) || '{}');
+	} catch {
+		return {};
+	}
+};
+
+const timerKey = (eid: number): string =>
+	`${Kind.v[eid]}:${Pos.x[eid].toFixed(2)}:${Pos.yd[eid].toFixed(2)}`;
 
 export default function ReactPalworldMap() {
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -73,8 +95,10 @@ export default function ReactPalworldMap() {
 		}).addTo(map);
 
 		const world = createMarkerWorld();
-		const ents = markerEntities(world);
 		const visible = new Set<number>(Object.values(KIND));
+		const timers = loadTimers();
+		const saveTimers = () =>
+			localStorage.setItem(TIMERS_KEY, JSON.stringify(timers));
 		const images = new Map<string, HTMLImageElement>();
 		const loadImage = (src: string) => {
 			if (images.has(src)) return images.get(src)!;
@@ -130,7 +154,22 @@ export default function ReactPalworldMap() {
 			};
 		})();
 
+		const fmtRemain = (ms: number): string => {
+			const s = Math.max(0, Math.ceil(ms / 1000));
+			return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+		};
+
+		const entPos = (eid: number, now: number): [number, number] => {
+			if (Kind.v[eid] !== KIND.player) return [Pos.x[eid], Pos.yd[eid]];
+			const t = Math.min(1, (now - (lerpStart[eid] || 0)) / LERP_MS);
+			return [
+				lerpFrom.x[eid] + (Pos.x[eid] - lerpFrom.x[eid]) * t,
+				lerpFrom.yd[eid] + (Pos.yd[eid] - lerpFrom.yd[eid]) * t,
+			];
+		};
+
 		const drawList: number[] = [];
+		const drawPos = new Map<number, [number, number]>();
 		const draw = () => {
 			const dpr = window.devicePixelRatio || 1;
 			const w = el.clientWidth;
@@ -145,80 +184,168 @@ export default function ReactPalworldMap() {
 			ctx.clearRect(0, 0, w, h);
 			screenXY.refresh();
 			const zoom = map.getZoom();
+			const now = performance.now();
+			const wallNow = Date.now();
+			let animating = false;
 			drawList.length = 0;
-			for (const eid of ents) {
+			drawPos.clear();
+			for (const eid of markerEntities(world)) {
 				const kind = Kind.v[eid];
 				if (!visible.has(kind)) continue;
-				const meta = KIND_META[kindName(kind)];
+				const meta = KIND_META[KIND_NAMES[kind]];
 				if (zoom < meta.minZoom) continue;
-				const sx = screenXY.x(Pos.x[eid]);
-				const sy = screenXY.y(Pos.yd[eid]);
-				if (sx < -40 || sy < -40 || sx > w + 40 || sy > h + 40) continue;
+				const [ux, uy] = entPos(eid, now);
+				const sx = screenXY.x(ux);
+				const sy = screenXY.y(uy);
+				if (sx < -60 || sy < -60 || sx > w + 60 || sy > h + 60) continue;
 				drawList.push(eid);
+				drawPos.set(eid, [sx, sy]);
 				const size = meta.size;
+				if (kind === KIND.player) {
+					animating = true;
+					ctx.beginPath();
+					ctx.arc(sx, sy, size / 2, 0, Math.PI * 2);
+					ctx.fillStyle = '#4ade80';
+					ctx.fill();
+					ctx.strokeStyle = '#ffffff';
+					ctx.lineWidth = 2;
+					ctx.stroke();
+					if (zoom >= 3) {
+						ctx.font = '600 11px system-ui, sans-serif';
+						ctx.textAlign = 'center';
+						ctx.fillStyle = '#ffffff';
+						ctx.strokeStyle = 'rgba(0,0,0,0.75)';
+						ctx.lineWidth = 3;
+						const name = labels[eid].split(' · ')[0];
+						ctx.strokeText(name, sx, sy - size / 2 - 4);
+						ctx.fillText(name, sx, sy - size / 2 - 4);
+					}
+					continue;
+				}
 				const src = iconKeys[eid] || meta.icon;
 				const img = loadImage(src);
-				if (!img.complete || !img.naturalWidth) continue;
-				if (kind === KIND.boss) {
-					ctx.save();
-					ctx.beginPath();
-					ctx.arc(sx, sy, size / 2, 0, Math.PI * 2);
-					ctx.fillStyle = '#0b1420';
-					ctx.fill();
-					ctx.clip();
-					ctx.drawImage(
-						img,
-						sx - size / 2,
-						sy - size / 2,
-						size,
-						size,
-					);
-					ctx.restore();
-					ctx.beginPath();
-					ctx.arc(sx, sy, size / 2, 0, Math.PI * 2);
-					ctx.strokeStyle = 'rgba(255,255,255,0.4)';
-					ctx.lineWidth = 1.5;
-					ctx.stroke();
-				} else {
-					ctx.drawImage(
-						img,
-						sx - size / 2,
-						sy - size / 2,
-						size,
-						size,
-					);
+				if (img.complete && img.naturalWidth) {
+					if (kind === KIND.boss) {
+						ctx.save();
+						ctx.beginPath();
+						ctx.arc(sx, sy, size / 2, 0, Math.PI * 2);
+						ctx.fillStyle = '#0b1420';
+						ctx.fill();
+						ctx.clip();
+						ctx.drawImage(
+							img,
+							sx - size / 2,
+							sy - size / 2,
+							size,
+							size,
+						);
+						ctx.restore();
+						ctx.beginPath();
+						ctx.arc(sx, sy, size / 2, 0, Math.PI * 2);
+						ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+						ctx.lineWidth = 1.5;
+						ctx.stroke();
+					} else {
+						ctx.drawImage(
+							img,
+							sx - size / 2,
+							sy - size / 2,
+							size,
+							size,
+						);
+					}
+				}
+				const tk = timerKey(eid);
+				const deadline = timers[tk];
+				if (deadline) {
+					if (deadline <= wallNow) {
+						delete timers[tk];
+						saveTimers();
+					} else {
+						const txt = fmtRemain(deadline - wallNow);
+						ctx.font = '600 10px system-ui, sans-serif';
+						ctx.textAlign = 'center';
+						const tw = ctx.measureText(txt).width + 8;
+						ctx.fillStyle = 'rgba(8,14,24,0.85)';
+						ctx.beginPath();
+						ctx.roundRect(sx - tw / 2, sy + size / 2 + 2, tw, 14, 4);
+						ctx.fill();
+						ctx.fillStyle = '#fbbf24';
+						ctx.fillText(txt, sx, sy + size / 2 + 12.5);
+					}
 				}
 			}
+			if (animating) scheduleDraw();
 		};
 
-		const kindName = (k: number): KindName =>
-			(Object.keys(KIND) as KindName[])[k];
-
-		const onMouseMove = (ev: MouseEvent) => {
-			const rect = el.getBoundingClientRect();
-			const mx = ev.clientX - rect.left;
-			const my = ev.clientY - rect.top;
+		const nearest = (mx: number, my: number, radius: number): number => {
 			let best = -1;
-			let bestD = 18 * 18;
+			let bestD = radius * radius;
 			for (const eid of drawList) {
-				const dx = screenXY.x(Pos.x[eid]) - mx;
-				const dy = screenXY.y(Pos.yd[eid]) - my;
+				const p = drawPos.get(eid);
+				if (!p) continue;
+				const dx = p[0] - mx;
+				const dy = p[1] - my;
 				const d = dx * dx + dy * dy;
 				if (d < bestD) {
 					bestD = d;
 					best = eid;
 				}
 			}
+			return best;
+		};
+
+		const onMouseMove = (ev: MouseEvent) => {
+			const rect = el.getBoundingClientRect();
+			const best = nearest(
+				ev.clientX - rect.left,
+				ev.clientY - rect.top,
+				18,
+			);
 			if (best >= 0) {
-				tooltip.textContent = labels[best];
-				tooltip.style.left = `${screenXY.x(Pos.x[best])}px`;
-				tooltip.style.top = `${screenXY.y(Pos.yd[best])}px`;
+				const p = drawPos.get(best)!;
+				let text = labels[best];
+				const deadline = timers[timerKey(best)];
+				if (deadline && deadline > Date.now())
+					text += ` — respawn ${fmtRemain(deadline - Date.now())}`;
+				else if (RESPAWN_MINUTES[KIND_NAMES[Kind.v[best]]])
+					text += ' — click to start timer';
+				tooltip.textContent = text;
+				tooltip.style.left = `${p[0]}px`;
+				tooltip.style.top = `${p[1]}px`;
 				tooltip.style.display = 'block';
 			} else {
 				tooltip.style.display = 'none';
 			}
 		};
+		let downAt: [number, number] | null = null;
+		const onMouseDown = (ev: MouseEvent) => {
+			downAt = [ev.clientX, ev.clientY];
+		};
+		const onClick = (ev: MouseEvent) => {
+			if (
+				!downAt ||
+				Math.hypot(ev.clientX - downAt[0], ev.clientY - downAt[1]) > 5
+			)
+				return;
+			const rect = el.getBoundingClientRect();
+			const best = nearest(
+				ev.clientX - rect.left,
+				ev.clientY - rect.top,
+				18,
+			);
+			if (best < 0) return;
+			const mins = RESPAWN_MINUTES[KIND_NAMES[Kind.v[best]]];
+			if (!mins) return;
+			const tk = timerKey(best);
+			if (timers[tk]) delete timers[tk];
+			else timers[tk] = Date.now() + mins * 60_000;
+			saveTimers();
+			scheduleDraw();
+		};
 		el.addEventListener('mousemove', onMouseMove);
+		el.addEventListener('mousedown', onMouseDown);
+		el.addEventListener('click', onClick);
 		el.addEventListener('mouseleave', () => {
 			tooltip.style.display = 'none';
 		});
@@ -226,6 +353,11 @@ export default function ReactPalworldMap() {
 		map.on('move zoom zoomend viewreset resize', scheduleDraw);
 		scheduleDraw();
 
+		const timerTick = setInterval(() => {
+			if (Object.keys(timers).length) scheduleDraw();
+		}, 1000);
+
+		const countSpans = new Map<number, Text>();
 		const control = new L.Control({ position: 'topright' });
 		control.onAdd = () => {
 			const div = L.DomUtil.create('div', 'pal-map-filters');
@@ -234,12 +366,13 @@ export default function ReactPalworldMap() {
 				'border:1px solid rgba(255,255,255,0.15);font:12px/1.7 system-ui,sans-serif';
 			L.DomEvent.disableClickPropagation(div);
 			const counts = new Map<number, number>();
-			for (const eid of ents)
+			for (const eid of markerEntities(world))
 				counts.set(Kind.v[eid], (counts.get(Kind.v[eid]) || 0) + 1);
 			for (const [name, kind] of Object.entries(KIND)) {
 				const meta = KIND_META[name as KindName];
 				const row = document.createElement('label');
-				row.style.cssText = 'display:flex;gap:6px;align-items:center;cursor:pointer';
+				row.style.cssText =
+					'display:flex;gap:6px;align-items:center;cursor:pointer';
 				const cb = document.createElement('input');
 				cb.type = 'checkbox';
 				cb.checked = true;
@@ -248,19 +381,49 @@ export default function ReactPalworldMap() {
 					scheduleDraw();
 				};
 				row.appendChild(cb);
-				row.appendChild(
-					document.createTextNode(
-						`${meta.plural} (${counts.get(kind) || 0})`,
-					),
+				const txt = document.createTextNode(
+					`${meta.plural} (${counts.get(kind) || 0})`,
 				);
+				countSpans.set(kind, txt);
+				row.appendChild(txt);
 				div.appendChild(row);
 			}
 			return div;
 		};
 		control.addTo(map);
 
+		const liveUrl =
+			new URLSearchParams(window.location.search).get('live') ||
+			LIVE_URL_DEFAULT;
+		let stopped = false;
+		const poll = async () => {
+			try {
+				const res = await fetch(liveUrl, { cache: 'no-store' });
+				if (!res.ok) throw new Error(String(res.status));
+				const data = (await res.json()) as { players?: LivePlayer[] };
+				if (stopped) return;
+				syncPlayers(world, data.players || [], performance.now());
+				const span = countSpans.get(KIND.player);
+				if (span)
+					span.textContent = `Players (${data.players?.length || 0})`;
+				scheduleDraw();
+			} catch {
+				if (stopped) return;
+				syncPlayers(world, [], performance.now());
+				const span = countSpans.get(KIND.player);
+				if (span) span.textContent = 'Players (offline)';
+			}
+		};
+		poll();
+		const pollTimer = setInterval(poll, LIVE_POLL_MS);
+
 		return () => {
+			stopped = true;
+			clearInterval(pollTimer);
+			clearInterval(timerTick);
 			el.removeEventListener('mousemove', onMouseMove);
+			el.removeEventListener('mousedown', onMouseDown);
+			el.removeEventListener('click', onClick);
 			map.remove();
 			canvas.remove();
 			tooltip.remove();

--- a/apps/kbve/astro-kbve/src/components/palworld/map/markerEcs.ts
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/markerEcs.ts
@@ -1,4 +1,10 @@
-import { createWorld, addEntity, addComponent, query } from 'bitecs';
+import {
+	createWorld,
+	addEntity,
+	removeEntity,
+	addComponent,
+	query,
+} from 'bitecs';
 import pois from './pois.json';
 
 const MAIN_X0 = -1099400;
@@ -20,6 +26,7 @@ export const KIND = {
 	effigy: 5,
 	egg: 6,
 	boss: 7,
+	player: 8,
 } as const;
 
 export type KindName = keyof typeof KIND;
@@ -71,6 +78,12 @@ export const KIND_META: Record<
 		minZoom: 4,
 	},
 	boss: { label: 'Alpha Boss', plural: 'Alpha Bosses', icon: '', size: 34, minZoom: 2 },
+	player: { label: 'Player', plural: 'Players', icon: '', size: 14, minZoom: 0 },
+};
+
+export const RESPAWN_MINUTES: Partial<Record<KindName, number>> = {
+	boss: 60,
+	dungeon: 60,
 };
 
 export const Pos = { x: [] as number[], yd: [] as number[] };
@@ -133,4 +146,53 @@ export type MarkerWorld = ReturnType<typeof createMarkerWorld>;
 
 export function markerEntities(world: MarkerWorld): readonly number[] {
 	return query(world, [Marker, Pos, Kind]);
+}
+
+export interface LivePlayer {
+	name: string;
+	level: number;
+	x: number;
+	y: number;
+}
+
+export const lerpFrom = { x: [] as number[], yd: [] as number[] };
+export const lerpStart: number[] = [];
+const playerEids = new Map<string, number>();
+
+export function syncPlayers(
+	world: MarkerWorld,
+	players: LivePlayer[],
+	now: number,
+): void {
+	const seen = new Set<string>();
+	for (const p of players) {
+		seen.add(p.name);
+		const [x, yd] = gameToUnits(p.x, p.y);
+		let eid = playerEids.get(p.name);
+		if (eid === undefined) {
+			eid = addEntity(world);
+			addComponent(world, eid, Marker);
+			addComponent(world, eid, Pos);
+			addComponent(world, eid, Kind);
+			Kind.v[eid] = KIND.player;
+			Pos.x[eid] = x;
+			Pos.yd[eid] = yd;
+			lerpFrom.x[eid] = x;
+			lerpFrom.yd[eid] = yd;
+			playerEids.set(p.name, eid);
+		} else {
+			lerpFrom.x[eid] = Pos.x[eid];
+			lerpFrom.yd[eid] = Pos.yd[eid];
+		}
+		Pos.x[eid] = x;
+		Pos.yd[eid] = yd;
+		lerpStart[eid] = now;
+		labels[eid] = `${p.name} · Lv ${p.level}`;
+	}
+	for (const [name, eid] of playerEids) {
+		if (!seen.has(name)) {
+			removeEntity(world, eid);
+			playerEids.delete(name);
+		}
+	}
 }

--- a/apps/kube/agones/palworld/manifests/gameserver.yaml
+++ b/apps/kube/agones/palworld/manifests/gameserver.yaml
@@ -161,8 +161,11 @@ spec:
                               command:
                                   - /usr/local/bin/agones-shim-prestop
                 - name: palworld-relay
-                  image: ghcr.io/kbve/agones-palworld-relay:0.0.7
+                  image: ghcr.io/kbve/agones-palworld-relay:0.0.8
                   imagePullPolicy: IfNotPresent
+                  ports:
+                      - containerPort: 8300
+                        protocol: TCP
                   env:
                       - name: PALWORLD_REST_ADDR
                         value: 'http://127.0.0.1:8212'
@@ -217,6 +220,8 @@ spec:
                         value: 'info,agones_palworld_relay=debug'
                       - name: CHAT_LOG_PATH
                         value: /shared/chat/chat.log
+                      - name: LIVE_API_PORT
+                        value: '8300'
                   volumeMounts:
                       - name: chat-relay
                         mountPath: /shared/chat

--- a/apps/kube/agones/palworld/manifests/live-httproute.yaml
+++ b/apps/kube/agones/palworld/manifests/live-httproute.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: palworld-live-route
+    namespace: palworld
+    labels:
+        app.kubernetes.io/part-of: palworld
+spec:
+    # parentRefs/backendRefs carry the API-server default group/kind (+ backendRef
+    # weight) EXPLICITLY — the Gateway API defaults them on the live object, so
+    # omitting them makes ArgoCD diff git-vs-live forever (perpetual OutOfSync).
+    # Mirrors the synced arpg-game-route manifest.
+    parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - palworld.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /live
+          backendRefs:
+              - group: ''
+                kind: Service
+                name: palworld-relay-live
+                port: 8300
+                weight: 1

--- a/apps/kube/agones/palworld/manifests/live-service.yaml
+++ b/apps/kube/agones/palworld/manifests/live-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: palworld-relay-live
+    namespace: palworld
+    labels:
+        app: palworld
+        app.kubernetes.io/part-of: palworld
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        app: palworld
+    ports:
+        - name: live
+          port: 8300
+          targetPort: 8300
+          protocol: TCP


### PR DESCRIPTION
## What

Hooks the palworld server up to `/palworld/map/` for live data.

### Relay (`agones-palworld-relay` 0.0.7 → 0.0.8)
- `Player` now captures `location_x/y` from the REST poll
- New `live_api` task: `GET /live/players` (axum, port 8300) serving the latest poll snapshot — name, level, x, y only (no IPs/IDs), `Access-Control-Allow-Origin: *`, `no-store`
- Poller writes the shared snapshot each tick; existing event/IRC/CH paths untouched

### Kube
- `palworld-relay-live` ClusterIP Service :8300
- HTTPRoute `palworld.kbve.com/live/*` → relay via kbve-gateway (covered by the `*.kbve.com` wildcard listener — no new cert)
- GameServer: relay image 0.0.8, container port 8300, `LIVE_API_PORT` env

### Map
- Polls `/live/players` every 5s (`?live=` query param overrides for local testing)
- Players are dynamic bitecs entities: green dot + name label, positions lerp between polls, joins/leaves add/remove entities; "Players (n)" live count in the filter control, "offline" fallback
- Boss + dungeon markers: click starts a respawn countdown (60m default), badge on marker + remaining time in tooltip, persisted in localStorage, click again to clear — server data for these isn't exposed by Palworld's REST API, so timers are manual

## Verification

- Relay: 25 tests pass; end-to-end smoke against a mock Palworld REST server — endpoint returns correct snapshot with CORS headers
- Map: playwright against local relay — player dot renders at the right world position with live count; site build green

## Notes

- Boss/dungeon *server-side* timers aren't possible without save-file parsing; revisit if we want authoritative respawns