### PR TITLE
feat(palworld): double village shop cake prices

### DIFF
--- a/apps/agones/palworld/mods/PalSchema/mods/KBVEShops/raw/kbve-shops.json
+++ b/apps/agones/palworld/mods/PalSchema/mods/KBVEShops/raw/kbve-shops.json
@@ -364,35 +364,35 @@
                     {
                         "StaticItemId": "Cake",
                         "ProductType": "EPalItemShopProductType::Normal",
-                        "OverridePrice": 1500,
+                        "OverridePrice": 3000,
                         "ProductNum": 1,
                         "Stock": 0
                     },
                     {
                         "StaticItemId": "Cake02",
                         "ProductType": "EPalItemShopProductType::Normal",
-                        "OverridePrice": 2500,
+                        "OverridePrice": 5000,
                         "ProductNum": 1,
                         "Stock": 0
                     },
                     {
                         "StaticItemId": "Cake03",
                         "ProductType": "EPalItemShopProductType::Normal",
-                        "OverridePrice": 3000,
+                        "OverridePrice": 6000,
                         "ProductNum": 1,
                         "Stock": 0
                     },
                     {
                         "StaticItemId": "Cake04",
                         "ProductType": "EPalItemShopProductType::Normal",
-                        "OverridePrice": 5000,
+                        "OverridePrice": 10000,
                         "ProductNum": 1,
                         "Stock": 0
                     },
                     {
                         "StaticItemId": "Cake05",
                         "ProductType": "EPalItemShopProductType::Normal",
-                        "OverridePrice": 50000,
+                        "OverridePrice": 100000,
                         "ProductNum": 1,
                         "Stock": 0
                     },

--- a/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
@@ -63,11 +63,11 @@ palshop:
         - { id: Eaglestew, type: Normal, price: 260, num: 1, stock: 0 }
         - { id: StewedIceDeer, type: Normal, price: 300, num: 1, stock: 0 }
         - { id: MushroomJuice, type: Normal, price: 90, num: 1, stock: 0 }
-        - { id: Cake, type: Normal, price: 1500, num: 1, stock: 0 }
-        - { id: Cake02, type: Normal, price: 2500, num: 1, stock: 0 }
-        - { id: Cake03, type: Normal, price: 3000, num: 1, stock: 0 }
-        - { id: Cake04, type: Normal, price: 5000, num: 1, stock: 0 }
-        - { id: Cake05, type: Normal, price: 50000, num: 1, stock: 0 }
+        - { id: Cake, type: Normal, price: 3000, num: 1, stock: 0 }
+        - { id: Cake02, type: Normal, price: 5000, num: 1, stock: 0 }
+        - { id: Cake03, type: Normal, price: 6000, num: 1, stock: 0 }
+        - { id: Cake04, type: Normal, price: 10000, num: 1, stock: 0 }
+        - { id: Cake05, type: Normal, price: 100000, num: 1, stock: 0 }
         - { id: Honey, type: Normal, price: 80, num: 1, stock: 0 }
         - { id: Sweet, type: Normal, price: 60, num: 1, stock: 0 }
         - { id: Flour, type: Normal, price: 40, num: 1, stock: 0 }


### PR DESCRIPTION
## Summary

Cakes in the Palworld Village Shop were underpriced relative to the rest of the food tier. Doubled all five cake entries.

| Item | Old | New |
|---|---|---|
| `Cake` | 1500 | 3000 |
| `Cake02` | 2500 | 5000 |
| `Cake03` | 3000 | 6000 |
| `Cake04` | 5000 | 10000 |
| `Cake05` | 50000 | 100000 |

## Changes

- `apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx` — the source of truth. Prices live in the `palshop` frontmatter for `Village_Shop_1`.
- `apps/agones/palworld/mods/PalSchema/mods/KBVEShops/raw/kbve-shops.json` — regenerated overlay. `OverridePrice` on the matching `DT_ItemShopCreateData` rows.

## Regeneration

Ran the same two commands as the `astro-kbve:gen:palworld-shops` nx target:

```
node scripts/validate-palworld-shops.mjs
node scripts/generate-palworld-shops.mjs
```

Both scripts use only node builtins. Verified no drift:

```
[palworld-shops] validation passed
[palworld-shops] check: in sync
```

So `gen:palworld-shops:check` should pass in CI.

## Deploy note

This updates the repo artifact only. `overlay.sh` copies the JSON into the PalSchema mods dir at container start, so the live server picks the new prices up on the next image build + gameserver restart — not done here.