### PR TITLE
fix(fudster): use new starlette TemplateResponse signature

### DIFF
--- a/packages/python/fudster/fudster/api/routes.py
+++ b/packages/python/fudster/fudster/api/routes.py
@@ -40,7 +40,7 @@ class Routes:
 
     def render(self, path: str, template_name: str):
         async def wrapper(request: Request):
-            return self.templates.TemplateResponse(template_name, {"request": request})
+            return self.templates.TemplateResponse(request, template_name)
 
         self.app.add_api_route(path, wrapper, methods=["GET"])
 


### PR DESCRIPTION
Fixes #15323

CI publish job for python-fudster failed in `tests/test_api.py::test_routes_render` with `TypeError: unhashable type: 'dict'`. Newer starlette moved to the `TemplateResponse(request, name, context)` signature, so the old `TemplateResponse(name, {"request": request})` call passed the context dict where the template name belongs and jinja2 tried to use it as a cache key.

Updated `Routes.render` in `packages/python/fudster/fudster/api/routes.py` to the request-first signature. Full fudster suite passes locally: 66 passed, 2 skipped.