### PR TITLE
fix(astro-kbve): palworld live poller leader failover

### DIFF
--- a/apps/kbve/astro-kbve/src/components/palworld/map/livePoller.ts
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/livePoller.ts
@@ -4,6 +4,7 @@ import type { DroidEventMap } from '@kbve/droid';
 export type LiveSnapshot = DroidEventMap['palworld-live-snapshot'];
 
 const POLL_MS = 5000;
+const STALE_MS = POLL_MS * 3;
 const CHANNEL = 'kbve-palworld-live';
 const LOCK = 'kbve-palworld-live-poller';
 
@@ -17,10 +18,22 @@ export function startLivePoller(url: string): void {
 		typeof BroadcastChannel !== 'undefined'
 			? new BroadcastChannel(CHANNEL)
 			: null;
-	const emit = (snap: LiveSnapshot) =>
+	let lastSnapAt = 0;
+	let interval: ReturnType<typeof setInterval> | null = null;
+	let release: (() => void) | null = null;
+	const emit = (snap: LiveSnapshot) => {
+		lastSnapAt = Date.now();
 		DroidEvents.emit('palworld-live-snapshot', snap);
-	channel?.addEventListener('message', (ev: MessageEvent<LiveSnapshot>) =>
-		emit(ev.data),
+	};
+	channel?.addEventListener(
+		'message',
+		(ev: MessageEvent<LiveSnapshot | null>) => {
+			if (ev.data) {
+				emit(ev.data);
+				return;
+			}
+			if (!interval && document.visibilityState === 'visible') contend();
+		},
 	);
 
 	const poll = async () => {
@@ -49,17 +62,50 @@ export function startLivePoller(url: string): void {
 		channel?.postMessage(snap);
 	};
 
-	const lead = () => {
-		poll();
-		setInterval(poll, POLL_MS);
-	};
-
-	if (typeof navigator !== 'undefined' && navigator.locks?.request) {
-		navigator.locks.request(LOCK, () => {
-			lead();
-			return new Promise<void>(() => {});
+	const lead = () =>
+		new Promise<void>((resolve) => {
+			poll();
+			interval = setInterval(poll, POLL_MS);
+			release = () => {
+				if (interval) clearInterval(interval);
+				interval = null;
+				release = null;
+				channel?.postMessage(null);
+				resolve();
+			};
 		});
+
+	const hasLocks =
+		typeof navigator !== 'undefined' && !!navigator.locks?.request;
+
+	function contend() {
+		if (!hasLocks || interval) return;
+		navigator.locks.request(LOCK, { ifAvailable: true }, (lock) =>
+			lock ? lead() : undefined,
+		);
+	}
+
+	if (hasLocks) {
+		contend();
+		document.addEventListener('visibilitychange', () => {
+			if (document.visibilityState === 'hidden') release?.();
+			else contend();
+		});
+		window.addEventListener('pagehide', () => release?.());
+		window.addEventListener('pageshow', () => {
+			if (document.visibilityState === 'visible') contend();
+		});
+		setInterval(() => {
+			if (
+				!interval &&
+				document.visibilityState === 'visible' &&
+				Date.now() - lastSnapAt > STALE_MS
+			) {
+				contend();
+				poll();
+			}
+		}, POLL_MS);
 	} else {
-		lead();
+		void lead();
 	}
 }


### PR DESCRIPTION
## Problem

The palworld map's shared live poller (#15118) elects a leader tab via Web Locks. If the leader tab is backgrounded, Chrome throttles/freezes it — it stops polling but never releases the lock, so visible follower tabs receive no snapshots and the map sits at "Players (0)" forever. Reproduced live: endpoint returned 1 player while an open map tab showed Players (0); a fresh browser window fixed it.

## Fix

- Leader releases the lock on `visibilitychange: hidden` and `pagehide`, and posts a null sentinel on the broadcast channel so a visible follower contends immediately.
- Lock contention uses `ifAvailable` (no forever-pending queue); tabs re-contend on becoming visible, on `pageshow` (bfcache), and on the handoff signal.
- Follower watchdog: if visible and no snapshot for 15s, re-contend and poll directly — self-heals even if a wedged tab somehow keeps the lock.

## Verification

Playwright, two tabs on local dev: tab A leads, tab B renders via broadcast ("Players (1)"); forcing tab A hidden released the lock, tab B took leadership within 2.5s and polled every 5s; hidden tab A made 0 further requests over 11s.