### PR TITLE
fix(astro-kbve): stop OSRS related-items linking into 404s

### DIFF
--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSRelatedItems.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSRelatedItems.astro
@@ -6,12 +6,15 @@
  * Uses slug field for proper internal linking
  */
 import type { OSRSRelatedItem } from '@/data/schema';
+import { getLinkTargets, resolveItemSlug } from '@/data/osrs/link-targets';
 
 interface Props {
 	relatedItems: OSRSRelatedItem[];
 }
 
 const { relatedItems } = Astro.props;
+
+const targets = await getLinkTargets();
 
 // Get relationship color and label
 function getRelationshipStyle(relationship: string): {
@@ -38,17 +41,11 @@ function getRelationshipStyle(relationship: string): {
 	}
 }
 
-// Generate URL from slug
-function getItemUrl(item: OSRSRelatedItem): string {
-	if (item.slug) {
-		return `/osrs/${item.slug}/`;
-	}
-	// Fallback: generate slug from name
-	const slug = (item.item_name ?? '')
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, '-')
-		.replace(/^-|-$/g, '');
-	return `/osrs/${slug}/`;
+// Resolves against the corpus rather than trusting the authored slug, and
+// yields null when nothing matches so the entry renders as text, not a 404.
+function getItemUrl(item: OSRSRelatedItem): string | null {
+	const slug = resolveItemSlug(targets, item.slug, item.item_name);
+	return slug ? `/osrs/${slug}/` : null;
 }
 ---
 
@@ -70,10 +67,15 @@ function getItemUrl(item: OSRSRelatedItem): string {
 				const style = getRelationshipStyle(
 					item.relationship ?? 'alternative',
 				);
+				const href = getItemUrl(item);
+				const Tag = href ? 'a' : 'div';
 				return (
-					<a
-						href={getItemUrl(item)}
-						class="osrs-related__item"
+					<Tag
+						href={href ?? undefined}
+						class:list={[
+							'osrs-related__item',
+							!href && 'osrs-related__item--static',
+						]}
 						data-osrs-tooltip
 						data-osrs-name={item.item_name}
 						data-osrs-slug={item.slug}
@@ -96,7 +98,7 @@ function getItemUrl(item: OSRSRelatedItem): string {
 								{item.description}
 							</span>
 						)}
-					</a>
+					</Tag>
 				);
 			})
 		}
@@ -153,6 +155,14 @@ function getItemUrl(item: OSRSRelatedItem): string {
 
 	.osrs-related__item:hover {
 		background: var(--sl-color-gray-6);
+	}
+
+	.osrs-related__item--static {
+		cursor: default;
+	}
+
+	.osrs-related__item--static .osrs-related__item-name {
+		color: var(--sl-color-gray-2);
 	}
 
 	.osrs-related__item-main {

--- a/apps/kbve/astro-kbve/src/data/osrs/link-targets.ts
+++ b/apps/kbve/astro-kbve/src/data/osrs/link-targets.ts
@@ -1,0 +1,84 @@
+/**
+ * Resolver for internal OSRS cross-links.
+ *
+ * `related_items` entries were authored by the v4 enrichment pass rather than
+ * generated from the corpus, so their `slug` and `item_id` fields drift from
+ * what actually exists on disk. Measured across the corpus:
+ *
+ *   4019  slug resolves to a page
+ *    167  slug resolves to a collapsed family member (308 to the base page)
+ *    104  page exists under a different slug ("ahrims-hood" vs "ahrim-s-hood")
+ *      5  collapsed variant under a slug families.json never assigned
+ *    556  no page anywhere — 480 of those name items that are not GE-tradeable
+ *          (charged forms, ornament variants, clue rewards, quest items) and
+ *          so will never have a price page
+ *
+ * Resolution runs slug, then name. `item_id` is deliberately NOT consulted:
+ * 1219 entries carry an id that disagrees with their own name and slug (id
+ * 6016 is labelled "Basket of tomatoes" but belongs to cactus-spine), so
+ * falling back to it would turn a dead link into a confidently wrong one.
+ * Name and slug agree in every observed mismatch, which makes name the
+ * trustworthy field.
+ *
+ * Recoverable cases therefore repair themselves at render time instead of
+ * requiring edits across 461 files. Anything still unresolved returns null and
+ * the caller renders plain text rather than a link into a 404.
+ */
+import { getCollection } from 'astro:content';
+import type { OSRSExtended } from '@/data/schema';
+
+export interface LinkTargets {
+	/** Page slugs, plus collapsed family member slugs that 308 to a base page. */
+	slugs: Set<string>;
+	byName: Map<string, string>;
+}
+
+let _targets: LinkTargets | null = null;
+let _building: Promise<LinkTargets> | null = null;
+
+export async function getLinkTargets(): Promise<LinkTargets> {
+	if (_targets) return _targets;
+	_building ??= build();
+	_targets = await _building;
+	_building = null;
+	return _targets;
+}
+
+async function build(): Promise<LinkTargets> {
+	const docs = await getCollection('docs');
+	const slugs = new Set<string>();
+	const byName = new Map<string, string>();
+
+	for (const entry of docs) {
+		const item = (entry.data as { osrs?: OSRSExtended }).osrs;
+		if (!item?.slug) continue;
+
+		slugs.add(item.slug);
+		if (item.name) byName.set(item.name.trim().toLowerCase(), item.slug);
+
+		// Collapsed variants have no page of their own; their slugs 308 to this
+		// page at the axum layer, so they stay valid link targets and resolve
+		// by name to the base page they redirect to.
+		for (const member of item.family?.members ?? []) {
+			if (member.slug) slugs.add(member.slug);
+			if (member.name && !byName.has(member.name.trim().toLowerCase())) {
+				byName.set(member.name.trim().toLowerCase(), item.slug);
+			}
+		}
+	}
+
+	return { slugs, byName };
+}
+
+export function resolveItemSlug(
+	targets: LinkTargets,
+	slug: string | undefined,
+	name: string | undefined,
+): string | null {
+	if (slug && targets.slugs.has(slug)) return slug;
+	if (name) {
+		const byName = targets.byName.get(name.trim().toLowerCase());
+		if (byName) return byName;
+	}
+	return null;
+}


### PR DESCRIPTION
## Problem

`related_items` was authored by the v4 enrichment pass ([enrichment-runbook.md](docs/plans/osrs/enrichment-runbook.md)), not generated from the corpus. Nothing validated its `slug` or `item_id` against pages that actually exist, so both drift. Measured across all 4,064 item pages:

```
4019  slug resolves to a page
 167  slug resolves to a collapsed family member (308 → base page)
 104  page exists under a different slug
   5  collapsed variant under a slug families.json never assigned
 556  no page anywhere
────
 665  links returning 404, across 461 pages
```

Confirmed live:

```
/osrs/ahrims-hood/       404      /osrs/ahrim-s-hood/       200
/osrs/inquisitors-mace/  404      /osrs/inquisitor-s-mace/  200
```

On a 4,000-page site, 665 dead internal links waste crawl budget and read as an unmaintained database.

## Fix

`src/data/osrs/link-targets.ts` builds a resolver once per build from the content collection — every page slug, every page name, plus collapsed family member slugs (which 308 to their base page and so remain valid targets).

Resolution order is **slug, then name**:

- authored slug valid → link unchanged (4,105)
- slug dead but name matches a page → **repairs itself** (106)
- neither matches → renders as `<div>` instead of `<a>` (640)

Net: **zero 404 links**, and no edits to any MDX file.

The 106 self-repairing cases are the apostrophe class — the enrichment slugified `Ahrim's hood` as `ahrims-hood` while the page generator produces `ahrim-s-hood`. Resolving at render means future drift heals too, rather than needing another repair pass.

## Why item_id is not used as a fallback

**1,219 entries carry an `item_id` that disagrees with their own name and slug.** `id 6016` is labelled `Basket of tomatoes` but belongs to `cactus-spine`; `id 1163` is labelled `Rune kiteshield` but belongs to `rune-full-helm`.

Falling back to id would convert a dead link into a confidently wrong one — a user clicking "Basket of tomatoes" and landing on Cactus spine is worse than a non-link. Name and slug agree in every observed mismatch, which makes name the trustworthy field. The bad IDs still want fixing at source; they only affect the icon and tooltip data attributes today.

## The 640 non-links are not missing pages

Cross-checked against the wiki's tradeable-item mapping (4,650 items):

```
tradeable items covered by pages + families   4500  (96.8%)
distinct linked-but-missing names               483
  ├─ not in the tradeable mapping at all        480
  └─ real tradeable items                         3
```

The 480 are items with no GE price — charged forms (`Toxic staff of the dead`), ornament variants (`Dragon pickaxe (or)`), clue rewards (`Reward casket (elite)`), quest items (`Chewed bones`). A price database has nothing to put on those pages, and generating 480 priceless stubs would recreate the thin-content problem. Rendering them as text is the correct terminal state, not a stopgap.

Some are naming variants of items already covered — the mapping has `Toxic blowpipe (empty)`, `Trident of the seas (full)`, `Rune pouch note`. Those could be remapped later; they render as text meanwhile.

## Verification

Resolver outcomes simulated against the real corpus:

```
link_as_authored       4105
link_repaired_by_name   106
rendered_as_text        640
remaining 404 links       0
```

`OSRSLinkTooltip` only queries `.osrs-panel`, so swapping the anchor for a div doesn't break tooltips.

**Build not run locally** — worktree has no `node_modules`, symlinking breaks Astro path resolution. CI is the gate. Worth checking on preview that a page with unresolvable entries (e.g. `/osrs/acorn/`) renders them as non-clickable text with styling intact.

## Follow-up work, separately scoped

- **24 Barrows degrade-tier items** (`Dharok's helm 0`, `Ahrim's hood 0`, …) are tradeable with no page and no family entry. The [README](docs/plans/osrs/README.md) specs Barrows collapse explicitly, but `families.json` contains no Barrows family — the collapse was specified and never implemented.
- **126 items newer than the corpus** need pages: chainshot and incendiary cannonballs across all metal tiers, `Demonic hood/robe/boots (t1/t2/t3)`, `Rubium splinters`.
- **Nothing reconciles the live mapping against the corpus**, so this will drift again. Wants a CI coverage check.
- **1,219 bad `item_id`s** want re-deriving from name at the data layer.

## Related

- #15295 sitemap chain · #15297 homepage entity clarity · #15298 baked GE prices