### PR TITLE
refactor(laser)!: split phaser and r3f behind subpath entry points

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -602,7 +602,7 @@
 		{
 			"key": "laser",
 			"package_name": "laser",
-			"version": "0.1.6",
+			"version": "0.2.0",
 			"version_toml": "packages/npm/laser/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/laser.mdx",
 			"version_target": "packages/npm/laser/package.json"

--- a/apps/agones/arpg/web/src/game/IsoArpgScene.ts
+++ b/apps/agones/arpg/web/src/game/IsoArpgScene.ts
@@ -2,10 +2,6 @@ import Phaser from 'phaser';
 import {
 	GameClient,
 	PROTOCOL_VERSION,
-	createWorldDustLayer,
-	drawHealthBar,
-	drawHealthBarCached,
-	type WorldDustHandle,
 	type EntityDelta,
 	type KindEntry,
 	type Snapshot,
@@ -18,6 +14,12 @@ import {
 	type CorpseContents,
 	ACTION_LOOT,
 } from '@kbve/laser';
+import {
+	createWorldDustLayer,
+	drawHealthBar,
+	drawHealthBarCached,
+	type WorldDustHandle,
+} from '@kbve/laser/phaser';
 import {
 	COLORS,
 	TILE_W,

--- a/apps/agones/arpg/web/src/game/entities/projectiles/arrows/bow.ts
+++ b/apps/agones/arpg/web/src/game/entities/projectiles/arrows/bow.ts
@@ -1,5 +1,5 @@
 import Phaser from 'phaser';
-import { floatingText } from '@kbve/laser';
+import { floatingText } from '@kbve/laser/phaser';
 import {
 	ARROW_SPEED,
 	ARROW_MAX_RANGE,

--- a/apps/agones/arpg/web/src/game/entities/projectiles/pool.ts
+++ b/apps/agones/arpg/web/src/game/entities/projectiles/pool.ts
@@ -1,1 +1,1 @@
-export { GameObjectPool } from '@kbve/laser';
+export { GameObjectPool } from '@kbve/laser/phaser';

--- a/apps/agones/arpg/web/src/game/systems/combat.ts
+++ b/apps/agones/arpg/web/src/game/systems/combat.ts
@@ -3,10 +3,9 @@ import {
 	GameClient,
 	EntityStore,
 	ACTION_SHOOT,
-	flashEntity,
-	floatingText,
 	type CombatEvent,
 } from '@kbve/laser';
+import { flashEntity, floatingText } from '@kbve/laser/phaser';
 import { DEPTH_UI, ARROW_MAX_RANGE, ARROW_SPEED } from '../config';
 import {
 	fireBow,

--- a/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
+++ b/apps/agones/arpg/web/src/test/laser-vitest-stub.ts
@@ -1,9 +1,0 @@
-/**
- * Vitest-only stand-in for the @kbve/laser runtime barrel. The real barrel
- * value-exports Phaser-backed helpers node-env vitest cannot load. This stub
- * re-exports the pure leaves the spec import graphs actually execute
- * (game-auth via config.ts, the Cat enum via targetLock.ts); laser type-only
- * imports are erased before resolution and never reach it.
- */
-export * from '../../../../../../packages/npm/laser/src/lib/auth/game-auth';
-export { Cat } from '../../../../../../packages/npm/laser/src/lib/ecs/store';

--- a/apps/agones/arpg/web/tsconfig.json
+++ b/apps/agones/arpg/web/tsconfig.json
@@ -16,6 +16,10 @@
 		"baseUrl": ".",
 		"paths": {
 			"@kbve/laser": ["../../../../packages/npm/laser/src/index.ts"],
+			"@kbve/laser/phaser": [
+				"../../../../packages/npm/laser/src/phaser.ts"
+			],
+			"@kbve/laser/r3f": ["../../../../packages/npm/laser/src/r3f.ts"],
 			"@kbve/observ": ["../../../../packages/npm/observ/src/index.ts"],
 			"@kbve/itemdb-data": [
 				"../../../../packages/data/codegen/generated/itemdb.json"

--- a/apps/agones/arpg/web/vite.config.ts
+++ b/apps/agones/arpg/web/vite.config.ts
@@ -96,25 +96,14 @@ function hashDiscordBundle(htmlTemplatePath: string) {
 
 const GAME_WS = process.env.PUBLIC_ARPG_GAME_WS || 'ws://localhost:7979/ws';
 
-function stubLaserR3F() {
-	const virtual = '\0arpg-laser-r3f-stub';
-	return {
-		name: 'stub-laser-r3f',
-		enforce: 'pre' as const,
-		resolveId(source: string) {
-			return /[\\/]lib[\\/]r3f[\\/]/.test(source) ? virtual : null;
-		},
-		load(id: string) {
-			return id === virtual
-				? 'export const Stage = () => null; export const useGameLoop = () => {};'
-				: null;
-		},
-	};
-}
-
 const laserAlias = {
 	find: /^@kbve\/laser$/,
 	replacement: path.join(repoRoot, 'packages/npm/laser/src/index.ts'),
+};
+
+const laserSubpathAlias = {
+	find: /^@kbve\/laser\/(ecs|mecs|phaser|r3f)$/,
+	replacement: path.join(repoRoot, 'packages/npm/laser/src/$1.ts'),
 };
 
 const observAlias = {
@@ -156,22 +145,17 @@ const itemdbSchemaAlias = {
 // arpg.kbve.com is the single source: app, embed bundle, and art all ship here.
 export default defineConfig(({ mode }) => {
 	const base = {
-		plugins: [stubLaserR3F(), react()],
+		plugins: [react()],
 		// Keep function/class names through esbuild minification so telemetry
 		// stack traces show real frames (not `t.a.b`) even without a source map.
 		esbuild: { keepNames: true },
 		resolve: {
-			// dedupe bitecs: laser declares it an optional peer, so aliasing
-			// @kbve/laser to source otherwise lets vite resolve laser's `bitecs`
-			// import to its optional-peer stub. That works at the repo root
-			// (hoisted node_modules) but breaks the container's isolated install
-			// ("query is not exported by __vite-optional-peer-dep:bitecs"). This
-			// app depends on bitecs directly, so pin everyone to that one copy.
-			// phaser + @phaserjs/rapier-connector are the same trap: laser source
-			// lives outside web/, so vite resolves its bare imports relative to
-			// packages/npm/laser, which has no node_modules in the container
-			// ("Could not resolve 'phaser' imported by @kbve/laser"). Pin them
-			// to this app's copy. Local builds mask it via root node_modules.
+			// laser is aliased to source, so its bare imports resolve relative to
+			// packages/npm/laser — which has no node_modules in the container. Each
+			// optional peer laser can reach from an entry point this app imports
+			// must be pinned to this app's copy, or vite substitutes an
+			// optional-peer stub that rollup then fails on. Local builds mask it
+			// via root node_modules, so a miss here only breaks the image build.
 			dedupe: [
 				'react',
 				'react-dom',
@@ -181,6 +165,7 @@ export default defineConfig(({ mode }) => {
 				'fastnoise-lite',
 			],
 			alias: [
+				laserSubpathAlias,
 				laserAlias,
 				observAlias,
 				itemdbDataAlias,

--- a/apps/agones/arpg/web/vitest.config.ts
+++ b/apps/agones/arpg/web/vitest.config.ts
@@ -2,22 +2,25 @@ import * as path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 // Unit tests for the game's pure logic (dungeon parity, etc). Kept separate from
-// the build config (vite.config.ts) — these specs need no DOM, no Phaser, and no
-// laser source alias; they exercise plain TS. The dungeon parity spec pins the
-// frozen FNV-1a fingerprint shared with simgrid's Rust arpg_dungeon.
-//
-// @kbve/laser resolves to a pure-leaf stub, not the runtime barrel: the barrel
-// value-exports Phaser-backed helpers that node-env vitest cannot load, while
-// the values these spec graphs execute live in pure leaves (game-auth).
-// Type-only laser imports are erased before resolution.
+// the build config (vite.config.ts) — these specs need no DOM and no Phaser.
+// laser is aliased to source; the root barrel is renderer-free (Phaser and
+// three live behind the /phaser and /r3f subpaths), so node-env vitest can load
+// it directly instead of the hand-written stub this used to need.
 export default defineConfig({
 	resolve: {
 		alias: [
 			{
+				find: /^@kbve\/laser\/(ecs|mecs|phaser|r3f)$/,
+				replacement: path.resolve(
+					__dirname,
+					'../../../../packages/npm/laser/src/$1.ts',
+				),
+			},
+			{
 				find: /^@kbve\/laser$/,
 				replacement: path.resolve(
 					__dirname,
-					'src/test/laser-vitest-stub.ts',
+					'../../../../packages/npm/laser/src/index.ts',
 				),
 			},
 		],

--- a/apps/chuckrpg/astro-chuckrpg/tsconfig.json
+++ b/apps/chuckrpg/astro-chuckrpg/tsconfig.json
@@ -10,7 +10,9 @@
 			"@/*": ["src/*"],
 			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
-			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
+			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/laser/phaser": ["../../../packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["../../../packages/npm/laser/src/r3f.ts"]
 		},
 		"ignoreDeprecations": "6.0"
 	}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -1,8 +1,9 @@
 import { useRef, useCallback, useMemo, memo, useEffect } from 'react';
 import Phaser from 'phaser';
 import GridEngine from 'grid-engine';
-import { PhaserGame, laserEvents } from '@kbve/laser';
-import type { PhaserGameRef } from '@kbve/laser';
+import { laserEvents } from '@kbve/laser';
+import { PhaserGame } from '@kbve/laser/phaser';
+import type { PhaserGameRef } from '@kbve/laser/phaser';
 import { NotContent } from '@kbve/astro/ui';
 import { PreloaderScene } from './scenes/PreloaderScene';
 import { CloudCityScene } from './scenes/CloudCityScene';

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -2,15 +2,6 @@ import Phaser, { Scene } from 'phaser';
 import {
 	GameClient,
 	laserEvents,
-	createBirdAnimation,
-	createDustMoteLayer,
-	flashEntity,
-	floatingText,
-	drawHealthBarCached,
-	attachCameraZoom,
-	setupKeyboardMap,
-	createArrowPool,
-	animateArrowProjectile,
 	findTilePath,
 	lineCast,
 	BOW_RANGE,
@@ -21,6 +12,17 @@ import {
 	KIND_CAT_NPC,
 	KIND_CAT_PLAYER,
 } from '@kbve/laser';
+import {
+	createBirdAnimation,
+	createDustMoteLayer,
+	flashEntity,
+	floatingText,
+	drawHealthBarCached,
+	attachCameraZoom,
+	setupKeyboardMap,
+	createArrowPool,
+	animateArrowProjectile,
+} from '@kbve/laser/phaser';
 import type {
 	CharacterEventData,
 	Snapshot,
@@ -28,9 +30,8 @@ import type {
 	ConnectionState,
 	BjActionKind,
 	ProjectileEvent,
-	GpuSpriteLayerHandle,
-	ArrowPool,
 } from '@kbve/laser';
+import type { GpuSpriteLayerHandle, ArrowPool } from '@kbve/laser/phaser';
 import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
 import { resolveNpcSprite } from '../data/npcVisuals';

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -17,6 +17,8 @@
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
 			"@kbve/observ": ["../../../packages/npm/observ/src/index.ts"],
 			"@kbve/laser/ecs": ["../../../packages/npm/laser/src/ecs.ts"],
+			"@kbve/laser/phaser": ["../../../packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["../../../packages/npm/laser/src/r3f.ts"],
 			"@kbve/chat/gamechat": [
 				"../../../packages/npm/chat/src/gamechat.ts"
 			],

--- a/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
@@ -24,6 +24,14 @@ export default defineConfig({
 				find: '@kbve/laser/ecs',
 				replacement: pkg('npm/laser/src/ecs.ts'),
 			},
+			{
+				find: '@kbve/laser/phaser',
+				replacement: pkg('npm/laser/src/phaser.ts'),
+			},
+			{
+				find: '@kbve/laser/r3f',
+				replacement: pkg('npm/laser/src/r3f.ts'),
+			},
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
 			{
 				find: '@kbve/chat/gamechat',

--- a/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
@@ -30,6 +30,14 @@ export default defineConfig({
 				find: '@kbve/laser/ecs',
 				replacement: pkg('npm/laser/src/ecs.ts'),
 			},
+			{
+				find: '@kbve/laser/phaser',
+				replacement: pkg('npm/laser/src/phaser.ts'),
+			},
+			{
+				find: '@kbve/laser/r3f',
+				replacement: pkg('npm/laser/src/r3f.ts'),
+			},
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
 			{
 				find: '@kbve/chat/gamechat',

--- a/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
+++ b/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
@@ -6,7 +6,7 @@ import {
 	POM_MARCH,
 	POM_SELF_SHADOW,
 	SPOM_SILHOUETTE,
-} from '@kbve/laser';
+} from '@kbve/laser/r3f';
 import { TILE } from '../config';
 
 const blankTex = new THREE.DataTexture(

--- a/apps/herbmail/herbmail-game/tsconfig.json
+++ b/apps/herbmail/herbmail-game/tsconfig.json
@@ -12,6 +12,8 @@
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
 			"@kbve/laser/ecs": ["../../../packages/npm/laser/src/ecs.ts"],
 			"@kbve/laser/mecs": ["../../../packages/npm/laser/src/mecs.ts"],
+			"@kbve/laser/phaser": ["../../../packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["../../../packages/npm/laser/src/r3f.ts"],
 			"@kbve/itemdb-data": [
 				"../../../packages/data/codegen/generated/itemdb.json"
 			],

--- a/apps/herbmail/herbmail-game/vite.config.ts
+++ b/apps/herbmail/herbmail-game/vite.config.ts
@@ -183,6 +183,14 @@ export default defineConfig({
 				find: '@kbve/laser/ecs',
 				replacement: path.join(laserSrc, 'ecs.ts'),
 			},
+			{
+				find: '@kbve/laser/phaser',
+				replacement: path.join(laserSrc, 'phaser.ts'),
+			},
+			{
+				find: '@kbve/laser/r3f',
+				replacement: path.join(laserSrc, 'r3f.ts'),
+			},
 			itemdbDataAlias,
 			itemdbSchemaAlias,
 		],

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/ReactBlackjackApp.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/ReactBlackjackApp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Phaser from 'phaser';
-import { PhaserGame, type LaserGameConfig } from '@kbve/laser';
+import { type LaserGameConfig } from '@kbve/laser';
+import { PhaserGame } from '@kbve/laser/phaser';
 import { useStore } from '@nanostores/react';
 import { $auth, setAuth } from '@kbve/droid';
 import { getSupa, initSupa } from '@/lib/supa';

--- a/apps/kbve/astro-kbve/src/arcade/runner/systems/RapierPhysicsSystem.ts
+++ b/apps/kbve/astro-kbve/src/arcade/runner/systems/RapierPhysicsSystem.ts
@@ -5,7 +5,7 @@
 // Uses dynamic bodies with real gravity (matches official Phaser Rapier examples)
 // ============================================================================
 
-import { RAPIER, createRapierPhysics } from '@kbve/laser';
+import { RAPIER, createRapierPhysics } from '@kbve/laser/phaser';
 import { getComponents, getPlatforms, type GameWorld } from '../ecs';
 
 // ============================================================================

--- a/apps/kbve/astro-kbve/src/arcade/solitaire/ReactSolitaireApp.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/solitaire/ReactSolitaireApp.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import Phaser from 'phaser';
-import { PhaserGame, type LaserGameConfig } from '@kbve/laser';
+import { type LaserGameConfig } from '@kbve/laser';
+import { PhaserGame } from '@kbve/laser/phaser';
 import { SolitaireScene } from './SolitaireScene';
 import { BASE_HEIGHT, BASE_WIDTH, COLORS } from './config';
 

--- a/apps/kbve/astro-kbve/src/arcade/towerdefense/ReactTowerDefenseApp.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/towerdefense/ReactTowerDefenseApp.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import Phaser from 'phaser';
-import { PhaserGame, type LaserGameConfig } from '@kbve/laser';
+import { type LaserGameConfig } from '@kbve/laser';
+import { PhaserGame } from '@kbve/laser/phaser';
 import { TowerDefenseScene } from './TowerDefenseScene';
 import { BASE_HEIGHT, BASE_WIDTH, COLORS } from './config';
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/laser.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/laser.mdx
@@ -14,7 +14,7 @@ tags:
 key: laser
 pipeline: npm
 package_name: laser
-version: "0.1.6"
+version: "0.2.0"
 source_path: packages/npm/laser
 version_toml: packages/npm/laser/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/standalone/solitaire/vite.config.ts
+++ b/apps/kbve/astro-kbve/standalone/solitaire/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
 	base: './',
 	resolve: {
 		alias: {
+			'@kbve/laser/phaser': path.resolve(
+				repoRoot,
+				'packages/npm/laser/src/phaser.ts',
+			),
 			'@kbve/laser': path.resolve(
 				repoRoot,
 				'packages/npm/laser/src/index.ts',

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -22,6 +22,8 @@
 			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/laser/phaser": ["../../../packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["../../../packages/npm/laser/src/r3f.ts"],
 			"@kbve/chat": ["../../../packages/npm/chat/src/index.ts"],
 			"@kbve/chat/*": ["../../../packages/npm/chat/src/*"],
 			"@kbve/proto": [

--- a/apps/kbve/astro-kbve/vitest.config.ts
+++ b/apps/kbve/astro-kbve/vitest.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
 				),
 			},
 			{
+				find: /^@kbve\/laser\/(ecs|mecs|phaser|r3f)$/,
+				replacement: path.resolve(
+					__dirname,
+					'../../../packages/npm/laser/src/$1.ts',
+				),
+			},
+			{
 				find: '@kbve/laser',
 				replacement: path.resolve(
 					__dirname,

--- a/apps/kbve/astro-kbve/vitest.unit-jsdom.config.ts
+++ b/apps/kbve/astro-kbve/vitest.unit-jsdom.config.ts
@@ -24,6 +24,14 @@ export default defineConfig({
 				__dirname,
 				'../../../packages/npm/droid/src/index.ts',
 			),
+			'@kbve/laser/phaser': path.resolve(
+				__dirname,
+				'../../../packages/npm/laser/src/phaser.ts',
+			),
+			'@kbve/laser/r3f': path.resolve(
+				__dirname,
+				'../../../packages/npm/laser/src/r3f.ts',
+			),
 			'@kbve/laser': path.resolve(
 				__dirname,
 				'../../../packages/npm/laser/src/index.ts',

--- a/apps/rareicon/astro-rareicon/tsconfig.json
+++ b/apps/rareicon/astro-rareicon/tsconfig.json
@@ -14,6 +14,8 @@
 			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/laser/phaser": ["../../../packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["../../../packages/npm/laser/src/r3f.ts"],
 			"@kbve/proto": [
 				"../../../packages/data/codegen/generated/index.ts"
 			],

--- a/packages/npm/laser-e2e/src/app/PhaserTest.tsx
+++ b/packages/npm/laser-e2e/src/app/PhaserTest.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import Phaser from 'phaser';
-import { PhaserGame } from '@kbve/laser';
+import { PhaserGame } from '@kbve/laser/phaser';
 
 class BootScene extends Phaser.Scene {
 	constructor() {

--- a/packages/npm/laser-e2e/src/app/R3FTest.tsx
+++ b/packages/npm/laser-e2e/src/app/R3FTest.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Stage } from '@kbve/laser';
+import { Stage } from '@kbve/laser/r3f';
 
 export const R3FTest: React.FC = () => {
 	return (

--- a/packages/npm/laser/package.json
+++ b/packages/npm/laser/package.json
@@ -28,9 +28,26 @@
 		".": {
 			"import": "./laser.es.js",
 			"types": "./index.d.ts"
+		},
+		"./ecs": {
+			"import": "./ecs.es.js",
+			"types": "./ecs.d.ts"
+		},
+		"./mecs": {
+			"import": "./mecs.es.js",
+			"types": "./mecs.d.ts"
+		},
+		"./phaser": {
+			"import": "./phaser.es.js",
+			"types": "./phaser.d.ts"
+		},
+		"./r3f": {
+			"import": "./r3f.es.js",
+			"types": "./r3f.d.ts"
 		}
 	},
 	"files": [
+		"*.es.js",
 		"laser.es.js",
 		"index.d.ts",
 		"**/*.d.ts",

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -24,68 +24,9 @@ export type {
 // Spatial
 export { Quadtree } from './lib/spatial/quadtree';
 
-// Phaser
-export { PhaserGame } from './lib/phaser/PhaserGame';
-export type { PhaserGameProps, PhaserGameRef } from './lib/phaser/PhaserGame';
-export { PhaserContext, usePhaserGame } from './lib/phaser/use-phaser';
-export { usePhaserEvent } from './lib/phaser/use-phaser-event';
-export { PlayerController } from './lib/phaser/player-controller';
-export { VirtualJoystick } from './lib/phaser/virtual-joystick';
-export type { VirtualJoystickConfig } from './lib/phaser/virtual-joystick';
-export {
-	flashEntity,
-	floatingText,
-	drawHealthBar,
-	drawHealthBarCached,
-	attachCameraZoom,
-} from './lib/phaser/entity-fx';
-export type { CameraZoomOptions } from './lib/phaser/entity-fx';
-export {
-	createGpuSpriteLayer,
-	populateGpuSpriteLayer,
-} from './lib/phaser/gpu-sprite-layer';
-export type {
-	GpuSpriteLayerOptions,
-	GpuSpriteLayerHandle,
-} from './lib/phaser/gpu-sprite-layer';
-export {
-	createDustMoteLayer,
-	createWorldDustLayer,
-	dustMemberAt,
-} from './lib/phaser/ambient-dust';
-export type {
-	DustMoteOptions,
-	WorldDustHandle,
-	WorldDustOptions,
-} from './lib/phaser/ambient-dust';
-export { GameObjectPool } from './lib/phaser/object-pool';
-export { setupKeyboardMap } from './lib/phaser/keyboard-map';
-export type { KeyboardMap } from './lib/phaser/keyboard-map';
-export {
-	createArrowPool,
-	animateArrowProjectile,
-} from './lib/phaser/arrow-projectile';
-export type {
-	ArrowPool,
-	ArrowPoolOptions,
-	ArrowShot,
-} from './lib/phaser/arrow-projectile';
-
 // Tile prediction — BFS pathing that mirrors the server grid
 export { findTilePath } from './lib/tile/path';
 export type { TileXY } from './lib/tile/path';
-export {
-	getBirdNum,
-	isBird,
-	createBirdSprites,
-	createShadowSprites,
-	createBirdAnimation,
-} from './lib/phaser/monsters/bird';
-
-// R3F
-export { Stage } from './lib/r3f/components/Stage';
-export type { StageProps } from './lib/r3f/components/Stage';
-export { useGameLoop } from './lib/r3f/hooks/use-game-loop';
 
 // WebGL context-loss guard (framework-agnostic; shared across WebGL games)
 export {
@@ -97,29 +38,6 @@ export type {
 	WebGLEventKind,
 	ContextGuardHandlers,
 } from './lib/webgl/context-guard';
-
-// WebGL — Parallax / Silhouette Occlusion Mapping (POM / SPOM) primitives
-export {
-	createPomUniforms,
-	toThreeUniforms,
-	POM_DEFAULTS,
-	POM_MAX_STEPS,
-	POM_VARYINGS,
-	DERIVE_TANGENT,
-	POM_MARCH,
-	SPOM_SILHOUETTE,
-	POM_SELF_SHADOW,
-	HEIGHT_HELPERS,
-	POM_SOURCE_BRICK,
-	POM_SOURCE_LUMA,
-	POM_SOURCE_MAP,
-	POM_WGSL_STUB,
-} from './lib/webgl/pom';
-export type {
-	PomUniformValues,
-	PomConfig,
-	PomMaterialType,
-} from './lib/webgl/pom';
 
 // ECS (bitecs) — full re-export of bitecs core API
 export * from './lib/ecs/bitecs';
@@ -143,9 +61,6 @@ export {
 	type SpawnData,
 	type UpdateData,
 } from './lib/ecs/store';
-
-// Physics (Rapier)
-export { RAPIER, createRapierPhysics } from './lib/physics/rapier';
 
 // Determinism — RNG primitives mirrored byte-for-byte by simgrid rng.rs
 export { Domain, mix32, mulberry32, stream, rollPct } from './lib/determ';

--- a/packages/npm/laser/src/phaser.ts
+++ b/packages/npm/laser/src/phaser.ts
@@ -1,0 +1,59 @@
+// Phaser subpath: every laser module that imports phaser at runtime, plus the
+// Rapier connector that only Phaser games use. Kept out of the main barrel so a
+// consumer that never boots Phaser (herbmail) does not drag those optional peers
+// into its module graph.
+
+export { PhaserGame } from './lib/phaser/PhaserGame';
+export type { PhaserGameProps, PhaserGameRef } from './lib/phaser/PhaserGame';
+export { PhaserContext, usePhaserGame } from './lib/phaser/use-phaser';
+export { usePhaserEvent } from './lib/phaser/use-phaser-event';
+export { PlayerController } from './lib/phaser/player-controller';
+export { VirtualJoystick } from './lib/phaser/virtual-joystick';
+export type { VirtualJoystickConfig } from './lib/phaser/virtual-joystick';
+export {
+	flashEntity,
+	floatingText,
+	drawHealthBar,
+	drawHealthBarCached,
+	attachCameraZoom,
+} from './lib/phaser/entity-fx';
+export type { CameraZoomOptions } from './lib/phaser/entity-fx';
+export {
+	createGpuSpriteLayer,
+	populateGpuSpriteLayer,
+} from './lib/phaser/gpu-sprite-layer';
+export type {
+	GpuSpriteLayerOptions,
+	GpuSpriteLayerHandle,
+} from './lib/phaser/gpu-sprite-layer';
+export {
+	createDustMoteLayer,
+	createWorldDustLayer,
+	dustMemberAt,
+} from './lib/phaser/ambient-dust';
+export type {
+	DustMoteOptions,
+	WorldDustHandle,
+	WorldDustOptions,
+} from './lib/phaser/ambient-dust';
+export { GameObjectPool } from './lib/phaser/object-pool';
+export { setupKeyboardMap } from './lib/phaser/keyboard-map';
+export type { KeyboardMap } from './lib/phaser/keyboard-map';
+export {
+	createArrowPool,
+	animateArrowProjectile,
+} from './lib/phaser/arrow-projectile';
+export type {
+	ArrowPool,
+	ArrowPoolOptions,
+	ArrowShot,
+} from './lib/phaser/arrow-projectile';
+export {
+	getBirdNum,
+	isBird,
+	createBirdSprites,
+	createShadowSprites,
+	createBirdAnimation,
+} from './lib/phaser/monsters/bird';
+
+export { RAPIER, createRapierPhysics } from './lib/physics/rapier';

--- a/packages/npm/laser/src/r3f.ts
+++ b/packages/npm/laser/src/r3f.ts
@@ -1,0 +1,30 @@
+// React Three Fiber subpath: every laser module that imports three,
+// @react-three/fiber or @react-three/drei. Kept out of the main barrel so a
+// consumer that never renders with three (arpg, cryptothrone) does not drag
+// those optional peers into its module graph.
+
+export { Stage } from './lib/r3f/components/Stage';
+export type { StageProps } from './lib/r3f/components/Stage';
+export { useGameLoop } from './lib/r3f/hooks/use-game-loop';
+
+export {
+	createPomUniforms,
+	toThreeUniforms,
+	POM_DEFAULTS,
+	POM_MAX_STEPS,
+	POM_VARYINGS,
+	DERIVE_TANGENT,
+	POM_MARCH,
+	SPOM_SILHOUETTE,
+	POM_SELF_SHADOW,
+	HEIGHT_HELPERS,
+	POM_SOURCE_BRICK,
+	POM_SOURCE_LUMA,
+	POM_SOURCE_MAP,
+	POM_WGSL_STUB,
+} from './lib/webgl/pom';
+export type {
+	PomUniformValues,
+	PomConfig,
+	PomMaterialType,
+} from './lib/webgl/pom';

--- a/packages/npm/laser/vite.config.ts
+++ b/packages/npm/laser/vite.config.ts
@@ -25,9 +25,17 @@ export default defineConfig({
 		outDir: '../../../dist/packages/npm/laser',
 		reportCompressedSize: true,
 		lib: {
-			entry: path.resolve(__dirname, 'src/index.ts'),
-			name: 'laser',
-			fileName: (format) => `laser.${format}.js`,
+			entry: {
+				index: path.resolve(__dirname, 'src/index.ts'),
+				ecs: path.resolve(__dirname, 'src/ecs.ts'),
+				mecs: path.resolve(__dirname, 'src/mecs.ts'),
+				phaser: path.resolve(__dirname, 'src/phaser.ts'),
+				r3f: path.resolve(__dirname, 'src/r3f.ts'),
+			},
+			fileName: (format, entryName) =>
+				entryName === 'index'
+					? `laser.${format}.js`
+					: `${entryName}.${format}.js`,
 			formats: ['es'],
 		},
 		rollupOptions: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,6 +27,8 @@
 			"@kbve/laser": ["packages/npm/laser/src/index.ts"],
 			"@kbve/laser/ecs": ["packages/npm/laser/src/ecs.ts"],
 			"@kbve/laser/mecs": ["packages/npm/laser/src/mecs.ts"],
+			"@kbve/laser/phaser": ["packages/npm/laser/src/phaser.ts"],
+			"@kbve/laser/r3f": ["packages/npm/laser/src/r3f.ts"],
 			"@kbve/npcdb": ["packages/data/codegen/npcdb.ts"],
 			"@kbve/spelldb": ["packages/data/codegen/spelldb.ts"],
 			"@kbve/observ": ["packages/npm/observ/src/index.ts"],


### PR DESCRIPTION
The durable fix behind #15034 / #15043 / #15079. Those addressed *where* deps install and *what version*; this removes the reason laser needed them resolvable at all.

## The pattern

`packages/npm/laser/src/index.ts` unioned modules needing **mutually exclusive** optional peers — phaser + rapier, three + fiber + drei, bitecs. Every consumer imports `@kbve/laser` and drags in all of them.

laser is consumed as **source** (a tsconfig path plus a vite alias), so its bare imports resolve relative to `packages/npm/laser`, which has no `node_modules`. At the repo root the hoisted tree covers that; a container's bounded install does not, so vite substitutes an optional-peer stub and rollup dies on the named import.

This had already failed three times, each patched with another `dedupe` entry in the consumer. From arpg's own vite config before this PR:

> dedupe bitecs: ... breaks the container's isolated install (`"query is not exported by __vite-optional-peer-dep:bitecs"`). **phaser + @phaserjs/rapier-connector are the same trap** ... (`"Could not resolve 'phaser' imported by @kbve/laser"`). **Local builds mask it via root node_modules.**

drei was the fourth, and the one the dedupe list happened to miss.

## Change

Move the renderer stacks behind entry points, following the pattern `ecs`/`mecs` already established — their comment states the intent outright: *"ZERO Phaser/R3F/Rapier dependency, so consumers ... don't evaluate the heavy rendering modules the main barrel pulls in."*

| Entry | Contents | Peers |
|---|---|---|
| `@kbve/laser` | core, spatial, tile, ecs, determ, combat, net, auth, embed, promo, i18n | bitecs, fastnoise-lite, react |
| `@kbve/laser/phaser` | `lib/phaser/*` + `physics/rapier` | phaser, @phaserjs/rapier-connector |
| `@kbve/laser/r3f` | `lib/r3f/*` + `webgl/pom` | three, @react-three/fiber, @react-three/drei |
| `@kbve/laser/ecs`, `/mecs` | unchanged | bitecs / none |

Type-only phaser imports (`lib/core/types.ts`) stay in the root — they are erased before resolution.

**The published package gains real subpath builds.** vite's `lib.entry` was single-entry, so `ecs` and `mecs` resolved for source consumers but did not exist in the tarball. It is now multi-entry and `package.json` `exports` declares all five. The root entry keeps its `laser.es.js` filename, so `.` is unchanged for existing installs.

## Workarounds deleted

- **`stubLaserR3F()`** — an arpg vite plugin that virtual-moduled away `lib/r3f/` because the barrel forced it into a game that never renders with three.
- **`laser-vitest-stub.ts`** — a hand-written re-export of the "pure leaves" node-env vitest could load, because *"the barrel value-exports Phaser-backed helpers node-env vitest cannot load."* The barrel is renderer-free now, so vitest aliases straight to source.

arpg's `dedupe` list keeps `phaser` and `@phaserjs/rapier-connector` — it genuinely imports `@kbve/laser/phaser` for the health-bar and dust helpers, so those still resolve through laser's path.

## Consumer churn

12 files, all mechanical import-specifier moves — no logic touched. arpg (3), cryptothrone (2), astro-kbve (4), herbmail (1), laser-e2e (2). Plus subpath entries in the tsconfig/vite/vitest alias tables that declare laser paths explicitly.

## Verification

| Target | Result |
|---|---|
| `laser:build` | 5 entries emitted (`laser.es.js`, `ecs`, `mecs`, `phaser`, `r3f` + d.ts) |
| `laser:test` | 200 passed |
| `arpg-web:build` / `:test` | clean / 35 passed |
| `herbmail-game:build` / `:test` | clean / 79 passed |
| `astro-cryptothrone:build` / `:test` | clean / 101 passed |
| `astro-kbve:build` / `:test` | clean / 327 passed |
| arpg-web docker image | builds clean |

## Versions

Bumped `laser` 0.1.6 → **0.2.0** — the root export surface shrank, which is breaking for anyone consuming the published package. Consumer apps are not bumped: the change is import specifiers only, identical symbols and runtime behaviour, so they pick it up on their normal release cadence.

## Not in this PR

The other half of the long-term fix — making arpg-web's container install reproduce the root resolution tree (`pnpm install --frozen-lockfile` from the root lockfile, as every `axum-*` Dockerfile already does) instead of maintaining a second dependency universe. With laser's barrel clean, arpg's bounded install is now legitimate rather than a liability, so that became optional rather than required. Worth doing for the Nx `affected` graph, which cannot see arpg-web's private `package.json` today.