### PR TITLE
build(deps): bump k8s-openapi 0.28 + kube 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +883,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -4395,7 +4412,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "annotate-snippets",
+ "annotate-snippets 0.11.5",
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
@@ -7067,6 +7084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8629,6 +8655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -10269,9 +10305,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64 0.22.1",
  "jiff",
@@ -10414,9 +10450,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+checksum = "208d7fe1380066abb194812a8a8e303cb896a33bb3d7b3177b71bd03ff39bf18"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -10427,9 +10463,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+checksum = "31e940a73033a7c5c7918b5ece7851d84571b58be25e937198da37fa13f116d3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -10448,10 +10484,11 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls 0.23.42",
+ "rustls-platform-verifier",
  "secrecy 0.10.3",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
@@ -10462,9 +10499,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+checksum = "a9d2353c118cf3462c352ee0b5bd5b0cf17990af456dfd8662d136ff9812eeb4"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -10481,9 +10518,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
+checksum = "92141c19e1fa83bf91633c1234c66b03375c29aa8ca5486331ddb47e3a3da9c0"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10495,9 +10532,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
+checksum = "3eb064ef71c7bea55e934a443960da9e9ec31fbb2ba63e47e4aeca32603d5cc7"
 dependencies = [
  "ahash 0.8.12",
  "async-broadcast",
@@ -16530,6 +16567,25 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash 0.8.12",
+ "annotate-snippets 0.12.16",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/agones/arpg/server/Cargo.workspace.toml
+++ b/apps/agones/arpg/server/Cargo.workspace.toml
@@ -38,8 +38,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/agones/cryptothrone/server/Cargo.workspace.toml
+++ b/apps/agones/cryptothrone/server/Cargo.workspace.toml
@@ -38,8 +38,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/agones/factorio/relay/Cargo.workspace.toml
+++ b/apps/agones/factorio/relay/Cargo.workspace.toml
@@ -38,8 +38,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/agones/palworld/relay/Cargo.workspace.toml
+++ b/apps/agones/palworld/relay/Cargo.workspace.toml
@@ -38,8 +38,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
+++ b/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
@@ -41,8 +41,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/discordsh/axum-discordsh/Cargo.workspace.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/discordsh/discordsh-bot/Cargo.workspace.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.workspace.toml
@@ -46,8 +46,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/herbmail/axum-herbmail/Cargo.workspace.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/irc/irc-gateway/Cargo.workspace.toml
+++ b/apps/irc/irc-gateway/Cargo.workspace.toml
@@ -41,8 +41,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/kbve/axum-kbve/Cargo.workspace.toml
+++ b/apps/kbve/axum-kbve/Cargo.workspace.toml
@@ -45,8 +45,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/kbve/kbve-gate/Cargo.workspace.toml
+++ b/apps/kbve/kbve-gate/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/memes/axum-memes/Cargo.workspace.toml
+++ b/apps/memes/axum-memes/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/rareicon/axum-rareicon/Cargo.workspace.toml
+++ b/apps/rareicon/axum-rareicon/Cargo.workspace.toml
@@ -42,8 +42,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/rentearth/axum-rentearth/Cargo.workspace.toml
+++ b/apps/rentearth/axum-rentearth/Cargo.workspace.toml
@@ -41,8 +41,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/vm/factorio-ctl/Cargo.workspace.toml
+++ b/apps/vm/factorio-ctl/Cargo.workspace.toml
@@ -38,8 +38,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/vm/firecracker-ctl/Cargo.workspace.toml
+++ b/apps/vm/firecracker-ctl/Cargo.workspace.toml
@@ -40,8 +40,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"

--- a/apps/vm/kubectl/Cargo.workspace.toml
+++ b/apps/vm/kubectl/Cargo.workspace.toml
@@ -37,8 +37,8 @@ http-body-util = "0.1"
 jni = "0.21"
 js-sys = { version = "0.3", default-features = false }
 jsonwebtoken = { version = "10.3.0", default-features = false }
-k8s-openapi = "0.27"
-kube = { version = "3", default-features = false }
+k8s-openapi = "0.28"
+kube = { version = "4", default-features = false }
 lightyear = { version = "0.28", default-features = false }
 log = "0.4"
 lru = "0.18"


### PR DESCRIPTION
Supersedes #15215.

## Why #15215 alone breaks the build

`kube` 3.x pins `k8s-openapi ^0.27`, so bumping `k8s-openapi` on its own resolved **two** copies into `Cargo.lock`:

```
k8s-openapi 0.27.1  <- kube, kube-client, kube-core, kube-runtime
k8s-openapi 0.28.0  <- axum-cryptothrone, rows, factorio-ctl
```

Nothing in our source imports `k8s_openapi` types directly — the dep exists purely to select the Kubernetes version feature (`v1_32`) that `k8s-openapi` requires. With the split, `v1_32` applied only to the 0.28 copy, leaving kube's 0.27 copy with no `v1_*` feature selected. That is a hard compile error, not just a duplicate-crate bloat issue, and it would have taken out every image linking kube.

## Fix

Bump `kube` 3 -> 4 alongside. kube 4.x moved to `k8s-openapi ^0.28`, so the graph collapses back to a single `k8s-openapi 0.28.0`.

- Feature sets unchanged. kube 4 `default` is still `["client", "rustls-tls", "ring"]`, and `client` / `rustls-tls` / `runtime` / `derive` all still exist.
- Re-ran `scripts/sync-cargo-workspace-stubs.py` so the 18 Docker stub manifests carry the updated `[workspace.dependencies]` table — that is the check that was failing on #15215.

## Verification

```
cargo check -p axum-cryptothrone -p factorio-ctl   # 0 errors
cargo check -p rows --all-targets                  # 0 errors
python3 scripts/sync-cargo-workspace-stubs.py --check   # drift: 0/18
grep -c 'name = "k8s-openapi"' Cargo.lock         # 1
```