### PR TITLE
chore(reel): activate observe-mode forwarded-port watcher

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.33"
+version: "0.1.34"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -44,7 +44,11 @@ spec:
                       - { name: WIREGUARD_MTU, value: '1320' }
                       - { name: SERVER_COUNTRIES, value: 'Germany' }
                       - { name: SERVER_CITIES, value: 'Frankfurt' }
-                      - { name: VPN_PORT_FORWARDING, value: 'off' }
+                      - { name: VPN_PORT_FORWARDING, value: 'on' }
+                      - {
+                            name: VPN_PORT_FORWARDING_STATUS_FILE,
+                            value: '/tmp/gluetun/forwarded_port',
+                        }
                   volumeMounts:
                       - { name: gluetun-run, mountPath: /tmp/gluetun }
                 - name: reel
@@ -66,6 +70,11 @@ spec:
                         }
                       - { name: REEL_LOG_JSON, value: 'true' }
                       - { name: REEL_ENCODE_THREADS, value: '16' }
+                      - {
+                            name: REEL_BT_PORT_FILE,
+                            value: '/tmp/gluetun/forwarded_port',
+                        }
+                      - { name: REEL_BT_PORT_WATCH_RESTART, value: 'false' }
                   envFrom:
                       - secretRef: { name: reel-api }
                   ports:


### PR DESCRIPTION
## What
Activates the observe-only forwarded-port instrumentation from #15074 in the reel namespace.

## Changes
- `reel.mdx` 0.1.33 → 0.1.34 (publishes image with the observe-mode watcher; manifest tag auto-pins on publish).
- gluetun: `VPN_PORT_FORWARDING: on` + `VPN_PORT_FORWARDING_STATUS_FILE=/tmp/gluetun/forwarded_port`.
- reel: `REEL_BT_PORT_FILE=/tmp/gluetun/forwarded_port`, `REEL_BT_PORT_WATCH_RESTART=false`.

## Why observe-only (not a repeat of #15063)
PF is on so gluetun requests the NAT-PMP port and writes the status file. reel reads it **only to log** how often Proton rotates it (`rotations_per_hour`). With `REEL_BT_PORT_WATCH_RESTART=false` the watcher never calls `restart.notify_one()`, so there is **no session teardown and no peer-wipe sawtooth** — the exact failure mode that #15063 reintroduced.

## Next
Read the reel logs for `vpn_forwarded_port_rotated` count + rate, then decide: if rotation is frequent → 3-crate librqbit fork (live re-announce); if rare → cheap fast-restart is enough.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)