### PR TITLE
feat(astro-kbve): wrap palworld map + village shop in the bento shell

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/palworld/map.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/palworld/map.mdx
@@ -26,9 +26,15 @@ jsonld:
           path: /palworld/map/
 ---
 
+import BentoShell from '@/components/hero/BentoShell.astro';
 import PalworldMapPanel from '@/components/palworld/map/PalworldMapPanel.astro';
 
-The **Palpagos Islands** — pan and zoom the full Palworld overworld. Points of
-interest and live player positions are on the way.
-
-<PalworldMapPanel />
+<BentoShell
+	id="map"
+	eyebrow="Palworld"
+	heading="Palpagos Islands"
+	sub="Pan and zoom the full Palworld overworld — live players, alpha boss timers, world events, and guild bases straight from the server.">
+	<div class="bento-band">
+		<PalworldMapPanel />
+	</div>
+</BentoShell>

--- a/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/palworld/palshop/village.mdx
@@ -84,10 +84,17 @@ palshop:
         - { id: PotatoSeeds, type: Normal, price: 40, num: 1, stock: 0 }
 ---
 
+import BentoShell from '@/components/hero/BentoShell.astro';
 import PalShopTable from '@/components/palworld/PalShopTable.astro';
 
-The **Village Shop** is the main general store — capture spheres, climate
-armor, healing supplies, food and cooked meals, farm goods and seeds, Pal
-materials, and cosmetics, all at fixed prices.
-
-<PalShopTable shop={frontmatter.palshop} />
+<BentoShell
+	id="village-shop"
+	eyebrow="Palshop"
+	heading="Village Shop"
+	sub="The main general store — capture spheres, climate armor, healing supplies, food and cooked meals, farm goods and seeds, Pal materials, and cosmetics, all at fixed prices.">
+	<div class="bento-band">
+		<div class="bento-card bento-cell">
+			<PalShopTable shop={frontmatter.palshop} />
+		</div>
+	</div>
+</BentoShell>


### PR DESCRIPTION
## What

[/palworld/map/](https://kbve.com/palworld/map/) and [/palworld/palshop/village/](https://kbve.com/palworld/palshop/village/) were bare `template: splash` bodies — raw prose + component with no frame. Both now compose the shared bento primitives per the site-wide rollout:

- `<BentoShell id eyebrow heading sub>` header + `.bento-band` content band (direct `.bento-section`, rails stay continuous)
- map: the interactive `PalworldMapPanel` sits in the band unchanged
- village: `PalShopTable` wrapped in `.bento-card.bento-cell`
- zero new CSS — pure composition

## Verification

Playwright screenshots on local dev: both pages render the shell header ("Palpagos Islands" / "Village Shop"), map fully functional inside the band (live players, bases, filters all working), shop table styled inside its card. No page errors.