### PR TITLE
chore(palworld-savetool): has_test false — no docker e2e suite

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -76,7 +76,7 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/agones-palworld-savetool",
 			"deployment_yaml": "apps/kube/agones/palworld/manifests/gameserver.yaml",
-			"has_test": true
+			"has_test": false
 		},
 		{
 			"key": "astro_kbve",

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -20,7 +20,7 @@ version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest
 image: kbve/agones-palworld-savetool
 deployment_yaml: apps/kube/agones/palworld/manifests/gameserver.yaml
-has_test: true
+has_test: false
 author: h0lybyte
 ---
 


### PR DESCRIPTION
Publish run [30808966178](https://github.com/KBVE/kbve/actions/runs/30808966178) failed in Test Docker: `has_test: true` with no `e2e_name` makes the job run `nx run :e2e` with an empty project, resolving to `@kbve/source:e2e` → `Cannot find configuration for task`. Relay uses `has_test: false` for the same reason.

- savetool MDX `has_test` → `false`
- ci-dispatch-manifest regenerated

Version untouched (MDX 0.0.2 vs toml 0.0.1) — gate re-trips on merge and proceeds straight to publish this time. Savetool's python unit tests remain runnable via `agones-palworld-savetool:test`.