### PR TITLE
fix(monitoring): kilobase alerts were firing on metrics that do not exist

### DIFF
--- a/apps/kube/cert-manager/manifests/kustomization.yaml
+++ b/apps/kube/cert-manager/manifests/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
     - cluster-issuer.yaml
     - letsencrypt-dns-issuer.yaml
     - kbve-cloudflare-rbac.yaml
+    - servicemonitor.yaml
 
 patches:
     - target:

--- a/apps/kube/cert-manager/manifests/servicemonitor.yaml
+++ b/apps/kube/cert-manager/manifests/servicemonitor.yaml
@@ -1,0 +1,28 @@
+# Scrape cert-manager.
+#
+# Nothing scraped cert-manager at all — no ServiceMonitor existed in the
+# namespace, so certmanager_* was absent cluster-wide. That matters here
+# because CNPG does NOT export any certificate-expiry metric (the name
+# cnpg_cluster_cert_expires_in_seconds used by the old alert appears nowhere
+# in cloudnative-pg), so cert-manager is the only real source of expiry data
+# for the kilobase certificates.
+#
+# The chart's own service already exposes the controller's 9402 endpoint under
+# the port name tcp-prometheus-servicemonitor.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: cert-manager-scrape
+    namespace: cert-manager
+    labels:
+        release: monitoring
+        kbve.com/category: observability
+        kbve.com/stack: core
+spec:
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: cert-manager
+            app.kubernetes.io/component: controller
+    endpoints:
+        - port: tcp-prometheus-servicemonitor
+          interval: 60s

--- a/apps/kube/cnpg/manifests/operator-podmonitor.yaml
+++ b/apps/kube/cnpg/manifests/operator-podmonitor.yaml
@@ -1,0 +1,22 @@
+# Scrape the CNPG operator itself.
+#
+# The chart ships a PodMonitor (cnpg-operator-cloudnative-pg) labelled only
+# with app.kubernetes.io/* + helm.sh/chart, which this Prometheus does not
+# select — so controller-runtime reconcile metrics were never collected. That
+# is the signal that would have caught kilobase sitting at Ready=False for
+# nine days while its server cert stayed signed by a rotated-out CA.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+    name: cnpg-operator-scrape
+    namespace: cnpg-system
+    labels:
+        release: monitoring
+        kbve.com/category: observability
+        kbve.com/stack: core
+spec:
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: cloudnative-pg
+    podMetricsEndpoints:
+        - port: metrics

--- a/apps/kube/kilobase/manifests/cert-expiry-alert.yaml
+++ b/apps/kube/kilobase/manifests/cert-expiry-alert.yaml
@@ -1,30 +1,51 @@
+# Certificate alerts for kilobase.
+#
+# These previously ran on cnpg_cluster_cert_expires_in_seconds. That metric
+# does not exist — the string appears nowhere in cloudnative-pg, and CNPG
+# exports no certificate-expiry metric at all. The rules could never fire, on
+# top of cnpg_* not being scraped in the first place (see cnpg-podmonitor.yaml).
+#
+# cert-manager is the real source: it owns supabase-server-tls and
+# supabase-replication-tls via internal-ca-issuer, and exports both expiry and
+# readiness per Certificate.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: cnpg-cert-expiry-alert
-  namespace: kilobase
-  labels:
-    prometheus: kube-prometheus
-    role: alert-rules
+    name: cnpg-cert-expiry-alert
+    namespace: kilobase
+    labels:
+        prometheus: kube-prometheus
+        role: alert-rules
 spec:
-  groups:
-    - name: cnpg-certificates
-      rules:
-        - alert: CNPGCertificateExpiringSoon
-          annotations:
-            description: "CloudNativePG certificate {{ $labels.secret_name }} in cluster {{ $labels.cluster }} expires in less than 14 days"
-            summary: "CNPG certificate expiring soon"
-          expr: |
-            cnpg_cluster_cert_expires_in_seconds < 1209600
-          for: 1h
-          labels:
-            severity: warning
-        - alert: CNPGCertificateExpiryCritical
-          annotations:
-            description: "CloudNativePG certificate {{ $labels.secret_name }} in cluster {{ $labels.cluster }} expires in less than 3 days!"
-            summary: "CNPG certificate expiry CRITICAL"
-          expr: |
-            cnpg_cluster_cert_expires_in_seconds < 259200
-          for: 5m
-          labels:
-            severity: critical
+    groups:
+        - name: cnpg-certificates
+          rules:
+              - alert: KilobaseCertificateExpiringSoon
+                annotations:
+                    description: 'Certificate {{ $labels.name }} in {{ $labels.namespace }} expires in less than 14 days.'
+                    summary: 'kilobase certificate expiring soon'
+                expr: |
+                    (certmanager_certificate_expiration_timestamp_seconds{namespace="kilobase"} - time()) < 1209600
+                for: 1h
+                labels:
+                    severity: warning
+
+              - alert: KilobaseCertificateExpiryCritical
+                annotations:
+                    description: 'Certificate {{ $labels.name }} in {{ $labels.namespace }} expires in less than 3 days!'
+                    summary: 'kilobase certificate expiry CRITICAL'
+                expr: |
+                    (certmanager_certificate_expiration_timestamp_seconds{namespace="kilobase"} - time()) < 259200
+                for: 5m
+                labels:
+                    severity: critical
+
+              - alert: KilobaseCertificateNotReady
+                annotations:
+                    description: 'Certificate {{ $labels.name }} in {{ $labels.namespace }} is not Ready. Note this does NOT catch a certificate signed by a rotated-out CA — cert-manager keeps reporting Ready=True in that case. CNPGReconcileErrors is the rule that covers that.'
+                    summary: 'kilobase certificate not ready'
+                expr: |
+                    certmanager_certificate_ready_status{namespace="kilobase",condition="True"} == 0
+                for: 30m
+                labels:
+                    severity: warning

--- a/apps/kube/kilobase/manifests/cnpg-podmonitor.yaml
+++ b/apps/kube/kilobase/manifests/cnpg-podmonitor.yaml
@@ -1,0 +1,45 @@
+# CNPG metric scrape wiring.
+#
+# The operator generates its own PodMonitors (spec.monitoring.enablePodMonitor
+# on the Cluster, plus one per Pooler), but labels them only with cnpg.io/*.
+# This Prometheus selects on podMonitorSelector.matchLabels.release=monitoring,
+# so none of them were ever picked up: 0 active targets, 0 cnpg_* series, and
+# every alert built on those metrics silently vacuous — including
+# cnpg-cert-expiry-alert and supabase-pooler-health.
+#
+# These mirror the operator's selectors with the release label added. Ports are
+# the operator's own names: 9187 (instance) and 9127 (pooler), both "metrics".
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+    name: supabase-cluster-scrape
+    namespace: kilobase
+    labels:
+        release: monitoring
+        kbve.com/category: observability
+        kbve.com/stack: core
+spec:
+    selector:
+        matchLabels:
+            cnpg.io/cluster: supabase-cluster
+            cnpg.io/podRole: instance
+    podMetricsEndpoints:
+        - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+    name: supabase-cluster-pooler-scrape
+    namespace: kilobase
+    labels:
+        release: monitoring
+        kbve.com/category: observability
+        kbve.com/stack: core
+spec:
+    selector:
+        matchLabels:
+            cnpg.io/cluster: supabase-cluster
+            cnpg.io/podRole: pooler
+    podMetricsEndpoints:
+        - port: metrics

--- a/apps/kube/kilobase/manifests/cnpg-reconcile-alert.yaml
+++ b/apps/kube/kilobase/manifests/cnpg-reconcile-alert.yaml
@@ -1,0 +1,39 @@
+# Alerts for the CNPG operator's own reconcile loop.
+#
+# cnpg-cert-expiry-alert only measures time-to-expiry, so it stays quiet when a
+# certificate is valid but unverifiable. That is exactly what happened on
+# 2026-07-27: internal-ca was rotated, supabase-server-tls kept its Jun 27
+# signature from the previous CA key, cert-manager reported Ready=True with a
+# renewal date of Aug 26, and the cluster sat at Ready=False for nine days with
+# nothing firing. The operator was failing every reconcile the whole time.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: cnpg-operator-reconcile-alert
+    namespace: kilobase
+    labels:
+        prometheus: kube-prometheus
+        role: alert-rules
+spec:
+    groups:
+        - name: cnpg-operator
+          rules:
+              - alert: CNPGReconcileErrors
+                annotations:
+                    description: 'CNPG operator controller {{ $labels.controller }} has been failing reconciles for 30m. Check `kubectl get cluster -n kilobase -o jsonpath={.status.phaseReason}` — a cluster stuck in a non-Ready phase cannot regenerate certificates or complete a failover, even while Postgres keeps serving.'
+                    summary: 'CNPG operator reconcile errors'
+                expr: |
+                    increase(controller_runtime_reconcile_errors_total{namespace="cnpg-system"}[15m]) > 0
+                for: 30m
+                labels:
+                    severity: warning
+
+              - alert: CNPGMetricsMissing
+                annotations:
+                    description: 'No cnpg_collector_up series for the kilobase cluster. CNPG metrics stopped being scraped, which silently disables every kilobase alert built on cnpg_* — cert expiry and pooler health included. Check that the PodMonitors still carry release=monitoring.'
+                    summary: 'CNPG metrics not being scraped'
+                expr: |
+                    absent(cnpg_collector_up{namespace="kilobase"})
+                for: 15m
+                labels:
+                    severity: warning


### PR DESCRIPTION
Follow-up to #15376. While wiring `cmctl` for the kilobase cert fix, I checked why nothing alerted during the nine days the cluster sat at `Ready=False` — every rule that should have caught it was inert, for two independent reasons.

## 1. Nothing scraped CNPG

Prometheus selects PodMonitors on `matchLabels.release=monitoring`. The operator labels the ones it generates with `cnpg.io/*` only:

```
podMonitorSelector = {"matchLabels":{"release":"monitoring"}}
podmonitor/supabase-cluster labels = {"cnpg.io/cluster":"supabase-cluster"}
```

Result: **0 active targets, 0 `cnpg_*` series cluster-wide.** That also silently disabled `supabase-pooler-health`, which runs on `cnpg_pgbouncer_pools_*` / `cnpg_pgbouncer_stats_*`. cert-manager was never scraped either — no ServiceMonitor existed in that namespace at all, so `certmanager_*` was absent too.

## 2. The cert alert used a metric that does not exist

Both rules in `cert-expiry-alert.yaml` ran on `cnpg_cluster_cert_expires_in_seconds`. That string appears **nowhere** in cloudnative-pg (`gh api search/code` → 0 hits), and CNPG exports no certificate-expiry metric at all. Those rules could never have fired even with scraping fixed.

## Changes

- **PodMonitors** with `release=monitoring` for cluster instances, poolers, and the operator; **ServiceMonitor** for cert-manager. Ports use the operator's own names, verified against live pods: `9187` instance, `9127` pooler, `9402` cert-manager controller.
- **Cert rules rebuilt on `certmanager_certificate_*`** — cert-manager owns these certificates via `internal-ca-issuer` and is the only real source of expiry data.
- **`CNPGReconcileErrors`** on `controller_runtime_reconcile_errors_total`. This is what would have caught the incident: the operator failed every reconcile for nine days while Postgres kept serving and no certificate was near expiry.
- **`CNPGMetricsMissing`** on `absent(cnpg_collector_up)` — so the scrape silently breaking again is itself alertable. That is the exact failure mode that produced this PR.

## Verification

Every metric name checked against upstream source rather than assumed, since assuming is how the dead name got in:

| metric | verified at |
|---|---|
| `controller_runtime_reconcile_errors_total` | controller-runtime `pkg/internal/controller/metrics/metrics.go` |
| `cnpg_collector_up` | cloudnative-pg v1.26.1 `pg_collector.go:126`, `PrometheusNamespace = "cnpg"` |
| `certmanager_certificate_expiration_timestamp_seconds` | cert-manager v1.19.0 `internal/collectors/certificate_collector.go:33` |
| `certmanager_certificate_ready_status` | same file, line 30 — label set includes `condition` |

All five manifests pass `kubectl apply --dry-run=server`.

## Known gap, stated deliberately

A certificate signed by a rotated-out CA still reports `Ready=True` to cert-manager, so **no `certmanager_*` rule catches that case**. `CNPGReconcileErrors` is the rule that does, and `KilobaseCertificateNotReady` carries that caveat in its own annotation so nobody trusts it for the wrong thing.

cert-manager's ServiceMonitor lives in that app rather than kilobase's, whose Argo destination namespace is `kilobase`.

## Still outstanding

`cmctl renew supabase-server-tls -n kilobase` has not been run — kilobase is still `Ready=False`. This PR makes the failure visible; it does not fix it.