### PR TITLE
fix(rn): make the iOS dev build link and boot

### DIFF
--- a/apps/kbve/kbve-react-native/package.json
+++ b/apps/kbve/kbve-react-native/package.json
@@ -10,8 +10,10 @@
 		"web": "expo start --web"
 	},
 	"dependencies": {
+		"@expo/vector-icons": "^15.1.1",
 		"@hcaptcha/react-native-hcaptcha": "4.1.0",
 		"@react-native-async-storage/async-storage": "2.2.0",
+		"@shopify/react-native-skia": "2.6.9",
 		"expo": "~57.0.9",
 		"expo-auth-session": "57.0.5",
 		"expo-build-properties": "~57.0.8",
@@ -21,9 +23,11 @@
 		"expo-web-browser": "57.0.2",
 		"react": "19.2.3",
 		"react-native": "0.86.2",
+		"react-native-gesture-handler": "~2.32.0",
 		"react-native-reanimated": "4.5.1",
 		"react-native-safe-area-context": "5.7.0",
 		"react-native-svg": "15.15.4",
+		"react-native-url-polyfill": "^4.0.0",
 		"react-native-webgpu": "0.8.1",
 		"react-native-webview": "13.16.1",
 		"react-native-worklets": "0.10.3",

--- a/packages/rust/kbve_wgpu/src/ffi.rs
+++ b/packages/rust/kbve_wgpu/src/ffi.rs
@@ -92,6 +92,27 @@ pub unsafe extern "C" fn kbve_wgpu_create_game(
     }
 }
 
+/// Stub used when the `bevy` feature is off. The Swift and Kotlin views call
+/// this symbol unconditionally, so it has to exist in every build or the host
+/// app fails to link. Returns null, which the callers already treat as
+/// "surface unavailable".
+///
+/// # Safety
+/// Same pointer contract as [`kbve_wgpu_create`].
+#[cfg(not(feature = "bevy"))]
+#[no_mangle]
+pub unsafe extern "C" fn kbve_wgpu_create_game(
+    _raw: *mut c_void,
+    _kind: u32,
+    _width: u32,
+    _height: u32,
+    _asset_root: *const u8,
+    _asset_root_len: usize,
+) -> *mut WgpuSurface {
+    log::error!("kbve_wgpu_create_game unavailable: built without the `bevy` feature");
+    ptr::null_mut()
+}
+
 /// # Safety
 /// `surface` must be a live pointer from `kbve_wgpu_create`.
 #[no_mangle]

--- a/packages/rust/kbve_wgpu/src/handle.rs
+++ b/packages/rust/kbve_wgpu/src/handle.rs
@@ -53,7 +53,7 @@ impl SurfaceSource {
 
         let view = NonNull::new(self.raw).expect("null UIView");
         wgpu::SurfaceTargetUnsafe::RawHandle {
-            raw_display_handle: RawDisplayHandle::UiKit(UiKitDisplayHandle::new()),
+            raw_display_handle: Some(RawDisplayHandle::UiKit(UiKitDisplayHandle::new())),
             raw_window_handle: RawWindowHandle::UiKit(UiKitWindowHandle::new(view)),
         }
     }
@@ -84,7 +84,7 @@ impl SurfaceSource {
         let raw_window_handle = RawWindowHandle::AndroidNdk(AndroidNdkWindowHandle::new(window));
         let raw_display_handle = RawDisplayHandle::Android(AndroidDisplayHandle::new());
         wgpu::SurfaceTargetUnsafe::RawHandle {
-            raw_display_handle,
+            raw_display_handle: Some(raw_display_handle),
             raw_window_handle,
         }
     }


### PR DESCRIPTION
Follow-up to #15317 (Expo SDK 56 -> 57) and #15321 (third-party bumps). These fixes were pushed to the #15321 branch after it had already merged, so they never made it into `dev` — this PR carries them over on their own.

Booting the app on a simulator to verify the SDK 57 upgrade surfaced three pre-existing breakages in the native path. None are caused by the Expo or third-party bumps; the iOS dev build had simply never been exercised.

## 1. `kbve_wgpu` did not compile for `aarch64-apple-ios`

wgpu 29 changed `SurfaceTargetUnsafe::RawHandle.raw_display_handle` to `Option<RawDisplayHandle>`. Wrapped in both the UiKit and Android arms of `handle.rs`.

## 2. Undefined symbol `_kbve_wgpu_create_game` at link time

The function is gated behind `#[cfg(feature = "bevy")]`, but `KbveWgpuView.swift` and `KbveWgpuView.kt` call it unconditionally, so any build without the feature fails to link. Added a non-bevy stub returning null, which both callers already handle as "surface unavailable".

The bevy-featured build is not a workaround here: `isometric-game` pulls `tauri-build 2.6.3`, which panics during the build with `missing cargo:dev instruction, please update tauri to latest`. Worth tracking separately.

Related: `build:native:ios` in the app's `project.json` wires up `kbve_wgpu:build:ios`, which omits the `bevy` feature the Swift view expects. With the stub it links cleanly, but game mode returns null. Left as-is here since fixing it properly depends on the tauri issue above.

## 3. App redboxed at startup

`TurboModuleRegistry.getEnforcing(...): 'RNGestureHandlerModule' could not be found`.

Four dependencies that `@kbve/rn` uses were missing from the app manifest, so Expo autolinking skipped their pods entirely: `react-native-gesture-handler`, `@shopify/react-native-skia`, `@expo/vector-icons`, `react-native-url-polyfill`. Added, and the dependency list sorted. `RNGestureHandler 2.32.0` and `react-native-skia 2.6.9` now appear in `Podfile.lock`.

## Verification

Verified on an iPhone 17 Pro simulator (Xcode 26.5): `expo prebuild` + `expo run:ios` builds, installs, launches, and the login screen renders with no redbox — gold theme, hCaptcha widget and the three OAuth buttons all present. Device logs are clean apart from an `AuthApiError: Invalid Refresh Token`, which is a stale session left in the simulator's AsyncStorage by a previous install.

`cargo clippy` is clean and the crate's tests pass. `cargo fmt --check` still fails on an unrelated import ordering in `lib.rs`'s `android_jni` module; that is pre-existing and deliberately left alone.

Still unverified: the `react-native-webgpu` 0.8.1 **runtime** GPU path. The pod compiles and links, but the FX screen sits behind `AuthGate`, so exercising it needs a real sign-in.
