### PR TITLE
fix(astro-kbve): restyle the section rail onto bento and rebuild the arcade

### DIFF
--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameCard.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameCard.astro
@@ -20,14 +20,9 @@ const {
 } = Astro.props;
 
 const statusLabel: Record<NonNullable<Props['status']>, string> = {
-	live: 'PLAYABLE',
-	beta: 'IN BETA',
-	soon: 'COMING SOON',
-};
-const statusClass: Record<NonNullable<Props['status']>, string> = {
-	live: 'border-emerald-500/35 bg-emerald-500/15 text-emerald-300',
-	beta: 'border-amber-400/35 bg-amber-400/15 text-amber-200',
-	soon: 'border-slate-400/35 bg-slate-400/15 text-slate-300',
+	live: 'Playable',
+	beta: 'In beta',
+	soon: 'Coming soon',
 };
 const isLink = status !== 'soon';
 const Tag = isLink ? 'a' : 'div';
@@ -43,90 +38,106 @@ const tooltipCta = isLink ? 'Click to play' : 'On the roadmap';
 <Tag
 	id={cardId}
 	data-arcade-card
+	data-arcade-status={status}
 	data-arcade-tooltip-title={title}
 	data-arcade-tooltip-status={status}
 	data-arcade-tooltip-desc={description}
 	data-arcade-tooltip-tags={tags.join('|')}
 	data-arcade-tooltip-cta={tooltipCta}
 	{...isLink ? { href } : {}}
-	class:list={[
-		'not-content group relative isolate flex flex-col overflow-hidden rounded-xl border border-purple-500/25 bg-slate-900/70 text-inherit no-underline transition duration-[420ms] ease-[cubic-bezier(0.16,1,0.3,1)]',
-		isLink &&
-			'cursor-pointer hover:-translate-y-1 hover:border-pink-500/55 hover:shadow-[0_18px_36px_-16px_rgba(0,0,0,0.55),0_0_0_1px_rgba(236,72,153,0.4)] focus-visible:-translate-y-1 focus-visible:border-pink-500/55',
-		!isLink && 'cursor-default opacity-85',
-	]}>
+	class="bento-cell bento-linkcard arcade-card">
 	<div
-		aria-hidden="true"
-		class="arcade-card-art relative flex aspect-[16/9] items-center justify-center overflow-hidden"
-		style={`background: ${gradient};`}>
-		<div class="arcade-card-art__fx pointer-events-none absolute inset-0">
-		</div>
-		<div
-			class="arcade-card-art__shine pointer-events-none absolute inset-0">
-		</div>
-		<div
-			class="relative text-[64px] text-white/95 transition-transform duration-[520ms] ease-[cubic-bezier(0.16,1,0.3,1)] [text-shadow:0_0_16px_rgba(0,0,0,0.45),0_0_30px_rgba(255,255,255,0.18)] group-hover:scale-110 group-hover:-rotate-2">
-			{icon}
-		</div>
+		class="arcade-card__art"
+		style={`background: ${gradient};`}
+		aria-hidden="true">
+		<div class="arcade-card__fx"></div>
+		<span class="arcade-card__glyph">{icon}</span>
 	</div>
 
-	<div class="flex flex-1 flex-col gap-2.5 px-5 pt-4 pb-5">
-		<div class="flex items-center justify-between gap-3">
-			<h3 class="m-0 -tracking-[0.01em] text-xl font-bold text-white">
-				{title}
-			</h3>
-			<span
-				class:list={[
-					'whitespace-nowrap rounded-full border px-2 py-1 font-mono text-[9.5px] font-bold uppercase tracking-[0.14em]',
-					statusClass[status],
-				]}>
+	<div class="arcade-card__body">
+		<div class="arcade-card__head">
+			<span class="bento-linkcard__title">{title}</span>
+			<span class="bento-chip arcade-card__status">
 				{statusLabel[status]}
 			</span>
 		</div>
-		<p class="m-0 text-[13px] leading-relaxed text-slate-300">
-			{description}
-		</p>
+
+		<p class="bento-linkcard__copy">{description}</p>
+
 		{
 			tags.length > 0 && (
-				<ul class="m-0 flex list-none flex-wrap gap-1.5 p-0">
+				<ul class="arcade-card__tags">
 					{tags.map((t) => (
-						<li class="rounded border border-purple-500/25 bg-purple-500/15 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.06em] text-purple-300">
-							{t}
-						</li>
+						<li class="bento-chip">{t}</li>
 					))}
 				</ul>
 			)
 		}
-		<div
-			class="mt-auto flex items-center justify-between pt-1 text-[13px] font-semibold text-fuchsia-300">
+
+		<span class="arcade-card__go">
+			<span>{isLink ? 'Play' : 'On the roadmap'}</span>
 			{
-				isLink ? (
-					<>
-						<span>Play</span>
-						<span
-							aria-hidden="true"
-							class="transition-transform duration-[420ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:translate-x-1">
-							→
-						</span>
-					</>
-				) : (
-					<span>On the roadmap</span>
+				isLink && (
+					<span class="bento-linkcard__go" aria-hidden="true">
+						<svg
+							viewBox="0 0 24 24"
+							width="16"
+							height="16"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round">
+							<path d="M5 12h14M13 6l6 6-6 6" />
+						</svg>
+					</span>
 				)
 			}
-		</div>
+		</span>
 	</div>
 </Tag>
 
 <style>
-	/* Scanlines and grid share one blended layer — every `mix-blend-mode`
+	/* Cell chrome, hover and seams come from .bento-cell/.bento-linkcard —
+	   only the art panel is arcade-specific. */
+	.arcade-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		padding: 0;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.arcade-card[data-arcade-status='soon'] {
+		cursor: default;
+		opacity: 0.7;
+	}
+
+	.arcade-card__art {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		aspect-ratio: 16 / 7;
+		overflow: hidden;
+		border-bottom: 1px solid var(--bento-hairline);
+	}
+
+	/* Scanlines and grid share one blended layer — each mix-blend-mode
 	   element forces its own compositing group, and the hub stacks these
-	   across every card in the catalog. */
-	.arcade-card-art__fx {
+	   across the whole catalog. */
+	.arcade-card__fx {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		opacity: 0.8;
+		mix-blend-mode: overlay;
 		background-image:
 			repeating-linear-gradient(
 				to bottom,
-				rgba(0, 0, 0, 0.32) 0,
-				rgba(0, 0, 0, 0.32) 1px,
+				rgba(0, 0, 0, 0.3) 0,
+				rgba(0, 0, 0, 0.3) 1px,
 				transparent 1px,
 				transparent 4px
 			),
@@ -140,17 +151,66 @@ const tooltipCta = isLink ? 'Click to play' : 'On the roadmap';
 			auto,
 			22px 22px,
 			22px 22px;
-		mix-blend-mode: overlay;
-		opacity: 0.85;
 	}
-	/* Screen-blending white over the art is equivalent to painting the same
-	   white at the same alpha, so this layer needs no blend mode at all. */
-	.arcade-card-art__shine {
-		background: radial-gradient(
-			circle at 28% 18%,
-			rgba(255, 255, 255, 0.32) 0%,
-			rgba(255, 255, 255, 0.08) 24%,
-			transparent 55%
-		);
+
+	.arcade-card__glyph {
+		position: relative;
+		font-size: clamp(2.25rem, 5vw, 3.25rem);
+		line-height: 1;
+		color: rgba(255, 255, 255, 0.95);
+		text-shadow: 0 0 16px rgba(0, 0, 0, 0.45);
+		transition: transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.arcade-card:hover .arcade-card__glyph {
+		transform: scale(1.08) rotate(-2deg);
+	}
+
+	.arcade-card__body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		flex: 1;
+		padding: 0.9rem 1rem 1rem;
+	}
+
+	.arcade-card__head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.arcade-card__status {
+		flex: none;
+	}
+
+	.arcade-card[data-arcade-status='live'] .arcade-card__status {
+		color: #6ee7b7;
+	}
+
+	.arcade-card[data-arcade-status='beta'] .arcade-card__status {
+		color: #fcd34d;
+	}
+
+	.arcade-card__tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.arcade-card__go {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		margin-top: auto;
+		padding-top: 0.35rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--bento-accent, var(--sl-color-accent-high));
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameGrid.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeGameGrid.astro
@@ -4,10 +4,9 @@ export interface Props {
 }
 
 const { columns = 2 } = Astro.props;
+const cols = columns >= 4 ? 4 : columns === 3 ? 3 : 2;
 ---
 
-<div
-	class="not-content mb-6 grid gap-[18px] grid-cols-[repeat(auto-fit,minmax(min(280px,100%),1fr))] lg:[grid-template-columns:repeat(var(--arcade-grid-cols,2),1fr)]"
-	style={`--arcade-grid-cols: ${columns};`}>
+<div class:list={['bento-board', `bento-board--cols-${cols}`]}>
 	<slot />
 </div>

--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
@@ -10,93 +10,135 @@ const {
 	tagline = 'Browser games we built ourselves — plus a few classics on the way.',
 	stats = [],
 } = Astro.props;
+
+const [head, ...tail] = title.split(' ');
 ---
 
 <section
-	aria-labelledby="arcade-hero-title"
-	class="not-content relative isolate mb-10 overflow-hidden rounded-2xl border border-purple-500/35 px-5 py-12 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.55),inset_0_0_0_1px_rgba(0,0,0,0.35)] sm:px-14">
-	<!-- Layered gradient background: a static base plus a warmer copy that
-	     cross-fades over it, so the pulse is a compositor-only opacity
-	     animation instead of an every-frame filter repaint. -->
-	<div
-		aria-hidden="true"
-		class="absolute inset-0 -z-30 bg-[radial-gradient(circle_at_12%_10%,rgba(236,72,153,0.55)_0%,transparent_45%),radial-gradient(circle_at_88%_80%,rgba(56,189,248,0.45)_0%,transparent_50%),linear-gradient(135deg,#0b0a18_0%,#1c1438_50%,#1f0c2e_100%)]">
-	</div>
-	<div
-		aria-hidden="true"
-		class="arcade-hero-pulse absolute inset-0 -z-30 bg-[radial-gradient(circle_at_12%_10%,rgba(249,115,22,0.55)_0%,transparent_45%),radial-gradient(circle_at_88%_80%,rgba(129,140,248,0.45)_0%,transparent_50%),linear-gradient(135deg,#120a18_0%,#241542_50%,#2a0e33_100%)]">
-	</div>
-	<!-- Faded grid behind content -->
-	<div
-		aria-hidden="true"
-		class="pointer-events-none absolute inset-0 -z-20 bg-[linear-gradient(rgba(168,85,247,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(168,85,247,0.08)_1px,transparent_1px)] [background-size:36px_36px] [mask-image:linear-gradient(to_bottom,transparent,black_30%,black_70%,transparent)] [-webkit-mask-image:linear-gradient(to_bottom,transparent,black_30%,black_70%,transparent)]">
-	</div>
-	<!-- CRT scanlines -->
-	<div
-		aria-hidden="true"
-		class="pointer-events-none absolute inset-0 -z-10 opacity-65 mix-blend-overlay bg-[repeating-linear-gradient(to_bottom,rgba(0,0,0,0.16)_0px,rgba(0,0,0,0.16)_1px,transparent_1px,transparent_4px)]">
-	</div>
-
-	<div class="relative z-10 max-w-[56ch]">
-		<p
-			class="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-fuchsia-300 [text-shadow:0_0_10px_rgba(240,171,252,0.45)]">
-			▸ NOW PLAYING
-		</p>
-		<h1
-			id="arcade-hero-title"
-			class="mb-3 text-[clamp(34px,6vw,56px)] font-extrabold leading-[1.05] -tracking-[0.01em] text-white [text-shadow:0_0_18px_rgba(236,72,153,0.55),0_0_38px_rgba(56,189,248,0.35)]">
-			{title}
-		</h1>
-		<p
-			class="mb-5 max-w-[60ch] text-[clamp(15px,1.4vw,17px)] leading-relaxed text-purple-200">
-			{tagline}
-		</p>
-		{
-			stats.length > 0 && (
-				<ul class="m-0 flex list-none flex-wrap gap-6 p-0">
-					{stats.map((s, i) => (
-						<li
-							class:list={[
-								'flex flex-col gap-1 border-purple-500/30 pr-6',
-								i < stats.length - 1 && 'border-r',
-							]}>
+	class="bento-hero bento-section not-content arcade-hero"
+	aria-labelledby="arcade-hero-title">
+	<div class="arcade-hero__bg" aria-hidden="true"></div>
+	<div class="arcade-hero__scan" aria-hidden="true"></div>
+	<div class="bento-hero__frame bento-frame">
+		<div class="bento-board bento-board--hero">
+			<div class="bento-cell bento-hero-copy">
+				<span class="bento-badge bento-chip">
+					<span class="bento-live-dot"></span>
+					Now playing
+				</span>
+				<h1 id="arcade-hero-title" class="bento-title">
+					{head}{' '}
+					<span class="bento-title__accent">{tail.join(' ')}</span>
+				</h1>
+				<p class="bento-lede">{tagline}</p>
+				<div class="bento-cta">
+					<a class="bento-btn bento-btn--primary" href="#available">
+						Browse games
+					</a>
+					<a class="bento-btn bento-btn--ghost" href="#soon">
+						What's coming
+					</a>
+				</div>
+			</div>
+			<div class="bento-cell bento-hero-aside arcade-hero__stats">
+				{
+					stats.map((s, i) => (
+						<div class="arcade-hero__stat">
 							<span
-								class="block h-[22px] font-serif text-[22px] font-bold leading-none text-amber-200"
+								class="arcade-hero__stat-value"
 								data-arcade-stat
 								data-arcade-stat-value={s.value}
 								data-arcade-stat-delay={i * 140}>
 								{s.value}
 							</span>
-							<span class="font-mono text-[11px] uppercase tracking-[0.12em] text-purple-300">
+							<span class="arcade-hero__stat-label">
 								{s.label}
 							</span>
-						</li>
-					))}
-				</ul>
-			)
-		}
+						</div>
+					))
+				}
+			</div>
+		</div>
 	</div>
 </section>
 
 <style>
-	@keyframes arcade-hero-pulse {
-		0%,
-		100% {
-			opacity: 0;
-		}
-		50% {
-			opacity: 0.55;
-		}
+	/* Arcade retint of the shared hero: only the backdrop and the accent
+	   vars are page-specific, the layout comes from the bento primitives. */
+	.arcade-hero {
+		position: relative;
+		isolation: isolate;
+		--bento-accent: #e879f9;
+		--bento-accent-2: #38bdf8;
+		--bento-btn-fg: #16021c;
+		--bento-live: #f0abfc;
+		/* .bento-btn--primary keys off the Starlight accent, not the bento
+		   one, so a retint has to set both. */
+		--sl-color-accent: #c026d3;
+		--sl-color-accent-high: #f0abfc;
 	}
-	.arcade-hero-pulse {
-		opacity: 0;
-		will-change: opacity;
-		animation: arcade-hero-pulse 14s ease-in-out infinite;
+
+	.arcade-hero__stats {
+		justify-content: center;
+		gap: 1.25rem;
 	}
-	@media (prefers-reduced-motion: reduce) {
-		.arcade-hero-pulse {
-			animation: none;
-		}
+
+	/* Deliberately not .bento-stat__value/__label — those are grid-placed
+	   and only behave inside a .bento-stat parent. */
+	.arcade-hero__stat {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		padding-inline-start: 0.9rem;
+		border-inline-start: 2px solid
+			color-mix(in srgb, var(--bento-accent) 55%, transparent);
+	}
+
+	.arcade-hero__stat-value {
+		font-size: 1.4rem;
+		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-white);
+	}
+
+	.arcade-hero__stat-label {
+		font-family: var(--__sl-font-mono, ui-monospace, monospace);
+		font-size: 0.6875rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sl-color-gray-3);
+	}
+
+	.arcade-hero__bg {
+		position: absolute;
+		inset: 0;
+		z-index: -2;
+		background:
+			radial-gradient(
+				circle at 12% 10%,
+				rgba(236, 72, 153, 0.35) 0%,
+				transparent 45%
+			),
+			radial-gradient(
+				circle at 88% 80%,
+				rgba(56, 189, 248, 0.28) 0%,
+				transparent 50%
+			);
+	}
+
+	.arcade-hero__scan {
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		opacity: 0.45;
+		background: repeating-linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0.16) 0px,
+			rgba(0, 0, 0, 0.16) 1px,
+			transparent 1px,
+			transparent 4px
+		);
 	}
 </style>
 

--- a/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
+++ b/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
@@ -62,6 +62,11 @@ const titleCase = (value: string): string =>
 	value.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 
 export const buildArcadeBreadcrumb = (pathname: string): BreadcrumbCrumb[] => {
+	const path0 = normalize(pathname);
+	// The root is its own crumb; group hrefs are in-page anchors on it, so
+	// matching them here would render "Arcade > Play now" on the hub.
+	if (path0 === ARCADE_ROOT.href) return [{ ...ARCADE_ROOT }];
+
 	const crumbs = buildBreadcrumbIn(ARCADE_NAV, ARCADE_ROOT, pathname);
 	const match = findActiveIn(ARCADE_NAV, ARCADE_ROOT.href, pathname);
 	const path = normalize(pathname);

--- a/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
@@ -39,8 +39,6 @@ import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 
 <ArcadeTooltipController client:only="react" />
 
-<BentoShell id="hero">
-
 <ArcadeHero
 	title="KBVE Arcade"
 	tagline="Browser games we built ourselves — blackjack, Klondike with monsters, a WebGL action-RPG demo, an isometric WebGPU prototype, and an endless runner. Plus a Ruffle integration in the oven for Flash classics."
@@ -50,8 +48,6 @@ import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 		{ value: 'Free', label: 'Enjoy the run!' },
 	]}
 />
-
-</BentoShell>
 
 <BentoShell id="available" eyebrow="Play now" heading="Available games">
 

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -1033,23 +1033,34 @@ body:has([data-kbve-section])
 		--kbve-sidebar-width: var(--sl-sidebar-width, 18rem);
 	}
 
+	/* The rail sits on the same surface as the bento bands it runs beside,
+	   divided by a hairline rather than Starlight's sidebar tint. */
+	:where(body:has([data-kbve-section])) .sidebar-pane {
+		background-color: var(--sl-color-black);
+		border-inline-end: 1px solid var(--bento-hairline);
+	}
+
+	/* Section header reads as a bento eyebrow, not a Starlight page title —
+	   the body font here is serif, which is why it looked pasted on. */
 	[data-kbve-section-root] {
 		box-sizing: border-box;
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.65rem 0.75rem;
-		border-bottom: 1px solid
-			var(--sl-color-hairline, var(--color-gold-dark));
-		color: var(--sl-color-white);
-		font-size: 0.75rem;
+		padding: 0.7rem 0.85rem;
+		border-bottom: 1px solid var(--bento-hairline);
+		font-family: var(--__sl-font-mono, ui-monospace, monospace);
+		font-size: 0.6875rem;
 		font-weight: 600;
-		letter-spacing: 0.08em;
+		letter-spacing: 0.1em;
 		text-transform: uppercase;
+		color: var(--sl-color-gray-3);
 		text-decoration: none;
+		transition: color 160ms ease;
 	}
 
 	[data-kbve-section-root]:hover {
+		color: var(--sl-color-white);
 		background-color: color-mix(
 			in srgb,
 			var(--sl-color-white) 4%,
@@ -1072,9 +1083,8 @@ body:has([data-kbve-section])
 		align-items: center;
 		gap: 0.5rem;
 		height: 3rem;
-		padding: 0.5rem 0.75rem;
-		border-bottom: 1px solid
-			var(--sl-color-hairline, var(--color-gold-dark));
+		padding: 0.5rem 0.85rem;
+		border-bottom: 1px solid var(--bento-hairline);
 	}
 
 	[data-kbve-rail-toggle] {
@@ -1109,20 +1119,28 @@ body:has([data-kbve-section])
 		flex: 1 1 auto;
 		min-width: 0;
 	}
+	/* Matches .facet-search__input — the gutter's search field. */
 	[data-kbve-filter] {
 		box-sizing: border-box;
 		width: 100%;
 		height: 2rem;
-		padding: 0.35rem 0.6rem;
-		font-size: 0.85rem;
-		color: var(--sl-color-white, var(--color-parchment));
-		background: var(--sl-color-bg, var(--color-bg-sunken));
-		border: 1px solid var(--sl-color-gray-5, var(--color-gold-dark));
-		border-radius: 0.4rem;
+		padding: 0.5rem 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--sl-color-white);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-white) 4%,
+			transparent
+		);
+		border: 1px solid var(--bento-hairline-strong);
+		border-radius: 8px;
 		outline: none;
 	}
+	[data-kbve-filter]::placeholder {
+		color: var(--sl-color-gray-4);
+	}
 	[data-kbve-filter]:focus {
-		border-color: var(--sl-color-accent, var(--color-gold));
+		border-color: var(--sl-color-accent);
 	}
 
 	[data-kbve-sidebar-scroll] {
@@ -1138,36 +1156,48 @@ body:has([data-kbve-section])
 		padding: 0;
 	}
 	[data-kbve-sublist] [data-kbve-sublist] {
-		margin-inline-start: 0.6rem;
-		padding-inline-start: 0.4rem;
-		border-inline-start: 1px solid
-			var(--sl-color-hairline, var(--color-gold-dark));
+		margin-inline-start: 0.85rem;
+		padding-inline-start: 0.6rem;
+		border-inline-start: 1px solid var(--bento-hairline-strong);
 	}
 	[data-kbve-item] {
-		margin: 0.2rem 0;
+		margin: 0.125rem 0;
 	}
 
+	/* Rows carry .facet-row metrics so the rail reads the same as the
+	   faceted browsers elsewhere in the bento system. */
 	[data-kbve-link],
 	[data-kbve-summary] {
 		display: flex;
 		align-items: center;
-		gap: 0.4rem;
-		padding: 0.3rem 0.5rem;
-		border-radius: 0.4rem;
-		font-size: 0.9rem;
+		gap: 0.5rem;
+		padding: 0.5rem;
+		border-radius: 6px;
+		font-size: 0.875rem;
 		line-height: 1.3;
-		color: var(--sl-color-gray-2, var(--color-parchment));
+		color: var(--sl-color-gray-2);
 		text-decoration: none;
 		cursor: pointer;
+		transition:
+			color 160ms ease,
+			background-color 160ms ease;
 	}
 	[data-kbve-link]:hover,
 	[data-kbve-summary]:hover {
-		background: var(--sl-color-gray-6, var(--color-bg-raised));
-		color: var(--sl-color-white, var(--color-parchment));
+		color: var(--sl-color-white);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-white) 4%,
+			transparent
+		);
 	}
 	[data-kbve-link][aria-current='page'] {
-		color: var(--sl-color-text-accent, var(--color-gold));
-		background: var(--sl-color-accent-low, rgba(166, 125, 67, 0.18));
+		color: var(--sl-color-white);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-accent-high) 18%,
+			transparent
+		);
 		font-weight: 600;
 	}
 	[data-kbve-label] {
@@ -1178,9 +1208,19 @@ body:has([data-kbve-section])
 		white-space: nowrap;
 	}
 
+	/* Group headers use the .facet-group__label eyebrow treatment rather
+	   than looking like slightly-bolder links. */
 	[data-kbve-summary] {
 		list-style: none;
+		font-family: var(--__sl-font-mono, ui-monospace, monospace);
+		font-size: 0.6875rem;
 		font-weight: 600;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sl-color-gray-4);
+	}
+	[data-kbve-summary]:hover {
+		color: var(--sl-color-gray-2);
 	}
 	[data-kbve-summary]::-webkit-details-marker {
 		display: none;
@@ -1205,14 +1245,31 @@ body:has([data-kbve-section])
 		background: var(--sl-color-accent, var(--color-gold-dark));
 	}
 
+	/* Rounded icon well, matching .bento-icon-tile. */
 	[data-kbve-group-icon] {
 		flex: none;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 1.125rem;
-		height: 1.125rem;
-		color: var(--sl-color-gray-3, var(--color-gold));
+		width: 1.5rem;
+		height: 1.5rem;
+		border-radius: 0.45rem;
+		color: var(--sl-color-gray-3);
+		background-color: color-mix(
+			in srgb,
+			var(--sl-color-white) 4%,
+			transparent
+		);
+		border: 1px solid var(--bento-hairline);
+		transition:
+			color 160ms ease,
+			border-color 160ms ease;
+	}
+
+	[data-kbve-group][open] > [data-kbve-summary] [data-kbve-group-icon],
+	[data-kbve-summary]:hover [data-kbve-group-icon] {
+		color: var(--sl-color-accent-high);
+		border-color: var(--bento-hairline-strong);
 	}
 	a[data-kbve-group-icon] {
 		cursor: pointer;
@@ -1232,8 +1289,10 @@ body:has([data-kbve-section])
 	[data-kbve-rail='collapsed'] [data-kbve-filter-field] {
 		display: none;
 	}
-	[data-kbve-rail='collapsed'] [data-kbve-sidebar-chrome] {
-		padding-inline-end: 0;
+	[data-kbve-rail='collapsed'] [data-kbve-sidebar-chrome],
+	[data-kbve-rail='collapsed'] [data-kbve-section-root] {
+		justify-content: center;
+		padding-inline: 0;
 	}
 
 	[data-kbve-rail='collapsed'] [data-kbve-label],
@@ -1243,6 +1302,29 @@ body:has([data-kbve-section])
 	}
 	[data-kbve-rail='collapsed'] [data-kbve-group] > [data-kbve-sublist] {
 		display: none;
+	}
+
+	/* Collapsed the rail is 4rem wide, and the expanded inline padding
+	   (sidebar-content + scroll + row) sums to 2rem — enough to shove the
+	   icon tile against the right edge and read as clipped. Zero it out and
+	   centre the rows instead. */
+	[data-kbve-rail='collapsed'] [data-kbve-sidebar-scroll] {
+		padding-inline: 0;
+		scrollbar-width: none;
+	}
+	[data-kbve-rail='collapsed'] [data-kbve-sidebar-scroll]::-webkit-scrollbar {
+		display: none;
+	}
+	[data-kbve-rail='collapsed'] [data-kbve-summary],
+	[data-kbve-rail='collapsed'] [data-kbve-link] {
+		justify-content: center;
+		gap: 0;
+		padding-inline: 0;
+	}
+	[data-kbve-rail='collapsed'] [data-kbve-sublist] [data-kbve-sublist] {
+		margin-inline-start: 0;
+		padding-inline-start: 0;
+		border-inline-start: 0;
 	}
 	[data-kbve-rail='collapsed']
 		[data-kbve-sidebar-scroll]
@@ -1263,7 +1345,13 @@ body:has([data-kbve-section])
 			--sl-sidebar-width: 4rem;
 		}
 		:root[data-kbve-rail='collapsed'] .sidebar-content {
-			padding-inline-end: 0;
+			padding-inline: 0;
+		}
+		/* Starlight reserves a stable scrollbar gutter on the pane, which
+		   offsets the centred icons by half its width once the rail is only
+		   4rem wide. */
+		:root[data-kbve-rail='collapsed'] .sidebar-pane {
+			scrollbar-gutter: auto;
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #15233 and #15252, from a report that `/arcade/` and its sidebar looked wrong.

## The rail kept working and stopped looking like the design system

#15233 merged the gutter's nav **data** into the Starlight sidebar but kept Starlight's **chrome**. The bento styling — hairline seams, icon tiles, accent-mix active rows, mono eyebrow labels — lived in `DashboardGutterNav.astro`'s scoped styles, and that file was deleted in the same PR. Hence a rail that navigates correctly and reads as old-Astro.

Restyled in `global.css`, so every section inherits it:

- bento surface + hairline seam in place of the Starlight sidebar tint
- `.facet-row` metrics, `accent-high 18%` active row, mono uppercase group labels
- group icons in `.bento-icon-tile` wells
- **collapsed at 4rem**: `.sidebar-content` 16px + scroll 8px + row 8px summed to 2rem of inline padding that only the labels and caret were being hidden from, pushing the icon tile against the pane edge — it read as clipped, and at some sizes as missing entirely. Padding zeroed, rows / chrome / section header centred, and the scrollbar gutter dropped since it offset the centring by half its width.

Measured tile position in the 64px collapsed pane:

```
before            x=32   (6px from the right edge, clipped)
padding fix       x=14
gutter fix        x=20   (centre ≈ 19)
```

## Arcade onto bento primitives

`ArcadeHero` and `ArcadeGameCard` contained **zero** `bento-*` classes — bespoke Tailwind with their own radius, borders and shadows, wrapped in a `<BentoShell>`. That is why the hub read as two design systems: a floating rounded hero with `mb-10` inside a frame whose whole job is flush seams.

- `ArcadeHero` → `.bento-hero` / `.bento-board--hero`, full-bleed with real seams; identity reduced to four retint vars
- `ArcadeGameCard` → `.bento-cell` / `.bento-linkcard` / `.bento-chip` in a seamed board, own chrome deleted
- `ArcadeGameGrid` → `.bento-board--cols-*` instead of a hand-rolled Tailwind grid
- breadcrumb no longer renders a phantom `Play now` crumb on the hub, where group hrefs are in-page anchors on the root itself

Two primitives bit during the rebuild and are worth knowing: `.bento-hero-copy` is required for the copy cell to span its half of `--hero` (without it the cell takes 1 of 4 columns and leaves the row half empty), and `.bento-stat__value` is grid-placed so it only behaves inside a `.bento-stat` parent — the hero uses its own stat classes.

## Verified

Production build, all 17 sections audited against the running site:

```
dashboard application journal theory mc palworld npcdb itemdb
mapdb stock arcade arcade-game legal store market   BENTO ok
gaming osrs                                         flat nav, no groups
```

`gaming`/`osrs` have no group headers by design, so there are no summaries or tiles to restyle; their rows do pick up the new treatment. Dark-theme check confirms the pane surface rule lands (`oklch(0.21 …)` + 1px hairline) — an earlier light-theme reading of `rgb(255,255,255)` was a false alarm, since `--sl-color-black` is white in light mode.

Screenshotted desktop, mobile and collapsed states on `/arcade/`, `/arcade/blackjack/` and `/dashboard/` before opening this.

## Not in scope

The rail restyle is global; the component conversion is arcade only. A scan of 208 `.astro` components finds leaf panels still carrying their own card chrome with no `bento-` classes — `MapDBPanel`, `ItemDBPanel`, `NPCDBPanel`, `NPCDBDialogue` are the real candidates, since their rails and hubs are already bento. Left for a separate PR.