### PR TITLE
fix(arpg): restore the client floor on join so a non-zero-z spawn can boot

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -112,7 +112,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.27",
+			"version": "0.1.28",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -125,7 +125,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.27",
+			"version": "0.1.28",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -1572,6 +1572,17 @@ export class IsoArpgScene extends Phaser.Scene {
 		// client renders its own floor and ignores the rest. Entities that left
 		// our floor fall out of the filtered set and despawn via applyEntitySync.
 		// Reuse scratch array to reduce GC churn (10-20 snapshots/sec).
+		if (this.myEid < 0) {
+			const mine = s.entities.find(
+				(e) =>
+					e.owner === this.mySlot &&
+					this.syncResolvers.cat(e.kind) === Cat.Player,
+			);
+			const mineZ = mine?.z ?? 0;
+			if (mine && mineZ !== this.currentFloor) {
+				this.onFloorChange({ z: mineZ, tile: mine.tile });
+			}
+		}
 		this.floorFilterScratch.length = 0;
 		for (const e of s.entities) {
 			if ((e.z ?? 0) === this.currentFloor) {

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_server
 pipeline: docker
 app_name: arpg-server
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/agones/arpg/server
 version_toml: apps/agones/arpg/server/version.toml
 # Pre-build sync: CI writes this MDX `version` into version_target (Cargo.toml →

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_web
 pipeline: docker
 app_name: arpg-web
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/agones/arpg
 version_toml: apps/agones/arpg/web/version.toml
 version_source: apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -1853,6 +1853,16 @@ fn sync_roster(
             .id();
         if let Some(f) = spawn_floor {
             commands.entity(entity).insert(Floor(f));
+            let event = proto::FloorChangeEvent {
+                z: f,
+                tile: spawn_tile,
+            };
+            let payload = proto::encode_inner(&event).unwrap_or_default();
+            let _ = bcast.tx.send(ServerEvent::Ephemeral {
+                kind: proto::EPHEMERAL_FLOOR,
+                to: *slot,
+                payload,
+            });
         }
         if was_in_space {
             commands.entity(entity).insert(ReturnedFromInstance);


### PR DESCRIPTION
## Problem

`https://arpg.kbve.com` hangs on the boot overlay — "Entering the dungeon", then after 12s the watchdog surfaces **"This is taking longer than it should / The server may be down or your session may be stale."** Retry does not help.

The server is healthy and the join succeeds:

```
09:20:40 INFO simgrid::net: player joined slot=0 username=h0lybyte ulid=7JNZ...
09:21:07 INFO simgrid::net: player joined slot=0 username=h0lybyte ulid=7JNZ...
```

(the second line is the user pressing Retry). Auth passes, protocol matches, no server errors.

## Root cause

`sync_roster` restores the persisted floor onto the respawned player:

```rust
if let Some(f) = spawn_floor {
    commands.entity(entity).insert(Floor(f));
}
```

but `FloorChangeEvent` / `EPHEMERAL_FLOOR` is emitted **only** by `stair_system`, on an actual stair transition. Nothing sends it on join.

The client starts at `currentFloor = 0` and filters the snapshot before handing it to `applyEntitySync`:

```ts
for (const e of s.entities) {
    if ((e.z ?? 0) === this.currentFloor) this.floorFilterScratch.push(e);
}
```

`applyEntitySync` is where `myEid` gets discovered (`cat === CAT_PLAYER && e.owner === state.mySlot`). If we were restored onto z != 0, our own entity never reaches it, `myEid` stays `-1`, and `emitBoot({ phase: 'ready' })` — which only fires on the first `myEid` resolution — never runs.

So: **log out on any dungeon floor, and you can never log back in.** Ground-floor players are unaffected, which is why this looked intermittent.

## Fix

**Server** (`simgrid`): emit `EPHEMERAL_FLOOR` to the joining slot whenever a spawn floor is restored, so the client re-streams the correct floor immediately.

**Client** (`IsoArpgScene`): while `myEid` is unresolved, adopt the z of our own player entity from the raw snapshot before the floor filter runs. This self-heals against any server that does not send the event — including one mid-rollout — so the fix does not depend on deploy ordering.

## Verification

- `./kbve.sh -nx simgrid:test` — 204 + 1 + 5 passed, 0 failed
- `./kbve.sh -nx arpg-web:test` — 35 passed, 0 failed
- `./kbve.sh -nx arpg-web:build` — clean
- `astro-kbve:build` then `sync:ci-manifest`

## Note

`cryptothrone` shares `simgrid` and picks up the server half on its next release; no version bump for it here.

Follow-up to #15024 (the chat 401s seen alongside this were a separate ES256 verification bug).