### PR TITLE
fix(ci): reset palworld manifest versions to published images

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -44,7 +44,7 @@
 		{
 			"key": "agones_palworld",
 			"app_name": "agones-palworld",
-			"version": "0.0.31",
+			"version": "0.0.30",
 			"version_toml": "apps/agones/palworld/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx",
 			"source_path": "apps/agones/palworld",
@@ -57,7 +57,7 @@
 		{
 			"key": "agones_palworld_relay",
 			"app_name": "agones-palworld-relay",
-			"version": "0.0.10",
+			"version": "0.0.9",
 			"version_toml": "apps/agones/palworld/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx",
 			"source_path": "apps/agones/palworld/relay",


### PR DESCRIPTION
Palworld gameserver is in ImagePullBackOff on `agones-palworld:0.0.31` / `agones-palworld-relay:0.0.10` — neither tag exists in ghcr. The `#15010` manifest sync bumped the manifest to those versions **without a publish having run**, so ci-docker's version gate reports "matches version.toml — publish will be skipped" on every dispatch (manual included). Classic manifest-version deadlock (same class as the June unity_rareicon incident, PR #12163).

Resets the two docker entries to the actually-published 0.0.30 / 0.0.9 so the next dispatch sees the version lag and builds for real. After merge to main, the queued kubelet backoff resolves itself once tags appear.

Durable fix note: the `read_source_version()` swap from #12164 covers game engines only — the docker path still trusts the manifest `.version` and stays vulnerable to a sync commit racing a publish.