### PR TITLE
test(palworld-savetool): real-save e2e round-trip + coverage gate

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -75,8 +75,9 @@
 			"source_path": "apps/agones/palworld/savetool",
 			"runner": "ubuntu-latest",
 			"image": "kbve/agones-palworld-savetool",
+			"e2e_name": "agones-palworld-savetool",
 			"deployment_yaml": "apps/kube/agones/palworld/manifests/gameserver.yaml",
-			"has_test": false
+			"has_test": true
 		},
 		{
 			"key": "astro_kbve",

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ apps/**/unreal-*/Config/Local*.ini
 .husky/_/pre-push
 .husky/_/pre-commit
 .husky/_/pre-rebase
+.e2e-venv/

--- a/apps/agones/palworld/savetool/e2e_save_intel.py
+++ b/apps/agones/palworld/savetool/e2e_save_intel.py
@@ -1,0 +1,216 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+from save_intel import decompress_sav, find_level_sav, snapshot_once
+
+GUILD_ID = "11111111-2222-3333-4444-555555555555"
+BASE_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+PLAYER_UID = "99999999-8888-7777-6666-555555555555"
+
+HEADER = {
+    "magic": 0x53415647,
+    "save_game_version": 3,
+    "package_file_version_ue4": 522,
+    "package_file_version_ue5": 1008,
+    "engine_version_major": 5,
+    "engine_version_minor": 1,
+    "engine_version_patch": 1,
+    "engine_version_changelist": 0,
+    "engine_version_branch": "++UE5+Release-5.1",
+    "custom_version_format": 3,
+    "custom_versions": [],
+    "save_game_class_name": "/Script/Pal.PalWorldSaveGame",
+}
+
+
+def transform(x, y, z):
+    return {
+        "rotation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        "translation": {"x": x, "y": y, "z": z},
+        "scale3d": {"x": 1.0, "y": 1.0, "z": 1.0},
+    }
+
+
+def build_fixture_sav(path):
+    from palworld_save_tools.gvas import GvasFile
+    from palworld_save_tools.palsav import compress_gvas_to_sav
+    from palworld_save_tools.paltypes import PALWORLD_CUSTOM_PROPERTIES
+
+    properties = {
+        "worldSaveData": {
+            "type": "StructProperty",
+            "struct_type": "PalWorldSaveData",
+            "struct_id": "00000000-0000-0000-0000-000000000000",
+            "id": None,
+            "value": {
+                "GroupSaveDataMap": {
+                    "type": "MapProperty",
+                    "custom_type": ".worldSaveData.GroupSaveDataMap",
+                    "key_type": "StructProperty",
+                    "value_type": "StructProperty",
+                    "key_struct_type": "Guid",
+                    "value_struct_type": "PalGroupSaveDataMapStruct",
+                    "id": None,
+                    "value": [
+                        {
+                            "key": GUILD_ID,
+                            "value": {
+                                "GroupType": {
+                                    "type": "EnumProperty",
+                                    "value": {
+                                        "type": "EPalGroupType",
+                                        "value": "EPalGroupType::Guild",
+                                    },
+                                    "id": None,
+                                },
+                                "RawData": {
+                                    "type": "ArrayProperty",
+                                    "array_type": "ByteProperty",
+                                    "id": None,
+                                    "value": {
+                                        "group_type": "EPalGroupType::Guild",
+                                        "group_id": GUILD_ID,
+                                        "group_name": "test",
+                                        "individual_character_handle_ids": [
+                                            {
+                                                "guid": PLAYER_UID,
+                                                "instance_id": BASE_ID,
+                                            }
+                                        ],
+                                        "org_type": 0,
+                                        "base_ids": [BASE_ID],
+                                        "base_camp_level": 7,
+                                        "map_object_instance_ids_base_camp_points": [],
+                                        "guild_name": "KBVE-E2E",
+                                        "admin_player_uid": PLAYER_UID,
+                                        "players": [
+                                            {
+                                                "player_uid": PLAYER_UID,
+                                                "player_info": {
+                                                    "last_online_real_time": 638,
+                                                    "player_name": "h0lybyte",
+                                                },
+                                            }
+                                        ],
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+                "BaseCampSaveData": {
+                    "type": "MapProperty",
+                    "key_type": "StructProperty",
+                    "value_type": "StructProperty",
+                    "key_struct_type": "Guid",
+                    "value_struct_type": "PalBaseCampSaveData",
+                    "id": None,
+                    "value": [
+                        {
+                            "key": BASE_ID,
+                            "value": {
+                                "RawData": {
+                                    "type": "ArrayProperty",
+                                    "array_type": "ByteProperty",
+                                    "custom_type": ".worldSaveData.BaseCampSaveData.Value.RawData",
+                                    "id": None,
+                                    "value": {
+                                        "id": BASE_ID,
+                                        "name": "",
+                                        "state": 0,
+                                        "transform": transform(
+                                            -92930.7, 17885.2, 5000.0
+                                        ),
+                                        "area_range": 2700.0,
+                                        "group_id_belong_to": GUILD_ID,
+                                        "fast_travel_local_transform": transform(
+                                            0.0, 0.0, 0.0
+                                        ),
+                                        "owner_map_object_instance_id": BASE_ID,
+                                    },
+                                }
+                            },
+                        }
+                    ],
+                },
+            },
+        }
+    }
+    gvas = GvasFile.load(
+        {"header": HEADER, "properties": properties, "trailer": "AAAAAA=="}
+    )
+    sav = compress_gvas_to_sav(gvas.write(PALWORLD_CUSTOM_PROPERTIES), 0x32)
+    with open(path, "wb") as f:
+        f.write(sav)
+    return sav
+
+
+def expect(cond, label):
+    if not cond:
+        print(f"FAIL: {label}", file=sys.stderr)
+        sys.exit(1)
+    print(f"ok: {label}")
+
+
+def main():
+    workdir = tempfile.mkdtemp(prefix="savetool-e2e-")
+    nested = os.path.join(workdir, "SaveGames", "0", "world")
+    os.makedirs(nested)
+    sav_path = os.path.join(nested, "Level.sav")
+    build_fixture_sav(sav_path)
+
+    expect(
+        find_level_sav(os.path.join(workdir, "SaveGames")) == sav_path,
+        "find_level_sav locates nested Level.sav",
+    )
+
+    out_path = os.path.join(workdir, "bases.json")
+    snap = snapshot_once(sav_path, out_path)
+    expect(snap["guild_count"] == 1, "one guild extracted")
+    expect(snap["guilds"][0]["name"] == "KBVE-E2E", "guild name")
+    expect(snap["guilds"][0]["base_camp_level"] == 7, "camp level")
+    expect(snap["guilds"][0]["pal_handles"] == 1, "pal handle count")
+    base = snap["guilds"][0]["bases"][0]
+    expect(abs(base["x"] - -92930.7) < 0.01, "base x coordinate")
+    expect(abs(base["y"] - 17885.2) < 0.01, "base y coordinate")
+    roster = snap["guilds"][0]["players"]
+    expect(
+        roster == [{"uid": PLAYER_UID, "name": "h0lybyte", "last_online": 638}],
+        "player roster",
+    )
+    with open(out_path) as f:
+        disk = json.load(f)
+    expect(disk["guilds"][0]["id"] == GUILD_ID, "atomic JSON written to disk")
+
+    cli = subprocess.run(
+        [sys.executable, "save_intel.py", "--sav", sav_path, "--out", "-"],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+    )
+    expect(cli.returncode == 0, "CLI exits 0")
+    expect(
+        json.loads(cli.stdout)["guilds"][0]["name"] == "KBVE-E2E",
+        "CLI stdout JSON",
+    )
+
+    plm = (
+        (100).to_bytes(4, "little")
+        + (14).to_bytes(4, "little")
+        + b"PlM\x31"
+        + b"not-oodle-data"
+    )
+    try:
+        decompress_sav(plm)
+        expect(False, "PlM garbage rejected")
+    except RuntimeError:
+        expect(True, "PlM path reaches oodle decoder")
+
+    print("e2e: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/agones/palworld/savetool/project.json
+++ b/apps/agones/palworld/savetool/project.json
@@ -11,6 +11,25 @@
 				"command": "python3 -m unittest discover ."
 			}
 		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"cwd": "apps/agones/palworld/savetool",
+				"parallel": false,
+				"commands": [
+					"rm -rf .e2e-venv && python3 -m venv .e2e-venv",
+					".e2e-venv/bin/pip install --quiet -r requirements.txt coverage",
+					".e2e-venv/bin/python -m coverage run --source=save_intel -m unittest discover .",
+					".e2e-venv/bin/python -m coverage run --append --source=save_intel e2e_save_intel.py",
+					".e2e-venv/bin/python -m coverage report --show-missing --fail-under=70"
+				]
+			},
+			"configurations": {
+				"local": {},
+				"ci": {}
+			}
+		},
 		"container": {
 			"executor": "nx:run-commands",
 			"defaultConfiguration": "local",

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -20,7 +20,8 @@ version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest
 image: kbve/agones-palworld-savetool
 deployment_yaml: apps/kube/agones/palworld/manifests/gameserver.yaml
-has_test: false
+has_test: true
+e2e_name: agones-palworld-savetool
 author: h0lybyte
 ---
 


### PR DESCRIPTION
## Why

The PlM regression (#15302) shipped because tests only covered synthetic dicts — no code path ever touched an actual `.sav`. This adds the missing end-to-end layer.

## What

- **`e2e_save_intel.py`** — builds a genuine `Level.sav` at test time: fixture world (guild `KBVE-E2E`, member, base camp at known coords) encoded through palworld-save-tools' own `GroupSaveDataMap`/`BaseCampSaveData` binary codecs, zlib-compressed via `compress_gvas_to_sav`. Then asserts 13 checks: `find_level_sav` nested discovery, `snapshot_once` extraction (guild/roster/coords/camp level/pal handles), atomic disk write, CLI subprocess exit + stdout JSON, and that a `PlM`-magic header actually reaches the oodle decoder.
- **nx `e2e` target** (`local`/`ci` configurations) — fresh venv, unittest + e2e both under `coverage`, combined report gated at `--fail-under=70` (currently 71%).
- **MDX**: `has_test: true` + `e2e_name: agones-palworld-savetool` → the docker CI Test stage (`pnpm nx e2e … --configuration=ci`) now runs this on every release build. Manifest regenerated.
- `.e2e-venv/` gitignored.

No version bump — test-only; the gate exercises it on the next release.

## Limitation

A real Oodle stream still can't be fabricated (pyooz decompresses only), so the PlM branch is covered to the decoder boundary. A cluster-save fixture can tighten that later.