### PR TITLE
feat(astro-kbve): sector the stock section and rebuild the hub

### DIFF
--- a/apps/kbve/astro-kbve/src/components/stock/StockSectorDirectory.astro
+++ b/apps/kbve/astro-kbve/src/components/stock/StockSectorDirectory.astro
@@ -1,0 +1,223 @@
+---
+import { getCollection } from 'astro:content';
+import { buildStockNav, SECTOR_META } from './stockNav';
+
+const raw = await getCollection(
+	'docs',
+	({ id }: { id: string }) =>
+		id.startsWith('stock/') && !id.endsWith('stock/index'),
+);
+const entries = raw.map((e: { id: string; data: Record<string, unknown> }) => ({
+	id: e.id,
+	data: e.data,
+}));
+
+const groups = buildStockNav(entries as any);
+
+const iconFor = (label: string): string =>
+	SECTOR_META.find((m) => m.label === label)?.icon ??
+	'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zM9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01';
+
+const anchorFor = (href: string): string =>
+	href.split('#')[1] ?? href.replace(/\W+/g, '');
+
+const total = groups.reduce((n, g) => n + g.items.length, 0);
+const funds = (entries as { data: Record<string, any> }[]).filter(
+	(e) => e.data.stock?.kind === 'etf',
+).length;
+
+const stats = [
+	{
+		label: 'Tickers covered',
+		value: String(total),
+		icon: 'M3 3v18h18M7 15l4-5 3 3 5-7',
+	},
+	{
+		label: 'Sectors',
+		value: String(groups.length),
+		icon: 'M3 3h7v7H3zM14 3h7v7h-7zM14 14h7v7h-7zM3 14h7v7H3z',
+	},
+	{
+		label: 'Funds & ETFs',
+		value: String(funds),
+		icon: 'M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
+	},
+];
+---
+
+<div class="stock-directory">
+	<div class="bento-board stock-directory__stats">
+		{
+			stats.map((s) => (
+				<div class="bento-cell bento-stat bento-card bento-card--glass bento-card--interactive">
+					<span class="bento-icon-tile">
+						<svg
+							viewBox="0 0 24 24"
+							width="16"
+							height="16"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true">
+							<path d={s.icon} />
+						</svg>
+					</span>
+					<span class="bento-stat__value">{s.value}</span>
+					<span class="bento-stat__label">{s.label}</span>
+				</div>
+			))
+		}
+	</div>
+
+	{
+		groups.map((group) => (
+			<section
+				id={anchorFor(group.href ?? group.label)}
+				class="stock-sector">
+				<header class="stock-sector__header">
+					<span class="bento-icon-tile">
+						<svg
+							viewBox="0 0 24 24"
+							width="17"
+							height="17"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true">
+							<path d={iconFor(group.label)} />
+						</svg>
+					</span>
+					<div class="stock-sector__heading">
+						<p class="bento-eyebrow">{group.eyebrow}</p>
+						<h3 class="stock-sector__title">{group.label}</h3>
+					</div>
+					<span class="stock-sector__count">
+						{group.items.length}
+					</span>
+				</header>
+				<div class="bento-board bento-board--cols-4">
+					{group.items.map((item) => (
+						<a
+							class="bento-cell bento-linkcard bento-card bento-card--glass bento-card--interactive"
+							href={item.href}>
+							<span class="stock-linkcard__body">
+								<span class="bento-linkcard__title">
+									{item.label}
+								</span>
+								{item.copy && (
+									<span class="bento-linkcard__copy">
+										{item.copy}
+									</span>
+								)}
+							</span>
+							<span class="bento-linkcard__go" aria-hidden="true">
+								<svg
+									viewBox="0 0 24 24"
+									width="16"
+									height="16"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round">
+									<path d="M5 12h14M13 6l6 6-6 6" />
+								</svg>
+							</span>
+						</a>
+					))}
+				</div>
+			</section>
+		))
+	}
+</div>
+
+<style>
+	.stock-directory {
+		display: flex;
+		flex-direction: column;
+		gap: 2.5rem;
+	}
+
+	.stock-directory__stats {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 1px;
+		background-color: var(--bento-hairline);
+	}
+
+	@media (max-width: 640px) {
+		.stock-directory__stats {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.stock-sector {
+		scroll-margin-top: 5rem;
+	}
+
+	.stock-sector__header {
+		display: flex;
+		align-items: center;
+		gap: 0.85rem;
+		padding: 0 0.25rem 1rem;
+	}
+
+	.stock-sector__heading {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.stock-sector__heading .bento-eyebrow {
+		margin: 0;
+	}
+
+	.stock-sector__title {
+		margin: 0.1rem 0 0;
+		font-size: 1.25rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--sl-color-white);
+	}
+
+	.stock-sector__count {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		padding: 0.2rem 0.55rem;
+		border-radius: 999px;
+		color: var(--sl-color-gray-2);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-white) 6%,
+			transparent
+		);
+	}
+
+	.stock-directory .bento-linkcard {
+		flex-direction: row;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.stock-linkcard__body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		min-width: 0;
+	}
+
+	.stock-directory .bento-linkcard__copy {
+		font-size: 0.75rem;
+		line-height: 1.3;
+		color: var(--sl-color-gray-3);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/a.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/a.mdx
@@ -1,10 +1,12 @@
 ---
 title: Agilent Technologies A
+template: splash
 description: |
     Agilent Technologies is a leading life sciences, diagnostic, and applied chemical measurement technologies company serving laboratories worldwide.
 sidebar:
     label: Agilent Technologies
     order: 435
+    hidden: true
 unsplash: 1576091160399-928745027040
 img: https://images.unsplash.com/photo-1576091160399-928745027040?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - life-sciences
   - agilent
   - analytical-instruments
+stock:
+  ticker: A
+  exchange: NYSE
+  symbol: nyse:a
+  name: "Agilent Technologies"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:a`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -259,3 +268,5 @@ Agilent has established a strong position in the analytical instrumentation mark
 - **End Market Dynamics**: Performance across key application areas
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aapl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aapl.mdx
@@ -1,10 +1,12 @@
 ---
 title: Apple AAPL
+template: splash
 description: |
     Apple Inc. is a multinational technology company known for consumer electronics, software, and services.
 sidebar:
     label: Apple AAPL
     order: 422
+    hidden: true
 unsplash: 1611532736946-e7317312c7ef
 img: https://images.unsplash.com/photo-1611532736946-e7317312c7ef?fit=crop&w=1400&h=700&q=75
 tags:
@@ -12,9 +14,16 @@ tags:
   - tech
   - aapl
   - technology
+stock:
+  ticker: AAPL
+  exchange: NASDAQ
+  symbol: nasdaq:aapl
+  name: "Apple"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -27,7 +36,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:aapl`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -123,3 +132,5 @@ Key areas for potential expansion include:
 - **Emerging Markets**: Expansion in India, Southeast Asia, and other developing regions
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/abbv.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/abbv.mdx
@@ -1,10 +1,12 @@
 ---
 title: AbbVie Inc. ABBV
+template: splash
 description: |
     AbbVie is a research-based biopharmaceutical company focused on developing innovative therapies in immunology, oncology, neuroscience, and eye care.
 sidebar:
     label: AbbVie ABBV
     order: 429
+    hidden: true
 unsplash: 1559757175-a5077471b5d4
 img: https://images.unsplash.com/photo-1559757175-a5077471b5d4?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - pharmaceuticals
   - abbv
   - biopharmaceutical
+stock:
+  ticker: ABBV
+  exchange: NYSE
+  symbol: nyse:abbv
+  name: "AbbVie Inc."
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:abbv`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -260,3 +269,5 @@ Recent analyst sentiment reflects confidence in AbbVie's post-Humira strategy:
 - **Dividend Sustainability**: Confidence in continued dividend growth
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/abnb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/abnb.mdx
@@ -1,10 +1,12 @@
 ---
 title: Airbnb Inc ABNB
+template: splash
 description: |
     Airbnb is the world's largest online marketplace for home sharing, connecting millions of hosts and guests for unique travel and accommodation experiences.
 sidebar:
     label: Airbnb ABNB
     order: 437
+    hidden: true
 unsplash: 1523217582924-d68aef1e6bcf
 img: https://images.unsplash.com/photo-1523217582924-d68aef1e6bcf?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - travel
   - abnb
   - home-sharing
+stock:
+  ticker: ABNB
+  exchange: NASDAQ
+  symbol: nasdaq:abnb
+  name: "Airbnb Inc"
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:abnb`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -256,3 +265,5 @@ Airbnb offers investors exposure to the evolving travel industry:
 - **Geographic Performance**: Growth trends across major regions
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/abt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/abt.mdx
@@ -1,10 +1,12 @@
 ---
 title: Abbott Laboratories ABT
+template: splash
 description: |
     Abbott Laboratories is a diversified global healthcare company that develops, manufactures, and markets medical devices, diagnostics, nutritional products, and pharmaceuticals.
 sidebar:
     label: Abbott ABT
     order: 428
+    hidden: true
 unsplash: 1559757148-97a5e8b32ba5
 img: https://images.unsplash.com/photo-1559757148-97a5e8b32ba5?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - medical-devices
   - abt
   - pharmaceuticals
+stock:
+  ticker: ABT
+  exchange: NYSE
+  symbol: nyse:abt
+  name: "Abbott Laboratories"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:abt`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -247,3 +256,5 @@ Recent analyst sentiment reflects positive long-term prospects:
 - **Innovation Recognition**: Positive reception of new product launches and pipeline
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aciw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aciw.mdx
@@ -1,10 +1,12 @@
 ---
 title: ACI Worldwide Inc. ACIW
+template: splash
 description: |
     ACI Worldwide is a leading global provider of real-time electronic payment software and solutions, enabling electronic payments for financial institutions, retailers, and processors around the world.
 sidebar:
     label: ACI Worldwide ACIW
     order: 488
+    hidden: true
 unsplash: 1556740758-8c1f6c6e4e4c
 img: https://images.unsplash.com/photo-1556740758-8c1f6c6e4e4c?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - fintech
   - aciw
   - payments
+stock:
+  ticker: ACIW
+  exchange: NASDAQ
+  symbol: nasdaq:aciw
+  name: "ACI Worldwide Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:aciw`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -291,3 +300,5 @@ ACIW offers exposure to global payment processing with real-time technology lead
 - **Operating Leverage**: Margin expansion and operational efficiency improvements
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/acn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/acn.mdx
@@ -1,10 +1,12 @@
 ---
 title: Accenture plc ACN
+template: splash
 description: |
     Accenture is a global professional services company providing strategy, consulting, digital, technology, and operations services across all industries.
 sidebar:
     label: Accenture ACN
     order: 430
+    hidden: true
 unsplash: 1551434678-e076c4d5ba66
 img: https://images.unsplash.com/photo-1551434678-e076c4d5ba66?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - consulting
   - acn
   - digital-transformation
+stock:
+  ticker: ACN
+  exchange: NYSE
+  symbol: nyse:acn
+  name: "Accenture plc"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:acn`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -290,3 +299,5 @@ For current and accurate dividend information:
 - **SEC Filings**: Current financial information available through SEC filings
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/adbe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/adbe.mdx
@@ -1,10 +1,12 @@
 ---
 title: Adobe Inc. ADBE
+template: splash
 description: |
     Adobe Inc. is a global leader in digital media and marketing software, providing creative tools, document services, and digital experience solutions worldwide.
 sidebar:
     label: Adobe ADBE
     order: 431
+    hidden: true
 unsplash: 1561070791-266dc8ce5c0b
 img: https://images.unsplash.com/photo-1561070791-266dc8ce5c0b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - software
   - adbe
   - creative-software
+stock:
+  ticker: ADBE
+  exchange: NASDAQ
+  symbol: nasdaq:adbe
+  name: "Adobe Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:adbe`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -265,3 +274,5 @@ Recent market performance and analyst views:
 - **AI Integration Success**: Adoption and impact of generative AI features
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/adi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/adi.mdx
@@ -1,10 +1,12 @@
 ---
 title: Analog Devices Inc. ADI
+template: splash
 description: |
     Analog Devices is a leading semiconductor company specializing in data conversion, signal processing, and power management technology across industrial, automotive, communications, and consumer markets.
 sidebar:
     label: Analog Devices ADI
     order: 458
+    hidden: true
 unsplash: 1518709268-98bad7b5feca
 img: https://images.unsplash.com/photo-1518709268-98bad7b5feca?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - technology
   - adi
   - analog-devices
+stock:
+  ticker: ADI
+  exchange: NASDAQ
+  symbol: nasdaq:adi
+  name: "Analog Devices Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:adi`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -294,3 +303,5 @@ ADI offers exposure to essential analog and mixed-signal technology with secular
 - **Technology Milestones**: New product introductions and technology breakthroughs
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/adm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/adm.mdx
@@ -1,10 +1,12 @@
 ---
 title: Archer Daniels Midland Company ADM
+template: splash
 description: |
     Archer Daniels Midland is a leading global food processing and commodities trading corporation, transforming crops into products for food, animal feed, industrial, and energy uses worldwide.
 sidebar:
     label: Archer Daniels Midland ADM
     order: 479
+    hidden: true
 unsplash: 1574323597517-7c0cfea4ef39
 img: https://images.unsplash.com/photo-1574323597517-7c0cfea4ef39?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - food-processing
   - adm
   - commodities
+stock:
+  ticker: ADM
+  exchange: NYSE
+  symbol: nyse:adm
+  name: "Archer Daniels Midland Company"
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:adm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -284,3 +293,5 @@ ADM offers exposure to essential agricultural infrastructure with global diversi
 - **Innovation Pipeline**: New product development and technology advancement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/adp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/adp.mdx
@@ -1,10 +1,12 @@
 ---
 title: Automatic Data Processing Inc. ADP
+template: splash
 description: |
     ADP is a leading global provider of cloud-based human capital management solutions, serving over 1.1 million clients worldwide with payroll, HR, and workforce management technology.
 sidebar:
     label: ADP 
     order: 462
+    hidden: true
 unsplash: 1507003211169-0a1dd7d0e536
 img: https://images.unsplash.com/photo-1507003211169-0a1dd7d0e536?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - human-resources
   - adp
   - payroll
+stock:
+  ticker: ADP
+  exchange: NASDAQ
+  symbol: nasdaq:adp
+  name: "Automatic Data Processing Inc."
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:adp`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -268,3 +277,5 @@ ADP offers exposure to essential HR technology with secular growth drivers:
 - **Market Share**: Position in competitive HCM technology landscape
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/adsk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/adsk.mdx
@@ -1,10 +1,12 @@
 ---
 title: Autodesk Inc. ADSK
+template: splash
 description: |
     Autodesk is a leading global provider of 3D design, engineering, and entertainment technology solutions, enabling customers to design and make anything across architecture, manufacturing, and media industries.
 sidebar:
     label: Autodesk ADSK
     order: 466
+    hidden: true
 unsplash: 1581090464532-4c7e1b2a3a2d
 img: https://images.unsplash.com/photo-1581090464532-4c7e1b2a3a2d?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - design
   - adsk
   - cad
+stock:
+  ticker: ADSK
+  exchange: NASDAQ
+  symbol: nasdaq:adsk
+  name: "Autodesk Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:adsk`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -290,3 +299,5 @@ ADSK offers exposure to essential design software with secular growth drivers:
 - **Market Position**: Competitive position in key design software categories
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aee.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aee.mdx
@@ -1,10 +1,12 @@
 ---
 title: Ameren Corporation AEE
+template: splash
 description: |
     Ameren Corporation is a regulated utility holding company providing electric and natural gas services in Missouri and Illinois with a focus on clean energy transition and grid modernization.
 sidebar:
     label: Ameren AEE
     order: 452
+    hidden: true
 unsplash: 1473341304170-971dccb5ac1e
 img: https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - electric
   - aee
   - renewable-energy
+stock:
+  ticker: AEE
+  exchange: NYSE
+  symbol: nyse:aee
+  name: "Ameren Corporation"
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aee`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -261,3 +270,5 @@ AEE offers exposure to essential utility services with clean energy growth:
 - **Operational Performance**: Safety, reliability, and customer satisfaction metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aep.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aep.mdx
@@ -1,10 +1,12 @@
 ---
 title: American Electric Power Company Inc. AEP
+template: splash
 description: |
     American Electric Power is one of the largest electric utilities in the United States, serving 5.6 million customers across 11 states with a focus on grid modernization and renewable energy.
 sidebar:
     label: American Electric Power AEP
     order: 453
+    hidden: true
 unsplash: 1473341304170-971dccb5ac1e
 img: https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - electric-power
   - aep
   - transmission
+stock:
+  ticker: AEP
+  exchange: NASDAQ
+  symbol: nasdaq:aep
+  name: "American Electric Power Company Inc."
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:aep`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -278,3 +287,5 @@ AEP offers exposure to essential electric utility services with infrastructure g
 - **Operational Performance**: Safety, reliability, and customer satisfaction metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aes.mdx
@@ -1,10 +1,12 @@
 ---
 title: AES Corporation AES
+template: splash
 description: |
     AES Corporation is a leading global energy company specializing in renewable power generation, energy storage, and utility operations across multiple continents.
 sidebar:
     label: AES Corporation
     order: 433
+    hidden: true
 unsplash: 1473341304170-7ddf126bb2df
 img: https://images.unsplash.com/photo-1473341304170-7ddf126bb2df?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - renewable-energy
   - aes
   - power-generation
+stock:
+  ticker: AES
+  exchange: NYSE
+  symbol: nyse:aes
+  name: "AES Corporation"
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aes`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -261,3 +270,5 @@ AES offers investors exposure to the global energy transition:
 - **Utility Rate Cases**: Regulatory proceedings and investment recovery
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/afl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/afl.mdx
@@ -1,10 +1,12 @@
 ---
 title: Aflac Incorporated AFL
+template: splash
 description: |
     Aflac is a leading supplemental insurance company providing health and life insurance products primarily in the United States and Japan.
 sidebar:
     label: Aflac AFL
     order: 434
+    hidden: true
 unsplash: 1454165804606-c3d57bc86b40
 img: https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - insurance
   - afl
   - supplemental-insurance
+stock:
+  ticker: AFL
+  exchange: NYSE
+  symbol: nyse:afl
+  name: "Aflac Incorporated"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:afl`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -252,3 +261,5 @@ Aflac offers investors a unique combination of characteristics:
 - **Operating Expenses**: Cost management and operational efficiency improvements
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ago.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ago.mdx
@@ -1,10 +1,12 @@
 ---
 title: Assured Guaranty Ltd. AGO
+template: splash
 description: |
     Assured Guaranty is a leading provider of credit protection products and services, offering financial guarantee insurance for municipal bonds, infrastructure finance, and structured finance transactions globally.
 sidebar:
     label: Assured Guaranty AGO
     order: 490
+    hidden: true
 unsplash: 1454165804606-c3d57bc86b40
 img: https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - financial-services
   - ago
   - municipal-bonds
+stock:
+  ticker: AGO
+  exchange: NYSE
+  symbol: nyse:ago
+  name: "Assured Guaranty Ltd."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ago`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -278,3 +287,5 @@ AGO offers exposure to infrastructure finance with strong capital returns and di
 - **Book Value Growth**: Adjusted book value per share growth
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aig.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aig.mdx
@@ -1,10 +1,12 @@
 ---
 title: American International Group Inc. AIG
+template: splash
 description: |
     American International Group is a leading global insurance organization providing property casualty insurance and other financial services to businesses and individuals in more than 200 countries.
 sidebar:
     label: AIG
     order: 454
+    hidden: true
 unsplash: 1450101499237-f1b8b1c65593
 img: https://images.unsplash.com/photo-1450101499237-f1b8b1c65593?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - financial-services
   - aig
   - property-casualty
+stock:
+  ticker: AIG
+  exchange: NYSE
+  symbol: nyse:aig
+  name: "American International Group Inc."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aig`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -258,3 +267,5 @@ AIG offers exposure to global insurance markets with transformation upside:
 - **Book Value**: Tangible book value per share growth
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aiz.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aiz.mdx
@@ -1,10 +1,12 @@
 ---
 title: Assurant Inc. AIZ
+template: splash
 description: |
     Assurant is a leading global provider of lifestyle and housing solutions that support, protect, and connect major consumer purchases, providing comprehensive risk management and customer service solutions.
 sidebar:
     label: Assurant AIZ
     order: 484
+    hidden: true
 unsplash: 1560472354-d18c6be8a10a
 img: https://images.unsplash.com/photo-1560472354-d18c6be8a10a?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - financial-services
   - aiz
   - protection
+stock:
+  ticker: AIZ
+  exchange: NYSE
+  symbol: nyse:aiz
+  name: "Assurant Inc."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aiz`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -285,3 +294,5 @@ AIZ offers exposure to growing consumer protection markets with technology advan
 - **Return on Equity**: Profitability and returns to shareholders
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ajg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ajg.mdx
@@ -1,10 +1,12 @@
 ---
 title: Arthur J. Gallagher & Co. AJG
+template: splash
 description: |
     Arthur J. Gallagher & Co. is a leading global insurance brokerage, risk management, and consulting company serving clients worldwide with comprehensive insurance and risk solutions.
 sidebar:
     label: Arthur J. Gallagher AJG
     order: 465
+    hidden: true
 unsplash: 1450101499237-f1b8b1c65593
 img: https://images.unsplash.com/photo-1450101499237-f1b8b1c65593?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - brokerage
   - ajg
   - risk-management
+stock:
+  ticker: AJG
+  exchange: NYSE
+  symbol: nyse:ajg
+  name: "Arthur J. Gallagher & Co."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ajg`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -244,3 +253,5 @@ AJG offers exposure to essential insurance services with secular growth drivers:
 - **Market Share**: Position in competitive insurance brokerage landscape
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/akam.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/akam.mdx
@@ -1,10 +1,12 @@
 ---
 title: Akamai Technologies AKAM
+template: splash
 description: |
     Akamai Technologies is a leading content delivery network and cybersecurity company providing cloud computing, security, and content delivery solutions globally.
 sidebar:
     label: Akamai Technologies
     order: 438
+    hidden: true
 unsplash: 1558494949-ef946d3dc4c1
 img: https://images.unsplash.com/photo-1558494949-ef946d3dc4c1?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - cybersecurity
   - akam
   - content-delivery
+stock:
+  ticker: AKAM
+  exchange: NASDAQ
+  symbol: nasdaq:akam
+  name: "Akamai Technologies"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:akam`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -244,3 +253,5 @@ Akamai offers investors exposure to critical internet infrastructure trends:
 - **Technology Innovation**: Development of new capabilities and solutions
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/alb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/alb.mdx
@@ -1,10 +1,12 @@
 ---
 title: Albemarle Corporation ALB
+template: splash
 description: |
     Albemarle Corporation is a leading global specialty chemicals company providing essential materials for lithium batteries, energy storage, and advanced manufacturing.
 sidebar:
     label: Albemarle ALB
     order: 439
+    hidden: true
 unsplash: 1580477667891-d0a45ed1dc3c
 img: https://images.unsplash.com/photo-1580477667891-d0a45ed1dc3c?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - specialty-chemicals
   - alb
   - lithium
+stock:
+  ticker: ALB
+  exchange: NYSE
+  symbol: nyse:alb
+  name: "Albemarle Corporation"
+  sector: Materials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:alb`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -258,3 +267,5 @@ Albemarle offers investors exposure to critical materials for the energy transit
 - **Market Share**: Competitive position in key end markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/algn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/algn.mdx
@@ -1,10 +1,12 @@
 ---
 title: Align Technology ALGN
+template: splash
 description: |
     Align Technology is a global medical device company revolutionizing orthodontic treatment through Invisalign clear aligners and iTero digital scanning technology.
 sidebar:
     label: Align Technology
     order: 441
+    hidden: true
 unsplash: 1606811841689-f26e7e635df3
 img: https://images.unsplash.com/photo-1606811841689-f26e7e635df3?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - medical-devices
   - algn
   - orthodontics
+stock:
+  ticker: ALGN
+  exchange: NASDAQ
+  symbol: nasdaq:algn
+  name: "Align Technology"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:algn`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -235,3 +244,5 @@ Align Technology offers investors exposure to transformative healthcare technolo
 - **Doctor Engagement**: Training programs and practice utilization rates
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/all.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/all.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Allstate Corporation ALL
+template: splash
 description: |
     Allstate is a leading property and casualty insurance company providing auto, home, and other insurance products with innovative protection solutions.
 sidebar:
     label: Allstate ALL
     order: 443
+    hidden: true
 unsplash: 1449824913935-8b5db0b83e47
 img: https://images.unsplash.com/photo-1449824913935-8b5db0b83e47?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - insurance
   - all
   - property-casualty
+stock:
+  ticker: ALL
+  exchange: NYSE
+  symbol: nyse:all
+  name: "The Allstate Corporation"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:all`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -241,3 +250,5 @@ Allstate offers investors exposure to the stable insurance industry:
 - **Market Share**: Competitive position in key markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/alle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/alle.mdx
@@ -1,10 +1,12 @@
 ---
 title: Allegion plc ALLE
+template: splash
 description: |
     Allegion is a global security products company providing door hardware, electronic access control, and integrated security solutions for commercial and residential markets.
 sidebar:
     label: Allegion ALLE
     order: 442
+    hidden: true
 unsplash: 1560472354-b33ff0c44a5a
 img: https://images.unsplash.com/photo-1560472354-b33ff0c44a5a?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - security
   - alle
   - access-control
+stock:
+  ticker: ALLE
+  exchange: NYSE
+  symbol: nyse:alle
+  name: "Allegion plc"
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:alle`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -245,3 +254,5 @@ Allegion offers investors exposure to the evolving security industry:
 - **Innovation Pipeline**: New product development and technology advancement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amat.mdx
@@ -1,10 +1,12 @@
 ---
 title: Applied Materials Inc. AMAT
+template: splash
 description: |
     Applied Materials is the global leader in semiconductor equipment, providing manufacturing technology solutions for the semiconductor, display, and related industries that enable the world's most advanced chips.
 sidebar:
     label: Applied Materials AMAT
     order: 475
+    hidden: true
 unsplash: 1518600506278-4e5046204d8d
 img: https://images.unsplash.com/photo-1518600506278-4e5046204d8d?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - semiconductors
   - amat
   - equipment
+stock:
+  ticker: AMAT
+  exchange: NASDAQ
+  symbol: nasdaq:amat
+  name: "Applied Materials Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:amat`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -278,3 +287,5 @@ AMAT offers exposure to semiconductor technology advancement with cyclical chara
 - **Market Share**: Position in key semiconductor equipment categories
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amcr.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amcr.mdx
@@ -1,10 +1,12 @@
 ---
 title: Amcor plc AMCR
+template: splash
 description: |
     Amcor is a global leader in developing, producing, and selling packaging products for food, beverages, pharmaceuticals, and consumer goods with a focus on sustainability and innovation.
 sidebar:
     label: Amcor AMCR
     order: 450
+    hidden: true
 unsplash: 1586864387967-d04b7b4e7e87
 img: https://images.unsplash.com/photo-1586864387967-d04b7b4e7e87?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - consumer-cyclical
   - amcr
   - sustainability
+stock:
+  ticker: AMCR
+  exchange: NYSE
+  symbol: nyse:amcr
+  name: "Amcor plc"
+  sector: Materials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:amcr`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -272,3 +281,5 @@ AMCR offers exposure to essential packaging markets with defensive characteristi
 - **Innovation Pipeline**: New product development and technology advancement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amd.mdx
@@ -1,10 +1,12 @@
 ---
 title: Advanced Micro Devices AMD
+template: splash
 description: |
     Advanced Micro Devices is a leading semiconductor company specializing in high-performance computing and graphics solutions for data centers, gaming, and AI applications.
 sidebar:
     label: AMD
     order: 432
+    hidden: true
 unsplash: 1555617981-467c30017578
 img: https://images.unsplash.com/photo-1555617981-467c30017578?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - semiconductors
   - amd
   - artificial-intelligence
+stock:
+  ticker: AMD
+  exchange: NASDAQ
+  symbol: nasdaq:amd
+  name: "Advanced Micro Devices"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:amd`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -275,3 +284,5 @@ AMD has successfully transformed from a primarily CPU company to a diversified s
 - **R&D Efficiency**: Innovation output relative to development investment
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ame.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ame.mdx
@@ -1,10 +1,12 @@
 ---
 title: AMETEK Inc. AME
+template: splash
 description: |
     AMETEK is a leading global provider of electronic instruments and electromechanical devices, serving aerospace, defense, process, medical, and industrial markets with differentiated technology solutions.
 sidebar:
     label: AMETEK AME
     order: 467
+    hidden: true
 unsplash: 1581092659329-a4e282bc100b
 img: https://images.unsplash.com/photo-1581092659329-a4e282bc100b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - instruments
   - ame
   - precision
+stock:
+  ticker: AME
+  exchange: NYSE
+  symbol: nyse:ame
+  name: "AMETEK Inc."
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ame`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -294,3 +303,5 @@ AME offers exposure to specialized industrial technology with secular growth dri
 - **Cash Flow Generation**: Free cash flow conversion and capital allocation discipline
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amgn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amgn.mdx
@@ -1,10 +1,12 @@
 ---
 title: Amgen Inc. AMGN
+template: splash
 description: |
     Amgen is a leading biotechnology company that discovers, develops, manufactures, and delivers innovative human therapeutics worldwide, focusing on serious illnesses with significant unmet medical needs.
 sidebar:
     label: Amgen AMGN
     order: 457
+    hidden: true
 unsplash: 1559757148-7d4e0223ce8c
 img: https://images.unsplash.com/photo-1559757148-7d4e0223ce8c?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - pharmaceuticals
   - amgn
   - healthcare
+stock:
+  ticker: AMGN
+  exchange: NASDAQ
+  symbol: nasdaq:amgn
+  name: "Amgen Inc."
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:amgn`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -276,3 +285,5 @@ AMGN offers exposure to biotechnology innovation with established commercial suc
 - **International Expansion**: Growth in international markets and emerging economies
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amp.mdx
@@ -1,10 +1,12 @@
 ---
 title: Ameriprise Financial Inc. AMP
+template: splash
 description: |
     Ameriprise Financial is a leading diversified financial services company providing financial planning, investment advice, and asset management services to individual and institutional clients worldwide.
 sidebar:
     label: Ameriprise Financial AMP
     order: 459
+    hidden: true
 unsplash: 1460925895917-afdab827c52f
 img: https://images.unsplash.com/photo-1460925895917-afdab827c52f?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - wealth-management
   - amp
   - ameriprise
+stock:
+  ticker: AMP
+  exchange: NYSE
+  symbol: nyse:amp
+  name: "Ameriprise Financial Inc."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:amp`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -278,3 +287,5 @@ AMP offers exposure to diversified financial services with secular growth driver
 - **Regulatory Developments**: Impact of regulatory changes on business operations and costs
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amt.mdx
@@ -1,10 +1,12 @@
 ---
 title: American Tower Corporation AMT
+template: splash
 description: |
     American Tower is one of the largest global REITs and a leading independent owner, operator, and developer of multitenant communications real estate with over 149,000 communications sites worldwide.
 sidebar:
     label: American Tower AMT
     order: 455
+    hidden: true
 unsplash: 1556075798-3cb3acd7f3ff
 img: https://images.unsplash.com/photo-1556075798-3cb3acd7f3ff?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - telecommunications
   - amt
   - infrastructure
+stock:
+  ticker: AMT
+  exchange: NYSE
+  symbol: nyse:amt
+  name: "American Tower Corporation"
+  sector: Real Estate
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:amt`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -269,3 +278,5 @@ AMT offers exposure to essential communications infrastructure with global growt
 - **Free Cash Flow**: Cash flow generation supporting dividends and growth investments
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/amzn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/amzn.mdx
@@ -1,10 +1,12 @@
 ---
 title: Amazon.com Inc. AMZN
+template: splash
 description: |
     Amazon is the world's largest e-commerce and cloud computing company, revolutionizing retail, logistics, and enterprise technology through comprehensive digital platforms.
 sidebar:
     label: Amazon AMZN
     order: 448
+    hidden: true
 unsplash: 1586864387967-d04b7b4e7e87
 img: https://images.unsplash.com/photo-1586864387967-d04b7b4e7e87?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - ecommerce
   - amzn
   - cloud-computing
+stock:
+  ticker: AMZN
+  exchange: NASDAQ
+  symbol: nasdaq:amzn
+  name: "Amazon.com Inc."
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:amzn`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -255,3 +264,5 @@ Amazon offers exposure to multiple high-growth technology trends:
 - **Innovation Pipeline**: New product development and technology advancement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/anet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/anet.mdx
@@ -1,10 +1,12 @@
 ---
 title: Arista Networks Inc. ANET
+template: splash
 description: |
     Arista Networks is a leading provider of cloud networking solutions for data centers, campuses, and routing, delivering software-driven network solutions for large data center, campus, and routing environments.
 sidebar:
     label: Arista Networks ANET
     order: 474
+    hidden: true
 unsplash: 1558494949-ef1c8c05c4e5
 img: https://images.unsplash.com/photo-1558494949-ef1c8c05c4e5?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - networking
   - anet
   - cloud
+stock:
+  ticker: ANET
+  exchange: NYSE
+  symbol: nyse:anet
+  name: "Arista Networks Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:anet`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -297,3 +306,5 @@ ANET offers exposure to cloud networking infrastructure with technology leadersh
 - **Technology Adoption**: Adoption of software platforms and subscription services
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/anss.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/anss.mdx
@@ -1,10 +1,12 @@
 ---
 title: ANSYS Inc. ANSS
+template: splash
 description: |
     ANSYS is a leading global engineering simulation software company enabling engineers, designers, and researchers to predict how their products will work in real-world environments.
 sidebar:
     label: ANSYS ANSS
     order: 460
+    hidden: true
 unsplash: 1581092795442-61b5e3bb1ad3
 img: https://images.unsplash.com/photo-1581092795442-61b5e3bb1ad3?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - engineering
   - anss
   - simulation
+stock:
+  ticker: ANSS
+  exchange: NASDAQ
+  symbol: nasdaq:anss
+  name: "ANSYS Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:anss`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -269,3 +278,5 @@ ANSS offers exposure to essential engineering software with secular growth drive
 - **Acquisition Integration**: Successful integration of acquired technologies and capabilities
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aon.mdx
@@ -1,10 +1,12 @@
 ---
 title: Aon plc AON
+template: splash
 description: |
     Aon is a leading global professional services firm providing a broad range of risk, retirement, and health solutions with over 60,000 colleagues in more than 120 countries.
 sidebar:
     label: Aon AON
     order: 461
+    hidden: true
 unsplash: 1450101499237-f1b8b1c65593
 img: https://images.unsplash.com/photo-1450101499237-f1b8b1c65593?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - professional-services
   - aon
   - risk-management
+stock:
+  ticker: AON
+  exchange: NYSE
+  symbol: nyse:aon
+  name: "Aon plc"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aon`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -286,3 +295,5 @@ AON offers exposure to essential professional services with global growth driver
 - **Acquisition Integration**: Success in integrating acquired businesses and capabilities
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aos.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aos.mdx
@@ -1,10 +1,12 @@
 ---
 title: A.O. Smith Corporation AOS
+template: splash
 description: |
     A.O. Smith Corporation is a leading manufacturer of water heating equipment and water treatment products with operations across North America, China, Europe, and India.
 sidebar:
     label: A.O. Smith AOS
     order: 427
+    hidden: true
 unsplash: 1558618666-fbd82c67e6cd
 img: https://images.unsplash.com/photo-1558618666-fbd82c67e6cd?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - manufacturing
   - aos
   - water-heating
+stock:
+  ticker: AOS
+  exchange: NYSE
+  symbol: nyse:aos
+  name: "A.O. Smith Corporation"
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aos`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -219,3 +228,5 @@ For current and accurate dividend information:
 - **SEC Filings**: Current financial information available through SEC filings
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/apa.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/apa.mdx
@@ -1,10 +1,12 @@
 ---
 title: APA Corporation APA
+template: splash
 description: |
     APA Corporation is an independent energy company that explores for, develops, and produces oil, natural gas, and natural gas liquids with operations primarily in the United States.
 sidebar:
     label: APA Corporation
     order: 464
+    hidden: true
 unsplash: 1461344552813-5985830be0a3
 img: https://images.unsplash.com/photo-1461344552813-5985830be0a3?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - oil-gas
   - apa
   - exploration
+stock:
+  ticker: APA
+  exchange: NASDAQ
+  symbol: nasdaq:apa
+  name: "APA Corporation"
+  sector: Energy
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:apa`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -199,3 +208,5 @@ APA offers exposure to North American unconventional oil and gas development:
 - **Balance Sheet**: Debt levels, liquidity, and credit profile maintenance
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/apd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/apd.mdx
@@ -1,10 +1,12 @@
 ---
 title: Air Products and Chemicals APD
+template: splash
 description: |
     Air Products is a leading global industrial gases company providing essential industrial gases, related equipment, and applications expertise to manufacturing markets.
 sidebar:
     label: Air Products APD
     order: 436
+    hidden: true
 unsplash: 1581833971804-8c58e3fcce40
 img: https://images.unsplash.com/photo-1581833971804-8c58e3fcce40?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - industrial-gases
   - apd
   - hydrogen
+stock:
+  ticker: APD
+  exchange: NYSE
+  symbol: nyse:apd
+  name: "Air Products and Chemicals"
+  sector: Materials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:apd`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -255,3 +264,5 @@ Air Products offers investors exposure to both traditional industrial gas market
 - **Geographic Performance**: Growth trends across major regional markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aph.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aph.mdx
@@ -1,10 +1,12 @@
 ---
 title: Amphenol Corporation APH
+template: splash
 description: |
     Amphenol is one of the world's largest designers, manufacturers, and marketers of connectors, interconnect systems, antennas, and sensors enabling the electronics revolution across diverse industries.
 sidebar:
     label: Amphenol APH
     order: 463
+    hidden: true
 unsplash: 1581092580970-4e7de18fc21c
 img: https://images.unsplash.com/photo-1581092580970-4e7de18fc21c?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - components
   - aph
   - connectors
+stock:
+  ticker: APH
+  exchange: NYSE
+  symbol: nyse:aph
+  name: "Amphenol Corporation"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aph`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -316,3 +325,5 @@ APH offers exposure to essential electronic infrastructure with secular growth d
 - **Operating Leverage**: Manufacturing efficiency and margin expansion
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/aptv.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/aptv.mdx
@@ -1,10 +1,12 @@
 ---
 title: Aptiv PLC APTV
+template: splash
 description: |
     Aptiv is a leading global technology company that develops advanced mobility solutions, including electrical/electronic architectures, autonomous driving platforms, and connected services for the automotive industry.
 sidebar:
     label: Aptiv APTV
     order: 478
+    hidden: true
 unsplash: 1449824913935-adfddc22eab5
 img: https://images.unsplash.com/photo-1449824913935-adfddc22eab5?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - technology
   - aptv
   - autonomous-driving
+stock:
+  ticker: APTV
+  exchange: NYSE
+  symbol: nyse:aptv
+  name: "Aptiv PLC"
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:aptv`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -295,3 +304,5 @@ APTV offers exposure to automotive technology transformation with growth potenti
 - **Margin Expansion**: Operating leverage and efficiency improvements
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/are.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/are.mdx
@@ -1,10 +1,12 @@
 ---
 title: Alexandria Real Estate Equities ARE
+template: splash
 description: |
     Alexandria Real Estate Equities is a leading life science REIT owning and developing collaborative megacampus ecosystems in premier innovation clusters.
 sidebar:
     label: Alexandria Real Estate
     order: 440
+    hidden: true
 unsplash: 1560448204-bb440551-f3e6-4e8b-a9bb-9a98de8da09
 img: https://images.unsplash.com/photo-1560448204-bb440551-f3e6-4e8b-a9bb-9a98de8da09?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - reit
   - are
   - life-sciences
+stock:
+  ticker: ARE
+  exchange: NYSE
+  symbol: nyse:are
+  name: "Alexandria Real Estate Equities"
+  sector: Real Estate
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:are`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -249,3 +258,5 @@ Alexandria offers investors unique exposure to life science real estate:
 - **Life Science Funding**: Venture capital and IPO activity affecting demand
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ato.mdx
@@ -1,10 +1,12 @@
 ---
 title: Atmos Energy Corporation ATO
+template: splash
 description: |
     Atmos Energy is one of the largest natural gas distribution companies in the United States, safely delivering reliable, affordable, efficient, and abundant natural gas to residential, commercial, and industrial customers.
 sidebar:
     label: Atmos Energy ATO
     order: 483
+    hidden: true
 unsplash: 1581094794329-c8112a89af12
 img: https://images.unsplash.com/photo-1581094794329-c8112a89af12?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - natural-gas
   - ato
   - energy
+stock:
+  ticker: ATO
+  exchange: NYSE
+  symbol: nyse:ato
+  name: "Atmos Energy Corporation"
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ato`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -281,3 +290,5 @@ ATO offers stable utility income with infrastructure investment growth:
 - **Capital Efficiency**: Return on invested capital and operational efficiency metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/avb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/avb.mdx
@@ -1,10 +1,12 @@
 ---
 title: AvalonBay Communities Inc. AVB
+template: splash
 description: |
     AvalonBay Communities is a leading real estate investment trust focused on developing, acquiring, owning, and operating luxury apartment communities in high-barrier-to-entry markets across the United States.
 sidebar:
     label: AvalonBay Communities AVB
     order: 481
+    hidden: true
 unsplash: 1545324418-cc1a4d9f1d15
 img: https://images.unsplash.com/photo-1545324418-cc1a4d9f1d15?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - real-estate
   - avb
   - apartments
+stock:
+  ticker: AVB
+  exchange: NYSE
+  symbol: nyse:avb
+  name: "AvalonBay Communities Inc."
+  sector: Real Estate
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:avb`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -265,3 +274,5 @@ AVB offers exposure to premier apartment markets with development upside:
 - **Balance Sheet Metrics**: Leverage ratios and credit profile management
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/avgo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/avgo.mdx
@@ -1,10 +1,12 @@
 ---
 title: Broadcom Inc. AVGO
+template: splash
 description: |
     Broadcom is a leading global technology company providing semiconductor and infrastructure software solutions for data center, networking, software, broadband, wireless, storage, and industrial markets worldwide.
 sidebar:
     label: Broadcom AVGO
     order: 504
+    hidden: true
 unsplash: 1518709268165-83c6b6536dd8
 img: https://images.unsplash.com/photo-1518709268165-83c6b6536dd8?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - semiconductors
   - avgo
   - enterprise-software
+stock:
+  ticker: AVGO
+  exchange: NASDAQ
+  symbol: nasdaq:avgo
+  name: "Broadcom Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:avgo`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -304,3 +313,5 @@ AVGO offers exposure to essential technology infrastructure with software divers
 - **Free Cash Flow**: Cash generation supporting dividends and capital allocation
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/avy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/avy.mdx
@@ -1,10 +1,12 @@
 ---
 title: Avery Dennison Corporation AVY
+template: splash
 description: |
     Avery Dennison is a leading global materials science and digital identification solutions company, providing labeling and functional materials, radio frequency identification (RFID), and software solutions.
 sidebar:
     label: Avery Dennison AVY
     order: 480
+    hidden: true
 unsplash: 1586953208448-b95a79798f07
 img: https://images.unsplash.com/photo-1586953208448-b95a79798f07?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - labeling
   - avy
   - rfid
+stock:
+  ticker: AVY
+  exchange: NYSE
+  symbol: nyse:avy
+  name: "Avery Dennison Corporation"
+  sector: Materials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:avy`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -284,3 +293,5 @@ AVY offers exposure to essential materials and identification solutions with tec
 - **International Growth**: Performance in emerging and international markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/awk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/awk.mdx
@@ -1,10 +1,12 @@
 ---
 title: American Water Works Company Inc. AWK
+template: splash
 description: |
     American Water Works is the largest publicly traded water and wastewater utility company in the United States, providing essential water services to approximately 3.5 million customers across 14 states.
 sidebar:
     label: American Water AWK
     order: 456
+    hidden: true
 unsplash: 1544966503-7ad5ac882d5d
 img: https://images.unsplash.com/photo-1544966503-7ad5ac882d5d?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - water
   - awk
   - infrastructure
+stock:
+  ticker: AWK
+  exchange: NYSE
+  symbol: nyse:awk
+  name: "American Water Works Company Inc."
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:awk`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -275,3 +284,5 @@ AWK offers exposure to essential water infrastructure with stable growth:
 - **Acquisition Activity**: Strategic acquisitions expanding service territories and customer base
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/axon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/axon.mdx
@@ -1,10 +1,12 @@
 ---
 title: Axon Enterprise Inc. AXON
+template: splash
 description: |
     Axon Enterprise is a leading provider of public safety technology solutions including TASER devices, body-worn cameras, digital evidence management, and cloud-based software for law enforcement and security.
 sidebar:
     label: Axon Enterprise AXON
     order: 476
+    hidden: true
 unsplash: 1571019613454-1cb2f99b0951
 img: https://images.unsplash.com/photo-1571019613454-1cb2f99b0951?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - public-safety
   - axon
   - law-enforcement
+stock:
+  ticker: AXON
+  exchange: NASDAQ
+  symbol: nasdaq:axon
+  name: "Axon Enterprise Inc."
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:axon`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -285,3 +294,5 @@ AXON offers exposure to public safety technology transformation with recurring r
 - **Profitability**: Gross margins and operating leverage in software business
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/axp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/axp.mdx
@@ -1,10 +1,12 @@
 ---
 title: American Express Company AXP
+template: splash
 description: |
     American Express is a globally integrated payments company offering premium credit cards, charge cards, and financial services with a focus on affluent customers and travel benefits.
 sidebar:
     label: American Express AXP
     order: 451
+    hidden: true
 unsplash: 1556742049-0996f16c75e9
 img: https://images.unsplash.com/photo-1556742049-0996f16c75e9?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - credit-cards
   - axp
   - payments
+stock:
+  ticker: AXP
+  exchange: NYSE
+  symbol: nyse:axp
+  name: "American Express Company"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:axp`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -264,3 +273,5 @@ AXP offers exposure to premium financial services with strong defensive characte
 - **International Expansion**: Growth in international markets and partnerships
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/azo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/azo.mdx
@@ -1,10 +1,12 @@
 ---
 title: AutoZone Inc. AZO
+template: splash
 description: |
     AutoZone is the leading retailer and distributor of automotive replacement parts and accessories in the Americas, serving DIY customers and professional service providers.
 sidebar:
     label: AutoZone AZO
     order: 468
+    hidden: true
 unsplash: 1461344552813-5985830be0a3
 img: https://images.unsplash.com/photo-1461344552813-5985830be0a3?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - automotive
   - azo
   - parts
+stock:
+  ticker: AZO
+  exchange: NYSE
+  symbol: nyse:azo
+  name: "AutoZone Inc."
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:azo`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -260,3 +269,5 @@ AZO offers exposure to essential automotive aftermarket services with defensive 
 - **Capital Returns**: Share repurchases and dividend policy
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ba.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ba.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Boeing Company BA
+template: splash
 description: |
     Boeing is a leading global aerospace company and the world's largest manufacturer of commercial airplanes, providing commercial and military aircraft, satellites, missiles, and advanced technology systems worldwide.
 sidebar:
     label: Boeing BA
     order: 495
+    hidden: true
 unsplash: 1540979388789-6cee28a1cdc9
 img: https://images.unsplash.com/photo-1540979388789-6cee28a1cdc9?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - defense
   - ba
   - aviation
+stock:
+  ticker: BA
+  exchange: NYSE
+  symbol: nyse:ba
+  name: "The Boeing Company"
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ba`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -287,3 +296,5 @@ BA offers exposure to aerospace recovery with long-term aviation growth potentia
 - **Market Share**: Competitive position versus Airbus and other competitors
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/bac.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/bac.mdx
@@ -1,10 +1,12 @@
 ---
 title: Bank of America Corporation BAC
+template: splash
 description: |
     Bank of America is one of the world's leading financial institutions serving individual consumers, small and middle-market businesses, and large corporations with a full range of banking, investing, asset management, and financial services globally.
 sidebar:
     label: Bank of America BAC
     order: 519
+    hidden: true
 unsplash: 1541354329998-f4d9a9f4157b
 img: https://images.unsplash.com/photo-1541354329998-f4d9a9f4157b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - banking
   - bac
   - investment-banking
+stock:
+  ticker: BAC
+  exchange: NYSE
+  symbol: nyse:bac
+  name: "Bank of America Corporation"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:bac`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -353,3 +362,5 @@ BAC offers exposure to comprehensive financial services with technology leadersh
 - **Market Share**: Market share in key business segments and geographic markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/brkb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/brkb.mdx
@@ -1,10 +1,12 @@
 ---
 title: Berkshire Hathaway Inc. Class B BRK.B
+template: splash
 description: |
     Berkshire Hathaway is a multinational conglomerate holding company led by Warren Buffett, owning subsidiaries engaged in insurance, energy, manufacturing, retail, and providing a diversified investment portfolio of public company holdings.
 sidebar:
     label: Berkshire Hathaway BRK.B
     order: 505
+    hidden: true
 unsplash: 1559526324-4b87b5e36e44
 img: https://images.unsplash.com/photo-1559526324-4b87b5e36e44?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - insurance
   - brkb
   - value-investing
+stock:
+  ticker: BRK.B
+  exchange: NYSE
+  symbol: nyse:brk.b
+  name: "Berkshire Hathaway Inc. Class B"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:brk.b`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -302,3 +311,5 @@ BRK.B offers exposure to diversified business operations with legendary investme
 - **Succession Progress**: Leadership development and succession planning progress
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/bsx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/bsx.mdx
@@ -1,10 +1,12 @@
 ---
 title: Boston Scientific Corporation BSX
+template: splash
 description: |
     Boston Scientific is a leading global medical technology company that develops, manufactures, and markets medical devices and technologies used in interventional medical specialties, including cardiology, endoscopy, urology, and neuromodulation.
 sidebar:
     label: Boston Scientific BSX
     order: 497
+    hidden: true
 unsplash: 1559757148-5c350ae2a6c0
 img: https://images.unsplash.com/photo-1559757148-5c350ae2a6c0?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - medical-devices
   - bsx
   - biotechnology
+stock:
+  ticker: BSX
+  exchange: NYSE
+  symbol: nyse:bsx
+  name: "Boston Scientific Corporation"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:bsx`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -303,3 +312,5 @@ BSX offers exposure to medical technology innovation with broad diversification:
 - **Clinical Outcomes**: Clinical trial results and evidence generation
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/cost.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/cost.mdx
@@ -1,10 +1,12 @@
 ---
 title: Costco Wholesale Corporation COST
+template: splash
 description: |
     Costco is a leading membership-only warehouse club providing a wide selection of merchandise and services at competitive prices to businesses and individuals through a global network of warehouse locations.
 sidebar:
     label: Costco COST
     order: 515
+    hidden: true
 unsplash: 1556742049-0ca8c6c56de4
 img: https://images.unsplash.com/photo-1556742049-0ca8c6c56de4?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - consumer-staples
   - cost
   - warehouse-club
+stock:
+  ticker: COST
+  exchange: NASDAQ
+  symbol: nasdaq:cost
+  name: "Costco Wholesale Corporation"
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:cost`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -335,3 +344,5 @@ COST offers exposure to defensive retail with membership-driven loyalty:
 - **Inventory Turnover**: Inventory management efficiency and working capital
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/crm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/crm.mdx
@@ -1,10 +1,12 @@
 ---
 title: Salesforce Inc. CRM
+template: splash
 description: |
     Salesforce is the global leader in customer relationship management (CRM) software, providing cloud-based solutions for sales, marketing, service, commerce, and analytics that help companies connect with customers and grow their businesses.
 sidebar:
     label: Salesforce CRM
     order: 530
+    hidden: true
 unsplash: 1460925895917-afdab827c52f
 img: https://images.unsplash.com/photo-1460925895917-afdab827c52f?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - cloud-software
   - crm
   - salesforce
+stock:
+  ticker: CRM
+  exchange: NYSE
+  symbol: nyse:crm
+  name: "Salesforce Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:crm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -385,3 +394,5 @@ CRM offers exposure to digital transformation leadership with platform advantage
 - **Profitability**: Operating margin expansion and cash flow generation
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/csco.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/csco.mdx
@@ -1,10 +1,12 @@
 ---
 title: Cisco Systems Inc. CSCO
+template: splash
 description: |
     Cisco is a leading global technology company providing networking hardware, software, and services that enable connectivity, security, and automation across the internet and digital infrastructure worldwide.
 sidebar:
     label: Cisco CSCO
     order: 526
+    hidden: true
 unsplash: 1558618047-3bf6c6d8d0e6
 img: https://images.unsplash.com/photo-1558618047-3bf6c6d8d0e6?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - networking
   - csco
   - cybersecurity
+stock:
+  ticker: CSCO
+  exchange: NASDAQ
+  symbol: nasdaq:csco
+  name: "Cisco Systems Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:csco`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -353,3 +362,5 @@ CSCO offers exposure to networking infrastructure leadership with security and c
 - **Innovation Pipeline**: Research and development productivity and new product launches
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/cvx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/cvx.mdx
@@ -1,10 +1,12 @@
 ---
 title: Chevron Corporation CVX
+template: splash
 description: |
     Chevron is one of the world's largest integrated energy companies engaged in oil and gas exploration, production, refining, marketing, and chemicals across the entire energy value chain globally.
 sidebar:
     label: Chevron CVX
     order: 527
+    hidden: true
 unsplash: 1497435334941-8c899ee9e8e9
 img: https://images.unsplash.com/photo-1497435334941-8c899ee9e8e9?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - oil-gas
   - cvx
   - integrated-oil
+stock:
+  ticker: CVX
+  exchange: NYSE
+  symbol: nyse:cvx
+  name: "Chevron Corporation"
+  sector: Energy
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:cvx`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -354,3 +363,5 @@ CVX offers exposure to integrated energy operations with technology leadership:
 - **Environmental Performance**: Progress on emissions reduction and climate goals
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/dis.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/dis.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Walt Disney Company DIS
+template: splash
 description: |
     Disney is a global entertainment and media conglomerate operating theme parks, film studios, television networks, streaming services, and consumer products, bringing magical experiences and storytelling to audiences worldwide.
 sidebar:
     label: Walt Disney DIS
     order: 535
+    hidden: true
 unsplash: 1512552288312-1324e97a2c5e
 img: https://images.unsplash.com/photo-1512552288312-1324e97a2c5e?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - media
   - dis
   - streaming
+stock:
+  ticker: DIS
+  exchange: NYSE
+  symbol: nyse:dis
+  name: "The Walt Disney Company"
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:dis`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -373,3 +382,5 @@ DIS offers exposure to entertainment leadership with streaming transformation:
 - **Franchise Performance**: Performance of key franchises across all business segments
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ge.mdx
@@ -1,10 +1,12 @@
 ---
 title: GE Aerospace GE
+template: splash
 description: |
     GE Aerospace is a leading aerospace company providing jet engines, components, and services for commercial and military aircraft worldwide, with a focus on innovation, efficiency, and sustainability in aviation technology.
 sidebar:
     label: GE Aerospace GE
     order: 528
+    hidden: true
 unsplash: 1540979388789-6cee28a1cdc9
 img: https://images.unsplash.com/photo-1540979388789-6cee28a1cdc9?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - aviation
   - ge
   - jet-engines
+stock:
+  ticker: GE
+  exchange: NYSE
+  symbol: nyse:ge
+  name: "GE Aerospace"
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ge`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -345,3 +354,5 @@ GE offers exposure to aerospace recovery with technology leadership:
 - **Innovation Pipeline**: Progress on next-generation engine and technology development
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/goog.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/goog.mdx
@@ -1,10 +1,12 @@
 ---
 title: Alphabet Inc. Class C GOOG
+template: splash
 description: |
     Alphabet Class C shares provide exposure to Google's technology ecosystem including search, advertising, cloud computing, and AI innovation without voting rights.
 sidebar:
     label: Alphabet GOOG
     order: 447
+    hidden: true
 unsplash: 1573804633-4ac980af8b31
 img: https://images.unsplash.com/photo-1573804633-4ac980af8b31?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - internet
   - goog
   - search-engine
+stock:
+  ticker: GOOG
+  exchange: NASDAQ
+  symbol: nasdaq:goog
+  name: "Alphabet Inc. Class C"
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:goog`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -238,3 +247,5 @@ GOOG offers identical technology exposure to GOOGL with potential cost advantage
 - **Innovation Pipeline**: New product development and technology breakthroughs
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/googl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/googl.mdx
@@ -1,10 +1,12 @@
 ---
 title: Alphabet Inc. Class A GOOGL
+template: splash
 description: |
     Alphabet is the parent company of Google, providing search, advertising, cloud computing, AI, and technology solutions that organize the world's information.
 sidebar:
     label: Alphabet GOOGL
     order: 445
+    hidden: true
 unsplash: 1573804633-4ac980af8b31
 img: https://images.unsplash.com/photo-1573804633-4ac980af8b31?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - internet
   - googl
   - search-engine
+stock:
+  ticker: GOOGL
+  exchange: NASDAQ
+  symbol: nasdaq:googl
+  name: "Alphabet Inc. Class A"
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:googl`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -243,3 +252,5 @@ Alphabet offers investors exposure to transformative technology trends:
 - **Regulatory Developments**: Antitrust and privacy regulation impacts
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/hd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/hd.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Home Depot Inc. HD
+template: splash
 description: |
     The Home Depot is the world's largest home improvement retailer providing tools, construction products, appliances, and services to do-it-yourself customers, professional contractors, and installation service providers through extensive retail stores and digital platforms.
 sidebar:
     label: Home Depot HD
     order: 518
+    hidden: true
 unsplash: 1558618047-3bf6c6d8d0e6
 img: https://images.unsplash.com/photo-1558618047-3bf6c6d8d0e6?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - home-improvement
   - hd
   - construction
+stock:
+  ticker: HD
+  exchange: NYSE
+  symbol: nyse:hd
+  name: "The Home Depot Inc."
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:hd`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -355,3 +364,5 @@ HD offers exposure to home improvement market leadership with professional focus
 - **New Store Performance**: New store productivity and market expansion success
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ibm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ibm.mdx
@@ -1,10 +1,12 @@
 ---
 title: International Business Machines Corporation IBM
+template: splash
 description: |
     IBM is a leading global technology and consulting company providing hybrid cloud and AI solutions, helping businesses transform through technology innovation across industries and geographies worldwide.
 sidebar:
     label: IBM
     order: 525
+    hidden: true
 unsplash: 1518709268372-d0531928ca8c
 img: https://images.unsplash.com/photo-1518709268372-d0531928ca8c?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - cloud-computing
   - ibm
   - artificial-intelligence
+stock:
+  ticker: IBM
+  exchange: NYSE
+  symbol: nyse:ibm
+  name: "International Business Machines Corporation"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ibm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -364,3 +373,5 @@ IBM offers exposure to enterprise technology transformation with hybrid cloud le
 - **Client Satisfaction**: Client satisfaction and retention metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Analysis
+template: splash
 description: |
     Stock analysis and financial data compilation for reference purposes.
 sidebar:
@@ -13,27 +14,44 @@ tags:
   - investing
 ---
 
-import {
-  Aside,
-  Steps,
-  Card,
-  CardGrid,
-  Code,
-  FileTree,
-} from '@astrojs/starlight/components';
+import BentoShell from '@/components/hero/BentoShell.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
+import StockSectorDirectory from '@/components/stock/StockSectorDirectory.astro';
+
+import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
 import { Giscus, Adsense } from '@/components/astropad';
+
+<section class="bento-hero bento-section not-content" style="--bento-accent:#22c55e; --bento-accent-2:#4ade80; --bento-btn-fg:#04140a">
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell">
+				<span class="bento-badge bento-chip">Reference only</span>
+				<h1 class="bento-title">
+					Stock <span class="bento-title__accent">Analysis</span>
+				</h1>
+				<p class="bento-lede">
+					Compiled reference pages for publicly traded companies and funds,
+					grouped by sector with a live chart on every ticker.
+				</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#sectors">Browse sectors</a>
+					<a class="bento-btn bento-btn--ghost" href="/stock/spy/">Start with SPY</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<BentoShell id="sectors" eyebrow="Directory" heading="Coverage by sector">
+	<StockSectorDirectory />
+</BentoShell>
+
+<BentoProse id="basics" eyebrow="Primer" heading="Investment and account types">
 
 <Aside title="Not Financial Advice" type="danger">
 This is not financial advice. The data compiled here is for easier referencing purposes only and may not be accurate. Always consult with a qualified financial advisor before making any investment decisions.
 </Aside>
-
-<Adsense />
-
-## Stock Analysis
-
-Welcome to our stock analysis section.
-This area contains compiled data and information about various publicly traded companies for reference purposes only.
 
 ### Investment Types
 
@@ -51,8 +69,6 @@ This area contains compiled data and information about various publicly traded c
     Real Estate Investment Trusts
   </Card>
 </CardGrid>
-
-
 
 ### Account Types
 
@@ -113,3 +129,10 @@ This area contains compiled data and information about various publicly traded c
 All information provided in this section is for educational and reference purposes only.
 Stock prices, financial data, and market analysis are subject to change and may not reflect current market conditions.
 Always conduct your own research and consult with qualified financial professionals before making investment decisions.
+
+</BentoProse>
+
+<BentoShell>
+	<Adsense />
+	<Giscus />
+</BentoShell>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/intu.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/intu.mdx
@@ -1,10 +1,12 @@
 ---
 title: Intuit Inc. INTU
+template: splash
 description: |
     Intuit is a leading financial software company providing business and personal finance management solutions through TurboTax, QuickBooks, Mint, and Credit Karma platforms, empowering prosperity for consumers and small businesses.
 sidebar:
     label: Intuit INTU
     order: 536
+    hidden: true
 unsplash: 1554224155-6726a640de24
 img: https://images.unsplash.com/photo-1554224155-6726a640de24?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - fintech
   - intu
   - tax-software
+stock:
+  ticker: INTU
+  exchange: NASDAQ
+  symbol: nasdaq:intu
+  name: "Intuit Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:intu`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -385,3 +394,5 @@ INTU offers exposure to financial technology leadership with recurring revenue g
 - **Innovation Pipeline**: New product development and AI capability advancement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/jnj.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/jnj.mdx
@@ -1,10 +1,12 @@
 ---
 title: Johnson & Johnson JNJ
+template: splash
 description: |
     Johnson & Johnson is a leading multinational healthcare corporation providing pharmaceuticals, medical devices, and consumer products worldwide, with a diversified portfolio spanning innovative medicines, surgical technologies, and trusted consumer brands.
 sidebar:
     label: Johnson & Johnson JNJ
     order: 517
+    hidden: true
 unsplash: 1559757148-5c9baccacc8f
 img: https://images.unsplash.com/photo-1559757148-5c9baccacc8f?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - pharmaceuticals
   - jnj
   - medical-devices
+stock:
+  ticker: JNJ
+  exchange: NYSE
+  symbol: nyse:jnj
+  name: "Johnson & Johnson"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:jnj`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -364,3 +373,5 @@ JNJ offers exposure to diversified healthcare with innovation leadership:
 - **Margin Expansion**: Operating leverage and margin improvement trends
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/jpm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/jpm.mdx
@@ -1,10 +1,12 @@
 ---
 title: JPMorgan Chase & Co. JPM
+template: splash
 description: |
     JPMorgan Chase is the largest bank in the United States and a leading global financial services firm providing investment banking, commercial banking, financial transaction processing, and asset management services to millions of consumers, small businesses, and institutional clients worldwide.
 sidebar:
     label: JPMorgan Chase JPM
     order: 507
+    hidden: true
 unsplash: 1541354329998-f4d9a9f4157b
 img: https://images.unsplash.com/photo-1541354329998-f4d9a9f4157b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - banking
   - jpm
   - investment-banking
+stock:
+  ticker: JPM
+  exchange: NYSE
+  symbol: nyse:jpm
+  name: "JPMorgan Chase & Co."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:jpm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -336,3 +345,5 @@ JPM offers exposure to comprehensive financial services with market leadership:
 - **Book Value**: Tangible book value per share growth and valuation metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ko.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ko.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Coca-Cola Company KO
+template: splash
 description: |
     The Coca-Cola Company is the world's leading beverage company offering over 500 brands to people in more than 200 countries, with a portfolio spanning sparkling soft drinks, water, enhanced water, juice, dairy, plant-based beverages, tea, and coffee.
 sidebar:
     label: Coca-Cola KO
     order: 522
+    hidden: true
 unsplash: 1554979062-7ebdecf0bbf5
 img: https://images.unsplash.com/photo-1554979062-7ebdecf0bbf5?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - beverages
   - ko
   - coca-cola
+stock:
+  ticker: KO
+  exchange: NYSE
+  symbol: nyse:ko
+  name: "The Coca-Cola Company"
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ko`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -333,3 +342,5 @@ KO offers exposure to global beverage leadership with brand excellence:
 - **Operating Leverage**: Margin expansion and operational efficiency improvements
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/lin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/lin.mdx
@@ -1,10 +1,12 @@
 ---
 title: Linde plc LIN
+template: splash
 description: |
     Linde is the world's largest industrial gas and engineering company, providing atmospheric gases, process gases, specialty gases, and engineering services to customers across healthcare, manufacturing, energy, and other industries globally.
 sidebar:
     label: Linde plc LIN
     order: 533
+    hidden: true
 unsplash: 1581094794329-c8112a89af12
 img: https://images.unsplash.com/photo-1581094794329-c8112a89af12?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - chemicals
   - lin
   - engineering
+stock:
+  ticker: LIN
+  exchange: NYSE
+  symbol: nyse:lin
+  name: "Linde plc"
+  sector: Materials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:lin`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -355,3 +364,5 @@ LIN offers exposure to essential industrial infrastructure with clean energy ups
 - **Clean Technology**: Progress in carbon capture, hydrogen, and clean energy technologies
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/lly.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/lly.mdx
@@ -1,10 +1,12 @@
 ---
 title: Eli Lilly and Company LLY
+template: splash
 description: |
     Eli Lilly is a leading global pharmaceutical company developing, manufacturing, and marketing innovative medicines for serious medical conditions including diabetes, cancer, immunology, neuroscience, and obesity, with a strong pipeline of breakthrough therapies.
 sidebar:
     label: Eli Lilly LLY
     order: 509
+    hidden: true
 unsplash: 1559757148-5c9baccacc8f
 img: https://images.unsplash.com/photo-1559757148-5c9baccacc8f?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - healthcare
   - lly
   - biotechnology
+stock:
+  ticker: LLY
+  exchange: NYSE
+  symbol: nyse:lly
+  name: "Eli Lilly and Company"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:lly`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -311,3 +320,5 @@ LLY offers exposure to pharmaceutical innovation with multiple growth drivers:
 - **Patent Protection**: Intellectual property portfolio and exclusivity maintenance
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/lnt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/lnt.mdx
@@ -1,10 +1,12 @@
 ---
 title: Alliant Energy Corporation LNT
+template: splash
 description: |
     Alliant Energy is a regulated utility company providing electric and natural gas services in Wisconsin and Iowa with a focus on clean energy transition.
 sidebar:
     label: Alliant Energy
     order: 444
+    hidden: true
 unsplash: 1473341304770-240fb2b83f33
 img: https://images.unsplash.com/photo-1473341304770-240fb2b83f33?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - electric
   - lnt
   - renewable-energy
+stock:
+  ticker: LNT
+  exchange: NASDAQ
+  symbol: nasdaq:lnt
+  name: "Alliant Energy Corporation"
+  sector: Utilities
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:lnt`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -239,3 +248,5 @@ Alliant Energy offers investors exposure to the regulated utility sector with cl
 - **Regulatory Outcomes**: Rate case decisions and regulatory support for investments
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ma.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ma.mdx
@@ -1,10 +1,12 @@
 ---
 title: Mastercard Incorporated MA
+template: splash
 description: |
     Mastercard is a leading global payments technology company connecting consumers, financial institutions, merchants, governments, and businesses worldwide through innovative payment solutions and financial services.
 sidebar:
     label: Mastercard MA
     order: 513
+    hidden: true
 unsplash: 1556742049-0ca8c6c56de4
 img: https://images.unsplash.com/photo-1556742049-0ca8c6c56de4?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - payments
   - ma
   - fintech
+stock:
+  ticker: MA
+  exchange: NYSE
+  symbol: nyse:ma
+  name: "Mastercard Incorporated"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ma`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -335,3 +344,5 @@ MA offers exposure to global digital payments growth with technology leadership:
 - **Market Share**: Payment network market share in key regions and segments
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/meta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/meta.mdx
@@ -1,10 +1,12 @@
 ---
 title: Meta Platforms Inc. META
+template: splash
 description: |
     Meta Platforms is a leading technology company building the next evolution of social technology and the metaverse, operating popular social media platforms including Facebook, Instagram, WhatsApp, and Messenger while developing virtual and augmented reality technologies.
 sidebar:
     label: Meta Platforms META
     order: 503
+    hidden: true
 unsplash: 1611162617263-4c4724f6ca1a
 img: https://images.unsplash.com/photo-1611162617263-4c4724f6ca1a?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - social-media
   - meta
   - metaverse
+stock:
+  ticker: META
+  exchange: NASDAQ
+  symbol: nasdaq:meta
+  name: "Meta Platforms Inc."
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:meta`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -298,3 +307,5 @@ META offers exposure to social media dominance with metaverse upside potential:
 - **Competition Response**: Competitive position versus TikTok and other platforms
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/mmm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/mmm.mdx
@@ -1,10 +1,12 @@
 ---
 title: 3M Company MMM
+template: splash
 description: |
     3M Company is a diversified industrial conglomerate providing technology services across safety, transportation, and consumer segments.
 sidebar:
     label: 3M MMM
     order: 424
+    hidden: true
 unsplash: 1504681994895-a96019046b8b
 img: https://images.unsplash.com/photo-1504681994895-a96019046b8b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -12,9 +14,16 @@ tags:
   - industrials
   - mmm
   - conglomerate
+stock:
+  ticker: MMM
+  exchange: NYSE
+  symbol: nyse:mmm
+  name: "3M Company"
+  sector: Industrials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -27,7 +36,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:mmm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -138,3 +147,5 @@ Key areas for potential expansion include:
 - **Emerging Markets**: Continued expansion in developing economies
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/mo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/mo.mdx
@@ -1,10 +1,12 @@
 ---
 title: Altria Group Inc. MO
+template: splash
 description: |
     Altria Group is a leading tobacco and nicotine company transforming its business through innovative smoke-free products and reduced-risk alternatives.
 sidebar:
     label: Altria Group
     order: 446
+    hidden: true
 unsplash: 1474112113431-c484be3d4580
 img: https://images.unsplash.com/photo-1474112113431-c484be3d4580?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - tobacco
   - mo
   - nicotine-products
+stock:
+  ticker: MO
+  exchange: NYSE
+  symbol: nyse:mo
+  name: "Altria Group Inc."
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:mo`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -238,3 +247,5 @@ Altria offers investors exposure to a transforming tobacco industry:
 - **Volume Performance**: Unit sales trends across product categories
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/ms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/ms.mdx
@@ -1,10 +1,12 @@
 ---
 title: Morgan Stanley MS
+template: splash
 description: |
     Morgan Stanley is a leading global financial services firm providing investment banking, securities, wealth management, and investment management services to corporations, governments, institutions, and individuals worldwide.
 sidebar:
     label: Morgan Stanley MS
     order: 534
+    hidden: true
 unsplash: 1611974789855-9c2a0a7236a3
 img: https://images.unsplash.com/photo-1611974789855-9c2a0a7236a3?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - investment-banking
   - ms
   - wealth-management
+stock:
+  ticker: MS
+  exchange: NYSE
+  symbol: nyse:ms
+  name: "Morgan Stanley"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:ms`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -383,3 +392,5 @@ MS offers exposure to leading investment banking and wealth management with tech
 - **Digital Adoption**: Technology investment results and digital client engagement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/msft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/msft.mdx
@@ -1,10 +1,12 @@
 ---
 title: Microsoft Corporation MSFT
+template: splash
 description: |
     Microsoft is a leading global technology company providing cloud computing, productivity software, artificial intelligence, gaming, and enterprise solutions that empower organizations and individuals to achieve more.
 sidebar:
     label: Microsoft MSFT
     order: 500
+    hidden: true
 unsplash: 1633419461186-7d40cd325d41
 img: https://images.unsplash.com/photo-1633419461186-7d40cd325d41?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - software
   - msft
   - cloud-computing
+stock:
+  ticker: MSFT
+  exchange: NASDAQ
+  symbol: nasdaq:msft
+  name: "Microsoft Corporation"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:msft`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -307,3 +316,5 @@ MSFT offers exposure to cloud computing leadership with AI innovation:
 - **Innovation Pipeline**: R&D investment and new product development
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/nflx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/nflx.mdx
@@ -1,10 +1,12 @@
 ---
 title: Netflix Inc. NFLX
+template: splash
 description: |
     Netflix is the world's leading streaming entertainment service serving over 270 million paid memberships across 190+ countries, offering TV series, documentaries, and feature films across a wide variety of genres and languages.
 sidebar:
     label: Netflix NFLX
     order: 512
+    hidden: true
 unsplash: 1611162616475-46b635cb6868
 img: https://images.unsplash.com/photo-1611162616475-46b635cb6868?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - streaming
   - nflx
   - media
+stock:
+  ticker: NFLX
+  exchange: NASDAQ
+  symbol: nasdaq:nflx
+  name: "Netflix Inc."
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:nflx`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -344,3 +353,5 @@ NFLX offers exposure to global streaming entertainment leadership with content d
 - **International Performance**: Performance and profitability in international markets
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/nvda.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/nvda.mdx
@@ -1,10 +1,12 @@
 ---
 title: NVIDIA Corporation NVDA
+template: splash
 description: |
     NVIDIA is a leading technology company specializing in graphics processing units (GPUs), artificial intelligence computing, and accelerated computing platforms that power everything from gaming to data centers and autonomous vehicles.
 sidebar:
     label: NVIDIA NVDA
     order: 501
+    hidden: true
 unsplash: 1518709268165-83c6b6536dd8
 img: https://images.unsplash.com/photo-1518709268165-83c6b6536dd8?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - semiconductors
   - nvda
   - artificial-intelligence
+stock:
+  ticker: NVDA
+  exchange: NASDAQ
+  symbol: nasdaq:nvda
+  name: "NVIDIA Corporation"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:nvda`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -313,3 +322,5 @@ NVDA offers exposure to the AI revolution with technology leadership:
 - **Competitive Position**: Market share and technology leadership maintenance
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/o.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/o.mdx
@@ -1,10 +1,12 @@
 ---
 title: Realty Income Corporation O
+template: splash
 description: |
     Realty Income Corporation is "The Monthly Dividend Company" - a premier net lease REIT with over 15,600 properties worldwide.
 sidebar:
     label: Realty Income O
     order: 425
+    hidden: true
 unsplash: 1560518897-e9c08dc3aaec
 img: https://images.unsplash.com/photo-1560518897-e9c08dc3aaec?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - realty
   - dividend
   - o
+stock:
+  ticker: O
+  exchange: NYSE
+  symbol: nyse:o
+  name: "Realty Income Corporation"
+  sector: Real Estate
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:o`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -213,3 +222,5 @@ For current and accurate dividend yield information:
 - **Tax Considerations**: Consult tax professionals regarding REIT dividend taxation
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/orcl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/orcl.mdx
@@ -1,10 +1,12 @@
 ---
 title: Oracle Corporation ORCL
+template: splash
 description: |
     Oracle is a leading global technology company providing database software, cloud computing services, and enterprise software applications that enable organizations to manage, analyze, and leverage their data for business success.
 sidebar:
     label: Oracle ORCL
     order: 511
+    hidden: true
 unsplash: 1551882450-bcee36ead61b
 img: https://images.unsplash.com/photo-1551882450-bcee36ead61b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - database
   - orcl
   - cloud-computing
+stock:
+  ticker: ORCL
+  exchange: NASDAQ
+  symbol: nasdaq:orcl
+  name: "Oracle Corporation"
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:orcl`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -327,3 +336,5 @@ ORCL offers exposure to enterprise technology transformation with database leade
 - **International Performance**: Global expansion and international market penetration
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/pg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/pg.mdx
@@ -1,10 +1,12 @@
 ---
 title: The Procter & Gamble Company PG
+template: splash
 description: |
     Procter & Gamble is a leading consumer goods company providing branded products and services to consumers in approximately 180 countries worldwide, with a portfolio of trusted household names across personal care, health care, fabric care, and home care categories.
 sidebar:
     label: Procter & Gamble PG
     order: 516
+    hidden: true
 unsplash: 1556742048-f6f84b636bd6
 img: https://images.unsplash.com/photo-1556742048-f6f84b636bd6?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - household-products
   - pg
   - personal-care
+stock:
+  ticker: PG
+  exchange: NYSE
+  symbol: nyse:pg
+  name: "The Procter & Gamble Company"
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:pg`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -360,3 +369,5 @@ PG offers exposure to defensive consumer staples with brand leadership:
 - **Brand Health**: Brand equity and consumer loyalty metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/pltr.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/pltr.mdx
@@ -1,10 +1,12 @@
 ---
 title: Palantir Technologies Inc. PLTR
+template: splash
 description: |
     Palantir Technologies is a leading software company specializing in big data analytics platforms that help organizations integrate, analyze, and act on large-scale data to solve complex problems in government, commercial, and healthcare sectors.
 sidebar:
     label: Palantir PLTR
     order: 520
+    hidden: true
 unsplash: 1551882450-bcee36ead61b
 img: https://images.unsplash.com/photo-1551882450-bcee36ead61b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - data-analytics
   - pltr
   - artificial-intelligence
+stock:
+  ticker: PLTR
+  exchange: NYSE
+  symbol: nyse:pltr
+  name: "Palantir Technologies Inc."
+  sector: Technology
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:pltr`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -353,3 +362,5 @@ PLTR offers exposure to AI and data analytics leadership with unique technology:
 - **Path to Profitability**: Progress toward consistent profitability and positive cash flow
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/pm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/pm.mdx
@@ -1,10 +1,12 @@
 ---
 title: Philip Morris International Inc. PM
+template: splash
 description: |
     Philip Morris International is a leading international tobacco company developing, manufacturing, and selling cigarettes and smoke-free products worldwide, with a focus on transitioning to reduced-risk products and smoke-free alternatives.
 sidebar:
     label: Philip Morris International PM
     order: 523
+    hidden: true
 unsplash: 1518611012118-696072aa579a
 img: https://images.unsplash.com/photo-1518611012118-696072aa579a?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - tobacco
   - pm
   - smoke-free
+stock:
+  ticker: PM
+  exchange: NYSE
+  symbol: nyse:pm
+  name: "Philip Morris International Inc."
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:pm`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -355,3 +364,5 @@ PM offers exposure to tobacco industry transformation with smoke-free leadership
 - **Profitability**: Operating margin trends and smoke-free product profitability
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/stag.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/stag.mdx
@@ -1,10 +1,12 @@
 ---
 title: STAG Industrial Inc. STAG
+template: splash
 description: |
     STAG Industrial is a focused industrial REIT specializing in single-tenant warehouse and distribution facilities across the United States.
 sidebar:
     label: STAG Industrial
     order: 426
+    hidden: true
 unsplash: 1586953208448-23231824b4ab
 img: https://images.unsplash.com/photo-1586953208448-23231824b4ab?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - industrial
   - logistics
   - stag
+stock:
+  ticker: STAG
+  exchange: NYSE
+  symbol: nyse:stag
+  name: "STAG Industrial Inc."
+  sector: Real Estate
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:stag`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -203,3 +212,5 @@ Recent analyst sentiment shows positive outlook:
 - **Growth Potential**: High growth subrating based on market opportunities
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/t.mdx
@@ -1,10 +1,12 @@
 ---
 title: AT&T Inc. T
+template: splash
 description: |
     AT&T is a leading global telecommunications company providing wireless, broadband, video, and voice services to consumers, businesses, and government customers across the United States and internationally.
 sidebar:
     label: AT&T T
     order: 491
+    hidden: true
 unsplash: 1556075798-3cb3acd7f3ff
 img: https://images.unsplash.com/photo-1556075798-3cb3acd7f3ff?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - wireless
   - t
   - broadband
+stock:
+  ticker: T
+  exchange: NYSE
+  symbol: nyse:t
+  name: "AT&T Inc."
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:t`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -305,3 +314,5 @@ T offers exposure to essential telecommunications infrastructure with dividend i
 - **Debt Reduction**: Progress on debt reduction and credit metrics improvement
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/tmus.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/tmus.mdx
@@ -1,10 +1,12 @@
 ---
 title: T-Mobile US Inc. TMUS
+template: splash
 description: |
     T-Mobile is a leading wireless telecommunications company providing mobile communications services and solutions across the United States, known for innovation, customer service excellence, and network leadership through 5G technology deployment.
 sidebar:
     label: T-Mobile US TMUS
     order: 529
+    hidden: true
 unsplash: 1556742502-ec7c0cd0b1e7
 img: https://images.unsplash.com/photo-1556742502-ec7c0cd0b1e7?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - wireless
   - tmus
   - 5g
+stock:
+  ticker: TMUS
+  exchange: NASDAQ
+  symbol: nasdaq:tmus
+  name: "T-Mobile US Inc."
+  sector: Communication Services
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:tmus`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -355,3 +364,5 @@ TMUS offers exposure to wireless industry leadership with 5G innovation:
 - **5G Monetization**: Revenue opportunities from 5G services and applications
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/tsla.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/tsla.mdx
@@ -1,19 +1,28 @@
 ---
 title: Tesla TSLA
+template: splash
 description: |
     Tesla is a multinational automotive / technology company.
 sidebar:
     label: Tesla TSLA
     order: 420
+    hidden: true
 unsplash: 1601158935942-52255782d322
 img: https://images.unsplash.com/photo-1601158935942-52255782d322?fit=crop&w=1400&h=700&q=75
 tags:
   - stock
   - automotive
   - technology
+stock:
+  ticker: TSLA
+  exchange: NASDAQ
+  symbol: nasdaq:tsla
+  name: "Tesla"
+  sector: Consumer Discretionary
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -26,7 +35,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nasdaq:tsla`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -109,3 +118,5 @@ As a pioneer in electric vehicles and autonomous driving technology, Tesla holds
 - **Energy Trading** opportunities through virtual power plants
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/unh.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/unh.mdx
@@ -1,10 +1,12 @@
 ---
 title: UnitedHealth Group Incorporated UNH
+template: splash
 description: |
     UnitedHealth Group is a leading healthcare company providing health insurance coverage and healthcare services through its diversified portfolio of businesses serving consumers, employers, health care providers, and government programs.
 sidebar:
     label: UnitedHealth Group UNH
     order: 524
+    hidden: true
 unsplash: 1576091160399-112ba8d25d1f
 img: https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - insurance
   - unh
   - managed-care
+stock:
+  ticker: UNH
+  exchange: NYSE
+  symbol: nyse:unh
+  name: "UnitedHealth Group Incorporated"
+  sector: Health Care
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:unh`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -323,3 +332,5 @@ UNH offers exposure to comprehensive healthcare services with integration advant
 - **Quality Metrics**: Clinical quality outcomes and member satisfaction scores
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/v.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/v.mdx
@@ -1,10 +1,12 @@
 ---
 title: Visa Inc. V
+template: splash
 description: |
     Visa is the world's leading digital payments technology company connecting consumers, businesses, banks, and governments in more than 200 countries and territories, facilitating secure and reliable electronic payments worldwide.
 sidebar:
     label: Visa V
     order: 510
+    hidden: true
 unsplash: 1556742502-ec7f9ad8f8eb
 img: https://images.unsplash.com/photo-1556742502-ec7f9ad8f8eb?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - payments
   - v
   - fintech
+stock:
+  ticker: V
+  exchange: NYSE
+  symbol: nyse:v
+  name: "Visa Inc."
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:v`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -334,3 +343,5 @@ V offers exposure to global digital payments growth with network advantages:
 - **Emerging Market Performance**: Growth in emerging market penetration and volume
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/voo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/voo.mdx
@@ -1,10 +1,12 @@
 ---
 title: Vanguard S&P 500 ETF VOO
+template: splash
 description: |
     VOO is a low-cost ETF that tracks the S&P 500 index, offering broad market exposure with minimal fees.
 sidebar:
     label: VOO ETF
     order: 423
+    hidden: true
 unsplash: 1563013544-71e8d4c2650e
 img: https://images.unsplash.com/photo-1563013544-71e8d4c2650e?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - voo
   - sp500
   - vanguard
+stock:
+  ticker: VOO
+  exchange: AMEX
+  symbol: amex:voo
+  name: "Vanguard S&P 500 ETF"
+  sector: ETF
+  kind: etf
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`amex:voo`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -157,3 +166,5 @@ For the most accurate and up-to-date yield data:
 - **Distribution History**: Available on Vanguard's website for historical dividend payments
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/wfc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/wfc.mdx
@@ -1,10 +1,12 @@
 ---
 title: Wells Fargo & Company WFC
+template: splash
 description: |
     Wells Fargo is a leading financial services company providing banking, investment, mortgage, and consumer finance services through extensive branch networks and digital platforms serving consumers, businesses, and institutions.
 sidebar:
     label: Wells Fargo WFC
     order: 531
+    hidden: true
 unsplash: 1541354329998-f4d9a9f4157b
 img: https://images.unsplash.com/photo-1541354329998-f4d9a9f4157b?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - banking
   - wfc
   - consumer-banking
+stock:
+  ticker: WFC
+  exchange: NYSE
+  symbol: nyse:wfc
+  name: "Wells Fargo & Company"
+  sector: Financials
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:wfc`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -375,3 +384,5 @@ WFC offers exposure to comprehensive banking services with operational improveme
 - **Digital Adoption**: Digital banking adoption and customer engagement metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/wmt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/wmt.mdx
@@ -1,10 +1,12 @@
 ---
 title: Walmart Inc. WMT
+template: splash
 description: |
     Walmart is the world's largest retailer operating a global network of discount stores, supercenters, and e-commerce platforms, serving millions of customers worldwide with everyday low prices and comprehensive retail solutions.
 sidebar:
     label: Walmart WMT
     order: 508
+    hidden: true
 unsplash: 1556742049-0ca8c6c56de4
 img: https://images.unsplash.com/photo-1556742049-0ca8c6c56de4?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - consumer-staples
   - wmt
   - e-commerce
+stock:
+  ticker: WMT
+  exchange: NYSE
+  symbol: nyse:wmt
+  name: "Walmart Inc."
+  sector: Consumer Staples
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:wmt`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -335,3 +344,5 @@ WMT offers exposure to global retail leadership with technology transformation:
 - **Customer Metrics**: Customer satisfaction, loyalty, and engagement metrics
 
 <Giscus />
+
+</StockLeaf>

--- a/apps/kbve/astro-kbve/src/content/docs/stock/xom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/xom.mdx
@@ -1,10 +1,12 @@
 ---
 title: Exxon Mobil Corporation XOM
+template: splash
 description: |
     ExxonMobil is one of the world's largest publicly traded energy companies, engaged in exploring, producing, transporting, and selling crude oil and natural gas, as well as manufacturing and marketing petroleum products and chemicals.
 sidebar:
     label: ExxonMobil XOM
     order: 514
+    hidden: true
 unsplash: 1497435334941-8c899ee9e8e9
 img: https://images.unsplash.com/photo-1497435334941-8c899ee9e8e9?fit=crop&w=1400&h=700&q=75
 tags:
@@ -13,9 +15,16 @@ tags:
   - oil-gas
   - xom
   - chemicals
+stock:
+  ticker: XOM
+  exchange: NYSE
+  symbol: nyse:xom
+  name: "Exxon Mobil Corporation"
+  sector: Energy
+  kind: equity
 ---
 
-import TradingView from '@/components/charts/TradingView.astro';
+import StockLeaf from '@/components/stock/StockLeaf.astro';
 
 import {
   Aside,
@@ -28,7 +37,7 @@ import {
 
 import { Giscus, Adsense } from '@/components/astropad';
 
-<TradingView data={`nyse:xom`} />
+<StockLeaf data={frontmatter.stock} lede={frontmatter.description?.trim()}>
 
 <Adsense />
 
@@ -345,3 +354,5 @@ XOM offers exposure to integrated energy operations with technology leadership:
 - **Free Cash Flow**: Free cash flow generation and capital return to shareholders
 
 <Giscus />
+
+</StockLeaf>


### PR DESCRIPTION
Follow-up to #15233, which merged the gutter rail into the Starlight sidebar and piloted the new stock section on SPY.

## Why

Every ticker page carried a bare TradingView embed and no structured metadata, so the section rail had nothing to group on — all 94 non-pilot tickers landed in a single `Unclassified` bucket.

## What changed

- **`stock:` frontmatter on all 94 remaining tickers** — ticker, exchange, symbol, name, GICS sector, kind. Exchange and symbol are lifted from the TradingView embed each page already declared, so the chart symbol is unchanged; sector is assigned per GICS.
- **Pages move to `template: splash` + `sidebar.hidden`** and render through `StockLeaf`, matching the SPY pilot: bento hero with ticker/exchange/sector stats, chart in its own shell, prose in a `BentoProse` slot.
- **`StockSectorDirectory.astro`** (new) — coverage stats plus per-sector ticker grids anchored at `#<sector>`, composed from bento primitives.
- **`stock/index.mdx`** becomes a bento splash hub, keeping the existing investment/account-type primer in a `BentoProse` slot.

## Verification

Full build, exit 0. From the built HTML:

```
/stock/          12 sector sections, 0 "Unclassified"
                 ETFs & Funds 2 | Technology 21 | Communication Services 7
                 Consumer Discretionary 6 | Consumer Staples 7 | Financials 16
                 Health Care 9 | Industrials 8 | Energy 3 | Materials 5
                 Utilities 6 | Real Estate 5          = 95 tickers

/stock/aapl/     stats: AAPL | NASDAQ | Technology
                 sidebar: all 12 sector groups, section rail scoped to stock
```

Spot-checked the awkward slugs — `brkb` resolves `nyse:brk.b` → ticker `BRK.B`, and single-letter slugs (`a`, `o`, `t`, `v`) map correctly.