### PR TITLE
feat(astro-kbve): roll the community rail out to every social page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -36,6 +36,7 @@ import {
 import { MAP_ROOT, buildMapNav, buildMapBreadcrumb } from '../mapdb/mapNav';
 import {
 	COMMUNITY_NAV,
+	COMMUNITY_RAIL_SLUGS,
 	COMMUNITY_ROOT,
 	buildCommunityBreadcrumb,
 } from '../social/socialNav';
@@ -81,9 +82,9 @@ const palShell = isPalworld
 const isNpcdb = pathname.startsWith('/npcdb/');
 const isItemdb = pathname.startsWith('/itemdb/');
 const isMapdb = pathname.startsWith('/mapdb/');
-// Community/social pages share one rail. Only /github/ opts in for now; add
-// other social slugs here as they get recut onto bento.
-const isCommunity = norm(pathname) === '/github/';
+// Community/social pages share one rail; the slug set is derived from the
+// nav itself, so adding a rail link adds its page unless it opts out there.
+const isCommunity = COMMUNITY_RAIL_SLUGS.has(norm(pathname));
 const isStore = norm(pathname) === '/store/';
 const isMarket = norm(pathname) === '/market/';
 

--- a/apps/kbve/astro-kbve/src/components/kbve/PackagesBento.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/PackagesBento.astro
@@ -77,6 +77,7 @@ const tabs = [
 ---
 
 <BentoShell
+	id="packages"
 	eyebrow="Published packages"
 	heading="Everything we ship to a public registry, pulled live from the collection.">
 	<div class="pkgb">

--- a/apps/kbve/astro-kbve/src/components/kbve/ProjectBento.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/ProjectBento.astro
@@ -115,6 +115,7 @@ const groups: FacetGroup[] = [
 ---
 
 <BentoShell
+	id="projects"
 	eyebrow="The KBVE collective"
 	heading="Games, tools, libraries, and studios under one roof.">
 	<div class="cookbook">

--- a/apps/kbve/astro-kbve/src/components/social/socialNav.ts
+++ b/apps/kbve/astro-kbve/src/components/social/socialNav.ts
@@ -63,6 +63,20 @@ export const COMMUNITY_NAV: DashboardNavEntry[] = [
 	},
 ];
 
+/**
+ * Rail links that deliberately do NOT render the rail on their own page.
+ * /graph/ is a full-bleed interactive graph a 15rem gutter would squash;
+ * /register/ is an auth flow, not a browsable community page.
+ */
+const RAIL_EXCLUDED = new Set(['/graph/', '/register/']);
+
+/** Every community page that renders the rail, derived from the nav itself. */
+export const COMMUNITY_RAIL_SLUGS: ReadonlySet<string> = new Set(
+	COMMUNITY_NAV.flatMap((entry) =>
+		'items' in entry ? entry.items.map((i) => i.href) : [entry.href],
+	).filter((href) => !RAIL_EXCLUDED.has(href)),
+);
+
 export const isCommunityActive = (pathname: string, href: string): boolean =>
 	isActiveIn(COMMUNITY_ROOT.href, pathname, href);
 

--- a/apps/kbve/astro-kbve/src/content/docs/github.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/github.mdx
@@ -11,7 +11,6 @@ next: false
 sidebar:
     label: GitHub
     order: 5
-    hidden: true
 ---
 
 import BentoShell from '@/components/hero/BentoShell.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/itch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itch.mdx
@@ -3,6 +3,7 @@ title: Itch.io
 description: Browse KBVE indie games, jam entries, and demos on itch.io.
 ogTitle: "KBVE on itch.io — Indie Games, Jam Entries, Demos"
 ogDescription: "Ship-when-ready indie projects from KBVE. Browse demos, jam entries, and free downloads."
+template: splash
 sidebar:
   label: Itch
   order: 9


### PR DESCRIPTION
Follow-up to #15176. That PR built the Community rail but only wired `/github/` into it, so the other twelve pages already listed in that nav still rendered without the sidebar.

## Changes

**`socialNav.ts`** — export `COMMUNITY_RAIL_SLUGS`, derived from `COMMUNITY_NAV` itself, so adding a rail link now adds its page automatically instead of needing a second edit that can drift. Two opt-outs live in `RAIL_EXCLUDED`:

- `/graph/` — full-bleed interactive graph; a 15rem gutter would squash the viz
- `/register/` — auth flow, not a browsable community page

Both stay as rail *links*, they just don't render the rail themselves.

**`MarkdownContent.astro`** — `isCommunity` reads that set instead of a hardcoded slug.

**`itch.mdx`** — add `template: splash`. It was the only community page still on the docs layout, so without this it would render the Starlight sidebar *and* the rail at once.

**`github.mdx`** — drop `sidebar.hidden`. Cosmetic parity: no sibling sets it, and these root pages aren't part of the Starlight sidebar tree anyway.

**`ProjectBento` / `PackagesBento`** — give both `BentoShell`s an `id`. The rail TOC keys off `.bento-section[id]`, so `/projects/` was the one railed page that would have shown an empty section list.

## Verification

`pnpm nx run astro-kbve:build` green. Checked the built HTML for all fifteen pages:

| page | rail | double sidebar | TOC anchors | breadcrumb |
|---|---|---|---|---|
| github | yes | 0 | 6 | Community > Open source > GitHub |
| projects | yes | 0 | 2 | Community > Open source > Projects |
| discord | yes | 0 | 3 | Community > Chat > Discord |
| chat | yes | 0 | 2 | Community > Chat > Chat |
| twitch | yes | 0 | 4 | Community > Chat > Twitch |
| bluesky | yes | 0 | 1 | Community > Social > Bluesky |
| twitter | yes | 0 | 1 | Community > Social > X / Twitter |
| youtube | yes | 0 | 1 | Community > Social > YouTube |
| tiktok | yes | 0 | 1 | Community > Social > TikTok |
| itch | yes | 0 | 2 | Community > Games > itch.io |
| steam | yes | 0 | 1 | Community > Games > Steam |
| donate | yes | 0 | 3 | Community > Support > Donate |
| about | yes | 0 | 5 | Community > Support > About |
| graph | no (opt-out) | 0 | — | — |
| register | no (opt-out) | 0 | — | — |