### PR TITLE
fix(dashboard): put Orders + Inventory in the gutter rail and breadcrumb

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/DashboardGutterNav.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/DashboardGutterNav.astro
@@ -205,6 +205,8 @@ const groupHasActive = (items: { href: string }[]) =>
 
 	:global(html[data-auth-tone='staff'])
 		.facet-group[data-auth-visibility='staff'],
+	:global(html[data-auth-tone='staff'])
+		.facet-group[data-auth-visibility='auth'],
 	:global(html[data-auth-tone='auth'])
 		.facet-group[data-auth-visibility='auth'] {
 		display: block;

--- a/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.test.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { DASHBOARD_NAV, buildBreadcrumb, flatItems } from './dashboardNav';
+
+describe('dashboardNav', () => {
+	it('resolves a breadcrumb past the root for every navigable page', () => {
+		// The gutter rail and the breadcrumb both read DASHBOARD_NAV, so a page
+		// that ships without an entry here renders a lone "Dashboard" crumb and
+		// no rail row — which is how /dashboard/orders/ and /dashboard/inventory/
+		// went live unnavigable.
+		for (const item of flatItems()) {
+			const crumbs = buildBreadcrumb(item.href);
+			if (item.href === '/dashboard/') {
+				expect(crumbs).toHaveLength(1);
+				continue;
+			}
+			expect(
+				crumbs.length,
+				`${item.href} resolved only to ${crumbs.map((c) => c.label).join(' / ')}`,
+			).toBeGreaterThan(1);
+			expect(crumbs[crumbs.length - 1]).toMatchObject({
+				label: item.label,
+				href: item.href,
+			});
+		}
+	});
+
+	it('places the store pages under their own group', () => {
+		expect(buildBreadcrumb('/dashboard/orders/').map((c) => c.label)).toEqual([
+			'Dashboard',
+			'Store',
+			'Orders',
+		]);
+		expect(
+			buildBreadcrumb('/dashboard/inventory/').map((c) => c.label),
+		).toEqual(['Dashboard', 'Store', 'Inventory']);
+	});
+
+	it('gates the store group behind auth rather than staff', () => {
+		const store = DASHBOARD_NAV.find(
+			(e) => 'items' in e && e.label === 'Store',
+		);
+		expect(store).toBeDefined();
+		expect(store && 'visibility' in store && store.visibility).toBe('auth');
+	});
+
+	it('has no duplicate hrefs across groups', () => {
+		const hrefs = flatItems().map((i) => i.href);
+		expect(new Set(hrefs).size).toBe(hrefs.length);
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
@@ -109,6 +109,23 @@ export const DASHBOARD_NAV: DashboardNavEntry[] = [
 		],
 	},
 	{
+		label: 'Store',
+		visibility: 'auth',
+		href: '/store/',
+		items: [
+			{
+				label: 'Orders',
+				href: '/dashboard/orders/',
+				icon: 'M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4zM3 6h18M16 10a4 4 0 0 1-8 0',
+			},
+			{
+				label: 'Inventory',
+				href: '/dashboard/inventory/',
+				icon: 'M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16zM3.27 6.96 12 12.01l8.73-5.05M12 22.08V12',
+			},
+		],
+	},
+	{
 		label: 'Insights',
 		visibility: 'staff',
 		eyebrow: 'Daily',


### PR DESCRIPTION
`/dashboard/orders/` and `/dashboard/inventory/` went live in #14921 reachable only by typing the URL.

Confirmed on production before touching anything:

- the gutter rail lists **24** dashboard pages, neither of them among it
- the visible breadcrumb renders a lone `Dashboard` with no trail to the current page (the JSON-LD breadcrumb was correct, which is why it looked fine to crawlers)

## Cause

Two nav sources, and #14921 only updated one:

| file | drives |
| --- | --- |
| `components/navigation/dashboardMenu.ts` | header dropdown (React) |
| `components/dashboard/dashboardNav.ts` | **gutter rail + breadcrumbs** |

`DashboardGutterNav` iterates `DASHBOARD_NAV`, and `buildBreadcrumb` resolves against that same array through `findActiveIn`. A page absent from it gets no rail row **and** no crumb past the root — one omission, two broken surfaces.

## Changes

1. **`dashboardNav.ts`** — a `Store` group holding Orders and Inventory, `visibility: 'auth'` rather than `'staff'`, since any signed-in buyer needs them.

2. **`DashboardGutterNav.astro`** — latent gating bug the new group would have tripped. The scoped CSS reveals `.facet-group[data-auth-visibility='auth']` only under `html[data-auth-tone='auth']`, with no `tone='staff'` rule. `global.css` grants staff the auth-visible `a`/`details`/`li`, so staff saw auth-gated *links* but would not have seen this auth-gated *group* — and only when `collapsible=false`, where the group renders as a `div` rather than a `details` and the global rules don't apply. Staff are authenticated; the rail now matches `global.css`.

3. **`dashboardNav.test.ts`** — asserts every navigable page resolves a breadcrumb past the root, so the next page that ships without a nav entry fails CI instead of shipping unnavigable.

## Verification

Negative-tested the new test by deleting the Store group:

```
AssertionError: expected [ 'Dashboard' ] to deeply equal [ 'Dashboard', 'Store', 'Orders' ]
```

That is precisely the symptom observed live. Restored, green.

- 327 tests pass (39 files) in the worktree
- `astro check`: 22 errors, all pre-existing recharts typing in Grafana/Kanban panels, none in the files touched here

No API or SQL changes — presentation only.