### PR TITLE
refactor(rn): break the ClickHouse dash require cycle

### DIFF
--- a/packages/npm/rn/src/dash/adapters/clickhouse.tsx
+++ b/packages/npm/rn/src/dash/adapters/clickhouse.tsx
@@ -2,120 +2,12 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import type { StreamLens } from '../types';
+import type { LogItem } from '../clickhouse/logItem';
+import { parseMetadataFacts } from '../clickhouse/logItem';
 import { buildStatsTotals, CH_CONTROLS } from '../clickhouse/clickhouseStream';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface RawLogRow {
-	timestamp: string;
-	level?: string;
-	message?: string;
-	pod_name?: string;
-	pod_namespace?: string;
-	service?: string;
-	container_name?: string;
-	metadata?: string;
-}
-
-export interface LogItem {
-	id: string;
-	timestamp: string;
-	level: string;
-	message: string;
-	podName: string;
-	namespace: string;
-	service: string;
-	container: string;
-	relativeTime: string;
-	metadataRaw: string;
-}
-
-// ---------------------------------------------------------------------------
-// Normalization
-// ---------------------------------------------------------------------------
-
-export function normalize(raw: RawLogRow): LogItem {
-	const level = (raw.level ?? 'info').toLowerCase();
-	const namespace = raw.pod_namespace ?? '';
-	const podName = raw.pod_name ?? '';
-	const service = raw.service ?? '';
-	const container = raw.container_name ?? '';
-	const message = raw.message ?? '';
-
-	// Create unique ID from timestamp + namespace + podName
-	const id = `${raw.timestamp}:${namespace}:${podName}`;
-
-	// Calculate relative time
-	const relativeTime = formatRelativeTime(raw.timestamp);
-
-	return {
-		id,
-		timestamp: raw.timestamp,
-		level,
-		message,
-		podName,
-		namespace,
-		service,
-		container,
-		relativeTime,
-		metadataRaw: raw.metadata ?? '',
-	};
-}
-
-const META_HIDDEN_KEYS = new Set([
-	'level',
-	'severity',
-	'msg',
-	'message',
-	'time',
-	'ts',
-	'timestamp',
-	'logger',
-	'logging_pod',
-]);
-
-export interface MetaFact {
-	key: string;
-	value: string;
-}
-
-export function parseMetadataFacts(rawMeta: string): MetaFact[] {
-	if (!rawMeta || rawMeta === '{}') return [];
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(rawMeta);
-	} catch {
-		return [{ key: 'metadata', value: rawMeta }];
-	}
-	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
-	const out: MetaFact[] = [];
-	for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-		if (META_HIDDEN_KEYS.has(key.toLowerCase())) continue;
-		if (value === null || value === undefined || value === '') continue;
-		const text =
-			typeof value === 'string' ? value : JSON.stringify(value) ?? '';
-		if (!text) continue;
-		out.push({ key, value: text });
-	}
-	return out.sort((a, b) => a.key.localeCompare(b.key));
-}
-
-function formatRelativeTime(ts: string): string {
-	try {
-		const then = new Date(ts.replace(' ', 'T') + 'Z').getTime();
-		const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
-		if (diffSec < 60) return `${diffSec}s ago`;
-		const diffMin = Math.round(diffSec / 60);
-		if (diffMin < 60) return `${diffMin}m ago`;
-		const diffHr = Math.round(diffMin / 60);
-		if (diffHr < 24) return `${diffHr}h ago`;
-		return `${Math.round(diffHr / 24)}d ago`;
-	} catch {
-		return ts;
-	}
-}
+export type { RawLogRow, LogItem, MetaFact } from '../clickhouse/logItem';
+export { normalize, parseMetadataFacts } from '../clickhouse/logItem';
 
 // ---------------------------------------------------------------------------
 // Lens
@@ -282,7 +174,11 @@ function MetadataFacts({ rawMeta }: { rawMeta: string }) {
 				Metadata:
 			</Text>
 			{facts.map((f) => (
-				<Stack key={f.key} direction="row" gap="sm" justify="space-between">
+				<Stack
+					key={f.key}
+					direction="row"
+					gap="sm"
+					justify="space-between">
 					<Text variant="caption" tone="muted">
 						{f.key}
 					</Text>

--- a/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/ErrorDigest.tsx
@@ -2,7 +2,7 @@ import { Pressable } from 'react-native';
 import { Stack } from '../_ui';
 import { useStream, useStreamLifecycle } from '../useStream';
 import type { StreamStore } from '../types';
-import type { LogItem } from '../adapters/clickhouse';
+import type { LogItem } from './logItem';
 import { errorGroupsLens, type ErrorGroupItem } from './errorGroupsStream';
 import { SectionDivider } from '../shared';
 

--- a/packages/npm/rn/src/dash/clickhouse/NamespaceFocus.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/NamespaceFocus.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet } from 'react-native';
 import { Surface, Stack, Text, Badge, tokens } from '../_ui';
 import { useStream } from '../useStream';
 import type { StreamStore } from '../types';
-import type { LogItem } from '../adapters/clickhouse';
+import type { LogItem } from './logItem';
 import { buildNamespaceRollup } from './chRollup';
 import { errorGroupsLens, type ErrorGroupItem } from './errorGroupsStream';
 import { SectionDivider } from '../shared';
@@ -99,7 +99,10 @@ export function NamespaceFocus({
 
 					{groups.length ? (
 						<Stack gap="xs">
-							<Text variant="caption" weight="medium" tone="muted">
+							<Text
+								variant="caption"
+								weight="medium"
+								tone="muted">
 								Top errors in {ns}
 							</Text>
 							{groups.slice(0, 5).map((g) => (

--- a/packages/npm/rn/src/dash/clickhouse/NamespaceGrid.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/NamespaceGrid.tsx
@@ -1,7 +1,7 @@
 import { Pressable, StyleSheet } from 'react-native';
 import { Surface, Stack, Text, Badge, tokens } from '../_ui';
 import type { StreamStore } from '../types';
-import type { LogItem } from '../adapters/clickhouse';
+import type { LogItem } from './logItem';
 import { buildNamespaceRollup, CLUSTER_NS_LABEL } from './chRollup';
 
 export function makeNamespaceGrid(store: StreamStore<LogItem>) {
@@ -27,7 +27,10 @@ export function makeNamespaceGrid(store: StreamStore<LogItem>) {
 								{r.namespace}
 							</Text>
 							{r.errors ? (
-								<Badge label={`${r.errors} err`} tone="danger" />
+								<Badge
+									label={`${r.errors} err`}
+									tone="danger"
+								/>
 							) : null}
 							{r.warns ? (
 								<Badge
@@ -40,7 +43,8 @@ export function makeNamespaceGrid(store: StreamStore<LogItem>) {
 							</Text>
 						</Surface>
 					);
-					if (!selectable) return <Stack key={r.namespace}>{body}</Stack>;
+					if (!selectable)
+						return <Stack key={r.namespace}>{body}</Stack>;
 					return (
 						<Pressable
 							key={r.namespace}

--- a/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
+++ b/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
@@ -5,8 +5,8 @@ import type {
 	StreamParams,
 	StreamStore,
 } from '../types';
-import { normalize } from '../adapters/clickhouse';
-import type { LogItem, RawLogRow } from '../adapters/clickhouse';
+import { normalize } from './logItem';
+import type { LogItem, RawLogRow } from './logItem';
 
 export interface ClickHouseStreamOptions {
 	getToken: () => Promise<string | null>;

--- a/packages/npm/rn/src/dash/clickhouse/logItem.ts
+++ b/packages/npm/rn/src/dash/clickhouse/logItem.ts
@@ -1,0 +1,104 @@
+export interface RawLogRow {
+	timestamp: string;
+	level?: string;
+	message?: string;
+	pod_name?: string;
+	pod_namespace?: string;
+	service?: string;
+	container_name?: string;
+	metadata?: string;
+}
+
+export interface LogItem {
+	id: string;
+	timestamp: string;
+	level: string;
+	message: string;
+	podName: string;
+	namespace: string;
+	service: string;
+	container: string;
+	relativeTime: string;
+	metadataRaw: string;
+}
+
+export interface MetaFact {
+	key: string;
+	value: string;
+}
+
+const META_HIDDEN_KEYS = new Set([
+	'level',
+	'severity',
+	'msg',
+	'message',
+	'time',
+	'ts',
+	'timestamp',
+	'logger',
+	'logging_pod',
+]);
+
+function formatRelativeTime(ts: string): string {
+	try {
+		const then = new Date(ts.replace(' ', 'T') + 'Z').getTime();
+		const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+		if (diffSec < 60) return `${diffSec}s ago`;
+		const diffMin = Math.round(diffSec / 60);
+		if (diffMin < 60) return `${diffMin}m ago`;
+		const diffHr = Math.round(diffMin / 60);
+		if (diffHr < 24) return `${diffHr}h ago`;
+		return `${Math.round(diffHr / 24)}d ago`;
+	} catch {
+		return ts;
+	}
+}
+
+export function normalize(raw: RawLogRow): LogItem {
+	const level = (raw.level ?? 'info').toLowerCase();
+	const namespace = raw.pod_namespace ?? '';
+	const podName = raw.pod_name ?? '';
+	const service = raw.service ?? '';
+	const container = raw.container_name ?? '';
+	const message = raw.message ?? '';
+
+	const id = `${raw.timestamp}:${namespace}:${podName}`;
+	const relativeTime = formatRelativeTime(raw.timestamp);
+
+	return {
+		id,
+		timestamp: raw.timestamp,
+		level,
+		message,
+		podName,
+		namespace,
+		service,
+		container,
+		relativeTime,
+		metadataRaw: raw.metadata ?? '',
+	};
+}
+
+export function parseMetadataFacts(rawMeta: string): MetaFact[] {
+	if (!rawMeta || rawMeta === '{}') return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawMeta);
+	} catch {
+		return [{ key: 'metadata', value: rawMeta }];
+	}
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+		return [];
+	const out: MetaFact[] = [];
+	for (const [key, value] of Object.entries(
+		parsed as Record<string, unknown>,
+	)) {
+		if (META_HIDDEN_KEYS.has(key.toLowerCase())) continue;
+		if (value === null || value === undefined || value === '') continue;
+		const text =
+			typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+		if (!text) continue;
+		out.push({ key, value: text });
+	}
+	return out.sort((a, b) => a.key.localeCompare(b.key));
+}


### PR DESCRIPTION
Metro warns on every app start:

```
Require cycle: dash/adapters/clickhouse.tsx
  -> dash/clickhouse/clickhouseStream.ts
  -> dash/adapters/clickhouse.tsx
```

The adapter pulled `buildStatsTotals` and `CH_CONTROLS` from the stream, while the stream pulled `normalize` plus the `LogItem`/`RawLogRow` types back out of the adapter. Cycles resolve to uninitialized values depending on evaluation order, so this is a real hazard rather than cosmetic noise — `normalize` is called on every row the stream ingests.

## Change

Extracted the pure log-row layer into `dash/clickhouse/logItem.ts`: `RawLogRow`, `LogItem`, `MetaFact`, `normalize`, `parseMetadataFacts`, and the private `formatRelativeTime` / `META_HIDDEN_KEYS`. None of it touches JSX, so it belongs below both modules rather than living in a `.tsx`.

The graph is now a DAG:

- `logItem.ts` — leaf, no imports from the dash tree
- `clickhouseStream.ts` -> `logItem`
- `ErrorDigest` / `NamespaceFocus` / `NamespaceGrid` -> `logItem`
- `adapters/clickhouse.tsx` -> `logItem` + `clickhouseStream`

`adapters/clickhouse.tsx` re-exports the moved symbols so the `dash/index.ts` barrel keeps its existing public API — `LogItem`, `normalize` and friends are still importable from `@kbve/rn` exactly as before. The three sibling views now import from `./logItem` directly, since they only ever wanted the type.

One subtlety worth noting for review: the adapter still *calls* `parseMetadataFacts` in its lens body, and a bare `export ... from` re-export does not bind a name locally, so it also imports it explicitly.

## Verification

- `kbve-react-native:typecheck` — green
- `rn:lint` — 0 errors (55 pre-existing `no-explicit-any` warnings, untouched)
