### PR TITLE
fix(astro-kbve): state the KBVE entity in the homepage headings

### DIFF
--- a/apps/kbve/astro-kbve/src/components/hero/BentoBoard.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoBoard.astro
@@ -20,12 +20,14 @@ interface Cell {
 interface Props {
 	eyebrow?: string;
 	heading?: string;
+	sub?: string;
 	cells?: Cell[];
 }
 
 const {
-	eyebrow = 'The KBVE stack',
-	heading = 'Everything the studio runs on, in one place.',
+	eyebrow = 'Infrastructure',
+	heading = 'The KBVE stack',
+	sub = 'Everything the studio runs on, in one place — the monorepo, the game servers, and the pipelines behind them.',
 	cells = [
 		{
 			title: 'Community',
@@ -82,7 +84,7 @@ const fillLg = (3 - (unitsLg % 3)) % 3;
 const fillMd = (2 - (cells.length % 2)) % 2;
 ---
 
-<BentoShell {eyebrow} {heading}>
+<BentoShell {eyebrow} {heading} {sub}>
 	<div class="bento-board__grid">
 		{
 			cells.map((cell) => {

--- a/apps/kbve/astro-kbve/src/components/hero/BentoFaq.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoFaq.astro
@@ -61,7 +61,10 @@ const jsonLd = {
 };
 ---
 
-<BentoShell eyebrow="FAQ" heading="Frequently asked questions">
+<BentoShell
+	eyebrow="FAQ"
+	heading="Frequently asked questions about KBVE"
+	sub="What Kilobyte Virtual Enterprise is, what we build, and how to get involved.">
 	<div class="bento-faq">
 		{
 			faqs.map((faq, i) => (

--- a/apps/kbve/astro-kbve/src/components/hero/BentoFlow.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoFlow.astro
@@ -5,15 +5,17 @@ import BentoFlowIsland from './flow/BentoFlowIsland';
 interface Props {
 	eyebrow?: string;
 	heading?: string;
+	sub?: string;
 }
 
 const {
-	eyebrow = 'How it ships',
-	heading = 'From commit to production, automatically.',
+	eyebrow = 'Pipeline',
+	heading = 'How KBVE ships software',
+	sub = 'From commit to production, automatically — every change flows through the same public pipeline.',
 } = Astro.props;
 ---
 
-<BentoShell {eyebrow} {heading} id="how-it-works">
+<BentoShell {eyebrow} {heading} {sub} id="how-it-works">
 	<div class="bento-flow">
 		<BentoFlowIsland client:idle />
 	</div>

--- a/apps/kbve/astro-kbve/src/components/hero/BentoGallery.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoGallery.astro
@@ -13,12 +13,14 @@ interface GalleryItem {
 interface Props {
 	eyebrow?: string;
 	heading?: string;
+	sub?: string;
 	items?: GalleryItem[];
 }
 
 const {
 	eyebrow = 'From the studio',
-	heading = 'Worlds, tools, and experiments we ship.',
+	heading = 'Games and tools KBVE builds',
+	sub = 'Worlds, tools, and experiments we ship — each one open source, each one playable.',
 	items = [
 		{
 			title: 'Rent Earth',
@@ -52,7 +54,7 @@ const fillLg = (3 - (unitsLg % 3)) % 3;
 const fillMd = (2 - (items.length % 2)) % 2;
 ---
 
-<BentoShell {eyebrow} {heading}>
+<BentoShell {eyebrow} {heading} {sub}>
 	<div class="bento-gallery">
 		{
 			items.map((item) => {

--- a/apps/kbve/astro-kbve/src/components/hero/BentoHero.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoHero.astro
@@ -3,6 +3,7 @@ import StackLogos from './StackLogos.astro';
 
 interface Props {
 	titleLines?: string[];
+	tagline?: string;
 	rotatingWord?: string;
 	rotatingWords?: string[];
 	description?: string;
@@ -19,7 +20,8 @@ interface Props {
 }
 
 const {
-	titleLines = ['KBVE is the best', 'way to build', 'games.'],
+	titleLines = ['KBVE —', 'Kilobyte Virtual', 'Enterprise'],
+	tagline = 'An open-source studio building games, tools, and worlds in public.',
 	rotatingWord = 'games',
 	rotatingWords = [
 		'games',
@@ -115,35 +117,33 @@ const dock = [
 								titleLines.map((line, idx) => (
 									<>
 										<span class="bento-hero__title-line">
-											{line.includes(rotatingWord) ? (
-												<>
-													{
-														line.split(
-															rotatingWord,
-														)[0]
-													}
-													<span
-														class="bento-hero__slot"
-														data-rotate={JSON.stringify(
-															rotatingWords,
-														)}>
-														{rotatingWord}
-													</span>
-													{
-														line.split(
-															rotatingWord,
-														)[1]
-													}
-												</>
-											) : (
-												line
-											)}
+											{line}
 										</span>
 										{idx < titleLines.length - 1 && ' '}
 									</>
 								))
 							}
 						</h1>
+
+						<p class="bento-hero__tagline">
+							{
+								tagline.includes(rotatingWord) ? (
+									<>
+										{tagline.split(rotatingWord)[0]}
+										<span
+											class="bento-hero__slot"
+											data-rotate={JSON.stringify(
+												rotatingWords,
+											)}>
+											{rotatingWord}
+										</span>
+										{tagline.split(rotatingWord)[1]}
+									</>
+								) : (
+									tagline
+								)
+							}
+						</p>
 
 						<div class="bento-hero__stack">
 							<p class="bento-hero__stack-label">
@@ -643,6 +643,16 @@ const dock = [
 	.bento-hero__title-line {
 		display: block;
 		white-space: nowrap;
+	}
+
+	.bento-hero__tagline {
+		margin-top: 1rem;
+		max-width: 40rem;
+		font-size: clamp(1.125rem, 2.2vw, 1.5rem);
+		font-weight: 500;
+		line-height: 1.35;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-gray-1);
 	}
 
 	.bento-hero__slot {

--- a/apps/kbve/astro-kbve/src/components/hero/BentoRoadmap.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoRoadmap.astro
@@ -66,12 +66,12 @@ const statusLabel: Record<MilestoneStatus, string> = {
 		<header class="bento-roadmap__intro">
 			<p class="bento-eyebrow">Roadmap</p>
 			<h2 class="bento-roadmap__heading">
-				Built in the open,<br />shipped in the open.
+				The KBVE roadmap
 			</h2>
 			<p class="bento-roadmap__sub">
-				Every milestone below maps to real issues, pull requests, and
-				deployments in the KBVE monorepo. No private backlog — the plan
-				is the repo.
+				Built in the open, shipped in the open. Every milestone below
+				maps to real issues, pull requests, and deployments in the KBVE
+				monorepo. No private backlog — the plan is the repo.
 			</p>
 			<div class="bento-roadmap__ctas">
 				<a

--- a/apps/kbve/astro-kbve/src/components/hero/BentoShell.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/BentoShell.astro
@@ -2,19 +2,21 @@
 interface Props {
 	eyebrow?: string;
 	heading?: string;
+	sub?: string;
 	id?: string;
 }
 
-const { eyebrow, heading, id } = Astro.props;
+const { eyebrow, heading, sub, id } = Astro.props;
 ---
 
 <section {id} class="bento-shell bento-section not-content">
 	<div class="bento-shell__inner bento-frame">
 		{
-			(eyebrow || heading) && (
+			(eyebrow || heading || sub) && (
 				<header class="bento-shell__header">
 					{eyebrow && <p class="bento-eyebrow">{eyebrow}</p>}
 					{heading && <h2 class="bento-heading">{heading}</h2>}
+					{sub && <p class="bento-shell__sub">{sub}</p>}
 				</header>
 			)
 		}
@@ -25,6 +27,14 @@ const { eyebrow, heading, id } = Astro.props;
 <style>
 	.bento-shell__header {
 		padding: 3rem 1rem 2rem;
+	}
+
+	.bento-shell__sub {
+		margin-top: 0.75rem;
+		max-width: 44rem;
+		font-size: 1rem;
+		line-height: 1.55;
+		color: var(--sl-color-gray-2);
 	}
 
 	@media (min-width: 640px) {

--- a/apps/kbve/astro-kbve/src/content/docs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/index.mdx
@@ -4,8 +4,8 @@ head:
     - tag: title
       content: KBVE | Kilobyte Virtual Enterprise
 description: >-
-    KBVE is the best way to build games. Games, tools, applications, packages,
-    infrastructure, and worlds — built in public by Kilobyte Virtual Enterprise.
+    KBVE (Kilobyte Virtual Enterprise) is an open-source studio building games,
+    developer tools, and infrastructure in public from a single monorepo.
 template: splash
 tableOfContents: false
 graph:


### PR DESCRIPTION
## Why

No Google manual action and no security issue on `kbve.com`, so the brand-term drop is a relevance problem, not a penalty. Auditing the rendered homepage turned up a concrete gap: **the page never says what KBVE is.**

Before this PR:

- **H1** — `KBVE is the best way to build games.` A superlative marketing claim with no entity definition.
- **All five H2s** were taglines carrying no entity noun and no brand token:
  - "Everything the studio runs on, in one place."
  - "Worlds, tools, and experiments we ship."
  - "From commit to production, automatically."
  - "Built in the open, shipped in the open."
  - "Frequently asked questions"
- The only real definition — *"KBVE (Kilobyte Virtual Enterprise) is an open-source collective building games, developer tools, and automation software from a single monorepo"* — sits in **FAQ item 01, roughly 5,000 characters down the page**, below the roadmap and sponsor blocks.
- "Kilobyte Virtual Enterprise" appeared in `<title>` and JSON-LD but nowhere visible above the fold.

For the query `kbve`, that gives Google a slogan where it needs an entity.

## What changed

**H1 leads with the entity, slogan becomes a subhead**

```
KBVE — Kilobyte Virtual Enterprise
An open-source studio building [games], tools, and worlds in public.
```

The rotating word (`games` → `apps` → `software` → …) survives untouched — it moves from the H1 into the new `.bento-hero__tagline`. The rotation script selects on `.bento-hero__slot[data-rotate]`, which is unchanged, so the animation, the character-level transitions, and the `shipBentoWord` pipeline hook all keep working.

**Section headings carry entity nouns, taglines preserved as sub-text**

| Section | H2 before | H2 after |
| --- | --- | --- |
| Board | Everything the studio runs on, in one place. | The KBVE stack |
| Gallery | Worlds, tools, and experiments we ship. | Games and tools KBVE builds |
| Flow | From commit to production, automatically. | How KBVE ships software |
| Roadmap | Built in the open, shipped in the open. | The KBVE roadmap |
| FAQ | Frequently asked questions | Frequently asked questions about KBVE |

No tagline is lost. `BentoShell` gains an optional `sub` prop rendered under the H2, mirroring the `bento-roadmap__sub` pattern already in `BentoRoadmap`. The roadmap's own tagline folds into its existing sub paragraph.

**Meta description** now leads with the definition rather than the superlative.

No layout, grid, or component structure changes — headings, one new paragraph in the hero, and one new paragraph slot in the shell.

## Verification status

**Not built locally.** The worktree has no `node_modules`; symlinking the main tree's copy breaks Astro path resolution (paths mangle to `/private/tmp/<worktree>/Users/alappatel/...` and the compiler errors on missing compile metadata), and copying into the main tree for a dev-server render was blocked by the permission classifier. **CI build is the gate here** — please eyeball the hero on the preview before merging, particularly:

- H1 line breaks at mobile widths (`.bento-hero__title-line` is `white-space: nowrap`, and "Kilobyte Virtual" is the longest line)
- the rotating word still animating in its new position

## Related

- #15295 — sitemap chain repair and de-indexing gated routes. Independent of this PR; both branch from `dev`.

## Still open

The largest remaining risk is unaddressed and needs a product decision: **84% of the indexed site is auto-generated database pages** (4,074 `/osrs/*`, 2,216 `/mc/*`), each roughly 1.3k unique characters wrapped in ~2.5k of shared nav boilerplate. That is the shape Google's scaled-content-abuse policy targets and the most plausible driver of a site-wide quality demotion. Consolidating, enriching, or pruning that long tail is the next call.