### PR TITLE
fix(dashboard): make ClickHouse namespace clicks drill down instead of dead-ending

### DIFF
--- a/packages/npm/rn/src/dash/clickhouse/ClickHouseView.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/ClickHouseView.tsx
@@ -5,6 +5,7 @@ import { clickhouseLens } from '../adapters/clickhouse';
 import { createClickHouseStream } from './clickhouseStream';
 import { createErrorGroupsStream } from './errorGroupsStream';
 import { makeNamespaceGrid } from './NamespaceGrid';
+import { NamespaceFocus } from './NamespaceFocus';
 import { ErrorDigest } from './ErrorDigest';
 import { SectionDivider } from '../shared';
 
@@ -53,17 +54,29 @@ export function ClickHouseView({
 		return {
 			...clickhouseLens,
 			metaPanel: (meta: unknown) => {
-				const panel = grid(meta);
-				if (!panel) return null;
+				const selectedNs = primary.get().params['pod_namespace'];
+				const panel = grid(
+					meta,
+					typeof selectedNs === 'string' ? selectedNs : '',
+				);
 				return (
 					<Stack gap="xs">
-						<SectionDivider label="Namespaces" />
-						{panel}
+						<NamespaceFocus
+							store={primary}
+							errors={errors}
+							meta={meta}
+						/>
+						{panel ? (
+							<>
+								<SectionDivider label="Namespaces" />
+								{panel}
+							</>
+						) : null}
 					</Stack>
 				);
 			},
 		};
-	}, [primary]);
+	}, [primary, errors]);
 
 	return (
 		<Stack gap="md">

--- a/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
@@ -15,6 +15,9 @@ export function ErrorDigest({
 }) {
 	useStreamLifecycle(store);
 	const state = useStream(store);
+	const primaryState = useStream(primary);
+	const focusedNs = primaryState.params['pod_namespace'];
+	if (typeof focusedNs === 'string' && focusedNs !== '') return null;
 	if (!state.items.length) return null;
 	return (
 		<Stack gap="xs">

--- a/packages/npm/rn/src/dash/clickhouse/NamespaceFocus.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/NamespaceFocus.tsx
@@ -1,0 +1,147 @@
+import { Pressable, StyleSheet } from 'react-native';
+import { Surface, Stack, Text, Badge, tokens } from '../_ui';
+import { useStream } from '../useStream';
+import type { StreamStore } from '../types';
+import type { LogItem } from '../adapters/clickhouse';
+import { buildNamespaceRollup } from './chRollup';
+import { errorGroupsLens, type ErrorGroupItem } from './errorGroupsStream';
+import { SectionDivider } from '../shared';
+
+const LEVELS = [
+	{ label: 'All', value: undefined },
+	{ label: 'Errors', value: 'error' },
+	{ label: 'Warnings', value: 'warn' },
+	{ label: 'Info', value: 'info' },
+] as const;
+
+export function NamespaceFocus({
+	store,
+	errors,
+	meta,
+}: {
+	store: StreamStore<LogItem>;
+	errors: StreamStore<ErrorGroupItem>;
+	meta: unknown;
+}) {
+	const state = useStream(store);
+	const errorState = useStream(errors);
+	const ns = state.params['pod_namespace'];
+	if (typeof ns !== 'string' || ns === '') return null;
+
+	const roll = buildNamespaceRollup(meta).find((r) => r.namespace === ns);
+	const activeLevel = state.params['level'];
+	const groups = errorState.items.filter((g) => g.namespace === ns);
+
+	return (
+		<Stack gap="sm">
+			<SectionDivider label="Namespace Focus" />
+			<Surface style={styles.panel}>
+				<Stack gap="sm">
+					<Stack direction="row" align="center" gap="sm" wrap>
+						<Text variant="subtitle" style={styles.title}>
+							{ns}
+						</Text>
+						<Pressable
+							onPress={() =>
+								store.setParams({
+									pod_namespace: undefined,
+									level: undefined,
+								})
+							}
+							style={styles.clear}>
+							<Text variant="caption" tone="muted">
+								✕ Clear
+							</Text>
+						</Pressable>
+					</Stack>
+
+					<Stack direction="row" gap="sm" wrap>
+						<Badge
+							label={`${roll?.errors ?? 0} errors`}
+							tone="danger"
+						/>
+						<Badge
+							label={`${roll?.warns ?? 0} warnings`}
+							tone="warning"
+						/>
+						<Text variant="caption" tone="muted">
+							{roll?.total ?? 0} total in window
+						</Text>
+					</Stack>
+
+					<Stack direction="row" gap="xs" wrap>
+						{LEVELS.map((l) => {
+							const on = activeLevel === l.value;
+							return (
+								<Pressable
+									key={l.label}
+									onPress={() =>
+										store.setParams({ level: l.value })
+									}
+									style={[
+										styles.seg,
+										on ? styles.segOn : null,
+									]}>
+									<Text
+										variant="caption"
+										weight={on ? 'medium' : undefined}
+										style={{
+											color: on
+												? tokens.color.onPrimary
+												: tokens.color.textMuted,
+										}}>
+										{l.label}
+									</Text>
+								</Pressable>
+							);
+						})}
+					</Stack>
+
+					{groups.length ? (
+						<Stack gap="xs">
+							<Text variant="caption" weight="medium" tone="muted">
+								Top errors in {ns}
+							</Text>
+							{groups.slice(0, 5).map((g) => (
+								<Pressable
+									key={errors.id(g)}
+									onPress={() =>
+										store.setParams({ level: 'error' })
+									}>
+									{errorGroupsLens.row(g, false)}
+								</Pressable>
+							))}
+						</Stack>
+					) : null}
+				</Stack>
+			</Surface>
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	panel: {
+		padding: tokens.space.md,
+		borderWidth: 1,
+		borderColor: tokens.color.primary,
+	},
+	title: { flexGrow: 1 },
+	clear: {
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 4,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	seg: {
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: 4,
+		borderRadius: tokens.radius.pill,
+		borderWidth: 1,
+		borderColor: tokens.color.border,
+	},
+	segOn: {
+		backgroundColor: tokens.color.primary,
+		borderColor: tokens.color.primary,
+	},
+});

--- a/packages/npm/rn/src/dash/clickhouse/NamespaceGrid.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/NamespaceGrid.tsx
@@ -2,35 +2,57 @@ import { Pressable, StyleSheet } from 'react-native';
 import { Surface, Stack, Text, Badge, tokens } from '../_ui';
 import type { StreamStore } from '../types';
 import type { LogItem } from '../adapters/clickhouse';
-import { buildNamespaceRollup } from './chRollup';
+import { buildNamespaceRollup, CLUSTER_NS_LABEL } from './chRollup';
 
 export function makeNamespaceGrid(store: StreamStore<LogItem>) {
-	return function NamespaceGrid(meta: unknown) {
+	return function NamespaceGrid(meta: unknown, selectedNs: string) {
 		const rows = buildNamespaceRollup(meta);
 		if (!rows.length) return null;
 		return (
 			<Stack gap="xs">
-				{rows.map((r) => (
-					<Pressable
-						key={r.namespace}
-						onPress={() =>
-							store.setParams({
-								pod_namespace: r.namespace === '(cluster)' ? undefined : r.namespace,
-							})
-						}
-					>
-						<Surface style={styles.row}>
-							<Text variant="caption" style={{ flexGrow: 1 }}>
+				{rows.map((r) => {
+					const selectable = r.namespace !== CLUSTER_NS_LABEL;
+					const on = selectable && r.namespace === selectedNs;
+					const body = (
+						<Surface
+							style={[
+								styles.row,
+								on ? styles.rowOn : null,
+								selectable ? null : styles.rowInert,
+							]}>
+							<Text
+								variant="caption"
+								weight={on ? 'medium' : undefined}
+								style={styles.name}>
 								{r.namespace}
 							</Text>
-							{r.errors ? <Badge label={`${r.errors} err`} tone="danger" /> : null}
-							{r.warns ? <Badge label={`${r.warns} warn`} tone="warning" /> : null}
+							{r.errors ? (
+								<Badge label={`${r.errors} err`} tone="danger" />
+							) : null}
+							{r.warns ? (
+								<Badge
+									label={`${r.warns} warn`}
+									tone="warning"
+								/>
+							) : null}
 							<Text variant="caption" tone="muted">
 								{r.total}
 							</Text>
 						</Surface>
-					</Pressable>
-				))}
+					);
+					if (!selectable) return <Stack key={r.namespace}>{body}</Stack>;
+					return (
+						<Pressable
+							key={r.namespace}
+							onPress={() =>
+								store.setParams({
+									pod_namespace: on ? undefined : r.namespace,
+								})
+							}>
+							{body}
+						</Pressable>
+					);
+				})}
 			</Stack>
 		);
 	};
@@ -43,4 +65,10 @@ const styles = StyleSheet.create({
 		gap: tokens.space.sm,
 		padding: tokens.space.sm,
 	},
+	rowOn: {
+		borderWidth: 1,
+		borderColor: tokens.color.primary,
+	},
+	rowInert: { opacity: 0.55 },
+	name: { flexGrow: 1 },
 });

--- a/packages/npm/rn/src/dash/clickhouse/__tests__/chRollup.test.ts
+++ b/packages/npm/rn/src/dash/clickhouse/__tests__/chRollup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNamespaceRollup } from '../chRollup';
+import { buildNamespaceRollup, CLUSTER_NS_LABEL } from '../chRollup';
 
 describe('buildNamespaceRollup', () => {
 	it('aggregates per namespace and sorts by total desc', () => {
@@ -13,5 +13,20 @@ describe('buildNamespaceRollup', () => {
 		const out = buildNamespaceRollup(meta);
 		expect(out[0].namespace).toBe('b');
 		expect(out.find((r) => r.namespace === 'a')).toMatchObject({ total: 110, errors: 10 });
+	});
+
+	it('buckets empty-string namespaces under the cluster label', () => {
+		const out = buildNamespaceRollup({
+			rows: [
+				{ pod_namespace: '', level: 'info', cnt: 3 },
+				{ level: 'error', cnt: 2 },
+			],
+		});
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			namespace: CLUSTER_NS_LABEL,
+			total: 5,
+			errors: 2,
+		});
 	});
 });

--- a/packages/npm/rn/src/dash/clickhouse/chRollup.ts
+++ b/packages/npm/rn/src/dash/clickhouse/chRollup.ts
@@ -5,13 +5,15 @@ export interface NsRollup {
 	warns: number;
 }
 
+export const CLUSTER_NS_LABEL = '(cluster)';
+
 export function buildNamespaceRollup(meta: unknown): NsRollup[] {
 	const rows =
 		(meta as { rows?: { pod_namespace?: string; level?: string; cnt?: number }[] })
 			?.rows ?? [];
 	const map = new Map<string, NsRollup>();
 	for (const r of rows) {
-		const ns = r.pod_namespace ?? '(cluster)';
+		const ns = r.pod_namespace || CLUSTER_NS_LABEL;
 		const cur = map.get(ns) ?? { namespace: ns, total: 0, errors: 0, warns: 0 };
 		const cnt = Number(r.cnt ?? 0);
 		cur.total += cnt;


### PR DESCRIPTION
Follow-up to #15088. Clicking a namespace on `/dashboard/clickhouse/` appeared to do nothing.

## The dead click was real

`buildNamespaceRollup` bucketed missing namespaces with `?? '(cluster)'`. But `observability.logs_raw` declares:

```sql
pod_namespace   LowCardinality(String) DEFAULT ''
```

ClickHouse returns an empty string there, never null, so `??` never fired. That produced a blank-labelled grid row, and clicking it called `setParams({ pod_namespace: '' })`. `buildBody` in `clickhouseStream.ts` skips empty values, so the request went out completely unfiltered — same rows back, nothing moved.

Bucket on falsy instead. The cluster row now renders inert (dimmed, not pressable), because `build_query_sql` has no way to express "namespace is empty" — it drops empty strings by design. Making it look clickable when the backend cannot honour it was the actual bug.

## The other namespaces were filtering silently

Selecting a real namespace did filter the feed. But the feed sits well below the grid, the stats tiles are namespace-agnostic (`build_stats_sql` only takes `minutes`), and nothing near the click acknowledged it. Indistinguishable from a no-op.

New `NamespaceFocus` panel renders directly above the grid whenever a namespace is selected:

- namespace name with a clear button (resets `pod_namespace` and `level`)
- error / warning / total counts for that namespace in the current window
- All / Errors / Warnings / Info quick-filters wired to the `level` param
- its top error signatures, pulled from the error-groups stream that `ClickHouseView` already keeps synced to the selected namespace

Plus: the selected grid row is outlined, and clicking it again deselects. `ErrorDigest` hides while a namespace is focused, since it would otherwise list the same groups the focus panel already shows.

## Verification

- `nx test rn --skip-nx-cache` — 45 files, 199 tests passing (added a `chRollup` case covering `pod_namespace: ''` and a missing key, both landing in the cluster bucket — the old `??` version fails it)
- `tsc --noEmit -p packages/npm/rn/tsconfig.lib.json` — clean on all changed files