### PR TITLE
fix(kubevirt): set customizeComponents to an empty patches list

### DIFF
--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -22,10 +22,12 @@ spec:
         network:
             permitBridgeInterfaceOnPodNetwork: true
     imagePullPolicy: IfNotPresent
-    # Must stay an explicit empty object. Omitting the key makes Argo's
-    # server-side apply send null to clear the field, and the CRD schema
-    # rejects null: "spec.customizeComponents in body must be of type object".
-    customizeComponents: {}
+    # Needs at least one field actually set. Both an omitted key and a bare
+    # {} serialize to null through server-side apply, and the CRD schema
+    # rejects null: "spec.customizeComponents in body must be of type
+    # object". An empty patches list means the same thing and validates.
+    customizeComponents:
+        patches: []
     workloadUpdateStrategy:
         workloadUpdateMethods:
             - LiveMigrate


### PR DESCRIPTION
Third attempt at the same field. This one is verified against the live API server *before* merge rather than after.

## Why #15346 didn't work either

It replaced the removed key with a bare `{}`. That fails identically. An object with no fields set is indistinguishable from unset, so server-side apply prunes it to null, and the CRD rejects null:

```
KubeVirt.kubevirt.io "kubevirt" is invalid: spec.customizeComponents:
Invalid value: "null": spec.customizeComponents in body must be of type object: "null"
```

Confirmed by server dry-run against the cluster:

| value | result |
|---|---|
| `customizeComponents: {}` | **invalid** — null |
| key omitted | **invalid** — null |
| `customizeComponents: {patches: []}` | `serverside-applied` |
| `customizeComponents: {flags: {}}` | `serverside-applied` |

An empty patches list means the same thing — no component patches — but has a field actually present, so it survives the merge.

## Current state this fixes

`kubevirt-cr` has been `OutOfSync` / operation `Failed` since #15325 merged — first retrying a stale revision, now on `bf3e02cc` which carries the `{}`. The live CR **still holds the #15294 patches**, because no sync has succeeded to remove them. This applies cleanly and clears them.

More importantly it unblocks the PostSync hook, which has never run once. `virt-handler-cert-seed` adds the `clientcertificates` mount, and the 1/min error finally stops.

## Verification

```
$ kubectl apply --server-side --field-manager=argocd-controller --dry-run=server \
    -f apps/kube/kubevirt/cr/kubevirt.yaml
kubevirt.kubevirt.io/kubevirt serverside-applied (server dry run)
```

Run against the exact committed file, after prettier, not a hand-written approximation.

## After sync

```bash
kubectl -n argocd get application kubevirt-cr -o jsonpath='{.status.sync.status} {.status.operationState.phase}{"\n"}'   # Synced Succeeded
kubectl get kubevirt kubevirt -n kubevirt -o jsonpath='{.spec.customizeComponents}{"\n"}'                                # {"patches":[]}
kubectl -n kubevirt logs job/virt-handler-cert-seed
kubectl -n kubevirt get ds virt-handler -o json | jq '.spec.template.spec.volumes[].name' | grep virt-handler-certs
kubectl -n kubevirt logs -l kubevirt.io=virt-handler --since=5m | grep -c "failed to load the certificate"               # 0
```