### PR TITLE
fix(astro-kbve): restore ToC opt-out and give the arcade its own rail

### DIFF
--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameCard.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameCard.astro
@@ -59,9 +59,7 @@ const tooltipCta = isLink ? 'Click to play' : 'On the roadmap';
 		aria-hidden="true"
 		class="arcade-card-art relative flex aspect-[16/9] items-center justify-center overflow-hidden"
 		style={`background: ${gradient};`}>
-		<div class="arcade-card-art__grid pointer-events-none absolute inset-0">
-		</div>
-		<div class="arcade-card-art__scan pointer-events-none absolute inset-0">
+		<div class="arcade-card-art__fx pointer-events-none absolute inset-0">
 		</div>
 		<div
 			class="arcade-card-art__shine pointer-events-none absolute inset-0">
@@ -120,38 +118,33 @@ const tooltipCta = isLink ? 'Click to play' : 'On the roadmap';
 </Tag>
 
 <style>
-	.arcade-card-art__scan {
-		background: repeating-linear-gradient(
-			to bottom,
-			rgba(0, 0, 0, 0.32) 0,
-			rgba(0, 0, 0, 0.32) 1px,
-			transparent 1px,
-			transparent 4px
-		);
-		mix-blend-mode: overlay;
-		opacity: 0.85;
-	}
-	.arcade-card-art__grid {
+	/* Scanlines and grid share one blended layer — every `mix-blend-mode`
+	   element forces its own compositing group, and the hub stacks these
+	   across every card in the catalog. */
+	.arcade-card-art__fx {
 		background-image:
+			repeating-linear-gradient(
+				to bottom,
+				rgba(0, 0, 0, 0.32) 0,
+				rgba(0, 0, 0, 0.32) 1px,
+				transparent 1px,
+				transparent 4px
+			),
 			linear-gradient(rgba(255, 255, 255, 0.07) 1px, transparent 1px),
 			linear-gradient(
 				90deg,
 				rgba(255, 255, 255, 0.07) 1px,
 				transparent 1px
 			);
-		background-size: 22px 22px;
+		background-size:
+			auto,
+			22px 22px,
+			22px 22px;
 		mix-blend-mode: overlay;
-		mask-image: radial-gradient(
-			ellipse at 50% 50%,
-			rgba(0, 0, 0, 0.95) 0%,
-			transparent 75%
-		);
-		-webkit-mask-image: radial-gradient(
-			ellipse at 50% 50%,
-			rgba(0, 0, 0, 0.95) 0%,
-			transparent 75%
-		);
+		opacity: 0.85;
 	}
+	/* Screen-blending white over the art is equivalent to painting the same
+	   white at the same alpha, so this layer needs no blend mode at all. */
 	.arcade-card-art__shine {
 		background: radial-gradient(
 			circle at 28% 18%,
@@ -159,6 +152,5 @@ const tooltipCta = isLink ? 'Click to play' : 'On the roadmap';
 			rgba(255, 255, 255, 0.08) 24%,
 			transparent 55%
 		);
-		mix-blend-mode: screen;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
@@ -15,10 +15,16 @@ const {
 <section
 	aria-labelledby="arcade-hero-title"
 	class="not-content relative isolate mb-10 overflow-hidden rounded-2xl border border-purple-500/35 px-5 py-12 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.55),inset_0_0_0_1px_rgba(0,0,0,0.35)] sm:px-14">
-	<!-- Layered animated gradient background -->
+	<!-- Layered gradient background: a static base plus a warmer copy that
+	     cross-fades over it, so the pulse is a compositor-only opacity
+	     animation instead of an every-frame filter repaint. -->
 	<div
 		aria-hidden="true"
-		class="arcade-hero-pulse absolute inset-0 -z-30 bg-[radial-gradient(circle_at_12%_10%,rgba(236,72,153,0.55)_0%,transparent_45%),radial-gradient(circle_at_88%_80%,rgba(56,189,248,0.45)_0%,transparent_50%),linear-gradient(135deg,#0b0a18_0%,#1c1438_50%,#1f0c2e_100%)]">
+		class="absolute inset-0 -z-30 bg-[radial-gradient(circle_at_12%_10%,rgba(236,72,153,0.55)_0%,transparent_45%),radial-gradient(circle_at_88%_80%,rgba(56,189,248,0.45)_0%,transparent_50%),linear-gradient(135deg,#0b0a18_0%,#1c1438_50%,#1f0c2e_100%)]">
+	</div>
+	<div
+		aria-hidden="true"
+		class="arcade-hero-pulse absolute inset-0 -z-30 bg-[radial-gradient(circle_at_12%_10%,rgba(249,115,22,0.55)_0%,transparent_45%),radial-gradient(circle_at_88%_80%,rgba(129,140,248,0.45)_0%,transparent_50%),linear-gradient(135deg,#120a18_0%,#241542_50%,#2a0e33_100%)]">
 	</div>
 	<!-- Faded grid behind content -->
 	<div
@@ -73,17 +79,19 @@ const {
 </section>
 
 <style>
-	@keyframes arcade-hero-hue {
+	@keyframes arcade-hero-pulse {
 		0%,
 		100% {
-			filter: hue-rotate(0deg) brightness(1);
+			opacity: 0;
 		}
 		50% {
-			filter: hue-rotate(20deg) brightness(1.08);
+			opacity: 0.55;
 		}
 	}
 	.arcade-hero-pulse {
-		animation: arcade-hero-hue 14s ease-in-out infinite;
+		opacity: 0;
+		will-change: opacity;
+		animation: arcade-hero-pulse 14s ease-in-out infinite;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		.arcade-hero-pulse {

--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeTooltipController.tsx
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeTooltipController.tsx
@@ -118,12 +118,25 @@ export default function ArcadeTooltipController() {
 					: rect.top - 12 + window.scrollY;
 			setPos({ top, left, placement });
 		};
+		// Scroll fires far faster than the compositor can present, and each
+		// call reads layout then sets state. Coalesce to one measurement per
+		// frame so a fast scroll cannot queue a reflow per event.
+		let frame = 0;
+		const schedule = () => {
+			if (frame) return;
+			frame = requestAnimationFrame(() => {
+				frame = 0;
+				compute();
+			});
+		};
+
 		compute();
-		window.addEventListener('scroll', compute, { passive: true });
-		window.addEventListener('resize', compute);
+		window.addEventListener('scroll', schedule, { passive: true });
+		window.addEventListener('resize', schedule);
 		return () => {
-			window.removeEventListener('scroll', compute);
-			window.removeEventListener('resize', compute);
+			if (frame) cancelAnimationFrame(frame);
+			window.removeEventListener('scroll', schedule);
+			window.removeEventListener('resize', schedule);
 		};
 	}, [open, tip]);
 

--- a/apps/kbve/astro-kbve/src/components/arcade/arcadeGames.ts
+++ b/apps/kbve/astro-kbve/src/components/arcade/arcadeGames.ts
@@ -1,0 +1,143 @@
+export type ArcadeStatus = 'live' | 'beta' | 'soon';
+
+export interface ArcadeGame {
+	slug: string;
+	title: string;
+	href: string;
+	description: string;
+	tags: string[];
+	status: ArcadeStatus;
+	gradient: string;
+	icon: string;
+}
+
+export const ARCADE_STATUS_LABEL: Record<ArcadeStatus, string> = {
+	live: 'Play now',
+	beta: 'In beta',
+	soon: 'Coming soon',
+};
+
+/**
+ * Single source of truth for the arcade catalog: drives the hub cards, the
+ * section rail, and the coverage stats. Adding a game here wires all three.
+ */
+export const ARCADE_GAMES: ArcadeGame[] = [
+	{
+		slug: 'tactics',
+		title: 'Frontline Grid',
+		href: '/arcade/tactics/',
+		description:
+			'Compact turn-based tactics on an 8×8 battlefield. Move blue command units across terrain, focus fire, survive red counter turns, and clear the convoy guard.',
+		tags: ['Tactics', 'Strategy', 'React'],
+		status: 'live',
+		gradient: 'linear-gradient(135deg, #0f766e 0%, #1d4ed8 100%)',
+		icon: '▦',
+	},
+	{
+		slug: 'blackjack',
+		title: 'Blackjack',
+		href: '/arcade/blackjack/',
+		description:
+			'Classic single-player blackjack against the dealer. Set your wager, hit, stand, double down, and manage a finite bankroll through a four-deck shoe.',
+		tags: ['Cards', 'Casino', 'Phaser'],
+		status: 'live',
+		gradient: 'linear-gradient(135deg, #14532d 0%, #7f1d1d 100%)',
+		icon: '♣',
+	},
+	{
+		slug: 'solitaire',
+		title: 'Solitaire',
+		href: '/arcade/solitaire/',
+		description:
+			'Klondike with a roguelite twist — bonus HP/cash cards, monster encounters pulled from npcdb, frozen-card status, and a Balatro-style blind/shop loop.',
+		tags: ['Cards', 'Roguelite', 'Phaser'],
+		status: 'live',
+		gradient: 'linear-gradient(135deg, #065f46 0%, #1e3a8a 100%)',
+		icon: '♠',
+	},
+	{
+		slug: 'towerdefense',
+		title: 'Tower Defense',
+		href: '/arcade/towerdefense/',
+		description:
+			'Procedurally-generated map, ECS sim with armor + status effects, repair drones, archers, card rewards between waves, and a Call for Ally Nation item. Hold the line through 20+ waves, then 5-card rewards kick in.',
+		tags: ['Tower Defense', 'Strategy', 'Phaser', 'ECS'],
+		status: 'live',
+		gradient: 'linear-gradient(135deg, #b45309 0%, #166534 100%)',
+		icon: '✛',
+	},
+	{
+		slug: 'runner',
+		title: 'Endless Runner',
+		href: '/arcade/runner/',
+		description:
+			'A quick endless-runner palette cleanser. Pick up speed, dodge what you can, see how far you get.',
+		tags: ['Action', 'Arcade', 'R3F'],
+		status: 'live',
+		gradient: 'linear-gradient(135deg, #f59e0b 0%, #b91c1c 100%)',
+		icon: '➤',
+	},
+	{
+		slug: 'arpg',
+		title: 'ARPG',
+		href: '/arcade/arpg/',
+		description:
+			'Diablo-style multiplayer isometric action RPG built on Phaser 4 and @kbve/laser. Party up, clear floors, and push deeper.',
+		tags: ['Action RPG', 'Multiplayer', 'Phaser'],
+		status: 'beta',
+		gradient: 'linear-gradient(135deg, #7f1d1d 0%, #312e81 100%)',
+		icon: '⚔',
+	},
+	{
+		slug: 'rareicon',
+		title: 'RareIcon (WebGL)',
+		href: '/arcade/rareicon/',
+		description:
+			'A playable demo of RareIcon — our 2D sci-fi action-RPG bullet-hell roguelite. Chip vs DaemonCorps, in your browser.',
+		tags: ['Action RPG', 'Bullet hell', 'WebGL'],
+		status: 'beta',
+		gradient: 'linear-gradient(135deg, #7c3aed 0%, #be185d 100%)',
+		icon: '✦',
+	},
+	{
+		slug: 'isometric',
+		title: 'Isometric',
+		href: '/arcade/isometric/',
+		description:
+			"WebGPU-powered isometric world prototype, built on Bevy + Rust + WASM. Wander, watch shadows snap, see what's possible at native frame rate.",
+		tags: ['Isometric', 'Bevy', 'WebGPU'],
+		status: 'beta',
+		gradient: 'linear-gradient(135deg, #0e7490 0%, #312e81 100%)',
+		icon: '◈',
+	},
+	{
+		slug: 'ruffle',
+		title: 'Ruffle Flash player',
+		href: '/arcade/',
+		description:
+			'WASM-based Flash player so we can bring SWF-era games back to life inside the arcade. Tracking integration, save-state, and controller mapping before we open the catalog.',
+		tags: ['Ruffle', 'WASM', 'Flash'],
+		status: 'soon',
+		gradient: 'linear-gradient(135deg, #b45309 0%, #4c1d95 100%)',
+		icon: '▶',
+	},
+	{
+		slug: 'more',
+		title: 'More first-party titles',
+		href: '/arcade/',
+		description:
+			'KBVE Studio keeps shipping. New titles drop here first — track the project changelog for what’s cooking next.',
+		tags: ['Roadmap', 'Studio'],
+		status: 'soon',
+		gradient: 'linear-gradient(135deg, #1e3a8a 0%, #0e7490 100%)',
+		icon: '✜',
+	},
+];
+
+export const ARCADE_PLAYABLE = ARCADE_GAMES.filter(
+	(game) => game.status !== 'soon',
+);
+
+export const ARCADE_UPCOMING = ARCADE_GAMES.filter(
+	(game) => game.status === 'soon',
+);

--- a/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
+++ b/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
@@ -1,0 +1,73 @@
+import type {
+	BreadcrumbCrumb,
+	DashboardNavGroup,
+	DashboardNavItem,
+} from '../dashboard/dashboardNav';
+import { buildBreadcrumbIn, findActiveIn } from '../dashboard/dashboardNav';
+import { ARCADE_GAMES, ARCADE_STATUS_LABEL } from './arcadeGames';
+import type { ArcadeStatus } from './arcadeGames';
+
+export const ARCADE_ROOT: DashboardNavItem = {
+	label: 'Arcade',
+	href: '/arcade/',
+};
+
+const STATUS_ORDER: ArcadeStatus[] = ['live', 'beta', 'soon'];
+
+const STATUS_META: Record<ArcadeStatus, { eyebrow: string; icon: string }> = {
+	live: {
+		eyebrow: 'Playable',
+		icon: 'M8 5v14l11-7z',
+	},
+	beta: {
+		eyebrow: 'Prototype',
+		icon: 'M12 2 15 8l7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1 3-6z',
+	},
+	soon: {
+		eyebrow: 'Roadmap',
+		icon: 'M12 6v6l4 2M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2z',
+	},
+};
+
+export const buildArcadeNav = (): DashboardNavGroup[] =>
+	STATUS_ORDER.flatMap((status) => {
+		const items = ARCADE_GAMES.filter(
+			(game) => game.status === status && game.href !== ARCADE_ROOT.href,
+		).map<DashboardNavItem>((game) => ({
+			label: game.title,
+			href: game.href,
+			copy: game.description,
+		}));
+		if (!items.length) return [];
+		return [
+			{
+				label: ARCADE_STATUS_LABEL[status],
+				eyebrow: STATUS_META[status].eyebrow,
+				icon: STATUS_META[status].icon,
+				href:
+					status === 'soon' ? '/arcade/#soon' : '/arcade/#available',
+				items,
+			},
+		];
+	});
+
+export const ARCADE_NAV = buildArcadeNav();
+
+const normalize = (path: string): string => {
+	const trimmed = path.split('?')[0].split('#')[0];
+	return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+};
+
+const titleCase = (value: string): string =>
+	value.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+export const buildArcadeBreadcrumb = (pathname: string): BreadcrumbCrumb[] => {
+	const crumbs = buildBreadcrumbIn(ARCADE_NAV, ARCADE_ROOT, pathname);
+	const match = findActiveIn(ARCADE_NAV, ARCADE_ROOT.href, pathname);
+	const path = normalize(pathname);
+	if (match && normalize(match.item.href) !== path) {
+		const leaf = path.replace(/\/$/, '').split('/').pop() ?? '';
+		if (leaf) crumbs.push({ label: titleCase(leaf), href: path });
+	}
+	return crumbs;
+};

--- a/apps/kbve/astro-kbve/src/components/dashboard/sectionNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/sectionNav.ts
@@ -58,6 +58,11 @@ import {
 	buildStockNav,
 	buildStockBreadcrumb,
 } from '../stock/stockNav';
+import {
+	ARCADE_NAV,
+	ARCADE_ROOT,
+	buildArcadeBreadcrumb,
+} from '../arcade/arcadeNav';
 import { adaptStarlightSidebar } from './starlightNav';
 import type { StarlightEntry } from './starlightNav';
 
@@ -221,11 +226,20 @@ export async function resolveSection(
 		};
 	}
 
-	if (
-		path.startsWith('/gaming/') ||
-		path === '/osrs/' ||
-		path === '/arcade/'
-	) {
+	if (path.startsWith('/arcade/')) {
+		return {
+			id: 'arcade',
+			entries: ARCADE_NAV,
+			root: ARCADE_ROOT,
+			menuLabel: 'Arcade games',
+			navLabel: 'Arcade',
+			crumbs: buildArcadeBreadcrumb(path),
+			collapsible: false,
+			withToc: false,
+		};
+	}
+
+	if (path.startsWith('/gaming/') || path === '/osrs/') {
 		return {
 			id: 'gaming',
 			entries: GAMING_NAV,

--- a/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
@@ -30,6 +30,10 @@ import {
 	ArcadeGameGrid,
 	ArcadeTooltipController,
 } from '@/components/arcade';
+import {
+	ARCADE_PLAYABLE,
+	ARCADE_UPCOMING,
+} from '@/components/arcade/arcadeGames';
 
 import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 
@@ -41,7 +45,7 @@ import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 	title="KBVE Arcade"
 	tagline="Browser games we built ourselves — blackjack, Klondike with monsters, a WebGL action-RPG demo, an isometric WebGPU prototype, and an endless runner. Plus a Ruffle integration in the oven for Flash classics."
 	stats={[
-		{ value: '7', label: 'Live games' },
+		{ value: String(ARCADE_PLAYABLE.length), label: 'Playable now' },
 		{ value: 'WASM', label: 'Phaser · Bevy · R3F' },
 		{ value: 'Free', label: 'Enjoy the run!' },
 	]}
@@ -57,69 +61,7 @@ with a deep library, plus a few first-party titles you can't get
 anywhere else.
 
 <ArcadeGameGrid columns={2}>
-	<ArcadeGameCard
-		title="Frontline Grid"
-		href="/arcade/tactics/"
-		description="Compact turn-based tactics on an 8×8 battlefield. Move blue command units across terrain, focus fire, survive red counter turns, and clear the convoy guard."
-		tags={['Tactics', 'Strategy', 'React']}
-		status="live"
-		gradient="linear-gradient(135deg, #0f766e 0%, #1d4ed8 100%)"
-		icon="▦"
-	/>
-	<ArcadeGameCard
-		title="Blackjack"
-		href="/arcade/blackjack/"
-		description="Classic single-player blackjack against the dealer. Set your wager, hit, stand, double down, and manage a finite bankroll through a four-deck shoe."
-		tags={['Cards', 'Casino', 'Phaser']}
-		status="live"
-		gradient="linear-gradient(135deg, #14532d 0%, #7f1d1d 100%)"
-		icon="♣"
-	/>
-	<ArcadeGameCard
-		title="Solitaire"
-		href="/arcade/solitaire/"
-		description="Klondike with a roguelite twist — bonus HP/cash cards, monster encounters pulled from npcdb, frozen-card status, and a Balatro-style blind/shop loop."
-		tags={['Cards', 'Roguelite', 'Phaser']}
-		status="live"
-		gradient="linear-gradient(135deg, #065f46 0%, #1e3a8a 100%)"
-		icon="♠"
-	/>
-	<ArcadeGameCard
-		title="RareIcon (WebGL)"
-		href="/arcade/rareicon/"
-		description="A playable demo of RareIcon — our 2D sci-fi action-RPG bullet-hell roguelite. Chip vs DaemonCorps, in your browser."
-		tags={['Action RPG', 'Bullet hell', 'WebGL']}
-		status="beta"
-		gradient="linear-gradient(135deg, #7c3aed 0%, #be185d 100%)"
-		icon="✦"
-	/>
-	<ArcadeGameCard
-		title="Isometric"
-		href="/arcade/isometric/"
-		description="WebGPU-powered isometric world prototype, built on Bevy + Rust + WASM. Wander, watch shadows snap, see what's possible at native frame rate."
-		tags={['Isometric', 'Bevy', 'WebGPU']}
-		status="beta"
-		gradient="linear-gradient(135deg, #0e7490 0%, #312e81 100%)"
-		icon="◈"
-	/>
-	<ArcadeGameCard
-		title="Endless Runner"
-		href="/arcade/runner/"
-		description="A quick endless-runner palette cleanser. Pick up speed, dodge what you can, see how far you get."
-		tags={['Action', 'Arcade', 'R3F']}
-		status="live"
-		gradient="linear-gradient(135deg, #f59e0b 0%, #b91c1c 100%)"
-		icon="➤"
-	/>
-	<ArcadeGameCard
-		title="Tower Defense"
-		href="/arcade/towerdefense/"
-		description="Procedurally-generated map, ECS sim with armor + status effects, repair drones, archers, card rewards between waves, and a Call for Ally Nation item. Hold the line through 20+ waves, then 5-card rewards kick in."
-		tags={['Tower Defense', 'Strategy', 'Phaser', 'ECS']}
-		status="live"
-		gradient="linear-gradient(135deg, #b45309 0%, #166534 100%)"
-		icon="✛"
-	/>
+	{ARCADE_PLAYABLE.map((game) => <ArcadeGameCard {...game} />)}
 </ArcadeGameGrid>
 
 </BentoShell>
@@ -139,24 +81,7 @@ file. Once the integration is stable we'll seed the library with a few
 fan-favorite classics and grow from there.
 
 <ArcadeGameGrid columns={2}>
-	<ArcadeGameCard
-		title="Ruffle Flash player"
-		href="/arcade/"
-		description="WASM-based Flash player so we can bring SWF-era games back to life inside the arcade. Tracking integration, save-state, and controller mapping before we open the catalog."
-		tags={['Ruffle', 'WASM', 'Flash']}
-		status="soon"
-		gradient="linear-gradient(135deg, #b45309 0%, #4c1d95 100%)"
-		icon="▶"
-	/>
-	<ArcadeGameCard
-		title="More first-party titles"
-		href="/arcade/"
-		description="KBVE Studio keeps shipping. New titles drop here first — track the project changelog for what's cooking next."
-		tags={['Roadmap', 'Studio']}
-		status="soon"
-		gradient="linear-gradient(135deg, #1e3a8a 0%, #0e7490 100%)"
-		icon="✜"
-	/>
+	{ARCADE_UPCOMING.map((game) => <ArcadeGameCard {...game} />)}
 </ArcadeGameGrid>
 
 <CardGrid>

--- a/apps/kbve/astro-kbve/src/starlightRouteData.ts
+++ b/apps/kbve/astro-kbve/src/starlightRouteData.ts
@@ -54,10 +54,16 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 	) as typeof route.sidebar;
 	route.pagination = { prev: undefined, next: undefined };
 
-	if (section.withToc && !route.toc) {
+	// `tableOfContents: false` is an explicit per-page opt-out. Restoring a ToC
+	// over it also restores the whole right sidebar, which mounts the site
+	// graph and the bento dock — real main-thread cost on pages that asked for
+	// neither.
+	const tocOptOut = route.entry?.data?.tableOfContents === false;
+
+	if (section.withToc && !route.toc && !tocOptOut) {
 		route.toc = buildToc(route.headings ?? []);
 	}
-	if (!section.withToc) {
+	if (!section.withToc || tocOptOut) {
 		route.toc = undefined;
 	}
 });


### PR DESCRIPTION
Started from a report that [kbve.com/arcade/](https://kbve.com/arcade/) goes unresponsive on arrival.

## Regression from #15233

The route middleware rebuilt a ToC for section pages without honouring `tableOfContents: false`. Restoring a ToC also restores the right sidebar, which mounts the site graph and the bento dock. Roughly 500 pages had explicitly opted out and were mounting both anyway — 367 journal, 46 mc, 44 application, 42 dashboard, and `/arcade/` among them. The middleware now respects the opt-out.

## Arcade

- `arcadeGames.ts` is the single source for the catalog; the hub cards and the new rail both read it, so adding a game is one entry
- `/arcade/` and every game page get an **Arcade** rail grouped by status. Previously the hub fell under Gaming and the game pages got the global site tree (or, on the splash ones, no rail at all)
- hero pulse cross-fades opacity between two gradient layers instead of running an infinite `filter: hue-rotate()` repaint
- card art collapses three stacked `mix-blend-mode` layers into one
- tooltip reposition coalesces scroll events into a single rAF instead of reading layout per event

## On the reported slowness

Profiling traced the ~850ms blocking task to the **AdSense loader**, not to page markup. The controlled comparison:

```
/arcade/  ads allowed  -> 1 long task, ~850ms
/arcade/  ads blocked  -> 0 long tasks
```

The same task shows on `/stock/` and `/gaming/`, so it is site-wide rather than arcade-specific. It also fires only on runs where the ad actually serves — repeat loads of identical code range from 0 to ~880ms, so single-run numbers here are not meaningful.

**The ad components are deliberately untouched in this PR.** Changing when the loader is injected changes impression behaviour and page-level ad features, which is a revenue decision rather than a perf one. Filed separately if we want to pursue it.

## Verified

Production build. `/arcade/` and `/arcade/blackjack/` both render `data-kbve-section="arcade"` with all 8 games in the rail, no right sidebar, no site graph, no bento dock. Hub renders 10 cards from the shared catalog.

Not verified: the blend-mode and filter changes. Headless Chromium stubs the GPU, so compositor cost does not show up in these measurements — those changes are reasoned, not measured.