### PR TITLE
revert(reel): re-disable VPN port forwarding (#15063 repeats reverted state)

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -44,11 +44,7 @@ spec:
                       - { name: WIREGUARD_MTU, value: '1320' }
                       - { name: SERVER_COUNTRIES, value: 'Germany' }
                       - { name: SERVER_CITIES, value: 'Frankfurt' }
-                      - { name: VPN_PORT_FORWARDING, value: 'on' }
-                      - {
-                            name: VPN_PORT_FORWARDING_STATUS_FILE,
-                            value: '/tmp/gluetun/forwarded_port',
-                        }
+                      - { name: VPN_PORT_FORWARDING, value: 'off' }
                   volumeMounts:
                       - { name: gluetun-run, mountPath: /tmp/gluetun }
                 - name: reel
@@ -70,10 +66,6 @@ spec:
                         }
                       - { name: REEL_LOG_JSON, value: 'true' }
                       - { name: REEL_ENCODE_THREADS, value: '16' }
-                      - {
-                            name: REEL_BT_PORT_FILE,
-                            value: '/tmp/gluetun/forwarded_port',
-                        }
                   envFrom:
                       - secretRef: { name: reel-api }
                   ports:


### PR DESCRIPTION
Reverts #15063.

## Why
#15063 re-enabled VPN port forwarding, but that state was already tried and **deliberately reverted**:

- #14797 enabled PF → #14871 disabled it "to stop peer-wipe churn" → #14872 pinned Germany for stability → #14883 disabled it again with the root cause.

Per #14883 (verified against live logs on two Proton servers): **ProtonVPN's NAT-PMP hands back a fresh forwarded port on every ~45–90s renewal** rather than honoring the held mapping — universal Proton+gluetun behavior, not a bad server. **librqbit can't hot-rebind its listen socket**, so each rotation forces a full session restart that rebuilds iptables and flushes conntrack, **wiping every live peer** (a sawtooth *worse* than steady outbound-only).

I missed this because the reel memory still reflected #14797's enabled state; the #14871/#14883 reversals post-dated it. Restoring inbound requires a VPN provider with a **static** forwarded port (e.g. AirVPN) — a separate follow-up, not a manifest toggle.

## Change
Restores `VPN_PORT_FORWARDING: 'off'` and drops `REEL_BT_PORT_FILE` / `VPN_PORT_FORWARDING_STATUS_FILE`. Manifest-only, no version bump.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)