### PR TITLE
fix(reel): typed stream events, classified errors + auto-reconnect UX

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -139,6 +139,7 @@ const MANIFEST_MIME = 'application/vnd.apple.mpegurl';
 const MAX_POLLS = 25;
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 5000;
+const MAX_RESURRECTS = 30;
 
 let mediaTokenCache: { token: string; expiresAtMs: number } | null = null;
 
@@ -372,10 +373,12 @@ export class ReelPlayer {
 	private tokenTimer: ReturnType<typeof setInterval> | null = null;
 	private recover: (() => void) | null = null;
 	private lastPos = 0;
+	private resurrects = 0;
 
 	async start(video: HTMLVideoElement, id: string): Promise<void> {
 		const gen = ++this.generation;
 		this.teardown();
+		this.resurrects = 0;
 		this.video = video;
 		$reelError.set(null);
 		$reelNotice.set(null);
@@ -634,6 +637,7 @@ export class ReelPlayer {
 			hls.on(Hls.Events.FRAG_BUFFERED, () => {
 				netRetries = 0;
 				mediaRetries = 0;
+				this.resurrects = 0;
 			});
 			hls.on(Hls.Events.ERROR, (_evt, data) => {
 				if (!data.fatal) return;
@@ -649,18 +653,18 @@ export class ReelPlayer {
 								}, 1000);
 							});
 						} else {
-							this.fail(`network error: ${data.details}`);
+							void this.resurrect(video, id, gen);
 						}
 						break;
 					case Hls.ErrorTypes.MEDIA_ERROR:
 						if (mediaRetries++ < MAX_RECOVER) {
 							hls.recoverMediaError();
 						} else {
-							this.fail(`media error: ${data.details}`);
+							void this.resurrect(video, id, gen);
 						}
 						break;
 					default:
-						this.fail(`HLS error: ${data.type}`);
+						void this.resurrect(video, id, gen);
 				}
 			});
 			// Auto-enable the first subtitle rendition (the live stream marks it
@@ -743,6 +747,43 @@ export class ReelPlayer {
 		$reelError.set(message);
 		$reelState.set('error');
 		this.teardown();
+	}
+
+	private async resurrect(
+		video: HTMLVideoElement,
+		id: string,
+		gen: number,
+	): Promise<void> {
+		if (this.generation !== gen) return;
+		if (this.resurrects++ >= MAX_RESURRECTS) {
+			this.fail('stream ended');
+			return;
+		}
+		this.stopWatchdog();
+		if (this.tokenTimer) {
+			clearInterval(this.tokenTimer);
+			this.tokenTimer = null;
+		}
+		this.recover = null;
+		if (this.hls) {
+			try {
+				this.hls.destroy();
+			} catch {
+				void 0;
+			}
+			this.hls = null;
+		}
+		if (this.video) this.video.onerror = null;
+		const token = await mediaToken(true);
+		if (this.generation !== gen) return;
+		if (!token) {
+			this.fail('sign in to watch');
+			return;
+		}
+		$reelState.set('probing');
+		await new Promise((r) => setTimeout(r, 1500));
+		if (this.generation !== gen) return;
+		await this.probe(video, id, token, 0, gen);
 	}
 
 	stop(reset = true): void {


### PR DESCRIPTION
## Problem
Live/leeching streams drop mid-watch, and when they do the player just shows a generic string or dies silently. No spine for *what* failed.

## Two parts

### 1. Auto-reconnect (resurrect)
A leeching stream changes shape mid-playback — completion nulls `hls_dir` → manifest returns 202 JSON; ffmpeg death leaves an un-ENDLIST'd playlist; a slow leech starves the live edge. hls.js exhausted its 6-step ladder and the player permanently `fail()`d. Now exhausted fatals route back through the probe/poll loop: destroy the dead hls, force a fresh token, wait for the server to settle, re-probe, resume as whatever it now is. Bounded (`MAX_RESURRECTS=30`), reset on `FRAG_BUFFERED`.

### 2. Typed event system (the real fix for observability/UX)
Instead of swallowing failures into generic strings, reel now reports through **droid's typed event bus**:
- New zod-validated **`reel-stream`** event in `@kbve/droid` (`{stage, code, message, attempt, max, fatal}`), sitting next to the existing `auth-error`/`worker-error`.
- `reelService` **classifies** every failure into a code — `token-expired`, `network`, `media`, `manifest-flip`, `transcode-timeout`, `not-found`, `reaped`, `sign-in`, `download-failed`, `unsupported` — and emits at each transition (loading → probing → playing → reconnecting → error).
- New `$reelStatus` atom carries the full payload; the player and live channel show the **actual reason** + **"Reconnecting N/30"** while it retries; terminal failures raise a **toast** via `addToast`.
- Any other module (mods, dashboards, telemetry) can now `DroidEvents.on('reel-stream', …)` — one place to observe stream health.

## Scope
- droid consumed as tsconfig source-alias → **no publish, no version bump**; frontend-only.
- Files: `droid/lib/types/event-types.ts`, `reelService.ts`, `ReactReelPlayer.tsx`, `ReactReelLive.tsx`.

## Follow-up (server, separate reel-crate PR)
Non-adopt completion should not null `hls_dir`/202 an in-flight viewer — keep serving live HLS until the replacement is ready, or write `ENDLIST`. Then reconnect becomes seamless instead of a ~2s re-probe. Known limit: a big non-h264 file that non-adopts into a full libx264 transcode can exceed the ~2min poll window.