### PR TITLE
fix(astro-kbve): stop the OSRS generator resurrecting collapsed items

### DIFF
--- a/apps/kbve/astro-kbve/scripts/generate-osrs-items.mjs
+++ b/apps/kbve/astro-kbve/scripts/generate-osrs-items.mjs
@@ -6,17 +6,31 @@
  * files are the single source of truth and are NEVER overwritten.
  * Slugs in existing files are preserved to protect SEO.
  *
+ * "New" also excludes items collapsed onto a family base page. Those had their
+ * MDX pruned on purpose and their URLs 301 at the axum layer, so they appear
+ * nowhere as a top-level osrs.id — indexing only top-level ids made all 461 of
+ * them look brand new and a run would have recreated every page the family
+ * collapse deleted. Exclusion reads family rosters in frontmatter plus the
+ * committed redirect table.
+ *
  * Run: node scripts/generate-osrs-items.mjs [--audit]
  *   --audit: report which existing items have stale data vs Wiki API (no writes)
  */
 
 import { writeFile, mkdir, readdir, readFile } from 'fs/promises';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 
 const OSRS_MAPPING_URL = 'https://prices.runescape.wiki/api/v1/osrs/mapping';
 const USER_AGENT = 'KBVE item_tracker - @h0lybyte on Discord';
 const OUTPUT_DIR = './src/content/docs/osrs';
+const REDIRECTS_PATH = fileURLToPath(
+	new URL(
+		'../../axum-kbve/src/transport/osrs_family_redirects.json',
+		import.meta.url,
+	),
+);
 
 const args = process.argv.slice(2);
 const auditMode = args.includes('--audit');
@@ -34,12 +48,46 @@ function nameToSlug(name) {
 }
 
 /**
- * Build an index of existing item IDs from MDX frontmatter.
- * Returns a Set of numeric IDs that already have MDX files.
- * This is the authoritative check — slug/filename doesn't matter.
+ * Load the slugs that already 301/308 to a family base page.
+ *
+ * Collapsed variants (poison tiers, potion doses, Barrows degrade levels) have
+ * their MDX deleted from disk and their URLs redirected at the axum layer. The
+ * redirect table is the durable record of that collapse — families.json cannot
+ * be, because it is regenerated from disk and pruning is one-way, so pruned
+ * members vanish from it while their redirects live on.
+ */
+async function loadRedirectedSlugs() {
+	try {
+		const raw = await readFile(REDIRECTS_PATH, 'utf-8');
+		const routes = JSON.parse(raw)?.routes ?? [];
+		const slugs = new Set();
+		for (const [source] of routes) {
+			const slug = String(source).replace(/\/+$/, '').split('/').pop();
+			if (slug) slugs.add(slug);
+		}
+		return slugs;
+	} catch (err) {
+		throw new Error(
+			`Failed to read the family redirect table at ${REDIRECTS_PATH}. ` +
+				'Refusing to generate: without it, every collapsed variant looks ' +
+				`like a new item and would be resurrected. (${err.message})`,
+		);
+	}
+}
+
+/**
+ * Build an index of item IDs that must never be regenerated.
+ *
+ * Two distinct sources, and both are required:
+ *   1. Top-level `osrs.id` — items with their own MDX page.
+ *   2. `osrs.family.members[].id` — variants collapsed onto a base page. Their
+ *      own MDX was pruned, so they appear nowhere as a top-level id. Indexing
+ *      only (1) makes all 461 of them look new, and a run would recreate every
+ *      page the family collapse deliberately deleted.
  */
 async function buildExistingIdIndex() {
 	const ids = new Set();
+	const collapsedIds = new Set();
 	const slugsById = new Map();
 
 	const files = await readdir(OUTPUT_DIR);
@@ -61,6 +109,11 @@ async function buildExistingIdIndex() {
 				slugsById.set(Number(id), fm.osrs.slug || file.replace('.mdx', ''));
 				indexed++;
 			}
+
+			for (const member of fm?.osrs?.family?.members ?? []) {
+				if (member?.id === undefined || member?.id === null) continue;
+				collapsedIds.add(Number(member.id));
+			}
 		} catch {
 			// Skip files that can't be parsed
 		}
@@ -71,7 +124,8 @@ async function buildExistingIdIndex() {
 	}
 
 	console.log(`  📋 Indexed ${ids.size} unique item IDs`);
-	return { ids, slugsById };
+	console.log(`  🔗 Indexed ${collapsedIds.size} collapsed family member IDs`);
+	return { ids, collapsedIds, slugsById };
 }
 
 /**
@@ -171,8 +225,14 @@ async function main() {
 	await mkdir(OUTPUT_DIR, { recursive: true });
 
 	// Build ID index from existing MDX files
-	const { ids: existingIds, slugsById: existingSlugs } =
-		await buildExistingIdIndex();
+	const {
+		ids: existingIds,
+		collapsedIds,
+		slugsById: existingSlugs,
+	} = await buildExistingIdIndex();
+
+	const redirectedSlugs = await loadRedirectedSlugs();
+	console.log(`  ↪️  Loaded ${redirectedSlugs.size} redirected slugs`);
 
 	// Track slugs to handle duplicates within this run
 	const usedSlugs = new Set();
@@ -183,6 +243,7 @@ async function main() {
 	let created = 0;
 	let skippedNoName = 0;
 	let skippedExisting = 0;
+	let skippedCollapsed = 0;
 	const staleItems = [];
 
 	for (const item of items) {
@@ -211,9 +272,23 @@ async function main() {
 			continue;
 		}
 
+		// Collapsed onto a family base page — its MDX was pruned on purpose and
+		// its URL already redirects. Regenerating would undo the collapse and
+		// shadow a live 301.
+		if (collapsedIds.has(item.id)) {
+			skippedCollapsed++;
+			continue;
+		}
+
 		// New item — generate slug, avoid collisions
 		let slug = nameToSlug(item.name);
 		if (usedSlugs.has(slug)) slug = `${slug}-${item.id}`;
+
+		if (redirectedSlugs.has(slug)) {
+			skippedCollapsed++;
+			continue;
+		}
+
 		usedSlugs.add(slug);
 
 		const filename = `${slug}.mdx`;
@@ -238,6 +313,7 @@ async function main() {
 	console.log(`\n✨ Done!`);
 	console.log(`  ${auditMode ? 'Would create' : 'Created'}: ${created} new items`);
 	console.log(`  Skipped (existing ID): ${skippedExisting}`);
+	console.log(`  Skipped (collapsed into a family): ${skippedCollapsed}`);
 	console.log(`  Skipped (no name): ${skippedNoName}`);
 
 	if (auditMode && staleItems.length > 0) {


### PR DESCRIPTION
## The hazard

`scripts/generate-osrs-items.mjs` decides what counts as a new item by indexing **only top-level `osrs.id`** in MDX frontmatter. Collapsed family variants (poison tiers, potion doses, Barrows degrade levels) had their MDX pruned on purpose and their URLs 301'd at the axum layer — so none of them appear as a top-level id anywhere.

To the generator, all 461 looked brand new. Running the command in its own header comment would have recreated every page the family collapse deliberately deleted, shadowing 1,118 live redirects.

Simulated before the fix:

```
generator would create:            587 pages
  RESURRECT collapsed variants:    461
  genuinely new:                   126
```

Nothing reconciled the generator with the collapse system. Both are correct in isolation; neither knew about the other.

## Fix

Exclusion now reads two sources, and both are needed:

1. **Family rosters in frontmatter** — `osrs.family.members[].id`, 663 collapsed member ids
2. **The committed redirect table** — `osrs_family_redirects.json`, 559 redirected slugs

`families.json` is deliberately *not* used. It is regenerated from disk and pruning is one-way, so pruned members vanish from it while their redirects live on — it cannot be the record of what was collapsed. The redirect table is marked MERGE-ONLY for precisely this reason, and that makes it the durable source of truth.

A missing or unreadable redirect table is now a **hard error rather than a silent pass**. Without it every collapsed variant looks new again, which is the exact failure this PR fixes — failing closed is the only safe default. That path also resolves from the script file rather than `process.cwd()`, so running from the repo root can't silently skip it.

## Verification

Ran in `--audit` mode (read-only, no writes) against the live mapping:

```
📦 Loaded 4650 items from API
📋 Indexed 4063 unique item IDs
🔗 Indexed 663 collapsed family member IDs
↪️  Loaded 559 redirected slugs
   Would create: 126 new items
   Skipped (existing ID): 4063
   Skipped (collapsed into a family): 461
   Skipped (no name): 0
```

461 resurrections prevented, and the 126 that remain are exactly the genuinely-new items — `demonic-boots-t1`, `adamant-chainshot-cannonball`, `ardeaglais-teleport`, `crimson-kisten`, and the rest of the recent content.

The fail-closed path was also confirmed live: an early version had the redirect path relative to cwd, and the run aborted with the intended error instead of generating 587 pages.

## Not in this PR

**The 126 pages are not generated here.** This PR makes generating them safe; committing them is a separate decision, because the generator emits mapping-level frontmatter only (id, name, examine, value, alchs, limit). Without a pass through `enrich-v3-wiki-stats.mjs` and the v4 enrichment they would land as the thinnest pages in the corpus — the opposite of what we want given the rest of this work.

Sequence I'd suggest: merge this, generate, enrich, then commit the pages once they carry equipment stats and `about` prose.

**Coverage still isn't automated.** Nothing diffs the live mapping against pages + families + redirects, which is why 126 items accumulated unnoticed. The exclusion logic added here is most of a coverage check; wiring it into CI is a small follow-up.

## Correction to an earlier claim

I previously reported that the Barrows collapse was specced but never implemented. That was wrong — it is implemented and live (`/osrs/dharok-s-helm-0/` 308s to `/osrs/dharok-s-helm/`). I had read `families.json` as the record when it is a post-prune artifact that structurally cannot show pruned members. No Barrows work is needed.

## Related

- #15295 sitemap chain · #15297 homepage entity clarity · #15298 baked GE prices · #15319 related-items link guard