### PR TITLE
fix(axum-kbve): recover Docker build from sccache hits missing their rlib

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -140,6 +140,8 @@ COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 
+COPY apps/kbve/axum-kbve/docker/cargo-retry.sh /usr/local/bin/cargo-retry
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
@@ -152,7 +154,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     else \
         echo "sccache: Redis password not provided, falling back to local disk cache"; \
     fi && \
-    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
+    cargo-retry cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
     (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
@@ -162,6 +164,7 @@ ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+COPY --from=builder-deps /usr/local/bin/cargo-retry /usr/local/bin/cargo-retry
 
 COPY --from=planner /app/Cargo.toml ./
 COPY Cargo.lock ./
@@ -191,7 +194,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
+    cargo-retry cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker \
         -p bevy_inventory -p bevy_items -p bevy_skills && \
     (sccache --show-stats || true)
 
@@ -236,7 +239,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p axum-kbve --features jemalloc && \
+    cargo-retry cargo build --release -p axum-kbve --features jemalloc && \
     (sccache --show-stats || true) && \
     strip target/release/axum-kbve
 

--- a/apps/kbve/axum-kbve/docker/cargo-retry.sh
+++ b/apps/kbve/axum-kbve/docker/cargo-retry.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+LOG=/tmp/cargo-retry.log
+STATUS=/tmp/cargo-retry.status
+
+{ if "$@" 2>&1; then echo 0 >"$STATUS"; else echo $? >"$STATUS"; fi; } | tee "$LOG"
+code=$(cat "$STATUS")
+
+if [ "$code" -eq 0 ]; then
+    exit 0
+fi
+
+if ! grep -q "extern location for .* does not exist" "$LOG"; then
+    exit "$code"
+fi
+
+echo "::warning::sccache returned a cache hit without its rlib; purging target and recompiling with SCCACHE_RECACHE=1"
+rm -rf target
+SCCACHE_RECACHE=1 "$@"


### PR DESCRIPTION
Closes #15250

## Problem

`CI - Docker / axum-kbve` failed at **`[STAGE D] cargo chef cook`** — not at the e2e test the tracker named:

```
error: extern location for version_check does not exist: /app/target/release/deps/libversion_check-61452213c827525c.rlib
  --> .../slotmap-1.1.1/build.rs:2:22
error: extern location for autocfg does not exist: /app/target/release/deps/libautocfg-b9ac9782ebac9da1.rlib
  --> .../num-traits-0.2.19/build.rs:2:14
thread 'main' panicked at .../cargo-chef-0.1.77/src/recipe.rs:224:27
```

From [run #30802695039](https://github.com/KBVE/kbve/actions/runs/30802695039):

- sccache ran with the Valkey/Redis backend (`sccache: Redis backend enabled`), prefix `axum-kbve`.
- ~60 crates went start→done in ~2s, so these were cache hits, not real compiles.
- `version_check` started at t=2.87s; at t=5.15s cargo handed its rlib path to dependent build scripts and the file did not exist.
- `/app/target` has no cache mount and no `CARGO_TARGET_DIR` override, so it is layer-local — nothing outside the build could have removed it. A unit reported success without producing its rlib, which only the rustc wrapper can cause.

So an sccache cache hit is being replayed without materialising the rlib. The bad entry stays in Valkey, so a plain re-run can fail the same way. This job has failed this way repeatedly: #15186, #15035, #14396, #14315, #14264.

## Fix

`apps/kbve/axum-kbve/docker/cargo-retry.sh` wraps the three cargo invocations (chef cook, foundation build, app build). On failure it:

1. matches only the `extern location for ... does not exist` signature — any other failure exits with the original status, unretried;
2. purges `target`;
3. re-runs with `SCCACHE_RECACHE=1`, which recompiles **and overwrites** the poisoned Valkey entry, so the next build starts clean too.

## Verification

- `docker buildx build --check` on the Dockerfile: no new findings (only the pre-existing `FromPlatformFlagConstDisallowed` warnings).
- Script exercised under the real `/bin/sh` (dash) inside `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder`:
  - success → exit 0, no retry
  - `error[E0433]` compile error → exit 101, **no** retry
  - `extern location for ...` → target purged, retried with `SCCACHE_RECACHE=1`, exit 0

An earlier revision of the script recorded the exit status on the left side of a pipeline under `set -e`, which aborted before the status was written; that is fixed and covered by the dash run above.

## Not covered

The same sccache + cargo-chef pattern is used by the other Rust services (`axum-chuckrpg`, `cryptothrone`, `discordsh`, `herbmail`, `irc-gateway`, `memes`, `jobboard`, `metrics`, arpg/cryptothrone servers). This PR only changes `axum-kbve`, matching the issue scope. Rolling the wrapper out to the rest is a follow-up if this holds.

The underlying sccache defect is not fixed here — this detects and heals it.