### PR TITLE
feat(palworld): pal breeding stats in base intel + map modal

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -69,7 +69,7 @@
 		{
 			"key": "agones_palworld_savetool",
 			"app_name": "agones-palworld-savetool",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"version_toml": "apps/agones/palworld/savetool/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx",
 			"source_path": "apps/agones/palworld/savetool",

--- a/apps/agones/palworld/savetool/e2e_save_intel.py
+++ b/apps/agones/palworld/savetool/e2e_save_intel.py
@@ -271,6 +271,45 @@ def build_fixture_sav(path, save_type=0x32):
                                                         "id": None,
                                                         "value": 12,
                                                     },
+                                                    "Gender": {
+                                                        "type": "EnumProperty",
+                                                        "id": None,
+                                                        "value": {
+                                                            "type": "EPalGenderType",
+                                                            "value": "EPalGenderType::Female",
+                                                        },
+                                                    },
+                                                    "Rank": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 2,
+                                                    },
+                                                    "Talent_HP": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 85,
+                                                    },
+                                                    "Talent_Shot": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 90,
+                                                    },
+                                                    "Talent_Defense": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 100,
+                                                    },
+                                                    "PassiveSkillList": {
+                                                        "type": "ArrayProperty",
+                                                        "array_type": "NameProperty",
+                                                        "id": None,
+                                                        "value": {
+                                                            "values": [
+                                                                "CraftSpeed_up1",
+                                                                "PAL_Sanity_Down_1",
+                                                            ]
+                                                        },
+                                                    },
                                                 },
                                             }
                                         },
@@ -330,8 +369,19 @@ def main():
     )
     pals = base["pals"]
     expect(
-        pals == [{"id": "SheepBall", "name": "Wooly", "level": 12}],
-        "base pal roster resolved via worker director container",
+        pals
+        == [
+            {
+                "id": "SheepBall",
+                "name": "Wooly",
+                "level": 12,
+                "gender": "F",
+                "rank": 2,
+                "talents": {"hp": 85, "attack": 90, "defense": 100},
+                "passives": ["CraftSpeed_up1", "PAL_Sanity_Down_1"],
+            }
+        ],
+        "base pal roster with breeding stats",
     )
     with open(out_path) as f:
         disk = json.load(f)

--- a/apps/agones/palworld/savetool/save_intel.py
+++ b/apps/agones/palworld/savetool/save_intel.py
@@ -63,10 +63,25 @@ def decode_character(raw_bytes):
     char_id = pv(sp, "CharacterID") or ""
     if not char_id:
         return None
+    gender = str(pv(sp, "Gender") or "")
+    passives_prop = pv(sp, "PassiveSkillList")
+    passives = (
+        passives_prop.get("values")
+        if isinstance(passives_prop, dict)
+        else passives_prop
+    ) or []
     return {
         "id": str(char_id),
         "name": pv(sp, "NickName") or "",
         "level": pv(sp, "Level") or 1,
+        "gender": "F" if "Female" in gender else "M" if "Male" in gender else "",
+        "rank": pv(sp, "Rank") or 1,
+        "talents": {
+            "hp": pv(sp, "Talent_HP") or 0,
+            "attack": pv(sp, "Talent_Shot") or 0,
+            "defense": pv(sp, "Talent_Defense") or 0,
+        },
+        "passives": [str(p) for p in passives],
     }
 
 

--- a/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
@@ -631,7 +631,15 @@ export default function ReactPalworldMap() {
 					`<path d="M6.5 14v-4h3v4" fill="rgba(52,211,153,0.5)"/>` +
 					`</svg></div>`,
 			});
-		type BasePal = { id: string; name: string; level: number };
+		type BasePal = {
+			id: string;
+			name: string;
+			level: number;
+			gender?: string;
+			rank?: number;
+			talents?: { hp: number; attack: number; defense: number };
+			passives?: string[];
+		};
 		type BaseIntel = {
 			id: string;
 			name?: string;
@@ -681,10 +689,30 @@ export default function ReactPalworldMap() {
 				`onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"/>` +
 				`<span style="display:none;width:34px;height:34px;border-radius:50%;background:#173042;color:#7dd3fc;` +
 				`align-items:center;justify-content:center;font-weight:600">${initial}</span>` +
-				`<span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">` +
+				`<div style="flex:1;min-width:0">` +
+				`<div style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">` +
 				`${esc(p.name || clean)}` +
 				(p.name ? `<span style="color:#8b9bb0"> · ${clean}</span>` : '') +
-				`</span>` +
+				(p.gender === 'F'
+					? `<span style="color:#f0abfc"> ♀</span>`
+					: p.gender === 'M'
+						? `<span style="color:#7dd3fc"> ♂</span>`
+						: '') +
+				(p.rank && p.rank > 1
+					? `<span style="color:#fbbf24"> ${'★'.repeat(Math.min(4, p.rank - 1))}</span>`
+					: '') +
+				`</div>` +
+				(p.talents
+					? `<div style="color:#8b9bb0;font-size:11px">IV ` +
+						`<span style="color:#a7f3d0">${p.talents.hp}</span>/` +
+						`<span style="color:#fca5a5">${p.talents.attack}</span>/` +
+						`<span style="color:#93c5fd">${p.talents.defense}</span>` +
+						(p.passives?.length
+							? ` · ${p.passives.map((s) => esc(s.replace(/_/g, ' '))).join(', ')}`
+							: '') +
+						`</div>`
+					: '') +
+				`</div>` +
 				`<span style="color:#34d399;font-variant-numeric:tabular-nums">Lv ${p.level}</span></div>`
 			);
 		};

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -14,7 +14,7 @@ tags:
 key: agones_palworld_savetool
 pipeline: docker
 app_name: agones-palworld-savetool
-version: "0.0.5"
+version: "0.0.6"
 source_path: apps/agones/palworld/savetool
 version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

The breeding-scouting layer on top of #15381/#15383 — pal entries in `/live/bases` gain:

```json
{ "id": "SheepBall", "name": "Wooly", "level": 12, "gender": "F", "rank": 2,
  "talents": { "hp": 85, "attack": 90, "defense": 100 },
  "passives": ["CraftSpeed_up1", "PAL_Sanity_Down_1"] }
```

(`Gender`/`Rank`/`Talent_HP`/`Talent_Shot`/`Talent_Defense`/`PassiveSkillList` from `SaveParameter`.)

The base modal on [kbve.com/palworld/map](https://kbve.com/palworld/map/) renders per pal: ♀/♂ glyph, condensation stars (rank>1), color-coded IV triple (HP/ATK/DEF), and the passive skill list. All fields optional — a pre-0.0.6 snapshot renders exactly as before.

## Verification

- savetool e2e round-trips the full stat set through palsav's codecs (fixture asserts gender F, rank 2, IVs 85/90/100, two passives) — all checks green
- playwright modal check: stats render, stat-less legacy pal degrades cleanly, hostile-name escaping still intact

MDX `0.0.5 → 0.0.6`, manifest regenerated.