### PR TITLE
fix(palworld-savetool): support PlM Oodle-compressed saves

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -69,7 +69,7 @@
 		{
 			"key": "agones_palworld_savetool",
 			"app_name": "agones-palworld-savetool",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"version_toml": "apps/agones/palworld/savetool/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx",
 			"source_path": "apps/agones/palworld/savetool",
@@ -81,7 +81,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.270",
+			"version": "1.0.271",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/agones/palworld/savetool/requirements.txt
+++ b/apps/agones/palworld/savetool/requirements.txt
@@ -1,1 +1,2 @@
 palworld-save-tools==0.24.0
+pyooz==0.0.8

--- a/apps/agones/palworld/savetool/save_intel.py
+++ b/apps/agones/palworld/savetool/save_intel.py
@@ -22,9 +22,28 @@ def pv(node, *keys):
     return node
 
 
+def decompress_sav(data):
+    from palworld_save_tools.palsav import decompress_sav_to_gvas
+
+    magic = data[8:11]
+    if magic == b"PlZ":
+        raw, _ = decompress_sav_to_gvas(data)
+        return raw
+    if magic == b"PlM":
+        import ooz
+
+        uncompressed_len = int.from_bytes(data[0:4], "little")
+        compressed_len = int.from_bytes(data[4:8], "little")
+        save_type = data[11]
+        if save_type not in (0x31, 0x32):
+            raise ValueError(f"unknown PlM save type {save_type:#x}")
+        body = data[12 : 12 + compressed_len]
+        return bytes(ooz.decompress(body, uncompressed_len))
+    raise ValueError(f"unknown save magic {magic!r}")
+
+
 def parse_sav(path):
     from palworld_save_tools.gvas import GvasFile
-    from palworld_save_tools.palsav import decompress_sav_to_gvas
     from palworld_save_tools.paltypes import (
         PALWORLD_CUSTOM_PROPERTIES,
         PALWORLD_TYPE_HINTS,
@@ -35,7 +54,7 @@ def parse_sav(path):
     }
     with open(path, "rb") as f:
         data = f.read()
-    raw_gvas, _ = decompress_sav_to_gvas(data)
+    raw_gvas = decompress_sav(data)
     gvas = GvasFile.read(raw_gvas, PALWORLD_TYPE_HINTS, custom, allow_nan=True)
     return gvas.properties
 

--- a/apps/agones/palworld/savetool/test_save_intel.py
+++ b/apps/agones/palworld/savetool/test_save_intel.py
@@ -1,6 +1,30 @@
 import unittest
 
-from save_intel import extract_guilds
+from save_intel import decompress_sav, extract_guilds
+
+
+def sav_header(magic, save_type=0x31, body=b""):
+    return (
+        len(body).to_bytes(4, "little")
+        + len(body).to_bytes(4, "little")
+        + magic
+        + bytes([save_type])
+        + body
+    )
+
+
+class DecompressSavTest(unittest.TestCase):
+    def test_unknown_magic_raises(self):
+        with self.assertRaises(ValueError):
+            decompress_sav(sav_header(b"PlQ"))
+
+    def test_plm_unknown_type_raises(self):
+        with self.assertRaises(ValueError):
+            decompress_sav(sav_header(b"PlM", save_type=0x99))
+
+    def test_plm_dispatches_to_ooz(self):
+        with self.assertRaises(RuntimeError):
+            decompress_sav(sav_header(b"PlM", body=b"not-oodle-data"))
 
 
 def wrap(value):

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -14,7 +14,7 @@ tags:
 key: agones_palworld_savetool
 pipeline: docker
 app_name: agones-palworld-savetool
-version: "0.0.2"
+version: "0.0.3"
 source_path: apps/agones/palworld/savetool
 version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Problem

Savetool 0.0.2 deployed fine but `/live/bases` stays `available: false`. Sidecar logs show every parse cycle failing:

```
intel error: not a compressed Palworld save, found b'PlM' instead of b'PlZ'
```

Palworld ≥0.6 writes `Level.sav` with **Oodle** compression (`PlM` magic); `palworld-save-tools==0.24.0` only handles zlib `PlZ` (upstream Oodle support is still an open PR — [cheahjs/palworld-save-tools#215](https://github.com/cheahjs/palworld-save-tools/pull/215)).

## Fix

- `decompress_sav` dispatcher: `PlZ` → existing palworld-save-tools path; `PlM` → header `[u32 raw_len][u32 comp_len]PlM[type]` + `ooz.decompress` (open-source Oodle, `pyooz==0.0.8`, manylinux wheels)
- unknown magic / unknown PlM save-type raise with the actual bytes for future format bumps
- MDX `0.0.2 → 0.0.3`, manifest regenerated

## Verification

- 7/7 unit tests (new: magic dispatch, bad save-type, ooz path reached)
- image builds; `import ooz` OK inside the amd64 container
- real-save parse validation pending a backup copy from the cluster (unit tests can't fabricate an Oodle stream)