### PR TITLE
feat(palworld): block Pal Sphere capture of merchant NPCs

### DIFF
--- a/apps/agones/palworld/mods/PalSchema/README.md
+++ b/apps/agones/palworld/mods/PalSchema/README.md
@@ -47,6 +47,23 @@ passives to `Shield_Ultra` / `Shield_SF` / `Shield_07`. Inspired by Multiclimate
 Shields by MelwenMods ([Nexus 2643](https://www.nexusmods.com/palworld/mods/2643));
 values are KBVE-authored. Server-side only.
 
+## Merchants (KBVEMerchants)
+
+`mods/KBVEMerchants/npcs/no_capture.jsonc` sets `CaptureRateCorrect` to `0.0` on
+every merchant row in `DT_PalHumanParameter`. Fixes merchants being caught with a
+Pal Sphere and never respawning — the NPC spawner does not re-fire for a captured
+merchant, so the vendor is gone until the world reloads.
+
+The `npcs` folder name is required: PalSchema's human loader registers itself as
+`PalModLoaderBase("npcs")`. There is no `IsUncapturable` field on the
+`PalCharacterParameterDatabaseRow` struct, so `CaptureRateCorrect` is the only
+lever; vanilla ships every merchant at `0.1` and `Male_Police_old` at `0.0`.
+
+Only row ids verified against a real `DT_PalHumanParameter` dump are listed.
+This matters: the loader **adds a new NPC row** when an id is not found
+(`FindRowUnchecked` → `Add`), so a typo silently creates junk data rather than
+erroring. Confirm additions against a dump before extending the list.
+
 ## Shops (KBVEShops)
 
 Shop tables (`DT_ItemShopCreateData`) are generated from MDX frontmatter under

--- a/apps/agones/palworld/mods/PalSchema/mods/KBVEMerchants/npcs/no_capture.jsonc
+++ b/apps/agones/palworld/mods/PalSchema/mods/KBVEMerchants/npcs/no_capture.jsonc
@@ -1,0 +1,30 @@
+// ======================================================
+// MOD: KBVEMerchants
+// PURPOSE: Block Pal Sphere capture of merchant NPCs
+// TABLE: DT_PalHumanParameter
+// NOTE: Vanilla merchants ship CaptureRateCorrect 0.1;
+//       Male_Police_old is the vanilla 0.0 precedent.
+// ======================================================
+
+{
+    "SalesPerson": { "CaptureRateCorrect": 0.0 },
+    "SalesPerson_Desert": { "CaptureRateCorrect": 0.0 },
+    "SalesPerson_Desert2": { "CaptureRateCorrect": 0.0 },
+    "SalesPerson_Volcano": { "CaptureRateCorrect": 0.0 },
+    "SalesPerson_Volcano2": { "CaptureRateCorrect": 0.0 },
+    "SalesPerson_Wander": { "CaptureRateCorrect": 0.0 },
+
+    "PalDealer": { "CaptureRateCorrect": 0.0 },
+    "PalDealer_Desert": { "CaptureRateCorrect": 0.0 },
+    "PalDealer_Volcano": { "CaptureRateCorrect": 0.0 },
+    "PalTrader": { "CaptureRateCorrect": 0.0 },
+
+    "Male_DarkTrader01": { "CaptureRateCorrect": 0.0 },
+    "Male_Trader01": { "CaptureRateCorrect": 0.0 },
+    "Male_Trader02": { "CaptureRateCorrect": 0.0 },
+    "Male_Trader03": { "CaptureRateCorrect": 0.0 },
+
+    "VisitingMerchant": { "CaptureRateCorrect": 0.0 },
+    "WeaponsDealer": { "CaptureRateCorrect": 0.0 },
+    "RandomEventShop": { "CaptureRateCorrect": 0.0 }
+}


### PR DESCRIPTION
## Problem

A merchant caught in a Pal Sphere is removed from the world and **never comes back**. The NPC spawner does not re-fire for a captured merchant, so that vendor is gone until the world reloads.

## Fix

New PalSchema mod `KBVEMerchants` — `npcs/no_capture.jsonc` sets `CaptureRateCorrect: 0.0` on every merchant row in `DT_PalHumanParameter`.

Why this field and this folder, from PalSchema source rather than guesswork:

- The human loader registers as `PalModLoaderBase("npcs")` and targets `DT_PalHumanParameter` ([`PalHumanModLoader.cpp`](https://github.com/Okaetsu/PalSchema/blob/main/src/Loader/PalHumanModLoader.cpp)). There is no `humans` folder.
- `PalCharacterParameterDatabaseRow` has **no** `IsUncapturable` field. `CaptureRateCorrect` is the only capture lever on the struct.
- Vanilla ships every merchant at `0.1`; `Male_Police_old` is the one row shipped at `0.0`. That's the precedent being matched.
- `IsTowerBoss: true` would also make them uncapturable but drags in battle BGM, damage-rate and drop changes. Rejected.

17 rows covered: `SalesPerson` ×6, `PalDealer` ×3, `PalTrader`, `Male_DarkTrader01`, `Male_Trader01-03`, `VisitingMerchant`, `WeaponsDealer`, `RandomEventShop`.

## Deliberately excluded

`NPC_Dungeon_Shop`, `Male_DarkTrader01_02/03/04`, `Male_DarkTrader02`, `Arena_Male_DarkTrader02` — these appear on paldb but I could not verify them against a real `DT_PalHumanParameter` dump. That matters here: the loader does `FindRowUnchecked` and **adds a new NPC row** when the id is missing, so an unverified id silently creates junk data instead of erroring. Arena merchants are already uncapturable in vanilla. Easy to extend once confirmed against a current dump.

## Verification needed after deploy

`CaptureRateCorrect: 0.0` blocking capture outright is inferred from the vanilla `Male_Police_old` precedent, not observed. If the game applies a minimum capture-chance floor, spheres would still land rarely. Check the PalSchema log for the applied rows on first boot, then throw a sphere at a merchant.

## Rollout

Requires an image rebuild — `mods/PalSchema` is baked in at [`Dockerfile:37`](https://github.com/KBVE/kbve/blob/dev/apps/agones/palworld/Dockerfile#L37), not mounted. Merge, then bump the GameServer image tag. Existing GameServers keep the old data until replaced. No `overlay.sh` change.