### PR TITLE
feat(astro-kbve): put /legal/ and its licenses on a bento rail

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/MarkdownContent.astro
@@ -40,6 +40,7 @@ import {
 	COMMUNITY_ROOT,
 	buildCommunityBreadcrumb,
 } from '../social/socialNav';
+import { LEGAL_NAV, LEGAL_ROOT, buildLegalBreadcrumb } from '../legal/legalNav';
 import {
 	MARKET_NAV,
 	STORE_ROOT,
@@ -85,6 +86,7 @@ const isMapdb = pathname.startsWith('/mapdb/');
 // Community/social pages share one rail; the slug set is derived from the
 // nav itself, so adding a rail link adds its page unless it opts out there.
 const isCommunity = COMMUNITY_RAIL_SLUGS.has(norm(pathname));
+const isLegal = pathname.startsWith('/legal/');
 const isStore = norm(pathname) === '/store/';
 const isMarket = norm(pathname) === '/market/';
 
@@ -282,17 +284,27 @@ const baseShell = isDashboard
 																}
 															: undefined;
 
-const shell = isCommunity
+const shell = isLegal
 	? {
-			entries: COMMUNITY_NAV,
-			root: COMMUNITY_ROOT,
-			menuLabel: 'Community menu',
-			navLabel: 'Community',
-			crumbs: buildCommunityBreadcrumb(pathname),
+			entries: LEGAL_NAV,
+			root: LEGAL_ROOT,
+			menuLabel: 'Legal menu',
+			navLabel: 'Legal',
+			crumbs: buildLegalBreadcrumb(pathname),
 			collapsible: true,
 			withToc: true,
 		}
-	: baseShell;
+	: isCommunity
+		? {
+				entries: COMMUNITY_NAV,
+				root: COMMUNITY_ROOT,
+				menuLabel: 'Community menu',
+				navLabel: 'Community',
+				crumbs: buildCommunityBreadcrumb(pathname),
+				collapsible: true,
+				withToc: true,
+			}
+		: baseShell;
 
 const crumbs = shell?.crumbs ?? [];
 ---

--- a/apps/kbve/astro-kbve/src/components/legal/LegalLeaf.astro
+++ b/apps/kbve/astro-kbve/src/components/legal/LegalLeaf.astro
@@ -1,0 +1,105 @@
+---
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
+import { LEGAL_META, legalKindLabel } from './legalMeta';
+import { LEGAL_NAV } from './legalNav';
+import { isGroup } from '../dashboard/dashboardNav';
+
+interface Props {
+	/** Slug under /legal/, e.g. "mit" or "privacy". */
+	slug: string;
+	/** Page title; pass `frontmatter.title`. */
+	title: string;
+	/** Hero lede; pass `frontmatter.description`. */
+	description?: string;
+	/** Heading over the document body. */
+	heading?: string;
+	/** Last review date, when the document tracks one. */
+	updated?: string;
+}
+
+const {
+	slug,
+	title,
+	description,
+	heading = 'Full text',
+	updated,
+} = Astro.props;
+
+const meta = LEGAL_META[slug];
+if (!meta) {
+	throw new Error(
+		`LegalLeaf: no LEGAL_META entry for "${slug}". Add it to legalMeta.ts.`,
+	);
+}
+
+const kindLabel = legalKindLabel(meta.kind);
+const isPolicy = meta.kind === 'policy';
+
+const lede = description
+	? String(description).trim().replace(/\s+/g, ' ')
+	: undefined;
+
+const stats = [
+	{ label: 'Identifier', value: meta.spdx, icon: 'license' },
+	{ label: 'Type', value: kindLabel, icon: isPolicy ? 'shield' : 'code' },
+	{ label: 'Requires', value: meta.obligation, icon: 'check' },
+];
+if (updated) {
+	stats.push({ label: 'Updated', value: updated, icon: 'clock' });
+}
+
+/** Sibling documents in the same rail group, minus this page. */
+const here = `/legal/${slug}/`;
+const group = LEGAL_NAV.filter(isGroup).find((g) =>
+	g.items.some((i) => i.href === here),
+);
+const siblings = (group?.items ?? [])
+	.filter((i) => i.href !== here)
+	.slice(0, 3)
+	.map((i) => ({
+		href: i.href,
+		title: i.label,
+		copy: `Also filed under ${group?.label.toLowerCase()}.`,
+		icon: isPolicy ? 'shield' : 'license',
+	}));
+
+/**
+ * BentoDoc renders `accent` as the tinted tail of the h1, not as a separate
+ * label, so split the title rather than passing the SPDX id twice.
+ * "MIT License" -> "MIT" + "License"; a one-word title is all accent.
+ */
+const cut = title.trim().lastIndexOf(' ');
+const titleLead = cut > 0 ? title.trim().slice(0, cut) : '';
+const titleAccent = cut > 0 ? title.trim().slice(cut + 1) : title.trim();
+
+const hero = {
+	badge: `${kindLabel} · ${meta.spdx}`,
+	title: titleLead ? `${titleLead} ` : '',
+	accent: titleAccent,
+	lede,
+	stats,
+	ctas: [
+		{ label: '← All legal documents', href: '/legal/' },
+		...(isPolicy
+			? []
+			: [{ label: 'Licenses index', href: '/legal/#licenses' }]),
+	],
+	related: [
+		...siblings,
+		{
+			href: '/legal/',
+			title: 'Legal index',
+			copy: 'Every policy and license that applies to KBVE software and assets.',
+			icon: 'book',
+		},
+	],
+	theme: { accent: meta.accent, accent2: meta.accent },
+};
+---
+
+<BentoDoc data={hero} class="legal-leaf">
+	<BentoProse id="document" eyebrow={kindLabel} heading={heading}>
+		<slot />
+	</BentoProse>
+</BentoDoc>

--- a/apps/kbve/astro-kbve/src/components/legal/legalMeta.ts
+++ b/apps/kbve/astro-kbve/src/components/legal/legalMeta.ts
@@ -1,0 +1,59 @@
+export type LegalKind = 'policy' | 'permissive' | 'copyleft' | 'content';
+
+export interface LegalMeta {
+	/** Which rail group the page belongs to. */
+	kind: LegalKind;
+	/** SPDX identifier, or the document type for policies. */
+	spdx: string;
+	/** One-line "what this obliges you to do", shown as a hero stat. */
+	obligation: string;
+	/** Hero accent; one hue per kind so the section reads as a set. */
+	accent: string;
+}
+
+const KIND_LABELS: Record<LegalKind, string> = {
+	policy: 'Policy',
+	permissive: 'Permissive license',
+	copyleft: 'Copyleft license',
+	content: 'Content license',
+};
+
+const ACCENTS: Record<LegalKind, string> = {
+	policy: '#38bdf8',
+	permissive: '#34d399',
+	copyleft: '#fbbf24',
+	content: '#c084fc',
+};
+
+const entry = (
+	kind: LegalKind,
+	spdx: string,
+	obligation: string,
+): LegalMeta => ({ kind, spdx, obligation, accent: ACCENTS[kind] });
+
+export const LEGAL_META: Record<string, LegalMeta> = {
+	disclaimer: entry('policy', 'Disclaimer', 'Informational only'),
+	privacy: entry('policy', 'Privacy Policy', 'Data handling'),
+	tos: entry('policy', 'Terms of Service', 'Binding on use'),
+	eula: entry('policy', 'EULA', 'Binding on install'),
+
+	mit: entry('permissive', 'MIT', 'Attribution'),
+	'apache-2': entry('permissive', 'Apache-2.0', 'Attribution + NOTICE'),
+	'bsd-2': entry('permissive', 'BSD-2-Clause', 'Attribution'),
+	'bsd-3': entry(
+		'permissive',
+		'BSD-3-Clause',
+		'Attribution + no endorsement',
+	),
+	isc: entry('permissive', 'ISC', 'Attribution'),
+
+	'gpl-3': entry('copyleft', 'GPL-3.0', 'Derivatives stay GPL'),
+	'lgpl-3': entry('copyleft', 'LGPL-3.0', 'Linking exception'),
+	'mpl-2': entry('copyleft', 'MPL-2.0', 'Modified files stay MPL'),
+
+	'cc-by-4': entry('content', 'CC-BY-4.0', 'Attribution'),
+	'cc-by-sa-4': entry('content', 'CC-BY-SA-4.0', 'Attribution + ShareAlike'),
+	unlicense: entry('content', 'Unlicense / CC0', 'No conditions'),
+};
+
+export const legalKindLabel = (kind: LegalKind): string => KIND_LABELS[kind];

--- a/apps/kbve/astro-kbve/src/components/legal/legalNav.ts
+++ b/apps/kbve/astro-kbve/src/components/legal/legalNav.ts
@@ -1,0 +1,63 @@
+import type {
+	BreadcrumbCrumb,
+	DashboardNavEntry,
+	DashboardNavItem,
+} from '../dashboard/dashboardNav';
+import { buildBreadcrumbIn, isActiveIn } from '../dashboard/dashboardNav';
+
+export const LEGAL_ROOT: DashboardNavItem = {
+	label: 'Legal',
+	href: '/legal/',
+};
+
+export const LEGAL_NAV: DashboardNavEntry[] = [
+	{
+		label: 'Policies',
+		eyebrow: 'How we operate',
+		icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.59a1 1 0 0 1 .7.29l5.42 5.42a1 1 0 0 1 .29.7V19a2 2 0 0 1-2 2z',
+		items: [
+			{ label: 'Disclaimer', href: '/legal/disclaimer/' },
+			{ label: 'Privacy Policy', href: '/legal/privacy/' },
+			{ label: 'Terms of Service', href: '/legal/tos/' },
+			{ label: 'EULA', href: '/legal/eula/' },
+		],
+	},
+	{
+		label: 'Permissive licenses',
+		eyebrow: 'Use, modify, redistribute',
+		icon: 'M16 18 22 12 16 6M8 6 2 12 8 18',
+		items: [
+			{ label: 'MIT', href: '/legal/mit/' },
+			{ label: 'Apache 2.0', href: '/legal/apache-2/' },
+			{ label: 'BSD 2-Clause', href: '/legal/bsd-2/' },
+			{ label: 'BSD 3-Clause', href: '/legal/bsd-3/' },
+			{ label: 'ISC', href: '/legal/isc/' },
+		],
+	},
+	{
+		label: 'Copyleft licenses',
+		eyebrow: 'Share-alike obligations',
+		icon: 'M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM15 9.5a4 4 0 1 0 0 5',
+		items: [
+			{ label: 'GPL-3.0', href: '/legal/gpl-3/' },
+			{ label: 'LGPL-3.0', href: '/legal/lgpl-3/' },
+			{ label: 'MPL-2.0', href: '/legal/mpl-2/' },
+		],
+	},
+	{
+		label: 'Content & public domain',
+		eyebrow: 'Assets and docs',
+		icon: 'M4 16l4.586-4.586a2 2 0 0 1 2.828 0L16 16m-2-2 1.586-1.586a2 2 0 0 1 2.828 0L20 14m-6-6h.01M6 20h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z',
+		items: [
+			{ label: 'CC BY 4.0', href: '/legal/cc-by-4/' },
+			{ label: 'CC BY-SA 4.0', href: '/legal/cc-by-sa-4/' },
+			{ label: 'Unlicense / CC0', href: '/legal/unlicense/' },
+		],
+	},
+];
+
+export const isLegalActive = (pathname: string, href: string): boolean =>
+	isActiveIn(LEGAL_ROOT.href, pathname, href);
+
+export const buildLegalBreadcrumb = (pathname: string): BreadcrumbCrumb[] =>
+	buildBreadcrumbIn(LEGAL_NAV, LEGAL_ROOT, pathname);

--- a/apps/kbve/astro-kbve/src/content/docs/legal/apache-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/apache-2.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apache License 2.0
 description: The Apache License 2.0 as used by open-source components within the KBVE monorepo.
+template: splash
 sidebar:
     label: Apache 2.0
     order: 11
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="apache-2"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## Apache License, Version 2.0
 
@@ -229,3 +237,5 @@ and trademark use restrictions.
 Many Rust crates in this monorepo are dual-licensed under `MIT OR Apache-2.0`,
 following the convention established by the Rust standard library and most of
 the Rust ecosystem. Users may choose either license at their discretion.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/bsd-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/bsd-2.mdx
@@ -1,6 +1,7 @@
 ---
 title: BSD 2-Clause License
 description: The BSD 2-Clause "Simplified" License as referenced by dependencies within the KBVE monorepo.
+template: splash
 sidebar:
     label: BSD 2-Clause
     order: 13
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="bsd-2"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## BSD 2-Clause "Simplified" License
 
@@ -61,3 +69,5 @@ Common in C/C++ libraries, system-level dependencies, and cryptographic tooling
 (e.g., OpenSSL derivatives, libc wrappers). When the KBVE monorepo depends on a
 BSD-2-Clause library, the binary distribution includes the required copyright
 notice in its attribution.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/bsd-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/bsd-3.mdx
@@ -1,6 +1,7 @@
 ---
 title: BSD 3-Clause License
 description: The BSD 3-Clause "New" or "Revised" License as referenced by dependencies within the KBVE monorepo.
+template: splash
 sidebar:
     label: BSD 3-Clause
     order: 14
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="bsd-3"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## BSD 3-Clause "New" or "Revised" License
 
@@ -64,3 +72,5 @@ promote derived products without explicit written permission. This is the
 Common in scientific computing libraries, networking stacks, and game engine
 dependencies. The additional clause prevents implying official endorsement
 when redistributing modified versions.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-4.mdx
@@ -1,6 +1,7 @@
 ---
 title: Creative Commons Attribution 4.0
 description: The CC BY 4.0 License as referenced for assets and documentation within the KBVE monorepo.
+template: splash
 sidebar:
     label: CC BY 4.0
     order: 18
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="cc-by-4"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## Creative Commons Attribution 4.0 International (CC BY 4.0)
 
@@ -46,3 +54,5 @@ CC BY 4.0 is used for:
 Each asset specifies its license in an accompanying `LICENSE` file or in the
 asset's metadata. Assets without a specified license fall under the
 [EULA](/legal/eula/) by default.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-sa-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-sa-4.mdx
@@ -1,6 +1,7 @@
 ---
 title: Creative Commons Attribution-ShareAlike 4.0
 description: The CC BY-SA 4.0 License as referenced for assets and community content within the KBVE monorepo.
+template: splash
 sidebar:
     label: CC BY-SA 4.0
     order: 19
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="cc-by-sa-4"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 
@@ -46,3 +54,5 @@ should stay open:
 
 The ShareAlike clause ensures that improvements and derivatives remain freely
 available to the community under the same terms.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/disclaimer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/disclaimer.mdx
@@ -2,6 +2,7 @@
 title: Disclaimer
 description: |
     The Official KBVE Disclaimer
+template: splash
 sidebar:
     label: Disclaimer
     order: 2
@@ -21,6 +22,14 @@ import {
 	Tabs,
 	TabItem,
 } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="disclaimer"
+	title={frontmatter.title}
+	description={frontmatter.description}
+	heading="Disclaimer">
 
 ## Disclaimer
 
@@ -54,3 +63,5 @@ the availability of, or the content located on or through it.
 Plus, any
 losses or damages occurred from using these contents or the internet
 generally.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
@@ -2,6 +2,7 @@
 title: EULA
 description: |
     The KBVE EULA
+template: splash
 sidebar:
     label: EULA
     order: 4
@@ -22,6 +23,14 @@ import {
 	TabItem,
 } from '@astrojs/starlight/components';
 
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="eula"
+	title={frontmatter.title}
+	description={frontmatter.description}
+	heading="End-User License Agreement"
+	updated="2022-12-13">
 
 ## EULA
 
@@ -237,3 +246,5 @@ By visiting this page on our website: [Support & Contact Us](https://kbve.com/su
 
 
 ---
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/gpl-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/gpl-3.mdx
@@ -1,6 +1,7 @@
 ---
 title: GNU General Public License v3.0
 description: The GPL-3.0 license as used by open-source components within the KBVE monorepo.
+template: splash
 sidebar:
     label: GPL-3.0
     order: 12
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="gpl-3"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## GNU General Public License v3.0
 
@@ -96,3 +104,5 @@ Proprietary KBVE applications covered by the [EULA](/legal/eula/) are distribute
 separately from GPL-3.0 components. Where a proprietary application incorporates
 a GPL-3.0 dependency, the relevant source code is made available as required by
 the license, and the EULA's scope explicitly excludes those GPL-licensed portions.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
@@ -3,6 +3,7 @@ title: Legal
 description: |
     Explore the legal documentation for KBVE, including our Privacy Policy, Cookie Policy, End-User License Agreement (EULA), and Terms of Service.
     Ensure you understand your rights and responsibilities as a user of our website and applications
+template: splash
 sidebar:
     label: Legal
     order: 1
@@ -12,102 +13,240 @@ tags:
     - legal
 ---
 
-import {
-	Card,
-	CardGrid,
-	LinkCard,
-	Steps,
-	Aside,
-	Tabs,
-	TabItem,
-} from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import Adsense from '@/components/astropad/adsense/Adsense.astro';
 
-# Legal Documentation Overview
+export const backdrop = 'https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?fit=crop&w=2400&q=75';
 
-<CardGrid>
-  <LinkCard href="/legal/privacy" title="Privacy Policy" icon="shield">
-    Explore how we extract data, use cookies, and protect your personal information.
-  </LinkCard>
-  <LinkCard href="/legal/disclaimer" title="Disclaimer" icon="document">
-    Under the legal disclaimer that refers to all our services, software and applications.
-  </LinkCard>
-  <LinkCard href="/legal/eula" title="End-User License Agreement (EULA)" icon="document">
-    Review the terms governing the use of our software applications.
-  </LinkCard>
-  <LinkCard href="/legal/tos" title="Terms of Service" icon="gavel">
-    Familiarize yourself with the rules and guidelines for using our services.
-  </LinkCard>
-</CardGrid>
+export const ARROW = 'M5 12h14M13 6l6 6-6 6';
 
-## Open-Source Licenses
+export const DOC_ICON = 'M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.59a1 1 0 0 1 .7.29l5.42 5.42a1 1 0 0 1 .29.7V19a2 2 0 0 1-2 2z';
 
-The KBVE monorepo and distributed applications include open-source components
-released under the following licenses. Each component specifies its license in
-its `Cargo.toml`, `package.json`, or `LICENSE` file.
+export const CODE_ICON = 'M16 18 22 12 16 6M8 6 2 12 8 18';
 
-<CardGrid>
-  <LinkCard href="/legal/mit" title="MIT License" icon="open-book">
-    Permissive — use, modify, redistribute with attribution.
-  </LinkCard>
-  <LinkCard href="/legal/apache-2" title="Apache License 2.0" icon="open-book">
-    Permissive — patent grant + trademark protections.
-  </LinkCard>
-  <LinkCard href="/legal/bsd-2" title="BSD 2-Clause" icon="open-book">
-    Permissive — minimal conditions, attribution only.
-  </LinkCard>
-  <LinkCard href="/legal/bsd-3" title="BSD 3-Clause" icon="open-book">
-    Permissive — attribution + no-endorsement clause.
-  </LinkCard>
-  <LinkCard href="/legal/isc" title="ISC License" icon="open-book">
-    Permissive — MIT-equivalent, common in npm ecosystem.
-  </LinkCard>
-  <LinkCard href="/legal/gpl-3" title="GPL-3.0" icon="open-book">
-    Copyleft — derivative works must carry the same license.
-  </LinkCard>
-  <LinkCard href="/legal/lgpl-3" title="LGPL-3.0" icon="open-book">
-    Weak copyleft — linking exception for proprietary code.
-  </LinkCard>
-  <LinkCard href="/legal/mpl-2" title="MPL-2.0" icon="open-book">
-    File-level copyleft — modified files stay MPL-2.0.
-  </LinkCard>
-  <LinkCard href="/legal/cc-by-4" title="CC BY 4.0" icon="open-book">
-    Creative Commons — share and adapt assets with attribution.
-  </LinkCard>
-  <LinkCard href="/legal/cc-by-sa-4" title="CC BY-SA 4.0" icon="open-book">
-    Creative Commons — attribution + ShareAlike for derivatives.
-  </LinkCard>
-  <LinkCard href="/legal/unlicense" title="Unlicense / CC0" icon="open-book">
-    Public domain — no conditions, no attribution required.
-  </LinkCard>
-</CardGrid>
+export const stats = [
+	{ label: 'Policies', value: '4', icon: DOC_ICON },
+	{ label: 'Licenses', value: '11', icon: CODE_ICON },
+	{ label: 'Governing entity', value: 'KBVE Holdings LLC', icon: 'M3 21h18M5 21V7l7-4 7 4v14M9 21v-6h6v6' },
+	{ label: 'Policies updated', value: 'Dec 2022', icon: 'M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0z' },
+];
 
+export const policies = [
+	{ href: '/legal/privacy/', title: 'Privacy Policy', copy: 'How we collect, use, store, and share your personal information — and the rights you have over it.' },
+	{ href: '/legal/disclaimer/', title: 'Disclaimer', copy: 'The limits of liability that apply across all KBVE services, software, and applications.' },
+	{ href: '/legal/eula/', title: 'End-User License Agreement', copy: 'The terms governing installation and use of our software applications.' },
+	{ href: '/legal/tos/', title: 'Terms of Service', copy: 'The rules and guidelines you agree to when using our services.' },
+];
 
-<Aside type="note" title="Important">
-  Please read each document carefully to fully understand your rights and obligations.
-</Aside>
+export const licenseGroups = [
+	{
+		id: 'permissive',
+		eyebrow: 'Use, modify, redistribute',
+		heading: 'Permissive licenses',
+		items: [
+			{ href: '/legal/mit/', title: 'MIT License', copy: 'Permissive — use, modify, redistribute with attribution.' },
+			{ href: '/legal/apache-2/', title: 'Apache License 2.0', copy: 'Permissive — patent grant plus trademark protections.' },
+			{ href: '/legal/bsd-2/', title: 'BSD 2-Clause', copy: 'Permissive — minimal conditions, attribution only.' },
+			{ href: '/legal/bsd-3/', title: 'BSD 3-Clause', copy: 'Permissive — attribution plus a no-endorsement clause.' },
+			{ href: '/legal/isc/', title: 'ISC License', copy: 'Permissive — MIT-equivalent, common in the npm ecosystem.' },
+		],
+	},
+	{
+		id: 'copyleft',
+		eyebrow: 'Share-alike obligations',
+		heading: 'Copyleft licenses',
+		items: [
+			{ href: '/legal/gpl-3/', title: 'GPL-3.0', copy: 'Copyleft — derivative works must carry the same license.' },
+			{ href: '/legal/lgpl-3/', title: 'LGPL-3.0', copy: 'Weak copyleft — linking exception for proprietary code.' },
+			{ href: '/legal/mpl-2/', title: 'MPL-2.0', copy: 'File-level copyleft — modified files stay MPL-2.0.' },
+		],
+	},
+	{
+		id: 'content',
+		eyebrow: 'Assets and documentation',
+		heading: 'Content & public domain',
+		items: [
+			{ href: '/legal/cc-by-4/', title: 'CC BY 4.0', copy: 'Creative Commons — share and adapt assets with attribution.' },
+			{ href: '/legal/cc-by-sa-4/', title: 'CC BY-SA 4.0', copy: 'Creative Commons — attribution plus ShareAlike for derivatives.' },
+			{ href: '/legal/unlicense/', title: 'Unlicense / CC0', copy: 'Public domain — no conditions, no attribution required.' },
+		],
+	},
+];
 
+export const faqs = [
+	{ q: 'What is the purpose of the Privacy Policy?', a: 'It explains how we handle your personal data, including collection, usage, and the measures we take to protect it.' },
+	{ q: 'How can I manage cookies on your site?', a: 'The cookie section of the Privacy Policy covers cookie management, including how to control or delete them.' },
+	{ q: 'What does the EULA cover?', a: 'The End-User License Agreement sets out the terms under which you may install and use our software applications.' },
+	{ q: 'Which license applies to a given component?', a: 'Each component declares its license in its own Cargo.toml, package.json, or LICENSE file. The pages here are the full texts those declarations point at.' },
+];
 
-## Steps to Access Legal Documents
+<div class="lg" style={`--bento-hero-bg: url('${backdrop}')`} data-legal-page>
 
-<Steps>
-  1. **Navigate to the desired document**: Click on the relevant card above to go to the specific legal document's page.
-  2. **Read the document thoroughly**: Ensure you comprehend all the terms and conditions outlined.
-  3. **Contact us for clarifications**: If you have any questions, reach out to our support team for assistance.
-</Steps>
+<section class="bento-hero bento-section not-content" aria-label="KBVE legal documentation">
+	<div class="bento-hero__bg" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy bento-card bento-card--glass">
+				<span class="bento-badge bento-chip">
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d={DOC_ICON} />
+					</svg>
+					<span>KBVE Holdings LLC · legal</span>
+				</span>
+				<h1 class="bento-title">
+					Your rights, and
+					<span class="bento-title__accent">what we owe you.</span>
+				</h1>
+				<p class="bento-lede">
+					Every policy that governs your use of KBVE services, plus the full
+					text of each open-source license our software and assets are
+					distributed under. Components declare their license in their own
+					manifest; these pages are what those declarations point at.
+				</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#policies">
+						Read the policies
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={ARROW} />
+						</svg>
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#licenses">Browse licenses</a>
+					<a class="bento-btn bento-btn--ghost" href="/support/">Ask a question →</a>
+				</div>
+			</div>
 
-## Frequently Asked Questions
+			<div class="bento-cell bento-hero-aside bento-card bento-card--glass">
+				<div class="bento-cell-eyebrow">Start here</div>
+				<ul class="bento-list lg-quick">
+					{policies.map((p) => (
+						<li><a href={p.href}>{p.title}</a></li>
+					))}
+				</ul>
+			</div>
 
-<Tabs>
-  <TabItem label="What is the purpose of the Privacy Policy?">
-    The Privacy Policy explains how we handle your personal data, including collection, usage, and protection measures.
-  </TabItem>
-  <TabItem label="How can I manage cookies on your site?">
-    Our Cookie Policy, under Policy, provides details on cookie management, including how to control or delete them as per your preferences.
-  </TabItem>
-  <TabItem label="What does the EULA cover?">
-    The End-User License Agreement outlines the terms under which you may use our software applications.
-  </TabItem>
-  <TabItem label="Where can I find the Terms of Service?">
-    The Terms of Service are accessible through the 'Terms of Service' card above, detailing the guidelines for using our services.
-  </TabItem>
-</Tabs>
+			{stats.map((s) => (
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d={s.icon} /></svg>
+					</span>
+					<span class="bento-stat__value">{s.value}</span>
+					<span class="bento-stat__label">{s.label}</span>
+				</div>
+			))}
+		</div>
+
+		<nav class="bento-jump" aria-label="On this page">
+			<a class="bento-chip" href="#policies">Policies</a>
+			<a class="bento-chip" href="#permissive">Permissive</a>
+			<a class="bento-chip" href="#copyleft">Copyleft</a>
+			<a class="bento-chip" href="#content">Content</a>
+			<a class="bento-chip" href="#faq">FAQ</a>
+		</nav>
+	</div>
+</section>
+
+<BentoShell id="policies" eyebrow="How we operate" heading="Policies">
+	<div class="bento-board bento-board--cols-2">
+		{policies.map((p) => (
+			<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href={p.href}>
+				<span class="bento-icon-tile">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d={DOC_ICON} />
+					</svg>
+				</span>
+				<span class="bento-linkcard__title">{p.title}</span>
+				<span class="bento-linkcard__copy">{p.copy}</span>
+				<span class="bento-linkcard__go" aria-hidden="true">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d={ARROW} /></svg>
+				</span>
+			</a>
+		))}
+	</div>
+</BentoShell>
+
+<BentoShell id="licenses" eyebrow="Open source" heading="Licenses we distribute under">
+	<div class="bento-board bento-board--cols-3">
+		<div class="bento-cell bento-featurecard bento-card bento-card--glass">
+			<h3 class="bento-featurecard__title">How to read these</h3>
+			<div class="bento-featurecard__body">
+				The KBVE monorepo and its distributed applications bundle open-source
+				components. Each one names its license in its own <code>Cargo.toml</code>,
+				<code>package.json</code>, or <code>LICENSE</code> file — the pages
+				below are the full texts those files point at.
+			</div>
+		</div>
+		<div class="bento-cell bento-featurecard bento-card bento-card--glass">
+			<h3 class="bento-featurecard__title">Proprietary vs open source</h3>
+			<div class="bento-featurecard__body">
+				KBVE applications themselves ship under the <a href="/legal/eula/">EULA</a>.
+				That agreement governs the application; the licenses here govern the
+				third-party components inside it.
+			</div>
+		</div>
+		<div class="bento-cell bento-featurecard bento-card bento-card--glass">
+			<h3 class="bento-featurecard__title">Attribution</h3>
+			<div class="bento-featurecard__body">
+				Every license listed requires attribution except the public-domain
+				dedications. Where a component requires a NOTICE file, it ships
+				alongside the distributed build.
+			</div>
+		</div>
+	</div>
+</BentoShell>
+
+{licenseGroups.map((g) => (
+	<BentoShell id={g.id} eyebrow={g.eyebrow} heading={g.heading}>
+		<div class="bento-board bento-board--auto">
+			{g.items.map((l) => (
+				<a class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive" href={l.href}>
+					<span class="bento-icon-tile">
+						<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<path d={CODE_ICON} />
+						</svg>
+					</span>
+					<span class="bento-linkcard__title">{l.title}</span>
+					<span class="bento-linkcard__copy">{l.copy}</span>
+					<span class="bento-linkcard__go" aria-hidden="true">
+						<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d={ARROW} /></svg>
+					</span>
+				</a>
+			))}
+		</div>
+	</BentoShell>
+))}
+
+<BentoShell id="faq" eyebrow="Common questions" heading="FAQ">
+	<div class="bento-board bento-board--cols-2">
+		{faqs.map((f) => (
+			<div class="bento-cell bento-faqcard bento-card bento-card--glass">
+				<h3 class="bento-faqcard__q">{f.q}</h3>
+				<p class="bento-faqcard__a">{f.a}</p>
+			</div>
+		))}
+	</div>
+</BentoShell>
+
+<section class="bento-section not-content">
+	<div class="bento-frame bento-band">
+		<Adsense />
+	</div>
+</section>
+
+</div>
+
+<style is:global>{`
+	.lg {
+		--bento-accent: #38bdf8;
+		--bento-accent-2: #818cf8;
+		--bento-btn-fg: #0b1220;
+	}
+
+	.lg .lg-quick a {
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+	}
+
+	.lg .lg-quick a:hover {
+		color: var(--sl-color-white);
+	}
+`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/isc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/isc.mdx
@@ -1,6 +1,7 @@
 ---
 title: ISC License
 description: The ISC License as referenced by dependencies within the KBVE monorepo.
+template: splash
 sidebar:
     label: ISC
     order: 15
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="isc"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## ISC License
 
@@ -52,3 +60,5 @@ The ISC License is the default license for npm packages and is used extensively
 in the Node.js ecosystem. Many transitive npm dependencies in the KBVE monorepo
 carry this license (e.g., semver, glob, minimatch, and hundreds of small
 utility packages).
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/lgpl-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/lgpl-3.mdx
@@ -1,6 +1,7 @@
 ---
 title: GNU Lesser General Public License v3.0
 description: The LGPL-3.0 License as referenced by dependencies within the KBVE monorepo.
+template: splash
 sidebar:
     label: LGPL-3.0
     order: 17
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="lgpl-3"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## GNU Lesser General Public License v3.0
 
@@ -45,3 +53,5 @@ codecs), GUI toolkits, and system libraries. When the KBVE monorepo links
 against an LGPL-3.0 library, the linking exception allows the surrounding
 proprietary application to remain under the [EULA](/legal/eula/), while the
 LGPL library itself retains its copyleft obligations.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/mit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/mit.mdx
@@ -1,6 +1,7 @@
 ---
 title: MIT License
 description: The MIT License as used by open-source components within the KBVE monorepo.
+template: splash
 sidebar:
     label: MIT License
     order: 10
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="mit"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## MIT License
 
@@ -59,3 +67,5 @@ Components in the KBVE monorepo that are released under the MIT License include
 select Bevy packages, shared utility crates, and npm packages. Each component's
 `Cargo.toml` or `package.json` specifies its license field. When a component
 does not specify a license, it falls under the [EULA](/legal/eula/) by default.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/mpl-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/mpl-2.mdx
@@ -1,6 +1,7 @@
 ---
 title: Mozilla Public License 2.0
 description: The MPL-2.0 License as referenced by dependencies within the KBVE monorepo.
+template: splash
 sidebar:
     label: MPL-2.0
     order: 16
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="mpl-2"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## Mozilla Public License Version 2.0
 
@@ -43,3 +51,5 @@ configuration parsers). When the KBVE monorepo depends on an MPL-2.0 library,
 the source of any modified MPL-2.0 files is made available as required.
 Unmodified MPL-2.0 dependencies used as-is satisfy the license by pointing to
 the upstream source repository.
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/privacy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/privacy.mdx
@@ -3,6 +3,7 @@ title: Privacy Policy
 description: |
     Explore the legal documentation for KBVE, including our Privacy Policy, Cookie Policy, End-User License Agreement (EULA), and Terms of Service.
     Ensure you understand your rights and responsibilities as a user of our website and applications
+template: splash
 sidebar:
     label: Privacy Policy
     order: 5
@@ -22,6 +23,15 @@ import {
 	Tabs,
 	TabItem,
 } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="privacy"
+	title={frontmatter.title}
+	description={frontmatter.description}
+	heading="Privacy notice"
+	updated="2022-12-14">
 
 ## PRIVACY NOTICE
 
@@ -426,3 +436,4 @@ If you have questions or comments about this notice, you may reach out to us via
 
 Based on the applicable laws of your country, you may have the right to request access to the personal information we collect from you, change that information, or delete it. To request to review, update, or delete your personal information, please visit: [KBVE Profile](https://kbve.com/profile) or contact [support](#contact)
 
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/tos.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/tos.mdx
@@ -2,6 +2,7 @@
 title: Terms of Service
 description: |
     The Official KBVE Disclaimer
+template: splash
 sidebar:
     label: Terms of Service
     order: 5
@@ -22,6 +23,14 @@ import {
 	TabItem,
 } from '@astrojs/starlight/components';
 
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="tos"
+	title={frontmatter.title}
+	description={frontmatter.description}
+	heading="Terms of Service"
+	updated="2022-12-13">
 
 ## TOS
 
@@ -190,3 +199,5 @@ Contact Us
 If you have any questions about these Terms of Service, You can contact us:
 
 By visiting this page on our website, [Support at KBVE](https://kbve.com/support/)
+
+</LegalLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/legal/unlicense.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/unlicense.mdx
@@ -1,6 +1,7 @@
 ---
 title: The Unlicense / CC0
 description: Public domain dedications as referenced by components and assets within the KBVE monorepo.
+template: splash
 sidebar:
     label: Unlicense / CC0
     order: 20
@@ -12,6 +13,13 @@ tags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+import LegalLeaf from '@/components/legal/LegalLeaf.astro';
+
+<LegalLeaf
+	slug="unlicense"
+	title={frontmatter.title}
+	description={frontmatter.description}>
 
 ## The Unlicense
 
@@ -75,3 +83,5 @@ Public domain dedications are used for:
 - Data files, lookup tables, and configuration templates
 - Sample code and educational examples
 - Assets explicitly donated to the public domain by contributors
+
+</LegalLeaf>


### PR DESCRIPTION
Same treatment as the community rail (#15179), applied to the sixteen pages under `/legal/`.

## The wrinkle

No legal page has an `h1` in its body — Starlight's docs layout was supplying the title from frontmatter. Switching to `template: splash` for the rail would have silently dropped the title off every policy and license page. The journal already solved this (all 367 leaves are splash plus a bento hero that carries the title), so legal follows that pattern rather than inventing a third one.

## Changes

**`legalNav.ts`** — rail rooted at `/legal/`, grouped Policies / Permissive / Copyleft / Content & public domain.

**`legalMeta.ts`** — per-slug SPDX id, a one-line obligation summary, and one accent hue per group so the section reads as a set.

**`LegalLeaf.astro`** — derives a `BentoDoc` hero from the page's own frontmatter and wraps the document in `BentoProse`, which keeps Starlight prose styling for the legal text. Siblings in the same rail group become the related links. `BentoDoc` renders `accent` as the tinted tail of the `h1` rather than as a separate label, so the title is split on its last word ("MIT" + "License") instead of appending the SPDX id — otherwise every page rendered as "MIT LicenseMIT".

**`MarkdownContent.astro`** — `isLegal` branch for `/legal/*`.

**15 leaf pages** — add `template: splash` and the `LegalLeaf` wrapper. The legal text itself is untouched; verified byte-identical modulo the wrapper.

**`index.mdx`** — recut as a bento hub. The `CardGrid` / `Steps` / `Tabs` markup becomes a hero, a policies grid, a licenses explainer, three grouped license grids, and an FAQ. Every previous link target is preserved.

## Verification

`pnpm nx run astro-kbve:build` green. Checked the built HTML for all sixteen pages — rail present, zero double sidebars, titles rendering once, breadcrumbs resolving through all four groups, prose intact:

| page | rail | double sidebar | prose chars | breadcrumb |
|---|---|---|---|---|
| index | yes | 0 | 3,460 | Legal |
| disclaimer | yes | 0 | 2,064 | Legal > Policies > Disclaimer |
| privacy | yes | 0 | 33,731 | Legal > Policies > Privacy Policy |
| tos | yes | 0 | 18,890 | Legal > Policies > Terms of Service |
| eula | yes | 0 | 18,760 | Legal > Policies > EULA |
| mit | yes | 0 | 2,724 | Legal > Permissive > MIT |
| apache-2 | yes | 0 | 11,910 | Legal > Permissive > Apache 2.0 |
| bsd-2 | yes | 0 | 4,198 | Legal > Permissive > BSD 2-Clause |
| bsd-3 | yes | 0 | 4,512 | Legal > Permissive > BSD 3-Clause |
| isc | yes | 0 | 2,915 | Legal > Permissive > ISC |
| gpl-3 | yes | 0 | 6,072 | Legal > Copyleft > GPL-3.0 |
| lgpl-3 | yes | 0 | 2,307 | Legal > Copyleft > LGPL-3.0 |
| mpl-2 | yes | 0 | 2,263 | Legal > Copyleft > MPL-2.0 |
| cc-by-4 | yes | 0 | 2,224 | Legal > Content & PD > CC BY 4.0 |
| cc-by-sa-4 | yes | 0 | 2,365 | Legal > Content & PD > CC BY-SA 4.0 |
| unlicense | yes | 0 | 3,081 | Legal > Content & PD > Unlicense / CC0 |