### PR TITLE
feat(reel): enable VPN port forwarding for inbound BitTorrent peers

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -44,7 +44,11 @@ spec:
                       - { name: WIREGUARD_MTU, value: '1320' }
                       - { name: SERVER_COUNTRIES, value: 'Germany' }
                       - { name: SERVER_CITIES, value: 'Frankfurt' }
-                      - { name: VPN_PORT_FORWARDING, value: 'off' }
+                      - { name: VPN_PORT_FORWARDING, value: 'on' }
+                      - {
+                            name: VPN_PORT_FORWARDING_STATUS_FILE,
+                            value: '/tmp/gluetun/forwarded_port',
+                        }
                   volumeMounts:
                       - { name: gluetun-run, mountPath: /tmp/gluetun }
                 - name: reel
@@ -66,6 +70,10 @@ spec:
                         }
                       - { name: REEL_LOG_JSON, value: 'true' }
                       - { name: REEL_ENCODE_THREADS, value: '16' }
+                      - {
+                            name: REEL_BT_PORT_FILE,
+                            value: '/tmp/gluetun/forwarded_port',
+                        }
                   envFrom:
                       - secretRef: { name: reel-api }
                   ports:


### PR DESCRIPTION
## Problem
Downloads are slow and peers keep dropping. Diagnosed as a connectivity config gap, not code:

- gluetun ran with **`VPN_PORT_FORWARDING: 'off'`**.
- reel had **no `REEL_BT_PORT_FILE`**, so the BitTorrent listener bound a **random port**.

Result: **zero inbound peer connectivity** — reel could only make outbound connections. That starves the swarm (far fewer peers, no inbound to replenish churned ones), which is exactly the "peers getting dropped / hours to download" symptom.

## Fix
- gluetun: `VPN_PORT_FORWARDING: 'on'` + `VPN_PORT_FORWARDING_STATUS_FILE=/tmp/gluetun/forwarded_port` (written to the shared `gluetun-run` volume). gluetun also opens the VPN-interface firewall for the forwarded port automatically.
- reel: `REEL_BT_PORT_FILE=/tmp/gluetun/forwarded_port` → binds the listener to the forwarded port at boot and rebinds via the existing `forwarded_port_watch_loop` when it changes.

## Safety / notes
- VPN provider stays in the `reel-gluetun` / `vpn-wireguard` secrets — nothing provider-identifying added here.
- If the connected server can't forward a port, the status file never appears and reel falls back to a random port **exactly as today** — no regression.
- Manifest-only. No version bump. After rollout, confirm inbound via `/status` (`inbound_ready: true`) and the reel boot log "using VPN forwarded port for BitTorrent listener".

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)