### PR TITLE
fix(observability): grafana provider dup warn, surface log metadata, virtualize CH feed

### DIFF
--- a/apps/kube/monitoring/manifests/values.yaml
+++ b/apps/kube/monitoring/manifests/values.yaml
@@ -31,12 +31,13 @@ grafana:
             providers:
                 - name: 'default'
                   orgId: 1
-                  folder: ''
+                  folder: 'KBVE'
                   type: file
                   disableDeletion: false
                   editable: true
                   options:
                       path: /var/lib/grafana/dashboards/default
+                      foldersFromFilesStructure: false
 
     dashboardsConfigMaps:
         default: 'grafana-dashboards'

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, Text, tokens } from './_ui';
@@ -196,11 +196,40 @@ function FilterChips({
 	);
 }
 
+const SEARCH_DEBOUNCE_MS = 200;
+const DEFAULT_MAX_LIST_HEIGHT = 640;
+
+function useDebouncedSearch(value: string, commit: (next: string) => void) {
+	const [draft, setDraft] = useState(value);
+	const commitRef = useRef(commit);
+	commitRef.current = commit;
+	const lastValueRef = useRef(value);
+
+	useEffect(() => {
+		if (value !== lastValueRef.current) {
+			lastValueRef.current = value;
+			setDraft(value);
+		}
+	}, [value]);
+
+	useEffect(() => {
+		if (draft === lastValueRef.current) return;
+		const t = setTimeout(() => {
+			lastValueRef.current = draft;
+			commitRef.current(draft);
+		}, SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(t);
+	}, [draft]);
+
+	return [draft, setDraft] as const;
+}
+
 export interface StreamViewProps<TItem> {
 	store: StreamStore<TItem>;
 	lens: StreamLens<TItem>;
 	layout?: 'rows' | 'cards';
 	searchPlaceholder?: string;
+	maxListHeight?: number;
 }
 
 export function StreamView<TItem>({
@@ -208,9 +237,14 @@ export function StreamView<TItem>({
 	lens,
 	layout = 'rows',
 	searchPlaceholder = 'Filter…',
+	maxListHeight = DEFAULT_MAX_LIST_HEIGHT,
 }: StreamViewProps<TItem>): ReactElement {
 	useStreamLifecycle(store);
 	const state = useStream(store);
+	const [searchDraft, setSearchDraft] = useDebouncedSearch(
+		state.search,
+		store.setSearch,
+	);
 
 	const pickFilter = (id: string | null) => {
 		const prev = lens.filters?.find((f) => f.id === state.filterId);
@@ -300,8 +334,8 @@ export function StreamView<TItem>({
 				) : null}
 				{lens.searchText ? (
 					<TextInput
-						value={state.search}
-						onChangeText={store.setSearch}
+						value={searchDraft}
+						onChangeText={setSearchDraft}
 						placeholder={searchPlaceholder}
 						placeholderTextColor={tokens.color.textFaint}
 						style={styles.search}
@@ -331,6 +365,12 @@ export function StreamView<TItem>({
 				)}
 				ItemSeparatorComponent={Separator}
 				ListEmptyComponent={EmptyRow}
+				style={{ maxHeight: maxListHeight }}
+				initialNumToRender={16}
+				maxToRenderPerBatch={16}
+				updateCellsBatchingPeriod={50}
+				windowSize={5}
+				removeClippedSubviews
 			/>
 		</Stack>
 	);

--- a/packages/npm/rn/src/dash/adapters/clickhouse.tsx
+++ b/packages/npm/rn/src/dash/adapters/clickhouse.tsx
@@ -16,6 +16,7 @@ export interface RawLogRow {
 	pod_namespace?: string;
 	service?: string;
 	container_name?: string;
+	metadata?: string;
 }
 
 export interface LogItem {
@@ -28,6 +29,7 @@ export interface LogItem {
 	service: string;
 	container: string;
 	relativeTime: string;
+	metadataRaw: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -58,7 +60,46 @@ export function normalize(raw: RawLogRow): LogItem {
 		service,
 		container,
 		relativeTime,
+		metadataRaw: raw.metadata ?? '',
 	};
+}
+
+const META_HIDDEN_KEYS = new Set([
+	'level',
+	'severity',
+	'msg',
+	'message',
+	'time',
+	'ts',
+	'timestamp',
+	'logger',
+	'logging_pod',
+]);
+
+export interface MetaFact {
+	key: string;
+	value: string;
+}
+
+export function parseMetadataFacts(rawMeta: string): MetaFact[] {
+	if (!rawMeta || rawMeta === '{}') return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawMeta);
+	} catch {
+		return [{ key: 'metadata', value: rawMeta }];
+	}
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+	const out: MetaFact[] = [];
+	for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+		if (META_HIDDEN_KEYS.has(key.toLowerCase())) continue;
+		if (value === null || value === undefined || value === '') continue;
+		const text =
+			typeof value === 'string' ? value : JSON.stringify(value) ?? '';
+		if (!text) continue;
+		out.push({ key, value: text });
+	}
+	return out.sort((a, b) => a.key.localeCompare(b.key));
 }
 
 function formatRelativeTime(ts: string): string {
@@ -222,14 +263,41 @@ export const clickhouseLens: StreamLens<LogItem> = {
 					<Text variant="caption" weight="medium" tone="muted">
 						Message:
 					</Text>
-					<Text variant="caption" tone="faint">
+					<Text variant="caption" tone="faint" selectable>
 						{it.message}
 					</Text>
 				</Stack>
 			)}
+			<MetadataFacts rawMeta={it.metadataRaw} />
 		</Stack>
 	),
 };
+
+function MetadataFacts({ rawMeta }: { rawMeta: string }) {
+	const facts = parseMetadataFacts(rawMeta);
+	if (!facts.length) return null;
+	return (
+		<Stack gap="xs">
+			<Text variant="caption" weight="medium" tone="muted">
+				Metadata:
+			</Text>
+			{facts.map((f) => (
+				<Stack key={f.key} direction="row" gap="sm" justify="space-between">
+					<Text variant="caption" tone="muted">
+						{f.key}
+					</Text>
+					<Text
+						variant="caption"
+						tone="faint"
+						selectable
+						style={styles.metaValue}>
+						{f.value}
+					</Text>
+				</Stack>
+			))}
+		</Stack>
+	);
+}
 
 function Fact({ label, value }: { label: string; value: string }) {
 	return (
@@ -266,6 +334,10 @@ const styles = StyleSheet.create({
 		flexShrink: 0,
 	},
 	factValue: {
+		flexShrink: 1,
+		textAlign: 'right',
+	},
+	metaValue: {
 		flexShrink: 1,
 		textAlign: 'right',
 	},


### PR DESCRIPTION
Two things, both driven by what is showing up on `/dashboard/clickhouse/`.

## 1. Grafana provisioning warn flooding ClickHouse

```
logger=provisioning.dashboard level=warn msg="dashboards provisioning provider has no database write permissions because of duplicates" provider=sidecarProvider orgId=1
```

`apps/kube/monitoring/manifests/values.yaml` declared the file dashboard provider `default` with `folder: ''` and `orgId: 1`. The kube-prometheus-stack sidecar registers `sidecarProvider` against the same folder + orgId, so Grafana treats them as duplicates, strips write permissions, and logs the warning on every provisioning poll — roughly 6/min, ~8.6k rows/day into `observability.logs_raw`.

`monitoring` is in vector's `noise_filter` noisy-namespace list, but the filter still passes anything matching `warn|error|fatal|...`, so these were flowing through.

Fix: move the file provider into its own `KBVE` folder and pin `foldersFromFilesStructure: false`. The sidecar keeps the root folder to itself.

## 2. `kilobase / supabase-cluster-8` GRPC errors were undebuggable

```
Error while handling GRPC request
```

That is the CNPG instance-manager talking to the barman-cloud plugin sidecar. The useful part — the `error` field, `controller`, `logging_pod` — was never visible.

It was not lost, though. Vector's `project_logs` remap parses the JSON line and keeps the full object in `logs_distributed.metadata`, and `build_query_sql` in `packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs` already SELECTs that column. The RN adapter just dropped it during `normalize`.

`RawLogRow`/`LogItem` now carry `metadata`, and the detail panel renders the parsed facts (hiding keys already shown as their own row: level, msg, ts, logging_pod, ...). Parsing is lazy — only on expand, not for all 500 rows per poll.

This does not fix the GRPC error itself; it makes the payload readable so the root cause can be pinned. Cluster config was checked and looks consistent: `object-store.yaml` destinationPath and credentials match the plugin parameters in `postgres-cluster.yaml`.

## 3. Dashboard was unresponsive

Not a data-volume problem — virtualization was simply not running.

`VirtualList` wraps react-native-web's `FlatList`, and it was mounted inside `.svc-dash__stream`, which sets `min-height: 60vh` and no height cap. RN-web measures the ScrollView as the full content height, concludes the viewport is effectively infinite, and windows nothing. All 500 rows stayed mounted, re-reconciled on every 30s poll, plus group headers.

Changes in `StreamView.tsx`:

- cap the list height (640 default, overridable via the new `maxListHeight` prop) so windowing actually engages
- `initialNumToRender` / `maxToRenderPerBatch` 16, `windowSize` 5, `removeClippedSubviews`
- debounce the search input at 200ms — previously every keystroke went straight to `store.setSearch`, re-filtering 500 items and re-rendering the whole feed

Tradeoff worth calling out: the feed now scrolls inside its own pane rather than with the page.

## Verification

- `nx test rn --skip-nx-cache` — 45 files, 198 tests, all passing
- `tsc --noEmit -p packages/npm/rn/tsconfig.lib.json` — clean on all three changed files (the pre-existing errors in `rows.tsx` and `ClusterChartsPanel.tsx` are untouched)

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)