### PR TITLE
fix(auth): accept ES256 Supabase tokens in irc-gateway and memes

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -44,7 +44,7 @@
 		{
 			"key": "agones_palworld",
 			"app_name": "agones-palworld",
-			"version": "0.0.30",
+			"version": "0.0.32",
 			"version_toml": "apps/agones/palworld/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx",
 			"source_path": "apps/agones/palworld",
@@ -57,7 +57,7 @@
 		{
 			"key": "agones_palworld_relay",
 			"app_name": "agones-palworld-relay",
-			"version": "0.0.9",
+			"version": "0.0.11",
 			"version_toml": "apps/agones/palworld/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx",
 			"source_path": "apps/agones/palworld/relay",
@@ -345,7 +345,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.28",
+			"version": "0.1.29",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -493,7 +493,7 @@
 		{
 			"key": "memes",
 			"app_name": "memes",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/memes/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/memes.mdx",
 			"version_target": "apps/memes/axum-memes/Cargo.toml",

--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 pub const SUPABASE_AUDIENCE: &str = "authenticated";
 pub const MAX_NICK_LEN: usize = 16;
@@ -100,9 +101,56 @@ pub fn extract_token(req: &Request) -> Option<String> {
         })
 }
 
-/// Validate JWT and return claims
+/// Process-wide accept-both verifier (HS256 + ES256/JWKS); `None` when no JWKS URI is configured.
+fn shared_verifier() -> Option<&'static jedi::jwks::JwtVerifier> {
+    static VERIFIER: OnceLock<Option<jedi::jwks::JwtVerifier>> = OnceLock::new();
+    VERIFIER
+        .get_or_init(|| {
+            let jwks_uri = std::env::var("SUPABASE_JWKS_URI")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .or_else(|| {
+                    std::env::var("SUPABASE_URL").ok().and_then(|u| {
+                        let u = u.trim().trim_end_matches('/');
+                        (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+                    })
+                })?;
+            let secret = hs256_secret();
+            let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                .ok()
+                .filter(|s| !s.trim().is_empty());
+            let verifier = jedi::jwks::JwtVerifier::new(
+                jwks_uri,
+                secret.as_deref().map(str::as_bytes),
+                issuer,
+                Some(SUPABASE_AUDIENCE.to_string()),
+            );
+            let bg = verifier.clone();
+            tokio::spawn(async move {
+                bg.start(std::time::Duration::from_secs(300)).await;
+            });
+            Some(verifier)
+        })
+        .as_ref()
+}
+
+fn hs256_secret() -> Option<String> {
+    std::env::var("JWT_SECRET")
+        .ok()
+        .or_else(|| std::env::var("SUPABASE_JWT_SECRET").ok())
+        .filter(|s| !s.is_empty())
+}
+
+/// Validate a Supabase JWT (HS256 shared secret or ES256 via GoTrue JWKS) and return claims.
 pub fn validate_token(token: &str) -> Result<Claims, StatusCode> {
-    let secret = std::env::var("JWT_SECRET").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if let Some(verifier) = shared_verifier() {
+        return verifier.verify::<Claims>(token).map_err(|e| {
+            tracing::debug!(error = %e, "jwt rejected");
+            StatusCode::UNAUTHORIZED
+        });
+    }
+
+    let secret = hs256_secret().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut validation = Validation::new(Algorithm::HS256);
     validation.set_required_spec_claims(&["sub", "exp", "iat", "aud"]);

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -11,7 +11,7 @@ tags:
 key: irc_gateway
 pipeline: docker
 app_name: irc-gateway
-version: "0.1.28"
+version: "0.1.29"
 source_path: apps/irc
 version_toml: apps/irc/version.toml
 version_target: apps/irc/irc-gateway/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
@@ -11,7 +11,7 @@ tags:
 key: memes
 pipeline: docker
 app_name: memes
-version: "0.1.8"
+version: "0.1.9"
 source_path: apps/memes
 version_toml: apps/memes/version.toml
 version_target: apps/memes/axum-memes/Cargo.toml

--- a/apps/kube/irc/manifests/irc-gateway-deployment.yaml
+++ b/apps/kube/irc/manifests/irc-gateway-deployment.yaml
@@ -48,6 +48,11 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: jwt-secret
+                      - name: SUPABASE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: SUPABASE_URL
                       - name: KBVE_KV_URL
                         valueFrom:
                             secretKeyRef:

--- a/apps/memes/axum-memes/src/meme/auth.rs
+++ b/apps/memes/axum-memes/src/meme/auth.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 /// Supabase JWT claims — only the fields we need.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -24,14 +25,50 @@ pub struct AuthUser {
     pub user_id: String,
 }
 
-/// Decode a Supabase JWT using the JWT secret.
-/// Returns the claims if valid, or an error string.
+/// Process-wide accept-both verifier (HS256 + ES256/JWKS); `None` when no JWKS URI is configured.
+fn shared_verifier() -> Option<&'static jedi::jwks::JwtVerifier> {
+    static VERIFIER: OnceLock<Option<jedi::jwks::JwtVerifier>> = OnceLock::new();
+    VERIFIER
+        .get_or_init(|| {
+            let jwks_uri = std::env::var("SUPABASE_JWKS_URI")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .or_else(|| {
+                    std::env::var("SUPABASE_URL").ok().and_then(|u| {
+                        let u = u.trim().trim_end_matches('/');
+                        (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+                    })
+                })?;
+            let secret = std::env::var("SUPABASE_JWT_SECRET")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                .ok()
+                .filter(|s| !s.trim().is_empty());
+            let verifier = jedi::jwks::JwtVerifier::new(
+                jwks_uri,
+                secret.as_deref().map(str::as_bytes),
+                issuer,
+                Some("authenticated".to_string()),
+            );
+            let bg = verifier.clone();
+            tokio::spawn(async move {
+                bg.start(std::time::Duration::from_secs(300)).await;
+            });
+            Some(verifier)
+        })
+        .as_ref()
+}
+
+/// Decode a Supabase JWT (HS256 shared secret or ES256 via GoTrue JWKS).
 fn decode_supabase_jwt(token: &str, secret: &str) -> Result<Claims, String> {
+    if let Some(verifier) = shared_verifier() {
+        return verifier.verify::<Claims>(token).map_err(|e| e.to_string());
+    }
+
     let key = DecodingKey::from_secret(secret.as_bytes());
     let mut validation = Validation::new(Algorithm::HS256);
-    // Supabase JWTs use "authenticated" as the audience
     validation.set_audience(&["authenticated"]);
-    // Allow some clock skew
     validation.leeway = 30;
 
     let token_data = decode::<Claims>(token, &key, &validation)
@@ -44,10 +81,10 @@ fn decode_supabase_jwt(token: &str, secret: &str) -> Result<Claims, String> {
 /// If valid, inserts `AuthUser` as a request extension.
 /// If missing or invalid, the request proceeds without `AuthUser` (anonymous).
 pub async fn optional_auth(mut request: Request, next: Next) -> Response {
-    let secret = match std::env::var("SUPABASE_JWT_SECRET") {
-        Ok(s) => s,
-        Err(_) => return next.run(request).await,
-    };
+    let secret = std::env::var("SUPABASE_JWT_SECRET").unwrap_or_default();
+    if secret.is_empty() && shared_verifier().is_none() {
+        return next.run(request).await;
+    }
 
     if let Some(auth_header) = request.headers().get("authorization") {
         if let Ok(header_str) = auth_header.to_str() {


### PR DESCRIPTION
## Problem

`wss://chat.kbve.com/gamechat` returns **401 for every user**. Realm chat is down for arpg, cryptothrone and the Minecraft bridge.

Supabase GoTrue now signs session JWTs with **ES256**:

```
header: {"alg":"ES256","kid":"36b2959c-450e-4cc9-b609-73a6dbcaf1ef","typ":"JWT"}
```

and publishes that key at `https://supabase.kbve.com/auth/v1/.well-known/jwks.json`.

`irc-gateway` verified **HS256-only** against the shared secret:

```rust
let mut validation = Validation::new(Algorithm::HS256);
decode::<Claims>(token, &DecodingKey::from_secret(secret.as_bytes()), &validation)
```

so no ES256 token can ever verify. Reproduced live with a valid, unexpired token (iat 09:21, exp +24h):

```
GET /gamechat?game=arpg&token=<valid ES256> -> HTTP/1.1 401 Unauthorized
```

Gateway logs show the browser retry loop hitting 401 every ~15s.

## Fix

Route verification through `jedi::jwks::JwtVerifier` — the accept-both (HS256 + ES256/JWKS) path already used by `arpg-server`, `jobboard`, `rows` and `axum-kbve`. Built once per process from `SUPABASE_JWKS_URI` (or derived from `SUPABASE_URL`), refreshing the key set every 5 minutes.

When no JWKS URI is configured the previous HS256-only decode still runs, so dev and the existing tests are unchanged.

`irc-gateway` also gains `SUPABASE_URL` in its deployment manifest — without it the verifier has no JWKS URI and the service stays HS256-only.

`axum-memes` was the only other remaining HS256-only Supabase verifier; it is migrated the same way. It previously skipped auth entirely when `SUPABASE_JWT_SECRET` was unset, and now proceeds whenever either the secret or the JWKS verifier is available.

## Note on the manifest diff

`.github/ci-dispatch-manifest.json` was regenerated in full (per the no-surgical-edit rule), so it also picks up the pending `palworld` 0.0.30 -> 0.0.32 and `palworld-relay` 0.0.9 -> 0.0.11 bumps that had not been synced yet.

## Verification

- `./kbve.sh -nx irc-gateway:test` — 55 passed, 0 failed
- `./kbve.sh -nx axum-memes:build` — clean
- `./kbve.sh -nx astro-kbve:build` then `astro-kbve:sync:ci-manifest`

## Not in scope

The ARPG boot overlay stall (`This is taking longer than it should`) is a **separate** issue — `ChatPanel` is independent of the scene boot path, and `arpg-server` logged successful joins (`player joined slot=0 username=h0lybyte`) at the same timestamps. That one is still being traced.

Docs: [apps/kube/irc/manifests/irc-gateway-deployment.yaml](apps/kube/irc/manifests/irc-gateway-deployment.yaml)