### PR TITLE
perf(herbmail-game): halve worst-frame shadow cost

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/character/Character.tsx
+++ b/apps/herbmail/herbmail-game/src/game/character/Character.tsx
@@ -128,6 +128,22 @@ function buildFlame(gripScale: number): {
 	return { flame, mats };
 }
 
+// Every caster is redrawn once per shadow-cube face, so a rig's 23 meshes cost
+// 23 x 6 draws per shadow light. Facial detail cannot resolve on a 256px cube
+// map — dropping it keeps the silhouette (body, head, hair, hands, feet) and
+// removes nine meshes per rig from every shadow refresh.
+const NO_SHADOW_SLOTS = new Set([
+	'EYEL',
+	'EYER',
+	'EBRL',
+	'EBRR',
+	'EARL',
+	'EARR',
+	'NOSE',
+	'TETH',
+	'TONG',
+]);
+
 const UPPER_BONE =
 	/spine|neck|head|clavicle|upperarm|lowerarm|hand|thumb|index|middle|ring|pinky|prop/i;
 
@@ -287,7 +303,7 @@ export function Character({
 		const s = cloneSkinned(gltf.scene);
 		s.traverse((o) => {
 			if ((o as THREE.Mesh).isMesh) {
-				o.castShadow = true;
+				o.castShadow = !NO_SHADOW_SLOTS.has(slotNameOf(o));
 				o.frustumCulled = false;
 			}
 		});

--- a/apps/herbmail/herbmail-game/src/game/render/LightSystem.ts
+++ b/apps/herbmail/herbmail-game/src/game/render/LightSystem.ts
@@ -321,7 +321,14 @@ export class LightSystem {
 		const occluderMoved =
 			Math.abs(sig - this.lastShadowSig) > SHADOW_MOVE_EPS;
 		if (occluderMoved) this.lastShadowSig = sig;
-		const refresh = occluderMoved || this.frame % 90 === 0;
+		// A point-light shadow redraws all six cube faces at once, so refreshing
+		// every caster light on the same frame stacks the whole cost into one
+		// spike — and while anything is moving that spike lands every frame.
+		// Phase the slots instead: one light per frame, so a moving scene costs
+		// a single cube refresh per frame and each light still updates every
+		// slots.length frames. Static scenes keep the rare safety tick.
+		const period = occluderMoved ? Math.max(1, this.slots.length) : 90;
+		let slotIndex = 0;
 
 		for (const slot of this.slots) {
 			const cur = slot.pos;
@@ -380,7 +387,9 @@ export class LightSystem {
 			const wasDark = sl.shadow.intensity === 0;
 			sl.shadow.intensity = slot.fade;
 			const show = slot.fade > 0;
-			if (show && (wasDark || moved || refresh)) {
+			const due = this.frame % period === slotIndex % period;
+			slotIndex++;
+			if (show && (wasDark || moved || due)) {
 				sl.shadow.needsUpdate = true;
 			}
 		}


### PR DESCRIPTION
## Where the draw calls actually were

Profiling the live scene: **73 visible shadow casters x 2 shadow lights x 6 cube faces = 876 projected shadow draws**, matching the measured gap between shadowed and unshadowed frames (1066 vs 202 calls). **67 of those 73 casters are character rigs.** The dungeon geometry does not cast at all, so chunk batching would not have touched this — a chunk-size sweep (8/12/16/24) confirmed it: mesh count fell 2289 -> 1427 while draw calls moved only 1066 -> 1044.

## Two fixes

**Facial detail no longer casts.** A rig is 23 separate skinned meshes and every one cast, so eyes, brows, ears, nose, teeth and tongue were each redrawn 12 times per refresh to contribute detail a 256px cube map cannot resolve. Silhouette only now — body, head, hair, hands, feet. Visible casters 73 -> 46.

**Shadow lights are phased.** Both refreshed on the same frame, and since `occluderMoved` fires whenever anything moves, that stacked the full cost into *every frame while walking* rather than the 90-frame safety tick. Now one cube refresh per frame, each light still updating every `slots.length` frames; the static tick is unchanged.

## Measured (spawn, production preview)

| | before | after |
| --- | --- | --- |
| peak draw calls | 1066 | **472** (-56%) |
| peak triangles | 269,347 | **143,131** (-47%) |

Steady-state frames at spawn were already 202 calls and are unchanged — this targets the worst frames, which is where the reported 1214-call readings in dense areas come from.

## Not changed

The player's cast shadow and the `CharacterShadow` catcher plane are untouched, so the visible shadow feature is intact. Armor parts still cast (they are large and read clearly).

## Verification

`nx typecheck`, `nx test` (102 passed), `nx e2e` (4 passed).