### PR TITLE
fix(isometric): only run tauri_build for desktop builds

### DIFF
--- a/apps/kbve/isometric/src-tauri/build.rs
+++ b/apps/kbve/isometric/src-tauri/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     let target = std::env::var("TARGET").unwrap_or_default();
-    if !target.contains("wasm32") {
+    let desktop = std::env::var_os("CARGO_FEATURE_DESKTOP").is_some();
+    if desktop && !target.contains("wasm32") {
         tauri_build::build()
     }
 }


### PR DESCRIPTION
Follow-up to #15389. This commit was pushed to that branch after it had already merged, so it never reached `dev` — carrying it over on its own.

`isometric-game`'s build script called `tauri_build::build()` for every non-wasm target, including the mobile builds that deliberately opt out of Tauri via `--no-default-features --features mobile`. With the `tauri` crate absent, `tauri-build 2.6.3` panics:

```
missing `cargo:dev` instruction, please update tauri to latest
```

That made the bevy-featured `kbve_wgpu` build impossible, which in turn meant the iOS app could only ever link the non-bevy stub of `kbve_wgpu_create_game` added in #15389 — so the isometric game could not load on device, even though the RN side was requesting game mode correctly (`componentId: 'kbve.wgpu'` != `"triangle"`, so `isGameMode` is true).

Gating the call on `CARGO_FEATURE_DESKTOP` fixes it. Mobile builds skip Tauri codegen entirely; desktop builds are untouched.

## Verification

- **Mobile**: `nx run kbve_wgpu:build:ios:bevy` now succeeds for both `aarch64-apple-ios` and `aarch64-apple-ios-sim` (436 crates, 0 errors). The resulting xcframework grows from 40MB to 124MB and exports the real `kbve_wgpu_create_game` — the stub's log string is gone from the binary.
- **Desktop**: `cargo check -p isometric-game` still compiles all 650 crates clean, confirming `tauri_build::build()` still runs where it is needed.
- The app rebuilds against the bevy-linked xcframework, installs, and reaches the signed-in home screen with the "Launch Isometric (Native GPU)" entry point.

Scoped to `build.rs` only. My local `cargo check` regenerated `gen/schemas/*.json`, but that churn is a local toolchain artifact and has been reverted out of this PR.

Still unverified: the isometric game's actual runtime behaviour on device. Exercising it needs a tap on the launch button, which I could not synthesise from this environment (no `idb`, `simctl` has no tap primitive). The `UiView` surface path (`kind = 2`) has never executed on device, and `AssetPlugin.file_path` points at a `KbveWgpuAssets.bundle` that currently ships only `shaders/` and `textures/` — worth watching if the game expects other asset folders.
