### PR TITLE
fix(astro-kbve): drop duplicate SUPABASE_URL breaking axum-kbve build (dev port)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -102,7 +102,6 @@ export interface ForgejoSummary {
 // Constants
 // ---------------------------------------------------------------------------
 
-const SUPABASE_URL = 'https://supabase.kbve.com';
 const CACHE_TTL_MS = 2 * 60 * 1000;
 const PROXY_BASE = `${DASH_PROXY_BASE}/dashboard/grafana/proxy`;
 const DS_CACHE_KEY = 'cache:grafana:ds-id';

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -56,10 +56,10 @@ COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 WORKDIR /app/apps/kbve/astro-kbve
 ARG ASTRO_CACHE_KEY=astro6
 RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-kbve-cache-${ASTRO_CACHE_KEY},sharing=locked \
-    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
+    { cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true; } && \
     npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \
-    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
+    { cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true; }
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
Port of #15046 to `dev`. Same two-line fix; `dev` still carries both bugs, so the next dev→main release PR would re-break `CI - Docker / axum-kbve` (#15035).

## Root cause

#15031 added `import { initSupa, getSupa, SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/supa'` to `homeService.ts` for `resolveStaffFlag(...)` but left the pre-existing identical local `const SUPABASE_URL`. Two declarations of the same binding in one module is a hard rolldown error:

```
2 │ import { initSupa, getSupa, SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supa";
  │                                   ╰─────── `SUPABASE_URL` has already been declared here
6 │ const SUPABASE_URL = "https://supabase.kbve.com";
  │             ╰─────── It can not be redeclared here
```

No `dist/` is emitted, and the container build dies two stages later with the misleading `COPY --from=astro-builder /app/dist/apps/astro-kbve: not found`.

## Changes

1. **`homeService.ts`** — remove the local const. Same literal as the export at `src/lib/supa.ts:14`, so every use (`${SUPABASE_URL}/functions/v1/...`) resolves to the imported binding. No runtime change.

2. **`apps/kbve/axum-kbve/Dockerfile`** — brace-group the optional `.astro` cache copies so the trailing `|| true` no longer covers the whole `&&` chain. Previously an `astro build` failure exited 0 and the builder stage logged `DONE`; future breaks now fail loudly where they happen.

## Verification

Built this branch's source directly (`astro sync` + `astro build`, worktree cwd, not main):

```
[build] 7508 page(s) built in 1m 48s
[build] Complete!   (exit 0)
```

`grep -rn "const SUPABASE_URL" src` returns only `lib/supa.ts:14`.