### PR TITLE
perf(herbmail-game): walk the scene graph once per frame, not once per pass

### DIFF
--- a/apps/herbmail/herbmail-game/e2e/matrix.spec.ts
+++ b/apps/herbmail/herbmail-game/e2e/matrix.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from '@playwright/test';
+
+declare global {
+	interface Window {
+		__vm: {
+			scene: {
+				matrixWorldAutoUpdate: boolean;
+				traverse(cb: (o: Record<string, unknown>) => void): void;
+			};
+		};
+		__coll?: { pos: unknown };
+		__mtx?: { frames: number; visits: number };
+	}
+}
+
+async function enterDungeon(page: Page): Promise<void> {
+	await page.goto('/', { waitUntil: 'load' });
+	await page.getByText('Play', { exact: true }).click({ timeout: 60_000 });
+	await page.waitForFunction(
+		() => typeof window.__coll?.pos === 'object',
+		undefined,
+		{ timeout: 90_000 },
+	);
+	await page.waitForTimeout(4000);
+}
+
+test.describe('world matrix updates', () => {
+	// Three passes render this scene each frame and WebGLRenderer.render rebuilds
+	// every world matrix before each one. AOComposer opts the scene out and drives
+	// a single update per frame instead. Nothing looks wrong when this regresses —
+	// the frame just costs ~1ms more — so it needs an explicit guard.
+	test('the graph is walked once per frame, not once per pass', async ({
+		page,
+	}) => {
+		await enterDungeon(page);
+
+		const objects = await page.evaluate(() => {
+			let n = 0;
+			window.__vm.scene.traverse(() => n++);
+			return n;
+		});
+		expect(objects).toBeGreaterThan(500);
+
+		await page.evaluate(() => {
+			const scene = window.__vm.scene;
+			let mesh: Record<string, unknown> | null = null;
+			scene.traverse((o) => {
+				if (!mesh && o.isMesh) mesh = o;
+			});
+			let p = Object.getPrototypeOf(mesh);
+			while (
+				p &&
+				!Object.prototype.hasOwnProperty.call(p, 'updateMatrixWorld')
+			)
+				p = Object.getPrototypeOf(p);
+
+			const s = { frames: 0, visits: 0 };
+			window.__mtx = s;
+			const orig = p.updateMatrixWorld;
+			p.updateMatrixWorld = function (this: unknown, force?: boolean) {
+				s.visits++;
+				return orig.call(this, force);
+			};
+			const tick = () => {
+				s.frames++;
+				requestAnimationFrame(tick);
+			};
+			requestAnimationFrame(tick);
+		});
+
+		await page.waitForTimeout(4000);
+
+		const { frames, visits } = await page.evaluate(() => ({
+			frames: window.__mtx!.frames,
+			visits: window.__mtx!.visits,
+		}));
+		expect(frames).toBeGreaterThan(30);
+
+		// Sector streaming and R3F mounts add visits on top of the render walk, so
+		// the bar is well clear of 1x while still failing loudly at the 3x this
+		// replaced.
+		const walksPerFrame = visits / frames / objects;
+		expect(walksPerFrame).toBeLessThan(2);
+	});
+
+	test('the scene opts out of per-render matrix updates', async ({
+		page,
+	}) => {
+		await enterDungeon(page);
+		expect(
+			await page.evaluate(() => window.__vm.scene.matrixWorldAutoUpdate),
+		).toBe(false);
+	});
+
+	// Static room chunks sit at identity under a group that never moves; both are
+	// frozen. A frozen mesh that is never marked dirty would render at the world
+	// origin, so this also covers markWorld still running on mount.
+	test('room chunks are frozen and still placed correctly', async ({
+		page,
+	}) => {
+		await enterDungeon(page);
+		const out = await page.evaluate(() => {
+			let chunks = 0,
+				frozen = 0,
+				detached = 0;
+			const rooms = new Set<string>();
+			window.__vm.scene.traverse((o) => {
+				const kind = (o.userData as { kind?: string } | undefined)
+					?.kind;
+				if (!o.isMesh || kind !== 'wall') return;
+				chunks++;
+				if (!o.matrixAutoUpdate) frozen++;
+				const e = (o.matrixWorld as { elements: number[] }).elements;
+				// The chunk's own matrix is identity, so a correctly propagated
+				// world matrix is exactly the parent's. A chunk that never got
+				// marked dirty keeps an identity world matrix and detaches from
+				// its room — invisible at the origin room, obvious anywhere else.
+				const p = (o.parent as { matrixWorld: { elements: number[] } })
+					.matrixWorld.elements;
+				if (
+					Math.hypot(e[12] - p[12], e[13] - p[13], e[14] - p[14]) >
+					1e-6
+				)
+					detached++;
+				rooms.add(
+					`${e[12].toFixed(2)},${e[13].toFixed(2)},${e[14].toFixed(2)}`,
+				);
+			});
+			return { chunks, frozen, detached, rooms: rooms.size };
+		});
+		expect(out.chunks).toBeGreaterThan(20);
+		expect(out.frozen).toBe(out.chunks);
+		expect(out.detached).toBe(0);
+		// More than one distinct room origin proves propagation actually ran:
+		// every chunk collapsing to one point is the failure this guards.
+		expect(out.rooms).toBeGreaterThan(1);
+	});
+});

--- a/apps/herbmail/herbmail-game/src/game/dungeon/RoomView.tsx
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/RoomView.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useLayoutEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import '../render/PsxMaterial';
 import { TILE } from '../config';
@@ -16,6 +16,13 @@ interface Props {
 	mats: DungeonMaterials;
 }
 
+// A frozen mesh never dirties itself, so without this its matrixWorld would stay
+// identity and it would draw at the world origin. One flag on mount is enough:
+// the next updateMatrixWorld multiplies it through the parent and clears it.
+function markWorld(m: THREE.Object3D | null): void {
+	if (m) m.matrixWorldNeedsUpdate = true;
+}
+
 function ChunkGroup({
 	geos,
 	kind,
@@ -30,9 +37,11 @@ function ChunkGroup({
 			{geos.map((g, i) => (
 				<mesh
 					key={i}
+					ref={markWorld}
 					geometry={g}
 					material={material}
 					userData={{ kind }}
+					matrixAutoUpdate={false}
 				/>
 			))}
 		</>
@@ -47,9 +56,27 @@ function RoomViewImpl({ desc, snap, affine, mats }: Props) {
 	);
 	const set = useMemo(() => getRoomGeoSet(desc), [desc.signature]);
 	const doors = useMemo(() => roomDoors(desc), [desc]);
+	const root = useRef<THREE.Group>(null);
+
+	// A room never moves once placed, and neither do its chunk meshes, which sit
+	// at identity under this group. Left on auto, three recomposes a matrix and
+	// multiplies by the parent for every one of them every frame — measured at
+	// 0.37ms across ~4800 objects, all of it recomputing constants. Freezing the
+	// meshes alone would do nothing: updateMatrixWorld cascades force=true to
+	// every child of a dirty parent, so this group has to be frozen too, which
+	// means composing its matrix by hand once per placement.
+	useLayoutEffect(() => {
+		const g = root.current;
+		if (!g) return;
+		g.matrixAutoUpdate = false;
+		g.updateMatrix();
+		g.matrixWorldNeedsUpdate = true;
+	}, [desc.originCol, desc.originRow]);
 
 	return (
-		<group position={[desc.originCol * TILE, 0, desc.originRow * TILE]}>
+		<group
+			ref={root}
+			position={[desc.originCol * TILE, 0, desc.originRow * TILE]}>
 			{set.walls.map((chunks, i) => (
 				<ChunkGroup
 					key={i}

--- a/apps/herbmail/herbmail-game/src/game/render/AOComposer.tsx
+++ b/apps/herbmail/herbmail-game/src/game/render/AOComposer.tsx
@@ -41,6 +41,20 @@ export function AOComposer() {
 
 	useEffect(() => () => composer.dispose(), [composer]);
 
+	// Three passes render this scene every frame (main, shadow map, AO depth) and
+	// WebGLRenderer.render walks the whole graph rebuilding world matrices before
+	// each one — 15k object visits and 14.8k matrix multiplies per frame against
+	// 4.8k objects, two thirds of it recomputing values that cannot have changed
+	// since nothing moves between passes of the same frame. Opting the scene out
+	// and driving it once here, after every priority-0 useFrame has moved what it
+	// owns, collapses that to a single pass.
+	useEffect(() => {
+		scene.matrixWorldAutoUpdate = false;
+		return () => {
+			scene.matrixWorldAutoUpdate = true;
+		};
+	}, [scene]);
+
 	useFrame(() => {
 		// Adaptive quality changes the renderer pixel ratio live; keep the
 		// composer's targets matched or the AO samples a stale-res buffer.
@@ -55,6 +69,9 @@ export function AOComposer() {
 		const on = aoEnabled();
 		ao.enabled = on;
 		plain.enabled = !on;
+		// Not forced: a forced update multiplies every node unconditionally, which
+		// would undo the frozen static geometry that relies on staying clean.
+		scene.updateMatrixWorld();
 		composer.render();
 	}, 1);
 


### PR DESCRIPTION
Follow-up to #15254, same worktree. Measurement first, then the fix.

## What the profiling found

Three passes render this scene every frame — main, shadow map, AO depth — and `WebGLRenderer.render` rebuilds every world matrix before each one. Against a 4,867-object scene:

```
object visits/frame     15,053
matrix composes/frame   13,871
world multiplies/frame  14,819
```

Two thirds of that recomputes values that cannot have changed, since nothing moves between passes of the same frame.

## The fix

Opt the scene out of the per-render update and drive it once from `AOComposer`, which runs at `useFrame` priority 1 — after every priority-0 callback has moved what it owns. The only callbacks running later are `DebugStats` (2) and `FrameProbe` (3), neither of which moves anything. The update is deliberately **not** forced: a forced walk multiplies every node unconditionally and would undo the freeze below.

Room chunks are frozen too. They sit at identity under a group that never moves once placed, so both levels drop `matrixAutoUpdate`. Freezing the meshes alone would have done nothing — `updateMatrixWorld` cascades `force = true` to every child of a dirty parent, so the group has to be frozen as well, which means composing its matrix by hand on placement. And a frozen mesh never dirties itself, so each is marked once on mount or it keeps an identity world matrix and draws at the world origin.

## Result

| | before | after |
|---|---|---|
| object visits / frame | 15,053 | **5,319** |
| world multiplies / frame | 14,819 | **5,240** |
| main scene pass | 2.02 ms | **1.69 ms** |
| shadow pass | 0.62 ms | **0.25 ms** |
| depth-only pass | 0.42 ms | **0.07 ms** |
| composer CPU / frame | 3.11 ms | **2.06 ms** |

## What was ruled out

Merging chunk geometry to cut draw calls was measured and rejected: 3,059 meshes already collapse to 131 draws because frustum culling discards 96% of the scene for 0.115 ms. A perfect merge by material would reach 43 draws — worth roughly 0.15 ms — while destroying the culling granularity that produces the 131. Chunking is load-bearing, not overhead.

## Verification

- 139 unit tests, 12 e2e (3 new), lint clean (0 errors, 27 pre-existing warnings)
- Audited all 4,866 objects for world matrices disagreeing with their parent chain: 27 mismatches, all `SkinnedMesh`, **identical on unmodified `dev`** — the deliberate `AttachedBindMode` override, not a regression
- Confirmed the new guards fail with the change reverted

Guards are e2e because nothing *looks* wrong when this regresses — the frame just costs a millisecond more.