### PR TITLE
fix(irc): render SUPABASE_URL into supabase-shared secret

### DIFF
--- a/apps/kube/irc/manifests/irc-gateway-externalsecret.yaml
+++ b/apps/kube/irc/manifests/irc-gateway-externalsecret.yaml
@@ -44,6 +44,7 @@ spec:
                 jwt-secret: '{{ .jwtsecret }}'
                 anon-key: '{{ .anonkey }}'
                 service-role-key: '{{ .servicekey }}'
+                SUPABASE_URL: 'http://kong.kilobase.svc.cluster.local:8000'
     data:
         - secretKey: jwtsecret
           remoteRef:


### PR DESCRIPTION
## Problem

`chat.kbve.com` WebSocket connects fail in a loop:

```
WS error: WebSocket error event (no detail in browser API)
Disconnected: code=1006 (abnormal)
Reconnecting…
```

The live gateway is still on the pre-ES256 build:

```
$ curl https://chat.kbve.com/health
{"status":"ok","uptime_seconds":2374596,"version":"0.1.28"}
```

## Root cause

#15024 added a `SUPABASE_URL` env var to `irc-gateway-deployment.yaml` sourced from `secretKeyRef` → `supabase-shared` / `SUPABASE_URL`, but the ExternalSecret template only rendered `jwt-secret`, `anon-key` and `service-role-key`. The key never existed:

```
Error: couldn't find key SUPABASE_URL in Secret irc/supabase-shared
Pulling image "ghcr.io/kbve/irc-gateway:0.1.29"  (x2157 over 8h)
```

Every `0.1.29` pod sat in `CreateContainerConfigError`. With `replicas: 1` and the default `maxUnavailable`, the old `0.1.28` ReplicaSet was never scaled down, so the HS256-only build kept serving traffic and returned `401` on every `/ws` upgrade carrying an ES256 session token — which the browser surfaces as `code=1006`.

ArgoCD showed `Synced` (manifests applied correctly) with `Degraded` health, so nothing flagged it as a failed release.

Verified against production with a valid ES256 token:

| probe | result |
| --- | --- |
| `/health` | `200`, reports `0.1.28` |
| `/ws` no token | `401` |
| `/ws` + valid ES256 token | `401` |

## Fix

Render `SUPABASE_URL` from the ExternalSecret template using the in-cluster Kong URL — the same approach `apps/kube/agones/arpg/manifests/external-secrets.yaml` already uses. The gateway derives its JWKS URI (`{SUPABASE_URL}/auth/v1/.well-known/jwks.json`) from it.

Once the ExternalSecret refreshes, the stuck ReplicaSet creates its container, `0.1.29` goes Ready, and the `0.1.28` pod scales down.

No version bump — `ghcr.io/kbve/irc-gateway:0.1.29` is the correct image and is already published.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)