### PR TITLE
feat(reel): observe-mode forwarded-port watcher

### DIFF
--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub bt_port_wait_secs: u64,
     pub bt_port_stable_secs: u64,
     pub bt_port_watch_secs: u64,
+    pub bt_port_watch_restart: bool,
 }
 
 pub const DEFAULT_TRACKERS_URLS: &[&str] = &[
@@ -212,6 +213,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         bt_port_wait_secs: env_u64("REEL_BT_PORT_WAIT_SECS", 20)?,
         bt_port_stable_secs: env_u64("REEL_BT_PORT_STABLE_SECS", 45)?,
         bt_port_watch_secs: env_u64("REEL_BT_PORT_WATCH_SECS", 30)?,
+        bt_port_watch_restart: env_bool("REEL_BT_PORT_WATCH_RESTART", false),
     })
 }
 
@@ -259,6 +261,7 @@ mod tests {
             "REEL_HLS_SEGMENT_SECS",
             "REEL_BT_PORT_FILE",
             "REEL_BT_PORT_WAIT_SECS",
+            "REEL_BT_PORT_WATCH_RESTART",
         ] {
             std::env::remove_var(k);
         }
@@ -307,6 +310,7 @@ mod tests {
         assert_eq!(c.bt_port_wait_secs, 20);
         assert_eq!(c.bt_port_stable_secs, 45);
         assert_eq!(c.bt_port_watch_secs, 30);
+        assert!(!c.bt_port_watch_restart);
     }
 
     #[test]

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -135,26 +135,57 @@ async fn await_forwarded_port(
     Some(current)
 }
 
-pub async fn forwarded_port_watch_loop(engine: Engine, interval_secs: u64, restart: Arc<Notify>) {
+pub async fn forwarded_port_watch_loop(
+    engine: Engine,
+    interval_secs: u64,
+    restart: Arc<Notify>,
+    restart_on_change: bool,
+) {
     if engine.bt_port_file.is_none() {
         return;
     }
     let interval = Duration::from_secs(interval_secs.max(5));
+    let started = now_secs();
+    let mut last_forwarded: Option<u16> = engine.forwarded_port();
+    let mut rotations = 0u64;
     let mut mismatches = 0u32;
+    tracing::info!(
+        initial = ?last_forwarded,
+        restart_on_change,
+        "forwarded-port watcher started (observe mode: logs rotation rate without tearing down the session)"
+    );
     loop {
         tokio::time::sleep(interval).await;
-        match (engine.forwarded_port(), engine.bt_listen_port()) {
-            (Some(forwarded), Some(listen)) if forwarded != listen => {
+        let forwarded = engine.forwarded_port();
+        if forwarded != last_forwarded {
+            rotations += 1;
+            let elapsed = now_secs().saturating_sub(started).max(1);
+            let per_hour = (rotations as f64) * 3600.0 / (elapsed as f64);
+            tracing::warn!(
+                from = ?last_forwarded,
+                to = ?forwarded,
+                rotations,
+                elapsed_secs = elapsed,
+                rotations_per_hour = per_hour,
+                "vpn_forwarded_port_rotated: Proton changed the NAT-PMP forwarded port"
+            );
+            last_forwarded = forwarded;
+        }
+        if !restart_on_change {
+            continue;
+        }
+        match (forwarded, engine.bt_listen_port()) {
+            (Some(f), Some(listen)) if f != listen => {
                 mismatches += 1;
                 tracing::warn!(
-                    forwarded,
+                    forwarded = f,
                     listen,
                     mismatches,
                     "VPN forwarded port no longer matches BitTorrent listener"
                 );
                 if mismatches >= 2 {
                     tracing::warn!(
-                        forwarded,
+                        forwarded = f,
                         listen,
                         "vpn_forwarded_port_changed: restarting to rebind listener to the forwarded port"
                     );

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> anyhow::Result<()> {
         eng.clone(),
         cfg.bt_port_watch_secs,
         restart.clone(),
+        cfg.bt_port_watch_restart,
     ));
 
     let store_for_flush = store.clone();


### PR DESCRIPTION
## What

Adds observe-only instrumentation for the NAT-PMP forwarded port so we can measure how often it actually rotates before deciding whether a librqbit fork is warranted.

## Changes
- New config `REEL_BT_PORT_WATCH_RESTART` (default `false`).
- `forwarded_port_watch_loop` now logs every rotation with a running count + `rotations_per_hour` rate.
- Session restart on port change only fires when the flag is set, so rotation is measured **without** the peer-wipe session teardown that caused the #15063 regression.

## Why
Peer/download-health work on vpn is outbound-only; inbound depends on the forwarded port. Whether following that port is worth a 3-crate librqbit fork hinges on rotation frequency, which has never been instrumented. This ships the measurement first.

## Follow-up
Separate PR flips the manifest (gluetun `VPN_PORT_FORWARDING: on` + `REEL_BT_PORT_FILE`, restart flag `false`) to activate the observe path in the reel namespace.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)