### PR TITLE
fix(ci-bevy): skip pre-compressed assets in deploy_wasm brotli step

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -197,20 +197,29 @@ jobs:
             - name: Brotli-compress static assets
               run: |
                   DEPLOY_DIR="apps/kbve/astro-kbve/public/isometric"
-                  apt-get update -qq && apt-get install -y -qq brotli > /dev/null 2>&1 || true
+                  command -v brotli > /dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq brotli > /dev/null; }
 
                   # Compress static assets that Vite's compression plugin doesn't handle:
                   # shaders (.wgsl), textures (.png), standalone JS shims, and WASM binaries.
+                  # The build may already ship .br/.gz siblings; skip those to stay idempotent.
                   find "$DEPLOY_DIR" -type f \( \
                     -name "*.wgsl" -o -name "*.png" -o -name "*.wasm" \
                     -o -name "*.js" -o -name "*.css" \
                   \) ! -name "*.br" ! -name "*.gz" | while read -r file; do
+                    if [ -f "${file}.br" ]; then
+                      echo "  skipped (exists): ${file}.br"
+                      continue
+                    fi
                     brotli --best --keep "$file"
                     echo "  compressed: ${file}.br ($(stat -c%s "${file}.br" 2>/dev/null || stat -f%z "${file}.br") bytes)"
                   done
 
                   # Also generate gzip for WASM (tower-http serves .wasm.gz as fallback)
                   find "$DEPLOY_DIR" -type f -name "*.wasm" ! -name "*.gz" | while read -r file; do
+                    if [ -f "${file}.gz" ]; then
+                      echo "  skipped (exists): ${file}.gz"
+                      continue
+                    fi
                     gzip -9 --keep "$file"
                     echo "  gzipped: ${file}.gz"
                   done


### PR DESCRIPTION
Fixes #15408

The CI - Bevy / deploy_wasm job fails at the Brotli-compress step with:

```
failed to open output file [apps/kbve/astro-kbve/public/isometric/safari-shim.js.br]: File exists
```

Since the rolldown-vite migration (ec22c48689), the isometric build emits .br/.gz siblings for js/png/wgsl assets directly into the WASM artifact, so the workflow's brotli pass hits already-existing .br files and `brotli --keep` refuses to overwrite.

Changes to the Brotli-compress step:
- Skip any file whose .br / .gz sibling already exists (idempotent against pre-compressed artifacts)
- Only run apt-get when brotli is missing, and with sudo (the bare `apt-get update` was failing with a lock permission error)

Verified locally by downloading the artifact from failing run 31050951697 and running the updated step against it: pre-compressed files skipped, remaining files compressed, exit 0.