### PR TITLE
perf(herbmail-game): walk tile cells for occluder visibility instead of fixed steps

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
+++ b/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
@@ -10,6 +10,7 @@ import {
 import { LIGHT_RANGE, TILE } from '../config';
 import { NEAR_D0, NEAR_D1 } from './bake/bakeTypes';
 import { MAX_CAPS } from './charShadow';
+import { OCC_CELLS, OCC_NEAR, OCC_REACH } from './occMarch';
 
 const blankTex = new THREE.DataTexture(
 	new Uint8Array(1),
@@ -81,7 +82,17 @@ const fragment = /* glsl */ `
 	#define LIGHT_RANGE ${LIGHT_RANGE.toFixed(1)}
 	#define NEAR_D0 ${NEAR_D0.toFixed(1)}
 	#define NEAR_D1 ${NEAR_D1.toFixed(1)}
-	#define OCC_STEPS 34
+	// Where the occluder march starts and stops, in world units. These are the
+	// bounds of the fixed 0.32-step loop the cell walk replaced (its first and
+	// last sample, 0.5 and 0.5 + 33*0.32) and are kept verbatim so lighting reach
+	// is unchanged — LIGHT_RANGE is 18, so the far third of a distant light's ray
+	// was never tested for occluders and still is not.
+	#define OCC_NEAR ${OCC_NEAR.toFixed(2)}
+	#define OCC_REACH ${OCC_REACH.toFixed(2)}
+	// Cells a ray can enter over OCC_REACH: at most ceil(span/GRID_TILE) on each
+	// axis plus one, with headroom for the diagonal case.
+	#define OCC_CELLS ${OCC_CELLS}
+	#define OCC_FAR 1e9
 	#define MAX_CAPS ${MAX_CAPS}
 	// Only the nearest lights throw character shadows. A third torch's copy of
 	// the same body reads as mush and costs another N capsule tests.
@@ -147,13 +158,12 @@ const fragment = /* glsl */ `
 	${SPOM_SILHOUETTE}
 	${POM_SELF_SHADOW}
 
-	float tileAtWorld(vec2 p) {
-		vec2 local = (p - uGridOrigin) / GRID_TILE;
-		float col = floor(local.x);
-		float row = floor(local.y);
-		if (col < 0.0 || row < 0.0 || col >= uGridSize.x || row >= uGridSize.y) return 0.0;
-		vec2 uvp = (vec2(col, row) + 0.5) / uGridSize;
-		return texture2D(uMapTex, uvp).r;
+	// Occluder lookup by grid cell rather than by world point: the march below
+	// walks cells directly, so it already knows which one it is in and has no
+	// reason to re-derive it from a position.
+	float tileAtCell(vec2 c) {
+		if (c.x < 0.0 || c.y < 0.0 || c.x >= uGridSize.x || c.y >= uGridSize.y) return 0.0;
+		return texture2D(uMapTex, (c + 0.5) / uGridSize).r;
 	}
 
 	// Open-sky exposure (G channel of the tile grid): 1 inside an oasis room, 0
@@ -218,16 +228,55 @@ const fragment = /* glsl */ `
 		return v;
 	}
 
+	// The tile grid is piecewise constant over GRID_TILE-sized cells, so the old
+	// fixed 0.32-unit march resampled the same cell about nine times before
+	// crossing into the next: up to 34 texture fetches per light per fragment to
+	// read at most four distinct cells. This walks cell boundaries instead
+	// (Amanatides-Woo), touching each cell the ray actually enters exactly once.
+	//
+	// Reach stays capped at what the fixed march covered — OCC_REACH, its last
+	// sample — so lights further away keep their unshadowed far field rather
+	// than suddenly picking up walls the old loop never reached.
+	//
+	// Not a pure speedup: a fixed step could stride over a cell the ray only
+	// clips, and this cannot, so corners that used to leak light now occlude.
+	// The set of cells tested is a superset of the old one, never a subset, so
+	// the change only ever adds shadow.
 	float visibility(vec2 frag, vec2 lp) {
 		vec2 d = lp - frag;
 		float len = length(d);
 		if (len < 0.6) return 1.0;
 		vec2 dir = d / len;
-		float end = len - 0.45;
-		for (int k = 0; k < OCC_STEPS; k++) {
-			float s = 0.5 + float(k) * 0.32;
-			if (s >= end) break;
-			if (tileAtWorld(frag + dir * s) > 0.75) return 0.0;
+		float travel = min(len - 0.45, OCC_REACH) - OCC_NEAR;
+		if (travel <= 0.0) return 1.0;
+
+		vec2 g = (frag + dir * OCC_NEAR - uGridOrigin) / GRID_TILE;
+		vec2 gd = dir / GRID_TILE;
+		vec2 cell = floor(g);
+		vec2 stp = sign(gd);
+		// An axis the ray does not move along never crosses a boundary; a huge
+		// tDelta keeps it from ever winning the min() below.
+		vec2 tDelta = vec2(
+			gd.x != 0.0 ? abs(1.0 / gd.x) : OCC_FAR,
+			gd.y != 0.0 ? abs(1.0 / gd.y) : OCC_FAR
+		);
+		vec2 tMax = vec2(
+			gd.x > 0.0 ? (cell.x + 1.0 - g.x) / gd.x
+				: (gd.x < 0.0 ? (cell.x - g.x) / gd.x : OCC_FAR),
+			gd.y > 0.0 ? (cell.y + 1.0 - g.y) / gd.y
+				: (gd.y < 0.0 ? (cell.y - g.y) / gd.y : OCC_FAR)
+		);
+
+		for (int k = 0; k < OCC_CELLS; k++) {
+			if (tileAtCell(cell) > 0.75) return 0.0;
+			if (min(tMax.x, tMax.y) >= travel) break;
+			if (tMax.x < tMax.y) {
+				cell.x += stp.x;
+				tMax.x += tDelta.x;
+			} else {
+				cell.y += stp.y;
+				tMax.y += tDelta.y;
+			}
 		}
 		return 1.0;
 	}

--- a/apps/herbmail/herbmail-game/src/game/render/occMarch.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/render/occMarch.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { TILE } from '../config';
+import {
+	OCC_CELLS,
+	OCC_NEAR,
+	OCC_REACH,
+	fixedStepCells,
+	marchCells,
+	type Cell,
+} from './occMarch';
+
+const key = (c: Cell) => `${c.x},${c.y}`;
+
+// Deterministic spread of rays: angles that hit axis-aligned, diagonal and
+// generic cases, over lengths short enough to terminate early and long enough
+// to clip OCC_REACH.
+function rays(): Array<[number, number, number, number]> {
+	const out: Array<[number, number, number, number]> = [];
+	const origins = [
+		[0, 0],
+		[1.5, 1.5],
+		[-4.25, 7.75],
+		[TILE, TILE * 2],
+		[0.01, -0.01],
+	];
+	for (const [ox, oy] of origins) {
+		for (let a = 0; a < 32; a++) {
+			const th = (a / 32) * Math.PI * 2;
+			for (const len of [0.7, 1.4, 3, 6.5, 11, 14, 25]) {
+				out.push([
+					ox,
+					oy,
+					ox + Math.cos(th) * len,
+					oy + Math.sin(th) * len,
+				]);
+			}
+		}
+	}
+	return out;
+}
+
+describe('occluder march', () => {
+	// The safety property. The walk may test cells the fixed step strode over —
+	// that is the point, corners stop leaking — but it must never miss one the
+	// old loop checked, or shadows would disappear rather than appear.
+	it('tests every cell the fixed-step march tested', () => {
+		for (const [fx, fy, lx, ly] of rays()) {
+			const walked = new Set(marchCells(fx, fy, lx, ly, 0, 0).map(key));
+			for (const c of fixedStepCells(fx, fy, lx, ly, 0, 0)) {
+				expect(walked.has(key(c))).toBe(true);
+			}
+		}
+	});
+
+	it('never exceeds the loop bound the shader compiles with', () => {
+		for (const [fx, fy, lx, ly] of rays()) {
+			expect(marchCells(fx, fy, lx, ly, 0, 0).length).toBeLessThanOrEqual(
+				OCC_CELLS,
+			);
+		}
+	});
+
+	it('visits each cell at most once', () => {
+		for (const [fx, fy, lx, ly] of rays()) {
+			const cells = marchCells(fx, fy, lx, ly, 0, 0);
+			expect(new Set(cells.map(key)).size).toBe(cells.length);
+		}
+	});
+
+	// Adjacent in the traversal means sharing an edge. A jump of more than one
+	// cell would mean skipping a wall the ray passed through.
+	it('walks a connected path', () => {
+		for (const [fx, fy, lx, ly] of rays()) {
+			const cells = marchCells(fx, fy, lx, ly, 0, 0);
+			for (let i = 1; i < cells.length; i++) {
+				const d =
+					Math.abs(cells[i].x - cells[i - 1].x) +
+					Math.abs(cells[i].y - cells[i - 1].y);
+				expect(d).toBe(1);
+			}
+		}
+	});
+
+	it('starts in the cell containing the near bound', () => {
+		for (const [fx, fy, lx, ly] of rays()) {
+			const cells = marchCells(fx, fy, lx, ly, 0, 0);
+			if (!cells.length) continue;
+			const len = Math.hypot(lx - fx, ly - fy);
+			const ux = (lx - fx) / len;
+			const uy = (ly - fy) / len;
+			expect(cells[0]).toEqual({
+				x: Math.floor((fx + ux * OCC_NEAR) / TILE),
+				y: Math.floor((fy + uy * OCC_NEAR) / TILE),
+			});
+		}
+	});
+
+	// Reach is the whole reason far-off geometry does not suddenly start casting
+	// shadows: a light 18 units away is only marched for the first ~11.
+	it('stops at OCC_REACH regardless of how far the light is', () => {
+		const far = marchCells(0, 0, 100, 0, 0, 0);
+		const atReach = marchCells(0, 0, OCC_REACH + 0.45, 0, 0, 0);
+		expect(far.length).toBe(atReach.length);
+		expect(far[far.length - 1].x * TILE).toBeLessThanOrEqual(OCC_REACH);
+	});
+
+	it('returns nothing for lights inside the near cutoff', () => {
+		expect(marchCells(0, 0, 0.5, 0, 0, 0)).toEqual([]);
+		expect(fixedStepCells(0, 0, 0.5, 0, 0, 0)).toEqual([]);
+	});
+
+	// The win being claimed, stated as a test so it cannot silently regress.
+	it('touches far fewer cells than the fixed step took samples', () => {
+		let walked = 0;
+		let stepped = 0;
+		for (const [fx, fy, lx, ly] of rays()) {
+			walked += marchCells(fx, fy, lx, ly, 0, 0).length;
+			stepped += fixedStepCells(fx, fy, lx, ly, 0, 0).length;
+		}
+		expect(walked * 3).toBeLessThan(stepped);
+	});
+
+	// Translating the ray and the grid origin together must not change which
+	// cells the ray occupies.
+	//
+	// Rays that begin within an epsilon of a cell boundary are excluded, and the
+	// exact step order is not asserted. Both are floating point, not algorithm:
+	// a start point whose true grid coordinate is 0 picks up a ~1e-16 term that
+	// the shift's add-then-subtract absorbs, flipping the sign floor() sees; and
+	// where a ray crosses precisely through a corner, tMax ties and rounding
+	// decides which axis steps first. The old fixed march used the same floor()
+	// and was ambiguous at boundaries in exactly the same way, so neither is a
+	// property this change is free to guarantee.
+	it('respects a shifted grid origin', () => {
+		const ox = -12.5;
+		const oy = 6.25;
+		const EPS = 1e-9;
+		const onBoundary = (v: number) => {
+			const m = Math.abs(v / TILE - Math.round(v / TILE));
+			return m < EPS;
+		};
+
+		let checked = 0;
+		for (const [fx, fy, lx, ly] of rays()) {
+			const len = Math.hypot(lx - fx, ly - fy);
+			if (len < 0.6) continue;
+			const sx = fx + ((lx - fx) / len) * OCC_NEAR;
+			const sy = fy + ((ly - fy) / len) * OCC_NEAR;
+			if (onBoundary(sx) || onBoundary(sy)) continue;
+
+			const base = marchCells(fx, fy, lx, ly, 0, 0);
+			const shifted = marchCells(
+				fx + ox,
+				fy + oy,
+				lx + ox,
+				ly + oy,
+				ox,
+				oy,
+			);
+			expect(shifted.length).toBe(base.length);
+			if (!base.length) continue;
+			expect(shifted[0]).toEqual(base[0]);
+			expect(shifted[shifted.length - 1]).toEqual(base[base.length - 1]);
+			checked++;
+		}
+		expect(checked).toBeGreaterThan(100);
+	});
+});

--- a/apps/herbmail/herbmail-game/src/game/render/occMarch.ts
+++ b/apps/herbmail/herbmail-game/src/game/render/occMarch.ts
@@ -1,0 +1,97 @@
+import { TILE } from '../config';
+
+// Bounds of the occluder march in world units, carried over verbatim from the
+// fixed 0.32-step loop the cell walk replaced: its first sample sat at 0.5 and
+// its last at 0.5 + 33*0.32. LIGHT_RANGE is 18, so a distant light's ray was
+// never tested past OCC_REACH and still is not — keeping these exact is what
+// stops the change from pulling far-off walls into shadow.
+export const OCC_NEAR = 0.5;
+export const OCC_REACH = 0.5 + 33 * 0.32;
+
+// Cells a ray can enter across the span. A ray crossing n tiles on each axis
+// touches at most 2n+1 of them, plus headroom for the exact-diagonal case where
+// both boundaries fall on the same parameter.
+const SPAN_TILES = Math.ceil((OCC_REACH - OCC_NEAR) / TILE);
+export const OCC_CELLS = SPAN_TILES * 2 + 4;
+
+export interface Cell {
+	x: number;
+	y: number;
+}
+
+// The cells the old fixed-step loop actually sampled. Kept so the walk below can
+// be checked against it rather than against a restatement of itself.
+export function fixedStepCells(
+	fx: number,
+	fy: number,
+	lx: number,
+	ly: number,
+	originX: number,
+	originY: number,
+): Cell[] {
+	const dx = lx - fx;
+	const dy = ly - fy;
+	const len = Math.hypot(dx, dy);
+	if (len < 0.6) return [];
+	const ux = dx / len;
+	const uy = dy / len;
+	const end = len - 0.45;
+	const out: Cell[] = [];
+	for (let k = 0; k < 34; k++) {
+		const s = OCC_NEAR + k * 0.32;
+		if (s >= end) break;
+		out.push({
+			x: Math.floor((fx + ux * s - originX) / TILE),
+			y: Math.floor((fy + uy * s - originY) / TILE),
+		});
+	}
+	return out;
+}
+
+// Amanatides-Woo grid traversal, mirroring the GLSL in PsxMaterial's
+// visibility(). Every cell the segment passes through, each visited once.
+export function marchCells(
+	fx: number,
+	fy: number,
+	lx: number,
+	ly: number,
+	originX: number,
+	originY: number,
+): Cell[] {
+	const dx = lx - fx;
+	const dy = ly - fy;
+	const len = Math.hypot(dx, dy);
+	if (len < 0.6) return [];
+	const ux = dx / len;
+	const uy = dy / len;
+	const travel = Math.min(len - 0.45, OCC_REACH) - OCC_NEAR;
+	if (travel <= 0) return [];
+
+	const gx = (fx + ux * OCC_NEAR - originX) / TILE;
+	const gy = (fy + uy * OCC_NEAR - originY) / TILE;
+	const gdx = ux / TILE;
+	const gdy = uy / TILE;
+	let cx = Math.floor(gx);
+	let cy = Math.floor(gy);
+	const sx = Math.sign(gdx);
+	const sy = Math.sign(gdy);
+	const FAR = 1e9;
+	const tdx = gdx !== 0 ? Math.abs(1 / gdx) : FAR;
+	const tdy = gdy !== 0 ? Math.abs(1 / gdy) : FAR;
+	let tmx = gdx > 0 ? (cx + 1 - gx) / gdx : gdx < 0 ? (cx - gx) / gdx : FAR;
+	let tmy = gdy > 0 ? (cy + 1 - gy) / gdy : gdy < 0 ? (cy - gy) / gdy : FAR;
+
+	const out: Cell[] = [];
+	for (let k = 0; k < OCC_CELLS; k++) {
+		out.push({ x: cx, y: cy });
+		if (Math.min(tmx, tmy) >= travel) break;
+		if (tmx < tmy) {
+			cx += sx;
+			tmx += tdx;
+		} else {
+			cy += sy;
+			tmy += tdy;
+		}
+	}
+	return out;
+}


### PR DESCRIPTION
Follow-up to #15283, which flagged this as the biggest remaining GPU item.

## The redundancy

`visibility()` marched the tile grid at a fixed **0.32 world units per step**. Tiles are **3 units** across, so the same cell was resampled about nine times before the ray crossed into the next — up to 34 texture fetches per light per fragment to read at most four distinct cells.

Real-hardware telemetry (`__frames.work()`, GPU timer queries, 0 disjoints) puts the game GPU-bound:

```
cpu  p50 5.47   p95 7.82   max 9.33   over16: 0
gpu  p50 8.17   p95 11.27  p99 12.49  max 15.93
```

## The change

Amanatides-Woo grid traversal — visit each cell the ray actually enters, exactly once. Over 20k randomised rays:

| | fixed step | cell walk |
|---|---|---|
| fetches per ray, avg | 22.96 | **4.02** |
| fetches per ray, worst | 34 | **7** |

**5.71×.**

Reach is unchanged: `OCC_NEAR` and `OCC_REACH` are the old loop's first and last sample (0.5 and 0.5 + 33×0.32) carried over verbatim, so the far third of a distant light's ray stays untested for occluders exactly as before, rather than suddenly picking up walls out at `LIGHT_RANGE` (18).

## This is not a pure speedup

A fixed step can stride over a cell the ray only clips; a cell walk cannot. **Corners that used to leak light now occlude.** The cells tested are a superset of the old set, never a subset — so the change only ever *adds* shadow, never removes it. That superset property is the first test in the suite.

A/B against the old shader at a fixed seed (`DUNGEON_SEED = 1337`), same spawn, no movement:

| comparison | pixels differing | mean luminance |
|---|---|---|
| new build vs itself (flicker noise) | 1.04% | +2.38% |
| old build vs itself (flicker noise) | 0.49% | +0.12% |
| **old vs new** | **0.58–0.83%** | **−0.12% / −2.32%** |

The old-vs-new difference sits **inside** the band two runs of the *same* build differ by from torch flicker alone. No visible change at that vantage point — though only one camera position in one room was sampled, and corner leaks are scene-specific, so this is evidence rather than proof.

## Testing

The traversal is mirrored in TypeScript (`occMarch.ts`) so it can actually be tested rather than eyeballed. 9 cases: the superset property against the old loop transcribed verbatim, the loop bound the shader compiles with, connectivity, single-visit, start cell, the reach cap, and origin shift.

Two of those tests initially failed and both were the test over-specifying, not the algorithm — worth recording:

- **Corner ties.** Where a ray passes exactly through a cell corner, `tMax.x == tMax.y` and which axis steps first is decided by floating-point rounding. Both orders traverse the same corner and reach the same cell.
- **Boundary starts.** A start point whose true grid coordinate is 0 picks up a ~1e-16 term that the shift's add-then-subtract absorbs, flipping the sign `floor()` sees. The old `tileAtWorld` used the same `floor()` and was ambiguous at boundaries identically — not a property this change is free to guarantee either way.

Both are documented in the test file rather than silently tolerated.

158 unit tests, 12 e2e, lint clean.