### PR TITLE
fix(reel): serve completed reels over HLS, not raw progressive

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.31"
+version: "0.1.32"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -405,13 +405,16 @@ async fn manifest(
             d
         }
     };
-    if delivery == transcode::Delivery::RawProgressive {
-        return (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({"delivery": "raw_progressive"})),
-        )
-            .into_response();
-    }
+    // A "raw progressive" source (h264 + aac + mp4) is already directly usable,
+    // so it skips background transcoding — but serving a multi-GB 4K file over
+    // progressive range requests drops the stream on every seek or network dip.
+    // Remux it into HLS on demand instead (`-c copy`, no re-encode, no quality
+    // loss): the player gets real segment buffering and the hls.js recovery path.
+    let delivery = if delivery == transcode::Delivery::RawProgressive {
+        transcode::Delivery::RemuxHls
+    } else {
+        delivery
+    };
 
     let outcome = st.hls.request(&id, delivery).await;
     hls_outcome_response(&st.store, &id, outcome).await


### PR DESCRIPTION
## Problem
Completed reels randomly drop mid-playback. Diagnosed on the live pod: the reel serves as \`delivery:\"progressive\"\` — raw MP4 **range requests** from disk (telemetry shows constant 64KB probes + multi-GB open-range reopens). A 4K MP4 played progressively has no segment buffering, so every seek or network dip re-opens the whole byte range and the stream stalls/drops. (Not a VPN issue — completed files are served from disk; cluster traffic already bypasses the gluetun killswitch.)

## Fix
`decide_delivery` still classifies h264+aac+mp4 as \`RawProgressive\` (so background auto-transcode keeps skipping them — no wasted work, source stays as-is). But the **playback** path now remuxes those sources into HLS on demand:

- `RawProgressive` → `RemuxHls` (\`-c copy\`) at manifest time — no re-encode, no quality loss, keeps the 4K crispy.
- Player receives a segmented HLS manifest → real buffering + the existing hls.js recovery ladder / stall watchdog (#14995) instead of a fragile single progressive connection.
- Reels that already produced live-HLS output are still served directly (`hls=Ready`), no double work.

## Notes
- Server-only (\`api.rs\`). reel \`0.1.31\` → \`0.1.32\` for CI publish + rollout.
- \`cargo test\`: 158 passed.
- Worktree \`reel-hls-completed\`.