### PR TITLE
fix(isometric): disable physics on harvest instead of removing components

### DIFF
--- a/apps/kbve/isometric/src-tauri/gen/schemas/acl-manifests.json
+++ b/apps/kbve/isometric/src-tauri/gen/schemas/acl-manifests.json
@@ -30,7 +30,8 @@
 				"allow-identifier",
 				"allow-bundle-type",
 				"allow-register-listener",
-				"allow-remove-listener"
+				"allow-remove-listener",
+				"allow-supports-multiple-windows"
 			]
 		},
 		"permissions": {
@@ -96,6 +97,14 @@
 				"identifier": "allow-set-dock-visibility",
 				"description": "Enables the set_dock_visibility command without any pre-configured scope.",
 				"commands": { "allow": ["set_dock_visibility"], "deny": [] }
+			},
+			"allow-supports-multiple-windows": {
+				"identifier": "allow-supports-multiple-windows",
+				"description": "Enables the supports_multiple_windows command without any pre-configured scope.",
+				"commands": {
+					"allow": ["supports_multiple_windows"],
+					"deny": []
+				}
 			},
 			"allow-tauri-version": {
 				"identifier": "allow-tauri-version",
@@ -169,6 +178,14 @@
 				"identifier": "deny-set-dock-visibility",
 				"description": "Denies the set_dock_visibility command without any pre-configured scope.",
 				"commands": { "allow": [], "deny": ["set_dock_visibility"] }
+			},
+			"deny-supports-multiple-windows": {
+				"identifier": "deny-supports-multiple-windows",
+				"description": "Denies the supports_multiple_windows command without any pre-configured scope.",
+				"commands": {
+					"allow": [],
+					"deny": ["supports_multiple_windows"]
+				}
 			},
 			"deny-tauri-version": {
 				"identifier": "deny-tauri-version",
@@ -709,6 +726,7 @@
 				"allow-set-visible",
 				"allow-set-temp-dir-path",
 				"allow-set-icon-as-template",
+				"allow-set-icon-with-as-template",
 				"allow-set-show-menu-on-left-click"
 			]
 		},
@@ -737,6 +755,14 @@
 				"identifier": "allow-set-icon-as-template",
 				"description": "Enables the set_icon_as_template command without any pre-configured scope.",
 				"commands": { "allow": ["set_icon_as_template"], "deny": [] }
+			},
+			"allow-set-icon-with-as-template": {
+				"identifier": "allow-set-icon-with-as-template",
+				"description": "Enables the set_icon_with_as_template command without any pre-configured scope.",
+				"commands": {
+					"allow": ["set_icon_with_as_template"],
+					"deny": []
+				}
 			},
 			"allow-set-menu": {
 				"identifier": "allow-set-menu",
@@ -795,6 +821,14 @@
 				"identifier": "deny-set-icon-as-template",
 				"description": "Denies the set_icon_as_template command without any pre-configured scope.",
 				"commands": { "allow": [], "deny": ["set_icon_as_template"] }
+			},
+			"deny-set-icon-with-as-template": {
+				"identifier": "deny-set-icon-with-as-template",
+				"description": "Denies the set_icon_with_as_template command without any pre-configured scope.",
+				"commands": {
+					"allow": [],
+					"deny": ["set_icon_with_as_template"]
+				}
 			},
 			"deny-set-menu": {
 				"identifier": "deny-set-menu",
@@ -1071,10 +1105,17 @@
 				"allow-cursor-position",
 				"allow-theme",
 				"allow-is-always-on-top",
+				"allow-activity-name",
+				"allow-scene-identifier",
 				"allow-internal-toggle-maximize"
 			]
 		},
 		"permissions": {
+			"allow-activity-name": {
+				"identifier": "allow-activity-name",
+				"description": "Enables the activity_name command without any pre-configured scope.",
+				"commands": { "allow": ["activity_name"], "deny": [] }
+			},
 			"allow-available-monitors": {
 				"identifier": "allow-available-monitors",
 				"description": "Enables the available_monitors command without any pre-configured scope.",
@@ -1237,6 +1278,11 @@
 				"identifier": "allow-scale-factor",
 				"description": "Enables the scale_factor command without any pre-configured scope.",
 				"commands": { "allow": ["scale_factor"], "deny": [] }
+			},
+			"allow-scene-identifier": {
+				"identifier": "allow-scene-identifier",
+				"description": "Enables the scene_identifier command without any pre-configured scope.",
+				"commands": { "allow": ["scene_identifier"], "deny": [] }
 			},
 			"allow-set-always-on-bottom": {
 				"identifier": "allow-set-always-on-bottom",
@@ -1464,6 +1510,11 @@
 				"description": "Enables the unminimize command without any pre-configured scope.",
 				"commands": { "allow": ["unminimize"], "deny": [] }
 			},
+			"deny-activity-name": {
+				"identifier": "deny-activity-name",
+				"description": "Denies the activity_name command without any pre-configured scope.",
+				"commands": { "allow": [], "deny": ["activity_name"] }
+			},
 			"deny-available-monitors": {
 				"identifier": "deny-available-monitors",
 				"description": "Denies the available_monitors command without any pre-configured scope.",
@@ -1626,6 +1677,11 @@
 				"identifier": "deny-scale-factor",
 				"description": "Denies the scale_factor command without any pre-configured scope.",
 				"commands": { "allow": [], "deny": ["scale_factor"] }
+			},
+			"deny-scene-identifier": {
+				"identifier": "deny-scene-identifier",
+				"description": "Denies the scene_identifier command without any pre-configured scope.",
+				"commands": { "allow": [], "deny": ["scene_identifier"] }
 			},
 			"deny-set-always-on-bottom": {
 				"identifier": "deny-set-always-on-bottom",

--- a/apps/kbve/isometric/src-tauri/gen/schemas/desktop-schema.json
+++ b/apps/kbve/isometric/src-tauri/gen/schemas/desktop-schema.json
@@ -325,10 +325,10 @@
 					"markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
 				},
 				{
-					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
+					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`",
 					"type": "string",
 					"const": "core:app:default",
-					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
+					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`"
 				},
 				{
 					"description": "Enables the app_hide command without any pre-configured scope.",
@@ -401,6 +401,12 @@
 					"type": "string",
 					"const": "core:app:allow-set-dock-visibility",
 					"markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the supports_multiple_windows command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:app:allow-supports-multiple-windows",
+					"markdownDescription": "Enables the supports_multiple_windows command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the tauri_version command without any pre-configured scope.",
@@ -485,6 +491,12 @@
 					"type": "string",
 					"const": "core:app:deny-set-dock-visibility",
 					"markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the supports_multiple_windows command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:app:deny-supports-multiple-windows",
+					"markdownDescription": "Denies the supports_multiple_windows command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the tauri_version command without any pre-configured scope.",
@@ -1009,10 +1021,10 @@
 					"markdownDescription": "Denies the close command without any pre-configured scope."
 				},
 				{
-					"description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`",
+					"description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`",
 					"type": "string",
 					"const": "core:tray:default",
-					"markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`"
+					"markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`"
 				},
 				{
 					"description": "Enables the get_by_id command without any pre-configured scope.",
@@ -1043,6 +1055,12 @@
 					"type": "string",
 					"const": "core:tray:allow-set-icon-as-template",
 					"markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the set_icon_with_as_template command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:tray:allow-set-icon-with-as-template",
+					"markdownDescription": "Enables the set_icon_with_as_template command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the set_menu command without any pre-configured scope.",
@@ -1109,6 +1127,12 @@
 					"type": "string",
 					"const": "core:tray:deny-set-icon-as-template",
 					"markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the set_icon_with_as_template command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:tray:deny-set-icon-with-as-template",
+					"markdownDescription": "Denies the set_icon_with_as_template command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the set_menu command without any pre-configured scope.",
@@ -1369,10 +1393,16 @@
 					"markdownDescription": "Denies the webview_size command without any pre-configured scope."
 				},
 				{
-					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`",
+					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`",
 					"type": "string",
 					"const": "core:window:default",
-					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`"
+					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`"
+				},
+				{
+					"description": "Enables the activity_name command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:allow-activity-name",
+					"markdownDescription": "Enables the activity_name command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the available_monitors command without any pre-configured scope.",
@@ -1565,6 +1595,12 @@
 					"type": "string",
 					"const": "core:window:allow-scale-factor",
 					"markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the scene_identifier command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:allow-scene-identifier",
+					"markdownDescription": "Enables the scene_identifier command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the set_always_on_bottom command without any pre-configured scope.",
@@ -1831,6 +1867,12 @@
 					"markdownDescription": "Enables the unminimize command without any pre-configured scope."
 				},
 				{
+					"description": "Denies the activity_name command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:deny-activity-name",
+					"markdownDescription": "Denies the activity_name command without any pre-configured scope."
+				},
+				{
 					"description": "Denies the available_monitors command without any pre-configured scope.",
 					"type": "string",
 					"const": "core:window:deny-available-monitors",
@@ -2021,6 +2063,12 @@
 					"type": "string",
 					"const": "core:window:deny-scale-factor",
 					"markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the scene_identifier command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:deny-scene-identifier",
+					"markdownDescription": "Denies the scene_identifier command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the set_always_on_bottom command without any pre-configured scope.",

--- a/apps/kbve/isometric/src-tauri/gen/schemas/macOS-schema.json
+++ b/apps/kbve/isometric/src-tauri/gen/schemas/macOS-schema.json
@@ -325,10 +325,10 @@
 					"markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
 				},
 				{
-					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
+					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`",
 					"type": "string",
 					"const": "core:app:default",
-					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
+					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`"
 				},
 				{
 					"description": "Enables the app_hide command without any pre-configured scope.",
@@ -401,6 +401,12 @@
 					"type": "string",
 					"const": "core:app:allow-set-dock-visibility",
 					"markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the supports_multiple_windows command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:app:allow-supports-multiple-windows",
+					"markdownDescription": "Enables the supports_multiple_windows command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the tauri_version command without any pre-configured scope.",
@@ -485,6 +491,12 @@
 					"type": "string",
 					"const": "core:app:deny-set-dock-visibility",
 					"markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the supports_multiple_windows command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:app:deny-supports-multiple-windows",
+					"markdownDescription": "Denies the supports_multiple_windows command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the tauri_version command without any pre-configured scope.",
@@ -1009,10 +1021,10 @@
 					"markdownDescription": "Denies the close command without any pre-configured scope."
 				},
 				{
-					"description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`",
+					"description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`",
 					"type": "string",
 					"const": "core:tray:default",
-					"markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`"
+					"markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`"
 				},
 				{
 					"description": "Enables the get_by_id command without any pre-configured scope.",
@@ -1043,6 +1055,12 @@
 					"type": "string",
 					"const": "core:tray:allow-set-icon-as-template",
 					"markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the set_icon_with_as_template command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:tray:allow-set-icon-with-as-template",
+					"markdownDescription": "Enables the set_icon_with_as_template command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the set_menu command without any pre-configured scope.",
@@ -1109,6 +1127,12 @@
 					"type": "string",
 					"const": "core:tray:deny-set-icon-as-template",
 					"markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the set_icon_with_as_template command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:tray:deny-set-icon-with-as-template",
+					"markdownDescription": "Denies the set_icon_with_as_template command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the set_menu command without any pre-configured scope.",
@@ -1369,10 +1393,16 @@
 					"markdownDescription": "Denies the webview_size command without any pre-configured scope."
 				},
 				{
-					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`",
+					"description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`",
 					"type": "string",
 					"const": "core:window:default",
-					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`"
+					"markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`"
+				},
+				{
+					"description": "Enables the activity_name command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:allow-activity-name",
+					"markdownDescription": "Enables the activity_name command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the available_monitors command without any pre-configured scope.",
@@ -1565,6 +1595,12 @@
 					"type": "string",
 					"const": "core:window:allow-scale-factor",
 					"markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the scene_identifier command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:allow-scene-identifier",
+					"markdownDescription": "Enables the scene_identifier command without any pre-configured scope."
 				},
 				{
 					"description": "Enables the set_always_on_bottom command without any pre-configured scope.",
@@ -1831,6 +1867,12 @@
 					"markdownDescription": "Enables the unminimize command without any pre-configured scope."
 				},
 				{
+					"description": "Denies the activity_name command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:deny-activity-name",
+					"markdownDescription": "Denies the activity_name command without any pre-configured scope."
+				},
+				{
 					"description": "Denies the available_monitors command without any pre-configured scope.",
 					"type": "string",
 					"const": "core:window:deny-available-monitors",
@@ -2021,6 +2063,12 @@
 					"type": "string",
 					"const": "core:window:deny-scale-factor",
 					"markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the scene_identifier command without any pre-configured scope.",
+					"type": "string",
+					"const": "core:window:deny-scene-identifier",
+					"markdownDescription": "Denies the scene_identifier command without any pre-configured scope."
 				},
 				{
 					"description": "Denies the set_always_on_bottom command without any pre-configured scope.",

--- a/apps/kbve/isometric/src-tauri/src/game/actions.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/actions.rs
@@ -257,8 +257,7 @@ fn process_action_buffer(
                 let angle = (req.entity_id as f32 * 1.618) % (2.0 * PI);
                 let fall_axis = Vec3::new(angle.cos(), 0.0, angle.sin()).normalize();
 
-                ec.remove::<RigidBody>();
-                ec.remove::<Collider>();
+                ec.insert((RigidBodyDisabled, ColliderDisabled));
                 ec.remove::<Interactable>();
                 ec.remove::<HoverOutline>();
                 ec.remove::<super::trees::TreeWindSway>();
@@ -277,8 +276,7 @@ fn process_action_buffer(
                     .map(item_from_rock_kind)
                     .unwrap_or(ItemKind::from_ref(ITEM_STONE));
 
-                ec.remove::<RigidBody>();
-                ec.remove::<Collider>();
+                ec.insert((RigidBodyDisabled, ColliderDisabled));
                 ec.remove::<Interactable>();
                 ec.remove::<HoverOutline>();
                 ec.remove::<RockKind>();
@@ -298,8 +296,7 @@ fn process_action_buffer(
                     .map(item_from_flower_archetype)
                     .unwrap_or(ItemKind::from_ref(ITEM_WILDFLOWER));
 
-                ec.remove::<RigidBody>();
-                ec.remove::<Collider>();
+                ec.insert((RigidBodyDisabled, ColliderDisabled));
                 ec.remove::<Sensor>();
                 ec.remove::<Interactable>();
                 ec.remove::<HoverOutline>();
@@ -318,8 +315,7 @@ fn process_action_buffer(
                     .map(item_from_mushroom_kind)
                     .unwrap_or(ItemKind::from_ref(ITEM_PORCINI));
 
-                ec.remove::<RigidBody>();
-                ec.remove::<Collider>();
+                ec.insert((RigidBodyDisabled, ColliderDisabled));
                 ec.remove::<Sensor>();
                 ec.remove::<Interactable>();
                 ec.remove::<HoverOutline>();


### PR DESCRIPTION
Harvesting a tree, rock, flower or mushroom crashed the game on a physical iPhone:

```
panicked at avian3d-0.7.0/src/data_structures/stable_vec.rs:334:
no element at index 1 in StableVec::index_mut
App terminated due to signal 6
```

Reproduced on an iPhone 12 Pro Max: the game initializes, renders, accepts native touch input, then dies on the first harvest tap.

## Cause

All four harvest actions stripped physics off a still-living entity:

```rust
ec.remove::<RigidBody>();
ec.remove::<Collider>();
```

Both removals fire avian observers during the same command flush:

- removing `RigidBody` migrates the collider from the dynamic tree to the static tree, reassigning its proxy id
- removing `Collider` frees a proxy slot in whichever tree the key names by that point

`ColliderTree::proxies` is a `StableVec` that recycles freed slots via an `IdPool`. So the collider tree's AABB pass can set a moved bit for a proxy index that `update_tree` then reads as vacant, panicking at `collider_tree/update.rs:996`:

```rust
let proxy = &mut tree.proxies[proxy_id.index()];  // vacant slot -> panic
```

The small index (1) is consistent with a recycled slot rather than a placeholder key, which would surface as `u32::MAX >> 2`.

This "remove a collider, then step" pattern is historically fragile across Bevy physics backends — cf. [rapier#163](https://github.com/dimforge/rapier/issues/163) and [rapier#342](https://github.com/dimforge/rapier/issues/342).

## Fix

Use avian's supported disable components:

```rust
ec.insert((RigidBodyDisabled, ColliderDisabled));
```

`update_tree` already queries `Without<ColliderDisabled>`, so a disabled collider is excluded from the pass that sets the moved bit, rather than having its slot freed mid-flush. Both components exist in avian3d 0.7.0, which is already the newest 0.7.x — there is no upstream patch to take instead.

Nothing in the game queries on `Collider` or `RigidBody` being absent (checked for `Without<Collider>`, `Has<Collider>`, `Option<&Collider>` — zero hits), and these entities are despawned by their `ChoppingTree` / `MiningRock` / `CollectingForageable` timers moments later, so behaviour should be unchanged.

## Verification

- `cargo check -p isometric-game --no-default-features --features mobile` — 0 errors
- `cargo check -p isometric-game` (default desktop features) — 0 errors
- `nx run kbve_wgpu:build:ios:bevy` succeeds and the app builds, signs, installs and launches on device

**Not yet verified: the crash itself has not been re-exercised against this build.** The fixed binary is installed on the test device but the harvest action has not been retriggered, so this is a well-reasoned fix rather than a confirmed one. The release-build backtrace confirmed the panic occurs inside a Bevy system (consistent with `update_tree`) but symbol collapsing prevented naming it directly. If the panic recurs, the next steps are a debug-symbol build for a full trace and an upstream issue against Avian, since removing a `Collider` from a live entity is a documented-supported operation that should not corrupt the tree.

## Context

Found while verifying the Expo SDK 57 upgrade (#15317, #15321, #15389, #15396, #15403) — the first time this native path had ever been built and run on iOS. Unrelated to Expo, wgpu or the renderer.

Also worth recording: the **iOS Simulator cannot run this path at all**. It fails SSAO setup with `WriteOnly access to storage textures with format R16Float is not supported` and Bevy then quits every frame to a black screen. The same build on physical hardware initializes with zero validation errors, so that failure is simulator-only and should not be "fixed" — the wgpu/Bevy path must be validated on device.
