### PR TITLE
fix(docker): mirror workspace.dependencies into Cargo stub manifests

### DIFF
--- a/.github/workflows/ci-cargo-stub-guard.yml
+++ b/.github/workflows/ci-cargo-stub-guard.yml
@@ -1,0 +1,44 @@
+name: CI - Cargo Workspace Stub Guard
+
+# Docker builds never see the root Cargo.toml — each Rust app copies its own
+# apps/**/Cargo.workspace.toml in as /app/Cargo.toml. Once #15165 moved crate
+# versions into the root [workspace.dependencies] table, every member manifest
+# using `dep.workspace = true` failed inside the image with
+# "`workspace.dependencies` was not defined", taking out all 18 Rust images at
+# once while `cargo build` on the host stayed green.
+#
+# This guard fails any PR where the stubs drift from the root table.
+
+on:
+    pull_request:
+        branches:
+            - main
+            - dev
+        paths:
+            - 'Cargo.toml'
+            - 'apps/**/Cargo.workspace.toml'
+            - 'scripts/sync-cargo-workspace-stubs.py'
+            - '.github/workflows/ci-cargo-stub-guard.yml'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    verify:
+        name: Verify Cargo.workspace.toml stubs match root
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v7
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: '3.13'
+
+            - name: Stubs carry the root [workspace.dependencies]
+              run: python3 scripts/sync-cargo-workspace-stubs.py --check

--- a/apps/agones/arpg/server/Cargo.workspace.toml
+++ b/apps/agones/arpg/server/Cargo.workspace.toml
@@ -8,6 +8,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/agones/cryptothrone/server/Cargo.workspace.toml
+++ b/apps/agones/cryptothrone/server/Cargo.workspace.toml
@@ -8,6 +8,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/agones/factorio/relay/Cargo.workspace.toml
+++ b/apps/agones/factorio/relay/Cargo.workspace.toml
@@ -8,6 +8,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/agones/palworld/relay/Cargo.workspace.toml
+++ b/apps/agones/palworld/relay/Cargo.workspace.toml
@@ -8,6 +8,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
+++ b/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
@@ -11,6 +11,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/discordsh/axum-discordsh/Cargo.workspace.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/discordsh/discordsh-bot/Cargo.workspace.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.workspace.toml
@@ -16,6 +16,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/herbmail/axum-herbmail/Cargo.workspace.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/irc/irc-gateway/Cargo.workspace.toml
+++ b/apps/irc/irc-gateway/Cargo.workspace.toml
@@ -11,6 +11,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/kbve/axum-kbve/Cargo.workspace.toml
+++ b/apps/kbve/axum-kbve/Cargo.workspace.toml
@@ -15,6 +15,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/kbve/kbve-gate/Cargo.workspace.toml
+++ b/apps/kbve/kbve-gate/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/memes/axum-memes/Cargo.workspace.toml
+++ b/apps/memes/axum-memes/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/rareicon/axum-rareicon/Cargo.workspace.toml
+++ b/apps/rareicon/axum-rareicon/Cargo.workspace.toml
@@ -12,6 +12,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/rentearth/axum-rentearth/Cargo.workspace.toml
+++ b/apps/rentearth/axum-rentearth/Cargo.workspace.toml
@@ -11,6 +11,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/factorio-ctl/Cargo.workspace.toml
+++ b/apps/vm/factorio-ctl/Cargo.workspace.toml
@@ -8,6 +8,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/firecracker-ctl/Cargo.workspace.toml
+++ b/apps/vm/firecracker-ctl/Cargo.workspace.toml
@@ -10,6 +10,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/vm/kubectl/Cargo.workspace.toml
+++ b/apps/vm/kubectl/Cargo.workspace.toml
@@ -7,6 +7,89 @@ members = [
 [workspace.package]
 rust-version = "1.96"
 
+[workspace.dependencies]
+agones = "1.57"
+ammonia = "4.1.2"
+anyhow = "1.0"
+argon2 = "0.5.0"
+askama = "0.16.0"
+async-trait = "0.1.88"
+avian3d = { version = "0.7", default-features = false }
+axum = { version = "0.8.9", default-features = false }
+axum-extra = "0.12.6"
+base64 = "0.22.1"
+bb8 = "0.9"
+bevy = { version = "0.19", default-features = false }
+bincode = "2.0"
+bitflags = "2.9.0"
+bytes = "1"
+chrono = { version = "0.4.44", default-features = false }
+criterion = { version = "0.5", default-features = false }
+crossbeam-channel = "0.5.15"
+dashmap = "6.1.0"
+dirs = "6"
+dotenvy = "0.15"
+futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
+http = "1.4.0"
+http-body-util = "0.1"
+jni = "0.21"
+js-sys = { version = "0.3", default-features = false }
+jsonwebtoken = { version = "10.3.0", default-features = false }
+k8s-openapi = "0.27"
+kube = { version = "3", default-features = false }
+lightyear = { version = "0.28", default-features = false }
+log = "0.4"
+lru = "0.18"
+metrics = "0.24"
+num_cpus = "1.17.0"
+objc2 = "0.6.3"
+pollster = "0.4"
+postcard = { version = "1.0", default-features = false }
+proc-macro2 = "1"
+prost = "0.14.1"
+prost-build = "0.14"
+prost-types = "0.14"
+quote = "1.0.44"
+rand = "0.10"
+raw-window-handle = "0.6.2"
+regex = "1.11"
+reqwest = { version = "0.13.4", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
+serde = "1.0"
+serde_json = "1.0"
+serial_test = "3"
+sha2 = "0.11"
+socket2 = "0.6.1"
+syn = "3"
+sysinfo = "0.38.2"
+tempfile = "3"
+thiserror = "2.0.12"
+tikv-jemallocator = "0.7"
+tokio = { version = "1.49", default-features = false }
+tokio-postgres = "0.7.2"
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
+tower = "0.5.3"
+tower-http = "0.7.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+ulid = "1.2.1"
+url = "2.5"
+utoipa = "5"
+uuid = "1"
+wasm-bindgen = { version = "=0.2.114", default-features = false }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+webpki-roots = "0.26"
+wgpu = "29"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/scripts/sync-cargo-workspace-stubs.py
+++ b/scripts/sync-cargo-workspace-stubs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Mirror the root Cargo.toml [workspace.dependencies] table into every
+apps/**/Cargo.workspace.toml Docker stub manifest.
+
+Docker builds copy the stub as /app/Cargo.toml, so any workspace-inherited
+dependency (`dep.workspace = true`) fails with "`workspace.dependencies` was
+not defined" unless the stub carries the same table.
+
+Usage:
+    python3 scripts/sync-cargo-workspace-stubs.py           # rewrite stubs
+    python3 scripts/sync-cargo-workspace-stubs.py --check   # CI drift check
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SECTION = "[workspace.dependencies]"
+
+
+def extract_section(text: str) -> str:
+    lines = text.splitlines()
+    try:
+        start = next(i for i, l in enumerate(lines) if l.strip() == SECTION)
+    except StopIteration:
+        raise SystemExit(f"root Cargo.toml is missing {SECTION}")
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i].startswith("["):
+            end = i
+            break
+    body = "\n".join(lines[start:end]).rstrip()
+    return body + "\n"
+
+
+def strip_section(text: str) -> str:
+    lines = text.splitlines()
+    out, i = [], 0
+    while i < len(lines):
+        if lines[i].strip() == SECTION:
+            i += 1
+            while i < len(lines) and not lines[i].startswith("["):
+                i += 1
+            while out and not out[-1].strip():
+                out.pop()
+            if out:
+                out.append("")
+            continue
+        out.append(lines[i])
+        i += 1
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render(stub_text: str, section: str) -> str:
+    base = strip_section(stub_text)
+    lines = base.splitlines()
+    anchor = next((i for i, l in enumerate(lines) if l.startswith("[profile")), len(lines))
+    head = "\n".join(lines[:anchor]).rstrip()
+    tail = "\n".join(lines[anchor:]).rstrip()
+    parts = [head, section.rstrip()]
+    if tail:
+        parts.append(tail)
+    return "\n\n".join(p for p in parts if p) + "\n"
+
+
+def main() -> int:
+    check = "--check" in sys.argv
+    section = extract_section((ROOT / "Cargo.toml").read_text())
+    stubs = sorted((ROOT / "apps").rglob("Cargo.workspace.toml"))
+    if not stubs:
+        raise SystemExit("no Cargo.workspace.toml stubs found under apps/")
+
+    drifted = []
+    for stub in stubs:
+        current = stub.read_text()
+        desired = render(current, section)
+        if current == desired:
+            continue
+        drifted.append(stub.relative_to(ROOT))
+        if not check:
+            stub.write_text(desired)
+
+    if check and drifted:
+        print("Cargo.workspace.toml stubs out of sync with root [workspace.dependencies]:")
+        for path in drifted:
+            print(f"  {path}")
+        print("Run: python3 scripts/sync-cargo-workspace-stubs.py")
+        return 1
+
+    print(f"{'drift' if check else 'synced'}: {len(drifted)}/{len(stubs)} stubs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

All 18 Rust Docker images fail at `cargo chef prepare`:

```
error inheriting `anyhow` from workspace root manifest's `workspace.dependencies.anyhow`
Caused by:
  `workspace.dependencies` was not defined
```

#15165 moved crate versions into the root `Cargo.toml` `[workspace.dependencies]` table. Docker builds never copy the root manifest — each app copies its own `apps/**/Cargo.workspace.toml` in as `/app/Cargo.toml`. That stub has no `[workspace.dependencies]`, so every member using `dep.workspace = true` fails inside the image while host `cargo build` stays green.

Broken: #15185 #15186 #15187 #15188 #15189 #15190 and the rest of CI - Docker.

## Fix

- `scripts/sync-cargo-workspace-stubs.py` mirrors the root table into all 18 stubs (`--check` for drift).
- Stubs regenerated.
- `CI - Cargo Workspace Stub Guard` fails any PR that edits the root table or a stub without re-syncing.

## Verification

`docker build --target planner` passes for `discordsh-bot`, `axum-kbve`, `arpg/server`, `vm/kubectl` — all previously failed at this stage.