### PR TITLE
chore(palworld): bump relay to 0.0.8 via mdx for image publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_palworld_relay
 pipeline: docker
 app_name: agones-palworld-relay
-version: "0.0.7"
+version: "0.0.8"
 source_path: apps/agones/palworld/relay
 version_toml: apps/agones/palworld/relay/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
Releases `agones-palworld-relay` 0.0.8 (live `/live/players` endpoint from #14997) through the MDX-driven dispatch pipeline — the previous PR bumped `version.toml` directly, which the dispatch manifest ignores, so ghcr never got 0.0.8 and the GameServer's new image pin can't pull (palworld.kbve.com 521s until this lands and the pod rolls).