### PR TITLE
fix(palworld-savetool): install deps for the test target

### DIFF
--- a/apps/agones/palworld/savetool/project.json
+++ b/apps/agones/palworld/savetool/project.json
@@ -8,7 +8,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"cwd": "apps/agones/palworld/savetool",
-				"command": "python3 -m unittest discover ."
+				"command": "uv run --with-requirements requirements.txt --python 3.12 python -m unittest discover ."
 			}
 		},
 		"e2e": {


### PR DESCRIPTION
## Problem

`nx run agones-palworld-savetool:test` errors on 3 of 7 tests:

```
ModuleNotFoundError: No module named 'palworld_save_tools'
```

Config gap, not a code bug.

`save_intel.py:26` imports `palworld_save_tools` *inside* `decompress_sav` — deliberately deferred so the pure-parsing tests don't need the native deps. But the import sits above the magic-validation branches, so all three `decompress_sav` tests hit it before reaching the `ValueError`/`RuntimeError` they assert.

The deps **are** declared in `requirements.txt` (`palworld-save-tools==0.24.0`, `pyooz==0.0.8`). The `test` target just never installed them — it ran bare `python3 -m unittest discover .` against system Python. So it passed only on a machine that happened to have those packages globally.

The sibling `e2e` target already builds a venv and pip-installs first, which is why that one works.

## Fix

```diff
-"command": "python3 -m unittest discover ."
+"command": "uv run --with-requirements requirements.txt --python 3.12 python -m unittest discover ."
```

Matches the workspace convention — `apps/pydesk` and `apps/discordsh/notification-bot` both use `uv run`. The savetool was the only Python project invoking `python3` directly.

## Verification

`./kbve.sh -nx agones-palworld-savetool:test`

```
Ran 7 tests in 0.007s

OK

 NX   Successfully ran target test for project agones-palworld-savetool
```

Was 4 passed / 3 errored; now 7/7.

## Note

This target isn't referenced in `.github/workflows/`, so CI never ran it — that's why the breakage went unnoticed. Worth wiring up separately if you want it guarded against silent regression.