### PR TITLE
fix(reel): restore lost event system (partial-merge) + self-healing live loop

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelLive.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelLive.astro
@@ -20,6 +20,93 @@ import ReactReelLive from '@/components/media/ReactReelLive';
 		}
 	}
 
+	:global(.reel-diag) {
+		margin-top: 1rem;
+		border: 1px solid #27272a;
+		border-radius: 0.75rem;
+		background: #0c0c0e;
+		padding: 0.75rem 1rem;
+	}
+
+	:global(.reel-diag__head) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+	}
+
+	:global(.reel-diag__title) {
+		color: #a1a1aa;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	:global(.reel-diag__live) {
+		color: #fcd34d;
+		font-size: 0.72rem;
+		font-weight: 600;
+	}
+
+	:global(.reel-diag__log) {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		max-height: 11rem;
+		overflow-y: auto;
+	}
+
+	:global(.reel-diag__ev) {
+		display: grid;
+		grid-template-columns: auto auto 1fr;
+		gap: 0.5rem;
+		align-items: baseline;
+		font-size: 0.72rem;
+		line-height: 1.35;
+	}
+
+	:global(.reel-diag__time) {
+		color: #71717a;
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	:global(.reel-diag__stage) {
+		color: #a1a1aa;
+		font-weight: 600;
+		text-transform: uppercase;
+		font-size: 0.62rem;
+		letter-spacing: 0.03em;
+		white-space: nowrap;
+	}
+
+	:global(.reel-diag__msg) {
+		color: #d4d4d8;
+		word-break: break-word;
+	}
+
+	:global(.reel-diag__ev--ok .reel-diag__stage) {
+		color: #6ee7b7;
+	}
+
+	:global(.reel-diag__ev--warn .reel-diag__stage) {
+		color: #fcd34d;
+	}
+
+	:global(.reel-diag__ev--err .reel-diag__stage),
+	:global(.reel-diag__ev--err .reel-diag__msg) {
+		color: #fca5a5;
+	}
+
+	:global(.reel-diag__ev--info .reel-diag__stage) {
+		color: #93c5fd;
+	}
+
 	:global(.reel-live) {
 		display: grid;
 		gap: 1.25rem;

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
@@ -7,6 +7,7 @@ import {
 	$reelState,
 	$reelError,
 	$reelNotice,
+	$reelStatus,
 	refreshReelList,
 	ReelPlayer,
 	type ReelTorrent,
@@ -48,6 +49,7 @@ export default function ReactReelLive() {
 	const state = useStore($reelState);
 	const error = useStore($reelError);
 	const notice = useStore($reelNotice);
+	const status = useStore($reelStatus);
 	const isStaff = useStore(homeService.$isStaff);
 	const authState = useStore(homeService.$authState);
 
@@ -230,11 +232,22 @@ export default function ReactReelLive() {
 									<p>
 										{state === 'error'
 											? 'Off air'
-											: 'Tuning in…'}
+											: state === 'reconnecting'
+												? 'Reconnecting…'
+												: 'Tuning in…'}
 									</p>
 									{now && (
 										<p className="reel-player__meta">
 											{now.name}
+										</p>
+									)}
+									{state === 'reconnecting' && (
+										<p className="reel-player__meta">
+											{status?.message ??
+												'Stream interrupted'}
+											{status?.attempt && status?.max
+												? ` · attempt ${status.attempt}/${status.max}`
+												: ''}
 										</p>
 									)}
 									{state === 'error' && error && (

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from '@nanostores/react';
+import { DroidEvents, type ReelStreamPayload } from '@kbve/droid';
 import { homeService } from '@/components/dashboard/homeService';
+import ReactReelDiagnostics from './ReactReelDiagnostics';
 import {
 	$reelList,
 	$reelListError,
@@ -14,6 +16,12 @@ import {
 } from './reelService';
 
 const POLL_MS = 15000;
+// After a reel errors for good, wait this long before rolling to the next so a
+// transient blip isn't skipped past instantly.
+const ERROR_ADVANCE_MS = 4000;
+// If every reel in the loop errors in a row, cool off before refreshing the
+// list and trying the channel again from the top.
+const LOOP_COOLDOWN_MS = 30000;
 
 function playable(t: ReelTorrent): boolean {
 	if (t.state !== 'Seeding') return false;
@@ -104,6 +112,55 @@ export default function ReactReelLive() {
 		const next = queue[(at + 1) % queue.length];
 		if (next) tuneTo(next.id);
 	}, [queue, nowId, tuneTo]);
+
+	// Keep the latest advance/queue-length reachable from the event handler
+	// without re-subscribing to the bus on every queue change.
+	const advanceRef = useRef(advance);
+	const queueLenRef = useRef(queue.length);
+	const errorStreak = useRef(0);
+	const loopTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(() => {
+		advanceRef.current = advance;
+		queueLenRef.current = queue.length;
+	}, [advance, queue.length]);
+
+	// Self-healing loop: the player reports every playback transition on the
+	// droid bus. When a reel errors for good, roll on by itself instead of
+	// stranding on "Off air"; a clean start resets the streak. If the whole loop
+	// errors in a row, cool off, refresh the list, and try again from the top.
+	useEffect(() => {
+		if (!started) return;
+		const handler = (p: ReelStreamPayload) => {
+			if (p.stage === 'playing') {
+				errorStreak.current = 0;
+				return;
+			}
+			if (p.stage !== 'error' || !p.fatal) return;
+			if (loopTimer.current) clearTimeout(loopTimer.current);
+			const len = Math.max(1, queueLenRef.current);
+			if (errorStreak.current < len) {
+				errorStreak.current += 1;
+				loopTimer.current = setTimeout(
+					() => advanceRef.current(),
+					ERROR_ADVANCE_MS,
+				);
+			} else {
+				errorStreak.current = 0;
+				loopTimer.current = setTimeout(() => {
+					void refreshReelList();
+					advanceRef.current();
+				}, LOOP_COOLDOWN_MS);
+			}
+		};
+		DroidEvents.on('reel-stream', handler);
+		return () => {
+			DroidEvents.off('reel-stream', handler);
+			if (loopTimer.current) {
+				clearTimeout(loopTimer.current);
+				loopTimer.current = null;
+			}
+		};
+	}, [started]);
 
 	const start = useCallback(() => {
 		const first = queue[0];
@@ -231,7 +288,7 @@ export default function ReactReelLive() {
 								<>
 									<p>
 										{state === 'error'
-											? 'Off air'
+											? 'Off air — skipping to next…'
 											: state === 'reconnecting'
 												? 'Reconnecting…'
 												: 'Tuning in…'}
@@ -269,7 +326,8 @@ export default function ReactReelLive() {
 					)}
 				</div>
 				{notice && <p className="reel-player__notice">{notice}</p>}
-			</div>
+					<ReactReelDiagnostics />
+				</div>
 
 			<aside className="reel-live__rail">
 				<div className="reel-live__now">

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
@@ -5,6 +5,7 @@ import {
 	$reelError,
 	$reelName,
 	$reelNotice,
+	$reelStatus,
 	$reelSelectedId,
 	ReelPlayer,
 } from './reelService';
@@ -15,6 +16,7 @@ const STATE_LABEL: Record<string, string> = {
 	probing: 'Preparing stream…',
 	raw: 'Playing',
 	hls: 'Playing (HLS)',
+	reconnecting: 'Reconnecting…',
 	error: 'Error',
 };
 
@@ -28,6 +30,7 @@ export default function ReactReelPlayer() {
 	const error = useStore($reelError);
 	const name = useStore($reelName);
 	const notice = useStore($reelNotice);
+	const status = useStore($reelStatus);
 	const selectedId = useStore($reelSelectedId);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [player] = useState(() => new ReelPlayer());
@@ -81,8 +84,12 @@ export default function ReactReelPlayer() {
 		}
 	};
 
-	const busy = state === 'loading' || state === 'probing';
+	const busy =
+		state === 'loading' ||
+		state === 'probing' ||
+		state === 'reconnecting';
 	const playing = state === 'raw' || state === 'hls';
+	const reconnecting = state === 'reconnecting';
 
 	return (
 		<div className={`reel-player${theater ? ' reel-player--theater' : ''}`}>
@@ -107,6 +114,14 @@ export default function ReactReelPlayer() {
 					<div className="reel-player__overlay">
 						<p>{STATE_LABEL[state] ?? state}</p>
 						{name && <p className="reel-player__meta">{name}</p>}
+						{reconnecting && (
+							<p className="reel-player__meta">
+								{status?.message ?? 'Stream interrupted'}
+								{status?.attempt && status?.max
+									? ` · attempt ${status.attempt}/${status.max}`
+									: ''}
+							</p>
+						)}
 						{state === 'error' && error && (
 							<p className="reel-player__error">{error}</p>
 						)}

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -1,6 +1,13 @@
 import { atom } from 'nanostores';
 import { authedApiFetch, ApiError } from '@/lib/apiFetch';
 import { DASH_PROXY_BASE } from '@/components/rnweb/dashProxyBase';
+import {
+	DroidEvents,
+	addToast,
+	type ReelStreamStage,
+	type ReelStreamErrorCode,
+	type ReelStreamPayload,
+} from '@kbve/droid';
 
 export type ReelState =
 	| 'idle'
@@ -8,12 +15,14 @@ export type ReelState =
 	| 'probing'
 	| 'raw'
 	| 'hls'
+	| 'reconnecting'
 	| 'error';
 
 export const $reelState = atom<ReelState>('idle');
 export const $reelError = atom<string | null>(null);
 export const $reelName = atom<string | null>(null);
 export const $reelNotice = atom<string | null>(null);
+export const $reelStatus = atom<ReelStreamPayload | null>(null);
 
 // The reel the player is currently bound to. Clicking Play in the console sets
 // this; the player island reacts and starts playback in place — no navigation,
@@ -380,21 +389,49 @@ export class ReelPlayer {
 	private recover: (() => void) | null = null;
 	private lastPos = 0;
 	private resurrects = 0;
+	private currentId: string | null = null;
+
+	private emit(
+		stage: ReelStreamStage,
+		message: string,
+		extra?: {
+			code?: ReelStreamErrorCode;
+			attempt?: number;
+			max?: number;
+			fatal?: boolean;
+		},
+	): void {
+		const payload: ReelStreamPayload = {
+			timestamp: Date.now(),
+			id: this.currentId ?? '',
+			stage,
+			message,
+			...extra,
+		};
+		$reelStatus.set(payload);
+		try {
+			DroidEvents.emit('reel-stream', payload);
+		} catch {
+			void 0;
+		}
+	}
 
 	async start(video: HTMLVideoElement, id: string): Promise<void> {
 		const gen = ++this.generation;
 		this.teardown();
 		this.resurrects = 0;
+		this.currentId = id;
 		this.video = video;
 		$reelError.set(null);
 		$reelNotice.set(null);
 		$reelName.set(null);
 		$reelState.set('loading');
+		this.emit('loading', 'Loading…');
 
 		const token = await mediaToken();
 		if (this.generation !== gen) return;
 		if (!token) {
-			this.fail('sign in to watch');
+			this.fail('sign in to watch', 'sign-in');
 			return;
 		}
 
@@ -409,30 +446,33 @@ export class ReelPlayer {
 					typeof detail.error === 'string' && detail.error
 						? detail.error
 						: 'this reel failed to download',
+					'download-failed',
 				);
 				return;
 			}
 			if (detail?.state === 'Reaped') {
 				this.fail(
 					'this reel expired and was removed — re-add it to watch',
+					'reaped',
 				);
 				return;
 			}
 		} catch (e) {
 			if (this.generation !== gen) return;
 			if (e instanceof ApiError && e.status === 404) {
-				this.fail('torrent not found');
+				this.fail('torrent not found', 'not-found');
 				return;
 			}
 			if (e instanceof ApiError && e.status === 401) {
-				this.fail('sign in to watch');
+				this.fail('sign in to watch', 'sign-in');
 				return;
 			}
-			this.fail(e instanceof Error ? e.message : String(e));
+			this.fail(e instanceof Error ? e.message : String(e), 'network');
 			return;
 		}
 
 		$reelState.set('probing');
+		this.emit('probing', 'Preparing stream…');
 		await this.probe(video, id, token, 0, gen);
 	}
 
@@ -453,7 +493,7 @@ export class ReelPlayer {
 			status = resp.status;
 		} catch {
 			if (this.generation !== gen) return;
-			this.fail('network error reaching reel');
+			this.fail('network error reaching reel', 'network');
 			return;
 		}
 		if (this.generation !== gen) return;
@@ -467,9 +507,16 @@ export class ReelPlayer {
 				return;
 			case 'poll':
 				if (attempt >= MAX_POLLS) {
-					this.fail('still preparing — retry in a moment');
+					this.fail(
+						'still preparing — retry in a moment',
+						'transcode-timeout',
+					);
 					return;
 				}
+				this.emit('probing', 'Preparing stream…', {
+					attempt: attempt + 1,
+					max: MAX_POLLS,
+				});
 				this.pollTimer = setTimeout(() => {
 					void this.probe(video, id, token, attempt + 1, gen);
 				}, backoffMs(attempt));
@@ -479,6 +526,7 @@ export class ReelPlayer {
 					status === 503
 						? 'HLS delivery disabled'
 						: `unexpected status ${status}`,
+					status === 503 ? 'unsupported' : 'unknown',
 				);
 				return;
 		}
@@ -494,6 +542,7 @@ export class ReelPlayer {
 		this.attachVideoError(video, gen);
 		video.src = mediaUrl(id, '/stream', token);
 		$reelState.set('raw');
+		this.emit('playing', 'Streaming');
 		void this.addSubtitleTracks(video, id, token, gen);
 		this.recover = () => {
 			// Re-request the byte-range stream from the current position.
@@ -649,7 +698,11 @@ export class ReelPlayer {
 				if (!data.fatal) return;
 				if (this.generation !== gen) return;
 				switch (data.type) {
-					case Hls.ErrorTypes.NETWORK_ERROR:
+					case Hls.ErrorTypes.NETWORK_ERROR: {
+						const expired = data.response?.code === 401;
+						const code: ReelStreamErrorCode = expired
+							? 'token-expired'
+							: 'network';
 						if (netRetries++ < MAX_RECOVER) {
 							void mediaToken(true).then((t) => {
 								if (this.generation !== gen) return;
@@ -659,18 +712,37 @@ export class ReelPlayer {
 								}, 1000);
 							});
 						} else {
-							void this.resurrect(video, id, gen);
+							void this.resurrect(
+								video,
+								id,
+								gen,
+								code,
+								`network error: ${data.details}`,
+							);
 						}
 						break;
+					}
 					case Hls.ErrorTypes.MEDIA_ERROR:
 						if (mediaRetries++ < MAX_RECOVER) {
 							hls.recoverMediaError();
 						} else {
-							void this.resurrect(video, id, gen);
+							void this.resurrect(
+								video,
+								id,
+								gen,
+								'media',
+								`media error: ${data.details}`,
+							);
 						}
 						break;
 					default:
-						void this.resurrect(video, id, gen);
+						void this.resurrect(
+							video,
+							id,
+							gen,
+							'manifest-flip',
+							`stream changed: ${data.details}`,
+						);
 				}
 			});
 			// Auto-enable the first subtitle rendition (the live stream marks it
@@ -684,6 +756,7 @@ export class ReelPlayer {
 			hls.loadSource(mediaUrl(id, '/manifest.m3u8', null));
 			hls.attachMedia(video);
 			$reelState.set('hls');
+			this.emit('playing', 'Streaming');
 			this.recover = () => {
 				hls.startLoad();
 				void video.play().catch(() => undefined);
@@ -701,6 +774,7 @@ export class ReelPlayer {
 			this.attachVideoError(video, gen);
 			video.src = mediaUrl(id, '/manifest.m3u8', token);
 			$reelState.set('hls');
+			this.emit('playing', 'Streaming');
 			this.recover = () => {
 				// Native HLS has no load API — reload the source at the same spot.
 				const at = video.currentTime;
@@ -721,7 +795,7 @@ export class ReelPlayer {
 			void video.play().catch(() => undefined);
 			return;
 		}
-		this.fail('HLS is not supported in this browser');
+		this.fail('HLS is not supported in this browser', 'unsupported');
 	}
 
 	private teardown(): void {
@@ -749,9 +823,20 @@ export class ReelPlayer {
 		}
 	}
 
-	private fail(message: string): void {
+	private fail(message: string, code: ReelStreamErrorCode = 'unknown'): void {
 		$reelError.set(message);
 		$reelState.set('error');
+		this.emit('error', message, { code, fatal: true });
+		try {
+			addToast({
+				id: `reel-${this.currentId ?? 'stream'}-${code}`,
+				message,
+				severity: 'error',
+				duration: 6000,
+			});
+		} catch {
+			void 0;
+		}
 		this.teardown();
 	}
 
@@ -759,12 +844,17 @@ export class ReelPlayer {
 		video: HTMLVideoElement,
 		id: string,
 		gen: number,
+		code: ReelStreamErrorCode,
+		reason: string,
 	): Promise<void> {
 		if (this.generation !== gen) return;
 		if (this.resurrects++ >= MAX_RESURRECTS) {
-			this.fail('stream ended');
+			this.fail('stream ended — could not recover', code);
 			return;
 		}
+		const attempt = this.resurrects;
+		$reelState.set('reconnecting');
+		this.emit('reconnecting', reason, { code, attempt, max: MAX_RESURRECTS });
 		this.stopWatchdog();
 		if (this.tokenTimer) {
 			clearInterval(this.tokenTimer);
@@ -783,10 +873,9 @@ export class ReelPlayer {
 		const token = await mediaToken(true);
 		if (this.generation !== gen) return;
 		if (!token) {
-			this.fail('sign in to watch');
+			this.fail('sign in to watch', 'sign-in');
 			return;
 		}
-		$reelState.set('probing');
 		await new Promise((r) => setTimeout(r, 1500));
 		if (this.generation !== gen) return;
 		await this.probe(video, id, token, 0, gen);
@@ -806,9 +895,11 @@ export class ReelPlayer {
 		}
 		if (reset) {
 			this.video = null;
+			this.currentId = null;
 			$reelState.set('idle');
 			$reelError.set(null);
 			$reelNotice.set(null);
+			$reelStatus.set(null);
 		}
 	}
 }

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -109,6 +109,42 @@ export const PalworldLiveSnapshotSchema = z.object({
 	),
 });
 
+export const ReelStreamStageSchema = z.enum([
+	'loading',
+	'probing',
+	'playing',
+	'reconnecting',
+	'error',
+]);
+export type ReelStreamStage = z.infer<typeof ReelStreamStageSchema>;
+
+export const ReelStreamErrorCodeSchema = z.enum([
+	'sign-in',
+	'not-found',
+	'reaped',
+	'download-failed',
+	'token-expired',
+	'network',
+	'media',
+	'manifest-flip',
+	'transcode-timeout',
+	'unsupported',
+	'unknown',
+]);
+export type ReelStreamErrorCode = z.infer<typeof ReelStreamErrorCodeSchema>;
+
+export const ReelStreamSchema = z.object({
+	timestamp: z.number(),
+	id: z.string(),
+	stage: ReelStreamStageSchema,
+	message: z.string(),
+	code: ReelStreamErrorCodeSchema.optional(),
+	attempt: z.number().optional(),
+	max: z.number().optional(),
+	fatal: z.boolean().optional(),
+});
+export type ReelStreamPayload = z.infer<typeof ReelStreamSchema>;
+
 export const DroidEventSchemas = {
 	'droid-first-connect': DroidFirstConnectSchema,
 	'droid-ready': DroidReadySchema,
@@ -126,6 +162,7 @@ export const DroidEventSchemas = {
 	'auth-ready': AuthReadySchema,
 	'auth-error': AuthErrorSchema,
 	'worker-error': WorkerErrorSchema,
+	'reel-stream': ReelStreamSchema,
 	'gateway-strategy-fallback': GatewayStrategyFallbackSchema,
 	'page-mount': PageLifecycleSchema,
 	'page-swap': PageLifecycleSchema,


### PR DESCRIPTION
## ⚠️ P0 first: dev is currently broken
A partial squash-merge dropped #15109's event-system commit from dev — but #15124 (already merged) added `ReactReelDiagnostics.tsx`, which imports `reel-stream` / `ReelStreamPayload` (droid) and `$reelStatus` (reelService). Those symbols are **missing from dev**, so `astro-kbve` fails to typecheck/build.

Only `resurrect` (commit 1 of #15109) landed; the typed-event commit (droid schema + `$reelStatus` + `emit` + reconnecting UI) was lost.

**Fix:** cherry-picked the surviving commit (`da527d52`) to restore it, resolving one conflict in `event-types.ts` (kept **both** the new `PalworldLiveSnapshotSchema` and the `ReelStream*` schemas / `reel-stream` registration). reelService auto-merged cleanly with #15120's `port_rotations` — both now present.

## Feature: self-healing live channel loop
Requested: the viewer just sits on /media/live/ and the channel runs itself, looping through the content.
- The live channel subscribes to the **droid `reel-stream`** bus. On a terminal playback error it **auto-advances** to the next reel (after `ERROR_ADVANCE_MS`) instead of stranding on 'Off air', and the queue **wraps** so it loops continuously.
- If the whole loop errors in a row (streak ≥ queue length), it **cools off** (`LOOP_COOLDOWN_MS`), refreshes the list, and restarts from the top — no tight error loop.
- A clean `playing` event resets the streak.
- Overlay now reads 'Off air — skipping to next…'.
- Mounts the **stream-activity diagnostics feed** on the live page so the operator sees every stage/error live.

## Notes
- Frontend + droid source only; no version bump.
- Not built in-worktree (no node_modules) — **please run `nx run astro-kbve:build` on merge**; this PR also unbreaks that build.
- Existing hands-off behavior (auto-start muted, auto-theater, auto-advance on end, reaped-content skip) is unchanged; this adds error-path recovery to complete the loop.