### PR TITLE
fix(arpg): drop dead WildTarget.level field

### DIFF
--- a/apps/agones/arpg/server/src/capture.rs
+++ b/apps/agones/arpg/server/src/capture.rs
@@ -134,7 +134,6 @@ mod tests {
             wild: Some(crate::duel::WildTarget {
                 entity: wild_entity,
                 species_ref: crate::wild::WILD_SPECIES_REF.to_string(),
-                level: 5,
             }),
         }
     }

--- a/apps/agones/arpg/server/src/duel.rs
+++ b/apps/agones/arpg/server/src/duel.rs
@@ -34,16 +34,16 @@ pub struct Duel {
     /// refuses to release a pet while its owner is dueling.
     pub pets: [Vec<Option<Entity>>; 2],
     /// Set only for a wild encounter. Carries what the Catch action needs: the world entity to
-    /// despawn once caught, and the species + level to mint the caught pet from. `None` for
-    /// trainer and PvP duels, which is exactly what makes them uncatchable.
+    /// despawn once caught, and the species to read `capture_rate` from. `None` for trainer and
+    /// PvP duels, which is exactly what makes them uncatchable.
     pub wild: Option<WildTarget>,
 }
 
-/// The wild pet a duel is against.
+/// The wild pet a duel is against. The caught pet is minted from the live combatant, not from
+/// here, so this carries no level.
 pub struct WildTarget {
     pub entity: Entity,
     pub species_ref: String,
-    pub level: u32,
 }
 
 #[derive(bevy::prelude::Resource, Default)]
@@ -304,7 +304,6 @@ pub fn apply_npc_challenges(
                 wild: Some(WildTarget {
                     entity: trainer_entity,
                     species_ref: wild.species_ref.clone(),
-                    level: wild.level,
                 }),
             };
             claimed.insert(trainer_entity);


### PR DESCRIPTION
## Problem

`arpg-server:lint` failing:

```
error: field `level` is never read
  --> apps/agones/arpg/server/src/duel.rs:46:9
= note: `-D dead-code` implied by `-D warnings`
```

## Fix

Removed `WildTarget.level` rather than suppressing with `#[expect(dead_code)]`.

The field was a duplicate source of truth:

- `simgrid::Combatant` already carries `level` and `species_ref`, and `duel.state.enemy.active()` is the live wild pet.
- `apply_catch` / `catch_odds` scale off `hp`, `max_hp`, and `status` — not level.
- `settle_catch` mints the caught pet from the live combatant snapshot, so it keeps its found level plus battle damage and PP spend.

Anything that later wants wild level (level-scaled catch rate, encounter label) reads the combatant and cannot drift out of sync.

Doc comments on `Duel.wild` and `WildTarget` updated — the old text claimed the struct carried "species + level to mint the caught pet from", which stopped being true when minting moved to the live combatant.

## Verification

- `cargo clippy -p arpg-server --all-targets -- -D warnings` — 0 errors
- `cargo test -p arpg-server` — 53 passed