### PR TITLE
feat(reel): live stream-activity diagnostics feed on the player page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -2,12 +2,14 @@
 import BentoShell from '@/components/hero/BentoShell.astro';
 import ReactReelPlayer from '@/components/media/ReactReelPlayer';
 import ReactReelConsole from '@/components/media/ReactReelConsole';
+import ReactReelDiagnostics from '@/components/media/ReactReelDiagnostics';
 ---
 
 <BentoShell id="reel-player-wrapper" eyebrow="Media" heading="Reel player.">
 	<div class="reel-dash not-content">
 		<div class="reel-dash__stream not-content">
 			<ReactReelPlayer client:only="react" />
+			<ReactReelDiagnostics client:only="react" />
 		</div>
 		<div class="reel-dash__console not-content">
 			<ReactReelConsole client:only="react" />
@@ -136,6 +138,93 @@ import ReactReelConsole from '@/components/media/ReactReelConsole';
 
 	.reel-dash__console {
 		margin-top: 2rem;
+	}
+
+	:global(.reel-diag) {
+		margin-top: 1rem;
+		border: 1px solid #27272a;
+		border-radius: 0.75rem;
+		background: #0c0c0e;
+		padding: 0.75rem 1rem;
+	}
+
+	:global(.reel-diag__head) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+	}
+
+	:global(.reel-diag__title) {
+		color: #a1a1aa;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	:global(.reel-diag__live) {
+		color: #fcd34d;
+		font-size: 0.72rem;
+		font-weight: 600;
+	}
+
+	:global(.reel-diag__log) {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		max-height: 11rem;
+		overflow-y: auto;
+	}
+
+	:global(.reel-diag__ev) {
+		display: grid;
+		grid-template-columns: auto auto 1fr;
+		gap: 0.5rem;
+		align-items: baseline;
+		font-size: 0.72rem;
+		line-height: 1.35;
+	}
+
+	:global(.reel-diag__time) {
+		color: #71717a;
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	:global(.reel-diag__stage) {
+		color: #a1a1aa;
+		font-weight: 600;
+		text-transform: uppercase;
+		font-size: 0.62rem;
+		letter-spacing: 0.03em;
+		white-space: nowrap;
+	}
+
+	:global(.reel-diag__msg) {
+		color: #d4d4d8;
+		word-break: break-word;
+	}
+
+	:global(.reel-diag__ev--ok .reel-diag__stage) {
+		color: #6ee7b7;
+	}
+
+	:global(.reel-diag__ev--warn .reel-diag__stage) {
+		color: #fcd34d;
+	}
+
+	:global(.reel-diag__ev--err .reel-diag__stage),
+	:global(.reel-diag__ev--err .reel-diag__msg) {
+		color: #fca5a5;
+	}
+
+	:global(.reel-diag__ev--info .reel-diag__stage) {
+		color: #93c5fd;
 	}
 
 	:global(.reel-console) {

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelDiagnostics.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelDiagnostics.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { DroidEvents, type ReelStreamPayload } from '@kbve/droid';
+import { $reelStatus } from './reelService';
+
+const CODE_HINT: Record<string, string> = {
+	'sign-in': 'Sign in as staff to watch.',
+	'not-found': 'This reel no longer exists on the server.',
+	reaped: 'Expired from the cache — re-add it to watch.',
+	'download-failed': 'The download failed on the server.',
+	'token-expired': 'Media token expired — refreshing automatically.',
+	network: 'Network hiccup reaching the stream.',
+	media: 'Decoder error — rebuilding the buffer.',
+	'manifest-flip':
+		'Stream changed shape (finished downloading, or switched to a transcode).',
+	'transcode-timeout': 'Still preparing — the server is transcoding.',
+	unsupported: 'This browser or delivery mode is unsupported.',
+	unknown: 'Unexpected error.',
+};
+
+const STAGE_CLASS: Record<string, string> = {
+	loading: 'reel-diag__ev--info',
+	probing: 'reel-diag__ev--info',
+	playing: 'reel-diag__ev--ok',
+	reconnecting: 'reel-diag__ev--warn',
+	error: 'reel-diag__ev--err',
+};
+
+interface LogEntry extends ReelStreamPayload {
+	seq: number;
+}
+
+const MAX_LOG = 25;
+
+export default function ReactReelDiagnostics() {
+	const status = useStore($reelStatus);
+	const [log, setLog] = useState<LogEntry[]>([]);
+	const seq = useRef(0);
+
+	useEffect(() => {
+		const handler = (p: ReelStreamPayload) => {
+			setLog((prev) =>
+				[...prev, { ...p, seq: seq.current++ }].slice(-MAX_LOG),
+			);
+		};
+		DroidEvents.on('reel-stream', handler);
+		return () => DroidEvents.off('reel-stream', handler);
+	}, []);
+
+	if (!log.length) return null;
+
+	const fmtTime = (ts: number) =>
+		new Date(ts).toLocaleTimeString([], {
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+		});
+
+	return (
+		<div className="reel-diag">
+			<div className="reel-diag__head">
+				<span className="reel-diag__title">Stream activity</span>
+				{status?.stage === 'reconnecting' &&
+					status.attempt &&
+					status.max && (
+						<span className="reel-diag__live">
+							reconnecting {status.attempt}/{status.max}
+						</span>
+					)}
+			</div>
+			<ul className="reel-diag__log">
+				{[...log].reverse().map((e) => (
+					<li
+						key={e.seq}
+						className={`reel-diag__ev ${STAGE_CLASS[e.stage] ?? ''}`}>
+						<span className="reel-diag__time">
+							{fmtTime(e.timestamp)}
+						</span>
+						<span className="reel-diag__stage">{e.stage}</span>
+						<span className="reel-diag__msg">
+							{e.message}
+							{e.code ? ` — ${CODE_HINT[e.code] ?? e.code}` : ''}
+							{e.stage === 'reconnecting' && e.attempt && e.max
+								? ` (${e.attempt}/${e.max})`
+								: ''}
+						</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}


### PR DESCRIPTION
## Goal
Make the /media/reel/ player easier to operate and understand — show more information and errors, live.

## What
New `ReactReelDiagnostics` island mounted under the player. It subscribes to the typed **`reel-stream`** events on droid's bus (shipped in #15109) and renders a rolling activity log:
- timestamp + color-coded **stage** (loading/probing/playing/reconnecting/error)
- the message, plus an **operator-friendly hint per error code** (`token-expired` → "session expired, refreshing", `manifest-flip` → "stream changed shape (finished downloading / switched to transcode)", `transcode-timeout`, `network`, `media`, `reaped`, …)
- a **"reconnecting N/max"** live indicator while resurrect retries

So instead of a single overlay line, the operator sees exactly what the player is doing and every error as it happens — the download/health side already shows in the console strip (VPN, inbound, port rotations, per-torrent errors from #15120), and this covers the playback side.

## Scope
- Frontend-only; no version bump.
- Files: new `ReactReelDiagnostics.tsx`, `AstroReelPlayer.astro` (mount + styles).
- Not built in-worktree (no node_modules) — verify with `nx run astro-kbve:build`.

## Possible follow-ups
- Same feed on the live channel page (`AstroReelLive`).
- A collapse toggle / copy-to-clipboard for the log.
- Persist the last session's events across reloads.