### PR TITLE
fix(arpg-web): install docker deps at /app so laser peers resolve

### DIFF
--- a/apps/agones/arpg/web/Dockerfile
+++ b/apps/agones/arpg/web/Dockerfile
@@ -13,9 +13,11 @@
 FROM node:24-bookworm-slim AS web
 WORKDIR /app
 
-# App deps first (cache layer independent of source).
-COPY apps/agones/arpg/web/package.json apps/agones/arpg/web/
-RUN cd apps/agones/arpg/web && npm install --no-save
+# App deps first (cache layer independent of source). Installed at /app, NOT the
+# app dir — resolution from the bare-source packages/npm/laser walks up to
+# /app/node_modules, so laser's optional peers (drei/three/fiber) resolve.
+COPY apps/agones/arpg/web/package.json package.json
+RUN npm install --no-save
 
 # The game source + sprite art now live entirely under apps/agones/arpg/web.
 # @kbve/laser and @kbve/observ are the cross-repo deps the vite config aliases to source.


### PR DESCRIPTION
Fixes #15034 — `CI - Docker / arpg-web` at 0.1.28.

## The failure

Not the docker build machinery — the vite/rollup step inside it:

```
../../../../packages/npm/laser/src/lib/webgl/pom/PomMaterial.tsx (2:9):
"shaderMaterial" is not exported by
"__vite-optional-peer-dep:@react-three/drei:@kbve/laser:false",
imported by "../../../../packages/npm/laser/src/lib/webgl/pom/PomMaterial.tsx".
```

## Why

The Dockerfile copies `packages/npm/laser` in as **bare source** (no `node_modules` of its own) but installed deps into `apps/agones/arpg/web/node_modules`:

```dockerfile
COPY apps/agones/arpg/web/package.json apps/agones/arpg/web/
RUN cd apps/agones/arpg/web && npm install --no-save
```

Node resolution from `packages/npm/laser/src/...` walks up `/app/packages/npm` → `/app/packages` → `/app` — it never descends into the app dir. So `@react-three/drei` is unresolvable *from laser's own modules*, even though arpg-web declares it in its `package.json`.

laser declares drei as an **optional** peer, so vite does not hard-fail the resolve — it substitutes a `__vite-optional-peer-dep` stub. Rollup then dies on the named import in `PomMaterial.tsx`, which laser's root barrel re-exports (`POM_SOURCE_BRICK` and friends via `./lib/webgl/pom`). arpg never uses POM; it is pulled in purely through the barrel.

## Fix

Install at `/app`. This matches every other Dockerfile that vendors `packages/npm/laser` — `axum-kbve`, `axum-cryptothrone`, `axum-chuckrpg`, `axum-rareicon` all install from the repo root. `npm run build` still runs from the app dir; npm puts every ancestor `node_modules/.bin` on PATH.

## Not a regression from recent commits

Reproduced the identical error building at **4c39db0be5**, before this week's arpg work (#15027, #15028, #15031). The trigger is dependency drift: `npm install --no-save` is unpinned, so vite/rollup float, and a newer vite applies optional-peer stubbing where an older one did not.

**Follow-up worth doing separately:** pin that install. The app dir already carries a `pnpm-lock.yaml` that `npm install` ignores. I tried `pnpm install --frozen-lockfile` here and it hits `ERR_PNPM_IGNORED_BUILDS` on `esbuild` under pnpm 10 — solvable, but it is its own change with its own risk, so I left it out of an outage fix.

## Verification

Built the image locally off this branch — `docker build -f apps/agones/arpg/web/Dockerfile --target web .` succeeds (3 vite builds, no rollup error). Same build on `origin/main` fails with the error above.

No version bump: 0.1.28 never published, so the existing dispatch succeeds on retry.