### PR TITLE
feat(astro-kbve): put /github/ on the bento community rail

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -35,6 +35,11 @@ import {
 } from '../itemdb/itemNav';
 import { MAP_ROOT, buildMapNav, buildMapBreadcrumb } from '../mapdb/mapNav';
 import {
+	COMMUNITY_NAV,
+	COMMUNITY_ROOT,
+	buildCommunityBreadcrumb,
+} from '../social/socialNav';
+import {
 	MARKET_NAV,
 	STORE_ROOT,
 	MARKET_ROOT,
@@ -76,6 +81,9 @@ const palShell = isPalworld
 const isNpcdb = pathname.startsWith('/npcdb/');
 const isItemdb = pathname.startsWith('/itemdb/');
 const isMapdb = pathname.startsWith('/mapdb/');
+// Community/social pages share one rail. Only /github/ opts in for now; add
+// other social slugs here as they get recut onto bento.
+const isCommunity = norm(pathname) === '/github/';
 const isStore = norm(pathname) === '/store/';
 const isMarket = norm(pathname) === '/market/';
 
@@ -83,7 +91,7 @@ const npcNav = isNpcdb ? buildNpcNav(await getCollection('npcdb')) : [];
 const itemNav = isItemdb ? buildItemNav(await getCollection('itemdb')) : [];
 const mapNav = isMapdb ? buildMapNav(await getCollection('mapdb')) : [];
 
-const shell = isDashboard
+const baseShell = isDashboard
 	? {
 			entries: DASHBOARD_NAV,
 			root: DASHBOARD_ROOT,
@@ -272,6 +280,18 @@ const shell = isDashboard
 																	withToc: false,
 																}
 															: undefined;
+
+const shell = isCommunity
+	? {
+			entries: COMMUNITY_NAV,
+			root: COMMUNITY_ROOT,
+			menuLabel: 'Community menu',
+			navLabel: 'Community',
+			crumbs: buildCommunityBreadcrumb(pathname),
+			collapsible: true,
+			withToc: true,
+		}
+	: baseShell;
 
 const crumbs = shell?.crumbs ?? [];
 ---

--- a/apps/kbve/astro-kbve/src/components/social/socialNav.ts
+++ b/apps/kbve/astro-kbve/src/components/social/socialNav.ts
@@ -1,0 +1,87 @@
+import type {
+	BreadcrumbCrumb,
+	DashboardNavEntry,
+	DashboardNavItem,
+} from '../dashboard/dashboardNav';
+import { findActiveIn, isActiveIn } from '../dashboard/dashboardNav';
+
+export const COMMUNITY_ROOT: DashboardNavItem = {
+	label: 'Community',
+	href: '/github/',
+};
+
+export const COMMUNITY_NAV: DashboardNavEntry[] = [
+	{
+		label: 'Open source',
+		eyebrow: 'Code',
+		icon: 'M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22',
+		items: [
+			{ label: 'GitHub', href: '/github/' },
+			{ label: 'Projects', href: '/projects/' },
+			{ label: 'Graph', href: '/graph/' },
+		],
+	},
+	{
+		label: 'Chat',
+		eyebrow: 'Talk to us',
+		icon: 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z',
+		items: [
+			{ label: 'Discord', href: '/discord/' },
+			{ label: 'Chat', href: '/chat/' },
+			{ label: 'Twitch', href: '/twitch/' },
+		],
+	},
+	{
+		label: 'Social',
+		eyebrow: 'Follow along',
+		icon: 'M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98',
+		items: [
+			{ label: 'Bluesky', href: '/bluesky/' },
+			{ label: 'X / Twitter', href: '/twitter/' },
+			{ label: 'YouTube', href: '/youtube/' },
+			{ label: 'TikTok', href: '/tiktok/' },
+		],
+	},
+	{
+		label: 'Games',
+		eyebrow: 'Play our stuff',
+		icon: 'M6 12h4m-2-2v4m7-1h.01M18 11h.01M17.32 5H6.68a4 4 0 0 0-3.98 3.6l-.6 6A4 4 0 0 0 6.08 19c1.2 0 2.32-.53 3.08-1.45L10 16.5h4l.84 1.05A4 4 0 0 0 17.92 19a4 4 0 0 0 3.98-4.4l-.6-6A4 4 0 0 0 17.32 5z',
+		items: [
+			{ label: 'itch.io', href: '/itch/' },
+			{ label: 'Steam', href: '/steam/' },
+		],
+	},
+	{
+		label: 'Support',
+		eyebrow: 'Back the work',
+		icon: 'M4.32 6.32a4.5 4.5 0 0 0 0 6.36L12 20.36l7.68-7.68a4.5 4.5 0 0 0-6.36-6.36L12 7.64l-1.32-1.32a4.5 4.5 0 0 0-6.36 0z',
+		items: [
+			{ label: 'Donate', href: '/donate/' },
+			{ label: 'About', href: '/about/' },
+			{ label: 'Register', href: '/register/' },
+		],
+	},
+];
+
+export const isCommunityActive = (pathname: string, href: string): boolean =>
+	isActiveIn(COMMUNITY_ROOT.href, pathname, href);
+
+/**
+ * The root href is /github/, so the shared builder would swallow the GitHub
+ * crumb as "the root itself". Always emit Community › Group › Page instead.
+ */
+export const buildCommunityBreadcrumb = (
+	pathname: string,
+): BreadcrumbCrumb[] => {
+	const crumbs: BreadcrumbCrumb[] = [COMMUNITY_ROOT];
+	const match = findActiveIn(COMMUNITY_NAV, COMMUNITY_ROOT.href, pathname);
+	if (!match) return crumbs;
+	if (match.group) {
+		crumbs.push({
+			label: match.group.label,
+			href: match.group.href ?? match.item.href,
+		});
+	}
+	crumbs.push({ label: match.item.label, href: match.item.href });
+	return crumbs;
+};

--- a/apps/kbve/astro-kbve/src/content/docs/github.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/github.mdx
@@ -3,49 +3,214 @@ title: GitHub Ecosystem
 description: KBVE open-source contributors, projects, and activity across our GitHub organization.
 ogTitle: "KBVE on GitHub — Open-Source Games + Cloud Infrastructure"
 ogDescription: "Browse contributors, repositories, and live activity across the KBVE org. PRs welcome."
+template: splash
 editUrl: false
 lastUpdated: false
+prev: false
 next: false
 sidebar:
     label: GitHub
     order: 5
+    hidden: true
 ---
 
+import BentoShell from '@/components/hero/BentoShell.astro';
 import DeferredAstroGithubHero from '@kbve/astro/components/social/github/GithubHero/DeferredAstroGithubHero.astro';
-import AstroGithubTabs from '@kbve/astro/components/social/github/Tabs/AstroGithubTabs.astro';
 import AstroGithubRepoCatalog from '@kbve/astro/components/social/github/RepoCatalog/AstroGithubRepoCatalog.astro';
 import AstroGithubActivity from '@kbve/astro/components/social/github/Activity/AstroGithubActivity.astro';
 import AstroGithubProjectBoard from '@kbve/astro/components/social/github/ProjectBoard/AstroGithubProjectBoard.astro';
 import AstroGithubContribute from '@kbve/astro/components/social/github/Contribute/AstroGithubContribute.astro';
+import Adsense from '@/components/astropad/adsense/Adsense.astro';
 
-<div class="ring-page kbve-dashboard-page relative min-h-screen w-full bg-transparent">
+export const backdrop = 'https://images.unsplash.com/photo-1618401471353-b98afee0b2eb?q=80&w=2400&auto=format&fit=crop';
 
-# GitHub
+export const stats = [
+	{ label: 'Monorepo', value: 'KBVE/kbve', icon: 'M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-6l-2-2H5a2 2 0 0 0-2 2z' },
+	{ label: 'PRs target', value: 'dev', icon: 'M6 3v12M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM15 6a9 9 0 0 1-9 9' },
+	{ label: 'License', value: 'OSS', icon: 'M16 18 22 12 16 6M8 6 2 12 8 18' },
+	{ label: 'CI', value: 'Nx + Actions', icon: 'M13 2L3 14h9l-1 8 10-12h-9l1-8z' },
+];
 
-Open-source games, cloud infrastructure, and the contributors building them.
-PRs land against `dev`, ship through CI to `main`. Pick an issue, fork the
-repo, open a worktree — the walkthrough lives under the **Contribute** tab.
+export const quickLinks = [
+	{ href: 'https://github.com/kbve/kbve/issues', label: 'Open issues' },
+	{ href: 'https://github.com/orgs/KBVE/projects/5', label: 'Project board' },
+	{ href: 'https://github.com/kbve/kbve/pulls', label: 'Pull requests' },
+	{ href: 'https://github.com/kbve/kbve/releases', label: 'Releases' },
+	{ href: 'https://github.com/orgs/KBVE/repositories', label: 'All repositories' },
+];
 
-<DeferredAstroGithubHero
-    title="Top Contributors"
-    subtitle="Thanks to everyone helping build the platform!"
-    commitsLabel="commits"
-    viewAllLabel="View all contributors"
-    issuesLabel="Issues"
-    projectLabel="Project Board"
-    errorMessage="Unable to load contributors. Please try again later."
-    rank1Label="1st Place"
-    rank2Label="2nd Place"
-    rank3Label="3rd Place"
-    newTabLabel="(opens in new tab)"
-/>
+export const related = [
+	{
+		href: 'https://github.com/kbve/kbve',
+		title: 'KBVE/kbve',
+		copy: 'The monorepo behind every KBVE project — games, services, infra.',
+		icon: 'M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22',
+		external: true,
+	},
+	{
+		href: '/discord/',
+		title: 'Discord',
+		copy: 'Ask questions, pair on issues, and catch the Saturday dev stream.',
+		icon: 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z',
+	},
+	{
+		href: '/projects/',
+		title: 'Projects',
+		copy: 'Every shipped crate, game, plugin, and service with its own doc.',
+		icon: 'M3 3h7v7H3zM14 3h7v7h-7zM14 14h7v7h-7zM3 14h7v7H3z',
+	},
+];
 
-<AstroGithubTabs>
-    <AstroGithubActivity slot="activity" />
-    <AstroGithubProjectBoard slot="board" />
-    <AstroGithubRepoCatalog slot="repos" />
-    <AstroGithubContribute slot="contribute" />
-</AstroGithubTabs>
+<div class="gh" style={`--bento-hero-bg: url('${backdrop}')`} data-github-page>
+
+<section class="bento-hero bento-section not-content" aria-label="KBVE on GitHub">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.2 1.9 1.2 1.1 1.9 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3z" />
+					</svg>
+					<span>KBVE org · open source</span>
+				</span>
+				<h1 class="bento-title">
+					Build with us on
+					<span class="bento-title__accent">GitHub</span>
+				</h1>
+				<p class="bento-lede">
+					Open-source games, cloud infrastructure, and the contributors
+					building them. PRs land against <code>dev</code> and ship through
+					CI to <code>main</code>. Pick an issue, fork the repo, open a
+					worktree — the walkthrough is under Contribute.
+				</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="https://github.com/kbve/kbve" target="_blank" rel="noopener noreferrer">
+						Open the monorepo
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M13 6l6 6-6 6" />
+						</svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#board">Good first issues</a>
+					<a class="bento-btn bento-btn--ghost" href="#contribute">How to contribute →</a>
+				</div>
+			</div>
+
+			<div class="bento-cell bento-hero-aside bento-card bento-card--glass">
+				<div class="bento-cell-eyebrow">
+					<span class="bento-live-dot" aria-hidden="true"></span>
+					Jump to GitHub
+				</div>
+				<ul class="bento-list gh-quick">
+					{quickLinks.map((l) => (
+						<li>
+							<a href={l.href} target="_blank" rel="noopener noreferrer">{l.label}</a>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			{stats.map((s) => (
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d={s.icon} /></svg>
+					</span>
+					<span class="bento-stat__value">{s.value}</span>
+					<span class="bento-stat__label">{s.label}</span>
+				</div>
+			))}
+		</div>
+
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#contributors">Contributors</a>
+			<a class="bento-chip" href="#activity">Activity</a>
+			<a class="bento-chip" href="#board">In Flight</a>
+			<a class="bento-chip" href="#repos">Repositories</a>
+			<a class="bento-chip" href="#contribute">Contribute</a>
+		</nav>
+	</div>
+</section>
+
+<BentoShell id="contributors" eyebrow="Thank you" heading="Top contributors">
+	<DeferredAstroGithubHero
+		header={false}
+		title="Top Contributors"
+		subtitle="Thanks to everyone helping build the platform!"
+		commitsLabel="commits"
+		viewAllLabel="View all contributors"
+		issuesLabel="Issues"
+		projectLabel="Project Board"
+		errorMessage="Unable to load contributors. Please try again later."
+		rank1Label="1st Place"
+		rank2Label="2nd Place"
+		rank3Label="3rd Place"
+		newTabLabel="(opens in new tab)"
+	/>
+</BentoShell>
+
+<BentoShell id="activity" eyebrow="Live from the org" heading="Recent activity">
+	<AstroGithubActivity header={false} />
+</BentoShell>
+
+<BentoShell id="board" eyebrow="Up for grabs" heading="In flight">
+	<AstroGithubProjectBoard header={false} />
+</BentoShell>
+
+<BentoShell id="repos" eyebrow="The catalog" heading="Repositories">
+	<AstroGithubRepoCatalog header={false} />
+</BentoShell>
+
+<BentoShell id="contribute" eyebrow="Your first PR" heading="How to contribute">
+	<AstroGithubContribute header={false} />
+</BentoShell>
+
+<BentoShell id="related" eyebrow="Elsewhere" heading="Keep going">
+	<div class="bento-board bento-board--cols-3">
+		{related.map((r) => (
+			<a
+				class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive"
+				href={r.href}
+				target={r.external ? '_blank' : undefined}
+				rel={r.external ? 'noopener noreferrer' : undefined}>
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d={r.icon} />
+					</svg>
+				</span>
+				<span class="bento-linkcard__title">{r.title}</span>
+				<span class="bento-linkcard__copy">{r.copy}</span>
+				<span class="bento-linkcard__go" aria-hidden="true">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M5 12h14M13 6l6 6-6 6" />
+					</svg>
+				</span>
+			</a>
+		))}
+	</div>
+</BentoShell>
+
+<section class="bento-section not-content">
+	<div class="bento-frame bento-band">
+		<Adsense />
+	</div>
+</section>
 
 </div>
 
+<style is:global>{`
+	.gh {
+		--bento-accent: #7c8cf8;
+		--bento-accent-2: #c084fc;
+		--bento-btn-fg: #0b1220;
+		--bento-live: #22c55e;
+	}
+
+	.gh .gh-quick a {
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+	}
+
+	.gh .gh-quick a:hover {
+		color: var(--sl-color-white);
+	}
+`}</style>

--- a/packages/npm/astro/src/components/social/github/Activity/AstroGithubActivity.astro
+++ b/packages/npm/astro/src/components/social/github/Activity/AstroGithubActivity.astro
@@ -25,12 +25,15 @@ interface Props {
 	title?: string;
 	subtitle?: string;
 	limit?: number;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 const {
 	title = 'Recent Activity',
 	subtitle = 'Pull requests and releases across the org',
 	limit = 12,
+	header = true,
 } = Astro.props;
 
 const GITHUB_ORG = 'KBVE';
@@ -144,11 +147,18 @@ function ago(iso: string): string {
 }
 ---
 
-<section class="github-activity" aria-labelledby="github-activity-title">
-	<header class="github-activity__header">
-		<h2 id="github-activity-title">{title}</h2>
-		<p>{subtitle}</p>
-	</header>
+<section
+	class="github-activity"
+	aria-labelledby={header ? 'github-activity-title' : undefined}
+	aria-label={header ? undefined : title}>
+	{
+		header && (
+			<header class="github-activity__header">
+				<h2 id="github-activity-title">{title}</h2>
+				<p>{subtitle}</p>
+			</header>
+		)
+	}
 
 	{
 		error && (

--- a/packages/npm/astro/src/components/social/github/Contribute/AstroGithubContribute.astro
+++ b/packages/npm/astro/src/components/social/github/Contribute/AstroGithubContribute.astro
@@ -7,11 +7,14 @@
 interface Props {
 	title?: string;
 	subtitle?: string;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 const {
 	title = 'Contribute',
 	subtitle = 'Fork → branch → PR. Worktrees make rebases painless.',
+	header = true,
 } = Astro.props;
 
 const STEPS = [
@@ -82,11 +85,18 @@ const LINKS = [
 ];
 ---
 
-<section class="github-contribute" aria-labelledby="github-contribute-title">
-	<header class="github-contribute__header">
-		<h2 id="github-contribute-title">{title}</h2>
-		<p>{subtitle}</p>
-	</header>
+<section
+	class="github-contribute"
+	aria-labelledby={header ? 'github-contribute-title' : undefined}
+	aria-label={header ? undefined : title}>
+	{
+		header && (
+			<header class="github-contribute__header">
+				<h2 id="github-contribute-title">{title}</h2>
+				<p>{subtitle}</p>
+			</header>
+		)
+	}
 
 	<ol class="github-contribute__steps" role="list">
 		{

--- a/packages/npm/astro/src/components/social/github/GithubHero/AstroGithubHero.astro
+++ b/packages/npm/astro/src/components/social/github/GithubHero/AstroGithubHero.astro
@@ -23,6 +23,8 @@ interface Props {
 	rank3Label?: string;
 	// a11y text
 	newTabLabel?: string;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 interface Contributor {
@@ -48,6 +50,7 @@ const {
 	rank2Label = '2nd Place',
 	rank3Label = '3rd Place',
 	newTabLabel = '(opens in new tab)',
+	header = true,
 } = Astro.props;
 
 // Hardcoded repo config
@@ -98,18 +101,24 @@ const getRankLabel = (index: number): string => {
 
 <section
 	class:list={['github-hero', className]}
-	aria-labelledby="github-hero-title">
+	aria-labelledby={header ? 'github-hero-title' : undefined}
+	aria-label={header ? undefined : title}>
 	<div class="github-hero-inner">
 		<div class="max-w-4xl mx-auto px-4">
-			<!-- Header -->
-			<div class="text-center mb-10">
-				<h2
-					id="github-hero-title"
-					class="text-3xl md:text-4xl font-bold text-[var(--sl-color-white)] mb-3">
-					{title}
-				</h2>
-				<p class="text-lg text-[var(--sl-color-gray-2)]">{subtitle}</p>
-			</div>
+			{
+				header && (
+					<div class="text-center mb-10">
+						<h2
+							id="github-hero-title"
+							class="text-3xl md:text-4xl font-bold text-[var(--sl-color-white)] mb-3">
+							{title}
+						</h2>
+						<p class="text-lg text-[var(--sl-color-gray-2)]">
+							{subtitle}
+						</p>
+					</div>
+				)
+			}
 
 			{
 				error ? (

--- a/packages/npm/astro/src/components/social/github/GithubHero/DeferredAstroGithubHero.astro
+++ b/packages/npm/astro/src/components/social/github/GithubHero/DeferredAstroGithubHero.astro
@@ -19,6 +19,8 @@ interface Props {
 	rank2Label?: string;
 	rank3Label?: string;
 	newTabLabel?: string;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 const props = Astro.props;

--- a/packages/npm/astro/src/components/social/github/ProjectBoard/AstroGithubProjectBoard.astro
+++ b/packages/npm/astro/src/components/social/github/ProjectBoard/AstroGithubProjectBoard.astro
@@ -27,6 +27,8 @@ interface Props {
 	subtitle?: string;
 	limit?: number;
 	label?: string;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 const {
@@ -34,6 +36,7 @@ const {
 	subtitle = 'Open issues labelled priority:medium — solid first-PR candidates.',
 	limit = 9,
 	label = 'priority:medium',
+	header = true,
 } = Astro.props;
 
 const GITHUB_OWNER = 'KBVE';
@@ -67,11 +70,18 @@ function ago(iso: string): string {
 }
 ---
 
-<section class="github-board" aria-labelledby="github-board-title">
-	<header class="github-board__header">
-		<h2 id="github-board-title">{title}</h2>
-		<p>{subtitle}</p>
-	</header>
+<section
+	class="github-board"
+	aria-labelledby={header ? 'github-board-title' : undefined}
+	aria-label={header ? undefined : title}>
+	{
+		header && (
+			<header class="github-board__header">
+				<h2 id="github-board-title">{title}</h2>
+				<p>{subtitle}</p>
+			</header>
+		)
+	}
 
 	{
 		error && (

--- a/packages/npm/astro/src/components/social/github/RepoCatalog/AstroGithubRepoCatalog.astro
+++ b/packages/npm/astro/src/components/social/github/RepoCatalog/AstroGithubRepoCatalog.astro
@@ -26,12 +26,15 @@ interface Props {
 	title?: string;
 	subtitle?: string;
 	limit?: number;
+	/** Render the built-in heading block; off when an outer shell supplies it. */
+	header?: boolean;
 }
 
 const {
 	title = 'Repositories',
 	subtitle = 'Active open-source projects across the KBVE org',
 	limit = 60,
+	header = true,
 } = Astro.props;
 
 const GITHUB_ORG = 'KBVE';
@@ -152,11 +155,16 @@ function shortDate(iso: string): string {
 
 <section
 	class="github-repo-catalog"
-	aria-labelledby="github-repo-catalog-title">
-	<header class="github-repo-catalog__header">
-		<h2 id="github-repo-catalog-title">{title}</h2>
-		<p>{subtitle}</p>
-	</header>
+	aria-labelledby={header ? 'github-repo-catalog-title' : undefined}
+	aria-label={header ? undefined : title}>
+	{
+		header && (
+			<header class="github-repo-catalog__header">
+				<h2 id="github-repo-catalog-title">{title}</h2>
+				<p>{subtitle}</p>
+			</header>
+		)
+	}
 
 	{
 		error && (


### PR DESCRIPTION
## What

`/github/` was the last social page still rendering on the default Starlight docs layout. This recuts it as a splash page inside the shared `dash-shell` rail, so it matches `/mc/`, `/npcdb/`, and the dashboard.

## Changes

**`socialNav.ts`** (new) — Community rail: Open source / Chat / Social / Games / Support. The rail root href is `/github/`, which `buildBreadcrumbIn` treats as "the root itself" and drops, so this module builds its own `Community > Group > Page` trail.

**`MarkdownContent.astro`** — new `isCommunity` branch, `collapsible: true`, `withToc: true`. The existing ternary chain is renamed `baseShell` and the new branch sits after it, so the diff does not reindent 190 lines. Only `/github/` opts in for now; other social slugs join by adding to that one line.

**`github.mdx`** — `template: splash` + `sidebar.hidden` so the rail is the only nav. The radio-driven tab group is replaced by six stacked `<BentoShell>` sections: contributors, activity, board, repos, contribute, related. Reason: the rail's TOC script reads `.dash-main section.bento-section[id]` + `.bento-heading`, and tab panels cannot be hash-linked from a rail. Adds the standard bento hero (badge / title / lede / CTAs / quick-links aside / 4 stats / jump chips) and an Adsense band, accent `#7c8cf8`.

**5 github components** (Hero, Deferred wrapper, Activity, ProjectBoard, RepoCatalog, Contribute) — optional `header?: boolean`, default `true` (no behavior change for existing callers). Off lets the outer `BentoShell` own the heading instead of rendering a second `h2`; `aria-labelledby` swaps to `aria-label` so it does not dangle.

`AstroGithubTabs` stays exported and untouched — `github.mdx` was its only consumer.

## Verification

`pnpm nx run astro-kbve:build` green (7525 pages). In the built `/github/index.html`:

- `sidebar-pane` count `0` — splash active, Starlight's own sidebar gone
- `dash-shell` / `dash-rail` / `dash-rail-toc` present
- all six section ids + `.bento-heading` labels present, so the rail TOC and scroll-spy populate
- breadcrumb renders `Community > Open source > GitHub`
- zero `github-tabs`, zero duplicate component headers