### PR TITLE
perf(herbmail-game): drop the dead silhouette discard so early-Z can work

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
+++ b/apps/herbmail/herbmail-game/src/game/render/PsxMaterial.tsx
@@ -28,6 +28,21 @@ export { LIGHT_RANGE };
 export const RELIEF_NEAR = 16;
 export const RELIEF_FAR = 22;
 
+// POM silhouette clipping, compiled in or out rather than switched by uniform.
+//
+// A `discard` anywhere in a fragment shader disables early depth rejection on
+// most GPUs: the hardware cannot know whether the fragment writes depth until
+// the shader has run, so it runs it for every fragment including ones a nearer
+// surface will cover. The clip was already inert — uSilhouette is built as 0
+// and nothing in the game ever writes it — but a uniform branch does not help,
+// because the cost is the statement being present in the compiled program, not
+// the branch being taken. Gating it here keeps the shipped shader free of it
+// while leaving the feature one flag away.
+//
+// Worth measuring on real hardware before assuming a win: this makes early-Z
+// possible, it does not by itself prove the dungeon had overdraw to reject.
+const SILHOUETTE_CLIP = false;
+
 const vertex = /* glsl */ `
 	uniform float uSnap;
 	uniform vec2 uRes;
@@ -301,7 +316,7 @@ const fragment = /* glsl */ `
 				hitDepth
 			);
 			pomHit = hitDepth;
-			if (uSilhouette > 0.5 && pomSilhouetteClip(uv, vec4(0.0, 0.0, 1.0, 1.0))) discard;
+			${SILHOUETTE_CLIP ? 'if (uSilhouette > 0.5 && pomSilhouetteClip(uv, vec4(0.0, 0.0, 1.0, 1.0))) discard;' : ''}
 			}
 		} else {
 			uv = mix(vUvCorrect, vUvAffine / vW, uAffine);
@@ -409,6 +424,10 @@ const fragment = /* glsl */ `
 		gl_FragColor = vec4(pow(rgb, vec3(2.2)), tex.a);
 	}
 `;
+
+// Exposed so the shipped program can be asserted on directly. Whether early-Z
+// survives is a property of the source text, not of any uniform value.
+export const PSX_FRAGMENT_SHADER = fragment;
 
 const PsxMaterialBase = shaderMaterial(
 	{

--- a/apps/herbmail/herbmail-game/src/game/render/psxShader.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/render/psxShader.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+//
+// Importing the material reaches charShadow, which installs a debug handle on
+// window at module scope under DEV. The shader source is a plain string and
+// needs no DOM of its own; this only satisfies that import.
+import { describe, it, expect } from 'vitest';
+import { PSX_FRAGMENT_SHADER } from './PsxMaterial';
+
+// The whole point of gating the silhouette clip at build time is that the
+// statement is absent from the compiled program. A uniform branch would read as
+// "off" while still costing early-Z, so asserting the uniform is 0 would prove
+// nothing — the source text is the thing that matters.
+// Comments are stripped before asserting: the injected POM chunk explains in
+// prose that a fragment "should be discarded", which a naive substring match
+// reads as the statement itself.
+const code = PSX_FRAGMENT_SHADER.replace(/\/\*[\s\S]*?\*\//g, '').replace(
+	/\/\/[^\n]*/g,
+	'',
+);
+
+describe('psx fragment shader', () => {
+	it('compiles without discard so early-Z stays available', () => {
+		expect(code).not.toContain('discard');
+	});
+
+	it('still contains the lighting work it is supposed to', () => {
+		expect(code).toContain('visibility(');
+		expect(code).toContain('skyAtWorld(');
+		expect(code).toContain('charShadow(');
+	});
+
+	it('writes no explicit fragment depth, the other early-Z disqualifier', () => {
+		expect(code).not.toContain('gl_FragDepth');
+	});
+});


### PR DESCRIPTION
Follow-up to #15310. Found while looking for the next fragment-shader win.

## The find

`PsxMaterial` carried this:

```glsl
if (uSilhouette > 0.5 && pomSilhouetteClip(uv, vec4(0.0, 0.0, 1.0, 1.0))) discard;
```

`uSilhouette` is built as `0` and **nothing in the game ever writes it** — repo-wide, the only references are the declaration, the default, and this line. The branch cannot be taken.

But it still cost something. **A `discard` anywhere in a fragment shader disables early depth rejection on most GPUs**: the hardware cannot know whether a fragment writes depth until the shader has run, so it runs it for every fragment — including ones a nearer surface goes on to cover. In this shader that means the full per-light occluder march and POM for pixels that are never seen.

A uniform branch does not help, because the cost is the statement being **present in the compiled program**, not the branch being taken. So it is gated at build time now and the shipped shader does not contain it. The feature stays one flag away.

## Honest scope

This makes early-Z *possible*. It does not prove the dungeon had overdraw worth rejecting — that depends on how much the walls, floor and ceiling occlude each other from a given camera, and I cannot measure it here: headless runs on SwiftShader, which has no meaningful early-Z. **Worth a `__frames.work()` before and after on real hardware.**

What is verified is that nothing changed visually — 0.98% of pixels differing against a **0.49–1.04% same-build flicker noise floor**, which is what an unreachable branch should do.

## On the test

Asserted against the shader source text, not the uniform value — the uniform would read as "off" in precisely the case this is fixing, so it proves nothing.

The first version of that assertion **failed**, and correctly so from its own point of view: the injected POM chunk contains a comment saying a fragment "should be discarded", which a naive substring match reads as the statement. Comments are stripped before matching now. Recording it because it is the same shape of mistake as asserting on the uniform — checking a proxy instead of the thing.

170 unit tests, 12 e2e, lint clean.