### PR TITLE
chore(palworld-savetool): publish sentinel — version.toml 0.0.1, MDX 0.0.2

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -69,7 +69,7 @@
 		{
 			"key": "agones_palworld_savetool",
 			"app_name": "agones-palworld-savetool",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"version_toml": "apps/agones/palworld/savetool/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx",
 			"source_path": "apps/agones/palworld/savetool",

--- a/apps/agones/palworld/savetool/version.toml
+++ b/apps/agones/palworld/savetool/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "0.0.1"

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -14,7 +14,7 @@ tags:
 key: agones_palworld_savetool
 pipeline: docker
 app_name: agones-palworld-savetool
-version: "0.0.1"
+version: "0.0.2"
 source_path: apps/agones/palworld/savetool
 version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Why

#15247 shipped the savetool with `version.toml = "0.0.0"` — but the publish gate treats `0.0.0` as a never-published stub and skips the image build entirely. Nothing would ever publish.

## What

- `apps/agones/palworld/savetool/version.toml` → `0.0.1` (the "wants to publish" sentinel)
- savetool MDX `version` → `0.0.2` (one ahead, trips the `local_version > version_toml` gate)
- full ci-dispatch-manifest regeneration

Post-publish sync will then set version.toml to the real published version and bump the image tag in `gameserver.yaml` via the usual `atom-post-publish-*` PR.