### PR TITLE
fix(herbmail-game): restore mesh node names dropped by gltfpack

### DIFF
--- a/apps/herbmail/herbmail-game/.gitignore
+++ b/apps/herbmail/herbmail-game/.gitignore
@@ -3,3 +3,5 @@ _*.mjs
 
 # blender autosave backups
 *.blend1
+test-results/
+playwright-report/

--- a/apps/herbmail/herbmail-game/e2e/spawn.spec.ts
+++ b/apps/herbmail/herbmail-game/e2e/spawn.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+interface MeshInfo {
+	slot: string;
+	named: boolean;
+	visible: boolean;
+}
+
+const ARMOR_SLOTS = ['TORS', 'HIPS', 'LEGL', 'LEGR', 'ABAC', 'AHED', 'HNDL'];
+const SKIN_SLOTS = ['SKIN_TORS', 'SKIN_HIPS', 'SKIN_LEGL', 'SKIN_LEGR'];
+
+// Known-harmless noise from three + the headless pointer-lock rejection.
+const IGNORED = [
+	'THREE.Clock',
+	'deprecated parameters for the initialization function',
+	'not valid for pointer lock',
+	'toNonIndexed',
+];
+
+async function enterDungeon(page: Page): Promise<MeshInfo[]> {
+	await page.goto('/', { waitUntil: 'load' });
+	await page.getByText('Play', { exact: true }).click({ timeout: 60_000 });
+	await page.waitForFunction(
+		() =>
+			typeof (window as unknown as { __coll?: { meshes?: unknown } })
+				.__coll?.meshes === 'function',
+		undefined,
+		{ timeout: 90_000 },
+	);
+	return page.evaluate(() =>
+		(
+			window as unknown as { __coll: { meshes: () => MeshInfo[] } }
+		).__coll.meshes(),
+	);
+}
+
+test.describe('production rig', () => {
+	test('every character mesh keeps its slot name', async ({ page }) => {
+		const meshes = await enterDungeon(page);
+		expect(meshes.length).toBeGreaterThan(0);
+		expect(meshes.filter((m) => !m.slot)).toEqual([]);
+	});
+
+	test('no mesh falls back to a GLTFLoader-generated name', async ({
+		page,
+	}) => {
+		const meshes = await enterDungeon(page);
+		// three names unnamed meshes 'mesh_N'. Any of those left in the
+		// resolved slots means a real slot name went missing in the artifact.
+		expect(meshes.filter((m) => /^mesh_\d+$/.test(m.slot))).toEqual([]);
+	});
+
+	test('player spawns naked: armor hidden, skin shown', async ({ page }) => {
+		const meshes = await enterDungeon(page);
+		const bySlot = new Map(meshes.map((m) => [m.slot, m.visible]));
+
+		// Presence first — a missing slot yields undefined, and an
+		// `=== true` filter would then pass on the very build this guards.
+		const unresolved = [...ARMOR_SLOTS, ...SKIN_SLOTS].filter(
+			(s) => !bySlot.has(s),
+		);
+		expect(unresolved).toEqual([]);
+
+		expect(ARMOR_SLOTS.map((s) => bySlot.get(s))).toEqual(
+			ARMOR_SLOTS.map(() => false),
+		);
+		expect(SKIN_SLOTS.map((s) => bySlot.get(s))).toEqual(
+			SKIN_SLOTS.map(() => true),
+		);
+	});
+
+	test('no shader or runtime errors on spawn', async ({ page }) => {
+		const bad: string[] = [];
+		page.on('console', (m) => {
+			if (m.type() !== 'error') return;
+			if (IGNORED.some((i) => m.text().includes(i))) return;
+			bad.push(m.text());
+		});
+		page.on('pageerror', (e) => {
+			if (IGNORED.some((i) => e.message.includes(i))) return;
+			bad.push(e.message);
+		});
+		await enterDungeon(page);
+		expect(bad).toEqual([]);
+	});
+});

--- a/apps/herbmail/herbmail-game/playwright.config.ts
+++ b/apps/herbmail/herbmail-game/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.HERBMAIL_E2E_PORT ?? 4399);
+
+export default defineConfig({
+	testDir: './e2e',
+	timeout: 120_000,
+	expect: { timeout: 30_000 },
+	fullyParallel: false,
+	workers: 1,
+	retries: process.env.CI ? 1 : 0,
+	reporter: process.env.CI ? 'list' : 'line',
+	use: {
+		baseURL: `http://localhost:${PORT}`,
+		screenshot: 'only-on-failure',
+		launchOptions: {
+			args: [
+				'--use-gl=angle',
+				'--use-angle=metal',
+				'--enable-unsafe-swiftshader',
+			],
+		},
+	},
+	projects: [
+		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+	],
+	webServer: {
+		command: `pnpm exec vite preview --config apps/herbmail/herbmail-game/vite.config.ts --port ${PORT} --strictPort`,
+		cwd: '../../..',
+		port: PORT,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/apps/herbmail/herbmail-game/project.json
+++ b/apps/herbmail/herbmail-game/project.json
@@ -65,6 +65,13 @@
 		"lint": {
 			"executor": "@nx/eslint:lint"
 		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["build"],
+			"options": {
+				"command": "pnpm exec playwright test -c apps/herbmail/herbmail-game/playwright.config.ts"
+			}
+		},
 		"test": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/apps/herbmail/herbmail-game/src/game/character/Character.tsx
+++ b/apps/herbmail/herbmail-game/src/game/character/Character.tsx
@@ -24,6 +24,7 @@ import { CastPhase, abilityById, castDuration } from '../combat/ability';
 import { EquipmentPhysics } from './equipmentPhysics';
 import { WEAPON_GRIP } from './weaponGrip';
 import { useCharacterParts } from './useCharacterParts';
+import { slotNameOf } from './partVisibility';
 import type { PartSet } from './armor';
 import { getEquipped, useEquippedArmor } from './armor';
 import { useBodySkinMorph } from './body';
@@ -165,6 +166,7 @@ export interface CharacterHandle {
 	setBlocking: (b: boolean, pose?: BlockPose) => void;
 	isBlocking: () => boolean;
 	bone: (name: string) => THREE.Object3D | null;
+	meshes: () => { slot: string; named: boolean; visible: boolean }[];
 }
 
 interface Props {
@@ -548,6 +550,22 @@ export function Character({
 			},
 			isBlocking: () => blockRef.current.on,
 			bone: (name: string) => scene.getObjectByName(name) ?? null,
+			meshes: () => {
+				const out: {
+					slot: string;
+					named: boolean;
+					visible: boolean;
+				}[] = [];
+				scene.traverse((o) => {
+					if (!(o as THREE.Mesh).isMesh) return;
+					out.push({
+						slot: slotNameOf(o),
+						named: !!o.name,
+						visible: o.visible,
+					});
+				});
+				return out;
+			},
 		};
 		onReady?.(handle);
 		return () => animator.dispose();

--- a/apps/herbmail/herbmail-game/src/game/character/ThirdPersonPlayer.tsx
+++ b/apps/herbmail/herbmail-game/src/game/character/ThirdPersonPlayer.tsx
@@ -463,6 +463,7 @@ export function ThirdPersonPlayer({ url, scale = 1 }: Props) {
 					(window as unknown as Record<string, unknown>).__coll = {
 						solid: solidAtWorld,
 						pos: h.motor.position,
+						meshes: h.meshes,
 					};
 				}}
 			/>

--- a/apps/herbmail/herbmail-game/src/game/character/partVisibility.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/partVisibility.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { ARMOR_PIECES, BODY_BASE } from './armor';
+import { applyPartVisibility, slotNameOf } from './partVisibility';
+
+const ARMOR_SLOTS = [
+	...new Set(
+		ARMOR_PIECES.flatMap((p) => p.slots).filter((s) => !BODY_BASE.has(s)),
+	),
+];
+const SKIN_SLOTS = [...BODY_BASE].filter((n) => n.startsWith('SKIN_'));
+const SLOTS = [...ARMOR_SLOTS, ...SKIN_SLOTS];
+
+// The rig as three sees it in dev: the slot name sits on the mesh itself.
+function devScene(): THREE.Object3D {
+	const root = new THREE.Object3D();
+	for (const name of SLOTS) {
+		const mesh = new THREE.Mesh();
+		mesh.name = name;
+		root.add(mesh);
+	}
+	return root;
+}
+
+// The rig as gltfpack emits it: the slot name sits on a wrapper node and the
+// mesh underneath is unnamed, so GLTFLoader stamps it 'mesh_N'. This is what
+// shipped the armored player.
+function packedScene(): THREE.Object3D {
+	const root = new THREE.Object3D();
+	SLOTS.forEach((name, i) => {
+		const wrapper = new THREE.Object3D();
+		wrapper.name = name;
+		const mesh = new THREE.Mesh();
+		mesh.name = `mesh_${i}`;
+		wrapper.add(mesh);
+		root.add(wrapper);
+	});
+	return root;
+}
+
+function visibilityBySlot(root: THREE.Object3D): Map<string, boolean> {
+	const out = new Map<string, boolean>();
+	root.traverse((o) => {
+		if (!(o as THREE.Mesh).isMesh) return;
+		out.set(slotNameOf(o), o.visible);
+	});
+	return out;
+}
+
+describe('applyPartVisibility', () => {
+	it('has armor slots to assert against', () => {
+		expect(ARMOR_SLOTS.length).toBeGreaterThan(0);
+		expect(SKIN_SLOTS.length).toBeGreaterThan(0);
+	});
+
+	for (const [shape, build] of [
+		['dev', devScene],
+		['packed', packedScene],
+	] as const) {
+		// Assert on presence, not just truthiness: if a slot name fails to
+		// resolve, `vis.get(slot)` is undefined and a `.filter(s => vis.get(s))`
+		// check would pass vacuously on exactly the rig this guards against.
+		it(`${shape} rig: every slot resolves to a real name`, () => {
+			const root = build();
+			applyPartVisibility(root, new Set());
+			const vis = visibilityBySlot(root);
+			const unresolved = SLOTS.filter((s) => !vis.has(s));
+			expect(unresolved).toEqual([]);
+			expect([...vis.keys()].filter((k) => /^mesh_\d+$/.test(k))).toEqual(
+				[],
+			);
+		});
+
+		it(`${shape} rig: nothing equipped hides every armor slot`, () => {
+			const root = build();
+			applyPartVisibility(root, new Set());
+			const vis = visibilityBySlot(root);
+			expect(ARMOR_SLOTS.map((s) => vis.get(s))).toEqual(
+				ARMOR_SLOTS.map(() => false),
+			);
+		});
+
+		it(`${shape} rig: nothing equipped keeps the skin base visible`, () => {
+			const root = build();
+			applyPartVisibility(root, new Set());
+			const vis = visibilityBySlot(root);
+			expect(SKIN_SLOTS.map((s) => vis.get(s))).toEqual(
+				SKIN_SLOTS.map(() => true),
+			);
+		});
+
+		it(`${shape} rig: equipping a piece reveals its own slots`, () => {
+			const piece = ARMOR_PIECES.find((p) =>
+				p.slots.some((s) => !BODY_BASE.has(s)),
+			)!;
+			const root = build();
+			applyPartVisibility(root, new Set([piece.id]));
+			const vis = visibilityBySlot(root);
+			for (const s of piece.slots)
+				if (!BODY_BASE.has(s)) expect(vis.get(s)).toBe(true);
+		});
+
+		it(`${shape} rig: the hide override wins over slot rules`, () => {
+			const piece = ARMOR_PIECES.find((p) =>
+				p.slots.some((s) => !BODY_BASE.has(s)),
+			)!;
+			const slot = piece.slots.find((s) => !BODY_BASE.has(s))!;
+			const root = build();
+			applyPartVisibility(root, new Set([piece.id]), new Set([slot]));
+			expect(visibilityBySlot(root).get(slot)).toBe(false);
+		});
+	}
+
+	it('resolves both rig shapes identically', () => {
+		const dev = devScene();
+		const packed = packedScene();
+		applyPartVisibility(dev, new Set());
+		applyPartVisibility(packed, new Set());
+		expect([...visibilityBySlot(packed)]).toEqual([...visibilityBySlot(dev)]);
+	});
+});

--- a/apps/herbmail/herbmail-game/src/game/character/partVisibility.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/partVisibility.ts
@@ -1,0 +1,30 @@
+import * as THREE from 'three';
+import type { PartSet } from './armor';
+import { BODY_BASE, hiddenSlotsFor } from './armor';
+
+// three's GLTFLoader invents 'mesh_0', 'mesh_1', ... for meshes the glTF left
+// unnamed, so an absent slot name never reads as empty at runtime. Treat those
+// generated names as missing and fall back to the wrapper node gltfpack parked
+// the real slot name on.
+const GENERATED_NAME = /^mesh_\d+$/;
+
+export function slotNameOf(o: THREE.Object3D): string {
+	if (o.name && !GENERATED_NAME.test(o.name)) return o.name;
+	return o.parent?.name || o.name || '';
+}
+
+export function applyPartVisibility(
+	scene: THREE.Object3D,
+	equipped: Set<string>,
+	hide?: Set<string>,
+	bodySet?: Exclude<PartSet, 'KNGT'>,
+): void {
+	const hidden = hiddenSlotsFor(equipped);
+	if (bodySet) for (const n of BODY_BASE) hidden.add(n);
+	scene.traverse((o) => {
+		if (!(o as THREE.Mesh).isMesh) return;
+		const slot = slotNameOf(o);
+		if (slot === 'SKIN_WRAP' && !bodySet) return;
+		o.visible = !hidden.has(slot) && !hide?.has(slot);
+	});
+}

--- a/apps/herbmail/herbmail-game/src/game/character/useCharacterParts.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/useCharacterParts.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import * as THREE from 'three';
 import type { PartSet } from './armor';
-import { BODY_BASE, hiddenSlotsFor, setsFor, useEquippedArmor } from './armor';
+import { setsFor, useEquippedArmor } from './armor';
 import { attachPartSet } from './partsLoader';
+import { applyPartVisibility } from './partVisibility';
 
 export function useCharacterParts(
 	scene: THREE.Object3D,
@@ -26,12 +27,6 @@ export function useCharacterParts(
 		};
 	}, [scene, equipped, bodySet]);
 	useEffect(() => {
-		const hidden = hiddenSlotsFor(equipped);
-		if (bodySet) for (const n of BODY_BASE) hidden.add(n);
-		scene.traverse((o) => {
-			if (o.name === 'SKIN_WRAP' && !bodySet) return;
-			if ((o as THREE.Mesh).isMesh)
-				o.visible = !hidden.has(o.name) && !hide?.has(o.name);
-		});
+		applyPartVisibility(scene, equipped, hide, bodySet);
 	}, [scene, equipped, attached, hide, bodySet]);
 }

--- a/apps/herbmail/herbmail-game/tools/glbNames.test.ts
+++ b/apps/herbmail/herbmail-game/tools/glbNames.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+	meshNodeNames,
+	readGltfJson,
+	restoreMeshNames,
+	type GltfJson,
+} from './glbNames';
+
+function buildGlb(gltf: GltfJson, binData = Buffer.from('BINARYDATA')): Buffer {
+	let json = Buffer.from(JSON.stringify(gltf), 'utf8');
+	const jsonPad = (4 - (json.length % 4)) % 4;
+	if (jsonPad) json = Buffer.concat([json, Buffer.alloc(jsonPad, 0x20)]);
+	let bin = binData;
+	const binPad = (4 - (bin.length % 4)) % 4;
+	if (binPad) bin = Buffer.concat([bin, Buffer.alloc(binPad, 0)]);
+	const jsonChunk = Buffer.alloc(8);
+	jsonChunk.writeUInt32LE(json.length, 0);
+	jsonChunk.write('JSON', 4, 'latin1');
+	const binChunk = Buffer.alloc(8);
+	binChunk.writeUInt32LE(bin.length, 0);
+	binChunk.write('BIN\0', 4, 'latin1');
+	const header = Buffer.alloc(12);
+	header.write('glTF', 0, 'latin1');
+	header.writeUInt32LE(2, 4);
+	header.writeUInt32LE(
+		12 + jsonChunk.length + json.length + binChunk.length + bin.length,
+		8,
+	);
+	return Buffer.concat([header, jsonChunk, json, binChunk, bin]);
+}
+
+function chunksValid(glb: Buffer): boolean {
+	if (glb.readUInt32LE(8) !== glb.length) return false;
+	let off = 12;
+	while (off < glb.length) {
+		const len = glb.readUInt32LE(off);
+		if (len % 4 !== 0) return false;
+		off += 8 + len;
+	}
+	return off === glb.length;
+}
+
+// The shape gltfpack emits: the slot name stays on a wrapper node and the mesh
+// moves to a fresh unnamed child.
+const packed: GltfJson = {
+	nodes: [
+		{ name: 'SKIN_TORS', children: [1] },
+		{ mesh: 0 },
+		{ name: 'TORS', children: [3] },
+		{ mesh: 1 },
+		{ name: 'Armature', children: [0, 2] },
+	],
+};
+
+describe('restoreMeshNames', () => {
+	it('moves the slot name onto the node that carries the mesh', () => {
+		const { glb, moved } = restoreMeshNames(buildGlb(packed));
+		expect(moved).toBe(2);
+		expect(meshNodeNames(glb)).toEqual(new Set(['SKIN_TORS', 'TORS']));
+	});
+
+	it('clears the name off the wrapper so no duplicates remain', () => {
+		const { glb } = restoreMeshNames(buildGlb(packed));
+		const names = (readGltfJson(glb).nodes ?? [])
+			.map((n) => n.name)
+			.filter(Boolean);
+		expect(names).toEqual([...new Set(names)]);
+	});
+
+	it('keeps the GLB structurally valid after the JSON rewrite', () => {
+		const { glb } = restoreMeshNames(buildGlb(packed));
+		expect(chunksValid(glb)).toBe(true);
+		expect(glb.subarray(0, 4).toString('latin1')).toBe('glTF');
+	});
+
+	it('preserves the BIN chunk byte for byte', () => {
+		const bin = Buffer.from('MESHOPT-PAYLOAD!');
+		const { glb } = restoreMeshNames(buildGlb(packed, bin));
+		expect(glb.subarray(glb.length - bin.length)).toEqual(bin);
+	});
+
+	it('is a no-op on an already-named rig (the dev shape)', () => {
+		const dev = buildGlb({
+			nodes: [
+				{ name: 'SKIN_TORS', mesh: 0 },
+				{ name: 'Armature', children: [0] },
+			],
+		});
+		const { glb, moved } = restoreMeshNames(dev);
+		expect(moved).toBe(0);
+		expect(glb).toEqual(dev);
+	});
+
+	it('is idempotent', () => {
+		const once = restoreMeshNames(buildGlb(packed));
+		const twice = restoreMeshNames(once.glb);
+		expect(twice.moved).toBe(0);
+		expect(meshNodeNames(twice.glb)).toEqual(meshNodeNames(once.glb));
+	});
+
+	it('leaves a wrapper alone when it has siblings to disambiguate', () => {
+		const shared: GltfJson = {
+			nodes: [
+				{ name: 'GROUP', children: [1, 2] },
+				{ mesh: 0 },
+				{ mesh: 1 },
+			],
+		};
+		const { glb, moved } = restoreMeshNames(buildGlb(shared));
+		expect(moved).toBe(0);
+		expect(readGltfJson(glb).nodes?.[0].name).toBe('GROUP');
+	});
+
+	it('leaves a wrapper alone when it carries a mesh of its own', () => {
+		const both: GltfJson = {
+			nodes: [
+				{ name: 'HOLDER', mesh: 0, children: [1] },
+				{ mesh: 1 },
+			],
+		};
+		const { moved } = restoreMeshNames(buildGlb(both));
+		expect(moved).toBe(0);
+	});
+
+	it('ignores a mesh node with no parent', () => {
+		const orphan: GltfJson = { nodes: [{ mesh: 0 }] };
+		const { moved } = restoreMeshNames(buildGlb(orphan));
+		expect(moved).toBe(0);
+	});
+});
+
+describe('meshNodeNames', () => {
+	it('reports only nodes that actually carry a mesh', () => {
+		expect(meshNodeNames(buildGlb(packed))).toEqual(new Set());
+	});
+
+	it('surfaces the names a packed build would have dropped', () => {
+		const source = buildGlb({
+			nodes: [
+				{ name: 'SKIN_TORS', mesh: 0 },
+				{ name: 'TORS', mesh: 1 },
+			],
+		});
+		const before = meshNodeNames(source);
+		const after = meshNodeNames(buildGlb(packed));
+		const missing = [...before].filter((n) => !after.has(n));
+		expect(missing).toEqual(['SKIN_TORS', 'TORS']);
+	});
+});

--- a/apps/herbmail/herbmail-game/tools/glbNames.ts
+++ b/apps/herbmail/herbmail-game/tools/glbNames.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+
+export interface GltfNode {
+	name?: string;
+	mesh?: number;
+	children?: number[];
+}
+
+export interface GltfJson {
+	nodes?: GltfNode[];
+}
+
+const HEADER = 12;
+const CHUNK_HEADER = 8;
+const JSON_START = HEADER + CHUNK_HEADER;
+
+export function readGltfJson(glb: Buffer): GltfJson {
+	const jsonLen = glb.readUInt32LE(HEADER);
+	return JSON.parse(
+		glb.subarray(JSON_START, JSON_START + jsonLen).toString('utf8'),
+	);
+}
+
+export function meshNodeNames(glb: Buffer): Set<string> {
+	const out = new Set<string>();
+	for (const n of readGltfJson(glb).nodes ?? [])
+		if (n.mesh !== undefined && n.name) out.add(n.name);
+	return out;
+}
+
+export function restoreMeshNames(glb: Buffer): {
+	glb: Buffer;
+	moved: number;
+} {
+	const jsonLen = glb.readUInt32LE(HEADER);
+	const jsonEnd = JSON_START + jsonLen;
+	const gltf = readGltfJson(glb);
+	const nodes = gltf.nodes ?? [];
+	const parentOf = new Map<number, number>();
+	nodes.forEach((n, i) => {
+		for (const c of n.children ?? []) parentOf.set(c, i);
+	});
+
+	let moved = 0;
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		if (node.mesh === undefined || node.name) continue;
+		const p = parentOf.get(i);
+		if (p === undefined) continue;
+		const parent = nodes[p];
+		if (!parent.name || parent.mesh !== undefined) continue;
+		if ((parent.children ?? []).length !== 1) continue;
+		node.name = parent.name;
+		delete parent.name;
+		moved++;
+	}
+	if (moved === 0) return { glb, moved: 0 };
+
+	let json = Buffer.from(JSON.stringify(gltf), 'utf8');
+	const pad = (4 - (json.length % 4)) % 4;
+	if (pad) json = Buffer.concat([json, Buffer.alloc(pad, 0x20)]);
+	const rest = glb.subarray(jsonEnd);
+	const header = Buffer.alloc(JSON_START);
+	glb.copy(header, 0, 0, JSON_START);
+	header.writeUInt32LE(HEADER + CHUNK_HEADER + json.length + rest.length, 8);
+	header.writeUInt32LE(json.length, HEADER);
+	return { glb: Buffer.concat([header, json, rest]), moved };
+}
+
+export function restoreMeshNamesInFile(file: string): number {
+	const { glb, moved } = restoreMeshNames(fs.readFileSync(file));
+	if (moved > 0) fs.writeFileSync(file, glb);
+	return moved;
+}
+
+export function meshNodeNamesInFile(file: string): Set<string> {
+	return meshNodeNames(fs.readFileSync(file));
+}

--- a/apps/herbmail/herbmail-game/vite.config.ts
+++ b/apps/herbmail/herbmail-game/vite.config.ts
@@ -7,6 +7,10 @@ import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import {
+	meshNodeNamesInFile,
+	restoreMeshNamesInFile,
+} from './tools/glbNames';
 
 const laserSrc = path.resolve(__dirname, '../../../packages/npm/laser/src');
 const generated = path.resolve(
@@ -128,61 +132,6 @@ function modelHashes(): Plugin {
 // and the part-set dedupe all key on that name, so a packed player spawned
 // wearing every mesh in the GLB. Push each name back down onto the node that
 // actually carries the mesh, restoring dev semantics.
-function readGltfJson(file: string): {
-	nodes?: { name?: string; mesh?: number; children?: number[] }[];
-} {
-	const buf = fs.readFileSync(file);
-	const jsonLen = buf.readUInt32LE(12);
-	return JSON.parse(buf.subarray(20, 20 + jsonLen).toString('utf8'));
-}
-
-function meshNodeNames(file: string): Set<string> {
-	const out = new Set<string>();
-	for (const n of readGltfJson(file).nodes ?? [])
-		if (n.mesh !== undefined && n.name) out.add(n.name);
-	return out;
-}
-
-function restoreMeshNames(file: string): number {
-	const buf = fs.readFileSync(file);
-	const jsonLen = buf.readUInt32LE(12);
-	const jsonStart = 20;
-	const jsonEnd = jsonStart + jsonLen;
-	const gltf = JSON.parse(buf.subarray(jsonStart, jsonEnd).toString('utf8'));
-	const nodes: { name?: string; mesh?: number; children?: number[] }[] =
-		gltf.nodes ?? [];
-	const parentOf = new Map<number, number>();
-	nodes.forEach((n, i) => {
-		for (const c of n.children ?? []) parentOf.set(c, i);
-	});
-
-	let moved = 0;
-	for (let i = 0; i < nodes.length; i++) {
-		const node = nodes[i];
-		if (node.mesh === undefined || node.name) continue;
-		const p = parentOf.get(i);
-		if (p === undefined) continue;
-		const parent = nodes[p];
-		if (!parent.name || parent.mesh !== undefined) continue;
-		if ((parent.children ?? []).length !== 1) continue;
-		node.name = parent.name;
-		delete parent.name;
-		moved++;
-	}
-	if (moved === 0) return 0;
-
-	let json = Buffer.from(JSON.stringify(gltf), 'utf8');
-	const pad = (4 - (json.length % 4)) % 4;
-	if (pad) json = Buffer.concat([json, Buffer.alloc(pad, 0x20)]);
-	const rest = buf.subarray(jsonEnd);
-	const header = Buffer.alloc(20);
-	buf.copy(header, 0, 0, 20);
-	header.writeUInt32LE(12 + 8 + json.length + rest.length, 8);
-	header.writeUInt32LE(json.length, 12);
-	fs.writeFileSync(file, Buffer.concat([header, json, rest]));
-	return moved;
-}
-
 // Post-build gltfpack pass (meshopt EXT_meshopt_compression) over the copied
 // public/ models. Sources in public/models stay uncompressed LFS truth; only
 // dist output is packed. -kn keeps node/mesh names (armor slots + bone lookups
@@ -219,7 +168,7 @@ function gltfpackModels(): Plugin {
 					continue;
 				}
 				const before = fs.statSync(f).size;
-				const wanted = meshNodeNames(f);
+				const wanted = meshNodeNamesInFile(f);
 				const tmp = `${f}.pack.glb`;
 				const run = spawnSync(
 					process.execPath,
@@ -229,10 +178,9 @@ function gltfpackModels(): Plugin {
 				if (run.status !== 0 || !fs.existsSync(tmp))
 					throw new Error(`gltfpack failed on ${f}`);
 				fs.renameSync(tmp, f);
-				const moved = restoreMeshNames(f);
-				const missing = [...wanted].filter(
-					(n) => !meshNodeNames(f).has(n),
-				);
+				const moved = restoreMeshNamesInFile(f);
+				const got = meshNodeNamesInFile(f);
+				const missing = [...wanted].filter((n) => !got.has(n));
 				if (missing.length)
 					throw new Error(
 						`gltfpack dropped mesh names in ${path.relative(outDir, f)}: ${missing.join(', ')}`,
@@ -286,7 +234,10 @@ export default defineConfig({
 		globals: true,
 		watch: false,
 		environment: 'node',
-		include: ['src/**/*.{test,spec}.{ts,tsx}'],
+		include: [
+			'src/**/*.{test,spec}.{ts,tsx}',
+			'tools/**/*.{test,spec}.ts',
+		],
 		reporters: ['default'],
 		// vitest's node resolver doesn't pick up the @kbve/laser/* tsconfig-path
 		// aliases (nxViteTsPaths only wires them for build/dev), so map the subpaths to

--- a/apps/herbmail/herbmail-game/vite.config.ts
+++ b/apps/herbmail/herbmail-game/vite.config.ts
@@ -122,6 +122,67 @@ function modelHashes(): Plugin {
 	};
 }
 
+// gltfpack re-parents every skinned mesh onto a fresh unnamed child node and
+// leaves the slot name on the parent, so SkinnedMesh.name is '' in a packed
+// build while it is 'SKIN_TORS' in dev. Armor visibility, the SKIN_WRAP morph
+// and the part-set dedupe all key on that name, so a packed player spawned
+// wearing every mesh in the GLB. Push each name back down onto the node that
+// actually carries the mesh, restoring dev semantics.
+function readGltfJson(file: string): {
+	nodes?: { name?: string; mesh?: number; children?: number[] }[];
+} {
+	const buf = fs.readFileSync(file);
+	const jsonLen = buf.readUInt32LE(12);
+	return JSON.parse(buf.subarray(20, 20 + jsonLen).toString('utf8'));
+}
+
+function meshNodeNames(file: string): Set<string> {
+	const out = new Set<string>();
+	for (const n of readGltfJson(file).nodes ?? [])
+		if (n.mesh !== undefined && n.name) out.add(n.name);
+	return out;
+}
+
+function restoreMeshNames(file: string): number {
+	const buf = fs.readFileSync(file);
+	const jsonLen = buf.readUInt32LE(12);
+	const jsonStart = 20;
+	const jsonEnd = jsonStart + jsonLen;
+	const gltf = JSON.parse(buf.subarray(jsonStart, jsonEnd).toString('utf8'));
+	const nodes: { name?: string; mesh?: number; children?: number[] }[] =
+		gltf.nodes ?? [];
+	const parentOf = new Map<number, number>();
+	nodes.forEach((n, i) => {
+		for (const c of n.children ?? []) parentOf.set(c, i);
+	});
+
+	let moved = 0;
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		if (node.mesh === undefined || node.name) continue;
+		const p = parentOf.get(i);
+		if (p === undefined) continue;
+		const parent = nodes[p];
+		if (!parent.name || parent.mesh !== undefined) continue;
+		if ((parent.children ?? []).length !== 1) continue;
+		node.name = parent.name;
+		delete parent.name;
+		moved++;
+	}
+	if (moved === 0) return 0;
+
+	let json = Buffer.from(JSON.stringify(gltf), 'utf8');
+	const pad = (4 - (json.length % 4)) % 4;
+	if (pad) json = Buffer.concat([json, Buffer.alloc(pad, 0x20)]);
+	const rest = buf.subarray(jsonEnd);
+	const header = Buffer.alloc(20);
+	buf.copy(header, 0, 0, 20);
+	header.writeUInt32LE(12 + 8 + json.length + rest.length, 8);
+	header.writeUInt32LE(json.length, 12);
+	fs.writeFileSync(file, Buffer.concat([header, json, rest]));
+	return moved;
+}
+
 // Post-build gltfpack pass (meshopt EXT_meshopt_compression) over the copied
 // public/ models. Sources in public/models stay uncompressed LFS truth; only
 // dist output is packed. -kn keeps node/mesh names (armor slots + bone lookups
@@ -158,6 +219,7 @@ function gltfpackModels(): Plugin {
 					continue;
 				}
 				const before = fs.statSync(f).size;
+				const wanted = meshNodeNames(f);
 				const tmp = `${f}.pack.glb`;
 				const run = spawnSync(
 					process.execPath,
@@ -167,9 +229,17 @@ function gltfpackModels(): Plugin {
 				if (run.status !== 0 || !fs.existsSync(tmp))
 					throw new Error(`gltfpack failed on ${f}`);
 				fs.renameSync(tmp, f);
+				const moved = restoreMeshNames(f);
+				const missing = [...wanted].filter(
+					(n) => !meshNodeNames(f).has(n),
+				);
+				if (missing.length)
+					throw new Error(
+						`gltfpack dropped mesh names in ${path.relative(outDir, f)}: ${missing.join(', ')}`,
+					);
 				const after = fs.statSync(f).size;
 				console.log(
-					`gltfpack: ${path.relative(outDir, f)} ${(before / 1024).toFixed(0)}K -> ${(after / 1024).toFixed(0)}K`,
+					`gltfpack: ${path.relative(outDir, f)} ${(before / 1024).toFixed(0)}K -> ${(after / 1024).toFixed(0)}K (${moved} mesh names restored)`,
 				);
 			}
 		},


### PR DESCRIPTION
## Problem

The published build spawns the player in full armor instead of the naked skin base. Reproduces on every browser, so it is not caching — the previous two PRs (#15090 frustum culling, #15111 asset cache-busting) were both real fixes but neither was this bug.

## Cause

The post-build gltfpack pass re-parents every skinned mesh onto a **fresh unnamed child node**, leaving the slot name on the parent:

```
source: node "SKIN_TORS" { mesh: 44 }
packed: node "SKIN_TORS" { children: [#0] }  ->  node <unnamed> { mesh: 44 }
```

So `SkinnedMesh.name` is `'SKIN_TORS'` in dev and `''` in a packed build — dev and production diverge, which is exactly the reported symptom. Verified directly on the artifact: all 49 mesh nodes in `dist/models/character-anim.glb` were `<unnamed>`, while `public/models/character-anim.glb` had all 49 named. Same for every part set.

Everything keyed on that name broke in production only:

- `hiddenSlotsFor()` matched nothing, so all 49 meshes stayed visible — the reported bug
- `useBodySkinMorph` never found `SKIN_WRAP`
- `attachPartSet`'s `root.getObjectByName(m.name)` dedupe called with `''` matches the first unnamed object, so part sets silently stopped attaching

`skin.ts:70` already carried a `mesh.parent.name` fallback — this behavior had been hit before and worked around for tinting only.

## Fix

Push each name back down onto the node that actually carries the mesh, right after gltfpack runs. One choke point in the build restores dev semantics for every consumer, rather than patching each name lookup and risking the next missed one.

Guarded: mesh-node names are diffed before and after packing, so a future gltfpack version that changes this fails the build instead of silently shipping an unnamed rig.

## Verification

Production `vite preview` build driven headlessly, same server, only `vite.config.ts` differing:

| build | dist mesh names | result |
| --- | --- | --- |
| without pass | 49x `<unnamed>` | full armored knight (the bug) |
| with pass | `SKIN_TORS, TORS, HIPS, ...` | naked skin base |

All 10 packed GLBs re-validated for chunk/length integrity after the JSON rewrite. `nx build` reports names restored per file (49 character, 26 scifi-civ09, 5 kurenai, ...). No new console errors beyond the known Clock/pointer-lock noise.