### PR TITLE
test(droid): assert event key set instead of a hardcoded count

### DIFF
--- a/packages/npm/droid/src/lib/types/event-types.spec.ts
+++ b/packages/npm/droid/src/lib/types/event-types.spec.ts
@@ -7,29 +7,43 @@ import {
 	DroidUpscaleSchema,
 } from './event-types';
 
+const EXPECTED_EVENT_KEYS = [
+	'auth-error',
+	'auth-ready',
+	'droid-downscale',
+	'droid-first-connect',
+	'droid-mod-ready',
+	'droid-ready',
+	'droid-upscale',
+	'gateway-strategy-fallback',
+	'modal-closed',
+	'modal-opened',
+	'page-hide',
+	'page-mount',
+	'page-swap',
+	'palworld-live-snapshot',
+	'panel-close',
+	'panel-open',
+	'reel-stream',
+	'toast-added',
+	'toast-removed',
+	'tooltip-closed',
+	'tooltip-opened',
+	'worker-error',
+];
+
 describe('DroidEventSchemas', () => {
-	it('has all expected event keys', () => {
-		const keys = Object.keys(DroidEventSchemas);
-		expect(keys).toContain('droid-first-connect');
-		expect(keys).toContain('droid-ready');
-		expect(keys).toContain('droid-mod-ready');
-		expect(keys).toContain('droid-downscale');
-		expect(keys).toContain('droid-upscale');
-		expect(keys).toContain('panel-open');
-		expect(keys).toContain('panel-close');
-		expect(keys).toContain('toast-added');
-		expect(keys).toContain('toast-removed');
-		expect(keys).toContain('tooltip-opened');
-		expect(keys).toContain('tooltip-closed');
-		expect(keys).toContain('modal-opened');
-		expect(keys).toContain('modal-closed');
-		expect(keys).toContain('auth-ready');
-		expect(keys).toContain('auth-error');
-		expect(keys).toContain('palworld-live-snapshot');
+	it('registers exactly the expected event keys', () => {
+		expect(Object.keys(DroidEventSchemas).sort()).toEqual(
+			EXPECTED_EVENT_KEYS,
+		);
 	});
 
-	it('has exactly 21 event types', () => {
-		expect(Object.keys(DroidEventSchemas)).toHaveLength(21);
+	it('maps every key to a parseable schema', () => {
+		for (const [key, schema] of Object.entries(DroidEventSchemas)) {
+			expect(schema, key).toBeDefined();
+			expect(typeof schema.safeParse, key).toBe('function');
+		}
 	});
 });
 


### PR DESCRIPTION
## Problem

`droid:test` fails on `dev`, blocking the Dev→Main validation run ([run 30737576842](https://github.com/KBVE/kbve/actions/runs/30737576842/job/91469081965)):

```
FAIL src/lib/types/event-types.spec.ts > DroidEventSchemas > has exactly 21 event types
AssertionError: expected [ 'droid-first-connect', …(21) ] to have a length of 21 but got 22
```

`5eee77a609` (#15134, reel-stream restore) added `'reel-stream'` to `DroidEventSchemas` — the 22nd key — without updating the spec. The preceding PR (#15118) added `palworld-live-snapshot` *and* bumped the count to 21, so the two landed out of order and the count went stale.

## Fix

The count assertion has drifted three times already (`aa4a24850a` bumped it to 19, then 21, now 22) and never says *which* key changed. Replaced it with a sorted key-set comparison against an explicit list, plus a check that every key maps to a parseable schema.

This also subsumes the old `has all expected event keys` test, which was a partial `toContain` list that silently ignored 6 of the registered events.

A new event now fails with the key name in the diff instead of an opaque length mismatch.

## Verification

```
nx run droid:test   14 files, 126 passed
nx run droid:lint   clean
```