### PR TITLE
feat(palworld): tier 1 climate resist on Giga and Tera shields

### DIFF
--- a/apps/agones/palworld/mods/PalSchema/README.md
+++ b/apps/agones/palworld/mods/PalSchema/README.md
@@ -43,7 +43,9 @@ new cap unreachable.
 ## Shields (KBVEShields)
 
 `mods/KBVEShields/items/shields.jsonc` grants `TemperatureResist_Heat*Cold*`
-passives to `Shield_Ultra` / `Shield_SF` / `Shield_07`. Inspired by Multiclimate
+passives to shields: `Shield_03` (Giga) and `Shield_04` (Tera) at tier 1,
+`Shield_Ultra` at tier 1, `Shield_SF` at tier 2, `Shield_07` at tier 3.
+Inspired by Multiclimate
 Shields by MelwenMods ([Nexus 2643](https://www.nexusmods.com/palworld/mods/2643));
 values are KBVE-authored. Server-side only.
 

--- a/apps/agones/palworld/mods/PalSchema/mods/KBVEShields/items/shields.jsonc
+++ b/apps/agones/palworld/mods/PalSchema/mods/KBVEShields/items/shields.jsonc
@@ -7,6 +7,12 @@
 // ======================================================
 
 {
+    "Shield_03": {
+        "PassiveSkill": "TemperatureResist_Heat1Cold1"
+    },
+    "Shield_04": {
+        "PassiveSkill": "TemperatureResist_Heat1Cold1"
+    },
     "Shield_Ultra": {
         "PassiveSkill": "TemperatureResist_Heat1Cold1"
     },


### PR DESCRIPTION
## What

`KBVEShields` now covers the mid-tier shields. Full ladder:

| Item | Shield | Passive |
|------|--------|---------|
| `Shield_03` | Giga | `TemperatureResist_Heat1Cold1` |
| `Shield_04` | Tera | `TemperatureResist_Heat1Cold1` |
| `Shield_Ultra` | Ultra | `TemperatureResist_Heat1Cold1` |
| `Shield_SF` | Advanced | `TemperatureResist_Heat2Cold2` |
| `Shield_07` | Ancient | `TemperatureResist_Heat3Cold3` |

`Shield_03` / `Shield_04` verified as real item ids against `DT_ItemNameText` (`ITEM_NAME_Shield_01` through `_06` exist; 03 is Giga, 04 is Tera).

## Rollout

Requires an image rebuild — `mods/PalSchema` is baked in at [`Dockerfile:37`](https://github.com/KBVE/kbve/blob/dev/apps/agones/palworld/Dockerfile#L37), not mounted. Merge, then bump the GameServer image tag. No `overlay.sh` change.