### PR TITLE
fix(reel): recover stalled leeches instead of deleting them

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.35"
+version: "0.1.36"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml
@@ -291,6 +291,24 @@ download the first watcher was still driving. That presented as the swarm
 "resetting to zero" mid-download and as finished files disappearing. The dedupe
 check removes the duplicate watcher entirely; a genuinely failed torrent can still
 be re-added to retry.
+
+A download that goes quiet is treated as a connection problem before it is treated
+as a missing file. Because there is no forwarded port behind the VPN, the swarm is
+outbound-only: nothing ever dials in, so once the peers Reel dialed out to go silent
+— a stale NAT mapping, a choke, a tunnel blip — nothing replaces them until the
+tracker is announced again, which can be half an hour away. The old watcher only
+looked at whether the byte count moved, waited five minutes, then declared that no
+seeders had the content and deleted the partial download. That verdict was wrong
+whenever the tracker showed a healthy seed count: the content was there, the
+connections were not. Reel now reads the peer counts it was already collecting. With
+peers still connected the stall budget stretches to fifteen minutes, since a
+connected-but-silent peer is choked rather than gone. When the budget does elapse,
+Reel pauses and unpauses the torrent — tearing down every stale socket and forcing a
+fresh announce — and retries that re-dial three times before giving up. A download
+that does finally fail keeps its partial data and reports what it actually saw (live,
+seen, and connecting peer counts) instead of a guess, so re-adding the magnet resumes
+where it stopped rather than starting over. The idle-TTL reaper still clears the
+leftovers.
 
 Playback is meant to be effortless: download a file and it becomes watchable on its
 own, with no manual transcode step and without keeping two copies. When a download

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -14,7 +14,9 @@ pub struct Config {
     pub vpn_watchdog_secs: u64,
     pub metadata_timeout_secs: u64,
     pub stall_timeout_secs: u64,
+    pub stall_connected_timeout_secs: u64,
     pub stall_check_secs: u64,
+    pub stall_recovery_attempts: u32,
     pub extra_trackers: Vec<String>,
     pub trackers_urls: Vec<String>,
     pub trackers_cache: PathBuf,
@@ -159,7 +161,9 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         vpn_watchdog_secs: env_u64("REEL_VPN_WATCHDOG_SECS", 60)?,
         metadata_timeout_secs: env_u64("REEL_METADATA_TIMEOUT_SECS", 120)?,
         stall_timeout_secs: env_u64("REEL_STALL_TIMEOUT_SECS", 300)?,
+        stall_connected_timeout_secs: env_u64("REEL_STALL_CONNECTED_TIMEOUT_SECS", 900)?,
         stall_check_secs: env_u64("REEL_STALL_CHECK_SECS", 15)?,
+        stall_recovery_attempts: env_u64("REEL_STALL_RECOVERY_ATTEMPTS", 3)? as u32,
         extra_trackers: match std::env::var("REEL_TRACKERS") {
             Ok(v) if !v.trim().is_empty() => parse_trackers(&v.replace(',', "\n")),
             _ => DEFAULT_TRACKERS.iter().map(|s| s.to_string()).collect(),
@@ -280,7 +284,9 @@ mod tests {
         assert!(c.vpn_check_urls.iter().all(|u| u.starts_with("https://")));
         assert_eq!(c.metadata_timeout_secs, 120);
         assert_eq!(c.stall_timeout_secs, 300);
+        assert_eq!(c.stall_connected_timeout_secs, 900);
         assert_eq!(c.stall_check_secs, 15);
+        assert_eq!(c.stall_recovery_attempts, 3);
         assert!(
             !c.extra_trackers.is_empty(),
             "embedded default trackers present"

--- a/apps/media/reel/src/engine.rs
+++ b/apps/media/reel/src/engine.rs
@@ -259,7 +259,9 @@ pub struct Engine {
     drain: Arc<Notify>,
     metadata_timeout: Duration,
     stall_timeout: Duration,
+    stall_connected_timeout: Duration,
     stall_check: Duration,
+    stall_recovery_attempts: u32,
     trackers: Arc<Mutex<Arc<Vec<String>>>>,
     bt_port_file: Option<PathBuf>,
     transcode_wake: Arc<Notify>,
@@ -275,6 +277,17 @@ pub fn is_stalled(
     stall_timeout_secs: u64,
 ) -> bool {
     cur_bytes <= prev_bytes && idle_secs >= stall_timeout_secs
+}
+
+/// Peers connected but sending nothing is a choke or a dead-but-not-yet-timed-out
+/// socket, not an empty swarm — give those the longer budget so a re-dial has a
+/// chance before we call the download lost.
+pub fn stall_budget_secs(peers_live: usize, dry_secs: u64, connected_secs: u64) -> u64 {
+    if peers_live > 0 {
+        connected_secs.max(dry_secs)
+    } else {
+        dry_secs
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -398,7 +411,9 @@ impl Engine {
             drain: Arc::new(Notify::new()),
             metadata_timeout: Duration::from_secs(cfg.metadata_timeout_secs),
             stall_timeout: Duration::from_secs(cfg.stall_timeout_secs),
+            stall_connected_timeout: Duration::from_secs(cfg.stall_connected_timeout_secs),
             stall_check: Duration::from_secs(cfg.stall_check_secs.max(1)),
+            stall_recovery_attempts: cfg.stall_recovery_attempts,
             trackers: Arc::new(Mutex::new(Arc::new(seed_trackers(
                 &cfg.trackers_cache,
                 &cfg.extra_trackers,
@@ -585,7 +600,9 @@ impl Engine {
         let transcode_wake = self.transcode_wake.clone();
         let metadata_timeout = self.metadata_timeout;
         let stall_timeout = self.stall_timeout;
+        let stall_connected_timeout = self.stall_connected_timeout;
         let stall_check = self.stall_check;
+        let stall_recovery_attempts = self.stall_recovery_attempts;
         let vpn_ok = self.vpn_ok.clone();
         tokio::spawn(async move {
             match tokio::time::timeout(metadata_timeout, handle.wait_until_initialized()).await {
@@ -621,23 +638,34 @@ impl Engine {
             tokio::pin!(completed);
             let mut last_bytes = 0u64;
             let mut idle_secs = 0u64;
+            let mut recoveries = 0u32;
             let outcome: anyhow::Result<()> = loop {
                 tokio::select! {
                     r = &mut completed => break r,
                     _ = tokio::time::sleep(stall_check) => {
                         let s = handle.stats();
-                        let (dl_mbps, peers_live) = s
+                        let (dl_mbps, peers_live, peers_seen, peers_connecting) = s
                             .live
                             .as_ref()
-                            .map(|l| (l.download_speed.mbps, l.snapshot.peer_stats.live))
-                            .unwrap_or((0.0, 0));
+                            .map(|l| {
+                                (
+                                    l.download_speed.mbps,
+                                    l.snapshot.peer_stats.live,
+                                    l.snapshot.peer_stats.seen,
+                                    l.snapshot.peer_stats.connecting,
+                                )
+                            })
+                            .unwrap_or((0.0, 0, 0, 0));
                         tracing::debug!(
                             id = %id,
                             progress_bytes = s.progress_bytes,
                             total_bytes = s.total_bytes,
                             peers_live,
+                            peers_seen,
+                            peers_connecting,
                             dl_mbps,
                             idle_secs,
+                            recoveries,
                             "leech heartbeat"
                         );
                         if s.finished {
@@ -653,10 +681,32 @@ impl Engine {
                         } else {
                             idle_secs = idle_secs.saturating_add(stall_check.as_secs());
                         }
-                        if is_stalled(last_bytes, s.progress_bytes, idle_secs, stall_timeout.as_secs()) {
+                        let budget = stall_budget_secs(
+                            peers_live,
+                            stall_timeout.as_secs(),
+                            stall_connected_timeout.as_secs(),
+                        );
+                        if is_stalled(last_bytes, s.progress_bytes, idle_secs, budget) {
+                            if recoveries < stall_recovery_attempts {
+                                recoveries += 1;
+                                tracing::warn!(
+                                    id = %id,
+                                    attempt = recoveries,
+                                    of = stall_recovery_attempts,
+                                    idle_secs,
+                                    peers_live,
+                                    peers_seen,
+                                    "leech stalled; re-dialing swarm"
+                                );
+                                crate::telemetry::torrent_stall_recovery(&id, recoveries);
+                                redial_swarm(&session, &handle, &id).await;
+                                idle_secs = 0;
+                                continue;
+                            }
                             break Err(anyhow::anyhow!(
-                                "no data received for {}s — no seeders have the content",
-                                stall_timeout.as_secs()
+                                "no data received for {budget}s after {recoveries} re-dial attempts \
+                                 (peers live={peers_live} seen={peers_seen} connecting={peers_connecting}) \
+                                 — swarm unreachable, partial data kept for retry"
                             ));
                         }
                     }
@@ -669,7 +719,10 @@ impl Engine {
                     m.error = Some(format!("download failed: {e}"));
                     ((), true)
                 });
-                delete_from_session(&session, &id, true).await;
+                // Keep the partial payload: re-adding the same magnet resumes
+                // from it instead of re-fetching everything. The reaper still
+                // clears it once the TTL expires.
+                delete_from_session(&session, &id, false).await;
                 return;
             }
             // Stop uploading the moment the download lands. The torrent is
@@ -1089,6 +1142,19 @@ pub fn needs_resume_watch(state: &state::TorrentState) -> bool {
     matches!(state, state::TorrentState::Leeching)
 }
 
+/// Drop every peer connection and re-announce. Sockets behind the VPN go quiet
+/// without closing, and with no inbound port nothing replaces them — a pause
+/// tears them down and the unpause redials the swarm from a fresh announce.
+async fn redial_swarm(session: &Arc<Session>, handle: &Arc<ManagedTorrent>, id: &str) {
+    if let Err(e) = session.pause(handle).await {
+        tracing::warn!(id = %id, error = %e, "stall recovery: pause failed");
+        return;
+    }
+    if let Err(e) = session.unpause(handle).await {
+        tracing::warn!(id = %id, error = %e, "stall recovery: unpause failed");
+    }
+}
+
 async fn delete_from_session(session: &Session, id: &str, delete_files: bool) {
     if let Ok(tid) = TorrentIdOrHash::parse(id) {
         if let Err(e) = session.delete(tid, delete_files).await {
@@ -1362,6 +1428,29 @@ mod tests {
             std::fs::write(&p2, b"43287").unwrap();
         });
         assert_eq!(await_forwarded_port(&path, 2, 2).await, Some(43287));
+    }
+
+    #[test]
+    fn stall_budget_extends_while_peers_connected() {
+        assert_eq!(stall_budget_secs(0, 300, 900), 300);
+        assert_eq!(stall_budget_secs(1, 300, 900), 900);
+        assert_eq!(
+            stall_budget_secs(4, 900, 300),
+            900,
+            "connected budget never shortens the dry budget"
+        );
+    }
+
+    #[test]
+    fn connected_peers_delay_stall_trip() {
+        let dry = stall_budget_secs(0, 300, 900);
+        let connected = stall_budget_secs(3, 300, 900);
+        assert!(is_stalled(500, 500, 300, dry));
+        assert!(
+            !is_stalled(500, 500, 300, connected),
+            "peers alive at 300s idle are choked, not gone"
+        );
+        assert!(is_stalled(500, 500, 900, connected));
     }
 
     #[test]

--- a/apps/media/reel/src/telemetry.rs
+++ b/apps/media/reel/src/telemetry.rs
@@ -26,6 +26,15 @@ pub fn torrent_failed(id: &str, phase: &str, reason: &str) {
     );
 }
 
+pub fn torrent_stall_recovery(id: &str, attempt: u32) {
+    tracing::warn!(
+        event = "torrent_stall_recovery",
+        id,
+        attempt,
+        "leech stalled; redialing swarm"
+    );
+}
+
 pub fn reaped(id: &str, name: &str, size: u64) {
     tracing::info!(event = "reaped", id, name, size, "reaped");
 }


### PR DESCRIPTION
## Problem

`download failed: no data received for 300s — no seeders have the content` fires on torrents whose tracker reports 100% seeders. The message is a guess, not a measurement — the stall watcher only tracked byte progress and never looked at peers.

Behind gluetun/ProtonVPN there is no forwarded port, so the swarm is outbound-only. When the peers we dialed out to go silent (stale WireGuard NAT mapping, choke, tunnel blip), detection waits on `REEL_PEER_READ_WRITE_TIMEOUT_SECS=120` and nothing re-dials until the next tracker announce — routinely 30m away, far past the 300s stall window. Worse, the failure path called `delete_from_session(..., delete_files: true)`, so one transient blip nuked the partial download.

## Fix

- **Peer-aware budget** — `stall_budget_secs()`: live peers → 900s (connected-but-silent is a choke, not an empty swarm); zero peers → 300s as before.
- **Re-dial before failing** — on trip, `session.pause()` + `session.unpause()` tears down stale sockets and forces a fresh announce. Retried 3× with the idle counter reset, so real budget is ~45m connected / ~15m dry.
- **Non-destructive failure** — `delete_files: false` on the download path; re-adding the magnet resumes from the partial instead of restarting. Metadata-timeout keeps `true` (nothing on disk yet). Idle-TTL reaper still clears leftovers.
- **Honest error** — reports observed live/seen/connecting peer counts.

## Config

| env | default |
| --- | --- |
| `REEL_STALL_CONNECTED_TIMEOUT_SECS` | 900 |
| `REEL_STALL_RECOVERY_ATTEMPTS` | 3 |

Not set in `apps/kube/reel/manifest/reel.yaml`, so defaults apply on deploy — no manifest change.

## Observability

New `torrent_stall_recovery` event (id, attempt) → ClickHouse `observability.logs_distributed`. Leech heartbeat now logs `peers_seen`, `peers_connecting`, `recoveries`.

## Tests

`stall_budget_extends_while_peers_connected`, `connected_peers_delay_stall_trip`, plus the config default assertions. `nx test reel` + `nx lint reel` pass.

Docs: [reel.mdx](apps/kbve/astro-kbve/src/content/docs/project/reel.mdx) 0.1.35 → 0.1.36.