### PR TITLE
release(arpg): cut 0.1.29 for web and server

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -124,7 +124,7 @@
 		{
 			"key": "arpg_server",
 			"app_name": "arpg-server",
-			"version": "0.1.28",
+			"version": "0.1.29",
 			"version_toml": "apps/agones/arpg/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx",
 			"version_target": "apps/agones/arpg/server/Cargo.toml",
@@ -137,7 +137,7 @@
 		{
 			"key": "arpg_web",
 			"app_name": "arpg-web",
-			"version": "0.1.28",
+			"version": "0.1.29",
 			"version_toml": "apps/agones/arpg/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx",
 			"version_target": "apps/agones/arpg/web/version.toml",

--- a/apps/agones/arpg/arpg-e2e/e2e/env.ts
+++ b/apps/agones/arpg/arpg-e2e/e2e/env.ts
@@ -7,4 +7,6 @@ export const SERVER_HTTP = `http://localhost:${SERVER_PORT}`;
 export const SERVER_WS = `ws://localhost:${SERVER_PORT}/ws`;
 export const WEB_URL = `http://localhost:${WEB_PORT}`;
 
-export const PROTOCOL_VERSION = 14;
+// Re-exported, never redeclared: a hardcoded copy silently drifted to 14 while
+// the wire moved to 16, which made the handshake assertion assert the wrong number.
+export { PROTOCOL_VERSION } from '@kbve/laser/wire';

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_server
 pipeline: docker
 app_name: arpg-server
-version: "0.1.28"
+version: "0.1.29"
 source_path: apps/agones/arpg/server
 version_toml: apps/agones/arpg/server/version.toml
 # Pre-build sync: CI writes this MDX `version` into version_target (Cargo.toml →

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_web
 pipeline: docker
 app_name: arpg-web
-version: "0.1.28"
+version: "0.1.29"
 source_path: apps/agones/arpg
 version_toml: apps/agones/arpg/web/version.toml
 version_source: apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx


### PR DESCRIPTION
Both arpg images have sat at `0.1.28` since 2026-07-31 while merged work piled up behind them.

## Unshipped since the 0.1.28 sync

| PR | |
|---|---|
| #15170 | pet move learning + hub XP bar |
| #15163 | pet XP and leveling, npcdb parser parity |
| #15160 | drop dead `WildTarget.level` |
| #15116 | arpg-web root pnpm install **+ the rolldown Discord-bundle fix** |
| #15092 | laser phaser/r3f subpath split |
| #15079 | pin the docker dep install |

The #15116 fix is the load-bearing one: `hashDiscordBundle` mutated the `generateBundle` bundle record, which rolldown ignores, so the Discord entry chunk was dropped and `index.html` shipped a 404 reference. That fix is **inert until an image is actually rebuilt** — which is what this bump does.

## Why both together

Pet XP spans server and client. `PROTOCOL_VERSION` is `16` on both sides ([protocol.ts](packages/npm/laser/src/lib/net/protocol.ts), [proto.rs](packages/rust/simgrid/src/proto.rs)) and unchanged since the 0.1.28 sync, so there's no handshake hazard mid-rollout — but shipping the client without the server would leave the pet XP UI reading fields nothing sends.

## e2e drift fixed on the way

[env.ts](apps/agones/arpg/arpg-e2e/e2e/env.ts) hardcoded `PROTOCOL_VERSION = 14` against a wire that had moved to 16, so `server.spec.ts` was asserting the wrong number and the stale-protocol rejection test was checking 13 instead of 15. Re-exported through the `@kbve/laser/wire` path mapping that already existed for exactly this purpose. Verified playwright resolves it (`--config playwright.server.config.ts --list` loads all 16 tests clean).

## Changed

- `arpg-web.mdx` / `arpg-server.mdx` frontmatter `version` → `0.1.29`
- `.github/ci-dispatch-manifest.json` regenerated via `astro-kbve:build` + `astro-kbve:sync:ci-manifest` — delta is exactly the two version strings, no unrelated churn
- `version.toml` files untouched; the post-publish sync workflow owns those