### PR TITLE
fix(isometric): allow swc/esbuild builds so pnpm install passes

### DIFF
--- a/apps/kbve/isometric/pnpm-workspace.yaml
+++ b/apps/kbve/isometric/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
-onlyBuiltDependencies: esbuild
+allowBuilds:
+  '@swc/core': true
+  esbuild: true


### PR DESCRIPTION
## CI - Bevy (isometric)

`pnpm build` died at install:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @swc/core@1.15.18, esbuild@0.25.12
```

`apps/kbve/isometric/pnpm-workspace.yaml` declared `onlyBuiltDependencies: esbuild` as a **scalar**, not a list, so pnpm 11 allowed nothing and hard-errored. Replaced with the `allowBuilds` map the root `pnpm-workspace.yaml` already uses, covering `@swc/core` and `esbuild`.

Verified locally with pnpm 11.15.0: `pnpm install --frozen-lockfile` in `apps/kbve/isometric` exits 0 on a clean `node_modules`.

## CI - Vite Game (herbmail-game) — fixed outside this PR

```
[c14af6e7e1ce2da706f330e4d93fd38ebcfc406ca8fa9e6be304a5b01bfd534f] Not Found: [404]
Failed to fetch some objects from 'https://git.kbve.com/KBVE/herbmail.git/info/lfs'
```

`apps/herbmail/herbmail-game/public/icons/items/pickaxe.png` was committed as an LFS pointer but its blob never reached the per-game Forgejo store. Pushed with `./kbve.sh -lfs herbmail register origin` (93 OIDs, server-deduped); the batch API now returns a download action for that OID. No code change needed.

Sibling nested workspaces (`desktop-kbve`, `chuck-launcher`) already use list form and have no `@swc/core` in their lockfiles — left alone.