### PR TITLE
fix(irc): answer ws heartbeat and surface idle disconnects

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/AstroChatRoom.astro
+++ b/apps/irc/astro-irc/src/components/chat/AstroChatRoom.astro
@@ -4,6 +4,7 @@ import { ConnectionPill } from './islands/ConnectionPill';
 import { MeAvatar } from './islands/MeAvatar';
 import { ChannelPill } from './islands/ChannelPill';
 import { ChannelRail } from './islands/ChannelRail';
+import { ConnectionBanner } from './islands/ConnectionBanner';
 import { MessageFeed } from './islands/MessageFeed';
 import { ChatInput } from './islands/ChatInput';
 import { UserList } from './islands/UserList';
@@ -50,6 +51,7 @@ const { wsUrl = 'wss://chat.kbve.com/ws' } = Astro.props;
 
 	<section class="kbve-chat__main">
 		<MessageFeed client:only="react" />
+		<ConnectionBanner client:only="react" wsUrl={wsUrl} />
 		<ChatInput client:only="react" />
 		<AuthOverlay client:only="react" />
 	</section>

--- a/apps/irc/astro-irc/src/components/chat/islands/ChatInput.tsx
+++ b/apps/irc/astro-irc/src/components/chat/islands/ChatInput.tsx
@@ -80,7 +80,13 @@ export const ChatInput: React.FC = () => {
 					type="text"
 					value={value}
 					onChange={(e) => setValue(e.target.value)}
-					placeholder={disabled ? 'Not connected' : 'Send a message…'}
+					placeholder={
+						status === 'idle'
+							? 'Disconnected for inactivity'
+							: disabled
+								? 'Not connected'
+								: 'Send a message…'
+					}
 					disabled={disabled}
 					className="kbve-chat__composer-input"
 				/>

--- a/apps/irc/astro-irc/src/components/chat/islands/ConnectionBanner.tsx
+++ b/apps/irc/astro-irc/src/components/chat/islands/ConnectionBanner.tsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect } from 'react';
+import { useStore } from '@nanostores/react';
+import { $connectionStatus, $disconnect, connect } from '../service';
+import { $authState, $authToken, $swReady } from '../auth';
+
+export interface ConnectionBannerProps {
+	wsUrl?: string;
+}
+
+export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
+	wsUrl = 'wss://chat.kbve.com/ws',
+}) => {
+	const status = useStore($connectionStatus);
+	const info = useStore($disconnect);
+	const authState = useStore($authState);
+	const token = useStore($authToken);
+	const swReady = useStore($swReady);
+
+	const reconnect = useCallback(() => {
+		if (token && swReady) connect(wsUrl, token);
+	}, [token, swReady, wsUrl]);
+
+	// Coming back to the tab is the signal that the user is no longer idle, so
+	// that's when we rejoin. The worker deliberately does not retry an idle
+	// close on its own — it can't tell whether anyone is still watching.
+	useEffect(() => {
+		if (status !== 'idle') return;
+		const onVisible = () => {
+			if (document.visibilityState === 'visible') reconnect();
+		};
+		document.addEventListener('visibilitychange', onVisible);
+		window.addEventListener('focus', onVisible);
+		return () => {
+			document.removeEventListener('visibilitychange', onVisible);
+			window.removeEventListener('focus', onVisible);
+		};
+	}, [status, reconnect]);
+
+	if (authState !== 'auth') return null;
+	if (status === 'connected') return null;
+	if (status === 'connecting') {
+		return (
+			<div className="kbve-chat__banner kbve-chat__banner--pending">
+				<span className="kbve-chat__banner-text">Reconnecting…</span>
+			</div>
+		);
+	}
+	if (!info) return null;
+
+	const text =
+		info.kind === 'idle'
+			? 'You were disconnected for inactivity.'
+			: info.kind === 'failed'
+				? "Couldn't reconnect after several tries."
+				: 'Connection lost.';
+
+	return (
+		<div
+			className={`kbve-chat__banner kbve-chat__banner--${info.kind === 'idle' ? 'idle' : 'error'}`}>
+			<span className="kbve-chat__banner-text">{text}</span>
+			<button
+				type="button"
+				onClick={reconnect}
+				disabled={!swReady || !token}
+				className="kbve-chat__banner-btn">
+				Reconnect
+			</button>
+		</div>
+	);
+};

--- a/apps/irc/astro-irc/src/components/chat/islands/ConnectionPill.tsx
+++ b/apps/irc/astro-irc/src/components/chat/islands/ConnectionPill.tsx
@@ -14,6 +14,7 @@ const STATUS_LABEL: Record<ConnectionStatus, string> = {
 	connected: 'Online',
 	connecting: 'Connecting…',
 	disconnected: 'Offline',
+	idle: 'Idle',
 	error: 'Error',
 };
 
@@ -61,7 +62,11 @@ export const ConnectionPill: React.FC<ConnectionPillProps> = ({
 				onClick={handleToggle}
 				disabled={connectDisabled}
 				className={`kbve-chat__btn ${status === 'connected' ? 'kbve-chat__btn--danger' : ''}`}>
-				{status === 'connected' ? 'Disconnect' : 'Connect'}
+				{status === 'connected'
+					? 'Disconnect'
+					: status === 'idle' || status === 'error'
+						? 'Reconnect'
+						: 'Connect'}
 			</button>
 		</>
 	);

--- a/apps/irc/astro-irc/src/components/chat/service.ts
+++ b/apps/irc/astro-irc/src/components/chat/service.ts
@@ -2,6 +2,7 @@ import {
 	$activeChannel,
 	$channels,
 	$connectionStatus,
+	$disconnect,
 	$error,
 	$nick,
 	handleIncoming,
@@ -32,6 +33,11 @@ const decoder = new TextDecoder();
 // ---------------------------------------------------------------------------
 let eventsChannel: BroadcastChannel | null = null;
 
+// Set while a user-initiated disconnect is in flight. The worker's close event
+// looks identical to a dropped socket, and we don't want the "connection lost"
+// banner for a disconnect the user asked for.
+let intentionalClose = false;
+
 function ensureEventsSubscription(): void {
 	if (eventsChannel) return;
 	if (typeof BroadcastChannel === 'undefined') {
@@ -56,7 +62,29 @@ function ensureEventsSubscription(): void {
 			if (status === 'connected') {
 				$connectionStatus.set('connected');
 				$error.set('');
+				$disconnect.set(null);
 				systemMessage($activeChannel.get(), 'Connected to IRC');
+			} else if (status === 'idle') {
+				// Gateway closed us out for inactivity. The worker does not
+				// auto-retry this one — the page decides when to come back.
+				$connectionStatus.set('idle');
+				$disconnect.set({
+					kind: 'idle',
+					code,
+					reason: reason || 'idle timeout',
+					at: Date.now(),
+				});
+				const message = 'Disconnected for inactivity';
+				$error.set(message);
+				systemMessage(
+					$activeChannel.get(),
+					`${message} — reconnect to rejoin the channel`,
+				);
+			} else if (status === 'disconnected' && intentionalClose) {
+				intentionalClose = false;
+				$connectionStatus.set('disconnected');
+				$disconnect.set(null);
+				$error.set('');
 			} else if (status === 'disconnected' || status === 'error') {
 				$connectionStatus.set(status as ConnectionStatus);
 				const detail =
@@ -68,6 +96,12 @@ function ensureEventsSubscription(): void {
 				const message = `${status === 'error' ? 'WS error' : 'Disconnected'}: ${detail}`;
 				console.warn('[chat]', message, evt);
 				$error.set(message);
+				$disconnect.set({
+					kind: 'network',
+					code,
+					reason,
+					at: Date.now(),
+				});
 				systemMessage($activeChannel.get(), message);
 			} else if (status === 'reconnecting') {
 				$connectionStatus.set('connecting');
@@ -75,6 +109,7 @@ function ensureEventsSubscription(): void {
 			} else if (status === 'failed') {
 				$connectionStatus.set('error');
 				$error.set('Reconnect failed — give up after retries');
+				$disconnect.set({ kind: 'failed', at: Date.now() });
 				systemMessage(
 					$activeChannel.get(),
 					'Reconnect failed — give up after retries',
@@ -112,6 +147,7 @@ export async function connect(wsUrl: string, token?: string): Promise<void> {
 
 	$connectionStatus.set('connecting');
 	$error.set('');
+	intentionalClose = false;
 
 	try {
 		const kbve = (window as any).kbve;
@@ -135,11 +171,13 @@ export async function connect(wsUrl: string, token?: string): Promise<void> {
 }
 
 export async function disconnect(): Promise<void> {
+	intentionalClose = true;
 	try {
 		const kbve = (window as any).kbve;
 		if (kbve?.ws) await kbve.ws.close();
 	} finally {
 		$connectionStatus.set('disconnected');
+		$disconnect.set(null);
 		systemMessage($activeChannel.get(), 'Disconnected from IRC');
 	}
 }

--- a/apps/irc/astro-irc/src/lib/chat/store.ts
+++ b/apps/irc/astro-irc/src/lib/chat/store.ts
@@ -24,7 +24,19 @@ export type ConnectionStatus =
 	| 'disconnected'
 	| 'connecting'
 	| 'connected'
+	| 'idle'
 	| 'error';
+
+export type DisconnectKind = 'idle' | 'network' | 'failed';
+
+export interface DisconnectInfo {
+	kind: DisconnectKind;
+	code?: number;
+	reason?: string;
+	at: number;
+}
+
+export const IDLE_CLOSE_CODE = 4001;
 
 export const DEFAULT_CHANNEL = '#general';
 export const MAX_MESSAGES_PER_CHANNEL = 500;
@@ -34,6 +46,7 @@ export const $activeChannel = atom<string>(DEFAULT_CHANNEL);
 export const $channels = atom<Map<string, ChannelState>>(new Map());
 export const $nick = atom<string>('');
 export const $error = atom<string>('');
+export const $disconnect = atom<DisconnectInfo | null>(null);
 
 const $messageStore = atom<Map<string, ChatMessage[]>>(new Map());
 
@@ -111,6 +124,7 @@ export function resetCore(): void {
 	$channels.set(new Map());
 	$nick.set('');
 	$error.set('');
+	$disconnect.set(null);
 	$messageStore.set(new Map());
 }
 

--- a/apps/irc/astro-irc/src/styles/global.css
+++ b/apps/irc/astro-irc/src/styles/global.css
@@ -418,6 +418,53 @@
 	}
 
 	/* Composer */
+	.kbve-chat__banner {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 10px 20px;
+		border-top: 1px solid var(--sl-color-border);
+		background: var(--chat-elev-2);
+		font-size: 13px;
+	}
+
+	.kbve-chat__banner--idle {
+		border-left: 3px solid #a855f7;
+	}
+	.kbve-chat__banner--error {
+		border-left: 3px solid #ef4444;
+	}
+	.kbve-chat__banner--pending {
+		border-left: 3px solid #f59e0b;
+	}
+
+	.kbve-chat__banner-text {
+		flex: 1;
+		min-width: 0;
+		color: var(--sl-color-text);
+	}
+
+	.kbve-chat__banner-btn {
+		flex-shrink: 0;
+		padding: 6px 14px;
+		border-radius: 999px;
+		border: 1px solid var(--sl-color-border);
+		background: var(--chat-elev-1);
+		color: var(--sl-color-text);
+		font-size: 12px;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.kbve-chat__banner-btn:hover:not(:disabled) {
+		border-color: var(--sl-color-accent);
+	}
+
+	.kbve-chat__banner-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
 	.kbve-chat__composer {
 		padding: 14px 20px 18px;
 		border-top: 1px solid var(--sl-color-border);
@@ -768,6 +815,9 @@
 	}
 	.kbve-chat__status-dot--error {
 		background: #ef4444;
+	}
+	.kbve-chat__status-dot--idle {
+		background: #a855f7;
 	}
 	.kbve-chat__status-dot--disconnected {
 		background: var(--sl-color-gray-4);

--- a/apps/irc/irc-gateway/src/gateway/websocket.rs
+++ b/apps/irc/irc-gateway/src/gateway/websocket.rs
@@ -1,11 +1,11 @@
 use axum::{
     extract::Request,
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
     http::StatusCode,
     response::IntoResponse,
 };
 use futures_util::{SinkExt, StreamExt};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::time::{interval, timeout};
 use tokio_tungstenite::connect_async;
 use tracing::{error, info, warn};
@@ -20,7 +20,23 @@ const NO_USERNAME_MSG: &str = "No provider username configured. Set a username o
 const WS_MAX_FRAME_BYTES: usize = 16 * 1024;
 const WS_MAX_MESSAGE_BYTES: usize = 64 * 1024;
 const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
-const WS_READ_DEADLINE: Duration = Duration::from_secs(90);
+const WS_READ_DEADLINE: Duration = Duration::from_secs(240);
+/// No client frame (heartbeat, pong, or IRC line) for this long means the tab
+/// is gone or throttled to death. We close with a labelled frame instead of
+/// letting the socket rot into a 1006 so the UI can say *why*.
+const CLIENT_IDLE_LIMIT: Duration = Duration::from_secs(120);
+const IDLE_CLOSE_CODE: u16 = 4001;
+const IDLE_CLOSE_REASON: &str = "idle timeout";
+
+/// The droid ws-worker heartbeat. It is a client↔gateway keepalive, not IRC —
+/// answer it here and never forward it to Ergo, which would see it as junk.
+const HEARTBEAT_PING: &str = r#"{"type":"ping"}"#;
+const HEARTBEAT_PONG: &str = r#"{"type":"pong"}"#;
+
+fn is_heartbeat_ping(text: &str) -> bool {
+    let t = text.trim();
+    t == HEARTBEAT_PING || (t.starts_with('{') && t.contains("\"ping\""))
+}
 
 pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse {
     let token = match jwt::extract_token(&req) {
@@ -89,9 +105,9 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     info!(user = %username, "Connected to Ergo");
 
     let (client_pulse_tx, mut client_pulse_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-    // Raw IRC NOTICE lines pushed back to the web client when a message is
-    // blocked. ergo_to_client owns the client sink, so c2e hands notices off
-    // through this channel.
+    // Frames pushed straight back to the web client without a round trip to
+    // Ergo — blocked-message notices and heartbeat pongs. ergo_to_client owns
+    // the client sink, so c2e hands them off through this channel.
     let (notice_tx, mut notice_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
     let client_to_ergo = async {
@@ -108,6 +124,10 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
             let ergo_msg = match msg {
                 Message::Text(t) => {
                     let text = t.to_string();
+                    if is_heartbeat_ping(&text) {
+                        let _ = notice_tx.send(HEARTBEAT_PONG.to_string());
+                        continue;
+                    }
                     // The web client speaks raw IRC. Gate every PRIVMSG line
                     // through the same anti-spam + content filter the game path
                     // uses, so a web client can't bypass it with a raw frame.
@@ -139,6 +159,7 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     let ergo_to_client = async {
         let mut ping_timer = interval(WS_PING_INTERVAL);
         ping_timer.tick().await;
+        let mut last_pulse = Instant::now();
         loop {
             tokio::select! {
                 msg = ergo_stream.next() => {
@@ -161,11 +182,22 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
                     }
                 }
                 _ = ping_timer.tick() => {
+                    if last_pulse.elapsed() >= CLIENT_IDLE_LIMIT {
+                        warn!(user = %username, "client idle; closing with idle frame");
+                        let _ = client_sink
+                            .send(Message::Close(Some(CloseFrame {
+                                code: IDLE_CLOSE_CODE,
+                                reason: IDLE_CLOSE_REASON.into(),
+                            })))
+                            .await;
+                        break;
+                    }
                     if client_sink.send(Message::Ping(Default::default())).await.is_err() {
                         break;
                     }
                 }
                 _ = client_pulse_rx.recv() => {
+                    last_pulse = Instant::now();
                     ping_timer.reset();
                 }
                 notice = notice_rx.recv() => {

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -47,6 +47,13 @@ let lastPongTime = 0;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 60000;
 
+// Server-side idle close. The gateway closes with this code when it has seen
+// no frame from us for its idle window — a throttled background tab, a slept
+// machine, a dead network. Auto-reconnecting from a worker that can't see the
+// document would just burn retries while nobody is looking, so we surface it
+// as its own status and let the page reconnect when the user comes back.
+const IDLE_CLOSE_CODE = 4001;
+
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 let lastUrl: string | null = null;
@@ -229,13 +236,14 @@ const wsInstanceAPI = {
 			);
 			ws = null;
 			stopHeartbeat();
-			broadcastStatus('disconnected', {
+			const idle = event.code === IDLE_CLOSE_CODE;
+			broadcastStatus(idle ? 'idle' : 'disconnected', {
 				code: event.code,
 				reason: event.reason,
 				wasClean: event.wasClean,
 			});
 
-			if (event.code !== 1000) {
+			if (event.code !== 1000 && !idle) {
 				attemptReconnect();
 			}
 		};


### PR DESCRIPTION
## Problem

`chat.kbve.com` sessions drop every 15–45 min with `code=1006 (abnormal)`, then silently reconnect. The feed only logs it — nothing in the UI says the user is no longer connected.

Root cause: the droid `ws-worker` sends a `{"type":"ping"}` keepalive every 30s, but `irc-gateway` forwarded it to Ergo as raw IRC junk and never replied with `{"type":"pong"}`. The worker's `lastPongTime` therefore never advanced, and the gateway's 90s `WS_READ_DEADLINE` tore the socket down without a close frame → `1006`.

## Changes

**Gateway** (`apps/irc/irc-gateway/src/gateway/websocket.rs`)
- Intercept the heartbeat ping, reply `{"type":"pong"}` on the client-out channel, never forward it to Ergo.
- Idle detection moved into `ergo_to_client` (tracks `last_pulse`). After 120s with no client frame it sends a real `Close(4001, "idle timeout")` instead of dropping the socket.
- `WS_READ_DEADLINE` 90s → 240s, now only a backstop.

**Worker** (`packages/npm/droid/src/lib/workers/ws-worker.ts`)
- Close code `4001` broadcasts status `idle` and skips auto-retry — the SharedWorker cannot see the document, so retrying at a dead tab just burns attempts.

**Chat client** (`apps/irc/astro-irc`)
- `ConnectionStatus` gains `idle`; new `$disconnect` atom carries `idle | network | failed`.
- New `ConnectionBanner` island above the composer: "You were disconnected for inactivity." + Reconnect, and auto-rejoins on tab visible/focus.
- Connection pill shows `Idle` (purple dot) and the button reads Reconnect; input placeholder states the reason.
- `intentionalClose` flag so a user-clicked Disconnect no longer renders as a lost connection.

## Verification

- `./kbve.sh -nx irc-gateway:build` ✅
- `./kbve.sh -nx astro-irc:build` ✅
- `./kbve.sh -nx droid:test` ✅