### PR TITLE
fix(herbmail-game): content-hash model URLs so prod serves fresh GLBs

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/character/heldItems.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/heldItems.ts
@@ -1,5 +1,7 @@
-export const SWORD_URL = '/models/sword.glb';
-export const TORCH_URL = '/models/torch.glb';
+import { modelUrl } from './modelUrl';
+
+export const SWORD_URL = modelUrl('/models/sword.glb');
+export const TORCH_URL = modelUrl('/models/torch.glb');
 
 export const VERTICAL_GRIP = {
 	pos: [-0.06, 0, 0.02] as [number, number, number],

--- a/apps/herbmail/herbmail-game/src/game/character/modelUrl.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/modelUrl.ts
@@ -1,3 +1,12 @@
-const V = import.meta.env.DEV ? `?v=${Date.now()}` : '';
+import hashes from 'virtual:model-hashes';
 
-export const CHARACTER_URL = `/models/character-anim.glb${V}`;
+const DEV = import.meta.env.DEV;
+const DEV_V = DEV ? `?v=${Date.now()}` : '';
+
+export function modelUrl(path: string): string {
+	if (DEV) return `${path}${DEV_V}`;
+	const h = hashes[path];
+	return h ? `${path}?v=${h}` : path;
+}
+
+export const CHARACTER_URL = modelUrl('/models/character-anim.glb');

--- a/apps/herbmail/herbmail-game/src/game/character/partsLoader.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/partsLoader.ts
@@ -2,11 +2,12 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { MeshoptDecoder } from './meshopt';
 import type { PartSet } from './armor';
+import { modelUrl } from './modelUrl';
 
 const SET_URL: Record<Exclude<PartSet, 'KNGT'>, string> = {
-	SCFI09: '/models/parts/scifi-civ09.glb',
-	SCFI10: '/models/parts/scifi-civ10.glb',
-	HORR01: '/models/parts/horr-viln01.glb',
+	SCFI09: modelUrl('/models/parts/scifi-civ09.glb'),
+	SCFI10: modelUrl('/models/parts/scifi-civ10.glb'),
+	HORR01: modelUrl('/models/parts/horr-viln01.glb'),
 };
 
 const loader = new GLTFLoader().setMeshoptDecoder(MeshoptDecoder);

--- a/apps/herbmail/herbmail-game/src/game/npc/KurenaiNpc.tsx
+++ b/apps/herbmail/herbmail-game/src/game/npc/KurenaiNpc.tsx
@@ -8,8 +8,9 @@ import { getDungeon } from '../dungeon/store';
 import { CharState, Transform3, Wander, isAlive } from '../mecs/props';
 import { CS } from '../character/charState';
 import { NPC_KURENAI, despawnGoblin, spawnGoblin } from './goblinSim';
+import { modelUrl } from '../character/modelUrl';
 
-const KURENAI_URL = '/models/parts/kurenai.glb';
+const KURENAI_URL = modelUrl('/models/parts/kurenai.glb');
 useGLTF.preload(KURENAI_URL);
 
 // spring-bone secondary motion for the cosmetic cloth chains that the baked

--- a/apps/herbmail/herbmail-game/src/game/prop/kinds.ts
+++ b/apps/herbmail/herbmail-game/src/game/prop/kinds.ts
@@ -1,3 +1,5 @@
+import { modelUrl } from '../character/modelUrl';
+
 export const PROP_TORCH = 1;
 export const PROP_CANDLE = 2;
 export const PROP_FIREFLY = 3;
@@ -8,4 +10,7 @@ export const MODEL_TORCH = 0;
 export const MODEL_CRATE = 1;
 export const MODEL_STONE = 2;
 
-export const MODEL_URLS: string[] = ['/models/torch.glb', '/models/crate.glb'];
+export const MODEL_URLS: string[] = [
+	modelUrl('/models/torch.glb'),
+	modelUrl('/models/crate.glb'),
+];

--- a/apps/herbmail/herbmail-game/src/game/viewmodel/equipment.ts
+++ b/apps/herbmail/herbmail-game/src/game/viewmodel/equipment.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { modelUrl } from '../character/modelUrl';
 
 export type HeldKind = 'empty' | 'tool' | 'weapon' | 'shield';
 
@@ -88,7 +89,7 @@ export const LOADOUT: Equipment[] = [
 		primaryImpulse: USE,
 		secondaryImpulse: REACH,
 		buildItem: () => null,
-		modelUrl: '/models/torch.glb',
+		modelUrl: modelUrl('/models/torch.glb'),
 		slot: 'light',
 		grip: {
 			pos: [0.02, -0.05, 0.06],
@@ -106,7 +107,7 @@ export const LOADOUT: Equipment[] = [
 		primaryImpulse: USE,
 		secondaryImpulse: REACH,
 		buildItem: () => null,
-		modelUrl: '/models/crate.glb',
+		modelUrl: modelUrl('/models/crate.glb'),
 		grip: {
 			pos: [0.1, -0.12, 0.15],
 			rot: [0.2, 0.4, 0],
@@ -123,7 +124,7 @@ export const LOADOUT: Equipment[] = [
 		primaryImpulse: FIRE,
 		secondaryImpulse: NONE,
 		buildItem: () => null,
-		modelUrl: '/models/sword.glb',
+		modelUrl: modelUrl('/models/sword.glb'),
 		grip: {
 			pos: [0, 0, 0],
 			rot: [0, 0, 0],
@@ -140,7 +141,7 @@ export const LOADOUT: Equipment[] = [
 		primaryImpulse: USE,
 		secondaryImpulse: REACH,
 		buildItem: () => null,
-		modelUrl: '/models/torch.glb',
+		modelUrl: modelUrl('/models/torch.glb'),
 		slot: 'light',
 		grip: {
 			pos: [0.02, -0.05, 0.06],

--- a/apps/herbmail/herbmail-game/src/types/model_hashes.d.ts
+++ b/apps/herbmail/herbmail-game/src/types/model_hashes.d.ts
@@ -1,0 +1,4 @@
+declare module 'virtual:model-hashes' {
+	const hashes: Record<string, string | undefined>;
+	export default hashes;
+}

--- a/apps/herbmail/herbmail-game/vite.config.ts
+++ b/apps/herbmail/herbmail-game/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig, type Plugin } from 'vite';
 import path from 'node:path';
 import fs from 'node:fs';
+import crypto from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import react from '@vitejs/plugin-react';
@@ -82,6 +83,45 @@ function iconStudioWriter(): Plugin {
 	};
 }
 
+const MODEL_HASHES_ID = 'virtual:model-hashes';
+
+function modelHashes(): Plugin {
+	const publicDir = path.resolve(__dirname, 'public');
+	const modelsDir = path.join(publicDir, 'models');
+	const build = () => {
+		const out: Record<string, string> = {};
+		const walk = (dir: string) => {
+			if (!fs.existsSync(dir)) return;
+			for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+				const p = path.join(dir, e.name);
+				if (e.isDirectory()) {
+					walk(p);
+					continue;
+				}
+				if (!e.name.endsWith('.glb')) continue;
+				const url = `/${path.relative(publicDir, p).split(path.sep).join('/')}`;
+				out[url] = crypto
+					.createHash('sha256')
+					.update(fs.readFileSync(p))
+					.digest('hex')
+					.slice(0, 8);
+			}
+		};
+		walk(modelsDir);
+		return out;
+	};
+	return {
+		name: 'model-hashes',
+		resolveId(id) {
+			return id === MODEL_HASHES_ID ? `\0${MODEL_HASHES_ID}` : null;
+		},
+		load(id) {
+			if (id !== `\0${MODEL_HASHES_ID}`) return null;
+			return `export default ${JSON.stringify(build())};`;
+		},
+	};
+}
+
 // Post-build gltfpack pass (meshopt EXT_meshopt_compression) over the copied
 // public/ models. Sources in public/models stay uncompressed LFS truth; only
 // dist output is packed. -kn keeps node/mesh names (armor slots + bone lookups
@@ -147,7 +187,13 @@ const coiHeaders = {
 export default defineConfig({
 	root: __dirname,
 	base: './',
-	plugins: [react(), nxViteTsPaths(), iconStudioWriter(), gltfpackModels()],
+	plugins: [
+		react(),
+		nxViteTsPaths(),
+		iconStudioWriter(),
+		modelHashes(),
+		gltfpackModels(),
+	],
 	resolve: {
 		alias: [itemdbDataAlias, itemdbSchemaAlias],
 	},
@@ -160,6 +206,7 @@ export default defineConfig({
 	},
 	worker: {
 		format: 'es',
+		plugins: () => [nxViteTsPaths(), modelHashes()],
 	},
 	build: {
 		outDir: '../../../dist/apps/herbmail/herbmail-game',


### PR DESCRIPTION
## Problem

In production the player spawns wearing the old armored model instead of the naked skin base.

## Cause

GLBs live in `public/`, so Vite never fingerprints them, and `modelUrl.ts` only appended a cache-buster under `import.meta.env.DEV`. Production served `/models/character-anim.glb` at a fixed URL, so browsers and CDNs held onto a pre-rebake GLB indefinitely.

That stale GLB's mesh names aren't in `ARMOR_PIECES`, so `hiddenSlotsFor()` has no slot entries to hide them — the armor renders even though `equipped` starts empty. Repo-side the asset and code are already correct (`naked skin base` landed in `1f951b4ea5`, before the last GLB rebake in `954b3cea29`); only the delivered bytes were old.

## Fix

- New `model-hashes` Vite plugin: sha256 of every `public/models/**.glb` at build time, exposed as the `virtual:model-hashes` module.
- `modelUrl(path)` appends `?v=<hash8>` in production. Stable across builds when the asset is unchanged, so caching still works — only changed models re-download.
- All `/models/` references route through it: character, held sword/torch, crate, prop `MODEL_URLS`, armor part sets, Kurenai.
- `worker.plugins` gets the plugin too — worker bundles don't inherit the top-level plugin list, and the sim worker imports `prop/kinds.ts`. `nxViteTsPaths` added alongside it for consistent resolution.

## Verification

`nx typecheck`, `nx test`, `nx build` all pass. Built bundle emits e.g. `/models/character-anim.glb?v=307431da` in both `index-*.js` and `sim.worker-*.js`.

Stacks on top of #15090 conceptually but touches disjoint files.