### PR TITLE
perf(herbmail-game): ship dungeon art at 256px

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/assetBase.ts
+++ b/apps/herbmail/herbmail-game/src/game/assetBase.ts
@@ -1,10 +1,22 @@
 import * as THREE from 'three';
+import hashes from 'virtual:asset-hashes';
 
 const ASSET_BASE = import.meta.env.BASE_URL;
+const DEV = import.meta.env.DEV;
+const DEV_V = DEV ? `?v=${Date.now()}` : '';
 
-export const asset = (url: string): string =>
-	url.startsWith('/') && !url.startsWith('//')
-		? ASSET_BASE + url.slice(1)
-		: url;
+// Every three loader resolves through here, so this is where public/ assets get
+// their cache key. Textures are rewritten on the way into dist (downscaled) at
+// a stable URL, so without a version they would be served from whatever the
+// browser cached. Callers that already versioned a URL — modelUrl() — carry a
+// query and are left alone rather than stacking a second one.
+export const asset = (url: string): string => {
+	if (!url.startsWith('/') || url.startsWith('//')) return url;
+	const based = ASSET_BASE + url.slice(1);
+	if (based.includes('?')) return based;
+	if (DEV) return `${based}${DEV_V}`;
+	const h = hashes[url];
+	return h ? `${based}?v=${h}` : based;
+};
 
 THREE.DefaultLoadingManager.setURLModifier(asset);

--- a/apps/herbmail/herbmail-game/src/game/character/modelUrl.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/modelUrl.ts
@@ -1,12 +1,15 @@
-import hashes from 'virtual:model-hashes';
+import hashes from 'virtual:asset-hashes';
 
 const DEV = import.meta.env.DEV;
 const DEV_V = DEV ? `?v=${Date.now()}` : '';
 
-export function modelUrl(path: string): string {
+export function assetUrl(path: string): string {
 	if (DEV) return `${path}${DEV_V}`;
 	const h = hashes[path];
 	return h ? `${path}?v=${h}` : path;
 }
+
+export const modelUrl = assetUrl;
+export const textureUrl = assetUrl;
 
 export const CHARACTER_URL = modelUrl('/models/character-anim.glb');

--- a/apps/herbmail/herbmail-game/src/types/asset_hashes.d.ts
+++ b/apps/herbmail/herbmail-game/src/types/asset_hashes.d.ts
@@ -1,4 +1,4 @@
-declare module 'virtual:model-hashes' {
+declare module 'virtual:asset-hashes' {
 	const hashes: Record<string, string | undefined>;
 	export default hashes;
 }

--- a/apps/herbmail/herbmail-game/tools/textureSize.test.ts
+++ b/apps/herbmail/herbmail-game/tools/textureSize.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isPowerOfTwo,
+	plannedSize,
+	preservesPowerOfTwo,
+} from './textureSize';
+
+describe('plannedSize', () => {
+	it('halves a 512 square to the 256 budget', () => {
+		expect(plannedSize({ width: 512, height: 512 }, 256)).toEqual({
+			width: 256,
+			height: 256,
+		});
+	});
+
+	it('skips art already within budget', () => {
+		expect(plannedSize({ width: 256, height: 256 }, 256)).toBeNull();
+		expect(plannedSize({ width: 64, height: 64 }, 256)).toBeNull();
+	});
+
+	it('clamps the longest edge and keeps aspect', () => {
+		expect(plannedSize({ width: 1024, height: 512 }, 256)).toEqual({
+			width: 256,
+			height: 128,
+		});
+	});
+
+	it('never rounds an edge away to zero', () => {
+		const out = plannedSize({ width: 4096, height: 1 }, 256)!;
+		expect(out.height).toBeGreaterThanOrEqual(1);
+	});
+
+	it('keeps power-of-two art power-of-two', () => {
+		for (const src of [512, 1024, 2048]) {
+			const out = plannedSize({ width: src, height: src }, 256)!;
+			expect(preservesPowerOfTwo({ width: src, height: src }, out)).toBe(
+				true,
+			);
+		}
+	});
+
+	it('flags a non-power-of-two result for power-of-two source', () => {
+		expect(
+			preservesPowerOfTwo(
+				{ width: 512, height: 512 },
+				{ width: 300, height: 300 },
+			),
+		).toBe(false);
+	});
+
+	it('does not constrain art that was never power-of-two', () => {
+		expect(
+			preservesPowerOfTwo(
+				{ width: 640, height: 480 },
+				{ width: 256, height: 192 },
+			),
+		).toBe(true);
+	});
+});
+
+describe('isPowerOfTwo', () => {
+	it('classifies sizes', () => {
+		expect([1, 2, 64, 256, 512].every(isPowerOfTwo)).toBe(true);
+		expect([0, 3, 100, 513].some(isPowerOfTwo)).toBe(false);
+	});
+});

--- a/apps/herbmail/herbmail-game/tools/textureSize.ts
+++ b/apps/herbmail/herbmail-game/tools/textureSize.ts
@@ -1,0 +1,29 @@
+export interface Size {
+	width: number;
+	height: number;
+}
+
+// Longest edge is clamped to max, aspect preserved, and the result is rounded
+// to whole pixels. Returns null when the image is already within budget so the
+// caller can skip re-encoding it.
+export function plannedSize(src: Size, max: number): Size | null {
+	const longest = Math.max(src.width, src.height);
+	if (longest <= max) return null;
+	const scale = max / longest;
+	return {
+		width: Math.max(1, Math.round(src.width * scale)),
+		height: Math.max(1, Math.round(src.height * scale)),
+	};
+}
+
+// Tiling art has to stay power-of-two or the wrap seams stop lining up, so a
+// power-of-two source must land on a power-of-two target.
+export function isPowerOfTwo(n: number): boolean {
+	return n > 0 && (n & (n - 1)) === 0;
+}
+
+export function preservesPowerOfTwo(src: Size, out: Size): boolean {
+	const srcPot = isPowerOfTwo(src.width) && isPowerOfTwo(src.height);
+	if (!srcPot) return true;
+	return isPowerOfTwo(out.width) && isPowerOfTwo(out.height);
+}

--- a/apps/herbmail/herbmail-game/vite.config.ts
+++ b/apps/herbmail/herbmail-game/vite.config.ts
@@ -11,6 +11,12 @@ import {
 	meshNodeNamesInFile,
 	restoreMeshNamesInFile,
 } from './tools/glbNames';
+import { plannedSize, preservesPowerOfTwo } from './tools/textureSize';
+
+// Dungeon art is authored at 512 and shipped at PSX scale. Sources in
+// public/textures stay full-res LFS truth exactly like the models; only the
+// dist copy is shrunk, so retargeting is one constant rather than a re-export.
+const MAX_TEXTURE_SIZE = 256;
 
 const laserSrc = path.resolve(__dirname, '../../../packages/npm/laser/src');
 const generated = path.resolve(
@@ -87,40 +93,48 @@ function iconStudioWriter(): Plugin {
 	};
 }
 
-const MODEL_HASHES_ID = 'virtual:model-hashes';
+const ASSET_HASHES_ID = 'virtual:asset-hashes';
 
-function modelHashes(): Plugin {
+// Textures are downscaled on the way into dist, so their shipped bytes change
+// without the source changing. Salting the texture hash with the target size
+// keeps a retarget from serving whatever the browser already cached.
+function assetHashes(): Plugin {
 	const publicDir = path.resolve(__dirname, 'public');
-	const modelsDir = path.join(publicDir, 'models');
 	const build = () => {
 		const out: Record<string, string> = {};
-		const walk = (dir: string) => {
+		const walk = (dir: string, match: RegExp, salt: string) => {
 			if (!fs.existsSync(dir)) return;
 			for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
 				const p = path.join(dir, e.name);
 				if (e.isDirectory()) {
-					walk(p);
+					walk(p, match, salt);
 					continue;
 				}
-				if (!e.name.endsWith('.glb')) continue;
+				if (!match.test(e.name)) continue;
 				const url = `/${path.relative(publicDir, p).split(path.sep).join('/')}`;
 				out[url] = crypto
 					.createHash('sha256')
 					.update(fs.readFileSync(p))
+					.update(salt)
 					.digest('hex')
 					.slice(0, 8);
 			}
 		};
-		walk(modelsDir);
+		walk(path.join(publicDir, 'models'), /\.glb$/i, '');
+		walk(
+			path.join(publicDir, 'textures'),
+			/\.(png|jpe?g)$/i,
+			`max=${MAX_TEXTURE_SIZE}`,
+		);
 		return out;
 	};
 	return {
-		name: 'model-hashes',
+		name: 'asset-hashes',
 		resolveId(id) {
-			return id === MODEL_HASHES_ID ? `\0${MODEL_HASHES_ID}` : null;
+			return id === ASSET_HASHES_ID ? `\0${ASSET_HASHES_ID}` : null;
 		},
 		load(id) {
-			if (id !== `\0${MODEL_HASHES_ID}`) return null;
+			if (id !== `\0${ASSET_HASHES_ID}`) return null;
 			return `export default ${JSON.stringify(build())};`;
 		},
 	};
@@ -194,6 +208,74 @@ function gltfpackModels(): Plugin {
 	};
 }
 
+function downscaleTextures(): Plugin {
+	let outDir = '';
+	return {
+		name: 'downscale-textures',
+		apply: 'build',
+		configResolved(config) {
+			outDir = path.resolve(config.root, config.build.outDir);
+		},
+		async closeBundle() {
+			const require = createRequire(import.meta.url);
+			let sharp: typeof import('sharp');
+			try {
+				sharp = require('sharp');
+			} catch {
+				throw new Error(
+					'downscale-textures: sharp is not installed; textures would ship at source resolution',
+				);
+			}
+
+			const files: string[] = [];
+			const walk = (dir: string) => {
+				if (!fs.existsSync(dir)) return;
+				for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+					const p = path.join(dir, e.name);
+					if (e.isDirectory()) walk(p);
+					else if (/\.(png|jpe?g)$/i.test(e.name)) files.push(p);
+				}
+			};
+			walk(path.join(outDir, 'textures'));
+
+			let shrunk = 0;
+			let before = 0;
+			let after = 0;
+			for (const f of files) {
+				const src = await sharp(f).metadata();
+				if (!src.width || !src.height) continue;
+				const out = plannedSize(
+					{ width: src.width, height: src.height },
+					MAX_TEXTURE_SIZE,
+				);
+				if (!out) continue;
+				if (
+					!preservesPowerOfTwo(
+						{ width: src.width, height: src.height },
+						out,
+					)
+				)
+					throw new Error(
+						`downscale-textures: ${path.relative(outDir, f)} ${src.width}x${src.height} -> ${out.width}x${out.height} breaks power-of-two tiling`,
+					);
+
+				const sizeBefore = fs.statSync(f).size;
+				const buf = await sharp(f)
+					.resize(out.width, out.height, { kernel: 'mitchell' })
+					.toBuffer();
+				fs.writeFileSync(f, buf);
+				before += sizeBefore;
+				after += buf.length;
+				shrunk++;
+			}
+			if (shrunk)
+				console.log(
+					`downscale-textures: ${shrunk}/${files.length} textures -> max ${MAX_TEXTURE_SIZE}px, ${(before / 1024).toFixed(0)}K -> ${(after / 1024).toFixed(0)}K`,
+				);
+		},
+	};
+}
+
 // Cross-origin isolation enables SharedArrayBuffer (worker/GPU shared memory).
 // Dev + preview set the headers directly; the built bundle relies on
 // coi-serviceworker.js (public/) so the itch upload is isolated on any static host.
@@ -209,8 +291,9 @@ export default defineConfig({
 		react(),
 		nxViteTsPaths(),
 		iconStudioWriter(),
-		modelHashes(),
+		assetHashes(),
 		gltfpackModels(),
+		downscaleTextures(),
 	],
 	resolve: {
 		alias: [itemdbDataAlias, itemdbSchemaAlias],
@@ -224,7 +307,7 @@ export default defineConfig({
 	},
 	worker: {
 		format: 'es',
-		plugins: () => [nxViteTsPaths(), modelHashes()],
+		plugins: () => [nxViteTsPaths(), assetHashes()],
 	},
 	build: {
 		outDir: '../../../dist/apps/herbmail/herbmail-game',

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"react": "19.2.3",
 		"react-dom": "19.2.3",
 		"rehype-external-links": "^3.0.0",
+		"sharp": "^0.34.5",
 		"starlight-site-graph": "^0.5.0",
 		"tailwindcss": "^4.1.3",
 		"ts-node": "10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       starlight-site-graph:
         specifier: ^0.5.0
         version: 0.5.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1(supports-color@10.2.2))(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0(supports-color@10.2.2))(terser@5.49.0)(yaml@2.9.0))(supports-color@10.2.2)(typescript@6.0.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0(supports-color@10.2.2))(terser@5.49.0)(yaml@2.9.0))
@@ -8790,6 +8793,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -19987,7 +19991,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':


### PR DESCRIPTION
## Correction first

I previously reported textures as "already fine, ~3.1MB, don't bother". That was wrong. My census read material *properties*, but the PSX materials are `ShaderMaterial`s whose textures live in `uniforms[x].value`, so it found 15 of 236 textures and missed every render target. Re-measured properly: **68.2MB** of texture memory.

## What this changes

Wall and door sets are authored at 512 with colour + normal + har each — roughly 21MB of that total. They are now downscaled into `dist` at build time, mirroring how gltfpack packs the models: `public/textures` stays full-res LFS truth, and retargeting is one constant (`MAX_TEXTURE_SIZE`) rather than a re-export.

Measured on a production preview build:

| | before | after |
| --- | --- | --- |
| texture VRAM | 68.2 MB | **49.2 MB** |
| on disk | 6374 K | **2027 K** (19 of 42 files) |
| 512² textures | 28 | 9 (render targets only) |

Normal and har maps are **kept** — this is a PS2-era look, not PS1 hardware accuracy, so the POM height and normal-strength tuning from #14123 stays intact and only resolution drops.

## Cache invalidation

Downscaled bytes ship at the same URL the source had — the exact setup that served stale models twice already (#15111, #15142). So the hash plugin now covers textures as well as models, **salted with the target size**, because the source file never changes when only `MAX_TEXTURE_SIZE` does.

Versioning moved into `assetBase`'s existing `DefaultLoadingManager` URL modifier — the one choke point every three loader already passes through — so no call site or `config.ts` entry needed touching. URLs `modelUrl()` already versioned carry a query and are skipped rather than stacking a second one.

## Notes

- `sharp` added as a root devDependency (already in the pnpm store as a transitive). The pass **throws** rather than silently shipping full-res art if sharp is missing.
- Power-of-two sources are asserted to stay power-of-two, so tiling seams can't drift.
- Unit tests cover the sizing logic (aspect, clamping, rounding, power-of-two preservation).

## Still the bigger win, not done here

**36MB of the remaining 49MB is per-oasis water render targets** — 6 × 1024² caustics (24MB) + 6 × 512² sim (12MB), allocated for all 6 mounted oases when at most one is visible. Pooling those to active oases is worth more than all of the art combined.

## Verification

`nx typecheck`, `nx test` (110 passed, 19 files), `nx build`, `nx e2e` (4 passed). Verified dist art is 256², source still 512², and texture URLs carry `?v=<hash>`.