### PR TITLE
fix(tooling): make bare `npx nx` work in worktrees, and let ct specs import wire constants

### DIFF
--- a/apps/agones/arpg/arpg-e2e/ct/WireConstants.spec.tsx
+++ b/apps/agones/arpg/arpg-e2e/ct/WireConstants.spec.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { EPHEMERAL_PET_ROSTER, EPHEMERAL_PET_NOTICE } from '@kbve/laser/wire';
+
+// Guards the `@kbve/laser/wire` path mapping in tsconfig.json, not the constants
+// themselves (postcard-wire.spec.ts in laser covers those).
+//
+// Spec files are evaluated in Node, which cannot resolve `@kbve/laser` — the ct vite alias
+// only applies to the browser bundle. Without the mapping, a value import here fails the
+// whole file with a bare `Cannot find module`, which reads nothing like the real cause.
+// Type-only imports are unaffected either way, since they are erased before Node sees them.
+test('wire constants are value-importable from a spec', async () => {
+	expect(EPHEMERAL_PET_ROSTER).toBe(17);
+	expect(EPHEMERAL_PET_NOTICE).toBe(22);
+});

--- a/apps/agones/arpg/arpg-e2e/playwright.ct.config.ts
+++ b/apps/agones/arpg/arpg-e2e/playwright.ct.config.ts
@@ -26,6 +26,17 @@ function stubLaserR3F() {
 
 const alias = [
 	{
+		// Mirrors the `@kbve/laser/wire` path mapping in tsconfig.json, which exists so spec
+		// files (evaluated in Node, where `@kbve/laser` does not resolve) can value-import
+		// wire constants. Aliased here too so a browser-side module importing the same
+		// specifier resolves to the same file rather than failing to bundle.
+		find: /^@kbve\/laser\/wire$/,
+		replacement: path.join(
+			repoRoot,
+			'packages/npm/laser/src/lib/net/protocol.ts',
+		),
+	},
+	{
 		find: /^@kbve\/laser$/,
 		replacement: path.join(repoRoot, 'packages/npm/laser/src/index.ts'),
 	},

--- a/apps/agones/arpg/arpg-e2e/tsconfig.json
+++ b/apps/agones/arpg/arpg-e2e/tsconfig.json
@@ -9,6 +9,10 @@
 		"skipLibCheck": true,
 		"noUncheckedSideEffectImports": false,
 		"types": ["*"],
+		"baseUrl": "../../../..",
+		"paths": {
+			"@kbve/laser/wire": ["packages/npm/laser/src/lib/net/protocol.ts"]
+		},
 		"ignoreDeprecations": "6.0"
 	},
 	"include": [

--- a/kbve.sh
+++ b/kbve.sh
@@ -217,6 +217,7 @@ ENVEOF
     (cd "$worktree_dir" && pnpm install)
     echo "Resetting Nx cache in worktree..."
     (cd "$worktree_dir" && export NX_WORKSPACE_ROOT_PATH="$worktree_dir" && pnpm nx reset)
+    _link_worktree_nx_data "$worktree_dir" "$worktree_basename"
 
     echo ""
     echo "=== Atomic worktree ready ==="
@@ -224,9 +225,13 @@ ENVEOF
     echo "  Branch: $branch_name"
     echo ""
     echo "Run the following to enter the worktree:"
-    echo "  cd $worktree_dir && export NX_WORKSPACE_ROOT_PATH=\$PWD"
+    echo "  cd $worktree_dir"
     echo ""
-    echo "Or use ./kbve.sh -nx from within the worktree (auto-sources .env.local)."
+    echo "Then run Nx targets with (auto-sources .env.local):"
+    echo "  ./kbve.sh -nx <project>:<target>"
+    echo ""
+    echo "Bare 'npx nx' works too — .nx/workspace-data is symlinked at the per-worktree"
+    echo "data dir so the CLI and its forked executors agree on one graph cache."
     echo ""
     echo "When done, push and ci-atom.yml will auto-create a PR to dev:"
     echo "  git push -u origin $branch_name"
@@ -319,6 +324,7 @@ ENVEOF
     (cd "$worktree_dir" && pnpm install)
     echo "Resetting Nx cache in worktree..."
     (cd "$worktree_dir" && export NX_WORKSPACE_ROOT_PATH="$worktree_dir" && pnpm nx reset)
+    _link_worktree_nx_data "$worktree_dir" "$worktree_basename"
 
     echo ""
     echo "=== Worktree ready ==="
@@ -326,9 +332,37 @@ ENVEOF
     echo "  Branch: $branch_name"
     echo ""
     echo "Run the following to enter the worktree:"
-    echo "  cd $worktree_dir && export NX_WORKSPACE_ROOT_PATH=\$PWD"
+    echo "  cd $worktree_dir"
     echo ""
-    echo "Or use ./kbve.sh -nx from within the worktree (auto-sources .env.local)."
+    echo "Then run Nx targets with (auto-sources .env.local):"
+    echo "  ./kbve.sh -nx <project>:<target>"
+    echo ""
+    echo "Bare 'npx nx' works too — .nx/workspace-data is symlinked at the per-worktree"
+    echo "data dir so the CLI and its forked executors agree on one graph cache."
+}
+
+# Point the default Nx data directory at the per-worktree one.
+#
+# .env.local sets NX_WORKSPACE_DATA_DIRECTORY to a worktree-suffixed path so worktrees do
+# not share a daemon or graph cache. Nx only loads .env.local for *task* processes, though,
+# not for the CLI parent — so a bare `npx nx run <target>` computes the graph into the
+# default .nx/workspace-data and then forks an executor that reads the suffixed one, which
+# fails with the thoroughly unhelpful:
+#
+#   [readCachedProjectGraph] ERROR: No cached ProjectGraph is available.
+#
+# Symlinking the default name at the suffixed directory makes both spellings resolve to the
+# same store, so the bare invocation works too. `./kbve.sh -nx` was always fine.
+_link_worktree_nx_data() {
+    local worktree_dir="$1"
+    local worktree_basename="$2"
+    local suffixed="$worktree_dir/.nx/workspace-data-${worktree_basename}"
+    local default="$worktree_dir/.nx/workspace-data"
+
+    mkdir -p "$suffixed"
+    # `nx reset` may have left a real directory behind; it is disposable cache either way.
+    [ -e "$default" ] && [ ! -L "$default" ] && rm -rf "$default"
+    ln -sfn "$suffixed" "$default"
 }
 
 # Remove a git worktree by name


### PR DESCRIPTION
Two traps hit while working in a fresh worktree on #15170. Both fail with an error that points nowhere near the cause, so both cost real time to diagnose.

## 1. `npx nx run <target>` fails in any worktree

```
[readCachedProjectGraph] ERROR: No cached ProjectGraph is available.
```

The graph was on disk the entire time — in a different directory.

`kbve.sh -worktree` writes a worktree-suffixed `NX_WORKSPACE_DATA_DIRECTORY` into `.env.local` so worktrees don't share a daemon or graph cache. But **Nx only loads `.env.local` for task processes, not for the CLI parent.** So:

- the parent computes the graph and writes it to the default `.nx/workspace-data`
- it forks an executor, which *does* get `.env.local`, and reads `.nx/workspace-data-<worktree>`
- that directory is empty, and the error blames a missing graph rather than a split one

`./kbve.sh -nx` was always fine — it sources `.env.local` for both halves. The failure only shows up on the bare invocation, which is exactly what the "worktree ready" banner was printing:

```
Run the following to enter the worktree:
  cd <dir> && export NX_WORKSPACE_ROOT_PATH=$PWD
```

**Fix:** symlink the default name at the suffixed directory, so both spellings resolve to one store and either invocation works. The banner now leads with `./kbve.sh -nx` and explains why the bare form is also fine.

Worth noting the executor reads the graph through `readCachedProjectGraph`, which has no fallback to computing one — so any split between those two paths is fatal rather than slow. The symlink closes the split at the source instead of teaching every caller the right incantation.

## 2. ct spec files can't value-import `@kbve/laser`

Spec files are evaluated in **Node**. The `@kbve/laser` alias in `playwright.ct.config.ts` is part of `ctViteConfig`, so it only applies to the browser bundle. Every existing spec happens to use `import type`, which is erased before Node ever sees it — so this had never surfaced.

A value import (say, a `PET_LEARN_OFFER` constant for a fixture) fails collection for the **whole file** with a bare `Cannot find module '@kbve/laser'`, which reads like a broken install.

**Fix:** map `@kbve/laser/wire` at the protocol module — types and constants, no heavy dependencies, so it loads in Node fine. Mapped in two places:

- `arpg-e2e/tsconfig.json` — for Playwright's own TS transform of spec files
- `playwright.ct.config.ts` — so a browser-side module importing the same specifier bundles the same file rather than failing to resolve

`WireConstants.spec.tsx` guards the mapping. It asserts two ephemeral kind constants, but the point is the import: laser's own `postcard-wire.spec.ts` already covers the values.

Aliasing the whole `@kbve/laser` barrel for Node was the other option and I skipped it — the barrel re-exports an r3f lane that the ct config already has to stub out for the browser bundle, and pulling that into Node buys nothing.

## Verification

Created a throwaway worktree with the patched script and ran the component target both ways:

- `npx nx run arpg-e2e:component` — passes (previously the failure case)
- `./kbve.sh -nx arpg-e2e:component` — passes

Then in this worktree, 11 component tests pass including the new mapping guard. Existing worktrees are unaffected until they're recreated; the symlink is created at worktree setup, and dropping it just restores today's behaviour.

Spotted while verifying, not fixed here: `./kbve.sh -worktree-rm <name>` fails with `ERROR: Could not resolve git repository root` when run from inside a worktree — it has to be run from the main repo. Pre-existing, and out of scope for this change.
