### PR TITLE
fix(astro-kbve): repair sitemap chain and drop gated routes from index

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -9,6 +9,7 @@ import worker from '@astropub/worker';
 import mermaid from 'astro-mermaid';
 import { unified } from '@astrojs/markdown-remark';
 import rehypeLinkAttrs from './src/lib/rehype-link-attrs.mjs';
+import { isIndexableUrl } from './src/lib/noindex-routes.mjs';
 import { readFileSync } from 'node:fs';
 import https from 'node:https';
 import { fileURLToPath } from 'node:url';
@@ -461,6 +462,7 @@ export default defineConfig({
 		}),
 		react(),
 		sitemap({
+			filter: isIndexableUrl,
 			i18n: {
 				defaultLocale: 'en',
 				locales: {

--- a/apps/kbve/astro-kbve/public/robots.txt
+++ b/apps/kbve/astro-kbve/public/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
 Allow: /
 
-Sitemap: https://kbve.com/sitemap.xml
+Sitemap: https://kbve.com/sitemap-index.xml

--- a/apps/kbve/astro-kbve/public/sitemap.xml
+++ b/apps/kbve/astro-kbve/public/sitemap.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://kbve.com/sitemap-index.xml</loc></sitemap></sitemapindex>

--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -12,6 +12,7 @@
  * Mirrors the rareicon Head override (apps/rareicon/astro-rareicon/...).
  */
 import { seo } from '@/lib/seo';
+import { isNoindexPath } from '@/lib/noindex-routes.mjs';
 import { dedupeGraph } from '@kbve/astro/seo';
 
 const route = Astro.locals.starlightRoute;
@@ -187,7 +188,7 @@ const jsonLdPayload = jsonLdGraph
 		: { '@context': 'https://schema.org', '@graph': jsonLdGraph }
 	: null;
 
-const noindex = data.noindex === true;
+const noindex = data.noindex === true || isNoindexPath(Astro.url.pathname);
 const robotsContent = noindex
 	? 'noindex, nofollow'
 	: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1';

--- a/apps/kbve/astro-kbve/src/lib/noindex-routes.mjs
+++ b/apps/kbve/astro-kbve/src/lib/noindex-routes.mjs
@@ -1,0 +1,29 @@
+export const NOINDEX_PREFIXES = [
+	'/dashboard/',
+	'/auth/',
+];
+
+export const NOINDEX_EXACT = [
+	'/404/',
+	'/500/',
+	'/502/',
+	'/503/',
+	'/login/',
+	'/logout/',
+	'/register/',
+];
+
+export function isNoindexPath(pathname) {
+	if (!pathname) return false;
+	const path = pathname.endsWith('/') ? pathname : `${pathname}/`;
+	if (NOINDEX_EXACT.includes(path)) return true;
+	return NOINDEX_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+export function isIndexableUrl(url) {
+	try {
+		return !isNoindexPath(new URL(url).pathname);
+	} catch {
+		return true;
+	}
+}


### PR DESCRIPTION
## Context

`kbve.com` dropped off Google for the brand term `kbve`. Homepage markup audited and is clean — Googlebot gets `200`, correct `<title>`, meta description, self-canonical, `robots: index, follow`, and Organization/WebSite/WebPage/FAQPage JSON-LD. The problems are site-level.

## What this fixes

**1. Sitemap chain was invalid — Google could not read it**

```
robots.txt → /sitemap.xml        (sitemapindex)
           → /sitemap-index.xml  (sitemapindex)   ← index inside an index = invalid
           → /sitemap-0.xml      (7529 urls)
```

The sitemaps protocol forbids a sitemap index containing another sitemap index. `public/sitemap.xml` was a hand-written wrapper around the `@astrojs/sitemap` output, so every one of the 7,529 URLs was effectively unsubmitted.

- `public/sitemap.xml` removed
- `robots.txt` now points at `/sitemap-index.xml` (the real, valid index)

**2. Auth-gated and error routes were submitted for indexing**

52 URLs in the live sitemap should never have been there — `/dashboard/**` (42 pages, all auth-walled), `/auth/**`, `/login/`, `/logout/`, `/register/`, `/502/`, `/503/`.

`src/lib/noindex-routes.mjs` is a single route list consumed by both:
- `astro.config.mjs` → `sitemap({ filter: isIndexableUrl })`
- `src/components/navigation/Head.astro` → emits `noindex, nofollow`

No `Disallow` added to robots.txt on purpose: these pages are already indexed, and blocking crawl would prevent Googlebot from ever seeing the `noindex` and freeze them in the index. They stay crawlable so they can be dropped.

Existing per-page `noindex: true` frontmatter still works and is OR'd with the route check.

## Verified

Filter run against the live sitemap (7,529 URLs):

```
total 7529   dropped 52   kept 7477
```

Nothing legitimate is caught — `/api/` (the API Hub page), `/project/api/`, `/osrs/**`, `/mc/**` all retained.

## Not in this PR

- **AdSense loader is eager on every page.** Real Core Web Vitals cost, but it is a perf issue, not a brand-deindex cause. Deferring it trades measurable ad revenue for CWV and deserves its own PR with lab numbers.
- **The redirect guard stays.** `src/lib/redirect-guard.js` blocks malvertising forced top-navigation. It is the mitigation for the highest-probability cause of a brand-term drop (a Google Security Issues manual action), not a contributor to it.
- **Scaled-content exposure.** 84% of the indexed site is auto-generated database pages (4,074 `/osrs/*`, 2,216 `/mc/*`), each carrying roughly 1.3k unique characters under ~2.5k of shared nav boilerplate. That shape is what Google's scaled-content-abuse policy targets and is the most likely driver of a site-wide quality demotion. Consolidating or pruning that long tail is a product decision, tracked separately.

## Post-merge, manual

1. Search Console → **Security & Manual Actions**. If a manual action is listed, it outranks everything here — file a reconsideration request.
2. Search Console → Sitemaps → remove `sitemap.xml`, submit `sitemap-index.xml`.
3. Search Console → Pages → check whether `https://kbve.com/` reads *Crawled – currently not indexed* versus indexed-but-demoted. Different diagnoses.