### PR TITLE
feat(engine): professiondb Phase 2b-Rust — migrate bevy_items + axum off reserved itemdb fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,6 +3443,7 @@ dependencies = [
  "bevy_inventory",
  "prost 0.14.4",
  "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "serde",
  "serde_json",
 ]

--- a/apps/kbve/axum-kbve/src/data/professiondb.json
+++ b/apps/kbve/axum-kbve/src/data/professiondb.json
@@ -1,0 +1,956 @@
+{
+	"professions": [
+		{
+			"description": "Brew potions from herbs and reagents. A production discipline consuming\nfarming output.\n",
+			"ref": "alchemy",
+			"key": 7,
+			"id": "01KPROFALCHEMY000000000007",
+			"name": "Alchemy",
+			"category": "PROFESSION_CATEGORY_PRODUCTION",
+			"emoji": "⚗️",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 55,
+				"growthFactor": 1.65,
+				"maxLevel": 99
+			},
+			"unlocks": [
+				{
+					"level": 12,
+					"actionRef": "brew-health-potion",
+					"description": "Health potions become brewable."
+				}
+			]
+		},
+		{
+			"description": "Turn raw ingredients into food that restores and buffs. A production\ndiscipline consuming fishing and farming output.\n",
+			"ref": "cooking",
+			"key": 6,
+			"id": "01KPROFCOOKING000000000006",
+			"name": "Cooking",
+			"category": "PROFESSION_CATEGORY_PRODUCTION",
+			"emoji": "🍳",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 40,
+				"growthFactor": 1.5,
+				"maxLevel": 99
+			},
+			"unlocks": [
+				{
+					"level": 5,
+					"actionRef": "bake-bread",
+					"description": "Baking unlocks with a mill and oven."
+				}
+			],
+			"actions": [
+				{
+					"ref": "compress-berry",
+					"key": 44,
+					"name": "Compress Berry",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "berry",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-carrot",
+					"key": 45,
+					"name": "Compress Carrot",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "carrot",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-cheese",
+					"key": 46,
+					"name": "Compress Cheese",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "cheese",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-cooked-beef",
+					"key": 47,
+					"name": "Compress Cooked Beef",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "cooked-beef",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-cooked-chicken",
+					"key": 48,
+					"name": "Compress Cooked Chicken",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "cooked-chicken",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-cooked-egg",
+					"key": 49,
+					"name": "Compress Cooked Egg",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "cooked-egg",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-cooked-mutton",
+					"key": 50,
+					"name": "Compress Cooked Mutton",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "cooked-mutton",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-dragonfruit",
+					"key": 51,
+					"name": "Compress Dragonfruit",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "dragonfruit",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-egg",
+					"key": 52,
+					"name": "Compress Egg",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "egg",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-fresh-milk",
+					"key": 53,
+					"name": "Compress Fresh Milk",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "fresh-milk",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-mushroom",
+					"key": 54,
+					"name": "Compress Mushroom",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "mushroom",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-prickly-pear",
+					"key": 55,
+					"name": "Compress Prickly Pear",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "prickly-pear",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-raw-beef",
+					"key": 56,
+					"name": "Compress Raw Beef",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "raw-beef",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-raw-chicken",
+					"key": 57,
+					"name": "Compress Raw Chicken",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "raw-chicken",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-raw-mutton",
+					"key": 58,
+					"name": "Compress Raw Mutton",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "raw-mutton",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "meal",
+							"quantity": 1
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Plant, tend, and harvest crops. A gathering discipline that feeds cooking\nand alchemy.\n",
+			"ref": "farming",
+			"key": 4,
+			"id": "01KPROFFARMING000000000004",
+			"name": "Farming",
+			"category": "PROFESSION_CATEGORY_GATHERING",
+			"emoji": "🌾",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 42,
+				"growthFactor": 1.5,
+				"maxLevel": 99
+			},
+			"unlocks": [
+				{
+					"level": 18,
+					"actionRef": "grow-herb",
+					"description": "Herb patches unlock for alchemy supply."
+				}
+			]
+		},
+		{
+			"description": "Catch fish from rivers, lakes, and the sea. A gathering discipline that\nfeeds cooking.\n",
+			"ref": "fishing",
+			"key": 3,
+			"id": "01KPROFFISHING000000000003",
+			"name": "Fishing",
+			"category": "PROFESSION_CATEGORY_GATHERING",
+			"emoji": "🎣",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 40,
+				"growthFactor": 1.5,
+				"maxLevel": 99
+			},
+			"unlocks": [
+				{
+					"level": 20,
+					"actionRef": "catch-trout",
+					"description": "Trout become catchable with a rod."
+				}
+			]
+		},
+		{
+			"description": "Gather flowers, mushrooms, and wild plants from the world. A gathering\ndiscipline feeding alchemy and cooking.\n",
+			"ref": "foraging",
+			"key": 8,
+			"id": "01KPROFFORAGING0000000008",
+			"name": "Foraging",
+			"category": "PROFESSION_CATEGORY_GATHERING",
+			"emoji": "🌿",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 40,
+				"growthFactor": 1.5,
+				"maxLevel": 99
+			},
+			"actions": [
+				{
+					"ref": "gather-allium",
+					"key": 23,
+					"name": "Forage Allium",
+					"requiredLevel": 0,
+					"xpReward": 5,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-allium",
+					"outputs": [
+						{
+							"itemRef": "allium",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-bellflower",
+					"key": 24,
+					"name": "Forage Bellflower",
+					"requiredLevel": 0,
+					"xpReward": 5,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-bell",
+					"outputs": [
+						{
+							"itemRef": "bellflower",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-blue-orchid",
+					"key": 25,
+					"name": "Forage Blue Orchid",
+					"requiredLevel": 0,
+					"xpReward": 8,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-blue-orchid",
+					"outputs": [
+						{
+							"itemRef": "blue-orchid",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-chanterelle",
+					"key": 26,
+					"name": "Forage Chanterelle",
+					"requiredLevel": 0,
+					"xpReward": 10,
+					"durationMs": 500,
+					"resourceNodeRef": "mushroom-chanterelle",
+					"outputs": [
+						{
+							"itemRef": "chanterelle",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-cornflower",
+					"key": 27,
+					"name": "Forage Cornflower",
+					"requiredLevel": 0,
+					"xpReward": 5,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-cornflower",
+					"outputs": [
+						{
+							"itemRef": "cornflower",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-daisy",
+					"key": 28,
+					"name": "Forage Daisy",
+					"requiredLevel": 0,
+					"xpReward": 5,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-daisy",
+					"outputs": [
+						{
+							"itemRef": "daisy",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-fly-agaric",
+					"key": 29,
+					"name": "Forage Fly Agaric",
+					"requiredLevel": 0,
+					"xpReward": 12,
+					"durationMs": 500,
+					"resourceNodeRef": "mushroom-fly-agaric",
+					"outputs": [
+						{
+							"itemRef": "fly-agaric",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-lavender",
+					"key": 30,
+					"name": "Forage Lavender",
+					"requiredLevel": 0,
+					"xpReward": 7,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-lavender",
+					"outputs": [
+						{
+							"itemRef": "lavender",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-porcini",
+					"key": 31,
+					"name": "Forage Porcini",
+					"requiredLevel": 0,
+					"xpReward": 8,
+					"durationMs": 500,
+					"resourceNodeRef": "mushroom-porcini",
+					"outputs": [
+						{
+							"itemRef": "porcini",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-rose",
+					"key": 32,
+					"name": "Forage Rose",
+					"requiredLevel": 0,
+					"xpReward": 6,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-rose",
+					"outputs": [
+						{
+							"itemRef": "rose",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-sunflower",
+					"key": 33,
+					"name": "Forage Sunflower",
+					"requiredLevel": 0,
+					"xpReward": 6,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-sunflower",
+					"outputs": [
+						{
+							"itemRef": "sunflower",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-tulip",
+					"key": 34,
+					"name": "Forage Tulip",
+					"requiredLevel": 0,
+					"xpReward": 5,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-tulip",
+					"outputs": [
+						{
+							"itemRef": "tulip",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-wildflower",
+					"key": 35,
+					"name": "Forage Wildflower",
+					"requiredLevel": 0,
+					"xpReward": 4,
+					"durationMs": 500,
+					"resourceNodeRef": "flower-wildflower",
+					"outputs": [
+						{
+							"itemRef": "wildflower",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-berry",
+					"key": 36,
+					"name": "Forage Berry",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "berry",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-cacti-needle",
+					"key": 37,
+					"name": "Forage Cacti Needle",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "cacti-needle",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-cacti-seeds",
+					"key": 38,
+					"name": "Forage Cacti Seeds",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "cacti-seeds",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-dragonfruit",
+					"key": 39,
+					"name": "Forage Dragonfruit",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "dragonfruit",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-herb",
+					"key": 40,
+					"name": "Forage Herb",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "herb",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-mushroom",
+					"key": 41,
+					"name": "Forage Mushroom",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "mushroom",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-prickly-pear",
+					"key": 42,
+					"name": "Forage Prickly Pear",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "prickly-pear",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-raw-cacti",
+					"key": 43,
+					"name": "Forage Raw Cacti",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "raw-cacti",
+							"quantity": 1
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Extract ore and stone from the world's rock. A gathering discipline that\nfeeds smithing and construction.\n",
+			"ref": "mining",
+			"key": 1,
+			"id": "01KPROFMINING0000000000001",
+			"name": "Mining",
+			"category": "PROFESSION_CATEGORY_GATHERING",
+			"emoji": "⛏️",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 50,
+				"growthFactor": 1.6,
+				"maxLevel": 99
+			},
+			"actions": [
+				{
+					"ref": "gather-copper-ore",
+					"key": 15,
+					"name": "Mine Copper Ore",
+					"requiredLevel": 1,
+					"xpReward": 18,
+					"durationMs": 3000,
+					"resourceNodeRef": "copper-vein",
+					"toolRefs": ["pickaxe"],
+					"outputs": [
+						{
+							"itemRef": "copper-ore",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-iron-ore",
+					"key": 16,
+					"name": "Mine Iron Ore",
+					"requiredLevel": 15,
+					"xpReward": 35,
+					"durationMs": 4000,
+					"resourceNodeRef": "iron-vein",
+					"toolRefs": ["pickaxe"],
+					"outputs": [
+						{
+							"itemRef": "iron-ore",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-crystal-ore",
+					"key": 17,
+					"name": "Mine Crystal Ore",
+					"requiredLevel": 30,
+					"xpReward": 65,
+					"durationMs": 5000,
+					"resourceNodeRef": "ore-crystal",
+					"toolRefs": ["pickaxe"],
+					"outputs": [
+						{
+							"itemRef": "crystal-ore",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-mossy-stone",
+					"key": 18,
+					"name": "Mine Mossy Stone",
+					"requiredLevel": 0,
+					"xpReward": 15,
+					"durationMs": 2500,
+					"resourceNodeRef": "mossy-rock",
+					"outputs": [
+						{
+							"itemRef": "mossy-stone",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-stone",
+					"key": 19,
+					"name": "Mine Stone",
+					"requiredLevel": 0,
+					"xpReward": 8,
+					"durationMs": 2000,
+					"resourceNodeRef": "boulder",
+					"outputs": [
+						{
+							"itemRef": "stone",
+							"quantity": 1
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Smelt ore into bars and forge bars into gear. A production discipline\nconsuming mining output.\n",
+			"ref": "smithing",
+			"key": 5,
+			"id": "01KPROFSMITHING00000000005",
+			"name": "Smithing",
+			"category": "PROFESSION_CATEGORY_PRODUCTION",
+			"emoji": "🔨",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 60,
+				"growthFactor": 1.7,
+				"maxLevel": 99
+			},
+			"unlocks": [
+				{
+					"level": 4,
+					"actionRef": "forge-bronze-dagger",
+					"description": "Bronze weaponry becomes forgeable."
+				}
+			],
+			"actions": [
+				{
+					"ref": "compress-stone",
+					"key": 60,
+					"name": "Compress Stone",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "stone",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "stone-block",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-coin",
+					"key": 61,
+					"name": "Compress Coin",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "coin",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "gold-bar",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-arrow",
+					"key": 62,
+					"name": "Compress Arrow",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "arrow",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "quiver",
+							"quantity": 1
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Fell trees for logs. A gathering discipline supplying construction,\nsmithing fuel, and crafting.\n",
+			"ref": "woodcutting",
+			"key": 2,
+			"id": "01KPROFWOODCUT00000000002",
+			"name": "Woodcutting",
+			"category": "PROFESSION_CATEGORY_GATHERING",
+			"emoji": "🪓",
+			"maxLevel": 99,
+			"experienceCurve": {
+				"kind": "CURVE_KIND_POLYNOMIAL",
+				"baseXp": 45,
+				"growthFactor": 1.55,
+				"maxLevel": 99
+			},
+			"actions": [
+				{
+					"ref": "gather-log",
+					"key": 20,
+					"name": "Chop Log",
+					"requiredLevel": 0,
+					"xpReward": 10,
+					"durationMs": 2500,
+					"resourceNodeRef": "oak-tree",
+					"outputs": [
+						{
+							"itemRef": "log",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-branches",
+					"key": 21,
+					"name": "Chop Branches",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "branches",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "gather-leaves",
+					"key": 22,
+					"name": "Chop Leaves",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"outputs": [
+						{
+							"itemRef": "leaves",
+							"quantity": 1
+						}
+					]
+				},
+				{
+					"ref": "compress-log",
+					"key": 59,
+					"name": "Compress Log",
+					"requiredLevel": 0,
+					"xpReward": 0,
+					"inputs": [
+						{
+							"itemRef": "log",
+							"quantity": 100
+						}
+					],
+					"outputs": [
+						{
+							"itemRef": "timber",
+							"quantity": 1
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -2008,10 +2008,6 @@ fn process_collect_requests(
                 }
             }
 
-            // Server-authoritative inventory: grant every rolled drop into the
-            // collecting player's inventory and push one InventoryUpdate per
-            // mutated slot. XP is granted per-drop based on each item's own
-            // SkillingInfo (a bonus "branches" drop also awards woodcutting XP).
             if let Some(&player_entity) = client_player_map.0.get(&client_entity) {
                 for (drop_ref, drop_qty) in &drops {
                     if drop_ref.is_empty() || *drop_qty == 0 {

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -19,7 +19,7 @@ use lightyear::prelude::*;
 use bevy_inventory::Inventory;
 use bevy_items::ItemDb;
 use bevy_items::inventory_adapter::{ProtoItemKind, init_item_db};
-use bevy_items::skilling_type_to_skill_ref;
+use bevy_items::profession::{ProfessionDb, init_profession_db};
 use bevy_kbve_net::npcdb::{self, ProtoNpcId, creature::CapturedCreatures};
 use bevy_kbve_net::{
     AuthAck, AuthMessage, AuthResponse, CapturedCreatureEntry, CollectRequest, CraftFailureReason,
@@ -183,6 +183,26 @@ fn load_server_itemdb() {
         Err(e) => tracing::warn!(
             "[itemdb] server failed to parse baked itemdb.json: {e:?} — \
              ProtoItemKind::max_stack() will fall back to 1"
+        ),
+    }
+}
+
+const BAKED_PROFESSIONDB_JSON: &str = include_str!("../data/professiondb.json");
+
+fn load_server_professiondb() {
+    match ProfessionDb::from_json(BAKED_PROFESSIONDB_JSON) {
+        Ok(db) => {
+            let gather_count = db.gather_len();
+            let compress_count = db.compress_len();
+            let db_static: &'static ProfessionDb = Box::leak(Box::new(db));
+            init_profession_db(db_static);
+            tracing::info!(
+                "[professiondb] server loaded {gather_count} gather / {compress_count} compress entries from baked professiondb.json"
+            );
+        }
+        Err(e) => tracing::warn!(
+            "[professiondb] server failed to parse baked professiondb.json: {e:?} — \
+             skilling gating/XP disabled"
         ),
     }
 }
@@ -793,9 +813,11 @@ fn run_bevy_app(
     let mut app = App::new();
 
     // Minimal headless Bevy — no window, no renderer
-    app.add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(
-        Duration::from_secs_f64(1.0 / 60.0),
-    )));
+    app.add_plugins(
+        MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
+            1.0 / 60.0,
+        ))),
+    );
     app.add_plugins(bevy::state::app::StatesPlugin);
     app.add_plugins(bevy::transform::TransformPlugin);
 
@@ -834,6 +856,7 @@ fn run_bevy_app(
     app.init_resource::<ConsumableCooldowns>();
     app.init_resource::<DeployedItems>();
     load_server_itemdb();
+    load_server_professiondb();
     app.add_plugins(BevySkillsPlugin);
     app.add_systems(Startup, register_server_skills);
     app.init_resource::<DayCycle>();
@@ -1905,38 +1928,28 @@ fn process_collect_requests(
                 }
             }
 
-            // Resolve the candidate item ref + skilling metadata up-front so we
-            // can gate the collect before marking the tile consumed.
             let candidate_item_ref = bevy_kbve_net::item_ref_at(tile.tx, tile.tz).unwrap_or("");
             let player_entity_opt = client_player_map.0.get(&client_entity).copied();
-            let skilling_meta = if candidate_item_ref.is_empty() {
+            let gather_meta = if candidate_item_ref.is_empty() {
                 None
             } else {
-                ProtoItemKind::from_ref(candidate_item_ref)
-                    .item()
-                    .and_then(|i| i.skilling.as_ref())
+                bevy_items::profession::get_profession_db()
+                    .and_then(|db| db.gather(candidate_item_ref))
             };
 
-            // Skill-level gating: reject the collect if the item declares a
-            // required skill level and the player hasn't reached it. Tile stays
-            // un-collected so the world object is still interactable.
-            if let (Some(player_entity), Some(skilling)) = (player_entity_opt, skilling_meta) {
-                if let Some(skill_ref) = skilling_type_to_skill_ref(
-                    bevy_items::SkillingType::try_from(skilling.skill)
-                        .unwrap_or(bevy_items::SkillingType::SkillingUnspecified),
-                ) {
-                    let required = skilling.skill_level.unwrap_or(0).max(0) as u32;
-                    if required > 0 {
-                        if let Ok(profile) = skill_profiles.get(player_entity) {
-                            let current = profile.level(SkillId::from_ref(skill_ref));
-                            if current < required {
-                                tracing::info!(
-                                    "[gameserver] collect rejected for player {player_entity:?}: \
-                                     {skill_ref} level {current} < required {required} \
-                                     (item={candidate_item_ref})"
-                                );
-                                continue;
-                            }
+            if let (Some(player_entity), Some(gather)) = (player_entity_opt, gather_meta) {
+                let required = gather.required_level;
+                if required > 0 {
+                    if let Ok(profile) = skill_profiles.get(player_entity) {
+                        let current = profile.level(SkillId::from_ref(&gather.skill_ref));
+                        if current < required {
+                            let skill_ref = &gather.skill_ref;
+                            tracing::info!(
+                                "[gameserver] collect rejected for player {player_entity:?}: \
+                                 {skill_ref} level {current} < required {required} \
+                                 (item={candidate_item_ref})"
+                            );
+                            continue;
                         }
                     }
                 }
@@ -2032,28 +2045,24 @@ fn process_collect_requests(
                         }
                     }
 
-                    // XP per-drop from the item's own skilling metadata.
-                    if let Some(skilling) = kind.item().and_then(|i| i.skilling.as_ref()) {
-                        if let Some(skill_ref) = skilling_type_to_skill_ref(
-                            bevy_items::SkillingType::try_from(skilling.skill)
-                                .unwrap_or(bevy_items::SkillingType::SkillingUnspecified),
-                        ) {
-                            let xp_per = skilling.xp_reward.unwrap_or(0.0).max(0.0);
-                            if xp_per > 0.0 {
-                                let amount = (xp_per * granted as f32).round() as u64;
-                                if amount > 0 {
-                                    xp_writer.write(GrantXpMsg {
-                                        entity: player_entity,
-                                        skill: SkillId::from_ref(skill_ref),
+                    if let Some(gather) = bevy_items::profession::get_profession_db()
+                        .and_then(|db| db.gather(drop_ref))
+                    {
+                        let xp_per = gather.xp_reward as f32;
+                        if xp_per > 0.0 {
+                            let amount = (xp_per * granted as f32).round() as u64;
+                            if amount > 0 {
+                                xp_writer.write(GrantXpMsg {
+                                    entity: player_entity,
+                                    skill: SkillId::from_ref(&gather.skill_ref),
+                                    amount,
+                                });
+                                if let Ok(mut sender) = xp_senders.get_mut(client_entity) {
+                                    sender.send::<bevy_kbve_net::GameChannel>(SkillXpGrant {
+                                        player_id: collector_id,
+                                        skill_ref: gather.skill_ref.clone(),
                                         amount,
                                     });
-                                    if let Ok(mut sender) = xp_senders.get_mut(client_entity) {
-                                        sender.send::<bevy_kbve_net::GameChannel>(SkillXpGrant {
-                                            player_id: collector_id,
-                                            skill_ref: skill_ref.to_string(),
-                                            amount,
-                                        });
-                                    }
                                 }
                             }
                         }

--- a/docs/superpowers/plans/2026-08-01-professiondb-phase2b-rust-consumers.md
+++ b/docs/superpowers/plans/2026-08-01-professiondb-phase2b-rust-consumers.md
@@ -1,0 +1,98 @@
+# professiondb Phase 2b-Rust — Engine Consumers Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Rust `bevy_items` + `axum-kbve` engine consumers off the now-reserved itemdb proto fields `Item.skilling`(42) / `Item.compress`(48) and `FoodInfo.cooking_level`(3) / `cooking_xp`(4). Add a professiondb loader to Rust (none exists today) and rewire the two axum gameserver sites that gate collects and grant skilling XP so they resolve gather economics from professiondb instead of `Item.skilling`.
+
+**Architecture:** A new `bevy_items::profession` module parses `professiondb-data.json` (serde, no proto/prost dependency) into two lookups — `item_ref → GatherInfo { skill_ref, required_level, xp_reward, resource_node_ref }` (from `gather-*` actions' outputs) and `item_ref → CompressInfo { target_ref, ratio }` (from `compress-*` actions' inputs/outputs). axum embeds the JSON (`include_str!`), builds a `ProfessionDb`, `Box::leak`s it into a process-global `OnceLock` (mirroring the existing `bevy_items::inventory_adapter` itemdb pattern), and the two gameserver sites query it by item ref. Profession `ref` (mining/woodcutting/foraging/…) equals the `bevy_skills` skill ref, so profession→skill is identity. The itemdb proto is regenerated (`BUILD_PROTO=1`), which removes the reserved fields **and** brings the checked-in generated `item.rs` up to date with the current proto (which has drifted well beyond the reservations — see Decision 1). The regen and the `json.rs`/axum fixes land in one commit so the workspace always compiles.
+
+**Tech Stack:** Rust, `prost` / `prost-build` (proto codegen, gated behind `BUILD_PROTO=1` in `build.rs`), `serde` / `serde_json`, Bevy, nx (`@monodon/rust`), `cargo`.
+
+## Global Constraints
+
+- Worktree: `/Users/alappatel/Documents/GitHub/kbve-professiondb-engine-consumers`, branch `trunk/professiondb-engine-consumers-1785586967`. All work here; never the main tree. Use absolute paths.
+- **No comments in authored Rust code** (repo rule — drop all `//` and `///` in new/edited code). The new `profession.rs` carries zero comments.
+- Commit messages: **no** `Co-Authored-By`, **no** "Generated with Claude" / "🤖 Generated" text.
+- **The proto regen (which removes the reserved fields) and the `json.rs` + axum fixes MUST land together in one commit (Task 4).** A regen alone leaves `json.rs`/`axum-kbve` referencing dead fields; the fixes alone won't compile against the stale generated file. Never leave a commit where `cargo build` fails.
+- `prost-build` shells out to `protoc` — ensure `protoc` is installed before the `BUILD_PROTO=1` regen step.
+- Build/test gates are `cargo` / nx `@monodon/rust`. bevy_items: `cargo build -p bevy_items`, `cargo test -p bevy_items`, `cargo clippy -p bevy_items -- -D warnings`. axum: `cargo build -p axum-kbve`. **`bevy_items` lint denies warnings**, so no dead code may remain.
+
+## Decisions (flag for confirmation at plan review)
+
+1. **The checked-in generated `packages/rust/bevy/bevy_items/src/proto/item.rs` is far more stale than "just the reserved fields."** A `BUILD_PROTO=1` regen will, besides **removing** `Item.skilling` and `FoodInfo.cooking_level`/`cooking_xp`, **add** ~20 fields the current proto grew (`Item` tags 49-57: stacking/pool*group/weapon/fuel/container/planting/projectile/trap/enchantment; `FoodInfo` tags 8-14: restore_energy/restore_mana/regen*\*/perishable/shelf_life_seconds/spoils_into_ref; `EquipmentInfo` tags 7-10) plus new messages. Because `json.rs` builds these prost structs with **exhaustive struct literals** (no `..Default::default()`), the regen breaks the `Item`/`FoodInfo`/`EquipmentInfo` literals with `E0063 missing fields` **beyond** the removals. **Chosen fix:** add `..Default::default()` to those three literals (prost structs impl `Default`) — matches json.rs's "unmapped fields ignored" philosophy and is forward-proof. **CONFIRM** over hand-mapping every new field (which would substantially grow Task 4).
+2. **`professiondb-data.json` already contains all 48 actions** (verified: mining/gather-copper-ore key 15, camelCase). The Task 2 regen is idempotent safety (refresh + copy to axum), NOT a "nothing to read" blocker. The JSON is **proto-canonical camelCase** (`requiredLevel`, `xpReward`, `itemRef`, `resourceNodeRef`, `durationMs`, `toolRefs`) — the serde structs use `rename_all = "camelCase"`.
+3. **Embed strategy:** copy the regenerated `professiondb-data.json` into `apps/kbve/axum-kbve/src/data/professiondb.json` and `include_str!("../data/professiondb.json")` — mirrors `BAKED_ITEMDB_JSON = include_str!("../data/itemdb.json")`, keeps the embed inside the crate's `src` tree (container-build safe), checked in. **CONFIRM** over `include_str!`-ing the generated path (fragile, not in Docker build context). Follow-up (out of scope): a sync script that writes `src/data/professiondb.json` like itemdb's.
+4. **profession `ref` → skill_ref is IDENTITY.** The 8 profession refs (`alchemy/cooking/farming/fishing/foraging/mining/smithing/woodcutting`) are all valid `bevy_skills` slugs already produced by the old `skilling_type_to_skill_ref`. No mapping table; pass `profession.ref` straight into `SkillId::from_ref`.
+5. **Global `OnceLock` accessor** in `bevy_items::profession` (mirrors `inventory_adapter::{init_item_db, get_item_db}`) rather than a Bevy `Resource` — the two gameserver sites already reach itemdb via the process-global, so this keeps the rewrite minimal. **CONFIRM** over a `Res<ProfessionDb>`.
+
+## Verified facts (anchors)
+
+- **Consumers of the vanishing fields (exhaustive):** only `apps/kbve/axum-kbve/src/gameserver/mod.rs` (site A ~L1908-1943 collect gating, site B ~L2035-2060 XP grant) and `packages/rust/bevy/bevy_items/src/json.rs` (`parse_food` ~L344, `parse_skilling`/`parse_skilling_type` ~L366/L224, and the `skilling:` assignment in `json_value_to_item` ~L112). `arpg-server`, `isometric-game`, `discordsh-bot` depend on `bevy_items` but reference none — post-regen `cargo check` only.
+- **Reservations in place** (`packages/data/proto/item/itemdb.proto`): `Item { reserved 42, 48; reserved "skilling","compress"; }`; `FoodInfo { reserved 3,4; reserved "cooking_level","cooking_xp"; }`. `message SkillingInfo` + `message CompressInfo` still exist (survive regen as standalone structs; only the `Item` fields referencing them are gone).
+- **itemdb load pattern to mirror** (`mod.rs`): `const BAKED_ITEMDB_JSON: &str = include_str!("../data/itemdb.json");` → `fn load_server_itemdb()` does `ItemDb::from_json` → `Box::leak` → `init_item_db`; called ~L836. `bevy_items::inventory_adapter` holds `static ITEM_DB_REF: OnceLock<&'static ItemDb>` with `init_item_db`/`get_item_db`.
+
+---
+
+### Task 1: Add the `bevy_items::profession` loader module
+
+**Files:** Create `packages/rust/bevy/bevy_items/src/profession.rs`; edit `packages/rust/bevy/bevy_items/src/lib.rs` (add `pub mod profession;`).
+
+- [ ] **Step 1:** Add `pub mod profession;` to `lib.rs` next to `pub mod json;`.
+- [ ] **Step 2:** Create `profession.rs` (no comments) with serde raw structs (`#[serde(rename_all = "camelCase")]`), public `GatherInfo`/`CompressInfo`/`ProfessionDb`, and a process-global accessor mirroring `inventory_adapter`. Build `gather` from `gather-*` actions' `outputs[].item_ref → { skill_ref = profession.ref, required_level, xp_reward, resource_node_ref }` and `compress` from `compress-*` actions' `inputs[0].item_ref → { target_ref = outputs[0].item_ref, ratio = inputs[0].quantity }`. `from_json(&str) -> Result<Self, ProfessionLoadError>`, `gather(item_ref)`, `compress(item_ref)`, `gather_len`/`compress_len`/`is_empty`, `static PROFESSION_DB_REF: OnceLock<&'static ProfessionDb>`, `init_profession_db`/`get_profession_db`. Include a `#[cfg(test)]` fixture test (camelCase JSON) asserting `gather("copper-ore") = {mining,1,18,Some("ore-copper")}` and `compress("berry") = {meal,100}`. (Full reference implementation in the plan's companion snippet — the implementer may reproduce it; key point: camelCase serde, `starts_with("gather-")`/`"compress-"`, `.or_insert_with` first-wins.)
+- [ ] **Step 3:** Gate: `cargo test -p bevy_items profession 2>&1 | tail -20` → `loads_gather_and_compress ... ok`. (This task does NOT touch the proto.)
+- [ ] **Step 4:** Gate: `cargo clippy -p bevy_items -- -D warnings 2>&1 | tail -5` → no warnings.
+- [ ] **Step 5:** Commit: `git commit -am "feat(bevy_items): add professiondb loader module"`.
+
+### Task 2: Embed professiondb data into axum
+
+**Files:** Refresh `packages/data/codegen/generated/professiondb-data.json` (idempotent); create `apps/kbve/axum-kbve/src/data/professiondb.json`.
+
+- [ ] **Step 1:** Refresh the data (idempotent — actions already present): `cd <worktree> && export NX_WORKSPACE_ROOT_PATH=$PWD && node packages/data/codegen/gen-professiondb-data.mjs 2>&1 | grep -v "npm warn"` → `Loaded 8 profession defs`, wrote json + binpb.
+- [ ] **Step 2:** Assert actions carry camelCase economics: `node -e "const d=require('./packages/data/codegen/generated/professiondb-data.json'); const m=d.professions.find(p=>p.ref==='mining').actions.find(a=>a.ref==='gather-copper-ore'); console.log(JSON.stringify(m)); const c=d.professions.find(p=>p.ref==='cooking').actions.find(a=>a.ref==='compress-berry'); console.log(JSON.stringify(c));"` → gather shows requiredLevel/xpReward:18/resourceNodeRef/outputs; compress shows inputs berry×100/outputs meal×1.
+- [ ] **Step 3:** Copy into axum crate src tree: `cp packages/data/codegen/generated/professiondb-data.json apps/kbve/axum-kbve/src/data/professiondb.json`.
+- [ ] **Step 4:** Round-trip sanity: `node -e "const d=require('./apps/kbve/axum-kbve/src/data/professiondb.json'); console.log('professions', d.professions.length, 'has-actions', d.professions.some(p=>(p.actions||[]).length>0));"` → `8 true`.
+- [ ] **Step 5:** Commit: `git commit -am "chore(axum-kbve): embed professiondb-data.json for the gameserver"`.
+
+### Task 3: Regen itemdb proto + fix `json.rs` + rewire axum — ONE atomic commit
+
+**Files:** Regenerate `packages/rust/bevy/bevy_items/src/proto/item.rs` (`BUILD_PROTO=1`); edit `packages/rust/bevy/bevy_items/src/json.rs`; edit `apps/kbve/axum-kbve/src/gameserver/mod.rs`.
+
+- [ ] **Step 1 — regen:** `BUILD_PROTO=1 cargo build -p bevy_items 2>&1 | tail -30`. Rewrites `item.rs` (build then FAILS on json.rs — expected, fixed below). Confirm: `node -e "const s=require('fs').readFileSync('packages/rust/bevy/bevy_items/src/proto/item.rs','utf8'); console.log('cooking_level', s.includes('cooking_level'), 'Item.skilling', /pub skilling:/.test(s), 'WeaponInfo', s.includes('struct WeaponInfo'));"` → `false false true`. (If protoc missing, install + retry.)
+- [ ] **Step 2 — json.rs `json_value_to_item`:** delete `skilling: parse_skilling(v.get("skilling")),` (~L112); add `..Default::default()` as the final element of the `item::Item { … }` literal (after `drafted: bool_opt(v, "drafted"),`).
+- [ ] **Step 3 — json.rs `parse_food`:** delete the `cooking_level:` and `cooking_xp:` fields; add `..Default::default()` after `buff_effects`.
+- [ ] **Step 4 — json.rs `parse_equipment` + dead-code:** add `..Default::default()` after the last field of the `item::EquipmentInfo { … }` literal (gained tags 7-10). Then DELETE `fn parse_skilling` and `fn parse_skilling_type` (now unused; `bevy_items` lint denies warnings). Leave `skilling_type_to_skill_ref` in lib.rs + the `SkillingType`/`SkillingInfo` proto types alone.
+- [ ] **Step 5 — gate bevy_items:** `cargo build -p bevy_items 2>&1 | tail -20 && cargo test -p bevy_items 2>&1 | tail -15 && cargo clippy -p bevy_items -- -D warnings 2>&1 | tail -5` → clean build, tests ok, no warnings.
+- [ ] **Step 6 — axum embed + loader:** in `mod.rs` next to `BAKED_ITEMDB_JSON`/`load_server_itemdb`, add `const BAKED_PROFESSIONDB_JSON: &str = include_str!("../data/professiondb.json");` + `fn load_server_professiondb()` that does `ProfessionDb::from_json(BAKED_PROFESSIONDB_JSON)` → on Ok `Box::leak` + `init_profession_db` + `tracing::info!` gather/compress counts; on Err `tracing::warn!` (gating/XP disabled). Call `load_server_professiondb();` right after `load_server_itemdb();` (~L836).
+- [ ] **Step 7 — axum site A (collect gating ~L1912-1943):** replace `skilling_meta` + the SkillingType-wrapped gate with: `let gather_meta = if candidate_item_ref.is_empty() { None } else { bevy_items::profession::get_profession_db().and_then(|db| db.gather(candidate_item_ref)) };` then gate on `gather.required_level` vs `profile.level(SkillId::from_ref(&gather.skill_ref))` (continue if below). Uses `gather.skill_ref` directly — no `skilling_type_to_skill_ref`.
+- [ ] **Step 8 — axum site B (XP grant ~L2035-2060):** replace `kind.item().and_then(|i| i.skilling.as_ref())` with `bevy_items::profession::get_profession_db().and_then(|db| db.gather(drop_ref))`; use `gather.xp_reward as f32` for `xp_per`, `SkillId::from_ref(&gather.skill_ref)`, and `gather.skill_ref.clone()` for the `SkillXpGrant.skill_ref`. (`drop_ref` is in scope from the `for (drop_ref, drop_qty) in &drops` loop.)
+- [ ] **Step 9 — remove unused import:** delete `use bevy_items::skilling_type_to_skill_ref;` (~L22). Verify: `node -e "const s=require('fs').readFileSync('apps/kbve/axum-kbve/src/gameserver/mod.rs','utf8'); console.log('helper', s.includes('skilling_type_to_skill_ref'), 'SkillingType', s.includes('SkillingType'), '.skilling', s.includes('.skilling'));"` → all `false`.
+- [ ] **Step 10 — gate axum:** `cargo build -p axum-kbve 2>&1 | tail -25` clean; then `cargo build -p bevy_items 2>&1 | tail -5` again (workspace coherent).
+- [ ] **Step 11 — commit (atomic):** `git commit -am "feat(engine): move Rust skilling gate/XP to professiondb; regen itemdb proto"` — one commit containing regenerated `item.rs` + `json.rs` + `mod.rs`.
+
+### Task 4: Verify other bevy_items consumers still compile
+
+- [ ] **Step 1:** `cargo check -p arpg-server 2>&1 | tail -15` → clean.
+- [ ] **Step 2:** `cargo check -p isometric-game 2>&1 | tail -15` → clean (if Tauri-feature-gated, also its nx check).
+- [ ] **Step 3:** `cargo check -p discordsh-bot 2>&1 | tail -15` → clean.
+- [ ] **Step 4:** Safety net: `cargo check -p bevy_items -p axum-kbve -p arpg-server -p isometric-game -p discordsh-bot 2>&1 | tail -20` → clean. Any break = a consumer used a removed field the grep missed; fix in place.
+- [ ] **Step 5:** If Steps 1-4 needed fixes, commit: `git commit -am "fix(engine): keep bevy_items consumers compiling after itemdb regen"`. Else no commit.
+
+### Task 5: Final lint, test, push
+
+- [ ] **Step 1:** `cargo test -p bevy_items 2>&1 | tail -15` + `cargo clippy -p bevy_items -- -D warnings 2>&1 | tail -5` → ok / no warnings.
+- [ ] **Step 2:** `cargo build -p axum-kbve 2>&1 | tail -10` → clean.
+- [ ] **Step 3:** No live refs to removed fields in hand code: `grep -rnE "\.skilling|\.compress\b|cooking_level|cooking_xp" apps packages --include=*.rs | grep -v "src/proto/item.rs" || echo CLEAN` → CLEAN (regenerated item.rs may still hold SkillingInfo/CompressInfo message structs — fine).
+- [ ] **Step 4:** Push `git push -u origin trunk/professiondb-engine-consumers-1785586967`. (Controller opens PR after final review.)
+
+## Rollback / risk
+
+- Task 3 Step 1 mutates a **tracked** generated file (`item.rs`); abort mid-way with `git checkout -- packages/rust/bevy/bevy_items/src/proto/item.rs` to restore the working stale version.
+- If Decision 1's `..Default::default()` is rejected, Task 3 Steps 2-4 must enumerate every new field — larger, error-prone.
+- Skill-ref parity assumed (Decision 4). If the gameserver's `SkillRegistry` ever diverges from the profession refs, `SkillId::from_ref` silently no-ops XP/gating. Defensive follow-up (out of scope): assert each profession ref is registered at load time.
+
+## Self-Review
+
+- **Scope:** unblocks the Rust half of Phase 2b (bevy_items + axum + 3 downstream crates). rareicon Unity is the separate 2b-Unity phase (deferred).
+- **Atomicity:** the field-removing regen and its fixes are one commit (Task 3) — workspace always compiles.
+- **Consistency:** `GatherInfo.skill_ref` = profession ref (identity, Decision 4); both axum sites use it via `SkillId::from_ref`; xp_reward is uint32 (always present). camelCase serde matches the verified JSON.
+- **Flagged for confirmation:** Decisions 1 (`..Default::default()`), 3 (embed path), 5 (OnceLock).

--- a/packages/data/codegen/generated/xref-index.json
+++ b/packages/data/codegen/generated/xref-index.json
@@ -124,6 +124,7 @@
     "pack": 532,
     "padded-sleeves": 620,
     "paradox-sack-of-potatoes": 5,
+    "pet-ball": 119,
     "pet-elixir": 118,
     "phoenix-feather": 83,
     "pickaxe": 634,

--- a/packages/rust/bevy/bevy_items/Cargo.toml
+++ b/packages/rust/bevy/bevy_items/Cargo.toml
@@ -21,6 +21,7 @@ bevy = { version = "0.19", default-features = false, features = [
     "bevy_state",
 ] }
 prost = { version = "0.14", features = ["derive"] }
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bevy_inventory = { version = "0.1", path = "../bevy_inventory", optional = true, default-features = false }

--- a/packages/rust/bevy/bevy_items/build.rs
+++ b/packages/rust/bevy/bevy_items/build.rs
@@ -29,6 +29,7 @@ fn main() {
     prost_build::Config::new()
         .out_dir(&out_dir)
         .type_attribute(".item", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .field_attribute(".item.Item.bonuses", "#[serde(skip)]")
         .compile_protos(
             &[item_proto.to_str().unwrap()],
             &[

--- a/packages/rust/bevy/bevy_items/src/json.rs
+++ b/packages/rust/bevy/bevy_items/src/json.rs
@@ -109,7 +109,6 @@ fn json_value_to_item(v: &Value) -> Option<item::Item> {
         use_effects: parse_use_effects(v.get("use_effects")),
         equipment: parse_equipment(v.get("equipment")),
         food: parse_food(v.get("food")),
-        skilling: parse_skilling(v.get("skilling")),
         recipes: parse_recipes(v.get("recipes")),
         deployable: parse_deployable(v.get("deployable")),
         resistances: parse_affinities(v.get("resistances")),
@@ -123,6 +122,7 @@ fn json_value_to_item(v: &Value) -> Option<item::Item> {
         extensions: parse_extensions(v.get("extensions")),
         credits: str_opt(v, "credits"),
         drafted: bool_opt(v, "drafted"),
+        ..Default::default()
     })
 }
 
@@ -221,27 +221,6 @@ fn parse_status_effect(v: Option<&Value>) -> i32 {
     }
 }
 
-fn parse_skilling_type(v: Option<&Value>) -> i32 {
-    match v.and_then(|v| v.as_str()) {
-        Some("cooking") => item::SkillingType::SkillingCooking as i32,
-        Some("smithing") => item::SkillingType::SkillingSmithing as i32,
-        Some("crafting") => item::SkillingType::SkillingCrafting as i32,
-        Some("alchemy") => item::SkillingType::SkillingAlchemy as i32,
-        Some("woodcutting") => item::SkillingType::SkillingWoodcutting as i32,
-        Some("mining") => item::SkillingType::SkillingMining as i32,
-        Some("fishing") => item::SkillingType::SkillingFishing as i32,
-        Some("farming") => item::SkillingType::SkillingFarming as i32,
-        Some("herblore") => item::SkillingType::SkillingHerblore as i32,
-        Some("fletching") => item::SkillingType::SkillingFletching as i32,
-        Some("hunting") => item::SkillingType::SkillingHunting as i32,
-        Some("foraging") => item::SkillingType::SkillingForaging as i32,
-        Some("enchanting") => item::SkillingType::SkillingEnchanting as i32,
-        Some("tailoring") => item::SkillingType::SkillingTailoring as i32,
-        Some("construction") => item::SkillingType::SkillingConstruction as i32,
-        _ => v.and_then(|v| v.as_i64()).unwrap_or(0) as i32,
-    }
-}
-
 fn parse_bonuses(v: Option<&Value>) -> Option<item::ItemBonuses> {
     let v = v?.as_object()?;
     Some(item::ItemBonuses {
@@ -306,6 +285,7 @@ fn parse_equipment(v: Option<&Value>) -> Option<item::EquipmentInfo> {
             .get("max_durability")
             .and_then(|v| v.as_i64())
             .map(|n| n as i32),
+        ..Default::default()
     })
 }
 
@@ -346,51 +326,13 @@ fn parse_food(v: Option<&Value>) -> Option<item::FoodInfo> {
     Some(item::FoodInfo {
         heals: v.get("heals").and_then(|v| v.as_i64()).map(|n| n as i32),
         doses: v.get("doses").and_then(|v| v.as_i64()).map(|n| n as i32),
-        cooking_level: v
-            .get("cooking_level")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32),
-        cooking_xp: v
-            .get("cooking_xp")
-            .and_then(|v| v.as_f64())
-            .map(|n| n as f32),
         burn_level: v
             .get("burn_level")
             .and_then(|v| v.as_i64())
             .map(|n| n as i32),
         duration: v.get("duration").and_then(|v| v.as_i64()).map(|n| n as i32),
         buff_effects: parse_use_effects(v.get("buff_effects")),
-    })
-}
-
-fn parse_skilling(v: Option<&Value>) -> Option<item::SkillingInfo> {
-    let v = v?.as_object()?;
-    Some(item::SkillingInfo {
-        skill: parse_skilling_type(v.get("skill")),
-        skill_level: v
-            .get("skill_level")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32),
-        xp_reward: v
-            .get("xp_reward")
-            .and_then(|v| v.as_f64())
-            .map(|n| n as f32),
-        tool_required: v
-            .get("tool_required")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        gather_time: v
-            .get("gather_time")
-            .and_then(|v| v.as_f64())
-            .map(|n| n as f32),
-        respawn_time: v
-            .get("respawn_time")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32),
-        resource_node: v
-            .get("resource_node")
-            .and_then(|v| v.as_str())
-            .map(String::from),
+        ..Default::default()
     })
 }
 

--- a/packages/rust/bevy/bevy_items/src/lib.rs
+++ b/packages/rust/bevy/bevy_items/src/lib.rs
@@ -30,6 +30,7 @@
 #[cfg(feature = "inventory")]
 pub mod inventory_adapter;
 pub mod json;
+pub mod profession;
 mod proto;
 mod registry;
 

--- a/packages/rust/bevy/bevy_items/src/profession.rs
+++ b/packages/rust/bevy/bevy_items/src/profession.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct RawRoot {
+    professions: Vec<RawProfession>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawProfession {
+    #[serde(rename = "ref")]
+    ref_: String,
+    #[serde(default)]
+    actions: Vec<RawAction>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawAction {
+    #[serde(rename = "ref")]
+    ref_: String,
+    #[serde(default)]
+    required_level: u32,
+    #[serde(default)]
+    xp_reward: u32,
+    #[serde(default)]
+    resource_node_ref: Option<String>,
+    #[serde(default)]
+    inputs: Vec<RawItemStack>,
+    #[serde(default)]
+    outputs: Vec<RawItemStack>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawItemStack {
+    item_ref: String,
+    quantity: u32,
+}
+
+#[derive(Debug)]
+pub enum ProfessionLoadError {
+    Parse(serde_json::Error),
+}
+
+impl std::fmt::Display for ProfessionLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "professiondb JSON parse error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ProfessionLoadError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatherInfo {
+    pub skill_ref: String,
+    pub required_level: u32,
+    pub xp_reward: u32,
+    pub resource_node_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompressInfo {
+    pub target_ref: String,
+    pub ratio: u32,
+}
+
+#[derive(Debug, Default)]
+pub struct ProfessionDb {
+    gather: HashMap<String, GatherInfo>,
+    compress: HashMap<String, CompressInfo>,
+}
+
+impl ProfessionDb {
+    pub fn from_json(json_str: &str) -> Result<Self, ProfessionLoadError> {
+        let root: RawRoot = serde_json::from_str(json_str).map_err(ProfessionLoadError::Parse)?;
+
+        let mut gather = HashMap::new();
+        let mut compress = HashMap::new();
+
+        for profession in &root.professions {
+            for action in &profession.actions {
+                if action.ref_.starts_with("gather-") {
+                    let resource_node_ref = action.resource_node_ref.clone().unwrap_or_default();
+                    for output in &action.outputs {
+                        gather
+                            .entry(output.item_ref.clone())
+                            .or_insert_with(|| GatherInfo {
+                                skill_ref: profession.ref_.clone(),
+                                required_level: action.required_level,
+                                xp_reward: action.xp_reward,
+                                resource_node_ref: resource_node_ref.clone(),
+                            });
+                    }
+                } else if action.ref_.starts_with("compress-")
+                    && let (Some(input), Some(output)) =
+                        (action.inputs.first(), action.outputs.first())
+                {
+                    compress
+                        .entry(input.item_ref.clone())
+                        .or_insert_with(|| CompressInfo {
+                            target_ref: output.item_ref.clone(),
+                            ratio: input.quantity,
+                        });
+                }
+            }
+        }
+
+        Ok(Self { gather, compress })
+    }
+
+    pub fn gather(&self, item_ref: &str) -> Option<&GatherInfo> {
+        self.gather.get(item_ref)
+    }
+
+    pub fn compress(&self, item_ref: &str) -> Option<&CompressInfo> {
+        self.compress.get(item_ref)
+    }
+
+    pub fn gather_len(&self) -> usize {
+        self.gather.len()
+    }
+
+    pub fn compress_len(&self) -> usize {
+        self.compress.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.gather.is_empty() && self.compress.is_empty()
+    }
+}
+
+static PROFESSION_DB_REF: OnceLock<&'static ProfessionDb> = OnceLock::new();
+
+pub fn init_profession_db(db: &'static ProfessionDb) {
+    let _ = PROFESSION_DB_REF.set(db);
+}
+
+pub fn get_profession_db() -> Option<&'static ProfessionDb> {
+    PROFESSION_DB_REF.get().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"
+    {
+        "professions": [
+            {
+                "ref": "mining",
+                "key": 1,
+                "name": "Mining",
+                "actions": [
+                    {
+                        "ref": "gather-copper-ore",
+                        "key": 15,
+                        "name": "Mine Copper Ore",
+                        "requiredLevel": 1,
+                        "xpReward": 18,
+                        "durationMs": 3000,
+                        "resourceNodeRef": "copper-vein",
+                        "toolRefs": ["pickaxe"],
+                        "outputs": [{"itemRef": "copper-ore", "quantity": 1}]
+                    }
+                ]
+            },
+            {
+                "ref": "cooking",
+                "key": 2,
+                "name": "Cooking",
+                "actions": [
+                    {
+                        "ref": "compress-berry",
+                        "key": 44,
+                        "name": "Compress Berry",
+                        "requiredLevel": 0,
+                        "xpReward": 0,
+                        "inputs": [{"itemRef": "berry", "quantity": 100}],
+                        "outputs": [{"itemRef": "meal", "quantity": 1}]
+                    }
+                ]
+            }
+        ]
+    }
+    "#;
+
+    #[test]
+    fn loads_gather_and_compress() {
+        let db = ProfessionDb::from_json(FIXTURE).unwrap();
+
+        assert_eq!(db.gather_len(), 1);
+        assert_eq!(db.compress_len(), 1);
+        assert!(!db.is_empty());
+
+        let gather = db.gather("copper-ore").unwrap();
+        assert_eq!(gather.skill_ref, "mining");
+        assert_eq!(gather.required_level, 1);
+        assert_eq!(gather.xp_reward, 18);
+        assert_eq!(gather.resource_node_ref, "copper-vein");
+
+        let compress = db.compress("berry").unwrap();
+        assert_eq!(compress.target_ref, "meal");
+        assert_eq!(compress.ratio, 100);
+
+        assert!(db.gather("nonexistent").is_none());
+        assert!(db.compress("nonexistent").is_none());
+    }
+
+    #[test]
+    fn empty_db_is_empty() {
+        let db = ProfessionDb::from_json(r#"{"professions": []}"#).unwrap();
+        assert!(db.is_empty());
+    }
+}

--- a/packages/rust/bevy/bevy_items/src/proto/item.rs
+++ b/packages/rust/bevy/bevy_items/src/proto/item.rs
@@ -59,6 +59,50 @@ pub struct EquipmentInfo {
     pub durability: ::core::option::Option<i32>,
     #[prost(int32, optional, tag = "6")]
     pub max_durability: ::core::option::Option<i32>,
+    /// Number of enchantments that can be applied
+    #[prost(int32, optional, tag = "7")]
+    pub enchantment_slots: ::core::option::Option<i32>,
+    /// Accepted enchantment slugs (e.g. "gem", "rune", "sigil")
+    #[prost(string, repeated, tag = "8")]
+    pub enchantment_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Cannot be unequipped without a remedy
+    #[prost(bool, optional, tag = "9")]
+    pub cursed: ::core::option::Option<bool>,
+    /// 0.0-1.0 speed reduction when worn (armor weight)
+    #[prost(float, optional, tag = "10")]
+    pub movement_penalty: ::core::option::Option<f32>,
+}
+/// Enchantment payload — describes what an enchantment grants when attached to
+/// a parent piece of equipment. Items carrying EnchantmentInfo (gems, runes,
+/// sigils, crafted enchantments) are eligible to occupy EquipmentInfo's slots.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct EnchantmentInfo {
+    /// Namespace matching EquipmentInfo.enchantment_types
+    #[prost(string, tag = "1")]
+    pub slug: ::prost::alloc::string::String,
+    /// Stat bonuses added to the parent while attached
+    #[prost(message, optional, tag = "2")]
+    pub bonuses: ::core::option::Option<ItemBonuses>,
+    /// Effects triggered when the parent item is used
+    #[prost(message, repeated, tag = "3")]
+    pub on_use: ::prost::alloc::vec::Vec<UseEffect>,
+    /// Continuous effects while the parent is equipped
+    #[prost(message, repeated, tag = "4")]
+    pub while_equipped: ::prost::alloc::vec::Vec<UseEffect>,
+    /// 1-N quality tier (matches rarity escalation)
+    #[prost(int32, optional, tag = "5")]
+    pub tier: ::core::option::Option<i32>,
+    /// Can be extracted intact (false = destroys on removal)
+    #[prost(bool, optional, tag = "6")]
+    pub removable: ::core::option::Option<bool>,
+    #[prost(int32, optional, tag = "7")]
+    pub level_requirement: ::core::option::Option<i32>,
+    /// Elemental boosts granted while attached
+    #[prost(message, repeated, tag = "8")]
+    pub affinities: ::prost::alloc::vec::Vec<ItemAffinity>,
+    /// Elemental resistances granted while attached
+    #[prost(message, repeated, tag = "9")]
+    pub resistances: ::prost::alloc::vec::Vec<ItemAffinity>,
 }
 /// A single use effect definition
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -200,12 +244,6 @@ pub struct FoodInfo {
     /// Number of doses (potions: 1-4)
     #[prost(int32, optional, tag = "2")]
     pub doses: ::core::option::Option<i32>,
-    /// Cooking level required to prepare
-    #[prost(int32, optional, tag = "3")]
-    pub cooking_level: ::core::option::Option<i32>,
-    /// XP awarded for cooking this item
-    #[prost(float, optional, tag = "4")]
-    pub cooking_xp: ::core::option::Option<f32>,
     /// Level at which burning stops
     #[prost(int32, optional, tag = "5")]
     pub burn_level: ::core::option::Option<i32>,
@@ -215,6 +253,27 @@ pub struct FoodInfo {
     /// Stat buffs granted on consumption
     #[prost(message, repeated, tag = "7")]
     pub buff_effects: ::prost::alloc::vec::Vec<UseEffect>,
+    /// Energy / hunger satiation restored on consumption
+    #[prost(int32, optional, tag = "8")]
+    pub restore_energy: ::core::option::Option<i32>,
+    /// Mana restored on consumption
+    #[prost(int32, optional, tag = "9")]
+    pub restore_mana: ::core::option::Option<i32>,
+    /// Post-consumption over-time regen rate (HP/sec)
+    #[prost(float, optional, tag = "10")]
+    pub regen_per_second: ::core::option::Option<f32>,
+    /// Seconds the regen buff lasts after consumption
+    #[prost(float, optional, tag = "11")]
+    pub regen_duration: ::core::option::Option<f32>,
+    /// Item decays over time if true
+    #[prost(bool, optional, tag = "12")]
+    pub perishable: ::core::option::Option<bool>,
+    /// Time from creation/harvest until spoil
+    #[prost(int32, optional, tag = "13")]
+    pub shelf_life_seconds: ::core::option::Option<i32>,
+    /// Item produced on spoilage (e.g. "rotten-meat")
+    #[prost(string, optional, tag = "14")]
+    pub spoils_into_ref: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Skilling properties — for items that interact with skill systems
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
@@ -240,6 +299,341 @@ pub struct SkillingInfo {
     /// World object ref (e.g. "oak_tree", "copper_vein")
     #[prost(string, optional, tag = "7")]
     pub resource_node: ::core::option::Option<::prost::alloc::string::String>,
+    /// 0-100 preference weight when the harvester has multiple eligible targets
+    #[prost(int32, optional, tag = "8")]
+    pub harvest_weight: ::core::option::Option<i32>,
+}
+/// Compression / consolidation — many small stacks fuse into one bulk item.
+/// Used by storage consolidators, granaries, smelters that batch raw stock into
+/// construction-grade output.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CompressInfo {
+    /// Output item ref (e.g. "timber" for wood-log compression)
+    #[prost(string, tag = "1")]
+    pub target_ref: ::prost::alloc::string::String,
+    /// Input units per single output unit
+    #[prost(int32, tag = "2")]
+    pub ratio: i32,
+    /// Required facility ref for the consolidation (optional)
+    #[prost(string, optional, tag = "3")]
+    pub facility: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Stack / inventory handling hints that go beyond raw max_stack.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StackingInfo {
+    /// Per-unit carried stack cap (distinct from storage max_stack)
+    #[prost(int32, optional, tag = "1")]
+    pub pack_max: ::core::option::Option<i32>,
+    /// Cannot be carried by a unit (storage-only, e.g. gold bars)
+    #[prost(bool, optional, tag = "2")]
+    pub no_pack: ::core::option::Option<bool>,
+    /// Logical group (e.g. "food") — any item with the same pool_group substitutes
+    #[prost(string, optional, tag = "3")]
+    pub pool_group: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Weapon properties — for items with ITEM_TYPE_WEAPON or ITEM_TYPE_COMBAT flag.
+/// Covers both melee and ranged; 0 range = melee. Ammo linkage is bow→arrow
+/// via ammo_ref (primary) and compatible_ammo (alternates).
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct WeaponInfo {
+    /// Reach in tiles/meters (0 or 1 = melee)
+    #[prost(float, optional, tag = "1")]
+    pub range: ::core::option::Option<f32>,
+    /// Attacks per second; lower = slower
+    #[prost(float, optional, tag = "2")]
+    pub attack_speed: ::core::option::Option<f32>,
+    /// Visual/entity projectile ref for ranged
+    #[prost(string, optional, tag = "3")]
+    pub projectile_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Primary consumed ammo item ref (e.g. "arrow")
+    #[prost(string, optional, tag = "4")]
+    pub ammo_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Alternate ammo accepted
+    #[prost(string, repeated, tag = "5")]
+    pub compatible_ammo: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(enumeration = "Element", optional, tag = "6")]
+    pub damage_element: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag = "7")]
+    pub min_damage: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag = "8")]
+    pub max_damage: ::core::option::Option<i32>,
+    #[prost(float, optional, tag = "9")]
+    pub crit_chance: ::core::option::Option<f32>,
+    #[prost(float, optional, tag = "10")]
+    pub crit_damage: ::core::option::Option<f32>,
+    /// Ticks before the swing lands
+    #[prost(int32, optional, tag = "11")]
+    pub windup_ticks: ::core::option::Option<i32>,
+    /// Post-swing lockout
+    #[prost(int32, optional, tag = "12")]
+    pub recovery_ticks: ::core::option::Option<i32>,
+    /// Area of effect radius in tiles (0 = single-target)
+    #[prost(int32, optional, tag = "13")]
+    pub aoe_radius: ::core::option::Option<i32>,
+    /// Occupies both hands even if slot = main_hand
+    #[prost(bool, optional, tag = "14")]
+    pub two_handed: ::core::option::Option<bool>,
+    /// Limited-use charges (wands, one-shots); 0 = unlimited
+    #[prost(int32, optional, tag = "15")]
+    pub charges: ::core::option::Option<i32>,
+}
+/// Fuel / combustible — for items that burn in furnaces, cookfires, campfires.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct FuelInfo {
+    /// Base burn duration per unit
+    #[prost(int32, tag = "1")]
+    pub burn_seconds: i32,
+    /// Relative heat rating (cookfire needs 1, smelter 3, etc.)
+    #[prost(int32, optional, tag = "2")]
+    pub heat_output: ::core::option::Option<i32>,
+    /// Item left over after burn (e.g. "ash")
+    #[prost(string, optional, tag = "3")]
+    pub residue_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// 0.0-1.0 probability of producing residue per unit
+    #[prost(float, optional, tag = "4")]
+    pub residue_chance: ::core::option::Option<f32>,
+    /// Regrows/crafts indefinitely (wood vs coal)
+    #[prost(bool, optional, tag = "5")]
+    pub renewable: ::core::option::Option<bool>,
+}
+/// Container capacity — for pouches, bags, quivers, and deployed chests.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct ContainerInfo {
+    /// Extra pack slots granted when equipped
+    #[prost(int32, optional, tag = "1")]
+    pub added_slots: ::core::option::Option<i32>,
+    /// Multiplier applied to base pack capacity (default 1.0)
+    #[prost(float, optional, tag = "2")]
+    pub volume_multiplier: ::core::option::Option<f32>,
+    /// 0.0-1.0 fraction by which contained items weigh less
+    #[prost(float, optional, tag = "3")]
+    pub weight_reduction: ::core::option::Option<f32>,
+    /// Tag filter — only matching items can be stored (empty = any)
+    #[prost(string, repeated, tag = "4")]
+    pub category_filter: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// For deployed chests: standalone storage capacity
+    #[prost(int32, optional, tag = "5")]
+    pub storage_slots: ::core::option::Option<i32>,
+    /// Deployed chests: contents visible to all allied units
+    #[prost(bool, optional, tag = "6")]
+    pub shared_inventory: ::core::option::Option<bool>,
+    /// Requires key or owner to access
+    #[prost(bool, optional, tag = "7")]
+    pub locked_by_default: ::core::option::Option<bool>,
+}
+/// Planting / farming — for seeds or saplings.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct PlantingInfo {
+    /// Item produced when the plant matures
+    #[prost(string, tag = "1")]
+    pub grows_into_ref: ::prost::alloc::string::String,
+    /// Growth time in seconds
+    #[prost(int32, tag = "2")]
+    pub grow_seconds: i32,
+    /// Output quantity per mature plant (default 1)
+    #[prost(int32, optional, tag = "3")]
+    pub yield_amount: ::core::option::Option<i32>,
+    /// Tile type slug (e.g. "farmland", "desert-sand")
+    #[prost(string, optional, tag = "4")]
+    pub required_tile: ::core::option::Option<::prost::alloc::string::String>,
+    /// 0-255 light level minimum
+    #[prost(int32, optional, tag = "5")]
+    pub required_light: ::core::option::Option<i32>,
+    /// Water units consumed per hour (0 = rain-fed)
+    #[prost(float, optional, tag = "6")]
+    pub water_per_hour: ::core::option::Option<f32>,
+    /// If true, plant regrows rather than being destroyed
+    #[prost(bool, optional, tag = "7")]
+    pub multi_harvest: ::core::option::Option<bool>,
+    /// Regrowth interval for multi-harvest plants
+    #[prost(int32, optional, tag = "8")]
+    pub regrow_seconds: ::core::option::Option<i32>,
+    /// Allowed season slug (e.g. "spring", "year-round")
+    #[prost(string, optional, tag = "9")]
+    pub season: ::core::option::Option<::prost::alloc::string::String>,
+    /// 0.0-1.0 survival in cold
+    #[prost(float, optional, tag = "10")]
+    pub frost_tolerance: ::core::option::Option<f32>,
+}
+/// Projectile flight / impact — for arrows, bolts, thrown items, magic bolts.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct ProjectileInfo {
+    /// Travel speed in tiles/sec
+    #[prost(float, optional, tag = "1")]
+    pub speed: ::core::option::Option<f32>,
+    /// 0 = flat trajectory; higher = arcing
+    #[prost(float, optional, tag = "2")]
+    pub gravity: ::core::option::Option<f32>,
+    /// Targets pierced before the projectile dies
+    #[prost(int32, optional, tag = "3")]
+    pub pierce_count: ::core::option::Option<i32>,
+    /// VFX slug on hit
+    #[prost(string, optional, tag = "4")]
+    pub impact_effect_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// VFX slug during flight
+    #[prost(string, optional, tag = "5")]
+    pub trail_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Tracks target in flight
+    #[prost(bool, optional, tag = "6")]
+    pub homing: ::core::option::Option<bool>,
+    /// AoE on impact (0 = single-target)
+    #[prost(int32, optional, tag = "7")]
+    pub splash_radius: ::core::option::Option<i32>,
+    /// 0.0-1.0 damage falloff at the edge
+    #[prost(float, optional, tag = "8")]
+    pub splash_falloff: ::core::option::Option<f32>,
+}
+/// Spell properties — for scrolls, tomes, wands, staves that cast or teach a spell.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct SpellInfo {
+    /// Spell slug (e.g. "fireball", "ice-shard")
+    #[prost(string, tag = "1")]
+    pub spell_ref: ::prost::alloc::string::String,
+    /// Mana consumed per cast
+    #[prost(int32, optional, tag = "2")]
+    pub mana_cost: ::core::option::Option<i32>,
+    /// Channel / cast time before the spell fires
+    #[prost(float, optional, tag = "3")]
+    pub cast_seconds: ::core::option::Option<f32>,
+    /// Post-cast lockout
+    #[prost(float, optional, tag = "4")]
+    pub cooldown_seconds: ::core::option::Option<f32>,
+    /// Stat that scales damage (e.g. "intelligence")
+    #[prost(string, optional, tag = "5")]
+    pub scaling_stat: ::core::option::Option<::prost::alloc::string::String>,
+    /// How much the stat contributes
+    #[prost(float, optional, tag = "6")]
+    pub scaling_multiplier: ::core::option::Option<f32>,
+    #[prost(int32, optional, tag = "7")]
+    pub base_damage: ::core::option::Option<i32>,
+    #[prost(enumeration = "Element", optional, tag = "8")]
+    pub element: ::core::option::Option<i32>,
+    /// Max casting distance
+    #[prost(float, optional, tag = "9")]
+    pub range: ::core::option::Option<f32>,
+    #[prost(int32, optional, tag = "10")]
+    pub aoe_radius: ::core::option::Option<i32>,
+    /// True for tomes that add the spell to the caster's book
+    #[prost(bool, optional, tag = "11")]
+    pub teaches_permanent: ::core::option::Option<bool>,
+    /// True for one-shot scrolls
+    #[prost(bool, optional, tag = "12")]
+    pub consumed_on_cast: ::core::option::Option<bool>,
+    /// Remaining casts (0 = unlimited)
+    #[prost(int32, optional, tag = "13")]
+    pub charges: ::core::option::Option<i32>,
+    /// Additional effects applied on cast
+    #[prost(message, repeated, tag = "14")]
+    pub side_effects: ::prost::alloc::vec::Vec<UseEffect>,
+}
+/// Book properties — for readable items (lore books, journals, recipe books).
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct BookInfo {
+    /// Full readable text
+    #[prost(string, optional, tag = "1")]
+    pub body_text: ::core::option::Option<::prost::alloc::string::String>,
+    /// Reference to external MDX / markdown asset
+    #[prost(string, optional, tag = "2")]
+    pub body_text_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Approximate time to read through
+    #[prost(int32, optional, tag = "3")]
+    pub reading_seconds: ::core::option::Option<i32>,
+    /// Granted CraftingRecipe on first read
+    #[prost(string, optional, tag = "4")]
+    pub teaches_recipe_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Granted SpellInfo on first read
+    #[prost(string, optional, tag = "5")]
+    pub teaches_spell_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Codex entry slug to reveal
+    #[prost(string, optional, tag = "6")]
+    pub unlocks_lore_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// True when the book crumbles / is used up
+    #[prost(bool, optional, tag = "7")]
+    pub consumed_on_read: ::core::option::Option<bool>,
+    /// Language slug for locale gating
+    #[prost(string, optional, tag = "8")]
+    pub language: ::core::option::Option<::prost::alloc::string::String>,
+    /// Ordered chapter/page slugs for paginated reading
+    #[prost(string, repeated, tag = "9")]
+    pub chapters: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Key properties — for items that unlock specific world entities.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct KeyInfo {
+    /// World entity / structure slug this key opens
+    #[prost(string, tag = "1")]
+    pub unlocks_ref: ::prost::alloc::string::String,
+    /// "door", "chest", "gate", "cell"
+    #[prost(string, optional, tag = "2")]
+    pub unlock_category: ::core::option::Option<::prost::alloc::string::String>,
+    /// True if the key is destroyed on unlock
+    #[prost(bool, optional, tag = "3")]
+    pub consumed_on_use: ::core::option::Option<bool>,
+    /// Optional item granted when unlock succeeds
+    #[prost(string, optional, tag = "4")]
+    pub grant_item_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Number of unlocks before the key breaks (0 = unlimited)
+    #[prost(int32, optional, tag = "5")]
+    pub uses: ::core::option::Option<i32>,
+    /// Faction slug required to use the key
+    #[prost(string, optional, tag = "6")]
+    pub faction_lock: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Vehicle / mount properties — for boats, carts, horses, mechanical conveyances.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct VehicleInfo {
+    /// Peak movement speed
+    #[prost(float, optional, tag = "1")]
+    pub max_speed: ::core::option::Option<f32>,
+    #[prost(float, optional, tag = "2")]
+    pub acceleration: ::core::option::Option<f32>,
+    #[prost(float, optional, tag = "3")]
+    pub turn_rate: ::core::option::Option<f32>,
+    /// How many units can ride (driver + passengers)
+    #[prost(int32, optional, tag = "4")]
+    pub passenger_capacity: ::core::option::Option<i32>,
+    /// Consumed fuel item ref (empty = self-propelled)
+    #[prost(string, optional, tag = "5")]
+    pub fuel_ref: ::core::option::Option<::prost::alloc::string::String>,
+    /// Fuel units per tile / meter
+    #[prost(float, optional, tag = "6")]
+    pub fuel_per_distance: ::core::option::Option<f32>,
+    /// "water", "land", "air", "amphibious"
+    #[prost(string, optional, tag = "7")]
+    pub terrain_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// Independent cargo-hold slots
+    #[prost(int32, optional, tag = "8")]
+    pub cargo_slots: ::core::option::Option<i32>,
+    #[prost(float, optional, tag = "9")]
+    pub cargo_weight_capacity: ::core::option::Option<f32>,
+    /// 0.0-1.0 hit absorption for riders
+    #[prost(float, optional, tag = "10")]
+    pub damage_reduction: ::core::option::Option<f32>,
+    /// Mount must be tamed / leashed before use
+    #[prost(bool, optional, tag = "11")]
+    pub requires_leash: ::core::option::Option<bool>,
+}
+/// Trap / hazard — for placed items that trigger on contact.
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct TrapInfo {
+    /// "step", "proximity", "timer"
+    #[prost(string, optional, tag = "1")]
+    pub trigger: ::core::option::Option<::prost::alloc::string::String>,
+    /// Time before the trap becomes active after placement
+    #[prost(int32, optional, tag = "2")]
+    pub arming_seconds: ::core::option::Option<i32>,
+    /// Activation radius for proximity traps
+    #[prost(int32, optional, tag = "3")]
+    pub proximity_radius: ::core::option::Option<i32>,
+    /// Uses before the trap is spent (0 = unlimited)
+    #[prost(int32, optional, tag = "4")]
+    pub max_triggers: ::core::option::Option<i32>,
+    /// Can be picked back up after triggering
+    #[prost(bool, optional, tag = "5")]
+    pub reusable: ::core::option::Option<bool>,
+    /// Effects applied to anything caught
+    #[prost(message, repeated, tag = "6")]
+    pub on_trigger: ::prost::alloc::vec::Vec<UseEffect>,
 }
 /// Item set definition — bonuses for wearing multiple pieces
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
@@ -412,9 +806,6 @@ pub struct Item {
     /// Food / consumable
     #[prost(message, optional, tag = "41")]
     pub food: ::core::option::Option<FoodInfo>,
-    /// Skilling / gathering
-    #[prost(message, optional, tag = "42")]
-    pub skilling: ::core::option::Option<SkillingInfo>,
     /// Crafting
     ///
     /// Ways to craft this item
@@ -448,6 +839,59 @@ pub struct Item {
     pub durability: ::core::option::Option<i32>,
     #[prost(int32, optional, tag = "47")]
     pub max_durability: ::core::option::Option<i32>,
+    /// Stacking & carry-capacity hints (beyond raw max_stack)
+    #[prost(message, optional, tag = "49")]
+    pub stacking: ::core::option::Option<StackingInfo>,
+    /// Logical pool this item belongs to (e.g. "food" — any member satisfies a
+    /// food-pool consumption). Shortcut for the common case where no other
+    /// StackingInfo fields are set.
+    #[prost(string, optional, tag = "50")]
+    pub pool_group: ::core::option::Option<::prost::alloc::string::String>,
+    /// Weapon specifics — range, projectile, ammo linkage
+    #[prost(message, optional, tag = "51")]
+    pub weapon: ::core::option::Option<WeaponInfo>,
+    /// Fuel / combustible behavior
+    #[prost(message, optional, tag = "52")]
+    pub fuel: ::core::option::Option<FuelInfo>,
+    /// Container / storage expansion when equipped or deployed
+    #[prost(message, optional, tag = "53")]
+    pub container: ::core::option::Option<ContainerInfo>,
+    /// Planting / farming data (seeds, saplings)
+    #[prost(message, optional, tag = "54")]
+    pub planting: ::core::option::Option<PlantingInfo>,
+    /// Projectile flight properties (arrows, bolts, thrown items)
+    #[prost(message, optional, tag = "55")]
+    pub projectile: ::core::option::Option<ProjectileInfo>,
+    /// Trap / hazard behavior
+    #[prost(message, optional, tag = "56")]
+    pub trap: ::core::option::Option<TrapInfo>,
+    /// Enchantment payload — present when the item itself is an enchantment
+    /// (gem, rune, sigil) that can be attached to an EquipmentInfo slot.
+    #[prost(message, optional, tag = "57")]
+    pub enchantment: ::core::option::Option<EnchantmentInfo>,
+    /// Physical volume (parallel to weight) for volume-aware containers
+    #[prost(float, optional, tag = "58")]
+    pub volume: ::core::option::Option<f32>,
+    /// Spell data — scrolls, tomes, wands, staves
+    #[prost(message, optional, tag = "59")]
+    pub spell: ::core::option::Option<SpellInfo>,
+    /// Book data — readable lore, journals, recipe books
+    #[prost(message, optional, tag = "60")]
+    pub book: ::core::option::Option<BookInfo>,
+    /// Key data — entity-unlocking items
+    #[prost(message, optional, tag = "61")]
+    pub unlock: ::core::option::Option<KeyInfo>,
+    /// Vehicle / mount data — boats, carts, horses, conveyances
+    #[prost(message, optional, tag = "62")]
+    pub vehicle: ::core::option::Option<VehicleInfo>,
+    /// Light emission — torches, lanterns, glowing items
+    ///
+    /// Tiles/meters of light cast (0 = no light)
+    #[prost(float, optional, tag = "63")]
+    pub light_radius: ::core::option::Option<f32>,
+    /// Hex color ("#ffcc88") or named slug ("warm", "cold")
+    #[prost(string, optional, tag = "64")]
+    pub light_color: ::core::option::Option<::prost::alloc::string::String>,
     /// Extensions — game-specific key-value pairs
     #[prost(message, repeated, tag = "38")]
     pub extensions: ::prost::alloc::vec::Vec<ItemExtension>,
@@ -457,6 +901,19 @@ pub struct Item {
     /// Hidden from production
     #[prost(bool, optional, tag = "40")]
     pub drafted: ::core::option::Option<bool>,
+    /// Numeric runtime identifier — authored per-item in MDX, stable across builds.
+    /// Primary lookup key for engines + the rareicon ItemId enum.
+    #[prost(int32, tag = "65")]
+    pub key: i32,
+    /// Sprite asset present (derived from `img`)
+    #[prost(bool, optional, tag = "66")]
+    pub has_img: ::core::option::Option<bool>,
+    /// Freeform stat bonuses authored flat in MDX. Heterogeneous by nature (numbers
+    /// like cookingSpeed/fireResist plus boolean flags like quantumFlux), so it is
+    /// an arbitrary JSON object rather than the fixed-field ItemBonuses message.
+    #[prost(message, optional, tag = "67")]
+    #[serde(skip)]
+    pub bonuses: ::core::option::Option<::prost_types::Struct>,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ItemRegistry {
@@ -785,6 +1242,12 @@ pub enum UseEffectType {
     UseEffectBuffParty = 12,
     UseEffectSummon = 13,
     UseEffectTransform = 14,
+    /// Blueprints — teaches a CraftingRecipe
+    UseEffectLearnRecipe = 15,
+    /// Tomes — adds a spell to the spellbook
+    UseEffectLearnSpell = 16,
+    /// Lore pickups — reveals a codex entry
+    UseEffectUnlockLore = 17,
 }
 impl UseEffectType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -808,6 +1271,9 @@ impl UseEffectType {
             Self::UseEffectBuffParty => "USE_EFFECT_BUFF_PARTY",
             Self::UseEffectSummon => "USE_EFFECT_SUMMON",
             Self::UseEffectTransform => "USE_EFFECT_TRANSFORM",
+            Self::UseEffectLearnRecipe => "USE_EFFECT_LEARN_RECIPE",
+            Self::UseEffectLearnSpell => "USE_EFFECT_LEARN_SPELL",
+            Self::UseEffectUnlockLore => "USE_EFFECT_UNLOCK_LORE",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -828,6 +1294,9 @@ impl UseEffectType {
             "USE_EFFECT_BUFF_PARTY" => Some(Self::UseEffectBuffParty),
             "USE_EFFECT_SUMMON" => Some(Self::UseEffectSummon),
             "USE_EFFECT_TRANSFORM" => Some(Self::UseEffectTransform),
+            "USE_EFFECT_LEARN_RECIPE" => Some(Self::UseEffectLearnRecipe),
+            "USE_EFFECT_LEARN_SPELL" => Some(Self::UseEffectLearnSpell),
+            "USE_EFFECT_UNLOCK_LORE" => Some(Self::UseEffectUnlockLore),
             _ => None,
         }
     }


### PR DESCRIPTION
## Phase 2b-Rust — professiondb engine consumers (Rust half)

Part of the professiondb unification epic (#14852). Migrates the **Rust** consumers off the now-reserved itemdb proto fields `Item.skilling`(42) / `Item.compress`(48) / `FoodInfo.cooking_level`(3) / `cooking_xp`(4) onto the new professiondb loader. Unity half deferred to Phase 2b-Unity.

### What changed
- **New `bevy_items::profession` loader** — serde parse of `professiondb-data.json` into `item_ref → GatherInfo{skill_ref, required_level, xp_reward, resource_node_ref}` (from `gather-*` actions) and `item_ref → CompressInfo{target_ref, ratio}` (from `compress-*` actions). Process-global `OnceLock` accessor mirrors the existing itemdb pattern. Fixture test.
- **axum-kbve** embeds `professiondb-data.json` (`include_str!`) and rewires the two gameserver sites:
  - collect-gating: gate on `gather.required_level` vs `profile.level(SkillId::from_ref(&gather.skill_ref))`
  - XP-grant: award `gather.xp_reward` to `gather.skill_ref`
  - old `Item.skilling` / `SkillingType` path removed.
- **itemdb proto regenerated** (`BUILD_PROTO=1`) — reserved fields gone; `json.rs` literals use `..Default::default()`; dead `parse_skilling`/`parse_skilling_type` deleted. Regen + fixes land in **one atomic commit** (workspace never broken).
- Divergence: regen surfaced pre-existing `Item.bonuses: Option<prost_types::Struct>` → added `prost-types = "0.14"` + `#[serde(skip)]` (necessary; `Item.bonuses` never populated in Rust, only `EquipmentInfo.bonuses` is read).

### Verification
- `bevy_items` build + test + clippy `-D warnings` clean.
- `axum-kbve` builds clean; `cargo check` of arpg-server / isometric-game / discordsh-bot / bevy_items / axum-kbve all exit 0.
- XP/gating **parity verified against real old itemdb data** (log 10→10, copper-ore 18→18, zero-xp drops stay 0).

### Follow-ups (epic, non-blocking)
- Delete orphaned `skilling_type_to_skill_ref` + Rust-unused `SkillingType`/`SkillingInfo` once TS/other consumers are off them (kept intentionally this PR).
- Load-time profession-ref → SkillRegistry assertion (Decision 4 hardening).
- Phase 2b-Unity: rareicon C# loader.

Docs: [Phase 2b-Rust plan](docs/superpowers/plans/2026-08-01-professiondb-phase2b-rust-consumers.md)