### PR TITLE
fix(edge): full npm specifier for clickhouse client in logs worker

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.47"
+version: "0.1.48"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -1,11 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-// Resolves through Deno's `npm:` specifier (mapped in apps/kbve/edge/deno.json
-// imports) instead of esm.sh. esm.sh started returning 500 on
-// @clickhouse/client-web@1.8.1/dist/index.d.ts (2026-05-08), which crashed
-// every worker boot of this function and surfaced as 0/0/0 logs on /dashboard.
-// `npm:` resolves through Deno's own npm cache, no third-party CDN in the
-// boot path.
-import { createClient } from "@clickhouse/client-web";
+// Full `npm:` specifier required: user workers boot with importMapPath null,
+// so the deno.json imports map never applies (bare specifier = boot crash).
+// npm: over esm.sh because esm.sh 500'd on this package (2026-05-08).
+import { createClient } from "npm:@clickhouse/client-web@1.8.1";
 import { preflight, withCors } from "../_shared/cors.ts";
 import { logError } from "../_shared/logging.ts";
 import { rateLimit, rateLimitKey } from "../_shared/ratelimit.ts";


### PR DESCRIPTION
## Problem
The `logs` edge function crashed at worker boot on every request:

```
worker boot error: failed to bootstrap runtime: failed to create the graph: Relative import path "@clickhouse/client-web" not prefixed with / or ./ or ../
```

Two holes lined up:
1. The Dockerfile never copies `deno.json` into the image, so the imports map that defined `@clickhouse/client-web` does not exist at runtime.
2. `main/index.ts` creates user workers with `importMapPath: null`, so an import map would not apply anyway.

`logs` was the only function using a bare specifier, so only ClickHouse log queries died — surfacing as 500s on the dashboard.

## Fix
Import `npm:@clickhouse/client-web@1.8.1` directly in `functions/logs/index.ts`. `deno check` passes.

Bumps edge MDX version to 0.1.48 to trigger the publish pipeline (version.toml + manifests sync via post-publish atom PR).