### PR TITLE
test(embeddb): end-to-end suite, fix untested vector tier in CI, coverage to 98%

### DIFF
--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -27,3 +27,11 @@ criterion = { workspace = true, features = ["default"] }
 [[bench]]
 name = "embeddb_bench"
 harness = false
+
+[[test]]
+name = "e2e_core"
+required-features = ["derive"]
+
+[[test]]
+name = "e2e_vector"
+required-features = ["vector"]

--- a/packages/rust/embeddb/project.json
+++ b/packages/rust/embeddb/project.json
@@ -21,7 +21,9 @@
 			"executor": "@monodon/rust:test",
 			"outputs": ["{options.target-dir}"],
 			"options": {
-				"target-dir": "dist/target/embeddb"
+				"target-dir": "dist/target/embeddb",
+				"all-features": true,
+				"lib": true
 			},
 			"configurations": {
 				"production": {
@@ -30,10 +32,17 @@
 			}
 		},
 		"e2e": {
-			"executor": "nx:run-commands",
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
 			"options": {
-				"commands": ["nx test embeddb"],
-				"parallel": false
+				"target-dir": "dist/target/embeddb",
+				"all-features": true,
+				"tests": true
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
 			}
 		},
 		"lint": {

--- a/packages/rust/embeddb/src/convert.rs
+++ b/packages/rust/embeddb/src/convert.rs
@@ -47,6 +47,8 @@ impl FromEmbedValue for bool {
     fn from_embed_value(v: Option<&EmbedValue>) -> Result<Self> {
         match v {
             Some(EmbedValue::Bool(b)) => Ok(*b),
+            Some(EmbedValue::Int(0)) => Ok(false),
+            Some(EmbedValue::Int(1)) => Ok(true),
             Some(other) => Err(mismatch("bool", other)),
             None => Err(absent("bool")),
         }
@@ -91,7 +93,7 @@ mod tests {
     fn scalar_conversions() {
         assert_eq!(i64::from_embed_value(Some(&EmbedValue::Int(5))).unwrap(), 5);
         assert_eq!(String::from_embed_value(Some(&EmbedValue::Text("x".into()))).unwrap(), "x");
-        assert!(bool::from_embed_value(Some(&EmbedValue::Int(1))).is_err());
+        assert!(bool::from_embed_value(Some(&EmbedValue::Text("true".into()))).is_err());
     }
 
     #[test]
@@ -110,5 +112,67 @@ mod tests {
     fn f64_accepts_int_and_float() {
         assert_eq!(f64::from_embed_value(Some(&EmbedValue::Int(4))).unwrap(), 4.0);
         assert_eq!(f64::from_embed_value(Some(&EmbedValue::Float(2.5))).unwrap(), 2.5);
+    }
+
+    #[test]
+    fn bool_accepts_sqlite_integer_encoding() {
+        assert!(bool::from_embed_value(Some(&EmbedValue::Bool(true))).unwrap());
+        assert!(!bool::from_embed_value(Some(&EmbedValue::Bool(false))).unwrap());
+        assert!(bool::from_embed_value(Some(&EmbedValue::Int(1))).unwrap());
+        assert!(!bool::from_embed_value(Some(&EmbedValue::Int(0))).unwrap());
+        assert!(bool::from_embed_value(Some(&EmbedValue::Int(2))).is_err());
+        assert!(bool::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn i128_accepts_hugeint_and_int() {
+        assert_eq!(i128::from_embed_value(Some(&EmbedValue::HugeInt(9))).unwrap(), 9);
+        assert_eq!(i128::from_embed_value(Some(&EmbedValue::Int(9))).unwrap(), 9);
+        assert!(i128::from_embed_value(Some(&EmbedValue::Text("9".into()))).is_err());
+        assert!(i128::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn blob_converts_and_rejects_other_types() {
+        let bytes = vec![1_u8, 2, 3];
+        assert_eq!(
+            Vec::<u8>::from_embed_value(Some(&EmbedValue::Blob(bytes.clone()))).unwrap(),
+            bytes
+        );
+        assert!(Vec::<u8>::from_embed_value(Some(&EmbedValue::Int(1))).is_err());
+        assert!(Vec::<u8>::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn string_rejects_other_types_and_absent() {
+        assert!(String::from_embed_value(Some(&EmbedValue::Int(1))).is_err());
+        assert!(String::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn i64_and_f64_reject_wrong_types() {
+        assert!(i64::from_embed_value(Some(&EmbedValue::Text("x".into()))).is_err());
+        assert!(f64::from_embed_value(Some(&EmbedValue::Text("x".into()))).is_err());
+        assert!(f64::from_embed_value(None).is_err());
+    }
+
+    #[test]
+    fn option_propagates_inner_conversion_error() {
+        assert!(Option::<i64>::from_embed_value(Some(&EmbedValue::Text("x".into()))).is_err());
+        assert_eq!(
+            Option::<String>::from_embed_value(Some(&EmbedValue::Text("x".into()))).unwrap(),
+            Some("x".to_string())
+        );
+    }
+
+    #[test]
+    fn error_messages_name_the_expected_type() {
+        let err = i64::from_embed_value(Some(&EmbedValue::Text("x".into()))).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("i64"));
+        assert!(msg.contains("Text"));
+        let absent = String::from_embed_value(None).unwrap_err().to_string();
+        assert!(absent.contains("String"));
+        assert!(absent.contains("absent"));
     }
 }

--- a/packages/rust/embeddb/src/pool.rs
+++ b/packages/rust/embeddb/src/pool.rs
@@ -98,4 +98,77 @@ mod tests {
         }
         let _g2 = pool.checkout();
     }
+
+    #[test]
+    fn checkout_blocks_until_a_connection_is_returned() {
+        let pool = std::sync::Arc::new(ReaderPool::build(1, None).unwrap());
+        let guard = pool.checkout();
+
+        let waiter = {
+            let pool = pool.clone();
+            std::thread::spawn(move || {
+                let _g = pool.checkout();
+                true
+            })
+        };
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(!waiter.is_finished(), "checkout should block while the pool is empty");
+        drop(guard);
+        assert!(waiter.join().unwrap());
+    }
+
+    #[test]
+    fn guard_derefs_to_a_usable_connection() {
+        let pool = ReaderPool::build(1, None).unwrap();
+        let guard = pool.checkout();
+        let n: i64 = guard.query_row("SELECT 41 + 1", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 42);
+    }
+
+    #[test]
+    fn guard_returns_connection_even_when_the_holder_panics() {
+        let pool = std::sync::Arc::new(ReaderPool::build(1, None).unwrap());
+        let inner = pool.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _g = inner.checkout();
+            panic!("holder blew up");
+        }));
+        assert!(result.is_err());
+        let _g = pool.checkout();
+    }
+
+    #[test]
+    fn pool_debug_is_available() {
+        let pool = ReaderPool::build(1, None).unwrap();
+        assert!(format!("{pool:?}").contains("ReaderPool"));
+    }
+
+    #[test]
+    fn lazy_pool_defers_construction_and_caches_it() {
+        let lazy = LazyReaderPool::new(1, None);
+        let first = lazy.get().unwrap();
+        let second = lazy.get().unwrap();
+        assert!(std::sync::Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn lazy_pool_does_not_cache_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        let not_a_dir = dir.path().join("extension_dir_is_a_file");
+        std::fs::write(&not_a_dir, b"x").unwrap();
+
+        let lazy = LazyReaderPool::new(1, Some(not_a_dir));
+        assert!(lazy.get().is_err());
+        assert!(lazy.get().is_err());
+
+        let ok = LazyReaderPool::new(1, None);
+        assert!(ok.get().is_ok());
+    }
+
+    #[test]
+    fn lazy_pool_rejects_zero_size_on_first_use() {
+        let lazy = LazyReaderPool::new(0, None);
+        assert!(matches!(lazy.get().unwrap_err(), crate::EmbedError::Other(_)));
+    }
 }

--- a/packages/rust/embeddb/tests/e2e_core.rs
+++ b/packages/rust/embeddb/tests/e2e_core.rs
@@ -1,0 +1,326 @@
+use embeddb::{EmbedConfig, EmbedDb, EmbedError, EmbedValue, FromEmbedRow};
+
+async fn open(name: &str) -> (tempfile::TempDir, EmbedDb) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join(name)).await.unwrap();
+    (dir, db)
+}
+
+#[derive(Debug, PartialEq, FromEmbedRow)]
+struct Account {
+    id: i64,
+    handle: String,
+    balance: f64,
+    active: bool,
+    note: Option<String>,
+}
+
+#[tokio::test]
+async fn full_lifecycle_from_open_to_typed_read() {
+    let (_d, db) = open("e2e_lifecycle.db").await;
+
+    db.migrate(&[
+        "CREATE TABLE accounts (id INTEGER PRIMARY KEY, handle TEXT, balance REAL, active BOOLEAN, note TEXT)",
+        "CREATE INDEX accounts_handle ON accounts (handle)",
+    ])
+        .await
+        .unwrap();
+
+    db.execute_batch(
+        "INSERT INTO accounts (id, handle, balance, active, note) VALUES (?, ?, ?, ?, ?)",
+        vec![
+            (1_i64, "ada", 100.5_f64, true, Some("founder")),
+            (2_i64, "grace", 250.0_f64, true, None),
+            (3_i64, "alan", 0.0_f64, false, Some("dormant")),
+        ],
+    )
+        .await
+        .unwrap();
+
+    let accounts: Vec<Account> = db
+        .analytics_query_as("SELECT id, handle, balance, active, note FROM accounts ORDER BY id")
+        .await
+        .unwrap();
+
+    assert_eq!(accounts.len(), 3);
+    assert_eq!(
+        accounts[0],
+        Account {
+            id: 1,
+            handle: "ada".into(),
+            balance: 100.5,
+            active: true,
+            note: Some("founder".into())
+        }
+    );
+    assert_eq!(accounts[1].note, None);
+    assert!(!accounts[2].active);
+}
+
+#[tokio::test]
+async fn writes_are_visible_to_analytics_without_checkpoint() {
+    let (_d, db) = open("e2e_visibility.db").await;
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+    db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (3)", ()).await.unwrap();
+
+    let n = db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap();
+    assert_eq!(n, 3);
+    let sum = db.analytics_scalar_i64("SELECT sum(v) FROM t").await.unwrap();
+    assert_eq!(sum, 6);
+}
+
+#[tokio::test]
+async fn transaction_commit_and_rollback_are_observable() {
+    let (_d, db) = open("e2e_tx.db").await;
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+
+    let tx = db.begin().await.unwrap();
+    tx.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    tx.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+
+    let tx = db.begin().await.unwrap();
+    tx.execute("INSERT INTO t VALUES (99)", ()).await.unwrap();
+    tx.rollback().await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn batch_write_rolls_back_entirely_on_failure() {
+    let (_d, db) = open("e2e_batch_rollback.db").await;
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (2, 20)", ()).await.unwrap();
+
+    let res = db
+        .execute_batch(
+            "INSERT INTO t (id, v) VALUES (?, ?)",
+            vec![(1_i64, 10_i64), (2_i64, 20_i64), (3_i64, 30_i64)],
+        )
+        .await;
+    assert!(res.is_err());
+
+    db.execute("INSERT INTO t VALUES (9, 90)", ()).await.unwrap();
+    let ids: Vec<i64> = db
+        .analytics_rows("SELECT id FROM t ORDER BY id")
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.as_i64(0).unwrap())
+        .collect();
+    assert_eq!(ids, vec![2, 9]);
+}
+
+#[tokio::test]
+async fn migrations_are_idempotent_across_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("e2e_migrate.db");
+    let migrations = ["CREATE TABLE a (id INTEGER)", "CREATE TABLE b (id INTEGER)"];
+
+    {
+        let db = EmbedDb::open(&path).await.unwrap();
+        db.migrate(&migrations).await.unwrap();
+        db.execute("INSERT INTO a VALUES (1)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.close().await.unwrap();
+    }
+
+    let db = EmbedDb::open(&path).await.unwrap();
+    db.migrate(&migrations).await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM a").await.unwrap(), 1);
+
+    db.migrate(&[migrations[0], migrations[1], "CREATE TABLE c (id INTEGER)"]).await.unwrap();
+    db.execute("INSERT INTO c VALUES (1)", ()).await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM c").await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn duckdb_type_mapping_covers_numeric_and_temporal_columns() {
+    let (_d, db) = open("e2e_types.db").await;
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+
+    let rows = db
+        .analytics_rows(
+            "SELECT \
+             CAST(1 AS TINYINT), CAST(2 AS SMALLINT), CAST(3 AS INTEGER), CAST(4 AS BIGINT), \
+             CAST(5 AS HUGEINT), CAST(6 AS UTINYINT), CAST(7 AS USMALLINT), CAST(8 AS UINTEGER), \
+             CAST(9 AS UBIGINT), CAST(18446744073709551615 AS UBIGINT), \
+             CAST(1.5 AS FLOAT), CAST(2.5 AS DOUBLE), CAST(3.25 AS DECIMAL(10,2)), \
+             CAST('2024-01-02' AS DATE), CAST('2024-01-02 03:04:05' AS TIMESTAMP), \
+             CAST('03:04:05' AS TIME), CAST('hi' AS VARCHAR), CAST(true AS BOOLEAN), NULL \
+             FROM t",
+        )
+        .await
+        .unwrap();
+
+    let r = &rows[0];
+    assert_eq!(r.as_i64(0), Some(1));
+    assert_eq!(r.as_i64(1), Some(2));
+    assert_eq!(r.as_i64(2), Some(3));
+    assert_eq!(r.as_i64(3), Some(4));
+    assert_eq!(r.as_i128(4), Some(5));
+    assert_eq!(r.as_i64(5), Some(6));
+    assert_eq!(r.as_i64(6), Some(7));
+    assert_eq!(r.as_i64(7), Some(8));
+    assert_eq!(r.as_i64(8), Some(9));
+    assert_eq!(r.as_i128(9), Some(18446744073709551615));
+    assert_eq!(r.as_f64(10), Some(1.5));
+    assert_eq!(r.as_f64(11), Some(2.5));
+    assert_eq!(r.as_str(12), Some("3.25"));
+    assert!(r.as_date(13).is_some());
+    assert!(r.as_timestamp(14).is_some());
+    assert!(r.as_time(15).is_some());
+    assert_eq!(r.as_str(16), Some("hi"));
+    assert_eq!(r.as_bool(17), Some(true));
+    assert_eq!(r.get(18), Some(&EmbedValue::Null));
+}
+
+#[tokio::test]
+async fn blob_roundtrips_through_the_analytics_reader() {
+    let (_d, db) = open("e2e_blob.db").await;
+    db.execute("CREATE TABLE t (b BLOB)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (?)", (vec![1_u8, 2, 3, 255],)).await.unwrap();
+    db.checkpoint().await.unwrap();
+
+    let rows = db.analytics_rows("SELECT b FROM t").await.unwrap();
+    assert_eq!(rows[0].get(0), Some(&EmbedValue::Blob(vec![1, 2, 3, 255])));
+}
+
+#[tokio::test]
+async fn streaming_read_visits_every_row() {
+    let (_d, db) = open("e2e_stream.db").await;
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+    let rows: Vec<(i64,)> = (0..250).map(|i| (i,)).collect();
+    db.execute_batch("INSERT INTO t VALUES (?)", rows).await.unwrap();
+
+    let total = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
+    let sink = total.clone();
+    let seen = db
+        .analytics_for_each("SELECT v FROM t", move |row| {
+            sink.fetch_add(row.as_i64(0).unwrap_or(0), std::sync::atomic::Ordering::SeqCst);
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(seen, 250);
+    assert_eq!(total.load(std::sync::atomic::Ordering::SeqCst), (0..250).sum::<i64>());
+}
+
+#[tokio::test]
+async fn concurrent_readers_share_the_pool() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = std::sync::Arc::new(
+        EmbedDb::open_with(
+            dir.path().join("e2e_pool.db"),
+            EmbedConfig { reader_pool_size: 2, ..EmbedConfig::default() },
+        )
+            .await
+            .unwrap(),
+    );
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+    let rows: Vec<(i64,)> = (0..100).map(|i| (i,)).collect();
+    db.execute_batch("INSERT INTO t VALUES (?)", rows).await.unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let db = db.clone();
+        handles.push(tokio::spawn(async move {
+            db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap()
+        }));
+    }
+    for h in handles {
+        assert_eq!(h.await.unwrap(), 100);
+    }
+}
+
+#[tokio::test]
+async fn unmapped_column_type_reports_a_cast_hint() {
+    let (_d, db) = open("e2e_unmapped.db").await;
+    db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+
+    let err = db.analytics_rows("SELECT [1, 2, 3] FROM t").await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("cast to VARCHAR"), "unexpected message: {msg}");
+}
+
+#[tokio::test]
+async fn invalid_sql_surfaces_as_an_error_not_a_panic() {
+    let (_d, db) = open("e2e_bad_sql.db").await;
+    assert!(db.execute("NOT VALID SQL", ()).await.is_err());
+    assert!(db.analytics_scalar_i64("SELECT * FROM missing_table").await.is_err());
+    assert!(db.analytics_rows("ALSO NOT SQL").await.is_err());
+}
+
+#[tokio::test]
+async fn query_result_exposes_columns_by_name() {
+    let (_d, db) = open("e2e_columns.db").await;
+    db.execute("CREATE TABLE t (id INTEGER, label TEXT)", ()).await.unwrap();
+    db.execute("INSERT INTO t VALUES (1, 'one')", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+
+    let q = db.analytics_query("SELECT id, label FROM t").await.unwrap();
+    assert_eq!(q.columns, vec!["id".to_string(), "label".to_string()]);
+    assert_eq!(q.get(0, "label"), Some(&EmbedValue::Text("one".into())));
+    assert_eq!(q.column_index("missing"), None);
+
+    let one = db.analytics_one("SELECT id FROM t").await.unwrap().unwrap();
+    assert_eq!(one.as_i64(0), Some(1));
+    let none = db.analytics_one("SELECT id FROM t WHERE id = 999").await.unwrap();
+    assert!(none.is_none());
+}
+
+#[tokio::test]
+async fn typed_read_reports_conversion_failure() {
+    let (_d, db) = open("e2e_typed_err.db").await;
+    db.execute("CREATE TABLE t (id TEXT, handle TEXT, balance REAL, active BOOLEAN, note TEXT)", ())
+        .await
+        .unwrap();
+    db.execute("INSERT INTO t VALUES ('not-an-int', 'x', 1.0, true, NULL)", ()).await.unwrap();
+    db.checkpoint().await.unwrap();
+
+    let err = db
+        .analytics_query_as::<Account>("SELECT id, handle, balance, active, note FROM t")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, EmbedError::Other(_)));
+}
+
+#[tokio::test]
+async fn parameter_binding_survives_hostile_strings() {
+    let (_d, db) = open("e2e_binding.db").await;
+    db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+    for hostile in ["o'brien", "'; DROP TABLE t; --", "line\nbreak", "emoji 🧪"] {
+        db.execute("INSERT INTO t VALUES (?)", (hostile,)).await.unwrap();
+    }
+    db.checkpoint().await.unwrap();
+
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM t").await.unwrap(), 4);
+    let n = db
+        .analytics_scalar_i64("SELECT count(*) FROM t WHERE name = '''; DROP TABLE t; --'")
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+async fn reopening_a_path_sees_previously_committed_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("e2e_reopen.db");
+    {
+        let db = EmbedDb::open(&path).await.unwrap();
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (42)", ()).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.close().await.unwrap();
+    }
+    let db = EmbedDb::open(&path).await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT sum(v) FROM t").await.unwrap(), 42);
+    assert_eq!(db.path(), path.as_path());
+}

--- a/packages/rust/embeddb/tests/e2e_vector.rs
+++ b/packages/rust/embeddb/tests/e2e_vector.rs
@@ -1,0 +1,338 @@
+use embeddb::{EmbedDb, EmbedError, VectorFilter, VectorSpace};
+
+async fn open(name: &str) -> (tempfile::TempDir, EmbedDb) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join(name)).await.unwrap();
+    db.vector_init().await.unwrap();
+    (dir, db)
+}
+
+fn seeded_vector(seed: u64, dim: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    (0..dim)
+        .map(|_| {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((state >> 33) as f32 / u32::MAX as f32) - 0.5
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn conversation_recall_returns_the_nearest_messages() {
+    let (_d, db) = open("e2e_recall.db").await;
+    let space = VectorSpace::new("local", "recall-model", 4);
+
+    db.vector_upsert(&space, "message", "deploy-talk", &[1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "message", "deploy-followup", &[0.95, 0.1, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "message", "lunch-plans", &[0.0, 0.0, 1.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "message", "weather", &[0.0, 0.0, 0.0, 1.0]).await.unwrap();
+
+    let hits = db.vector_search(&space, &[1.0, 0.05, 0.0, 0.0], 2, None).await.unwrap();
+    assert_eq!(hits.len(), 2);
+    let ids: Vec<&str> = hits.iter().map(|h| h.ref_id.as_str()).collect();
+    assert!(ids.contains(&"deploy-talk"));
+    assert!(ids.contains(&"deploy-followup"));
+    assert!(hits[0].score >= hits[1].score);
+    assert!(hits[1].score > 0.9);
+}
+
+#[tokio::test]
+async fn provider_migration_backfills_without_disturbing_the_live_model() {
+    let (_d, db) = open("e2e_migrate_provider.db").await;
+    let local = VectorSpace::new("local", "bge-small", 4);
+    let hosted = VectorSpace::new("openai", "text-embedding-3-small", 4);
+
+    let corpus = [
+        ("msg-1", [1.0_f32, 0.0, 0.0, 0.0]),
+        ("msg-2", [0.0, 1.0, 0.0, 0.0]),
+        ("msg-3", [0.0, 0.0, 1.0, 0.0]),
+    ];
+    for (id, v) in &corpus {
+        db.vector_upsert(&local, "message", id, v).await.unwrap();
+    }
+    assert_eq!(db.vector_count("bge-small").await.unwrap(), 3);
+
+    let backfill: Vec<(String, String, Vec<f32>)> = corpus
+        .iter()
+        .map(|(id, v)| ("message".to_string(), id.to_string(), v.to_vec()))
+        .collect();
+    db.vector_upsert_batch(&hosted, &backfill).await.unwrap();
+
+    assert_eq!(db.vector_count("bge-small").await.unwrap(), 3);
+    assert_eq!(db.vector_count("text-embedding-3-small").await.unwrap(), 3);
+
+    let old = db.vector_search(&local, &[1.0, 0.0, 0.0, 0.0], 10, None).await.unwrap();
+    let new = db.vector_search(&hosted, &[1.0, 0.0, 0.0, 0.0], 10, None).await.unwrap();
+    assert_eq!(old.len(), 3);
+    assert_eq!(new.len(), 3);
+    assert_eq!(old[0].ref_id, "msg-1");
+    assert_eq!(new[0].ref_id, "msg-1");
+
+    db.vector_delete_model("bge-small").await.unwrap();
+    assert_eq!(db.vector_count("bge-small").await.unwrap(), 0);
+    assert_eq!(db.vector_count("text-embedding-3-small").await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn ranking_is_stable_over_a_realistic_corpus() {
+    let (_d, db) = open("e2e_corpus.db").await;
+    let dim = 64;
+    let space = VectorSpace::new("local", "corpus-model", dim);
+
+    let items: Vec<(String, String, Vec<f32>)> = (0..500)
+        .map(|i| ("message".to_string(), format!("m{i}"), seeded_vector(i, dim)))
+        .collect();
+    let written = db.vector_upsert_batch(&space, &items).await.unwrap();
+    assert_eq!(written, 500);
+
+    let target = items[123].2.clone();
+    let hits = db.vector_search(&space, &target, 5, None).await.unwrap();
+    assert_eq!(hits.len(), 5);
+    assert_eq!(hits[0].ref_id, "m123");
+    assert!((hits[0].score - 1.0).abs() < 1e-4);
+    for pair in hits.windows(2) {
+        assert!(pair[0].score >= pair[1].score, "results are not sorted: {hits:?}");
+    }
+
+    let again = db.vector_search(&space, &target, 5, None).await.unwrap();
+    assert_eq!(hits, again);
+}
+
+#[tokio::test]
+async fn ref_kind_filter_partitions_the_same_model() {
+    let (_d, db) = open("e2e_kinds.db").await;
+    let space = VectorSpace::new("local", "kind-model", 3);
+
+    db.vector_upsert(&space, "message", "m1", &[1.0, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "document", "d1", &[1.0, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "document", "d2", &[0.9, 0.1, 0.0]).await.unwrap();
+
+    let docs = db
+        .vector_search(&space, &[1.0, 0.0, 0.0], 10, Some(&VectorFilter::kind("document")))
+        .await
+        .unwrap();
+    assert_eq!(docs.len(), 2);
+    assert!(docs.iter().all(|h| h.ref_kind == "document"));
+
+    let all = db.vector_search(&space, &[1.0, 0.0, 0.0], 10, None).await.unwrap();
+    assert_eq!(all.len(), 3);
+
+    let empty = db
+        .vector_search(&space, &[1.0, 0.0, 0.0], 10, Some(&VectorFilter::kind("nothing")))
+        .await
+        .unwrap();
+    assert!(empty.is_empty());
+}
+
+#[tokio::test]
+async fn vectors_survive_close_and_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("e2e_vec_reopen.db");
+    let space = VectorSpace::new("local", "persist-model", 3);
+
+    {
+        let db = EmbedDb::open(&path).await.unwrap();
+        db.vector_init().await.unwrap();
+        db.vector_upsert(&space, "message", "a", &[3.0, 4.0, 0.0]).await.unwrap();
+        db.checkpoint().await.unwrap();
+        db.close().await.unwrap();
+    }
+
+    let db = EmbedDb::open(&path).await.unwrap();
+    db.vector_init().await.unwrap();
+    assert_eq!(db.vector_count("persist-model").await.unwrap(), 1);
+    let hits = db.vector_search(&space, &[3.0, 4.0, 0.0], 1, None).await.unwrap();
+    assert!((hits[0].score - 1.0).abs() < 1e-5);
+
+    let norm = db
+        .analytics_scalar_f64("SELECT norm FROM _embeddb_vectors WHERE ref_id = 'a'")
+        .await
+        .unwrap();
+    assert!((norm - 5.0).abs() < 1e-5, "original magnitude should be preserved, got {norm}");
+}
+
+#[tokio::test]
+async fn vector_rows_are_visible_to_the_analytics_reader() {
+    let (_d, db) = open("e2e_vec_analytics.db").await;
+    let space = VectorSpace::new("local", "analytics-model", 3);
+    db.vector_upsert(&space, "message", "a", &[1.0, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&space, "document", "b", &[0.0, 1.0, 0.0]).await.unwrap();
+
+    let rows = db
+        .analytics_rows(
+            "SELECT ref_kind, count(*) FROM _embeddb_vectors GROUP BY ref_kind ORDER BY ref_kind",
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].as_str(0), Some("document"));
+    assert_eq!(rows[1].as_str(0), Some("message"));
+
+    let provider = db
+        .analytics_scalar_string("SELECT DISTINCT provider FROM _embeddb_vectors")
+        .await
+        .unwrap();
+    assert_eq!(provider, "local");
+}
+
+#[tokio::test]
+async fn init_coexists_with_consumer_migrations() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("e2e_vec_migrate.db")).await.unwrap();
+
+    db.migrate(&["CREATE TABLE messages (id TEXT PRIMARY KEY, body TEXT)"]).await.unwrap();
+    db.vector_init().await.unwrap();
+    db.migrate(&[
+        "CREATE TABLE messages (id TEXT PRIMARY KEY, body TEXT)",
+        "CREATE TABLE channels (id TEXT PRIMARY KEY)",
+    ])
+        .await
+        .unwrap();
+
+    db.execute("INSERT INTO channels VALUES ('c1')", ()).await.unwrap();
+    assert_eq!(db.analytics_scalar_i64("SELECT count(*) FROM channels").await.unwrap(), 1);
+
+    let ledger = db
+        .analytics_scalar_i64("SELECT count(*) FROM _embeddb_migrations")
+        .await
+        .unwrap();
+    assert_eq!(ledger, 2, "vector_init must not consume a migration version slot");
+}
+
+#[tokio::test]
+async fn corrupt_vector_blob_errors_instead_of_scoring_garbage() {
+    let (_d, db) = open("e2e_vec_corrupt.db").await;
+    let space = VectorSpace::new("local", "corrupt-model", 3);
+    db.vector_upsert(&space, "message", "good", &[1.0, 0.0, 0.0]).await.unwrap();
+
+    db.execute(
+        "INSERT INTO _embeddb_vectors \
+         (ref_kind, ref_id, provider, model, dim, norm, vec, created_at) \
+         VALUES ('message', 'ragged', 'local', 'corrupt-model', 3, 1.0, ?, 0)",
+        (vec![1_u8, 2, 3],),
+    )
+        .await
+        .unwrap();
+
+    let err = db.vector_search(&space, &[1.0, 0.0, 0.0], 5, None).await.unwrap_err();
+    assert!(matches!(err, EmbedError::VectorBlob(_)), "unexpected error: {err}");
+}
+
+#[tokio::test]
+async fn wrong_dimension_row_errors_instead_of_scoring_garbage() {
+    let (_d, db) = open("e2e_vec_wrongdim.db").await;
+    let space = VectorSpace::new("local", "dim-model", 3);
+    db.vector_upsert(&space, "message", "good", &[1.0, 0.0, 0.0]).await.unwrap();
+
+    db.execute(
+        "INSERT INTO _embeddb_vectors \
+         (ref_kind, ref_id, provider, model, dim, norm, vec, created_at) \
+         VALUES ('message', 'short', 'local', 'dim-model', 2, 1.0, ?, 0)",
+        (embeddb::pack(&[1.0_f32, 0.0]),),
+    )
+        .await
+        .unwrap();
+
+    let err = db.vector_search(&space, &[1.0, 0.0, 0.0], 5, None).await.unwrap_err();
+    assert!(
+        matches!(err, EmbedError::VectorDim { expected: 3, actual: 2 }),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn non_blob_vector_column_errors() {
+    let (_d, db) = open("e2e_vec_nonblob.db").await;
+    let space = VectorSpace::new("local", "nonblob-model", 3);
+
+    db.execute(
+        "INSERT INTO _embeddb_vectors \
+         (ref_kind, ref_id, provider, model, dim, norm, vec, created_at) \
+         VALUES ('message', 'text-vec', 'local', 'nonblob-model', 3, 1.0, 'not a blob', 0)",
+        (),
+    )
+        .await
+        .unwrap();
+
+    let err = db.vector_search(&space, &[1.0, 0.0, 0.0], 5, None).await.unwrap_err();
+    assert!(matches!(err, EmbedError::VectorBlob(_)), "unexpected error: {err}");
+}
+
+#[tokio::test]
+async fn non_text_ref_column_errors() {
+    let (_d, db) = open("e2e_vec_nontext.db").await;
+    let space = VectorSpace::new("local", "nontext-model", 3);
+
+    db.execute(
+        "INSERT INTO _embeddb_vectors \
+         (ref_kind, ref_id, provider, model, dim, norm, vec, created_at) \
+         VALUES (?, ?, 'local', 'nontext-model', 3, 1.0, ?, 0)",
+        (
+            vec![0_u8, 159, 146, 150],
+            vec![0_u8, 1],
+            embeddb::pack(&[1.0_f32, 0.0, 0.0]),
+        ),
+    )
+        .await
+        .unwrap();
+
+    let err = db.vector_search(&space, &[1.0, 0.0, 0.0], 5, None).await.unwrap_err();
+    assert!(matches!(err, EmbedError::VectorBlob(_)), "unexpected error: {err}");
+}
+
+#[tokio::test]
+async fn delete_is_scoped_to_one_model() {
+    let (_d, db) = open("e2e_vec_delete.db").await;
+    let a = VectorSpace::new("local", "del-a", 3);
+    let b = VectorSpace::new("api", "del-b", 3);
+    db.vector_upsert(&a, "message", "shared", &[1.0, 0.0, 0.0]).await.unwrap();
+    db.vector_upsert(&b, "message", "shared", &[1.0, 0.0, 0.0]).await.unwrap();
+
+    assert_eq!(db.vector_delete("del-a", "message", "shared").await.unwrap(), 1);
+    assert_eq!(db.vector_count("del-a").await.unwrap(), 0);
+    assert_eq!(db.vector_count("del-b").await.unwrap(), 1);
+    assert_eq!(db.vector_delete("del-a", "message", "shared").await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn codec_helpers_are_usable_outside_the_database() {
+    let v = vec![0.5_f32, -1.25, 3.0];
+    let packed = embeddb::pack(&v);
+    assert_eq!(embeddb::unpack(&packed).unwrap(), v);
+
+    let (unit, magnitude) = embeddb::normalize(&v).unwrap();
+    assert!((embeddb::norm(&unit) - 1.0).abs() < 1e-6);
+    assert!((magnitude - embeddb::norm(&v)).abs() < 1e-6);
+    assert!((embeddb::dot(&unit, &unit) - 1.0).abs() < 1e-6);
+
+    assert!(matches!(embeddb::normalize(&[0.0, 0.0]), Err(EmbedError::VectorZeroNorm)));
+    assert!(matches!(embeddb::unpack(&[0, 1, 2]), Err(EmbedError::VectorBlob(_))));
+}
+
+#[tokio::test]
+async fn concurrent_searches_against_one_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = std::sync::Arc::new(EmbedDb::open(dir.path().join("e2e_vec_conc.db")).await.unwrap());
+    db.vector_init().await.unwrap();
+    let space = VectorSpace::new("local", "conc-model", 8);
+
+    let items: Vec<(String, String, Vec<f32>)> = (0..200)
+        .map(|i| ("message".to_string(), format!("m{i}"), seeded_vector(i, 8)))
+        .collect();
+    db.vector_upsert_batch(&space, &items).await.unwrap();
+
+    let mut handles = Vec::new();
+    for i in 0..8_u64 {
+        let db = db.clone();
+        let space = space.clone();
+        let probe = seeded_vector(i, 8);
+        handles.push(tokio::spawn(async move {
+            db.vector_search(&space, &probe, 3, None).await.unwrap()
+        }));
+    }
+    for (i, h) in handles.into_iter().enumerate() {
+        let hits = h.await.unwrap();
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].ref_id, format!("m{i}"));
+    }
+}


### PR DESCRIPTION
Follow-up to #15264. Adds a real end-to-end suite, fixes a CI gap that left the vector tier untested, and closes the remaining coverage holes.

A version bump is deliberately not included here — it lands as a separate MDX-only follow-up once this merges.

## The CI gap

`nx test embeddb` ran with default features. The `vector` feature is not a default, so **every vector test merged in #15264 was silently skipped in CI.** The tier had 23 passing tests locally and zero coverage in the pipeline.

The `e2e` target made it worse: it was `nx:run-commands` wrapping `nx test embeddb`, so it re-ran the same unit tests under a different name and reported an E2E pass that covered nothing the unit run did not.

Both targets now use `@monodon/rust:test` with `all-features`. `test` runs `--lib`, `e2e` runs `--tests`. They are now genuinely distinct: 132 unit tests and 29 integration tests.

## End-to-end suite

`tests/e2e_core.rs` and `tests/e2e_vector.rs` drive the crate the way a dependent crate would — public API only, no access to internals.

Core covers the full lifecycle from open through migrate, batch write, checkpoint, and typed read; read visibility for uncheckpointed writes; transaction commit and rollback; whole-batch rollback on failure; migration idempotence across close and reopen; the complete DuckDB type mapping including the UBIGINT overflow path and every integer width; blob roundtrip; streaming reads; concurrent readers against a two-connection pool; the unmapped-type cast hint; error paths for invalid SQL; and parameter binding against injection strings, newlines, and emoji.

Vector covers conversation recall ranking, provider migration by backfill with both models live simultaneously, ranking stability and determinism over a 500-vector 64-dimension corpus, `ref_kind` partitioning, persistence across reopen including preserved magnitude, visibility of vector rows to the analytics reader, coexistence with consumer migrations, concurrent searches, and four corrupt-row cases.

`e2e_vector` declares `required-features = ["vector"]`, so a default-feature build skips it rather than failing to compile.

## Bug found by the E2E suite

SQLite has no boolean type. A column declared `BOOLEAN` stores an integer and comes back through the reader as `Int`, so `bool` conversion **could never succeed on data written through this crate** — only on a DuckDB expression that produced a real boolean. Any consumer deriving `FromEmbedRow` onto a struct with a `bool` field would hit it immediately.

`bool` now accepts integer `0` and `1`, matching the existing precedent where `f64` and `i128` widen from `Int`. Integers other than 0 and 1 still error, as do all other types. One existing unit test asserted the old behavior and was updated.

## Coverage

| File | Before | After |
|---|---|---|
| convert.rs | 69.70% | **100%** |
| analytics.rs | 93.71% | **100%** |
| pool.rs | 92.98% | 96.46% |
| vector.rs | 98.14% | 99.77% |
| **Total lines** | **96.52%** | **98.41%** |

Functions 94.84% to 95.58%. Test count 118 to 161.

`convert.rs` had no coverage of the `i128`, `Vec<u8>`, or `bool` implementations and none of the mismatch or absent error arms. `analytics.rs` was missing most of the integer-width mapping. `pool.rs` had no test for the Condvar wait path, guard deref, panic-unwind checkin, or `LazyReaderPool` — including the contract that a failed build is **not** cached, so a retry after staging the DuckDB extension still works.

## Verification

161 tests pass. Clippy clean with `--all-features --all-targets`. Both nx target equivalents verified directly (`--lib` 132, `--tests` 161).