### PR TITLE
ci+build(deps): pnpm/action-setup v6 sweep and standalone Tauri workspace alignment

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -123,7 +123,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-daily-content.yml
+++ b/.github/workflows/ci-daily-content.yml
@@ -108,7 +108,7 @@ jobs:
 
             - name: Setup pnpm v10
               if: contains(matrix.needs, 'node')
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -47,7 +47,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-manifest-guard.yml
+++ b/.github/workflows/ci-manifest-guard.yml
@@ -37,7 +37,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-manifest-sync.yml
+++ b/.github/workflows/ci-manifest-sync.yml
@@ -59,7 +59,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-mc-gradle-cache.yml
+++ b/.github/workflows/ci-mc-gradle-cache.yml
@@ -81,7 +81,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-mc-mods-cache.yml
+++ b/.github/workflows/ci-mc-mods-cache.yml
@@ -74,7 +74,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-mc-smoke.yml
+++ b/.github/workflows/ci-mc-smoke.yml
@@ -67,7 +67,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false
@@ -127,7 +127,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-playwright-snapshots.yml
+++ b/.github/workflows/ci-playwright-snapshots.yml
@@ -44,7 +44,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-tauri-builder.yml
+++ b/.github/workflows/ci-tauri-builder.yml
@@ -153,7 +153,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false
@@ -260,7 +260,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false
@@ -432,7 +432,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false
@@ -528,7 +528,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/ci-unity.yml
+++ b/.github/workflows/ci-unity.yml
@@ -208,7 +208,7 @@ jobs:
 
             - name: Setup pnpm
               if: ${{ contains(inputs.project_path, 'rareicon') }}
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
 
@@ -334,7 +334,7 @@ jobs:
 
             - name: Setup pnpm
               if: ${{ contains(inputs.project_path, 'rareicon') }}
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
 

--- a/.github/workflows/ci-vite-game.yml
+++ b/.github/workflows/ci-vite-game.yml
@@ -133,7 +133,7 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
 
             - name: Setup pnpm ${{ env.PNPM_VERSION }}
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: ${{ env.PNPM_VERSION }}
                   run_install: false

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -213,7 +213,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -26,7 +26,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -48,7 +48,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-astro-deployment.yml
+++ b/.github/workflows/utils-astro-deployment.yml
@@ -57,7 +57,7 @@ jobs:
                   node-version: ${{ inputs.node_version }}
 
             - name: Setup pnpm ${{ inputs.pnpm_version }}
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: ${{ inputs.pnpm_version }}
                   run_install: false

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -68,7 +68,7 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
                   registry-url: https://registry.npmjs.org/
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-nx-kbve-shell.yml
+++ b/.github/workflows/utils-nx-kbve-shell.yml
@@ -55,7 +55,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -143,7 +143,7 @@ jobs:
 
             - name: Setup pnpm v10
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -46,7 +46,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -165,7 +165,7 @@ jobs:
 
             - name: Setup pnpm v10
               if: inputs.setup_node
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -134,7 +134,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@v6
               with:
                   version: 11.15.0
                   run_install: false

--- a/apps/chuckrpg/chuck-launcher/src-tauri/Cargo.lock
+++ b/apps/chuckrpg/chuck-launcher/src-tauri/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 name = "chuck-launcher"
 version = "0.1.0"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "erust",
  "futures-util",
  "reqwest 0.12.28",
@@ -848,32 +848,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -884,7 +863,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
 ]
 
@@ -1662,11 +1641,11 @@ dependencies = [
 
 [[package]]
 name = "holy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3039,17 +3018,6 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3743,6 +3711,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,7 +3820,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs 6.0.0",
+ "dirs",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3891,7 +3870,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs 6.0.0",
+ "dirs",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4517,7 +4496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "libappindicator",
  "muda",
  "objc2",
@@ -5169,15 +5148,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5225,21 +5195,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5301,12 +5256,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5325,12 +5274,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5346,12 +5289,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5385,12 +5322,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5406,12 +5337,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5433,12 +5358,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5454,12 +5373,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5529,7 +5442,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "dom_query",
  "dpi",
  "dunce",

--- a/apps/chuckrpg/chuck-launcher/src-tauri/Cargo.toml
+++ b/apps/chuckrpg/chuck-launcher/src-tauri/Cargo.toml
@@ -26,11 +26,11 @@ tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 futures-util = "0.3"
 zip = "2"
-dirs = "5"
+dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2"
+thiserror = "2.0.12"

--- a/apps/deathslayer/deathslayer-launcher/src-tauri/Cargo.toml
+++ b/apps/deathslayer/deathslayer-launcher/src-tauri/Cargo.toml
@@ -26,11 +26,11 @@ tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 futures-util = "0.3"
 zip = "2"
-dirs = "5"
+dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2"
+thiserror = "2.0.12"

--- a/apps/kbve/desktop-kbve/src-tauri/Cargo.lock
+++ b/apps/kbve/desktop-kbve/src-tauri/Cargo.lock
@@ -2443,11 +2443,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
+++ b/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
@@ -58,7 +58,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-process = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-macos-permissions = "2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 dashmap = "6"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
The two loose ends left after #15161 and #15165. Independent of both — touches only workflow files and the three Tauri manifests.

## 1. `pnpm/action-setup` → v6 (closes #10241)

Supersedes the stale dependabot PR, which covered 20 workflows and left the rest on v5 with `ci-unity.yml` still on v4. This takes **all 29 call sites across 24 workflows**, so there's no v4/v5/v6 split left to reason about.

v6 exists to add **pnpm v11 support**, and the workspace is on pnpm 11.15.0. Every call site pins that version explicitly so v5 wasn't visibly broken, but running a major that predates our pnpm version isn't worth the ambiguity.

The action's input surface is **identical** between v5 and v6 — same `version`, `dest`, `run_install`, `cache`, `cache_dependency_path`, `package_json_file`, `standalone`, same `node24` runtime — so nothing but the ref changed. All 62 workflow files still parse as YAML.

## 2. Tauri workspaces

`chuck-launcher`, `deathslayer-launcher` and `desktop-kbve/src-tauri` each declare their own `[workspace]`, so cargo cannot bind them to the root `[workspace.dependencies]` from #15165. They need manual tracking.

Aligned:
- **`dirs` 5 → 6** in both launchers. Only `dirs::data_local_dir()` is used, unchanged across the bump. Also drops the old `dirs-sys` 0.4 subtree (`redox_users` + a full `windows-sys`/`windows-targets` set) — the launcher lock gets **smaller**.
- **`tokio` 1 → 1.49**, **`thiserror` 2 → 2.0.12** — floor raises.

### reqwest deliberately NOT bumped here

⚠️ This is the interesting part, and it's the opposite call from #15165.

I bumped these to 0.13 first and checked the lockfile. `aws-lc-rs`, `aws-lc-sys` and `cmake` appeared in the launcher lock — none of which it needed before, since it was on ring via `rustls-tls`. In the main workspace that was a non-issue because rustls 0.23 already pulls aws-lc-rs; **here it's a genuinely new native build dependency.**

`ci-tauri-builder.yml` runs on `macos-latest`, `windows-latest` and a Linux runner with **no cmake or NASM setup step**, and `aws-lc-sys` wants both on Windows.

Since these are separate workspaces with separate lockfiles, aligning reqwest buys no deduplication — only cosmetic consistency. Not worth risking the 3-platform desktop release pipeline for a version string, so it's reverted and they stay on 0.12.

`desktop-kbve` also stays put for a second reason: it uses reqwest's **default** features (native-tls), so it was never on the rustls path the main workspace migrated.

## Verification

`cargo check --all-targets` run in each of the three Tauri workspaces separately — 0 errors each.

`deathslayer-launcher` cannot build at all without generated icons (only `icons/README.md` is tracked, so `tauri::generate_context!` fails on unmodified `dev` too) — verified with the icon set temporarily stubbed in, then removed.

## Noted, not changed

`deathslayer-launcher`'s `Cargo.lock` is untracked while `chuck-launcher`'s and `desktop-kbve`'s are committed. Inconsistent, but out of scope here.