### PR TITLE
fix(palworld): gameops CH schema + join/leave identity + loud insert failures

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -57,7 +57,7 @@
 		{
 			"key": "agones_palworld_relay",
 			"app_name": "agones-palworld-relay",
-			"version": "0.0.14",
+			"version": "0.0.15",
 			"version_toml": "apps/agones/palworld/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx",
 			"source_path": "apps/agones/palworld/relay",

--- a/apps/agones/palworld/relay/src/ch_writer.rs
+++ b/apps/agones/palworld/relay/src/ch_writer.rs
@@ -5,7 +5,7 @@ use jedi::state::sidecar::ClickHouseConfig;
 use serde_json::json;
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::error::RecvError;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::config::Config;
@@ -14,11 +14,14 @@ use crate::event::{GameEvent, GameEventKind};
 const SNAPSHOTS_TABLE: &str = "gameops.palworld_snapshots_raw";
 const PLAYER_EVENTS_TABLE: &str = "gameops.palworld_player_events_raw";
 
+const LOUD_FAILURE_THRESHOLD: u32 = 3;
+
 struct Producer {
     ch: ClickHouseConfig,
     cfg: Config,
     rotation_id: String,
     started: Instant,
+    consecutive_failures: u32,
 }
 
 impl Producer {
@@ -28,7 +31,7 @@ impl Producer {
             .to_string()
     }
 
-    async fn snapshot(&self, ev: &GameEvent) {
+    async fn snapshot(&mut self, ev: &GameEvent) {
         let row = json!({
             "ts": Self::now_ts(),
             "server_id": self.cfg.server_id,
@@ -42,7 +45,7 @@ impl Producer {
         self.insert(SNAPSHOTS_TABLE, row).await;
     }
 
-    async fn player_event(&self, ev: &GameEvent, event: &str) {
+    async fn player_event(&mut self, ev: &GameEvent, event: &str) {
         let row = json!({
             "ts": Self::now_ts(),
             "server_id": self.cfg.server_id,
@@ -53,14 +56,32 @@ impl Producer {
         self.insert(PLAYER_EVENTS_TABLE, row).await;
     }
 
-    async fn insert(&self, table: &str, row: serde_json::Value) {
+    async fn insert(&mut self, table: &str, row: serde_json::Value) {
         match self
             .ch
             .execute_insert(table, std::slice::from_ref(&row))
             .await
         {
-            Ok(()) => debug!(table, "inserted row"),
-            Err(e) => warn!(table, error = %e, "clickhouse insert failed"),
+            Ok(()) => {
+                if self.consecutive_failures >= LOUD_FAILURE_THRESHOLD {
+                    info!(table, "clickhouse inserts recovered");
+                }
+                self.consecutive_failures = 0;
+                debug!(table, "inserted row");
+            }
+            Err(e) => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                if self.consecutive_failures >= LOUD_FAILURE_THRESHOLD {
+                    error!(
+                        table,
+                        error = %e,
+                        consecutive = self.consecutive_failures,
+                        "clickhouse inserts failing — telemetry is being dropped (missing table?)"
+                    );
+                } else {
+                    warn!(table, error = %e, "clickhouse insert failed");
+                }
+            }
         }
     }
 
@@ -102,6 +123,7 @@ pub async fn run(cfg: Config, mut rx: Receiver<GameEvent>) -> Result<()> {
         ch,
         rotation_id: Uuid::new_v4().to_string(),
         started: Instant::now(),
+        consecutive_failures: 0,
         cfg,
     };
 

--- a/apps/agones/palworld/relay/src/poller.rs
+++ b/apps/agones/palworld/relay/src/poller.rs
@@ -41,6 +41,7 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>, live: SharedLive) -> Result
     )?;
 
     let mut prev: HashSet<String> = HashSet::new();
+    let mut known_names: HashMap<String, String> = HashMap::new();
     let mut ticker = time::interval(Duration::from_secs(cfg.poll_interval_secs));
     ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
@@ -65,22 +66,18 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>, live: SharedLive) -> Result
                 }
             })
             .collect();
-        let name_by_id: HashMap<String, String> = players
-            .players
-            .iter()
-            .map(|p| {
-                let id = if p.player_id.is_empty() {
-                    p.name.clone()
-                } else {
-                    p.player_id.clone()
-                };
-                (id, p.name.clone())
-            })
-            .collect();
+        for p in &players.players {
+            let id = if p.player_id.is_empty() {
+                p.name.clone()
+            } else {
+                p.player_id.clone()
+            };
+            known_names.insert(id, p.name.clone());
+        }
 
         let (joined, left) = diff_players(&prev, &curr);
         for id in joined {
-            let name = name_by_id.get(&id).cloned().unwrap_or_else(|| id.clone());
+            let name = known_names.get(&id).cloned().unwrap_or_else(|| id.clone());
             let _ = tx.send(GameEvent {
                 kind: GameEventKind::Join,
                 player: Some(name),
@@ -90,9 +87,10 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>, live: SharedLive) -> Result
             });
         }
         for id in left {
+            let name = known_names.remove(&id).unwrap_or(id);
             let _ = tx.send(GameEvent {
                 kind: GameEventKind::Leave,
-                player: Some(id),
+                player: Some(name),
                 text: String::new(),
                 raw: String::new(),
                 fields: HashMap::new(),

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_palworld_relay
 pipeline: docker
 app_name: agones-palworld-relay
-version: "0.0.14"
+version: "0.0.15"
 source_path: apps/agones/palworld/relay
 version_toml: apps/agones/palworld/relay/version.toml
 runner: ubuntu-latest

--- a/packages/data/ch/schemas/palworld.sql
+++ b/packages/data/ch/schemas/palworld.sql
@@ -1,0 +1,93 @@
+-- Palworld GameOps telemetry schema.
+--
+-- Source of truth for the `gameops.palworld_*` tables (issue #15362). The
+-- relay sidecar at apps/agones/palworld/relay/ has been producing these rows
+-- since it shipped, but the tables were never created — every insert failed
+-- (and was swallowed as a warn). This file closes that gap.
+--
+-- Producers write to the `*_raw` tables; readers (discordsh-bot
+-- /palworld-online, dashboards) query through the `Distributed` twins so the
+-- factorio reader convention carries over unchanged. Column sets are dictated
+-- by the producer's json! literals in ch_writer.rs.
+--
+-- Retention: 14 days on both tables, matching factorio_snapshots_raw /
+-- factorio_player_events_raw.
+--
+-- Apply: every DDL is `IF NOT EXISTS` + `ON CLUSTER 'cluster'`, so re-running
+-- against a partially-applied cluster is safe.
+--
+--   kubectl -n clickhouse exec -i \
+--     chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+--     clickhouse-client --multiquery < packages/data/ch/schemas/palworld.sql
+--
+-- Record the apply in the standard migrations ledger:
+--
+--   INSERT INTO observability.schema_migrations (name, applied_by)
+--   VALUES ('palworld_gameops_init', '<operator>');
+
+-- ---------------------------------------------------------------------------
+-- Database
+-- ---------------------------------------------------------------------------
+
+CREATE DATABASE IF NOT EXISTS gameops ON CLUSTER 'cluster';
+
+-- ---------------------------------------------------------------------------
+-- palworld_snapshots_raw — periodic snapshot of the server's live state.
+--
+-- One row per relay poll (default 10s). `fps`/`frametime_ms` come from the
+-- Palworld REST /v1/api/metrics payload; `map_age_wall_s` is the relay
+-- process uptime, a proxy for time since the pod (and world) came up.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS gameops.palworld_snapshots_raw ON CLUSTER 'cluster'
+(
+    ts             DateTime64(3, 'UTC'),
+    server_id      LowCardinality(String),
+    rotation_id    UUID,
+    players        UInt16,
+    fps            Int32,
+    uptime_s       UInt64,
+    frametime_ms   Float32,
+    map_age_wall_s UInt64,
+    ingested_at    DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplicatedMergeTree(
+    '/clickhouse/tables/{shard}/gameops/palworld_snapshots_raw',
+    '{replica}'
+)
+ORDER BY (server_id, ts)
+PARTITION BY toYYYYMMDD(ts)
+TTL toDateTime(ts) + INTERVAL 14 DAY;
+
+CREATE TABLE IF NOT EXISTS gameops.palworld_snapshots ON CLUSTER 'cluster'
+AS gameops.palworld_snapshots_raw
+ENGINE = Distributed('cluster', 'gameops', 'palworld_snapshots_raw', rand());
+
+-- ---------------------------------------------------------------------------
+-- palworld_player_events_raw — one row per join / leave.
+--
+-- `player` is the display name for both events (relay resolves leaves
+-- through a persistent id→name map; see poller.rs). Roster queries group by
+-- `player` and take argMax(event, ts).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS gameops.palworld_player_events_raw ON CLUSTER 'cluster'
+(
+    ts          DateTime64(3, 'UTC'),
+    server_id   LowCardinality(String),
+    rotation_id UUID,
+    player      LowCardinality(String),
+    event       Enum8('join' = 1, 'leave' = 2),
+    ingested_at DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplicatedMergeTree(
+    '/clickhouse/tables/{shard}/gameops/palworld_player_events_raw',
+    '{replica}'
+)
+ORDER BY (server_id, ts)
+PARTITION BY toYYYYMMDD(ts)
+TTL toDateTime(ts) + INTERVAL 14 DAY;
+
+CREATE TABLE IF NOT EXISTS gameops.palworld_player_events ON CLUSTER 'cluster'
+AS gameops.palworld_player_events_raw
+ENGINE = Distributed('cluster', 'gameops', 'palworld_player_events_raw', rand());


### PR DESCRIPTION
Closes #15362 — all three items.

## 1. `packages/data/ch/schemas/palworld.sql` (new)

`gameops.palworld_snapshots_raw` + `palworld_player_events_raw` with `Distributed` twins — factorio conventions (ReplicatedMergeTree, `{shard}`/`{replica}` macros, `ORDER BY (server_id, ts)`, daily partitions, 14-day TTL). Columns cross-checked against the producer's `json!` literals in `ch_writer.rs`. Everything `IF NOT EXISTS` + `ON CLUSTER 'cluster'` — additive, safe to re-run.

**Not applied.** Apply is a planned-window operator step (command + migrations-ledger insert documented in the file header) — say the word and I'll run it, or run it yourself.

## 2. Poller identity fix (deeper than the issue's one-liner)

The issue proposed mirroring the join-side lookup — but `name_by_id` is built from the **current** tick, and the leaver is gone from it, so the mirror can't resolve. The poller now keeps a persistent `known_names` id→name map merged every poll; join reads it, leave `remove()`s from it (resolution + pruning in one). Both events now write the display name. Bonus: IRC leave announcements stop showing raw player ids too — same `GameEvent` feeds both sinks.

## 3. Loud failures

`ch_writer` escalates `warn` → `error` after 3 consecutive insert failures ("telemetry is being dropped (missing table?)") and logs recovery on the next success. A missing table can't hide again.

## Deploy note

Relay ships as a gameserver sidecar → pod recreate → Palworld restart. MDX `0.0.14 → 0.0.15` stacks on the already-pending 0.0.14 roll, so this batch rides the same planned restart. `cargo test` 34/34.