### PR TITLE
fix(kubevirt): seed virt-handler cert mount, drop ineffective CR patch

### DIFF
--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -22,21 +22,6 @@ spec:
         network:
             permitBridgeInterfaceOnPodNetwork: true
     imagePullPolicy: IfNotPresent
-    # virt-operator renders four cert mounts for virt-handler
-    # (components/daemonsets.go:283-286) but the live DaemonSet is missing
-    # the clientcertificates one, so virt-handler's cert manager fails to
-    # open it once a minute. Nothing strips it — customizeComponents was
-    # empty and there are no Kyverno mutations — the operator simply never
-    # re-rendered and reports the stale spec as in sync. Upstream
-    # kubevirt/kubevirt#16255 and #16264 are open with no maintainer reply.
-    # Re-adding it here also bumps the customizer identifier, which forces
-    # the re-render.
-    customizeComponents:
-        patches:
-            - resourceType: DaemonSet
-              resourceName: virt-handler
-              type: strategic
-              patch: '{"spec":{"template":{"spec":{"volumes":[{"name":"kubevirt-virt-handler-certs","secret":{"secretName":"kubevirt-virt-handler-certs","defaultMode":420,"optional":true}}],"containers":[{"name":"virt-handler","volumeMounts":[{"name":"kubevirt-virt-handler-certs","mountPath":"/etc/virt-handler/clientcertificates","readOnly":true}]}]}}}}'
     workloadUpdateStrategy:
         workloadUpdateMethods:
             - LiveMigrate

--- a/apps/kube/kubevirt/cr/virt-handler-cert-seed.yaml
+++ b/apps/kube/kubevirt/cr/virt-handler-cert-seed.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: virt-handler-cert-seed
+    namespace: kubevirt
+    labels:
+        app.kubernetes.io/part-of: kubevirt
+        app.kubernetes.io/component: cert-seed
+        kbve.com/category: virtualization
+        kbve.com/stack: core
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: virt-handler-cert-seed
+    namespace: kubevirt
+    labels:
+        app.kubernetes.io/part-of: kubevirt
+        app.kubernetes.io/component: cert-seed
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+rules:
+    - apiGroups: ['apps']
+      resources: ['daemonsets']
+      resourceNames: ['virt-handler']
+      verbs: ['get', 'patch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: virt-handler-cert-seed
+    namespace: kubevirt
+    labels:
+        app.kubernetes.io/part-of: kubevirt
+        app.kubernetes.io/component: cert-seed
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: virt-handler-cert-seed
+subjects:
+    - kind: ServiceAccount
+      name: virt-handler-cert-seed
+      namespace: kubevirt
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: virt-handler-cert-seed
+    namespace: kubevirt
+    labels:
+        app.kubernetes.io/part-of: kubevirt
+        app.kubernetes.io/component: cert-seed
+        kbve.com/category: virtualization
+        kbve.com/stack: core
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+    ttlSecondsAfterFinished: 3600
+    backoffLimit: 2
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/part-of: kubevirt
+                app.kubernetes.io/component: cert-seed
+        spec:
+            serviceAccountName: virt-handler-cert-seed
+            automountServiceAccountToken: true
+            restartPolicy: Never
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: seed
+                  image: ghcr.io/kbve/kubectl:0.1.9
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: PATCH
+                        value: '{"spec":{"template":{"spec":{"volumes":[{"name":"kubevirt-virt-handler-certs","secret":{"secretName":"kubevirt-virt-handler-certs","defaultMode":420,"optional":true}}],"containers":[{"name":"virt-handler","volumeMounts":[{"name":"kubevirt-virt-handler-certs","mountPath":"/etc/virt-handler/clientcertificates","readOnly":true}]}]}}}}'
+                  command: ['/bin/sh', '-c']
+                  args:
+                      - |
+                          set -eu
+                          NS=kubevirt
+                          DS=virt-handler
+                          VOL=kubevirt-virt-handler-certs
+
+                          if kubectl -n "$NS" get ds "$DS" -o json | jq -e --arg v "$VOL" '.spec.template.spec.volumes[]? | select(.name==$v)' >/dev/null; then
+                            echo "volume $VOL already on ds/$DS; nothing to do"
+                            exit 0
+                          fi
+
+                          echo "seeding $VOL onto ds/$DS"
+                          kubectl -n "$NS" patch ds "$DS" --type=strategic -p "$PATCH"
+                          echo "seeded; virt-operator retains the mount from here"
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  resources:
+                      requests:
+                          cpu: 25m
+                          memory: 64Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi


### PR DESCRIPTION
Supersedes the approach in #15294. That PR merged and did **not** fix the error — this explains why and fixes it properly.

## Why #15294 didn't work

virt-operator strips the mount on every render:

```go
// pkg/virt-operator/resource/apply/apps.go:200-203  (processCanaryUpgrade)
if !hasCertificateSecret(&cachedDaemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName) &&
    hasCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName) {
    unattachCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName)
}
```

If the **running** DaemonSet lacks the `kubevirt-virt-handler-certs` volume but the **newly generated** one has it, the operator removes it from the generated spec. `components/daemonsets.go:283` adds the mount, this takes it straight back out, and the state sustains itself — the live DaemonSet lacks the volume precisely because it lacks the volume.

The guard reads only the live object, so **no CR-level change can escape it**, including the `customizeComponents` patch from #15294. That patch was applied to the generated DaemonSet and then unattached by this same guard, so the operator saw no diff and correctly reported no change needed.

Observed after #15294 merged and synced:

| Signal | Result |
|---|---|
| DS `customizer-identifier` | `bf21a9e8` → `05d0ffd2` (operator did process the CR) |
| DS `kubevirt.io/generation` | 3 → 4 |
| DS pod template | **unchanged** |
| virt-handler pod age | still 57d, never rolled |
| cert errors | still 1/min |

I had diagnosed this as "the operator never re-rendered and reports a stale spec as in sync." That was wrong. It completes a full pass every ~6 seconds logging `All KubeVirt resources created` / `All KubeVirt components ready` — it isn't stalled, it's actively removing the mount each cycle.

## The fix

The only exit is to put the volume on the **live** DaemonSet once. After that `hasCertificateSecret(cached)` is true, the guard stops firing, and `daemonsets.go:283` supplies the mount on every subsequent render.

This adds a PostSync hook Job that does exactly that, and reverts the now-provably-ineffective `customizeComponents` patch so the CR doesn't carry a no-op that reads like a working fix.

**Idempotent** — it inspects the DaemonSet first and exits without patching when the volume is already present, so it's a no-op on every sync after the first. It also re-seeds automatically if the state ever regresses (e.g. the DaemonSet is recreated without the mount).

**Scoped RBAC** — `get`/`patch` on the single `daemonsets` `resourceName: virt-handler`, nothing else. Non-root, read-only rootfs, all capabilities dropped, following the existing `arc-runner-reaper` pattern in this repo.

## Risk

Rolls the virt-handler DaemonSet on first run. No VMIs are running, so node-level VM management pauses briefly and no guest is affected. If the Job fails, the DaemonSet stays as it is today — no regression.

## Verify after sync

```bash
kubectl -n kubevirt logs job/virt-handler-cert-seed
kubectl -n kubevirt get ds virt-handler -o json | jq '.spec.template.spec.volumes[].name' | grep virt-handler-certs
kubectl -n kubevirt logs -l kubevirt.io=virt-handler --since=5m | grep -c "failed to load the certificate"   # expect 0
```

Then confirm it holds: the operator re-renders every ~6s, so if the mount is still present a minute later the guard has stopped firing for good.

## Upstream

This is the answer neither reporter got on [#16255](https://github.com/kubevirt/kubevirt/issues/16255) / [#16264](https://github.com/kubevirt/kubevirt/issues/16264) — both open and stale since v1.4. Worth posting back, since any cluster that ever ran a virt-handler DaemonSet without this volume is permanently stuck the same way.