### PR TITLE
fix(herbmail-game): unblock affected lint gate (#15237)

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/npc/doorwaySteer.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/npc/doorwaySteer.test.ts
@@ -4,8 +4,8 @@ const doorwayAt = vi.fn();
 
 vi.mock('../dungeon/collision', () => ({
 	doorwayAt: (x: number, z: number) => doorwayAt(x, z),
-	makeMover: () => () => {},
-	registerBody: () => () => {},
+	makeMover: () => vi.fn(),
+	registerBody: () => vi.fn(),
 }));
 
 const { steerThroughDoorway } = await import('./goblinSim');


### PR DESCRIPTION
Closes #15237.

`herbmail-game:lint` failed the Dev→Main validation gate with 2 errors:

```
src/game/npc/doorwaySteer.test.ts
  7:25  error  Unexpected empty arrow function  @typescript-eslint/no-empty-function
  8:28  error  Unexpected empty arrow function  @typescript-eslint/no-empty-function
```

The `../dungeon/collision` mock returned bare `() => {}` disposers from `makeMover`/`registerBody`. Swapped to `vi.fn()`.

Verified in worktree:
- `herbmail-game:lint` → 0 errors, 24 warnings (warnings pre-existing, non-blocking)
- `herbmail-game:test` → 21 files, 125 tests passed