### PR TITLE
fix(dashboard): resolve staff gate async on SSG loads (storage + S3)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import { ShieldOff } from 'lucide-react';
 import { S3BackupPanel } from '@kbve/rn/dash';
@@ -42,15 +42,26 @@ const styles = {
 
 export default function ReactS3BackupRN() {
 	const isStaff = useStore(homeService.$isStaff);
+	const authState = useStore(homeService.$authState);
 	const token = useMemo(() => getToken, []);
 
+	useEffect(() => {
+		void homeService.initAuth();
+	}, []);
+
 	if (!isStaff) {
+		const pending =
+			authState === 'loading' || authState === 'authenticated';
 		return (
 			<div style={styles.centered}>
 				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
-				<h2 style={styles.heading}>Staff Access Required</h2>
+				<h2 style={styles.heading}>
+					{pending ? 'Checking access…' : 'Staff Access Required'}
+				</h2>
 				<p style={styles.sub}>
-					The AWS S3 backup panel is restricted to KBVE staff.
+					{pending
+						? 'Verifying your staff permissions.'
+						: 'The AWS S3 backup panel is restricted to KBVE staff.'}
 				</p>
 			</div>
 		);

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import { ShieldOff } from 'lucide-react';
 import { StreamView, createLonghornStream, longhornLens } from '@kbve/rn/dash';
@@ -42,18 +42,29 @@ const styles = {
 
 export default function ReactStorageDashRN() {
 	const isStaff = useStore(homeService.$isStaff);
+	const authState = useStore(homeService.$authState);
 	const store = useMemo(
 		() => createLonghornStream({ getToken, baseUrl: DASH_PROXY_BASE }),
 		[],
 	);
 
+	useEffect(() => {
+		void homeService.initAuth();
+	}, []);
+
 	if (!isStaff) {
+		const pending =
+			authState === 'loading' || authState === 'authenticated';
 		return (
 			<div style={styles.centered}>
 				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
-				<h2 style={styles.heading}>Staff Access Required</h2>
+				<h2 style={styles.heading}>
+					{pending ? 'Checking access…' : 'Staff Access Required'}
+				</h2>
 				<p style={styles.sub}>
-					The Longhorn storage dashboard is restricted to KBVE staff.
+					{pending
+						? 'Verifying your staff permissions.'
+						: 'The Longhorn storage dashboard is restricted to KBVE staff.'}
 				</p>
 			</div>
 		);


### PR DESCRIPTION
## Summary
- `/dashboard/storage/` showed **Staff Access Required** to signed-in staff on direct page load: the island read `homeService.$isStaff` (atom defaults `false`) but nothing on the SSG page ever called `homeService.initAuth()`, so the flag never hydrated.
- Fix mirrors `ReactReelConsole`: call `initAuth()` on mount, watch `$authState`, and render **Checking access…** while the session hydrates (`loading`/`authenticated`) instead of latching the denial screen.
- `ReactS3BackupRN` had the same latent bug (identical gate, no `initAuth()`) — fixed the same way.

## Testing
- Pattern matches the working reel console gate; `applyAuthState()` sets `$isStaff` reactively once `$auth` hydrates, flipping the gate to the dashboard.

Follow-up to #15394.