### PR TITLE
feat(palworld-savetool): per-base pal rosters in the intel snapshot

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -69,7 +69,7 @@
 		{
 			"key": "agones_palworld_savetool",
 			"app_name": "agones-palworld-savetool",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"version_toml": "apps/agones/palworld/savetool/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx",
 			"source_path": "apps/agones/palworld/savetool",

--- a/apps/agones/palworld/savetool/e2e_save_intel.py
+++ b/apps/agones/palworld/savetool/e2e_save_intel.py
@@ -9,6 +9,8 @@ from save_intel import decompress_sav, find_level_sav, snapshot_once
 GUILD_ID = "11111111-2222-3333-4444-555555555555"
 BASE_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 PLAYER_UID = "99999999-8888-7777-6666-555555555555"
+CONTAINER_ID = "cccccccc-1111-2222-3333-444444444444"
+PAL_INSTANCE_ID = "dddddddd-5555-6666-7777-888888888888"
 
 HEADER = {
     "magic": 0x53415647,
@@ -137,6 +139,145 @@ def build_fixture_sav(path, save_type=0x32):
                                         "owner_map_object_instance_id": BASE_ID,
                                         "trailing_bytes": [0, 0, 0, 0],
                                     },
+                                },
+                                "WorkerDirector": {
+                                    "type": "StructProperty",
+                                    "struct_type": "PalBaseCampWorkerDirectorSaveData",
+                                    "struct_id": "00000000-0000-0000-0000-000000000000",
+                                    "id": None,
+                                    "value": {
+                                        "RawData": {
+                                            "type": "ArrayProperty",
+                                            "array_type": "ByteProperty",
+                                            "custom_type": ".worldSaveData.BaseCampSaveData.Value.WorkerDirector.RawData",
+                                            "id": None,
+                                            "value": {
+                                                "id": BASE_ID,
+                                                "spawn_transform": transform(
+                                                    0.0, 0.0, 0.0
+                                                ),
+                                                "current_order_type": 0,
+                                                "current_battle_type": 0,
+                                                "container_id": CONTAINER_ID,
+                                                "trailing_bytes": [0, 0, 0, 0],
+                                            },
+                                        }
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+                "CharacterContainerSaveData": {
+                    "type": "MapProperty",
+                    "key_type": "StructProperty",
+                    "value_type": "StructProperty",
+                    "key_struct_type": "StructProperty",
+                    "value_struct_type": "StructProperty",
+                    "id": None,
+                    "value": [
+                        {
+                            "key": {
+                                "ID": {
+                                    "type": "StructProperty",
+                                    "struct_type": "Guid",
+                                    "struct_id": "00000000-0000-0000-0000-000000000000",
+                                    "id": None,
+                                    "value": CONTAINER_ID,
+                                }
+                            },
+                            "value": {
+                                "Slots": {
+                                    "type": "ArrayProperty",
+                                    "array_type": "StructProperty",
+                                    "id": None,
+                                    "value": {
+                                        "prop_name": "Slots",
+                                        "prop_type": "StructProperty",
+                                        "type_name": "PalCharacterSlotSaveData",
+                                        "id": "00000000-0000-0000-0000-000000000000",
+                                        "values": [
+                                            {
+                                                "RawData": {
+                                                    "type": "ArrayProperty",
+                                                    "array_type": "ByteProperty",
+                                                    "custom_type": ".worldSaveData.CharacterContainerSaveData.Value.Slots.Slots.RawData",
+                                                    "id": None,
+                                                    "value": {
+                                                        "player_uid": "00000000-0000-0000-0000-000000000000",
+                                                        "instance_id": PAL_INSTANCE_ID,
+                                                        "permission_tribe_id": 0,
+                                                    },
+                                                }
+                                            }
+                                        ],
+                                    },
+                                }
+                            },
+                        }
+                    ],
+                },
+                "CharacterSaveParameterMap": {
+                    "type": "MapProperty",
+                    "key_type": "StructProperty",
+                    "value_type": "StructProperty",
+                    "key_struct_type": "StructProperty",
+                    "value_struct_type": "StructProperty",
+                    "id": None,
+                    "value": [
+                        {
+                            "key": {
+                                "PlayerUId": {
+                                    "type": "StructProperty",
+                                    "struct_type": "Guid",
+                                    "struct_id": "00000000-0000-0000-0000-000000000000",
+                                    "id": None,
+                                    "value": "00000000-0000-0000-0000-000000000000",
+                                },
+                                "InstanceId": {
+                                    "type": "StructProperty",
+                                    "struct_type": "Guid",
+                                    "struct_id": "00000000-0000-0000-0000-000000000000",
+                                    "id": None,
+                                    "value": PAL_INSTANCE_ID,
+                                },
+                            },
+                            "value": {
+                                "RawData": {
+                                    "type": "ArrayProperty",
+                                    "array_type": "ByteProperty",
+                                    "custom_type": ".worldSaveData.CharacterSaveParameterMap.Value.RawData",
+                                    "id": None,
+                                    "value": {
+                                        "object": {
+                                            "SaveParameter": {
+                                                "type": "StructProperty",
+                                                "struct_type": "PalIndividualCharacterSaveParameter",
+                                                "struct_id": "00000000-0000-0000-0000-000000000000",
+                                                "id": None,
+                                                "value": {
+                                                    "CharacterID": {
+                                                        "type": "NameProperty",
+                                                        "id": None,
+                                                        "value": "SheepBall",
+                                                    },
+                                                    "NickName": {
+                                                        "type": "StrProperty",
+                                                        "id": None,
+                                                        "value": "Wooly",
+                                                    },
+                                                    "Level": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 12,
+                                                    },
+                                                },
+                                            }
+                                        },
+                                        "unknown_bytes": [0, 0, 0, 0],
+                                        "group_id": GUILD_ID,
+                                        "trailing_bytes": [0, 0, 0, 0],
+                                    },
                                 }
                             },
                         }
@@ -186,6 +327,11 @@ def main():
     expect(
         roster == [{"uid": PLAYER_UID, "name": "h0lybyte", "last_online": 638}],
         "player roster",
+    )
+    pals = base["pals"]
+    expect(
+        pals == [{"id": "SheepBall", "name": "Wooly", "level": 12}],
+        "base pal roster resolved via worker director container",
     )
     with open(out_path) as f:
         disk = json.load(f)

--- a/apps/agones/palworld/savetool/save_intel.py
+++ b/apps/agones/palworld/savetool/save_intel.py
@@ -9,7 +9,11 @@ import time
 WANTED_PROPERTIES = (
     ".worldSaveData.GroupSaveDataMap",
     ".worldSaveData.BaseCampSaveData.Value.RawData",
+    ".worldSaveData.BaseCampSaveData.Value.WorkerDirector.RawData",
+    ".worldSaveData.CharacterContainerSaveData.Value.Slots.Slots.RawData",
 )
+
+MAX_BASE_PALS = 60
 
 
 def pv(node, *keys):
@@ -46,10 +50,84 @@ def parse_sav(path):
     return gvas.properties
 
 
+def decode_character(raw_bytes):
+    from palsav.archive import FArchiveReader
+    from palsav.paltypes import PALWORLD_TYPE_HINTS
+    from palsav.rawdata import character
+
+    parent = FArchiveReader(b"", PALWORLD_TYPE_HINTS, {})
+    data = character.decode_bytes(parent, raw_bytes) or {}
+    sp = pv(data.get("object") or {}, "SaveParameter") or {}
+    if pv(sp, "IsPlayer"):
+        return None
+    char_id = pv(sp, "CharacterID") or ""
+    if not char_id:
+        return None
+    return {
+        "id": str(char_id),
+        "name": pv(sp, "NickName") or "",
+        "level": pv(sp, "Level") or 1,
+    }
+
+
+def container_slot_instances(world):
+    containers = pv(world, "CharacterContainerSaveData") or []
+    by_container = {}
+    for entry in containers:
+        key_id = pv(entry.get("key"), "ID")
+        if not key_id:
+            continue
+        slots_prop = pv(entry.get("value"), "Slots")
+        slots = (
+            slots_prop.get("values")
+            if isinstance(slots_prop, dict)
+            else slots_prop
+        ) or []
+        instances = []
+        for slot in slots:
+            raw = pv(slot, "RawData")
+            inst = raw.get("instance_id") if isinstance(raw, dict) else None
+            if inst:
+                instances.append(str(inst))
+        by_container[str(key_id)] = instances
+    return by_container
+
+
+def character_bytes_by_instance(world):
+    chars = pv(world, "CharacterSaveParameterMap") or []
+    by_instance = {}
+    for entry in chars:
+        inst = pv(entry.get("key"), "InstanceId")
+        raw = pv(entry.get("value"), "RawData")
+        values = raw.get("values") if isinstance(raw, dict) else None
+        if inst and values:
+            by_instance[str(inst)] = values
+    return by_instance
+
+
+def resolve_base_pals(camp_value, containers, char_bytes):
+    director = pv(camp_value, "WorkerDirector", "RawData") or {}
+    container_id = str(director.get("container_id") or "")
+    pals = []
+    for inst in containers.get(container_id, [])[:MAX_BASE_PALS]:
+        raw = char_bytes.get(inst)
+        if not raw:
+            continue
+        try:
+            pal = decode_character(raw)
+        except Exception:
+            continue
+        if pal:
+            pals.append(pal)
+    return pals
+
+
 def extract_guilds(properties):
     world = pv(properties, "worldSaveData") or {}
     groups = pv(world, "GroupSaveDataMap") or []
     camps = pv(world, "BaseCampSaveData") or []
+    containers = container_slot_instances(world)
+    char_bytes = character_bytes_by_instance(world)
 
     camp_by_id = {}
     for entry in camps:
@@ -65,6 +143,9 @@ def extract_guilds(properties):
             "x": translation.get("x", 0.0),
             "y": translation.get("y", 0.0),
             "z": translation.get("z", 0.0),
+            "pals": resolve_base_pals(
+                entry.get("value") or {}, containers, char_bytes
+            ),
         }
 
     guilds = []

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -14,7 +14,7 @@ tags:
 key: agones_palworld_savetool
 pipeline: docker
 app_name: agones-palworld-savetool
-version: "0.0.4"
+version: "0.0.5"
 source_path: apps/agones/palworld/savetool
 version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Bases in `/live/bases` now include the pals working them:

```json
"bases": [{ "id": "…", "x": …, "y": …, "pals": [{ "id": "SheepBall", "name": "Wooly", "level": 12 }] }]
```

Resolution chain: base camp `WorkerDirector.RawData.container_id` → `CharacterContainerSaveData` slots (`instance_id`s) → `CharacterSaveParameterMap` → `SaveParameter` (`CharacterID`/`NickName`/`Level`). Players filtered out, capped at 60 pals/base.

## Perf

`CharacterSaveParameterMap` is the dominant chunk of a world save — it is deliberately parsed **without** the per-entry character decoder (raw bytes kept), and only the handful of instances actually sitting in base containers get decoded. Parse cost stays bounded regardless of how many wild/party pals exist.

## Verification

- e2e fixture now encodes the full chain (worker director + container slot + character entry) through palsav's own codecs; new assertion: roster resolves to `Wooly the SheepBall Lv 12`. 17 checks green, coverage 86%.
- unit tests unchanged, pass.

MDX `0.0.4 → 0.0.5`, manifest regenerated. Map modal consuming `pals[]` lands in the follow-up frontend PR.