### PR TITLE
feat(dashboard): Longhorn storage dashboard at /dashboard/storage/

### DIFF
--- a/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
@@ -98,6 +98,7 @@ export const DASHBOARD_ROUTES: readonly DashboardRoute[] = [
 		label: 'Forgejo',
 		title: 'Forgejo Dashboard',
 	},
+	{ path: '/dashboard/storage/', label: 'Storage', title: 'Storage' },
 	{
 		path: '/dashboard/grafana/',
 		label: 'Grafana',

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroStorageDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroStorageDashboard.astro
@@ -1,0 +1,40 @@
+---
+import BentoShell from '@/components/hero/BentoShell.astro';
+import ReactStorageDashRN from '@/components/rnweb/ReactStorageDashRN';
+import RnDashSkeleton from '@/components/dashboard/RnDashSkeleton.astro';
+---
+
+<BentoShell
+	id="storage-dashboard-wrapper"
+	eyebrow="Storage"
+	heading="Longhorn volumes and disks.">
+	<div class="svc-dash not-content">
+		<div class="svc-dash__stream not-content">
+			<ReactStorageDashRN client:only="react">
+				<RnDashSkeleton slot="fallback" />
+			</ReactStorageDashRN>
+		</div>
+	</div>
+</BentoShell>
+
+<style>
+	.svc-dash {
+		padding: 1.5rem 1rem 3rem;
+	}
+
+	@media (min-width: 640px) {
+		.svc-dash {
+			padding-inline: 1.5rem;
+		}
+	}
+
+	.svc-dash__stream {
+		min-height: 60vh;
+	}
+
+	:global(@keyframes spin) {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
@@ -77,6 +77,11 @@ export const DASHBOARD_NAV: DashboardNavEntry[] = [
 				icon: 'M13 2L3 14h9l-1 8 10-12h-9l1-8z',
 			},
 			{
+				label: 'Storage',
+				href: '/dashboard/storage/',
+				icon: 'M12 2C7 2 3 3.34 3 5v4c0 1.66 4 3 9 3s9-1.34 9-3V5c0-1.66-4-3-9-3zM3 9v6c0 1.66 4 3 9 3s9-1.34 9-3V9M3 15v4c0 1.66 4 3 9 3s9-1.34 9-3v-4',
+			},
+			{
 				label: 'Virtual Machines',
 				href: '/dashboard/vm/',
 				icon: 'M2 2h20v8H2zM2 14h20v8H2zM6 6h.01M6 18h.01',

--- a/apps/kbve/astro-kbve/src/components/navigation/dashboardMenu.ts
+++ b/apps/kbve/astro-kbve/src/components/navigation/dashboardMenu.ts
@@ -42,6 +42,7 @@ export const dashboardNav: NavNode[] = [
 	{ label: 'Cube', link: '/dashboard/cube/', staff: true },
 	{ label: 'Forgejo', link: '/dashboard/forgejo/', staff: true },
 	{ label: 'Grafana', link: '/dashboard/grafana/', staff: true },
+	{ label: 'Storage', link: '/dashboard/storage/', staff: true },
 	{ label: 'Virtual Machines', link: '/dashboard/vm/', staff: true },
 	{ label: 'IDE', link: '/dashboard/ide/', staff: true },
 	{

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import { ShieldOff } from 'lucide-react';
+import { StreamView, createLonghornStream, longhornLens } from '@kbve/rn/dash';
+import { homeService } from '@/components/dashboard/homeService';
+import { initSupa, getSupa } from '@/lib/supa';
+import { DASH_PROXY_BASE } from './dashProxyBase';
+
+async function getToken(): Promise<string | null> {
+	try {
+		await initSupa();
+		const result = await getSupa()
+			.getSession()
+			.catch(() => null);
+		return result?.session?.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: {
+		margin: 0,
+		fontSize: '1.75rem',
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	sub: {
+		margin: 0,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		maxWidth: '40rem',
+	},
+};
+
+export default function ReactStorageDashRN() {
+	const isStaff = useStore(homeService.$isStaff);
+	const store = useMemo(
+		() => createLonghornStream({ getToken, baseUrl: DASH_PROXY_BASE }),
+		[],
+	);
+
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>
+					The Longhorn storage dashboard is restricted to KBVE staff.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<StreamView
+			store={store}
+			lens={longhornLens}
+			layout="rows"
+			searchPlaceholder="filter by volume / claim / disk / node"
+		/>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/storage/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/storage/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Storage
+description: KBVE Longhorn Storage Dashboard
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+editUrl: false
+lastUpdated: false
+next: false
+sidebar:
+    label: Storage
+    order: 2
+unsplash: 1597852074816-d933c7d2b988
+img: https://images.unsplash.com/photo-1597852074816-d933c7d2b988?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - storage
+---
+
+import AstroStorageDashboard from '@/components/dashboard/AstroStorageDashboard.astro';
+
+<AstroStorageDashboard />

--- a/apps/kbve/axum-kbve-e2e/e2e/dashboard-proxy.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/dashboard-proxy.spec.ts
@@ -20,6 +20,7 @@ const DASHBOARD_PROXIES = [
 	{ path: '/dashboard/chuckrpg/proxy/', label: 'ChuckRPG' },
 	{ path: '/dashboard/clickhouse/proxy/', label: 'ClickHouse' },
 	{ path: '/dashboard/forgejo/proxy/', label: 'Forgejo' },
+	{ path: '/dashboard/storage/proxy/', label: 'Longhorn' },
 ] as const;
 
 describe('Dashboard proxy auth gate', () => {

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -203,6 +203,12 @@ async fn main() -> anyhow::Result<()> {
         warn!("Edge proxy not configured (SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set)");
     }
 
+    if transport::proxy::init_longhorn_proxy() {
+        info!("Longhorn proxy initialized - /dashboard/storage/proxy enabled");
+    } else {
+        warn!("Longhorn proxy not configured");
+    }
+
     if transport::proxy::init_kubevirt_proxy() {
         info!("KubeVirt proxy initialized - /dashboard/vm/proxy enabled");
     } else {

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -851,6 +851,14 @@ fn router(state: AppState) -> Router {
             any(super::proxy::edge_proxy_handler),
         )
         .route(
+            "/dashboard/storage/proxy/{*path}",
+            any(super::proxy::longhorn_proxy_handler),
+        )
+        .route(
+            "/dashboard/storage/proxy",
+            any(super::proxy::longhorn_proxy_handler),
+        )
+        .route(
             "/dashboard/chuckrpg/tenants",
             axum::routing::get(super::proxy::chuckrpg_tenants_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy/simple.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy/simple.rs
@@ -241,6 +241,24 @@ simple_proxy!(
     }
 );
 
+simple_proxy!(
+    LONGHORN,
+    LONGHORN_SPEC,
+    init_longhorn_proxy,
+    longhorn_proxy_handler,
+    ProxySpec {
+        name: "Longhorn",
+        upstream_env: "LONGHORN_UPSTREAM_URL",
+        upstream_default: Some("http://longhorn-frontend.longhorn-system.svc.cluster.local:80"),
+        upstream_suffix: Some("/v1"),
+        token_env: None,
+        ca_cert_env: None,
+        connect_timeout: Duration::from_secs(5),
+        timeout: Duration::from_secs(15),
+        gate: GateMode::View,
+    }
+);
+
 static FACTORIO: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_factorio_proxy() -> bool {

--- a/packages/npm/rn/src/dash/adapters/__tests__/longhorn.test.ts
+++ b/packages/npm/rn/src/dash/adapters/__tests__/longhorn.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+	diskLabelFromPath,
+	formatBytesBin,
+	longhornLens,
+	normalizeVolume,
+	summarizeDisks,
+	volumeHealth,
+} from '../longhorn';
+import type { RawLonghornNode, RawLonghornVolume } from '../longhorn';
+
+const rawVolume: RawLonghornVolume = {
+	name: 'pvc-37639f20-f478-418c-9f7f-9bf82de00f5d',
+	size: '2147483648',
+	state: 'attached',
+	robustness: 'healthy',
+	created: '2026-04-10T00:00:00Z',
+	numberOfReplicas: 1,
+	kubernetesStatus: {
+		namespace: 'firecracker',
+		pvcName: 'firecracker-rootfs',
+		pvName: 'pvc-37639f20-f478-418c-9f7f-9bf82de00f5d',
+		workloadsStatus: [{ workloadName: 'firecracker-vm', podName: 'fc-0' }],
+	},
+	replicas: [
+		{
+			name: 'r-4f939edb',
+			mode: 'RW',
+			running: true,
+			hostId: 'talos-4bn-whr',
+			diskPath: '/var/lib/longhorn',
+		},
+		{
+			name: 'r-c4b9fcd4',
+			running: false,
+			hostId: 'talos-4bn-whr',
+			diskPath: '/var/mnt/longhorn-sdb',
+			failedAt: '2026-06-06T01:54:48Z',
+		},
+	],
+	controllers: [{ actualSize: '1073741824', hostId: 'talos-4bn-whr' }],
+};
+
+const rawNodes: RawLonghornNode[] = [
+	{
+		name: 'talos-4bn-whr',
+		disks: {
+			'default-disk-080500000000': {
+				path: '/var/lib/longhorn',
+				storageMaximum: 957000000000,
+				storageAvailable: 478000000000,
+				storageScheduled: 444000000000,
+				storageReserved: 286000000000,
+			},
+			'sdb-longhorn': {
+				path: '/var/mnt/longhorn-sdb',
+				storageMaximum: 959000000000,
+				storageAvailable: 208000000000,
+				storageScheduled: 1427000000000,
+				storageReserved: 0,
+			},
+		},
+	},
+];
+
+describe('Longhorn Adapter', () => {
+	describe('diskLabelFromPath', () => {
+		it('maps default path to sda', () => {
+			expect(diskLabelFromPath('/var/lib/longhorn')).toBe('sda');
+		});
+
+		it('maps mounted disks by suffix', () => {
+			expect(diskLabelFromPath('/var/mnt/longhorn-sdb')).toBe('sdb');
+			expect(diskLabelFromPath('/var/mnt/longhorn-sdc')).toBe('sdc');
+		});
+
+		it('falls back to last segment then unknown', () => {
+			expect(diskLabelFromPath('/mnt/extra')).toBe('extra');
+			expect(diskLabelFromPath(undefined)).toBe('unknown');
+		});
+	});
+
+	describe('normalizeVolume', () => {
+		it('normalizes claim, sizes, disk, and replica counts', () => {
+			const item = normalizeVolume(rawVolume);
+			expect(item.claim).toBe('firecracker/firecracker-rootfs');
+			expect(item.sizeBytes).toBe(2147483648);
+			expect(item.actualSizeBytes).toBe(1073741824);
+			expect(item.node).toBe('talos-4bn-whr');
+			expect(item.diskLabel).toBe('sda');
+			expect(item.replicaCount).toBe(2);
+			expect(item.failedReplicas).toBe(1);
+			expect(item.workloads).toBe('firecracker-vm');
+		});
+
+		it('falls back to volume name when kubernetesStatus is empty', () => {
+			const item = normalizeVolume({ name: 'pvc-x' });
+			expect(item.claim).toBe('pvc-x');
+			expect(item.state).toBe('unknown');
+			expect(item.diskLabel).toBe('unknown');
+			expect(item.sizeBytes).toBe(0);
+		});
+	});
+
+	describe('volumeHealth', () => {
+		it('flags failed replicas as degraded even when robust', () => {
+			expect(volumeHealth(normalizeVolume(rawVolume))).toBe('degraded');
+		});
+
+		it('classifies healthy, detached, faulted', () => {
+			expect(
+				volumeHealth(
+					normalizeVolume({
+						...rawVolume,
+						replicas: [rawVolume.replicas![0]],
+					}),
+				),
+			).toBe('healthy');
+			expect(
+				volumeHealth(normalizeVolume({ name: 'v', state: 'detached' })),
+			).toBe('detached');
+			expect(
+				volumeHealth(
+					normalizeVolume({ name: 'v', robustness: 'faulted' }),
+				),
+			).toBe('faulted');
+		});
+	});
+
+	describe('summarizeDisks', () => {
+		it('flattens node disk maps sorted by label', () => {
+			const disks = summarizeDisks(rawNodes);
+			expect(disks).toHaveLength(2);
+			expect(disks[0].label).toBe('sda');
+			expect(disks[1].label).toBe('sdb');
+			expect(disks[1].scheduledBytes).toBe(1427000000000);
+			expect(disks[1].node).toBe('talos-4bn-whr');
+		});
+	});
+
+	describe('longhornLens', () => {
+		it('groups by disk and computes stats with disk meta', () => {
+			const item = normalizeVolume(rawVolume);
+			expect(longhornLens.group?.(item)).toBe('Disk: sda');
+
+			const stats = longhornLens.stats?.([item], summarizeDisks(rawNodes));
+			const ids = (stats ?? []).map((s) => s.id);
+			expect(ids).toContain('disk_sda');
+			expect(ids).toContain('disk_sdb');
+			const sdb = stats?.find((s) => s.id === 'disk_sdb');
+			expect(sdb?.value).toBe('149%');
+			expect(sdb?.tone).toBe('danger');
+		});
+
+		it('filters stale replicas', () => {
+			const stale = longhornLens.filters?.find((f) => f.id === 'stale');
+			expect(stale?.predicate(normalizeVolume(rawVolume))).toBe(true);
+			expect(stale?.predicate(normalizeVolume({ name: 'v' }))).toBe(false);
+		});
+	});
+
+	describe('formatBytesBin', () => {
+		it('formats binary units', () => {
+			expect(formatBytesBin(0)).toBe('0 B');
+			expect(formatBytesBin(2147483648)).toBe('2.0 GiB');
+			expect(formatBytesBin(1099511627776)).toBe('1.00 TiB');
+		});
+	});
+});

--- a/packages/npm/rn/src/dash/adapters/longhorn.tsx
+++ b/packages/npm/rn/src/dash/adapters/longhorn.tsx
@@ -1,0 +1,486 @@
+import { StyleSheet, View } from 'react-native';
+import { Badge, Stack, Surface, Text, tokens } from '../_ui';
+import type { BadgeTone } from '../_ui';
+import { createStreamSource } from '../createStreamSource';
+import type { StatModel, StreamLens, StreamStore } from '../types';
+
+export interface RawLonghornReplica {
+	name?: string;
+	mode?: string;
+	running?: boolean;
+	hostId?: string;
+	diskPath?: string;
+	failedAt?: string;
+}
+
+export interface RawLonghornVolume {
+	name: string;
+	size?: string;
+	state?: string;
+	robustness?: string;
+	created?: string;
+	numberOfReplicas?: number;
+	kubernetesStatus?: {
+		namespace?: string;
+		pvcName?: string;
+		pvName?: string;
+		workloadsStatus?:
+			| { podName?: string; workloadName?: string; workloadType?: string }[]
+			| null;
+	};
+	replicas?: RawLonghornReplica[] | null;
+	controllers?: { actualSize?: string; hostId?: string }[] | null;
+}
+
+export interface RawLonghornDisk {
+	path?: string;
+	storageMaximum?: number;
+	storageAvailable?: number;
+	storageScheduled?: number;
+	storageReserved?: number;
+}
+
+export interface RawLonghornNode {
+	name?: string;
+	id?: string;
+	disks?: Record<string, RawLonghornDisk> | null;
+}
+
+export interface LonghornVolumeItem {
+	name: string;
+	claim: string;
+	state: string;
+	robustness: string;
+	sizeBytes: number;
+	actualSizeBytes: number;
+	node: string;
+	diskLabel: string;
+	specReplicas: number;
+	replicaCount: number;
+	failedReplicas: number;
+	created?: string;
+	workloads: string;
+}
+
+export interface DiskSummary {
+	node: string;
+	name: string;
+	label: string;
+	path: string;
+	maxBytes: number;
+	availableBytes: number;
+	scheduledBytes: number;
+	reservedBytes: number;
+}
+
+export interface LonghornStreamOptions {
+	getToken: () => Promise<string | null>;
+	baseUrl?: string;
+	pollMs?: number;
+}
+
+export function formatBytesBin(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+	if (bytes < 1024) return `${bytes} B`;
+	const kib = bytes / 1024;
+	if (kib < 1024) return `${kib.toFixed(1)} KiB`;
+	const mib = kib / 1024;
+	if (mib < 1024) return `${mib.toFixed(1)} MiB`;
+	const gib = mib / 1024;
+	if (gib < 1024) return `${gib.toFixed(1)} GiB`;
+	return `${(gib / 1024).toFixed(2)} TiB`;
+}
+
+export function diskLabelFromPath(path: string | undefined): string {
+	if (!path) return 'unknown';
+	if (path === '/var/lib/longhorn') return 'sda';
+	const match = path.match(/longhorn-([a-z0-9]+)/);
+	if (match) return match[1];
+	const segments = path.split('/').filter(Boolean);
+	return segments[segments.length - 1] ?? path;
+}
+
+export function normalizeVolume(raw: RawLonghornVolume): LonghornVolumeItem {
+	const ks = raw.kubernetesStatus;
+	const claim =
+		ks?.namespace && ks?.pvcName ? `${ks.namespace}/${ks.pvcName}` : raw.name;
+	const replicas = raw.replicas ?? [];
+	const activeReplica = replicas.find((r) => r.running && r.diskPath);
+	const failedReplicas = replicas.filter((r) => r.failedAt).length;
+	const controller = raw.controllers?.[0];
+	const workloads = (ks?.workloadsStatus ?? [])
+		.map((w) => w.workloadName || w.podName || '')
+		.filter(Boolean)
+		.join(', ');
+
+	return {
+		name: raw.name,
+		claim,
+		state: raw.state ?? 'unknown',
+		robustness: raw.robustness ?? 'unknown',
+		sizeBytes: Number(raw.size ?? 0),
+		actualSizeBytes: Number(controller?.actualSize ?? 0),
+		node:
+			controller?.hostId ??
+			activeReplica?.hostId ??
+			replicas[0]?.hostId ??
+			'—',
+		diskLabel: diskLabelFromPath(
+			activeReplica?.diskPath ?? replicas[0]?.diskPath,
+		),
+		specReplicas: raw.numberOfReplicas ?? 0,
+		replicaCount: replicas.length,
+		failedReplicas,
+		created: raw.created,
+		workloads,
+	};
+}
+
+export function summarizeDisks(nodes: RawLonghornNode[]): DiskSummary[] {
+	const out: DiskSummary[] = [];
+	for (const node of nodes) {
+		const disks = node.disks ?? {};
+		for (const [name, disk] of Object.entries(disks)) {
+			out.push({
+				node: node.name ?? node.id ?? '—',
+				name,
+				label: diskLabelFromPath(disk.path),
+				path: disk.path ?? '—',
+				maxBytes: disk.storageMaximum ?? 0,
+				availableBytes: disk.storageAvailable ?? 0,
+				scheduledBytes: disk.storageScheduled ?? 0,
+				reservedBytes: disk.storageReserved ?? 0,
+			});
+		}
+	}
+	return out.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+async function fetchCollection<T>(
+	url: string,
+	token: string | null,
+	signal?: AbortSignal,
+): Promise<T[]> {
+	const res = await fetch(url, {
+		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+		signal,
+	});
+	if (res.status === 403) throw new Error('Access restricted');
+	if (res.status === 503) throw new Error('Longhorn proxy not configured');
+	if (!res.ok) throw new Error(`Longhorn error: ${res.status}`);
+	const json = (await res.json()) as { data?: T[] };
+	return Array.isArray(json?.data) ? json.data : [];
+}
+
+export function createLonghornStream(
+	opts: LonghornStreamOptions,
+): StreamStore<LonghornVolumeItem> {
+	const { getToken, baseUrl = '', pollMs = 30_000 } = opts;
+
+	return createStreamSource<RawLonghornVolume, LonghornVolumeItem>({
+		key: 'longhorn:volumes',
+		pollMs,
+		cacheTtlMs: 30_000,
+		id: (it) => it.name,
+		signature: (it) =>
+			`${it.state}|${it.robustness}|${it.actualSizeBytes}|${it.node}|${it.replicaCount}|${it.failedReplicas}`,
+		normalize: normalizeVolume,
+		fetch: async ({ signal }) => {
+			const token = await getToken();
+			const volumes = await fetchCollection<RawLonghornVolume>(
+				`${baseUrl}/dashboard/storage/proxy/volumes`,
+				token,
+				signal,
+			);
+			return volumes.sort((a, b) => a.name.localeCompare(b.name));
+		},
+		fetchMeta: async ({ signal }) => {
+			try {
+				const token = await getToken();
+				const nodes = await fetchCollection<RawLonghornNode>(
+					`${baseUrl}/dashboard/storage/proxy/nodes`,
+					token,
+					signal,
+				);
+				return summarizeDisks(nodes);
+			} catch {
+				return null;
+			}
+		},
+	});
+}
+
+export type VolumeHealth = 'healthy' | 'degraded' | 'detached' | 'faulted';
+
+export function volumeHealth(it: LonghornVolumeItem): VolumeHealth {
+	if (it.robustness === 'faulted') return 'faulted';
+	if (it.state === 'detached') return 'detached';
+	if (it.robustness === 'healthy' && it.failedReplicas === 0) return 'healthy';
+	return 'degraded';
+}
+
+function healthTone(health: VolumeHealth): BadgeTone {
+	if (health === 'healthy') return 'success';
+	if (health === 'detached') return 'neutral';
+	if (health === 'degraded') return 'warning';
+	return 'danger';
+}
+
+function healthColor(health: VolumeHealth): string {
+	if (health === 'healthy') return tokens.color.success;
+	if (health === 'detached') return tokens.color.textFaint;
+	if (health === 'degraded') return tokens.color.warning;
+	return tokens.color.danger;
+}
+
+function diskTone(disk: DiskSummary): BadgeTone | undefined {
+	if (disk.maxBytes <= 0) return undefined;
+	if (disk.scheduledBytes > disk.maxBytes) return 'danger';
+	if (disk.availableBytes < disk.maxBytes * 0.15) return 'warning';
+	return 'success';
+}
+
+export const longhornLens: StreamLens<LonghornVolumeItem> = {
+	searchText: (it) =>
+		`${it.name} ${it.claim} ${it.state} ${it.robustness} ${it.diskLabel} ${it.node} ${it.workloads}`,
+	group: (it) => `Disk: ${it.diskLabel}`,
+	filters: [
+		{
+			id: 'healthy',
+			label: 'Healthy',
+			tone: 'success',
+			predicate: (it) => volumeHealth(it) === 'healthy',
+		},
+		{
+			id: 'degraded',
+			label: 'Degraded',
+			tone: 'warning',
+			predicate: (it) =>
+				volumeHealth(it) === 'degraded' || volumeHealth(it) === 'faulted',
+		},
+		{
+			id: 'detached',
+			label: 'Detached',
+			tone: 'neutral',
+			predicate: (it) => volumeHealth(it) === 'detached',
+		},
+		{
+			id: 'stale',
+			label: 'Stale Replicas',
+			tone: 'danger',
+			predicate: (it) => it.failedReplicas > 0,
+		},
+	],
+	stats: (items, meta) => {
+		const out: StatModel[] = [
+			{ id: 'total', label: 'Volumes', value: items.length },
+			{
+				id: 'healthy',
+				label: 'Healthy',
+				tone: 'success',
+				value: items.filter((i) => volumeHealth(i) === 'healthy').length,
+			},
+			{
+				id: 'detached',
+				label: 'Detached',
+				value: items.filter((i) => volumeHealth(i) === 'detached').length,
+			},
+			{
+				id: 'provisioned',
+				label: 'Provisioned',
+				value: formatBytesBin(
+					items.reduce((sum, i) => sum + i.sizeBytes, 0),
+				),
+			},
+			{
+				id: 'used',
+				label: 'Used',
+				value: formatBytesBin(
+					items.reduce((sum, i) => sum + i.actualSizeBytes, 0),
+				),
+			},
+		];
+		const disks = (meta as DiskSummary[] | null) ?? [];
+		for (const disk of disks) {
+			const pct =
+				disk.maxBytes > 0
+					? Math.round((disk.scheduledBytes / disk.maxBytes) * 100)
+					: 0;
+			out.push({
+				id: `disk_${disk.label}`,
+				label: `${disk.label} scheduled`,
+				tone: diskTone(disk),
+				value: `${pct}%`,
+			});
+			out.push({
+				id: `disk_${disk.label}_free`,
+				label: `${disk.label} free`,
+				tone: diskTone(disk),
+				value: formatBytesBin(disk.availableBytes),
+			});
+		}
+		return out;
+	},
+	metaPanel: (meta) => {
+		const disks = (meta as DiskSummary[] | null) ?? [];
+		if (disks.length === 0) return null;
+		return (
+			<Surface style={styles.card}>
+				<Stack gap="sm">
+					<Text variant="label">Disks</Text>
+					{disks.map((disk) => (
+						<Stack key={`${disk.node}/${disk.name}`} gap="xs">
+							<Stack direction="row" align="center" gap="xs" wrap>
+								<Text variant="label">{disk.label}</Text>
+								<Badge
+									label={`${formatBytesBin(disk.scheduledBytes)} / ${formatBytesBin(disk.maxBytes)} scheduled`}
+									tone={diskTone(disk)}
+								/>
+							</Stack>
+							<Text variant="caption" tone="faint">
+								{disk.node} · {disk.path} ·{' '}
+								{formatBytesBin(disk.availableBytes)} free ·{' '}
+								{formatBytesBin(disk.reservedBytes)} reserved
+							</Text>
+						</Stack>
+					))}
+				</Stack>
+			</Surface>
+		);
+	},
+	row: (it) => {
+		const health = volumeHealth(it);
+		return (
+			<Surface padded={false} style={styles.row}>
+				<View
+					style={[
+						styles.statusDot,
+						{ backgroundColor: healthColor(health) },
+					]}
+				/>
+				<Stack gap="xs" style={styles.rowContent}>
+					<Stack direction="row" align="center" gap="xs" wrap>
+						<Text variant="label" numberOfLines={1} style={styles.name}>
+							{it.claim}
+						</Text>
+						<Badge label={health.toUpperCase()} tone={healthTone(health)} />
+						{it.failedReplicas > 0 && (
+							<Badge
+								label={`${it.failedReplicas} STALE`}
+								tone="danger"
+							/>
+						)}
+					</Stack>
+					<Text variant="caption" tone="faint" numberOfLines={1}>
+						{formatBytesBin(it.sizeBytes)}
+						{it.actualSizeBytes > 0
+							? ` · ${formatBytesBin(it.actualSizeBytes)} used`
+							: ''}{' '}
+						· {it.diskLabel} · {it.node}
+					</Text>
+				</Stack>
+			</Surface>
+		);
+	},
+	card: (it) => {
+		const health = volumeHealth(it);
+		return (
+			<Surface style={styles.card}>
+				<Stack gap="sm">
+					<Stack direction="row" align="center" gap="xs">
+						<View
+							style={[
+								styles.statusDot,
+								{ backgroundColor: healthColor(health) },
+							]}
+						/>
+						<Text variant="label" numberOfLines={1} style={styles.name}>
+							{it.claim}
+						</Text>
+					</Stack>
+					<Stack direction="row" gap="sm" wrap>
+						<Badge label={health.toUpperCase()} tone={healthTone(health)} />
+						<Badge label={it.diskLabel} tone="primary" />
+					</Stack>
+					<Text variant="caption" tone="faint">
+						{formatBytesBin(it.sizeBytes)}
+						{it.actualSizeBytes > 0
+							? ` · ${formatBytesBin(it.actualSizeBytes)} used`
+							: ''}
+					</Text>
+				</Stack>
+			</Surface>
+		);
+	},
+	detail: (it) => (
+		<Stack gap="xs">
+			<Fact label="Volume" value={it.name} />
+			<Fact label="Claim" value={it.claim} />
+			<Fact label="State" value={it.state} />
+			<Fact label="Robustness" value={it.robustness} />
+			<Fact label="Provisioned" value={formatBytesBin(it.sizeBytes)} />
+			{it.actualSizeBytes > 0 && (
+				<Fact label="Used" value={formatBytesBin(it.actualSizeBytes)} />
+			)}
+			<Fact label="Disk" value={it.diskLabel} />
+			<Fact label="Node" value={it.node} />
+			<Fact
+				label="Replicas"
+				value={`${it.replicaCount} (${it.specReplicas} desired)`}
+			/>
+			{it.failedReplicas > 0 && (
+				<Fact label="Stale Replicas" value={String(it.failedReplicas)} />
+			)}
+			{it.workloads !== '' && <Fact label="Workloads" value={it.workloads} />}
+			{it.created && (
+				<Fact
+					label="Created"
+					value={new Date(it.created).toLocaleString()}
+				/>
+			)}
+		</Stack>
+	),
+};
+
+function Fact({ label, value }: { label: string; value: string }) {
+	return (
+		<Stack direction="row" gap="sm" justify="space-between">
+			<Text variant="caption" tone="muted">
+				{label}
+			</Text>
+			<Text variant="caption" numberOfLines={1} style={styles.factValue}>
+				{value}
+			</Text>
+		</Stack>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: tokens.space.sm,
+		paddingHorizontal: tokens.space.md,
+		paddingVertical: tokens.space.sm,
+	},
+	rowContent: {
+		flexShrink: 1,
+		flexGrow: 1,
+	},
+	card: {
+		padding: tokens.space.md,
+	},
+	statusDot: {
+		width: 10,
+		height: 10,
+		borderRadius: 5,
+		flexShrink: 0,
+	},
+	name: {
+		flexShrink: 1,
+	},
+	factValue: {
+		flexShrink: 1,
+		textAlign: 'right',
+	},
+});

--- a/packages/npm/rn/src/dash/index.ts
+++ b/packages/npm/rn/src/dash/index.ts
@@ -19,6 +19,7 @@ export * from './adapters/rows';
 export * from './adapters/factorio';
 export * from './adapters/minecraft';
 export * from './adapters/kilobaseBackup';
+export * from './adapters/longhorn';
 export * from './clickhouse';
 export * from './adapters/cube';
 export * from './cube';


### PR DESCRIPTION
## Summary
- New staff-gated `/dashboard/storage/` page showing Longhorn volumes with a clear per-disk (sda/sdb) breakdown.
- axum-kbve: `simple_proxy!` LONGHORN spec → `longhorn-frontend.longhorn-system.svc:80/v1`, `GateMode::View` (read-only), routes at `/dashboard/storage/proxy`. Override upstream via `LONGHORN_UPSTREAM_URL`.
- @kbve/rn dash adapter `createLonghornStream` + `longhornLens`: volumes from `/v1/volumes`, disk capacity meta from `/v1/nodes` (Rancher `{data:[]}` envelope unwrapped). Groups by disk, filters healthy/degraded/detached/stale-replicas, stats include per-disk scheduled % (danger when overcommitted) and free space, plus a disks meta panel.
- Astro: `AstroStorageDashboard.astro` + staff-gated `ReactStorageDashRN` island + MDX page, nav entries in both `dashboardNav.ts` and `dashboardMenu.ts`, e2e route table entries.

## Testing
- `cargo check` clean (743 crates).
- 11 new vitest cases for the adapter (normalize, disk labels, health classification, disk summary, lens stats — including the 149% sdb overcommit tone).

## Notes
- Dev `/__dashproxy` forwards to live kbve.com, so the proxy path only works locally after axum-kbve deploys.
- axum-kbve pod needs egress to `longhorn-system`; if a Cilium policy blocks it the dashboard shows the proxy error state.

Docs: [apps/kube/storage](https://github.com/KBVE/kbve/tree/dev/apps/kube/storage)