### PR TITLE
fix(reel): stream downloading torrents via live HLS, not looping progressive

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -322,7 +322,7 @@ export async function refreshReelList(): Promise<void> {
 	}
 }
 
-export type ProbeAction = 'raw' | 'raw-leeching' | 'hls' | 'poll' | 'error';
+export type ProbeAction = 'raw' | 'hls' | 'poll' | 'error';
 
 export function nextFromManifestStatus(status: number): ProbeAction {
 	switch (status) {
@@ -332,8 +332,13 @@ export function nextFromManifestStatus(status: number): ProbeAction {
 			return 'poll';
 		case 409:
 			return 'raw';
+		// 425 Too Early: a still-downloading torrent whose live HLS job hasn't
+		// warmed up yet. Poll for it — never fall back to progressive playback of
+		// an in-flight file: that stream isn't seekable, so the first stall
+		// reloads it from the start and the video loops the opening seconds
+		// forever. Live HLS is the only correct path while leeching.
 		case 425:
-			return 'raw-leeching';
+			return 'poll';
 		default:
 			return 'error';
 	}
@@ -445,10 +450,7 @@ export class ReelPlayer {
 
 		switch (nextFromManifestStatus(status)) {
 			case 'raw':
-				this.playRaw(video, id, token, false, gen);
-				return;
-			case 'raw-leeching':
-				this.playRaw(video, id, token, true, gen);
+				this.playRaw(video, id, token, gen);
 				return;
 			case 'hls':
 				await this.playHls(video, id, token, gen);
@@ -476,18 +478,12 @@ export class ReelPlayer {
 		video: HTMLVideoElement,
 		id: string,
 		token: string,
-		leeching: boolean,
 		gen: number,
 	): void {
 		if (this.generation !== gen) return;
 		this.attachVideoError(video, gen);
 		video.src = mediaUrl(id, '/stream', token);
 		$reelState.set('raw');
-		if (leeching) {
-			$reelNotice.set(
-				'still downloading — playing the available portion',
-			);
-		}
 		void this.addSubtitleTracks(video, id, token, gen);
 		this.recover = () => {
 			// Re-request the byte-range stream from the current position.


### PR DESCRIPTION
## Problem
Click **Stream** on a still-downloading torrent → plays a couple seconds, loops back to the start, repeats forever.

## Root cause
The probe maps HTTP `425 Too Early` (live HLS job not warmed up yet) to `raw-leeching` → **progressive playback of the in-flight file**. That path latches for the whole play session (probe runs once). An in-flight librqbit stream isn't seekable, so:
1. Plays the downloaded couple seconds.
2. Playhead hits the download edge → stalls (`readyState < 3`).
3. Watchdog `recover()` **reloads `/stream` from scratch** (resets to t=0); the `currentTime = at` reseek can't seek a still-downloading stream → stays at 0 → plays from the start again. Loop.

## Fix
`425 → poll` instead of `raw-leeching`: wait for the live HLS job to produce segments, then play HLS — the only correct path while leeching (`run_live` handles any codec: h264 stream-copy, else transcode). Removed the `raw-leeching` progressive branch and simplified `playRaw` (the `leeching` param was now always false). Poll budget is already generous (25 × up to 5s backoff).

## Notes
- Frontend-only (`reelService.ts`). No version bump. CI validates the astro build.
- Complements #15029 (completed reels → HLS). Together: nothing plays as raw progressive except a genuine complete-on-disk fallback.
- Worktree `reel-leech-live-only`.