### PR TITLE
fix(arc): cap arc-runner-set to maxRunners 1

### DIFF
--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -20,8 +20,11 @@ controllerServiceAccount:
     namespace: arc-systems
 
 # Scaling configuration
+# Capped at 1: two concurrent DinD runners wrote ~171 MB/s into the
+# emptyDir on sda, driving the queue depth to 52 and stalling etcd's
+# fsyncs until every leader-electing controller lost its lease.
 minRunners: 0
-maxRunners: 2
+maxRunners: 1
 
 # Runner group (optional - for enterprise/org runners)
 # runnerGroup: "default"


### PR DESCRIPTION
Mitigation for a recurring cluster-wide control-plane stall. One line; the real fix needs storage work that's still blocked.

## What happens

Two concurrent DinD runners are enough to take down every leader-electing controller in the cluster. Measured during the 17:31 UTC window on 2026-08-03:

```
arc-runner-set-hbk2f-runner-6nxbh   17:31=54  17:32=88 MB/s
arc-runner-set-hbk2f-runner-vfqvd   17:31=66  17:32=83 MB/s
                              sum:  ~120     ~171 MB/s
```

Their `dind-storage` is an `emptyDir`, which lands on `/var/lib/kubelet` — the EPHEMERAL partition on **sda**, the same disk as etcd's WAL. sda over that window:

```
17:19–17:28   0.8 MB/s written,  queue ≈ 0.0
17:29        64 MB/s,  queue 18.1
17:30        48 MB/s,  queue 14.5
17:31        72 MB/s,  queue 19.5   ← 28 pods die here
17:32       148 MB/s,  queue 52.9
17:34+        back to baseline
```

Queue depth 52 on etcd's disk. fsyncs stall, lease renewals miss their deadlines, and every leader exits at once — **28 pods across 14 namespaces**: kube-controller-manager, kube-scheduler, cilium-operator, kyverno, cdi, cnpg, keda, external-secrets, virt-controller, virt-operator and more.

That's what the ~700-restart counters on those pods are. Not independent bugs — the accumulated record of these bursts, recurring every 2–3h.

Supporting evidence that the disk is the cause and not load: etcd is 81 MB with 200 pods at ~47 req/s, and a live 45s sample showed **0 requests over 1s**. The cluster is idle between bursts. Longhorn's instance-manager spikes to 209 MB/s at 17:34 — *after* the stall, reacting to it.

## Why this change

Capping to 1 halves the peak burst. It doesn't fix the root cause — runner scratch is still on etcd's disk — but it meaningfully reduces how often the control plane gets knocked over, for one line and no infrastructure work.

## What it costs

CI concurrency on `arc-runner-set` drops from 2 to 1. Jobs queue rather than fail.

## The actual fix, and why it isn't here

Moving `dind-storage` and `_work` to `longhorn-sdb` via generic ephemeral volumes. That work is staged but **blocked**: sdb is `Schedulable=False` with `DiskPressure` (212 GB available of 960 GB; Longhorn reserves 25% = 240 GB; already 148% overprovisioned). Longhorn will not provision any new volume there, so the runners would sit Pending — worse than today. Needs a cache prune first (`arc-runner-cache-sdb` at 145 GB is the natural candidate).

Worth noting the same disk also hosts CDI scratch space and both registry-mirror caches (`longhorn` default SC = `/var/lib/longhorn` on sda), so the runners aren't the only writer — just the largest.

Longer term this is a single-node problem: a control plane hosting privileged DinD has no scheduling escape. [talos-worker.yaml](apps/kube/talos-worker.yaml) is scaffolded but stale (kubelet v1.32.1 against a v1.33.2 cluster).

## Verify after sync

```bash
kubectl -n arc-runners get autoscalingrunnerset -o jsonpath='{.items[*].spec.maxRunners}{"\n"}'   # expect 1
```

Then watch whether the 2–3h stall cadence drops.