### PR TITLE
feat(kubectl): bundle cmctl for forced Certificate renewal

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -21,7 +21,7 @@ jsonld:
           answer: The image tag is pinned across every manifest listed in the deployment_yamls frontmatter field, and all of them auto-bump on each publish via the post-publish version sync.
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.9"
+version: "0.1.10"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml
@@ -144,6 +144,7 @@ Alpine-based kubectl image with a static musl Rust CLI wrapper for KubeVirt VM m
 | Tool | Purpose |
 |------|---------|
 | `kubectl` | Kubernetes API access (static binary) |
+| `cmctl` | cert-manager CLI (static binary) — `cmctl renew` to force a Certificate re-issue |
 | `curl` | HTTP requests |
 | `jq` | JSON processing |
 | `/bin/sh` | Shell script execution (Alpine ash) |

--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -5,7 +5,7 @@
 #   [A] cargo-chef planner (rust:alpine)
 #   [B] cargo-chef cook (cache musl deps)
 #   [C] Build kbve-kubectl static musl binary
-#   [D] Download kubectl static binary
+#   [D] Download kubectl + cmctl static binaries
 #   [Z] Alpine runtime with shell, curl, jq, bash, coreutils, openssl, kubectl, kbve-kubectl
 #
 # Features:
@@ -13,6 +13,7 @@
 #   - bash, GNU coreutils (date -d), openssl for Job scripts
 #   - curl, jq via apk
 #   - kubectl static binary
+#   - cmctl static binary (cert-manager CLI; forced Certificate renewal)
 #   - kbve-kubectl: musl-static, no glibc dependency
 #   - Non-root user (uid 10001 / appuser)
 #
@@ -83,10 +84,21 @@ FROM --platform=linux/amd64 alpine:3.21 AS tools-dl
 RUN apk add --no-cache curl ca-certificates
 
 ARG KUBECTL_VERSION=1.33.2
+ARG CMCTL_VERSION=2.5.0
 
 RUN curl -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
         -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
+
+# cmctl — cert-manager CLI. Static Go binary, so it runs on musl unmodified.
+# Needed for `cmctl renew`, which is the only supported way to force a
+# Certificate re-issue: cert-manager renews on a timer and does not notice
+# when its issuing CA is rotated underneath it, so a cert signed by the old
+# CA key stays Ready until its scheduled renewal.
+RUN curl -fSL "https://github.com/cert-manager/cmctl/releases/download/v${CMCTL_VERSION}/cmctl_linux_amd64" \
+        -o /usr/local/bin/cmctl && \
+    chmod +x /usr/local/bin/cmctl && \
+    cmctl --help >/dev/null
 
 # ============================================================================
 # [STAGE Z] - Alpine runtime
@@ -100,6 +112,7 @@ RUN apk add --no-cache ca-certificates curl jq bash coreutils openssl && \
     chown appuser:appgroup /app /scripts
 
 COPY --from=tools-dl /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=tools-dl /usr/local/bin/cmctl /usr/local/bin/cmctl
 COPY --from=builder /app/target/release/kbve-kubectl /usr/local/bin/kbve-kubectl
 
 WORKDIR /app


### PR DESCRIPTION
Adds `cmctl` (cert-manager CLI) to `ghcr.io/kbve/kubectl`.

## Why now

cert-manager renews Certificates on a **timer** and has no idea when its issuing CA is rotated underneath it. A leaf signed by the old CA key keeps reporting `Ready=True` until its scheduled renewal, while anything verifying it against the *current* CA fails.

`kilobase` is in exactly that state:

| secret | issued | issuer | note |
|---|---|---|---|
| `internal-ca-key-pair` | **2026-07-27** | self | rotated, ECDSA |
| `supabase-server-tls` | **2026-06-27** | `internal-ca` | signed by the **pre-rotation** key |
| `supabase-replication-tls` | 2026-07-29 | `internal-ca` | re-issued after rotation, fine |

`supabase-server-tls` is `Ready=True` with `renewalTime: 2026-08-26`, so cert-manager will not act for another three weeks. Meanwhile CNPG cannot verify it and the cluster sits at:

```
phase:  Unable to create required cluster objects
reason: generating server TLS certificate: failed to verify certificate:
        x509: certificate signed by unknown authority (possibly because of
        "x509: ECDSA verification failure" while trying to verify candidate
        authority certificate "internal-ca")
Ready=False  ClusterIsNotReady
```

Postgres itself is healthy — 3/3 ready, `ContinuousArchiving=True`, `LastBackupSucceeded=True`. What is blocked is **operator reconciliation**, including cert regeneration during a failover.

`cmctl renew` is the supported way to force the re-issue, and it was not available anywhere in the cluster. Adding it to the image beats curling a binary into a one-off Job.

## Changes

- New `CMCTL_VERSION=2.5.0` arg in stage `[D]`, downloaded alongside `kubectl` and copied into the runtime stage.
- Static Go binary, so it runs on musl unmodified — same shape as the existing kubectl download. ~67MB, comparable to kubectl.
- MDX bundled-tools table and `version:` 0.1.9 → 0.1.10. `version.toml` and the pinned manifests auto-sync via post-publish.

## Verification

Download URL returns 200 and the asset is `ELF 64-bit LSB executable, x86-64, statically linked` — both checked before commit. The image builds in CI; there is no local docker daemon, so the layer itself is unbuilt here. The smoke test in the layer is `cmctl --help`, deliberately not a version flag I would be guessing at.

## Follow-up

Once published, the actual remediation is one command, to be run deliberately rather than as part of this PR:

```
cmctl renew supabase-server-tls -n kilobase
```

That re-issues against the current CA and should clear the cluster's `Ready=False`.