### PR TITLE
fix(kubevirt): restore explicit empty customizeComponents

### DIFF
--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -22,6 +22,10 @@ spec:
         network:
             permitBridgeInterfaceOnPodNetwork: true
     imagePullPolicy: IfNotPresent
+    # Must stay an explicit empty object. Omitting the key makes Argo's
+    # server-side apply send null to clear the field, and the CRD schema
+    # rejects null: "spec.customizeComponents in body must be of type object".
+    customizeComponents: {}
     workloadUpdateStrategy:
         workloadUpdateMethods:
             - LiveMigrate


### PR DESCRIPTION
Hotfix — the `kubevirt-cr` Argo app is currently **OutOfSync with the operation Failed**, and that is blocking the fix from #15325 from ever running.

## What broke

#15325 removed the `customizeComponents` key outright. This app syncs with `ServerSideApply=true`, so dropping a field Argo owns sends `null` to clear it. The CRD schema rejects that:

```
KubeVirt.kubevirt.io "kubevirt" is invalid: spec.customizeComponents:
Invalid value: "null": spec.customizeComponents in body must be of type object: "null"
(retried 10 times)
```

My mistake: the CR carried an explicit `{}` before #15294, and the correct revert was restoring that value, not deleting the key.

## Impact

Worse than a failed sync on its own. **Because the sync failed, the PostSync hook never fired** — the `virt-handler-cert-seed` Job from #15325 never ran, so the `clientcertificates` mount is still missing and the error is still firing at 1/min. The whole point of #15325 is currently inert.

## Fix

Restore `customizeComponents: {}` explicitly, with a comment so nobody "tidies up" the empty object again. Intent is unchanged — no component patches.

## Verify after sync

```bash
kubectl -n argocd get application kubevirt-cr -o jsonpath='{.status.sync.status} {.status.operationState.phase}{"\n"}'   # expect Synced Succeeded
kubectl -n kubevirt logs job/virt-handler-cert-seed
kubectl -n kubevirt get ds virt-handler -o json | jq '.spec.template.spec.volumes[].name' | grep virt-handler-certs
kubectl -n kubevirt logs -l kubevirt.io=virt-handler --since=5m | grep -c "failed to load the certificate"   # expect 0
```

Once the app syncs cleanly the hook runs on its own; no manual intervention needed.