### PR TITLE
fix(astro-kbve): drop duplicate SUPABASE_URL breaking axum-kbve build

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -102,7 +102,6 @@ export interface ForgejoSummary {
 // Constants
 // ---------------------------------------------------------------------------
 
-const SUPABASE_URL = 'https://supabase.kbve.com';
 const CACHE_TTL_MS = 2 * 60 * 1000;
 const PROXY_BASE = `${DASH_PROXY_BASE}/dashboard/grafana/proxy`;
 const DS_CACHE_KEY = 'cache:grafana:ds-id';

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -56,10 +56,10 @@ COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 WORKDIR /app/apps/kbve/astro-kbve
 ARG ASTRO_CACHE_KEY=astro6
 RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-kbve-cache-${ASTRO_CACHE_KEY},sharing=locked \
-    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    { cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true; } && \
     npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \
-    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
+    { cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true; }
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
Fixes #15035.

## Root cause

`CI - Docker / axum-kbve` failed at `Nx e2e axum-kbve-e2e` with an opaque error:

```
COPY --from=astro-builder /app/dist/apps/astro-kbve /static
ERROR: failed to compute cache key: "/app/dist/apps/astro-kbve": not found
```

The real failure was 160s earlier, inside the `astro-builder` stage:

```
2 │ import { initSupa, getSupa, SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supa";
  │                             ──────┬─────
  │                                   ╰─────── `SUPABASE_URL` has already been declared here
6 │ const SUPABASE_URL = "https://supabase.kbve.com";
  │             ╰─────── It can not be redeclared here
```

#15031 added the `SUPABASE_URL` / `SUPABASE_ANON_KEY` import for `resolveStaffFlag(...)` but left the pre-existing identical local `const`. Two declarations of the same binding in one module is a hard rolldown error → no `dist/` → the COPY blows up two stages later.

Only `main` carries this; `dev` never had the import.

## Changes

1. **`homeService.ts`** — remove the local `const SUPABASE_URL = 'https://supabase.kbve.com'`. Same literal as the export in `src/lib/supa.ts:14`, so every existing use (`${SUPABASE_URL}/functions/v1/...`) now resolves to the imported binding. No runtime change.

2. **`apps/kbve/axum-kbve/Dockerfile`** — brace-group the optional `.astro` cache copies:

   ```dockerfile
   { cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true; } && \
   npx astro sync && \
   ... npx astro build && \
   { cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true; }
   ```

   The trailing `|| true` previously covered the whole `&&` chain, so an `astro build` failure exited 0 and the stage logged `DONE 160.8s`. Future build breaks now fail loudly at the builder stage instead of masquerading as a missing-path COPY error.

## Verification

Built the worktree source directly (`astro sync` + `astro build` against the branch, not main):

```
[build] 7508 page(s) built in 1m 51s
[build] Complete!   (exit 0)
```

`dist/apps/astro-kbve` produced; `grep -rn "const SUPABASE_URL" src` now returns only `lib/supa.ts:14`.