### PR TITLE
fix(vector): grant palworld ES reader access to clickhouse credentials

### DIFF
--- a/apps/kube/vector/manifests/palworld-ch-credentials-rbac.yaml
+++ b/apps/kube/vector/manifests/palworld-ch-credentials-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: clickhouse-credentials-reader-for-palworld
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['clickhouse-vector-credentials']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: palworld-read-clickhouse-credentials
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: clickhouse-credentials-reader-for-palworld
+subjects:
+    - kind: ServiceAccount
+      name: palworld-external-secrets
+      namespace: palworld


### PR DESCRIPTION
Follow-up to #15397 / #15362 — found while double-checking the deploy: even with schema + identity fixed, the relay logs

```
WARN ch_writer disabled: CLICKHOUSE_URL not set
```

because `palworld/clickhouse-credentials` never materializes: the `vector-remote-secret-store` SecretStore in the palworld namespace is `Ready=False / ValidationFailed` — [apps/kube/vector/manifests/](https://github.com/KBVE/kbve/tree/main/apps/kube/vector/manifests) carries reader grants for factorio, discordsh, and kbve, but the palworld one was never authored. The whole telemetry path was double-dead: no tables (#15397) **and** no credentials (this).

Adds `palworld-ch-credentials-rbac.yaml` — Role + RoleBinding in the `vector` namespace letting `palworld:palworld-external-secrets` read the `clickhouse-vector-credentials` secret, byte-for-byte the factorio pattern.

After merge/sync: ExternalSecret refreshes (1h interval, or instant on the next reconcile), secret lands, and the relay picks it up on its next pod start — no extra restart needed beyond the one already queued for relay 0.0.15… which has already rolled, so the env lands on the next natural pod recreate, or a planned one.

Docs: [project/agones-palworld-relay](https://kbve.com/project/agones-palworld-relay/).