### PR TITLE
fix(herbmail-game): stop character mesh vanishing mid-move

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/character/Character.tsx
+++ b/apps/herbmail/herbmail-game/src/game/character/Character.tsx
@@ -284,7 +284,10 @@ export function Character({
 	const scene = useMemo(() => {
 		const s = cloneSkinned(gltf.scene);
 		s.traverse((o) => {
-			if ((o as THREE.Mesh).isMesh) o.castShadow = true;
+			if ((o as THREE.Mesh).isMesh) {
+				o.castShadow = true;
+				o.frustumCulled = false;
+			}
 		});
 		return s;
 	}, [gltf]);


### PR DESCRIPTION
## Problem

In production the main player's model intermittently disappears while moving.

## Cause

`THREE.SkinnedMesh` (three 0.184) caches `boundingSphere` on the first frustum test, computed from whatever pose the rig is in at that moment, and never recomputes it. Clips that translate the pelvis (`Jog_Fwd_Loop`, `Sprint_Loop`, `Jump_Start`, strafes) move verts outside that stale sphere. With the close third-person rig (`CAM_DIST 2.2`, lerped follow) the sphere sits on the frustum edge, so the whole body gets culled for a few frames.

The base body clone in `Character.tsx` was the only rig left with culling enabled — attached armor (`partsLoader.ts`) and `KurenaiNpc.tsx` already set `frustumCulled = false`. That's why armor stayed visible while the body popped out.

## Fix

Set `frustumCulled = false` on the cloned character meshes alongside the existing `castShadow` pass.

## Notes

`Character` also backs Goblins and the Live Rig, so they lose frustum culling too — same latent bug there. Cost is that skinned character meshes are always submitted; negligible at current NPC counts, but if goblin counts grow this should become a per-instance opt-out prop.

`nx typecheck herbmail-game` passes.