### PR TITLE
fix(ci): drop TS6 opts from TS5-pinned tsconfigs

### DIFF
--- a/apps/chuckrpg/chuck-launcher/tsconfig.json
+++ b/apps/chuckrpg/chuck-launcher/tsconfig.json
@@ -17,11 +17,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"paths": {
 			"@/*": ["./src/*"]
-		},
-		"noUncheckedSideEffectImports": false,
-		"types": ["*"],
-		"esModuleInterop": false,
-		"ignoreDeprecations": "6.0"
+		}
 	},
 	"include": ["src"]
 }

--- a/apps/kbve/desktop-kbve/tsconfig.json
+++ b/apps/kbve/desktop-kbve/tsconfig.json
@@ -17,11 +17,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"paths": {
 			"@/*": ["./src/*"]
-		},
-		"noUncheckedSideEffectImports": false,
-		"types": ["*"],
-		"esModuleInterop": false,
-		"ignoreDeprecations": "6.0"
+		}
 	},
 	"include": ["src"]
 }

--- a/apps/kbve/isometric/tsconfig.json
+++ b/apps/kbve/isometric/tsconfig.json
@@ -14,11 +14,7 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true,
-		"noUncheckedSideEffectImports": false,
-		"types": ["*"],
-		"esModuleInterop": false,
-		"ignoreDeprecations": "6.0"
+		"noFallthroughCasesInSwitch": true
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
Closes #15168

## Problem

`CI - Bevy / build_wasm` has failed on **every run that actually executed** since 2026-08-02. The green runs in between are misleading — the job is gated on `needs.alter.outputs.isometric == 'true'` and was **skipped**, not passing.

The failure is not Rust or Bevy. The wasm compiles fine. `apps/kbve/isometric`'s build script is:

```
npm run build:wasm && npx tsc && vite build && ...
```

and `npx tsc` dies ~14 min in:

```
error TS2688: Cannot find type definition file for '*'.
tsconfig.json(21,25): error TS5103: Invalid value for '--ignoreDeprecations'.
```

## Root cause

Nx migration `6fc54490a4` (`23-1-0-add-ignore-deprecations-for-ts6`, 2026-07-21) blanket-injected four TS6-compat options into every tsconfig in the repo:

```json
"noUncheckedSideEffectImports": false,
"types": ["*"],
"esModuleInterop": false,
"ignoreDeprecations": "6.0"
```

Three of those targets are **isolated pnpm workspaces** with their own lockfiles pinning `typescript: ^5.0.0` → **5.9.3**, not the root's `6.0.3`. TS 5.9 rejects `ignoreDeprecations: "6.0"` (TS5103) and `types: ["*"]` (TS2688).

Failures started 08-02 rather than 07-21 because the job only fires when isometric files change; that was the first isometric-touching push after the migration.

## Fix

Revert the injected hunk in the three TS5-pinned workspaces:

- `apps/kbve/isometric` — the one breaking CI
- `apps/kbve/desktop-kbve` — same defect, not yet surfaced
- `apps/chuckrpg/chuck-launcher` — same defect, not yet surfaced

`esModuleInterop: false` and `noUncheckedSideEffectImports: false` are already the TS5 defaults, so removing them is behavior-neutral under 5.9. Repo-root `tsconfig.base.json` is left alone — root is on TS 6.0.3 where these are valid.

## Verification

`apps/kbve/isometric` with the fixed config, using the app-local TS 5.9.3:

```
$ node_modules/.bin/tsc -p tsconfig.json
EXIT=0
```

Clean. That is the exact command CI runs.

## Note on the other two apps

`TS5103` is a config-level fatal, so tsc previously aborted before checking any files. Removing it un-masks pre-existing type errors in `desktop-kbve` (`TS6133`, `TS2339` in `views/onichan.tsx`) and `chuck-launcher`. Those are pre-existing and out of scope here — both apps were already failing, just at the config stage instead.

No automatic CI impact: neither app is built by any push/PR-triggered workflow. Their `build` (and therefore `tsc`) runs only under manual `workflow_dispatch` of `ci-tauri.yml`. The only automatic nx gate (`utils-ci-lint-test.yml`) runs `lint` and `test` targets only, never `build`.

## Follow-up

A future nx migration may re-inject these. If so, the three isolated workspaces need to be excluded or bumped to TS 6.