### PR TITLE
fix(arpg-e2e): unblock the weekly run and guard the laser barrel split

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -428,6 +428,21 @@ jobs:
                   echo "::warning::install-deps exhausted; trying install --with-deps"
                   pnpm exec playwright install --with-deps ${BROWSERS}
 
+            # Rust-backed e2e projects boot their server via `cargo run` as a
+            # playwright webServer. The agones crate's build script shells out to
+            # protoc, which no runner image ships — arpg-e2e died here on every
+            # weekly run since it was added. Non-Rust projects just skip it.
+            - name: Install protoc
+              run: |
+                  if command -v protoc >/dev/null 2>&1; then
+                    echo "protoc already present: $(protoc --version)"
+                    exit 0
+                  fi
+                  sudo apt-get update -qq \
+                    && sudo apt-get install -y --no-install-recommends protobuf-compiler \
+                    && protoc --version \
+                    || echo "::warning::protoc install failed; Rust e2e projects that need it will fail with a clear prost-build error"
+
             - name: Nx e2e ${{ inputs.project }}
               env:
                   BUILDKIT_PROGRESS: plain

--- a/apps/agones/arpg/arpg-e2e/playwright.config.ts
+++ b/apps/agones/arpg/arpg-e2e/playwright.config.ts
@@ -6,6 +6,10 @@ const workspaceRoot = resolve(__dirname, '../../../..');
 
 export default defineConfig({
 	testDir: './e2e',
+	// cdn.spec.ts asserts nginx container behavior (CORS, immutable cache headers,
+	// the hashed Discord bundle). This config serves the app from vite dev, where
+	// none of that exists — it belongs to playwright.cdn.config.ts alone.
+	testIgnore: 'cdn.spec.ts',
 	fullyParallel: true,
 	forbidOnly: !!process.env['CI'],
 	retries: process.env['CI'] ? 2 : 0,

--- a/packages/npm/laser/src/entrypoints.spec.ts
+++ b/packages/npm/laser/src/entrypoints.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guards the entry-point split. laser is consumed as SOURCE (tsconfig path +
+ * vite alias), so its bare imports resolve relative to packages/npm/laser, which
+ * has no node_modules. The repo root's hoisted tree masks that locally; a
+ * container's bounded install does not, and vite substitutes an optional-peer
+ * stub that rollup then dies on. That failure is always CI-only, and it landed
+ * four separate times (bitecs, phaser, @phaserjs/rapier-connector, drei) before
+ * the barrel was split. This asserts the split statically so a fifth import
+ * can't quietly re-widen an entry point.
+ */
+
+const SRC = __dirname;
+
+/** Non-optional peers. They are always installed, so they can never be stubbed. */
+const ALWAYS = ['react', 'react-dom'];
+
+/** Optional peers each entry point is allowed to reach. */
+const ALLOWED: Record<string, readonly string[]> = {
+	'index.ts': ['bitecs', 'fastnoise-lite'],
+	'ecs.ts': ['bitecs'],
+	'mecs.ts': [],
+	'phaser.ts': ['phaser', '@phaserjs/rapier-connector'],
+	'r3f.ts': ['three', '@react-three/fiber', '@react-three/drei'],
+};
+
+const BARE = /^[^./]/;
+
+function resolveRelative(fromFile: string, spec: string): string | null {
+	const base = path.resolve(path.dirname(fromFile), spec);
+	const candidates = [
+		base,
+		`${base}.ts`,
+		`${base}.tsx`,
+		path.join(base, 'index.ts'),
+		path.join(base, 'index.tsx'),
+	];
+	return (
+		candidates.find((c) => existsSync(c) && statSync(c).isFile()) ?? null
+	);
+}
+
+/**
+ * Bare specifiers reachable from `entry`, following relative imports. Type-only
+ * imports are erased before resolution, so they can't pull a peer at runtime and
+ * are excluded.
+ */
+function bareImports(entry: string): Set<string> {
+	const seen = new Set<string>();
+	const bare = new Set<string>();
+	const queue = [entry];
+
+	while (queue.length) {
+		const file = queue.pop()!;
+		if (seen.has(file)) continue;
+		seen.add(file);
+
+		const src = readFileSync(file, 'utf8');
+		const statements = src.matchAll(
+			/(?:^|\n)\s*(?:import|export)\s+([\s\S]*?)\s*from\s*['"]([^'"]+)['"]/g,
+		);
+
+		for (const [, clause, spec] of statements) {
+			if (/^\s*type\b/.test(clause)) continue;
+			if (BARE.test(spec)) {
+				// Subpath imports of a peer still pull the peer.
+				bare.add(
+					spec.startsWith('@')
+						? spec.split('/').slice(0, 2).join('/')
+						: spec.split('/')[0],
+				);
+				continue;
+			}
+			const next = resolveRelative(file, spec);
+			if (next) queue.push(next);
+		}
+
+		for (const [, spec] of src.matchAll(
+			/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+		)) {
+			if (BARE.test(spec)) {
+				bare.add(
+					spec.startsWith('@')
+						? spec.split('/').slice(0, 2).join('/')
+						: spec.split('/')[0],
+				);
+			} else {
+				const next = resolveRelative(file, spec);
+				if (next) queue.push(next);
+			}
+		}
+	}
+
+	return bare;
+}
+
+describe('laser entry points', () => {
+	for (const entry of Object.keys(ALLOWED)) {
+		it(`${entry} exists`, () => {
+			expect(existsSync(path.join(SRC, entry))).toBe(true);
+		});
+	}
+
+	for (const [entry, allowed] of Object.entries(ALLOWED)) {
+		it(`${entry} pulls no peer outside its declared set`, () => {
+			const leaked = [...bareImports(path.join(SRC, entry))]
+				.filter((s) => !s.startsWith('node:'))
+				.filter((s) => !ALWAYS.includes(s) && !allowed.includes(s))
+				.sort();
+
+			expect(
+				leaked,
+				`${entry} reaches ${leaked.join(', ')}. A module needing an optional ` +
+					`peer belongs behind a subpath entry, not in this one — see ` +
+					`package.json "exports".`,
+			).toEqual([]);
+		});
+	}
+
+	it('every exports subpath maps to a real entry file', () => {
+		const pkg = JSON.parse(
+			readFileSync(path.join(SRC, '..', 'package.json'), 'utf8'),
+		) as { exports: Record<string, unknown> };
+
+		for (const key of Object.keys(pkg.exports)) {
+			const name = key === '.' ? 'index.ts' : `${key.slice(2)}.ts`;
+			expect(
+				existsSync(path.join(SRC, name)),
+				`exports["${key}"] has no src/${name}`,
+			).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
Started as "tidy the arpg e2e loose ends" and turned up that the weekly suite has never actually run for arpg.

## 1. arpg-e2e has failed every weekly run since it was added

[CI - E2E](https://github.com/KBVE/kbve/actions/workflows/ci-e2e.yml) is `failure` for at least the last five weeks. The arpg-e2e row dies before a single test executes:

```
error: failed to run custom build command for `agones v1.59.0`
  panicked at agones-1.59.0/build.rs:18:10:
  failed to compile protobuffers: Could not find `protoc`.
```

`playwright.config.ts` boots the server as a webServer via `./kbve.sh -nx arpg-server:run` → `cargo run -p arpg-server`, and the `agones` crate's build script shells out to `protoc`. Neither `ubuntu-latest` nor the runner image ships it, and `docker-test-app.yml` never installed it.

Added an install step, no-op when protoc is already present, warning-not-fatal if apt is unavailable — a project that actually needs it still fails downstream with prost-build's own clear message.

## 2. The combined config was running a container-only spec against a dev server

Every sibling config declares a `testMatch`; `playwright.config.ts` was the only one that didn't, so it globbed all of `e2e/`:

```
playwright.config.ts       -> cdn.spec.ts, pilot.spec.ts, server.spec.ts, web.spec.ts
playwright.cdn.config.ts   -> cdn.spec.ts
playwright.server.config.ts-> server.spec.ts
playwright.web.config.ts   -> web.spec.ts
```

`cdn.spec.ts` asserts nginx container behavior — `access-control-allow-origin: *`, `immutable` cache headers, `/arpg-embed.js`, the hashed Discord bundle. This config serves from vite dev, where none of that exists. It would have kept the job red right after the protoc fix. Now scoped to the three specs that belong to it; `e2e:cdn` still owns `cdn.spec.ts` against the real image via `arpg:e2e`.

## 3. Static guard for the optional-peer leak

The bug that produced #15034 landed **four times** — `bitecs`, `phaser`, `@phaserjs/rapier-connector`, `@react-three/drei` — and each was CI-only, because the repo root's hoisted `node_modules` masks it locally while a container's bounded install does not. #15092 split the barrel; nothing stopped a fifth.

[`entrypoints.spec.ts`](packages/npm/laser/src/entrypoints.spec.ts) walks each entry's transitive *relative* imports and asserts the bare ones stay inside that entry's declared optional-peer set:

| Entry | Allowed optional peers |
|---|---|
| `index.ts` | bitecs, fastnoise-lite |
| `ecs.ts` | bitecs |
| `mecs.ts` | — |
| `phaser.ts` | phaser, @phaserjs/rapier-connector |
| `r3f.ts` | three, @react-three/fiber, @react-three/drei |

`react`/`react-dom` are non-optional peers, always installed, so they can never be stubbed and are allowed everywhere. Type-only imports are excluded — erased before resolution. Also asserts every `package.json` `exports` subpath has a real entry file.

Verified it catches the real thing by re-adding the exact #15034 import:

```
AssertionError: index.ts reaches @react-three/drei. A module needing an optional
peer belongs behind a subpath entry, not in this one — see package.json "exports".
```

40ms, versus finding out in a container build.

## Verified

- `laser:test` — 214 passed / 30 files (was 203)
- Config collection re-listed after the `testIgnore`, output above
- `docker-test-app.yml` parses