### PR TITLE
chore(embeddb): bump to 0.2.0 to release the vector tier

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -769,7 +769,7 @@
 		{
 			"key": "embeddb_crate",
 			"package_name": "embeddb",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"version_toml": "packages/rust/embeddb/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx",
 			"version_target": "packages/rust/embeddb/Cargo.toml"

--- a/apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/embeddb-crate.mdx
@@ -11,7 +11,7 @@ tags:
 key: embeddb_crate
 pipeline: crates
 package_name: embeddb
-version: "0.1.0"
+version: "0.2.0"
 source_path: packages/rust/embeddb
 version_toml: packages/rust/embeddb/version.toml
 author: h0lybyte
@@ -29,6 +29,8 @@ jsonld:
           answer: embeddb is a foundational Rust library providing a single-file embedded database. It pairs Turso (a pure-Rust async SQLite rewrite) as the write path with DuckDB as the analytics read path over one SQLite-format file, so a single file gives both transactional writes and columnar analytics.
         - question: What does embeddb provide?
           answer: Parameterized writes and transactions via Turso, a DuckDB reader pool for parallel analytics, streaming row callbacks, batched writes, migrations and config, a rich EmbedValue type set, QueryResult with column names, and a FromEmbedRow derive for mapping rows into structs.
+        - question: Can embeddb store and search embeddings?
+          answer: Yes, via the optional vector feature. Embeddings are stored as packed f32 blobs in the same single file, normalized on write so similarity search reduces to a dot product, and ranked by brute-force cosine similarity. The feature adds no dependencies and reads through Turso rather than DuckDB, so it works in distroless and egress-restricted images. Embedding model identity is part of each row, and every search filters on it, because vectors from different models do not share a comparable space.
         - question: How does concurrency and freshness work?
           answer: Turso owns all writes; DuckDB attaches the same file read-only for analytics. DuckDB replays uncheckpointed WAL frames, so analytics reflect committed writes even before a checkpoint, and concurrent reads stay consistent. The reader pool builds lazily on the first analytics call, so write-only use never loads the analytics engine.
 bento:
@@ -59,7 +61,7 @@ bento:
     stats:
         - { label: Package, value: embeddb, icon: package }
         - { label: Edition, value: "2021", icon: rust }
-        - { label: Version, value: "0.1.0", icon: branch }
+        - { label: Version, value: "0.2.0", icon: branch }
         - { label: License, value: MIT, icon: license }
     features:
         - title: Turso write path
@@ -77,6 +79,9 @@ bento:
         - title: Live-read freshness
           icon: shield
           body: DuckDB replays uncheckpointed WAL, so analytics reflect committed writes without a forced checkpoint.
+        - title: Vector search
+          icon: network
+          body: Optional vector feature stores embeddings as packed f32 blobs and ranks them by cosine similarity, adding no dependencies.
     related:
         - title: EmbedDB Derive
           href: /project/embeddb-derive-crate/


### PR DESCRIPTION
Release follow-up to #15264 and #15311. MDX-only version bump plus the regenerated manifest — no crate code changes.

## Why this is needed

Both the vector tier and the E2E suite are merged to dev, but crates.io still has embeddb 0.1.0. The publish gate only fires when the MDX version exceeds the published version in `version.toml`, so nothing ships until this lands and dev syncs to main.

`version.toml` stays at 0.1.0 (the published value) and `Cargo.toml` is untouched — CI patches those at publish time. MDX remains the source of truth.

## Minor, not patch

The `vector` feature is additive and off by default. The one behavior change in #15311 — `bool` conversion accepting SQLite's integer encoding — widens what is accepted rather than narrowing it, so no existing caller breaks.

## Changes

- `version: "0.1.0"` → `"0.2.0"` in the crate MDX, and the matching Bento version stat.
- Regenerated `.github/ci-dispatch-manifest.json` via `nx run astro-kbve:gen:ci-manifest`. Only the embeddb version field changed; summary counts are unchanged at 27 crates / 107 total and remain internally consistent.
- Added a vector feature card and an FAQ entry to the crate page. Without these the release page would not mention the headline capability being released.

## Verification

Frontmatter parses, both version fields agree at 0.2.0, and every feature icon resolves against `bento-icons.ts` — `search` is not a key in that map and would have silently fallen back to a generic glyph, so the card uses `network` instead.

`nx run astro-kbve:check` could not run here: the worktree has no real node_modules and the symlinked root fails pnpm resolution for the vitest and eslint plugins. That is the known worktree limitation, unrelated to this change, and CI runs the check on a full install.