### PR TITLE
feat(astro-kbve): bake OSRS GE prices into static HTML

### DIFF
--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemFamily.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemFamily.astro
@@ -1,6 +1,7 @@
 ---
 import OSRSCharts from './OSRSCharts.tsx';
 import type { OSRSFamily } from '@/data/schema';
+import { getPriceSnapshot } from '@/data/osrs/prices';
 
 interface Props {
 	family: OSRSFamily;
@@ -32,6 +33,8 @@ function icon(name: string): string {
 function gp(v: number | null | undefined): string {
 	return v === undefined || v === null ? '—' : v.toLocaleString();
 }
+
+const { prices } = await getPriceSnapshot();
 ---
 
 <div class="osrs-family">
@@ -62,6 +65,16 @@ function gp(v: number | null | undefined): string {
 							<span>High alch {gp(m.highalch)}</span>
 						</div>
 					</div>
+					<dl class="osrs-family__ge">
+						<div class="osrs-family__ge-cell">
+							<dt>Buy</dt>
+							<dd>{gp(prices.get(m.id)?.high)} gp</dd>
+						</div>
+						<div class="osrs-family__ge-cell">
+							<dt>Sell</dt>
+							<dd>{gp(prices.get(m.id)?.low)} gp</dd>
+						</div>
+					</dl>
 					<OSRSCharts client:visible itemId={m.id} />
 				</div>
 			))
@@ -106,6 +119,34 @@ function gp(v: number | null | undefined): string {
 		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 		gap: 0.75rem;
 		padding: 0.75rem;
+	}
+
+	.osrs-family__ge {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.375rem;
+		margin: 0 0 0.5rem;
+		padding: 0 0.5rem;
+	}
+
+	.osrs-family__ge-cell {
+		border-radius: 0.375rem;
+		border: 1px solid var(--sl-color-gray-6);
+		padding: 0.375rem 0.5rem;
+	}
+
+	.osrs-family__ge dt {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sl-color-gray-3);
+	}
+
+	.osrs-family__ge dd {
+		margin: 0;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--sl-color-white);
 	}
 
 	.osrs-family__member {

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemJsonLd.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemJsonLd.astro
@@ -5,12 +5,16 @@ import type {
 	OSRSRecipe,
 	OSRSUsedIn,
 } from '@/data/schema';
+import { getPriceSnapshot } from '@/data/osrs/prices';
 
 interface Props {
 	data: OSRSExtended;
 }
 
 const { data: item } = Astro.props;
+
+const { prices, fetchedAt: priceFetchedAt } = await getPriceSnapshot();
+const gePrice = prices.get(item.id) ?? null;
 
 const SITE = 'https://kbve.com';
 const ITEM_URL = `${SITE}/osrs/${item.slug}/`;
@@ -134,7 +138,28 @@ const product = {
 					},
 				]
 			: []),
+		...(gePrice?.high !== null && gePrice?.high !== undefined
+			? [
+					{
+						'@type': 'PropertyValue',
+						name: 'Grand Exchange buy price (gp)',
+						value: gePrice.high,
+						unitText: 'gp',
+					},
+				]
+			: []),
+		...(gePrice?.low !== null && gePrice?.low !== undefined
+			? [
+					{
+						'@type': 'PropertyValue',
+						name: 'Grand Exchange sell price (gp)',
+						value: gePrice.low,
+						unitText: 'gp',
+					},
+				]
+			: []),
 	],
+	...(priceFetchedAt ? { dateModified: priceFetchedAt.toISOString() } : {}),
 	sameAs: [WIKI_URL, GE_URL],
 };
 

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
@@ -25,6 +25,7 @@ import OSRSItemJsonLd from './OSRSItemJsonLd.astro';
 import OSRSDisclaimer from './OSRSDisclaimer.astro';
 import OSRSAdsenseSlot from './OSRSAdsenseSlot.astro';
 import { getUsedInIndex } from '@/data/osrs-used-in-index';
+import { averageOf, getPrice } from '@/data/osrs/prices';
 import type {
 	OSRSExtended,
 	OSRSUsedIn as OSRSUsedInEntry,
@@ -90,6 +91,19 @@ const gatheringData = showGathering ? getGathering(item) : undefined;
 const showMarketStrategy = hasMarketStrategy(item);
 const showTradingTips = hasTradingTips(item);
 const showShops = hasShopSources(item);
+const bakedPrice = await getPrice(item.id);
+const seedPrice = bakedPrice
+	? {
+			id: item.id,
+			name: item.name,
+			high: bakedPrice.high,
+			low: bakedPrice.low,
+			avg: averageOf(bakedPrice),
+			high_time: bakedPrice.highTime,
+			low_time: bakedPrice.lowTime,
+		}
+	: null;
+
 const showHistory = hasHistory(item);
 const showTrivia = hasItemTrivia(item);
 const showFaq = hasFaq(item);
@@ -253,7 +267,11 @@ const accentHigh = accent.replace(/(\d+)%\)?$/, '') + '72%';
 				<span class="osrs-section__dot"></span>
 				<h4 class="osrs-section__title">Live GE Prices</h4>
 			</div>
-			<OSRSPriceWidget itemId={item.id} client:visible />
+			<OSRSPriceWidget
+				itemId={item.id}
+				initialPrice={seedPrice}
+				client:load
+			/>
 		</div>
 
 		<!-- Price History Chart — full width -->

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSPriceWidget.tsx
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSPriceWidget.tsx
@@ -19,6 +19,12 @@ interface OSRSPriceWidgetProps {
 	itemId: number;
 	apiBaseUrl?: string;
 	refreshInterval?: number; // in milliseconds, 0 to disable
+	/**
+	 * Build-time price seed. Present so the rendered HTML carries real numbers
+	 * instead of a loading state for crawlers and no-JS visitors; the effect
+	 * below still refreshes to live data once hydrated.
+	 */
+	initialPrice?: PriceData | null;
 }
 
 /**
@@ -226,10 +232,11 @@ export default function OSRSPriceWidget({
 	itemId,
 	apiBaseUrl = '',
 	refreshInterval = 60000, // Default: refresh every 60 seconds
+	initialPrice = null,
 }: OSRSPriceWidgetProps) {
-	const [priceData, setPriceData] = useState<PriceData | null>(null);
+	const [priceData, setPriceData] = useState<PriceData | null>(initialPrice);
 	const [volumeData, setVolumeData] = useState<VolumeData | null>(null);
-	const [loading, setLoading] = useState(true);
+	const [loading, setLoading] = useState(initialPrice === null);
 	const [error, setError] = useState<string | null>(null);
 	const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
@@ -371,7 +378,7 @@ export default function OSRSPriceWidget({
 						{formatGP(priceData.high)}
 						<span style={styles.cardGp}>gp</span>
 					</div>
-					<div style={styles.cardTime}>
+					<div style={styles.cardTime} suppressHydrationWarning>
 						{formatRelativeTime(priceData.high_time)}
 					</div>
 				</div>
@@ -383,7 +390,7 @@ export default function OSRSPriceWidget({
 						{formatGP(priceData.low)}
 						<span style={styles.cardGp}>gp</span>
 					</div>
-					<div style={styles.cardTime}>
+					<div style={styles.cardTime} suppressHydrationWarning>
 						{formatRelativeTime(priceData.low_time)}
 					</div>
 				</div>

--- a/apps/kbve/astro-kbve/src/data/osrs/prices.ts
+++ b/apps/kbve/astro-kbve/src/data/osrs/prices.ts
@@ -1,0 +1,119 @@
+/**
+ * Build-time Grand Exchange price snapshot.
+ *
+ * Every OSRS item page ships a client-side price widget, but the widget only
+ * hydrates in a browser — the served HTML carries "Loading prices..." and
+ * nothing else. Crawlers that skip or defer JS therefore never see the market
+ * data that makes these pages worth indexing.
+ *
+ * This module fetches the wiki's bulk `latest` endpoint exactly once per build
+ * (~340KB, ~4.5k items, one request) and hands each page a seed price so the
+ * numbers are present in the static HTML. The island still hydrates and
+ * refreshes to live data for real visitors.
+ *
+ * Failure is non-fatal: an unreachable API yields an empty snapshot and pages
+ * fall back to the previous loading-state behaviour rather than failing the
+ * build.
+ */
+const LATEST_ENDPOINT = 'https://prices.runescape.wiki/api/v1/osrs/latest';
+const USER_AGENT = 'KBVE item_tracker - @h0lybyte on Discord';
+
+// The wiki reports untraded items as int32 max rather than omitting them.
+const UNTRADED_SENTINEL = 2147483647;
+
+export interface OSRSPricePoint {
+	high: number | null;
+	low: number | null;
+	highTime: number | null;
+	lowTime: number | null;
+}
+
+export interface OSRSPriceSnapshot {
+	prices: Map<number, OSRSPricePoint>;
+	fetchedAt: Date | null;
+}
+
+interface LatestResponse {
+	data?: Record<
+		string,
+		{
+			high?: number | null;
+			low?: number | null;
+			highTime?: number | null;
+			lowTime?: number | null;
+		}
+	>;
+}
+
+const EMPTY: OSRSPriceSnapshot = { prices: new Map(), fetchedAt: null };
+
+let snapshotPromise: Promise<OSRSPriceSnapshot> | null = null;
+
+function sanitize(value: number | null | undefined): number | null {
+	if (value === null || value === undefined) return null;
+	if (!Number.isFinite(value)) return null;
+	if (value <= 0 || value >= UNTRADED_SENTINEL) return null;
+	return value;
+}
+
+async function fetchSnapshot(): Promise<OSRSPriceSnapshot> {
+	try {
+		const response = await fetch(LATEST_ENDPOINT, {
+			headers: { 'User-Agent': USER_AGENT },
+		});
+
+		if (!response.ok) {
+			console.warn(
+				`[osrs/prices] latest endpoint returned ${response.status}; pages will fall back to client-side pricing`,
+			);
+			return EMPTY;
+		}
+
+		const json = (await response.json()) as LatestResponse;
+		const entries = json.data ?? {};
+		const prices = new Map<number, OSRSPricePoint>();
+
+		for (const [rawId, point] of Object.entries(entries)) {
+			const id = Number(rawId);
+			if (!Number.isInteger(id)) continue;
+
+			const high = sanitize(point?.high);
+			const low = sanitize(point?.low);
+			if (high === null && low === null) continue;
+
+			prices.set(id, {
+				high,
+				low,
+				highTime: point?.highTime ?? null,
+				lowTime: point?.lowTime ?? null,
+			});
+		}
+
+		console.info(`[osrs/prices] baked ${prices.size} item prices`);
+		return { prices, fetchedAt: new Date() };
+	} catch (error) {
+		console.warn(
+			'[osrs/prices] snapshot fetch failed; pages will fall back to client-side pricing',
+			error,
+		);
+		return EMPTY;
+	}
+}
+
+export function getPriceSnapshot(): Promise<OSRSPriceSnapshot> {
+	snapshotPromise ??= fetchSnapshot();
+	return snapshotPromise;
+}
+
+export async function getPrice(id: number): Promise<OSRSPricePoint | null> {
+	const { prices } = await getPriceSnapshot();
+	return prices.get(id) ?? null;
+}
+
+export function averageOf(point: OSRSPricePoint | null): number | null {
+	if (!point) return null;
+	if (point.high !== null && point.low !== null) {
+		return Math.floor((point.high + point.low) / 2);
+	}
+	return point.high ?? point.low ?? null;
+}


### PR DESCRIPTION
## Problem

All 4,064 OSRS item pages served their market data as this:

```
Live GE Prices    Loading prices...
Price History     6H 24H 7D 30D    Loading price history...
```

`OSRSPriceWidget` and `OSRSCharts` are React islands whose initial state is `null`, so the server-rendered HTML is the loading branch. `/api/v1/osrs/{id}` works fine and returns live data — the widget isn't broken, it just only ever runs in a browser. The market data that makes per-item pages worth ranking never reaches the index.

That is the actual difference between these pages and GE-Tracker's. Same public wiki API behind both; theirs puts the numbers in the HTML.

## Approach

Bake at build, refresh on the client.

`src/data/osrs/prices.ts` fetches the wiki's bulk `latest` endpoint **once per build** and memoizes it in a module-level promise:

```
GET prices.runescape.wiki/api/v1/osrs/latest
HTTP 200  time=0.168s  bytes=341472  →  4517 raw entries, 4514 usable
```

One request covers the whole catalog. Each page gets a seed price rendered server-side; the island hydrates and overwrites it with live data, so visitors still see real-time numbers.

**Untraded items** report `high: 2147483647` (int32 max) rather than omitting a price. Those sanitize to `null` and fall back to the existing client-side behaviour — e.g. `3rd age axe` (id 20011) has no real trades and correctly bakes nothing.

**Failure is non-fatal.** An unreachable or non-200 API logs a warning and yields an empty snapshot; pages render exactly as they do today rather than failing the build.

## Consolidated families

This is where it matters most. 202 pages carry a `family` block covering 663 variant ids, and those variants price independently:

```
1215  Dragon dagger       high 17,500  low 17,170
1231  Dragon dagger(p)    high 17,617  low 17,617
5680  Dragon dagger(p+)   high 16,045  low 16,045
5698  Dragon dagger(p++)  high 17,999  low 17,902
```

`OSRSItemFamily` is titled "Variants & Prices" but the only prices in its HTML were static `value` / `highalch` from frontmatter — actual GE prices came from `<OSRSCharts client:visible />`, client-only again. Each variant now renders baked buy/sell directly in HTML, so `/osrs/dragon-dagger/` carries all four variants' real market data. The 308s from `/osrs/dragon-dagger-p/` stay as they are.

## Also

- GE buy/sell added to the item JSON-LD, plus `dateModified` from the snapshot timestamp — the structured data previously carried no market data and no freshness signal at all.
- Price widget moves `client:visible` → `client:load`. The seed can be up to a build old, so it should refresh promptly rather than waiting for intersection. Charts stay lazy.
- `suppressHydrationWarning` on the two relative-time nodes, since "3 hours ago" is computed at build and again at hydration.

## Verification

Snapshot parsing was validated against the live payload — sentinel filtering, id coercion, and per-variant lookups all confirmed against real data (numbers quoted above are from that run).

**The build itself was not run locally.** The worktree has no `node_modules`, symlinking the main tree's copy breaks Astro path resolution, and copying into the main tree was blocked. CI is the gate. Worth eyeballing on the preview:

- an item page's HTML contains real gp values with JS disabled
- a family page (`/osrs/dragon-dagger/`) shows four distinct variant prices
- the widget still refreshes to live numbers after hydration

## Follow-up, not in this PR

`related_items` slugs are wrong on family pages. In `dragon-dagger.mdx`, ids `5680` (p+) and `5698` (p++) both carry `slug: dragon-dagger-p`, while the family block gives them `dragon-dagger-p-5680` / `dragon-dagger-p-5698`. All three poison variants link to the same slug, which 308s back to the page the reader is already on. It's generated data, so it wants a fix at the generator rather than in 202 files by hand.

## Related

- #15295 — sitemap chain repair, gated routes de-indexed
- #15297 — homepage entity clarity