### PR TITLE
perf(herbmail-game): bake the open-sky 3x3 max into the tile grid

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/character/fixedStep.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/character/fixedStep.test.ts
@@ -19,9 +19,6 @@ function travel(frameDts: number[]): number {
 	return motor.position.z;
 }
 
-/** Step callback for cases that assert the step count, not what a step does. */
-const noop = (_dt: number): void => undefined;
-
 /** `count` frames of `dt`, i.e. exactly count*dt seconds of wall time. */
 function steady(count: number, dt: number): number[] {
 	return Array.from({ length: count }, () => dt);
@@ -35,20 +32,20 @@ describe('FixedStep', () => {
 		expect(seen).toEqual([0.1, 0.1]);
 		expect(s.pending).toBeCloseTo(0.05, 10);
 		// The carried 0.05 plus 0.06 is one more whole step, not zero.
-		expect(s.run(0.06, noop)).toBe(1);
+		expect(s.run(0.06, () => undefined)).toBe(1);
 	});
 
 	it('drops the backlog instead of repaying a long stall at once', () => {
 		const s = new FixedStep(0.1, 3);
-		expect(s.run(10, noop)).toBe(3);
+		expect(s.run(10, () => undefined)).toBe(3);
 		expect(s.pending).toBe(0);
 	});
 
 	it('never advances on a frame shorter than one step', () => {
 		const s = new FixedStep(0.1, 8);
-		expect(s.run(0.04, noop)).toBe(0);
-		expect(s.run(0.04, noop)).toBe(0);
-		expect(s.run(0.04, noop)).toBe(1);
+		expect(s.run(0.04, () => undefined)).toBe(0);
+		expect(s.run(0.04, () => undefined)).toBe(0);
+		expect(s.run(0.04, () => undefined)).toBe(1);
 	});
 
 	// The reason this exists: the same input held for the same wall time has to

--- a/apps/herbmail/herbmail-game/src/game/dungeon/occlusion.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/occlusion.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { PAD, dilateSky } from './occlusion';
+
+// What skyAtWorld used to do per fragment: max the G channel over the 3x3 tile
+// neighbourhood, skipping neighbours outside the grid. Kept here verbatim so the
+// baked version is checked against the thing it replaced, not against itself.
+function shaderSky(
+	data: Uint8Array,
+	cols: number,
+	rows: number,
+	col: number,
+	row: number,
+): number {
+	let best = 0;
+	for (let dy = -1; dy <= 1; dy++) {
+		for (let dx = -1; dx <= 1; dx++) {
+			const c = col + dx;
+			const r = row + dy;
+			if (c < 0 || r < 0 || c >= cols || r >= rows) continue;
+			best = Math.max(best, data[(r * cols + c) * 2 + 1]);
+		}
+	}
+	return best;
+}
+
+function grid(
+	cols: number,
+	rows: number,
+	open: Array<[number, number]>,
+): Uint8Array {
+	const d = new Uint8Array(cols * rows * 2);
+	for (const [c, r] of open) d[(r * cols + c) * 2 + 1] = 254;
+	return d;
+}
+
+describe('dilateSky', () => {
+	it('matches the 3x3 max the shader used to compute per fragment', () => {
+		const cols = 9;
+		const rows = 7;
+		const open: Array<[number, number]> = [
+			[4, 3],
+			[5, 3],
+			[1, 1],
+			[8, 6],
+			[0, 0],
+		];
+		const before = grid(cols, rows, open);
+		const after = grid(cols, rows, open);
+		dilateSky(after, cols, rows);
+
+		for (let r = 0; r < rows; r++) {
+			for (let c = 0; c < cols; c++) {
+				expect(after[(r * cols + c) * 2 + 1]).toBe(
+					shaderSky(before, cols, rows, c, r),
+				);
+			}
+		}
+	});
+
+	it('leaves the occluder channel untouched', () => {
+		const cols = 5;
+		const rows = 5;
+		const d = new Uint8Array(cols * rows * 2);
+		d[(2 * cols + 2) * 2] = 254;
+		d[(2 * cols + 2) * 2 + 1] = 254;
+		dilateSky(d, cols, rows);
+
+		let occluders = 0;
+		for (let i = 0; i < cols * rows; i++) if (d[i * 2]) occluders++;
+		expect(occluders).toBe(1);
+		expect(d[(2 * cols + 2) * 2]).toBe(254);
+	});
+
+	// The border is what makes the bake exact rather than approximate: without it
+	// a tile just outside the grid still saw in-range neighbours in the shader,
+	// and a single fetch at that centre would read nothing.
+	it('reproduces the shader for centres outside the unpadded grid', () => {
+		expect(PAD).toBeGreaterThanOrEqual(1);
+
+		const inner = 5;
+		const cols = inner + PAD * 2;
+		const rows = inner + PAD * 2;
+		// Open tile on the very edge of the unpadded region.
+		const open: Array<[number, number]> = [[PAD, PAD]];
+		const before = grid(cols, rows, open);
+		const after = grid(cols, rows, open);
+		dilateSky(after, cols, rows);
+
+		// The centre one tile outside the unpadded grid: in the old shader this
+		// was an out-of-range col that still maxed over its in-range neighbours.
+		const c = PAD - 1;
+		const r = PAD;
+		expect(after[(r * cols + c) * 2 + 1]).toBe(254);
+		expect(after[(r * cols + c) * 2 + 1]).toBe(
+			shaderSky(before, cols, rows, c, r),
+		);
+	});
+
+	it('is a no-op on a grid with no open sky', () => {
+		const d = new Uint8Array(4 * 4 * 2).fill(0);
+		for (let i = 0; i < 16; i++) d[i * 2] = 254;
+		dilateSky(d, 4, 4);
+		for (let i = 0; i < 16; i++) expect(d[i * 2 + 1]).toBe(0);
+	});
+});

--- a/apps/herbmail/herbmail-game/src/game/dungeon/occlusion.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/occlusion.ts
@@ -24,6 +24,40 @@ function makeTex(
 	return tex;
 }
 
+// One tile of empty border on every side. skyAtWorld used to take the 3x3 max in
+// the fragment shader and skip neighbours that fell outside the grid; baking that
+// max here would otherwise disagree at the boundary, where a centre tile sits
+// outside but its neighbours do not. With the border, every centre the shader
+// could have evaluated is in range and the padding contributes 0 exactly as the
+// skipped samples did — so the baked result is identical, not merely close.
+export const PAD = 1;
+
+// The 3x3 max over the open-sky channel, hoisted out of the fragment shader. It
+// only changes when the active room set does, but was costing 9 texture fetches
+// on every lit fragment of every wall, floor and ceiling.
+export function dilateSky(data: Uint8Array, cols: number, rows: number): void {
+	// Written to a scratch buffer: dilating in place would feed each result into
+	// the next window and smear the mask across the grid.
+	const out = new Uint8Array(cols * rows);
+	for (let y = 0; y < rows; y++) {
+		for (let x = 0; x < cols; x++) {
+			let best = 0;
+			for (let dy = -1; dy <= 1; dy++) {
+				const ny = y + dy;
+				if (ny < 0 || ny >= rows) continue;
+				for (let dx = -1; dx <= 1; dx++) {
+					const nx = x + dx;
+					if (nx < 0 || nx >= cols) continue;
+					const v = data[(ny * cols + nx) * 2 + 1];
+					if (v > best) best = v;
+				}
+			}
+			out[y * cols + x] = best;
+		}
+	}
+	for (let i = 0; i < out.length; i++) data[i * 2 + 1] = out[i];
+}
+
 export function useOcclusionField(): OcclusionField {
 	const rooms = useActiveRooms();
 	const field = useMemo(() => {
@@ -46,26 +80,27 @@ export function useOcclusionField(): OcclusionField {
 			maxR = Math.max(maxR, desc.originRow + desc.rows);
 		}
 
-		const cols = maxC - minC;
-		const rows = maxR - minR;
+		const cols = maxC - minC + PAD * 2;
+		const rows = maxR - minR + PAD * 2;
 		// R = occluder (blocks torch light), G = open-sky (oasis, takes sky light).
 		const data = new Uint8Array(cols * rows * 2);
 		for (const { desc } of rooms) {
 			for (let rr = 0; rr < desc.rows; rr++) {
 				for (let cc = 0; cc < desc.cols; cc++) {
 					const t = desc.tiles[rr * desc.cols + cc];
-					const gx = desc.originCol + cc - minC;
-					const gy = desc.originRow + rr - minR;
+					const gx = desc.originCol + cc - minC + PAD;
+					const gy = desc.originRow + rr - minR + PAD;
 					const gi = (gy * cols + gx) * 2;
 					if (t & OCCLUDES) data[gi] = 254;
 					if (t & OPEN) data[gi + 1] = 254;
 				}
 			}
 		}
+		dilateSky(data, cols, rows);
 
 		return {
 			tex: makeTex(data, cols, rows),
-			origin: new THREE.Vector2(minC * TILE, minR * TILE),
+			origin: new THREE.Vector2((minC - PAD) * TILE, (minR - PAD) * TILE),
 			size: new THREE.Vector2(cols, rows),
 		};
 	}, [rooms]);

--- a/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
+++ b/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
@@ -157,21 +157,18 @@ const fragment = /* glsl */ `
 	}
 
 	// Open-sky exposure (G channel of the tile grid): 1 inside an oasis room, 0
-	// under a closed ceiling. Samples the 3x3 neighbourhood so oasis walls (which
-	// sit on the boundary tile) still catch the sky instead of going dark.
+	// under a closed ceiling. The 3x3 neighbourhood max that keeps oasis walls
+	// (which sit on the boundary tile) from going dark is baked into the channel
+	// when the grid is built — see dilateSky in dungeon/occlusion.ts. It only
+	// changes when the active room set does, and cost 9 texture fetches here on
+	// every lit fragment of every wall, floor and ceiling.
 	float skyAtWorld(vec2 p) {
 		vec2 local = (p - uGridOrigin) / GRID_TILE;
-		float best = 0.0;
-		for (int dy = -1; dy <= 1; dy++) {
-			for (int dx = -1; dx <= 1; dx++) {
-				float col = floor(local.x) + float(dx);
-				float row = floor(local.y) + float(dy);
-				if (col < 0.0 || row < 0.0 || col >= uGridSize.x || row >= uGridSize.y) continue;
-				vec2 uvp = (vec2(col, row) + 0.5) / uGridSize;
-				best = max(best, texture2D(uMapTex, uvp).g);
-			}
-		}
-		return best;
+		float col = floor(local.x);
+		float row = floor(local.y);
+		if (col < 0.0 || row < 0.0 || col >= uGridSize.x || row >= uGridSize.y) return 0.0;
+		vec2 uvp = (vec2(col, row) + 0.5) / uGridSize;
+		return texture2D(uMapTex, uvp).g;
 	}
 
 	// Shortest distance between the fragment->light segment and a character's


### PR DESCRIPTION
Independent of #15280 — different files, either can land first.

## Why fragment work

Telemetry from real hardware (`__frames.work()`, GPU timer queries, 0 disjoints) says the game is **GPU-bound**:

```
cpu  p50 5.47   p95 7.82   max 9.33   over16: 0
gpu  p50 8.17   p95 11.27  p99 12.49  max 15.93
```

GPU is 1.5× the CPU at the median and `max 15.93` grazes the 16.67 ms budget for 60 fps, while the CPU never misses a frame. Fragment work is the half worth cutting.

## The change

`skyAtWorld` took the 3×3 neighbourhood max of the open-sky channel in the fragment shader — **9 texture fetches on every lit fragment of every wall, floor and ceiling** — recomputing a value that only changes when the active room set does. It's now baked into the G channel when the occlusion grid is built, and the shader reads a single texel.

## Why the grid gains a one-tile border

Without it the two are **not** equivalent. The old loop skipped neighbours falling outside the grid, so a centre tile just outside the bounds still returned the max of its in-range neighbours — where a single fetch at that centre reads nothing. That's a seam at the edge of the streamed region.

With the border, every centre the shader could have evaluated is in range, and the padding contributes 0 exactly as the skipped samples did. The occluder channel is unaffected: a padded tile reads 0, which is what `tileAtWorld` already returned out of bounds.

## Verification

- 4 unit tests checking the baked grid against the original shader loop **transcribed verbatim**, cell by cell — including the out-of-bounds centres the border exists for. An equality proof, not a smoke test.
- 149 unit tests, 12 e2e, lint clean
- Rendered and inspected for shader errors

## Second commit

`fixedStep.test.ts` landed on `dev` with five empty arrow callbacks, so `herbmail-game:lint` **currently fails on dev** with 5 errors. Fixed with `() => undefined`, the no-op form already used elsewhere in this app, rather than silencing the rule. Unrelated to the perf work and separated so it can be dropped or landed on its own.

## Follow-up found, not taken

`visibility()` marches the tile grid at **0.32 units per step with `TILE = 3`** — roughly 9 texture fetches per tile crossed, up to 34 steps per light per fragment. Same redundancy as this change, an order of magnitude larger, and the biggest remaining GPU item after resolution. A DDA that visits each tile once would cut it ~7×, but unlike this change it is not free of visual consequence — fixed-step sampling can skip thin occluders that DDA catches, so shadows would shift slightly (in the more-correct direction). Left for a deliberate call.