### PR TITLE
refactor(auth): single-source staff gating on droid $isStaff + boot race fix

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGameOpsPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGameOpsPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	ShieldOff,
@@ -6,7 +7,8 @@ import {
 	Pickaxe,
 	ArrowRight,
 } from 'lucide-react';
-import { homeService } from './homeService';
+import { $auth, $isStaff } from '@kbve/droid';
+import { initSupa } from '@/lib/supa';
 
 type TileStatus = 'live' | 'phase-0' | 'planned';
 
@@ -142,17 +144,25 @@ const styles = {
 };
 
 export default function ReactGameOpsPanel() {
-	const isStaff = useStore(homeService.$isStaff);
+	const isStaff = useStore($isStaff);
+	const tone = useStore($auth).tone;
+
+	useEffect(() => {
+		void initSupa().catch(() => {});
+	}, []);
 
 	if (!isStaff) {
+		const pending = tone === 'loading' || tone === 'auth';
 		return (
 			<div style={styles.centered}>
 				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
-				<h2 style={styles.heading}>Staff Access Required</h2>
+				<h2 style={styles.heading}>
+					{pending ? 'Checking access…' : 'Staff Access Required'}
+				</h2>
 				<p style={styles.sub}>
-					GameOps is restricted to KBVE staff. Sign in with a staff
-					account, or contact an administrator if you believe this is
-					an error.
+					{pending
+						? 'Verifying your staff permissions.'
+						: 'GameOps is restricted to KBVE staff. Sign in with a staff account, or contact an administrator if you believe this is an error.'}
 				</p>
 			</div>
 		);

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelConsole.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
-import { homeService } from '@/components/dashboard/homeService';
+import { $auth, $isStaff } from '@kbve/droid';
+import { initSupa } from '@/lib/supa';
 import {
 	$reelList,
 	$reelListError,
@@ -164,8 +165,8 @@ export default function ReactReelConsole() {
 	const live = useStore($reelLive);
 	const health = useStore($reelHealth);
 	const selectedId = useStore($reelSelectedId);
-	const isStaff = useStore(homeService.$isStaff);
-	const authState = useStore(homeService.$authState);
+	const isStaff = useStore($isStaff);
+	const tone = useStore($auth).tone;
 
 	const [source, setSource] = useState('');
 	const [adding, setAdding] = useState(false);
@@ -173,7 +174,7 @@ export default function ReactReelConsole() {
 	const [actionError, setActionError] = useState<string | null>(null);
 
 	useEffect(() => {
-		void homeService.initAuth();
+		void initSupa().catch(() => {});
 	}, []);
 
 	useEffect(() => {
@@ -244,7 +245,7 @@ export default function ReactReelConsole() {
 		return (
 			<div className="reel-console reel-console--gated">
 				<p className="reel-console__gate">
-					{authState === 'loading' || authState === 'authenticated'
+					{tone === 'loading' || tone === 'auth'
 						? 'Checking access…'
 						: 'Reel management is restricted to KBVE staff. Sign in with a staff account to add, transcode, or remove reels.'}
 				</p>

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelLive.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from '@nanostores/react';
-import { DroidEvents, type ReelStreamPayload } from '@kbve/droid';
-import { homeService } from '@/components/dashboard/homeService';
+import { $auth, $isStaff, DroidEvents, type ReelStreamPayload } from '@kbve/droid';
+import { initSupa } from '@/lib/supa';
 import ReactReelDiagnostics from './ReactReelDiagnostics';
 import {
 	$reelList,
@@ -58,8 +58,8 @@ export default function ReactReelLive() {
 	const error = useStore($reelError);
 	const notice = useStore($reelNotice);
 	const status = useStore($reelStatus);
-	const isStaff = useStore(homeService.$isStaff);
-	const authState = useStore(homeService.$authState);
+	const isStaff = useStore($isStaff);
+	const tone = useStore($auth).tone;
 
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const stageRef = useRef<HTMLDivElement>(null);
@@ -75,7 +75,7 @@ export default function ReactReelLive() {
 	const upNext = nowIndex >= 0 ? queue.slice(nowIndex + 1) : queue;
 
 	useEffect(() => {
-		void homeService.initAuth();
+		void initSupa().catch(() => {});
 	}, []);
 
 	useEffect(() => {
@@ -234,7 +234,7 @@ export default function ReactReelLive() {
 		return (
 			<div className="reel-live__gate">
 				<p>
-					{authState === 'loading' || authState === 'authenticated'
+					{tone === 'loading' || tone === 'auth'
 						? 'Checking access…'
 						: 'Sign in with a staff account to watch the channel.'}
 				</p>

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactS3BackupRN.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import { ShieldOff } from 'lucide-react';
 import { S3BackupPanel } from '@kbve/rn/dash';
-import { homeService } from '@/components/dashboard/homeService';
+import { $auth, $isStaff } from '@kbve/droid';
 import { initSupa, getSupa } from '@/lib/supa';
 import { DASH_PROXY_BASE } from './dashProxyBase';
 
@@ -41,17 +41,16 @@ const styles = {
 };
 
 export default function ReactS3BackupRN() {
-	const isStaff = useStore(homeService.$isStaff);
-	const authState = useStore(homeService.$authState);
+	const isStaff = useStore($isStaff);
+	const tone = useStore($auth).tone;
 	const token = useMemo(() => getToken, []);
 
 	useEffect(() => {
-		void homeService.initAuth();
+		void initSupa().catch(() => {});
 	}, []);
 
 	if (!isStaff) {
-		const pending =
-			authState === 'loading' || authState === 'authenticated';
+		const pending = tone === 'loading' || tone === 'auth';
 		return (
 			<div style={styles.centered}>
 				<ShieldOff size={48} color="var(--sl-color-gray-3)" />

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactStorageDashRN.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import { ShieldOff } from 'lucide-react';
 import { StreamView, createLonghornStream, longhornLens } from '@kbve/rn/dash';
-import { homeService } from '@/components/dashboard/homeService';
+import { $auth, $isStaff } from '@kbve/droid';
 import { initSupa, getSupa } from '@/lib/supa';
 import { DASH_PROXY_BASE } from './dashProxyBase';
 
@@ -41,20 +41,19 @@ const styles = {
 };
 
 export default function ReactStorageDashRN() {
-	const isStaff = useStore(homeService.$isStaff);
-	const authState = useStore(homeService.$authState);
+	const isStaff = useStore($isStaff);
+	const tone = useStore($auth).tone;
 	const store = useMemo(
 		() => createLonghornStream({ getToken, baseUrl: DASH_PROXY_BASE }),
 		[],
 	);
 
 	useEffect(() => {
-		void homeService.initAuth();
+		void initSupa().catch(() => {});
 	}, []);
 
 	if (!isStaff) {
-		const pending =
-			authState === 'loading' || authState === 'authenticated';
+		const pending = tone === 'loading' || tone === 'auth';
 		return (
 			<div style={styles.centered}>
 				<ShieldOff size={48} color="var(--sl-color-gray-3)" />

--- a/apps/kbve/astro-kbve/src/lib/supa.ts
+++ b/apps/kbve/astro-kbve/src/lib/supa.ts
@@ -1,6 +1,6 @@
 // src/lib/supa.ts
 // Unified Supabase gateway — powered by @kbve/droid
-import { SupabaseGateway } from '@kbve/droid';
+import { $auth, SupabaseGateway } from '@kbve/droid';
 import { bootAuth, resolveStaffFlag } from '@kbve/astro';
 import { migrateAuthStorage } from './storage-migration';
 
@@ -70,6 +70,24 @@ async function autoRecoverStaleClient(): Promise<void> {
 	window.location.reload();
 }
 
+// resolveStaffFlag early-returns unless $auth.tone === 'auth', and on a cold
+// load the worker session often hydrates after bootAuth resolves — a single
+// fire-and-forget call at boot silently never resolves staff. Subscribe and
+// re-kick once per authenticated user id instead.
+let _staffResolvedForId: string | null = null;
+
+function watchStaffFlag(gateway: SupabaseGateway): void {
+	const kick = () => {
+		const { tone, id } = $auth.get();
+		if (tone !== 'auth' || !id) return;
+		if (_staffResolvedForId === id) return;
+		_staffResolvedForId = id;
+		void resolveStaffFlag(gateway, SUPABASE_URL, SUPABASE_ANON_KEY);
+	};
+	kick();
+	$auth.subscribe(kick);
+}
+
 /** Call once early (e.g. in a provider) or on-demand anywhere */
 export function initSupa(options?: Record<string, unknown>): Promise<void> {
 	if (_initPromise) return _initPromise;
@@ -92,7 +110,7 @@ export function initSupa(options?: Record<string, unknown>): Promise<void> {
 
 		await bootAuth(gateway);
 
-		void resolveStaffFlag(gateway, SUPABASE_URL, SUPABASE_ANON_KEY);
+		watchStaffFlag(gateway);
 	})()
 		.then(() => {})
 		.catch((e) => {


### PR DESCRIPTION
## Summary
Follow-up to #15419 — that fix worked but duplicated hydration wiring instead of using the single source of truth.

- **Single source:** `@kbve/droid` already owns `$auth` (storage-seeded, booted by ReactNav on every page) and exports `$isStaff` computed from it. `homeService.$isStaff` is a mirror that only syncs after a manual per-island `initAuth()` call — the footgun behind the storage/S3 SSG gate bug.
- Swapped all remaining mirror-based gates to droid's `$auth`/`$isStaff`: `ReactStorageDashRN`, `ReactS3BackupRN`, `ReactReelConsole`, `ReactReelLive`, `ReactGameOpsPanel`. Now consistent with `DashboardNav`, `ReactMinecraftDashRN`, `ReactStoreAdminRN` which already gate on droid. Islands keep a fire-and-forget `initSupa()` on mount so they don't depend on nav mounting first.
- **Root race fixed:** `initSupa()` fired `resolveStaffFlag` once fire-and-forget right after `bootAuth`, but it early-returns while `$auth.tone` is still `loading` — on cold loads staff never resolved without homeService's re-kick. `supa.ts` now subscribes to `$auth` and kicks `resolveStaffFlag` once per authenticated user id, so droid's `$isStaff` is self-sufficient.
- `homeService.initAuth()`/`$isStaff` kept for its side effects (welcome/staff toasts, dashboard-home flows); gates just no longer depend on it.

## Testing
- Grep-verified no remaining `homeService.$isStaff` gate consumers outside homeService's own dashboard-home components.
- Gate pending copy unchanged: shows 'Checking access…' while `tone` is `loading`/`auth`, denial only once definitively non-staff.

Follow-up to #15394 / #15419.