### PR TITLE
fix(ci): skip auto-approve when PAT owner authored the atomic PR

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -460,6 +460,10 @@ jobs:
 
                         console.log(`PR #${prNumber} approved`);
                       } catch (error) {
+                        if (/own pull request/i.test(error.message)) {
+                          console.log(`Skipping approval: PR #${prNumber} was authored by the PAT owner, so it cannot self-approve. Auto-merge does not require this review.`);
+                          return;
+                        }
                         console.error(`Failed to approve PR: ${error.message}`);
                         core.setFailed(`Failed to approve PR: ${error.message}`);
                       }


### PR DESCRIPTION
## Summary
Fixes #15312.

The atomic auto-merge job approves PRs with `UNITY_PAT`. That works for PRs the workflow creates itself (author = github-actions[bot]), but when the PAT owner pre-creates the PR — as with #15310 — GitHub rejects the review with 422 `Can not approve your own pull request` and the whole job fails, even though the approval is not required for merge.

## Change
Catch the self-approval 422 in the `Auto-approve PR` step, log it, and continue to the auto-merge step instead of failing.