### PR TITLE
feat(reel): surface peer-drop diagnostics to the user (port rotations, VPN streak)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -286,6 +286,20 @@ export default function ReactReelConsole() {
 							? `● inbound :${health.forwarded_port}`
 							: '○ outbound-only'}
 					</span>
+					{health.port_rotations > 0 && (
+						<span
+							className="reel-console__health-bad"
+							title="Each VPN port rotation wipes the peer swarm — a likely cause of peers dropping.">
+							⟳ {health.port_rotations} port rotations
+						</span>
+					)}
+					{health.vpn_fail_streak > 0 && (
+						<span
+							className="reel-console__health-bad"
+							title="Consecutive failed VPN checks — the swarm pauses while the VPN is unverified.">
+							⚠ VPN checks failing ×{health.vpn_fail_streak}
+						</span>
+					)}
 					<span>
 						{health.counts.seeding} seeding · {health.counts.leeching}{' '}
 						leeching · {health.counts.failed} failed

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -112,6 +112,8 @@ export interface ReelStatusReport {
 	bt_listen_port?: number;
 	forwarded_port?: number;
 	inbound_ready: boolean;
+	port_rotations: number;
+	vpn_fail_streak: number;
 	counts: ReelCounts;
 	torrents: ReelStatusTorrent[];
 }
@@ -122,6 +124,8 @@ export interface ReelHealth {
 	bt_listen_port?: number;
 	forwarded_port?: number;
 	inbound_ready: boolean;
+	port_rotations: number;
+	vpn_fail_streak: number;
 	counts: ReelCounts;
 }
 
@@ -298,6 +302,8 @@ export async function refreshReelList(): Promise<void> {
 			bt_listen_port: report.bt_listen_port,
 			forwarded_port: report.forwarded_port,
 			inbound_ready: report.inbound_ready,
+			port_rotations: report.port_rotations,
+			vpn_fail_streak: report.vpn_fail_streak,
 			counts: report.counts,
 		});
 		$reelListError.set(null);

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.34"
+version: "0.1.35"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -103,6 +103,8 @@ struct StatusReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     forwarded_port: Option<u16>,
     inbound_ready: bool,
+    port_rotations: u64,
+    vpn_fail_streak: u32,
     counts: Counts,
     torrents: Vec<TorrentView>,
 }
@@ -199,6 +201,8 @@ async fn status(State(st): State<AppState>, headers: HeaderMap) -> impl IntoResp
         bt_listen_port,
         forwarded_port,
         inbound_ready: inbound_ready(bt_listen_port, forwarded_port),
+        port_rotations: st.engine.port_rotations(),
+        vpn_fail_streak: st.engine.vpn_fail_streak(),
         counts,
         torrents,
     })

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -158,7 +158,7 @@ pub async fn forwarded_port_watch_loop(
         tokio::time::sleep(interval).await;
         let forwarded = engine.forwarded_port();
         if forwarded != last_forwarded {
-            rotations += 1;
+            rotations = engine.port_rotations.fetch_add(1, Ordering::Relaxed) + 1;
             let elapsed = now_secs().saturating_sub(started).max(1);
             let per_hour = (rotations as f64) * 3600.0 / (elapsed as f64);
             tracing::warn!(
@@ -263,6 +263,7 @@ pub struct Engine {
     trackers: Arc<Mutex<Arc<Vec<String>>>>,
     bt_port_file: Option<PathBuf>,
     transcode_wake: Arc<Notify>,
+    port_rotations: Arc<AtomicU64>,
 }
 
 const LEECH_DRAIN_CAP: Duration = Duration::from_secs(6 * 3600);
@@ -404,6 +405,7 @@ impl Engine {
             )))),
             bt_port_file: cfg.bt_port_file.clone(),
             transcode_wake: Arc::new(Notify::new()),
+            port_rotations: Arc::new(AtomicU64::new(0)),
         };
         engine.resume_on_start();
         Ok(engine)
@@ -1204,6 +1206,14 @@ impl Engine {
     pub fn forwarded_port(&self) -> Option<u16> {
         let path = self.bt_port_file.as_ref()?;
         parse_forwarded_port(&std::fs::read_to_string(path).ok()?)
+    }
+
+    pub fn port_rotations(&self) -> u64 {
+        self.port_rotations.load(Ordering::Relaxed)
+    }
+
+    pub fn vpn_fail_streak(&self) -> u32 {
+        self.vpn_fail_streak.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
## Goal
Get the errors that cause peers to drop **back to the user**, so we can see *what* is happening instead of reading pod logs.

## What was missing
Per-torrent errors (`error`/`hls_error`/`transcode_error`) already flow through `/status` and render in the console. The one peer-drop signal that was **log-only** was the forwarded-port rotation counter from observe mode (#15074) — and on ProtonVPN each rotation wipes the swarm, so it's the prime suspect for "peers drop".

## Changes
**Server (reel 0.1.34 → 0.1.35):**
- Engine holds a shared `AtomicU64` rotation counter; the observe watch loop increments it.
- New `port_rotations()` / `vpn_fail_streak()` accessors, added to the `/status` report.

**Frontend:**
- `ReelStatusReport`/`ReelHealth` gain `port_rotations` + `vpn_fail_streak`; `refreshReelList` populates them.
- Console health strip shows **⟳ N port rotations** (tooltip: each rotation wipes the peer swarm) and **⚠ VPN checks failing ×N** when non-zero.

## Result
The staff console now shows, at a glance: VPN state, inbound vs outbound-only, **how many times the port rotated** (peer-wipe cause), VPN-check failures, and per-torrent failure reasons — the full "why are peers dropping" picture.

## Notes
- reel image tag auto-pins from the mdx version on publish; no manifest edit.
- 158 reel tests pass. Frontend not built in-worktree (no node_modules) — verify with `nx run astro-kbve:build`.

Docs: [kbve.com/application/kubernetes](https://kbve.com/application/kubernetes/)