### PR TITLE
feat(palworld): shared live poller via @kbve/droid + lazy map repaint

### DIFF
--- a/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { DroidEvents } from '@kbve/droid';
+import { startLivePoller, type LiveSnapshot } from './livePoller';
 import {
 	KIND,
 	KIND_META,
@@ -13,7 +15,6 @@ import {
 	iconKeys,
 	gameToUnits,
 	type KindName,
-	type LivePlayer,
 } from './markerEcs';
 
 const MAX_ZOOM = 8;
@@ -21,7 +22,6 @@ const PAL_TILE_BASE = '/palworld/tiles';
 const PAL_MAX_NATIVE_ZOOM = 6;
 const WT_TILE_BASE = '/palworld/wt-overlay';
 const LIVE_URL_DEFAULT = 'https://palworld.kbve.com/live/players';
-const LIVE_POLL_MS = 5000;
 const LERP_MS = 4000;
 const TIMERS_KEY = 'palworld-map-timers';
 const PAD = 0.5;
@@ -222,7 +222,9 @@ export default function ReactPalworldMap() {
 		let originX = 0;
 		let originY = 0;
 
+		let redrawCount = 0;
 		const redraw = () => {
+			redrawCount++;
 			const dpr = window.devicePixelRatio || 1;
 			const w = el.clientWidth;
 			const h = el.clientHeight;
@@ -270,13 +272,7 @@ export default function ReactPalworldMap() {
 					dpr,
 				);
 				if (sp)
-					ctx.drawImage(
-						sp,
-						lx - size / 2,
-						ly - size / 2,
-						size,
-						size,
-					);
+					ctx.drawImage(sp, lx - size / 2, ly - size / 2, size, size);
 				if (deadline) {
 					const total =
 						(RESPAWN_MINUTES[KIND_NAMES[kind]] || 60) * 60_000;
@@ -315,20 +311,34 @@ export default function ReactPalworldMap() {
 			});
 		};
 
-		const settle = () => {
-			L.DomUtil.setTransform(pane, L.point(0, 0), 1);
-			settleP0 = map.getPixelOrigin().clone();
+		let settledZoom = NaN;
+		const settle = (force = true) => {
 			const w = el.clientWidth;
 			const h = el.clientHeight;
+			if (!force && map.getZoom() === settledZoom) {
+				const tl = map.containerPointToLayerPoint([0, 0]);
+				const slackX = w * (PAD - 0.15);
+				const slackY = h * (PAD - 0.15);
+				if (
+					Math.abs(tl.x - originX - w * PAD) <= slackX &&
+					Math.abs(tl.y - originY - h * PAD) <= slackY
+				) {
+					return;
+				}
+			}
+			L.DomUtil.setTransform(pane, L.point(0, 0), 1);
+			settleP0 = map.getPixelOrigin().clone();
+			settledZoom = map.getZoom();
 			const o = map.containerPointToLayerPoint([-w * PAD, -h * PAD]);
 			originX = o.x;
 			originY = o.y;
 			L.DomUtil.setPosition(canvas, o);
 			redraw();
 		};
-		map.on('moveend zoomend viewreset resize', settle);
+		map.on('moveend', () => settle(false));
+		map.on('zoomend viewreset resize', () => settle(true));
 		map.on('zoom', () => {
-			if (!wheelActive) settle();
+			if (!wheelActive) settle(true);
 		});
 		settle();
 
@@ -654,6 +664,7 @@ export default function ReactPalworldMap() {
 				drawPos,
 				latlngs,
 				getOrigin: () => [originX, originY],
+				getRedraws: () => redrawCount,
 			};
 		}
 
@@ -661,96 +672,77 @@ export default function ReactPalworldMap() {
 			new URLSearchParams(window.location.search).get('live') ||
 			LIVE_URL_DEFAULT;
 		let stopped = false;
-		const poll = async () => {
-			try {
-				const res = await fetch(liveUrl, { cache: 'no-store' });
-				if (!res.ok) throw new Error(String(res.status));
-				const data = (await res.json()) as {
-					players?: LivePlayer[];
-					bosses?: {
-						id: string;
-						x: number;
-						y: number;
-						respawn_at: number;
-					}[];
-					events?: {
-						kind: string;
-						x: number;
-						y: number;
-						first_seen: number;
-					}[];
-				};
-				if (stopped) return;
-				syncEvents(data.events || []);
-				const seen = new Set<string>();
-				for (const p of data.players || []) {
-					seen.add(p.name);
-					const ll = L.latLng(gameToLatLng(p.x, p.y));
-					const existing = playerMarkers.get(p.name);
-					if (existing) {
-						existing.from = existing.m.getLatLng();
-						existing.to = ll;
-						existing.t0 = performance.now();
-					} else {
-						const m = L.marker(ll, {
-							icon: playerIcon(`${p.name} · Lv ${p.level}`),
-							keyboard: false,
-							interactive: false,
-							zIndexOffset: 500,
-						});
-						m.addTo(playerLayer);
-						playerMarkers.set(p.name, {
-							m,
-							from: ll,
-							to: ll,
-							t0: performance.now(),
-						});
-					}
-				}
-				for (const [name, p] of playerMarkers) {
-					if (!seen.has(name)) {
-						playerLayer.removeLayer(p.m);
-						playerMarkers.delete(name);
-					}
-				}
-				if (!playerRaf && playerMarkers.size)
-					playerRaf = requestAnimationFrame(playerFrame);
-				serverTimers.clear();
-				for (const b of data.bosses || []) {
-					const [ux, uy] = gameToUnits(b.x, b.y);
-					let bestEid = -1;
-					let bestD = 9;
-					for (const eid of bossEnts) {
-						const dx = Pos.x[eid] - ux;
-						const dy = Pos.yd[eid] - uy;
-						const d = dx * dx + dy * dy;
-						if (d < bestD) {
-							bestD = d;
-							bestEid = eid;
-						}
-					}
-					if (bestEid >= 0) serverTimers.set(bestEid, b.respawn_at);
-				}
-				if (data.bosses?.length) scheduleRedraw();
-				const span = countTexts.get(KIND.player);
-				if (span)
-					span.textContent = `Players (${data.players?.length || 0})`;
-			} catch {
-				if (stopped) return;
+		const onSnapshot = (snap: LiveSnapshot) => {
+			if (stopped) return;
+			if (snap.offline) {
 				for (const [name, p] of playerMarkers) {
 					playerLayer.removeLayer(p.m);
 					playerMarkers.delete(name);
 				}
 				const span = countTexts.get(KIND.player);
 				if (span) span.textContent = 'Players (offline)';
+				return;
 			}
+			syncEvents(snap.events);
+			const seen = new Set<string>();
+			for (const p of snap.players) {
+				seen.add(p.name);
+				const ll = L.latLng(gameToLatLng(p.x, p.y));
+				const existing = playerMarkers.get(p.name);
+				if (existing) {
+					existing.from = existing.m.getLatLng();
+					existing.to = ll;
+					existing.t0 = performance.now();
+				} else {
+					const m = L.marker(ll, {
+						icon: playerIcon(`${p.name} · Lv ${p.level}`),
+						keyboard: false,
+						interactive: false,
+						zIndexOffset: 500,
+					});
+					m.addTo(playerLayer);
+					playerMarkers.set(p.name, {
+						m,
+						from: ll,
+						to: ll,
+						t0: performance.now(),
+					});
+				}
+			}
+			for (const [name, p] of playerMarkers) {
+				if (!seen.has(name)) {
+					playerLayer.removeLayer(p.m);
+					playerMarkers.delete(name);
+				}
+			}
+			if (!playerRaf && playerMarkers.size)
+				playerRaf = requestAnimationFrame(playerFrame);
+			serverTimers.clear();
+			for (const b of snap.bosses) {
+				const [ux, uy] = gameToUnits(b.x, b.y);
+				let bestEid = -1;
+				let bestD = 9;
+				for (const eid of bossEnts) {
+					const dx = Pos.x[eid] - ux;
+					const dy = Pos.yd[eid] - uy;
+					const d = dx * dx + dy * dy;
+					if (d < bestD) {
+						bestD = d;
+						bestEid = eid;
+					}
+				}
+				if (bestEid >= 0) serverTimers.set(bestEid, b.respawn_at);
+			}
+			if (snap.bosses.length) scheduleRedraw();
+			const span = countTexts.get(KIND.player);
+			if (span) span.textContent = `Players (${snap.players.length})`;
 		};
-		poll();
-		const pollTimer = setInterval(poll, LIVE_POLL_MS);
+		DroidEvents.on('palworld-live-snapshot', onSnapshot);
+		startLivePoller(liveUrl);
 
 		return () => {
 			stopped = true;
-			clearInterval(pollTimer);
+			DroidEvents.off('palworld-live-snapshot', onSnapshot);
 			clearInterval(cooldownTick);
 			if (wheelRaf) cancelAnimationFrame(wheelRaf);
 			if (playerRaf) cancelAnimationFrame(playerRaf);

--- a/apps/kbve/astro-kbve/src/components/palworld/map/livePoller.ts
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/livePoller.ts
@@ -1,0 +1,65 @@
+import { DroidEvents } from '@kbve/droid';
+import type { DroidEventMap } from '@kbve/droid';
+
+export type LiveSnapshot = DroidEventMap['palworld-live-snapshot'];
+
+const POLL_MS = 5000;
+const CHANNEL = 'kbve-palworld-live';
+const LOCK = 'kbve-palworld-live-poller';
+
+let startedUrl: string | null = null;
+
+export function startLivePoller(url: string): void {
+	if (startedUrl) return;
+	startedUrl = url;
+
+	const channel =
+		typeof BroadcastChannel !== 'undefined'
+			? new BroadcastChannel(CHANNEL)
+			: null;
+	const emit = (snap: LiveSnapshot) =>
+		DroidEvents.emit('palworld-live-snapshot', snap);
+	channel?.addEventListener('message', (ev: MessageEvent<LiveSnapshot>) =>
+		emit(ev.data),
+	);
+
+	const poll = async () => {
+		let snap: LiveSnapshot;
+		try {
+			const res = await fetch(url, { cache: 'no-store' });
+			if (!res.ok) throw new Error(String(res.status));
+			const d = (await res.json()) as Partial<LiveSnapshot>;
+			snap = {
+				ts: d.ts ?? Date.now(),
+				offline: false,
+				players: d.players ?? [],
+				bosses: d.bosses ?? [],
+				events: d.events ?? [],
+			};
+		} catch {
+			snap = {
+				ts: Date.now(),
+				offline: true,
+				players: [],
+				bosses: [],
+				events: [],
+			};
+		}
+		emit(snap);
+		channel?.postMessage(snap);
+	};
+
+	const lead = () => {
+		poll();
+		setInterval(poll, POLL_MS);
+	};
+
+	if (typeof navigator !== 'undefined' && navigator.locks?.request) {
+		navigator.locks.request(LOCK, () => {
+			lead();
+			return new Promise<void>(() => {});
+		});
+	} else {
+		lead();
+	}
+}

--- a/apps/kbve/astro-kbve/src/content/docs/project/droid.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/droid.mdx
@@ -12,7 +12,7 @@ tags:
 key: droid
 pipeline: npm
 package_name: droid
-version: "0.1.1"
+version: "0.1.2"
 source_path: packages/npm/droid
 version_toml: packages/npm/droid/version.toml
 author: h0lybyte

--- a/packages/npm/droid/src/lib/types/event-types.spec.ts
+++ b/packages/npm/droid/src/lib/types/event-types.spec.ts
@@ -25,10 +25,11 @@ describe('DroidEventSchemas', () => {
 		expect(keys).toContain('modal-closed');
 		expect(keys).toContain('auth-ready');
 		expect(keys).toContain('auth-error');
+		expect(keys).toContain('palworld-live-snapshot');
 	});
 
-	it('has exactly 20 event types', () => {
-		expect(Object.keys(DroidEventSchemas)).toHaveLength(20);
+	it('has exactly 21 event types', () => {
+		expect(Object.keys(DroidEventSchemas)).toHaveLength(21);
 	});
 });
 

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -78,6 +78,37 @@ export const PageLifecycleSchema = z.object({
 	source: z.enum(['initial', 'astro-swap', 'page-reveal', 'bfcache']),
 });
 
+export const PalworldLiveSnapshotSchema = z.object({
+	ts: z.number(),
+	offline: z.boolean(),
+	players: z.array(
+		z.object({
+			name: z.string(),
+			level: z.number(),
+			x: z.number(),
+			y: z.number(),
+		}),
+	),
+	bosses: z.array(
+		z.object({
+			id: z.string(),
+			x: z.number(),
+			y: z.number(),
+			defeated_at: z.number(),
+			respawn_at: z.number(),
+		}),
+	),
+	events: z.array(
+		z.object({
+			kind: z.string(),
+			class: z.string(),
+			x: z.number(),
+			y: z.number(),
+			first_seen: z.number(),
+		}),
+	),
+});
+
 export const DroidEventSchemas = {
 	'droid-first-connect': DroidFirstConnectSchema,
 	'droid-ready': DroidReadySchema,
@@ -99,6 +130,7 @@ export const DroidEventSchemas = {
 	'page-mount': PageLifecycleSchema,
 	'page-swap': PageLifecycleSchema,
 	'page-hide': PageLifecycleSchema,
+	'palworld-live-snapshot': PalworldLiveSnapshotSchema,
 };
 
 export type DroidEventMap = {


### PR DESCRIPTION
## What

### Shared live poller (`livePoller.ts` + @kbve/droid)
- Map's fetch loop extracted into a singleton poller: **leader tab elected via Web Locks API** (`kbve-palworld-live-poller`), polls `/live/players` every 5s, emits a typed `palworld-live-snapshot` on the `DroidEvents` bus and broadcasts it over a `BroadcastChannel` (`kbve-palworld-live`) — the same pattern droid's `sync-bus` uses for profile/staff.
- Effects: N open map tabs → **one request stream**; background tabs stay fresh via broadcasts instead of throttled intervals; any future consumer (nav player-count badge, dashboard widget) subscribes to the same event with zero extra fetches.
- Map component now only subscribes (`DroidEvents.on`); offline behavior identical to before. Leader crash/close → next tab acquires the lock automatically (verified: tab2 held pending lock + received live data).

### Droid
- New `PalworldLiveSnapshotSchema` + `palworld-live-snapshot` key in `DroidEventSchemas` (flows into `DroidEventMap` types). Spec updated (126/126 passing via nx). **MDX-only bump to 0.1.2.**

### Lazy repaint
- `settle()` skips reposition+repaint when a pan leaves the viewport inside the padded canvas coverage (15% edge margin). Casual panning now does **zero canvas work** — the pane transform alone carries the markers; repaint happens only when drifting near the canvas edge, on zoom, viewreset, or resize.

## Verified (playwright, dev server)
- Small pan: 0 redraws; cumulative large pan: exactly 1; zoom: repaints as before.
- Two tabs: single poller lock held + pending waiter, follower tab renders live data from broadcasts.
- Droid tests 126/126.