### PR TITLE
feat(palworld): world-event presence pipeline (supply drops, meteorites, dungeons)

### DIFF
--- a/apps/agones/palworld/mods/PalEventRelay/scripts/main.lua
+++ b/apps/agones/palworld/mods/PalEventRelay/scripts/main.lua
@@ -1,6 +1,8 @@
 local EVENTS_LOG = os.getenv("PALWORLD_EVENTS_LOG") or "/shared/chat/events.log"
 local DEBUG_ALL = os.getenv("PALWORLD_EVENT_DEBUG") == "1"
 local RETRY_MS = 15000
+local SCAN_MS = tonumber(os.getenv("PALWORLD_EVENT_SCAN_MS") or "") or 20000
+local DEATH_DEDUPE_S = 600
 
 local CANDIDATES = {
     "/Script/Pal.PalCharacterParameterComponent:OnDeath",
@@ -17,6 +19,41 @@ local CLASS_PROBES = {
     "/Script/Pal.PalBossBattleManager",
 }
 
+local SCAN_KINDS = {
+    supply = {
+        "PalSupplyDrop",
+        "BP_SupplyDrop_C",
+        "PalCargoDrop",
+        "BP_PalCargoDrop_C",
+        "PalTreasureBoxSupplyDrop",
+        "PalSupplyDropModel",
+    },
+    meteor = {
+        "PalMeteorFragment",
+        "BP_Meteor_C",
+        "PalMeteorDropSpawner",
+        "PalHugeMeteorFragment",
+        "PalMeteorDropModel",
+    },
+    dungeon = {
+        "PalDungeonPortal",
+        "BP_DungeonEntrance_C",
+        "PalOneshotDungeonPortal",
+        "PalDungeonPointMarkerModel",
+    },
+}
+
+local extra = os.getenv("PALWORLD_EVENT_CLASSES")
+if extra then
+    for pair in extra:gmatch("[^,]+") do
+        local kind, cls = pair:match("^%s*(%w+)%s*=%s*(.+)%s*$")
+        if kind and cls then
+            SCAN_KINDS[kind] = SCAN_KINDS[kind] or {}
+            table.insert(SCAN_KINDS[kind], cls)
+        end
+    end
+end
+
 local function log(msg)
     print("[PalEventRelay] " .. msg)
 end
@@ -26,17 +63,21 @@ local function now_ms()
 end
 
 local function sanitize(s)
-    return (s:gsub("[\t\r\n]", " "))
+    return (s:gsub("[\t\r\n;]", " "))
 end
 
-local function append(kind, id, x, y)
+local function append_line(line)
     local f = io.open(EVENTS_LOG, "a")
     if not f then
         log("append failed: cannot open " .. EVENTS_LOG)
         return
     end
-    f:write(string.format("%s\t%s\t%s\t%.1f\t%.1f\n", now_ms(), kind, sanitize(id), x, y))
+    f:write(line .. "\n")
     f:close()
+end
+
+local function append(kind, id, x, y)
+    append_line(string.format("%s\t%s\t%s\t%.1f\t%.1f", now_ms(), kind, sanitize(id), x, y))
 end
 
 local function resolve_actor(obj)
@@ -68,6 +109,30 @@ local function is_boss_name(name)
     return u:find("BOSS_", 1, true) ~= nil or u:find("GYM_", 1, true) ~= nil
 end
 
+local seen_deaths = {}
+local seen_count = 0
+
+local function death_seen(full)
+    local now = os.time()
+    if seen_count > 256 then
+        for k, t in pairs(seen_deaths) do
+            if now - t > DEATH_DEDUPE_S then
+                seen_deaths[k] = nil
+                seen_count = seen_count - 1
+            end
+        end
+    end
+    local t = seen_deaths[full]
+    if t and now - t < DEATH_DEDUPE_S then
+        return true
+    end
+    if not t then
+        seen_count = seen_count + 1
+    end
+    seen_deaths[full] = now
+    return false
+end
+
 local function on_death(self, ...)
     local ok, err = pcall(function()
         local obj = self and self:get()
@@ -80,6 +145,9 @@ local function on_death(self, ...)
             log("death observed: " .. full)
         end
         if not is_boss_name(full) then
+            return
+        end
+        if death_seen(full) then
             return
         end
         append("BOSS_DEFEAT", full, loc.X, loc.Y)
@@ -106,7 +174,7 @@ local function harvest_hooks()
         if ok and cls and cls:IsValid() then
             pcall(function()
                 cls:ForEachFunction(function(fn)
-                    local ok2 = pcall(function()
+                    pcall(function()
                         local name = fn:GetFName():ToString()
                         if
                             name:find("Dead")
@@ -114,7 +182,6 @@ local function harvest_hooks()
                             or name:find("Defeat")
                         then
                             local full = c .. ":" .. name
-                            log("candidate fn discovered: " .. full)
                             if
                                 not registered[full]
                                 and pcall(RegisterHook, full, on_death)
@@ -124,9 +191,6 @@ local function harvest_hooks()
                             end
                         end
                     end)
-                    if not ok2 and DEBUG_ALL then
-                        log("harvest iteration error on " .. c)
-                    end
                 end)
             end)
         end
@@ -134,7 +198,6 @@ local function harvest_hooks()
 end
 
 local function try_register()
-    local any = false
     for _, fn in ipairs(CANDIDATES) do
         if not registered[fn] then
             if pcall(RegisterHook, fn, on_death) then
@@ -142,16 +205,14 @@ local function try_register()
                 log("death hook registered on " .. fn)
             end
         end
-        if registered[fn] then
-            any = true
-        end
     end
-    return any
+    return next(registered) ~= nil
 end
 
 local function schedule()
     harvest_hooks()
     if try_register() then
+        log("death hooks active; harvest loop stopped")
         return
     end
     probe_classes()
@@ -159,6 +220,43 @@ local function schedule()
     pcall(ExecuteWithDelay, RETRY_MS, schedule)
 end
 
+local scan_found_logged = {}
+
+local function sweep_events()
+    local items = {}
+    for kind, classes in pairs(SCAN_KINDS) do
+        for _, cls in ipairs(classes) do
+            local ok, objs = pcall(FindAllOf, cls)
+            if ok and objs then
+                if not scan_found_logged[cls] then
+                    scan_found_logged[cls] = true
+                    log("event class active: " .. kind .. "=" .. cls .. " (" .. #objs .. ")")
+                end
+                for _, obj in ipairs(objs) do
+                    local actor, loc = resolve_actor(obj)
+                    if actor and loc then
+                        items[#items + 1] = string.format(
+                            "%s:%s:%.1f:%.1f",
+                            kind,
+                            sanitize(cls),
+                            loc.X,
+                            loc.Y
+                        )
+                    end
+                end
+            end
+        end
+    end
+    append_line(
+        now_ms() .. "\tEVENTS\t" .. (#items > 0 and table.concat(items, ";") or "-")
+    )
+    if DEBUG_ALL then
+        log("event sweep: " .. #items .. " present")
+    end
+    pcall(ExecuteWithDelay, SCAN_MS, sweep_events)
+end
+
 log("loaded; events log = " .. EVENTS_LOG .. "; debug=" .. tostring(DEBUG_ALL))
 probe_classes()
 schedule()
+pcall(ExecuteWithDelay, SCAN_MS, sweep_events)

--- a/apps/agones/palworld/relay/src/event_tail.rs
+++ b/apps/agones/palworld/relay/src/event_tail.rs
@@ -12,6 +12,10 @@ use tracing::{info, warn};
 
 use crate::config::Config;
 
+const BOSS_DEDUPE_DIST: f64 = 2000.0;
+const BOSS_DEDUPE_MS: i64 = 180_000;
+const EVENT_MATCH_DIST: f64 = 1000.0;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct BossDefeat {
     pub id: String,
@@ -21,7 +25,17 @@ pub struct BossDefeat {
     pub respawn_at: i64,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct WorldEvent {
+    pub kind: String,
+    pub class: String,
+    pub x: f64,
+    pub y: f64,
+    pub first_seen: i64,
+}
+
 pub type SharedBosses = Arc<RwLock<HashMap<String, BossDefeat>>>;
+pub type SharedEvents = Arc<RwLock<Vec<WorldEvent>>>;
 
 pub fn normalize_id(raw: &str) -> String {
     let name = raw
@@ -67,7 +81,62 @@ pub fn parse_line(line: &str, respawn_secs: i64) -> Option<BossDefeat> {
     })
 }
 
-pub async fn run(cfg: Config, bosses: SharedBosses) -> Result<()> {
+pub fn parse_events_line(line: &str) -> Option<(i64, Vec<WorldEvent>)> {
+    let mut parts = line.trim().split('\t');
+    let ts: i64 = parts.next()?.parse().ok()?;
+    if parts.next()? != "EVENTS" {
+        return None;
+    }
+    let payload = parts.next()?;
+    if payload == "-" {
+        return Some((ts, Vec::new()));
+    }
+    let mut items = Vec::new();
+    for item in payload.split(';') {
+        let mut f = item.split(':');
+        let (Some(kind), Some(class), Some(xs), Some(ys)) =
+            (f.next(), f.next(), f.next(), f.next())
+        else {
+            continue;
+        };
+        let (Ok(x), Ok(y)) = (xs.parse::<f64>(), ys.parse::<f64>()) else {
+            continue;
+        };
+        items.push(WorldEvent {
+            kind: kind.to_string(),
+            class: class.to_string(),
+            x,
+            y,
+            first_seen: ts,
+        });
+    }
+    Some((ts, items))
+}
+
+pub fn is_duplicate_defeat(existing: &HashMap<String, BossDefeat>, d: &BossDefeat) -> bool {
+    existing.values().any(|b| {
+        b.id == d.id
+            && (d.defeated_at - b.defeated_at).abs() < BOSS_DEDUPE_MS
+            && ((b.x - d.x).powi(2) + (b.y - d.y).powi(2)).sqrt() < BOSS_DEDUPE_DIST
+    })
+}
+
+pub fn merge_events(current: &[WorldEvent], incoming: Vec<WorldEvent>) -> Vec<WorldEvent> {
+    incoming
+        .into_iter()
+        .map(|mut e| {
+            if let Some(prev) = current.iter().find(|p| {
+                p.kind == e.kind
+                    && ((p.x - e.x).powi(2) + (p.y - e.y).powi(2)).sqrt() < EVENT_MATCH_DIST
+            }) {
+                e.first_seen = prev.first_seen;
+            }
+            e
+        })
+        .collect()
+}
+
+pub async fn run(cfg: Config, bosses: SharedBosses, events: SharedEvents) -> Result<()> {
     let path = cfg.events_log_path.clone();
     let respawn_secs = cfg.boss_respawn_secs as i64;
     info!(path = %path, respawn_secs, "event_tail starting");
@@ -116,14 +185,20 @@ pub async fn run(cfg: Config, bosses: SharedBosses) -> Result<()> {
             let line = carry[..nl].to_string();
             carry.drain(..=nl);
             if let Some(defeat) = parse_line(&line, respawn_secs) {
+                let mut guard = bosses.write().await;
+                if is_duplicate_defeat(&guard, &defeat) {
+                    continue;
+                }
                 info!(id = %defeat.id, x = defeat.x, y = defeat.y, "boss defeat");
-                let key = format!(
-                    "{}:{}:{}",
-                    defeat.id,
-                    defeat.x.round(),
-                    defeat.y.round()
-                );
-                bosses.write().await.insert(key, defeat);
+                let key = format!("{}:{}:{}", defeat.id, defeat.x.round(), defeat.y.round());
+                guard.insert(key, defeat);
+            } else if let Some((_, incoming)) = parse_events_line(&line) {
+                let mut guard = events.write().await;
+                let merged = merge_events(&guard, incoming);
+                if merged.len() != guard.len() {
+                    info!(count = merged.len(), "world events snapshot");
+                }
+                *guard = merged;
             }
         }
         prune(&bosses).await;
@@ -167,5 +242,77 @@ mod tests {
     fn rejects_non_defeat_lines() {
         assert!(parse_line("123\tCHAT\thello\t0\t0", 3600).is_none());
         assert!(parse_line("garbage", 3600).is_none());
+    }
+
+    #[test]
+    fn parses_events_snapshot() {
+        let (ts, items) = parse_events_line(
+            "1785580000000\tEVENTS\tsupply:PalSupplyDrop:-1000.5:2000.0;meteor:BP_Meteor_C:3.0:4.0",
+        )
+        .unwrap();
+        assert_eq!(ts, 1785580000000);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].kind, "supply");
+        assert_eq!(items[0].x, -1000.5);
+        assert_eq!(items[1].kind, "meteor");
+    }
+
+    #[test]
+    fn parses_empty_events_snapshot() {
+        let (_, items) = parse_events_line("1785580000000\tEVENTS\t-").unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn dedupes_repeated_defeats() {
+        let mut map = HashMap::new();
+        let a = parse_line(
+            "1785579935000\tBOSS_DEFEAT\tBP_Boss_Eagle_C_1\t-226993.8\t191072.5",
+            3600,
+        )
+        .unwrap();
+        map.insert("k".to_string(), a);
+        let b = parse_line(
+            "1785579937000\tBOSS_DEFEAT\tBP_Boss_Eagle_C_2\t-227373.7\t190387.1",
+            3600,
+        )
+        .unwrap();
+        assert!(is_duplicate_defeat(&map, &b));
+        let far = parse_line(
+            "1785579937000\tBOSS_DEFEAT\tBP_Boss_Eagle_C_3\t-100000.0\t50000.0",
+            3600,
+        )
+        .unwrap();
+        assert!(!is_duplicate_defeat(&map, &far));
+    }
+
+    #[test]
+    fn merge_preserves_first_seen() {
+        let current = vec![WorldEvent {
+            kind: "supply".into(),
+            class: "PalSupplyDrop".into(),
+            x: 100.0,
+            y: 200.0,
+            first_seen: 111,
+        }];
+        let incoming = vec![
+            WorldEvent {
+                kind: "supply".into(),
+                class: "PalSupplyDrop".into(),
+                x: 150.0,
+                y: 220.0,
+                first_seen: 999,
+            },
+            WorldEvent {
+                kind: "meteor".into(),
+                class: "BP_Meteor_C".into(),
+                x: 9999.0,
+                y: 9999.0,
+                first_seen: 999,
+            },
+        ];
+        let merged = merge_events(&current, incoming);
+        assert_eq!(merged[0].first_seen, 111);
+        assert_eq!(merged[1].first_seen, 999);
     }
 }

--- a/apps/agones/palworld/relay/src/live_api.rs
+++ b/apps/agones/palworld/relay/src/live_api.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 use tracing::info;
 
 use crate::config::Config;
-use crate::event_tail::{BossDefeat, SharedBosses};
+use crate::event_tail::{BossDefeat, SharedBosses, SharedEvents, WorldEvent};
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct LivePlayer {
@@ -32,6 +32,7 @@ pub type SharedLive = Arc<RwLock<LiveSnapshot>>;
 pub struct LiveState {
     pub snap: SharedLive,
     pub bosses: SharedBosses,
+    pub events: SharedEvents,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -39,7 +40,19 @@ struct LiveResponse {
     #[serde(flatten)]
     snap: LiveSnapshot,
     bosses: Vec<BossDefeat>,
+    events: Vec<WorldEvent>,
 }
+
+#[derive(Debug, Clone, Serialize)]
+struct EventsResponse {
+    ts: i64,
+    events: Vec<WorldEvent>,
+}
+
+const LIVE_HEADERS: [(header::HeaderName, &str); 2] = [
+    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+    (header::CACHE_CONTROL, "no-store"),
+];
 
 async fn players(State(state): State<LiveState>) -> impl IntoResponse {
     let snap = state.snap.read().await.clone();
@@ -53,12 +66,25 @@ async fn players(State(state): State<LiveState>) -> impl IntoResponse {
         .cloned()
         .collect();
     bosses.sort_by_key(|b| b.respawn_at);
+    let events = state.events.read().await.clone();
     (
-        [
-            (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        Json(LiveResponse { snap, bosses }),
+        LIVE_HEADERS,
+        Json(LiveResponse {
+            snap,
+            bosses,
+            events,
+        }),
+    )
+}
+
+async fn events(State(state): State<LiveState>) -> impl IntoResponse {
+    let events = state.events.read().await.clone();
+    (
+        LIVE_HEADERS,
+        Json(EventsResponse {
+            ts: chrono::Utc::now().timestamp_millis(),
+            events,
+        }),
     )
 }
 
@@ -69,6 +95,7 @@ async fn healthz() -> &'static str {
 pub async fn run(cfg: Config, state: LiveState) -> Result<()> {
     let app = Router::new()
         .route("/live/players", get(players))
+        .route("/live/events", get(events))
         .route("/live/healthz", get(healthz))
         .with_state(state);
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", cfg.live_api_port)).await?;

--- a/apps/agones/palworld/relay/src/main.rs
+++ b/apps/agones/palworld/relay/src/main.rs
@@ -51,9 +51,11 @@ async fn main() -> Result<()> {
 
     let live = live_api::SharedLive::default();
     let bosses = event_tail::SharedBosses::default();
+    let events = event_tail::SharedEvents::default();
     let live_state = live_api::LiveState {
         snap: live.clone(),
         bosses: bosses.clone(),
+        events: events.clone(),
     };
 
     let poller_handle = tokio::spawn(poller::run(cfg.clone(), game_tx.clone(), live.clone()));
@@ -66,7 +68,7 @@ async fn main() -> Result<()> {
     let ch_handle = tokio::spawn(ch_writer::run(cfg.clone(), game_tx.subscribe()));
     let agones_handle = tokio::spawn(agones_health::run(cfg.clone()));
     let live_handle = tokio::spawn(live_api::run(cfg.clone(), live_state));
-    let event_handle = tokio::spawn(event_tail::run(cfg.clone(), bosses));
+    let event_handle = tokio::spawn(event_tail::run(cfg.clone(), bosses, events));
 
     drop(game_tx);
 

--- a/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
@@ -294,10 +294,7 @@ export default function ReactPalworldMap() {
 			settleP0 = map.getPixelOrigin().clone();
 			const w = el.clientWidth;
 			const h = el.clientHeight;
-			const o = map.containerPointToLayerPoint([
-				-w * PAD,
-				-h * PAD,
-			]);
+			const o = map.containerPointToLayerPoint([-w * PAD, -h * PAD]);
 			originX = o.x;
 			originY = o.y;
 			L.DomUtil.setPosition(canvas, o);
@@ -498,6 +495,88 @@ export default function ReactPalworldMap() {
 					`</div>`,
 			});
 
+		const EVENT_STYLE: Record<
+			string,
+			{ svg: string; ring: string; label: string }
+		> = {
+			supply: {
+				ring: '#fbbf24',
+				label: 'Supply drop',
+				svg:
+					`<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="#fbbf24" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">` +
+					`<path d="M2 5a6 4.5 0 0 1 12 0" fill="rgba(251,191,36,0.25)"/>` +
+					`<path d="M2 5l3.5 4M14 5l-3.5 4M8 5v4"/>` +
+					`<rect x="5.5" y="9" width="5" height="4.5" rx="0.5" fill="rgba(251,191,36,0.35)"/>` +
+					`</svg>`,
+			},
+			meteor: {
+				ring: '#f87171',
+				label: 'Meteorite',
+				svg:
+					`<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="#f87171" stroke-width="1.3" stroke-linecap="round">` +
+					`<path d="M14 2L7.5 8.5M13 6L9 10M10 3l-4 4"/>` +
+					`<circle cx="5.5" cy="10.5" r="3.2" fill="rgba(248,113,113,0.35)"/>` +
+					`</svg>`,
+			},
+			dungeon: {
+				ring: '#a78bfa',
+				label: 'Dungeon (open)',
+				svg:
+					`<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="#a78bfa" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">` +
+					`<path d="M3 14V7a5 5 0 0 1 10 0v7" fill="rgba(167,139,250,0.25)"/>` +
+					`<path d="M2 14h12"/>` +
+					`<path d="M6.5 14v-3.5a1.5 1.5 0 0 1 3 0V14" fill="rgba(167,139,250,0.5)"/>` +
+					`</svg>`,
+			},
+		};
+		const eventLayer = L.layerGroup().addTo(map);
+		const eventMarkers = new Map<string, L.Marker>();
+		const eventIcon = (style: { svg: string; ring: string }) =>
+			L.divIcon({
+				className: 'pal-event',
+				iconSize: [26, 26],
+				iconAnchor: [13, 13],
+				html:
+					`<div style="width:26px;height:26px;border-radius:50%;background:rgba(8,14,24,0.88);` +
+					`border:2px solid ${style.ring};display:flex;align-items:center;justify-content:center;` +
+					`box-shadow:0 0 10px ${style.ring}99">${style.svg}</div>`,
+			});
+		const syncEvents = (
+			list: { kind: string; x: number; y: number; first_seen: number }[],
+		) => {
+			const seen = new Set<string>();
+			for (const e of list) {
+				const style = EVENT_STYLE[e.kind];
+				if (!style) continue;
+				const key = `${e.kind}:${Math.round(e.x / 100)}:${Math.round(e.y / 100)}`;
+				seen.add(key);
+				if (eventMarkers.has(key)) continue;
+				const m = L.marker(gameToLatLng(e.x, e.y), {
+					icon: eventIcon(style),
+					keyboard: false,
+					zIndexOffset: 400,
+				});
+				m.bindTooltip(
+					() => {
+						const mins = Math.max(
+							0,
+							Math.round((Date.now() - e.first_seen) / 60_000),
+						);
+						return `${style.label} — spotted ${mins}m ago`;
+					},
+					{ direction: 'top', offset: [0, -14], opacity: 0.95 },
+				);
+				m.addTo(eventLayer);
+				eventMarkers.set(key, m);
+			}
+			for (const [key, m] of eventMarkers) {
+				if (!seen.has(key)) {
+					eventLayer.removeLayer(m);
+					eventMarkers.delete(key);
+				}
+			}
+		};
+
 		const countTexts = new Map<number, Text>();
 		const control = new L.Control({ position: 'topright' });
 		control.onAdd = () => {
@@ -568,8 +647,15 @@ export default function ReactPalworldMap() {
 						y: number;
 						respawn_at: number;
 					}[];
+					events?: {
+						kind: string;
+						x: number;
+						y: number;
+						first_seen: number;
+					}[];
 				};
 				if (stopped) return;
+				syncEvents(data.events || []);
 				const seen = new Set<string>();
 				for (const p of data.players || []) {
 					seen.add(p.name);

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_palworld_relay
 pipeline: docker
 app_name: agones-palworld-relay
-version: "0.0.11"
+version: "0.0.12"
 source_path: apps/agones/palworld/relay
 version_toml: apps/agones/palworld/relay/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_palworld
 pipeline: docker
 app_name: agones-palworld
-version: "0.0.34"
+version: "0.0.35"
 source_path: apps/agones/palworld
 version_toml: apps/agones/palworld/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

### PalEventRelay (Lua)
- Stop the hook-harvest retry loop once any death hook is registered (was retrying + log-spamming every 15s forever despite working hooks).
- Dedupe repeated death callbacks per actor instance — `IsDead` is a query the engine calls repeatedly for the same corpse, which produced 4x duplicate `BOSS_DEFEAT` lines per kill in prod.
- New presence scanner: every 20s, `FindAllOf` over candidate supply-drop / meteorite / dungeon-entrance actor classes, appending an `EVENTS` snapshot line to the shared log. Class guesses are extendable at runtime via `PALWORLD_EVENT_CLASSES` (kind=Class,...) and active classes are logged once for discovery — first deploy tells us the real class names to pin.

### Relay (Rust)
- Parse `EVENTS` snapshot lines into a world-events list; `first_seen` survives across sweeps by kind+proximity matching. Snapshot semantics: an event vanishing from the sweep (looted supply drop) drops out of the API automatically.
- Dedupe boss defeats within 2000 units / 180s of an existing entry.
- `events[]` added to `/live/players`; new `/live/events` route for standalone consumption. 6 new/updated tests, all passing via nx.

### Map (astro-kbve)
- Transient SVG badge markers (parachute crate, comet, dungeon arch) for events; appear on poll, auto-removed when the event leaves the snapshot. Tooltip shows "spotted Nm ago".

## Versions (MDX-only)
- agones-palworld: 0.0.35
- agones-palworld-relay: 0.0.12

## Follow-up after deploy
Read server logs for `event class active:` lines to pin the real actor class names; adjust `SCAN_KINDS` defaults if the guesses miss.