### PR TITLE
perf(herbmail-game): cut water surface tessellation to 64x64

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/water/OasisInstance.ts
+++ b/apps/herbmail/herbmail-game/src/game/water/OasisInstance.ts
@@ -5,7 +5,13 @@ import { PoolPass } from './vendor/PoolPass';
 import { WaterSurfacePass } from './vendor/WaterSurfacePass';
 import { WaterOpticsState } from './vendor/WaterOpticsState';
 import { ObjectTexturePass } from './vendor/ObjectTexturePass';
-import { OASIS_CORNER_RADIUS, OASIS_DEPTH, SURFACE_DROP } from './constants';
+import {
+	CAUSTICS_SEGMENTS,
+	OASIS_CORNER_RADIUS,
+	OASIS_DEPTH,
+	SURFACE_DROP,
+	WATER_SURFACE_SEGMENTS,
+} from './constants';
 import { drainDisturbs, type OasisDef } from './oasis';
 
 const LIGHT_DIR = new THREE.Vector3(1.4, 2, -0.8).normalize();
@@ -47,6 +53,7 @@ export class OasisInstance {
 			this.optics,
 			this.otp.shadowTarget.texture,
 			CAUSTICS_SIZE,
+			CAUSTICS_SEGMENTS,
 		);
 		this.pool = new PoolPass(
 			tiles,
@@ -62,6 +69,7 @@ export class OasisInstance {
 			this.otp.clippedReflectionTarget.texture,
 			this.otp.refractionTarget.texture,
 			this.optics,
+			WATER_SURFACE_SEGMENTS,
 		);
 		const r = OASIS_CORNER_RADIUS;
 		this.pool.setPoolShape('Rounded', r, def.halfW, this.depth, def.halfL);

--- a/apps/herbmail/herbmail-game/src/game/water/constants.ts
+++ b/apps/herbmail/herbmail-game/src/game/water/constants.ts
@@ -4,3 +4,14 @@ export const SWIM_SINK = 1.15;
 export const OASIS_ACTIVE_RADIUS = 34;
 export const OASIS_VISIBLE_RADIUS = 50;
 export const OASIS_CORNER_RADIUS = 1.2;
+
+// Wave-surface grid resolution. The vendored default of 200 builds an 80k-tri
+// plane per surface, and a visible oasis carries two (above + below), so one
+// pool cost 160k triangles — more than half the frame at spawn and far past
+// what the PSX look needs. Raise if the wave silhouette reads too faceted.
+export const WATER_SURFACE_SEGMENTS = 64;
+
+// Caustics render into their own 1024 target and their grid density drives the
+// caustic pattern detail, not the scene triangle count. Left at the vendored
+// density until the coarser value can be compared on real hardware.
+export const CAUSTICS_SEGMENTS = 200;

--- a/apps/herbmail/herbmail-game/src/game/water/vendor/CausticsPass.ts
+++ b/apps/herbmail/herbmail-game/src/game/water/vendor/CausticsPass.ts
@@ -47,6 +47,7 @@ export class CausticsPass {
 		private readonly state: WaterOpticsState,
 		private readonly objectShadowTexture: THREE.Texture,
 		size = 1024,
+		segments = 200,
 	) {
 		this.target = new THREE.WebGLRenderTarget(size, size, {
 			minFilter: THREE.LinearFilter,
@@ -71,7 +72,7 @@ export class CausticsPass {
 		});
 
 		this.mesh = new THREE.Mesh(
-			new THREE.PlaneGeometry(2, 2, 200, 200),
+			new THREE.PlaneGeometry(2, 2, segments, segments),
 			this.boxMaterial,
 		);
 		this.mesh.frustumCulled = false;

--- a/apps/herbmail/herbmail-game/src/game/water/vendor/WaterSurfacePass.ts
+++ b/apps/herbmail/herbmail-game/src/game/water/vendor/WaterSurfacePass.ts
@@ -64,6 +64,7 @@ export class WaterSurfacePass {
 		private readonly objectClippedReflectionTexture: THREE.Texture,
 		private readonly objectRefractionTexture: THREE.Texture,
 		private readonly state: WaterOpticsState,
+		segments = 200,
 	) {
 		this.aboveMaterial = this.createMaterial(
 			waterAboveVert,
@@ -93,7 +94,7 @@ export class WaterSurfacePass {
 		this.belowMaterial.transparent = true;
 		this.belowMaterial.depthWrite = false;
 
-		const geometry = new THREE.PlaneGeometry(2, 2, 200, 200);
+		const geometry = new THREE.PlaneGeometry(2, 2, segments, segments);
 		this.aboveMesh = new THREE.Mesh(geometry, this.aboveMaterial);
 		this.belowMesh = new THREE.Mesh(geometry.clone(), this.belowMaterial);
 		this.aboveMesh.frustumCulled = false;


### PR DESCRIPTION
## Problem

The vendored water lib builds its wave surface from `PlaneGeometry(2, 2, 200, 200)` — 40,000 quads = **80,000 triangles per surface**. A visible oasis carries two (above + below), so a single pool cost **160,000 triangles**: more than a third of the frame at spawn, and far past what a PSX look needs from a body of water.

## Measured

Production preview build, same spawn state both runs (1066 draw calls):

| | peak tris |
| --- | --- |
| before | 412,963 |
| after | 269,347 |

**−143,616 (−34.8%)**, which is exactly 2 x (80,000 − 8,192) — the whole delta is the two surface meshes, nothing else moved.

For reference, standing next to an oasis measured 486,984 peak before this change, which is the ~500k that prompted the investigation.

## Approach

Segment count is a constructor arg on both passes, defaulting to the vendored `200` so the vendor files remain drop-in replaceable. The app picks the value in `water/constants.ts`, where it is one number to tune if the wave silhouette reads too faceted.

## What is deliberately not changed

`CAUSTICS_SEGMENTS` stays at 200. The caustics grid renders into its own 1024 target and its density drives caustic *pattern detail*, not scene triangle count — so it contributes no part of the win above, and lowering it is a pure visual risk. I could not verify it: headless warping to an oasis drops the player out of the streamed world, so there is no trustworthy visual A/B from this environment. It is now a named constant, so it is a one-line change if it looks fine on real hardware.

Worth flagging: this reduces triangles, and triangles were previously measured (PR #14123) not to be the frame-time bottleneck. The real lag suspect is still ~3,026 meshes / ~1,030 draw calls at ~93 tris each. This is the cheap, PSX-correct win, not the fix for lag.

## Verification

`nx typecheck`, `nx test` (102 passed), `nx build` and `nx e2e` (4 passed against a real preview build) all green.