### PR TITLE
fix(palworld): shield passives via lua bypass + self-discovering boss hooks

### DIFF
--- a/apps/agones/palworld/Dockerfile
+++ b/apps/agones/palworld/Dockerfile
@@ -33,6 +33,7 @@ RUN set -eux \
 
 COPY apps/agones/palworld/mods/PalChatRelay /opt/palchatrelay/PalChatRelay
 COPY apps/agones/palworld/mods/PalEventRelay /opt/palchatrelay/PalEventRelay
+COPY apps/agones/palworld/mods/PalTweaks /opt/palchatrelay/PalTweaks
 COPY apps/agones/palworld/mods/PalForge /opt/palchatrelay/PalForge
 COPY apps/agones/palworld/mods/PalSchema /opt/palchatrelay/PalSchema-overlay
 COPY apps/agones/palworld/overlay.sh /opt/palchatrelay/overlay.sh

--- a/apps/agones/palworld/mods/PalEventRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalEventRelay/scripts/main.lua
@@ -90,6 +90,8 @@ local function on_death(self, ...)
     end
 end
 
+local registered = {}
+
 local function probe_classes()
     for _, c in ipairs(CLASS_PROBES) do
         local ok, obj = pcall(StaticFindObject, c)
@@ -98,7 +100,38 @@ local function probe_classes()
     end
 end
 
-local registered = {}
+local function harvest_hooks()
+    for _, c in ipairs(CLASS_PROBES) do
+        local ok, cls = pcall(StaticFindObject, c)
+        if ok and cls and cls:IsValid() then
+            pcall(function()
+                cls:ForEachFunction(function(fn)
+                    local ok2 = pcall(function()
+                        local name = fn:GetFName():ToString()
+                        if
+                            name:find("Dead")
+                            or name:find("Death")
+                            or name:find("Defeat")
+                        then
+                            local full = c .. ":" .. name
+                            log("candidate fn discovered: " .. full)
+                            if
+                                not registered[full]
+                                and pcall(RegisterHook, full, on_death)
+                            then
+                                registered[full] = true
+                                log("death hook registered on " .. full)
+                            end
+                        end
+                    end)
+                    if not ok2 and DEBUG_ALL then
+                        log("harvest iteration error on " .. c)
+                    end
+                end)
+            end)
+        end
+    end
+end
 
 local function try_register()
     local any = false
@@ -117,6 +150,7 @@ local function try_register()
 end
 
 local function schedule()
+    harvest_hooks()
     if try_register() then
         return
     end

--- a/apps/agones/palworld/mods/PalTweaks/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalTweaks/scripts/main.lua
@@ -1,0 +1,86 @@
+local RETRY_MS = 30000
+local MAX_TRIES = 40
+
+local SHIELD_PASSIVES = {
+    Shield_Ultra = "TemperatureResist_Heat1Cold1",
+    Shield_SF = "TemperatureResist_Heat2Cold2",
+    Shield_07 = "TemperatureResist_Heat3Cold3",
+}
+
+local ITEM_CLASSES = {
+    "PalStaticArmorItemData",
+    "PalStaticShieldItemData",
+    "PalStaticItemDataBase",
+}
+
+local function log(msg)
+    print("[PalTweaks] " .. msg)
+end
+
+local applied = {}
+local tries = 0
+
+local function pending_count()
+    local n = 0
+    for id in pairs(SHIELD_PASSIVES) do
+        if not applied[id] then
+            n = n + 1
+        end
+    end
+    return n
+end
+
+local function try_apply_object(obj)
+    local ok = pcall(function()
+        local name = obj:GetFName():ToString()
+        local id = nil
+        for candidate in pairs(SHIELD_PASSIVES) do
+            if name == candidate or name:find("^" .. candidate .. "_") then
+                id = candidate
+                break
+            end
+        end
+        if not id or applied[id] then
+            return
+        end
+        local passive = SHIELD_PASSIVES[id]
+        obj.PassiveSkillName = FName(passive)
+        local check = tostring(obj.PassiveSkillName:ToString())
+        if check == passive then
+            applied[id] = true
+            log(("applied %s -> %s (object %s)"):format(id, passive, name))
+        else
+            log(("write did not stick on %s (read back %s)"):format(name, check))
+        end
+    end)
+    return ok
+end
+
+local function sweep()
+    tries = tries + 1
+    for _, cls in ipairs(ITEM_CLASSES) do
+        if pending_count() == 0 then
+            break
+        end
+        local ok, objs = pcall(FindAllOf, cls)
+        if ok and objs then
+            for _, obj in ipairs(objs) do
+                if obj and obj:IsValid() then
+                    try_apply_object(obj)
+                end
+            end
+        end
+    end
+    if pending_count() == 0 then
+        log("all shield passives applied")
+        return
+    end
+    if tries >= MAX_TRIES then
+        log(("giving up after %d sweeps; still pending: %d"):format(tries, pending_count()))
+        return
+    end
+    pcall(ExecuteWithDelay, RETRY_MS, sweep)
+end
+
+log("loaded; patching shield passives outside the PalSchema items loader")
+pcall(ExecuteWithDelay, RETRY_MS, sweep)

--- a/apps/agones/palworld/mods/mods.txt
+++ b/apps/agones/palworld/mods/mods.txt
@@ -1,4 +1,5 @@
 PalChatRelay : 1
 PalEventRelay : 1
+PalTweaks : 1
 PalForge : 1
 PalSchema : 1

--- a/apps/agones/palworld/overlay.sh
+++ b/apps/agones/palworld/overlay.sh
@@ -46,6 +46,21 @@ if [[ -d "${EVENT_SRC}" ]]; then
     fi
 fi
 
+TWEAKS_SRC=/opt/palchatrelay/PalTweaks
+if [[ -d "${TWEAKS_SRC}" ]]; then
+    echo "[palchatrelay-overlay] staging PalTweaks into ${MODS_DIR}"
+    rm -rf "${MODS_DIR}/PalTweaks"
+    cp -a "${TWEAKS_SRC}" "${MODS_DIR}/PalTweaks"
+    if [[ -d "${MODS_DIR}/PalTweaks/scripts" ]] && [[ ! -d "${MODS_DIR}/PalTweaks/Scripts" ]]; then
+        mv "${MODS_DIR}/PalTweaks/scripts" "${MODS_DIR}/PalTweaks/Scripts"
+    fi
+    if grep -qiE '^[[:space:]]*PalTweaks[[:space:]]*:' "${MODS_TXT}"; then
+        sed -i -E 's|^[[:space:]]*PalTweaks[[:space:]]*:.*|PalTweaks : 1|I' "${MODS_TXT}"
+    else
+        echo "PalTweaks : 1" >> "${MODS_TXT}"
+    fi
+fi
+
 FORGE_SRC=/opt/palchatrelay/PalForge
 if [[ -d "${FORGE_SRC}" ]]; then
     echo "[palchatrelay-overlay] staging PalForge into ${MODS_DIR}"

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.32"
+version: "0.0.33"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Why shields never worked

PalSchema applies `items/` mods only during its `GameInstanceInit` phase, driven by a vtable hook on `UPalGameInstance::Init` installed at PostEngineInit. On a dedicated server the instance init races ahead, the hook never fires, and every items-folder mod silently no-ops — our logs show exactly one `Loading mod:` sweep and zero `Modified Item` lines. Verified against the upstream Multiclimate Shields 2.1 rar: byte-identical approach to our port, fails the same way. `raw/` + `blueprints/` loaders are unaffected — shops and guild chest applied fine.

## Fix

- **PalTweaks** (new lua mod): after world load, finds the shield static item data objects and writes `PassiveSkillName` directly (`Shield_Ultra/SF/07` → `TemperatureResist_Heat1Cold1/2/3` — vanilla passive rows, same ones the Multiclimate Undershirts use). 30s retry sweeps until all three stick, logs each application
- **PalEventRelay v2**: classes probed FOUND but no guessed death-hook name bound — now harvests function names matching `Dead|Death|Defeat` from the probe classes via `ForEachFunction`, registers hooks dynamically, and logs every discovered candidate

## Versioning

MDX-only bump (0.0.32 → 0.0.33); version.toml stays at published 0.0.32 so the publish gate sees the lag and actually builds (today's outage lesson). GameServer pin follows once the tag exists; reaper (#15030) covers the stuck-pod class regardless.

## Guild chest (documented, deferred)

Applied correctly but capacity persists per guild — only newly created guilds get 108.