### PR TITLE
fix(kubevirt): restore virt-handler clientcertificates mount

### DIFF
--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -22,6 +22,21 @@ spec:
         network:
             permitBridgeInterfaceOnPodNetwork: true
     imagePullPolicy: IfNotPresent
+    # virt-operator renders four cert mounts for virt-handler
+    # (components/daemonsets.go:283-286) but the live DaemonSet is missing
+    # the clientcertificates one, so virt-handler's cert manager fails to
+    # open it once a minute. Nothing strips it — customizeComponents was
+    # empty and there are no Kyverno mutations — the operator simply never
+    # re-rendered and reports the stale spec as in sync. Upstream
+    # kubevirt/kubevirt#16255 and #16264 are open with no maintainer reply.
+    # Re-adding it here also bumps the customizer identifier, which forces
+    # the re-render.
+    customizeComponents:
+        patches:
+            - resourceType: DaemonSet
+              resourceName: virt-handler
+              type: strategic
+              patch: '{"spec":{"template":{"spec":{"volumes":[{"name":"kubevirt-virt-handler-certs","secret":{"secretName":"kubevirt-virt-handler-certs","defaultMode":420,"optional":true}}],"containers":[{"name":"virt-handler","volumeMounts":[{"name":"kubevirt-virt-handler-certs","mountPath":"/etc/virt-handler/clientcertificates","readOnly":true}]}]}}}}'
     workloadUpdateStrategy:
         workloadUpdateMethods:
             - LiveMigrate


### PR DESCRIPTION
## Problem

`virt-handler` logs this once a minute, ~1440/day/node:

```
failed to load the certificate /etc/virt-handler/clientcertificates/tls.crt and
/etc/virt-handler/clientcertificates/tls.key
reason: open /etc/virt-handler/clientcertificates/tls.crt: no such file or directory
pos: cert-manager.go:189
```

It surfaced while tracing a cluster-wide etcd stall. It turned out to be unrelated to that — and, unlike the leaderelection errors alongside it, actually fixable here.

## Root cause

`virt-operator` v1.7.2 renders **four** cert mounts for the virt-handler DaemonSet, unconditionally:

```go
// pkg/virt-operator/resource/generate/components/daemonsets.go:283-286
attachCertificateSecret(pod, VirtHandlerCertSecretName, "/etc/virt-handler/clientcertificates")
attachCertificateSecret(pod, VirtHandlerServerCertSecretName, "/etc/virt-handler/servercertificates")
attachCertificateSecret(pod, VirtHandlerMigrationClientCertSecretName, "/etc/virt-handler/migrationservercertificates")
attachCertificateSecret(pod, VirtHandlerVsockClientCertSecretName, "/etc/virt-handler/vsockclientcertificates")
```

The live DaemonSet has three. `clientcertificates` is absent. The secret itself is healthy — `kubevirt-virt-handler-certs` exists, rotates on the normal 24h schedule, and `virt-api` mounts it at that same path.

Nothing external removed it:

- `spec.customizeComponents` was `{}` — its hash `bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f` matches the `kubevirt.io/customizer-identifier` annotation on the DaemonSet exactly, so no patch had been applied
- zero Kyverno `mutate` policies cluster-wide

The DaemonSet carries `install-strategy-version: v1.7.2` and `kubevirt.io/generation: 3` against a live `metadata.generation: 4`. `virt-operator` logs `DaemonSet loaded` on each leader acquisition and takes no action — it reports the stale spec as in sync.

## Fix

Add the mount via `customizeComponents.patches`. Strategic merge, so it merges by name into the existing lists rather than replacing them — verified against the live spec (container name `virt-handler` matches; `kubevirt-virt-handler-certs` doesn't collide with the three present volumes). It also changes the customizer identifier, which forces the re-render that hasn't happened on its own.

## Scope

The cert backs exactly one consumer:

```go
// cmd/virt-handler/virt-handler.go:732
app.migrationOldClientTLSConfig = kvtls.SetupTLSForVirtHandlerClients(app.caManager, app.clientcertmanager, ...)
// :733 — current path, uses a different and correctly-mounted cert
app.migrationClientTLSConfig    = kvtls.SetupTLSForVirtHandlerClients(app.caManager, app.migrationCertManager, ...)
// :313
migrationProxy := migrationproxy.NewMigrationProxyManager(migrationServerTLSConfig, migrationOldClientTLSConfig, migrationClientTLSConfig, ...)
```

That's the **legacy** client TLS path for live migration — the fallback for migrating against a node running an older virt-handler. The current path uses `migrationCertManager`, which is mounted, and this DaemonSet runs `--migration-cn-types migration` with `kubevirt.io/supports-migration-cn-types=true`.

**Nothing is degraded today** — single-node cluster, nowhere to migrate to. This is hygiene ahead of a second node joining, plus removing ~1440 error lines/day from ClickHouse.

## Upstream

[kubevirt/kubevirt#16255](https://github.com/kubevirt/kubevirt/issues/16255) and [#16264](https://github.com/kubevirt/kubevirt/issues/16264) report the same symptom since v1.4. Both open and stale, no maintainer response. Neither reporter checked the operator's generator, which does emit the mount — worth reporting back upstream.

## Risk

Rolls the virt-handler DaemonSet. No VMIs are running, so node-level VM management is briefly unavailable and no guest is affected.

## Verify after sync

```bash
kubectl -n kubevirt get ds virt-handler -o jsonpath='{.spec.template.spec.containers[0].volumeMounts}' | tr ',' '\n' | grep clientcert
kubectl -n kubevirt logs -l kubevirt.io=virt-handler --since=5m | grep -c "failed to load the certificate"   # expect 0
```