### PR TITLE
feat(palworld): pal condition + soul data in base intel and modal

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -69,7 +69,7 @@
 		{
 			"key": "agones_palworld_savetool",
 			"app_name": "agones-palworld-savetool",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"version_toml": "apps/agones/palworld/savetool/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx",
 			"source_path": "apps/agones/palworld/savetool",

--- a/apps/agones/palworld/savetool/e2e_save_intel.py
+++ b/apps/agones/palworld/savetool/e2e_save_intel.py
@@ -299,6 +299,62 @@ def build_fixture_sav(path, save_type=0x32):
                                                         "id": None,
                                                         "value": 100,
                                                     },
+                                                    "Hp": {
+                                                        "type": "StructProperty",
+                                                        "struct_type": "FixedPoint64",
+                                                        "struct_id": "00000000-0000-0000-0000-000000000000",
+                                                        "id": None,
+                                                        "value": {
+                                                            "Value": {
+                                                                "type": "Int64Property",
+                                                                "id": None,
+                                                                "value": 183000,
+                                                            }
+                                                        },
+                                                    },
+                                                    "SanityValue": {
+                                                        "type": "FloatProperty",
+                                                        "id": None,
+                                                        "value": 62.4,
+                                                    },
+                                                    "FullStomach": {
+                                                        "type": "FloatProperty",
+                                                        "id": None,
+                                                        "value": 105.0,
+                                                    },
+                                                    "MaxFullStomach": {
+                                                        "type": "FloatProperty",
+                                                        "id": None,
+                                                        "value": 350.0,
+                                                    },
+                                                    "IsRarePal": {
+                                                        "type": "BoolProperty",
+                                                        "id": None,
+                                                        "value": True,
+                                                    },
+                                                    "WorkerSick": {
+                                                        "type": "EnumProperty",
+                                                        "id": None,
+                                                        "value": {
+                                                            "type": "EPalBaseCampWorkerSickType",
+                                                            "value": "EPalBaseCampWorkerSickType::DepressionSprain",
+                                                        },
+                                                    },
+                                                    "FriendshipPoint": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 1250,
+                                                    },
+                                                    "Rank_HP": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 3,
+                                                    },
+                                                    "Rank_Attack": {
+                                                        "type": "IntProperty",
+                                                        "id": None,
+                                                        "value": 0,
+                                                    },
                                                     "PassiveSkillList": {
                                                         "type": "ArrayProperty",
                                                         "array_type": "NameProperty",
@@ -379,9 +435,16 @@ def main():
                 "rank": 2,
                 "talents": {"hp": 85, "attack": 90, "defense": 100},
                 "passives": ["CraftSpeed_up1", "PAL_Sanity_Down_1"],
+                "hp": 183,
+                "sanity": 62,
+                "hunger": 30,
+                "lucky": True,
+                "sick": "DepressionSprain",
+                "friendship": 1250,
+                "souls": {"hp": 3, "attack": 0, "defense": 0, "craft": 0},
             }
         ],
-        "base pal roster with breeding stats",
+        "base pal roster with condition + breeding stats",
     )
     with open(out_path) as f:
         disk = json.load(f)

--- a/apps/agones/palworld/savetool/save_intel.py
+++ b/apps/agones/palworld/savetool/save_intel.py
@@ -70,7 +70,7 @@ def decode_character(raw_bytes):
         if isinstance(passives_prop, dict)
         else passives_prop
     ) or []
-    return {
+    pal = {
         "id": str(char_id),
         "name": pv(sp, "NickName") or "",
         "level": pv(sp, "Level") or 1,
@@ -83,6 +83,36 @@ def decode_character(raw_bytes):
         },
         "passives": [str(p) for p in passives],
     }
+    hp = pv(sp, "Hp", "Value")
+    if hp is not None:
+        pal["hp"] = int(hp) // 1000
+    max_hp = pv(sp, "MaxHP", "Value")
+    if max_hp is not None:
+        pal["max_hp"] = int(max_hp) // 1000
+    sanity = pv(sp, "SanityValue")
+    if sanity is not None:
+        pal["sanity"] = round(float(sanity))
+    stomach = pv(sp, "FullStomach")
+    max_stomach = pv(sp, "MaxFullStomach")
+    if stomach is not None and max_stomach:
+        pal["hunger"] = round(100 * float(stomach) / float(max_stomach))
+    if pv(sp, "IsRarePal"):
+        pal["lucky"] = True
+    sick = str(pv(sp, "WorkerSick") or "")
+    if sick and not sick.endswith("::None"):
+        pal["sick"] = sick.rsplit("::", 1)[-1]
+    friendship = pv(sp, "FriendshipPoint")
+    if friendship:
+        pal["friendship"] = friendship
+    souls = {
+        "hp": pv(sp, "Rank_HP") or 0,
+        "attack": pv(sp, "Rank_Attack") or 0,
+        "defense": pv(sp, "Rank_Defence") or 0,
+        "craft": pv(sp, "Rank_CraftSpeed") or 0,
+    }
+    if any(souls.values()):
+        pal["souls"] = souls
+    return pal
 
 
 def container_slot_instances(world):

--- a/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
+++ b/apps/kbve/astro-kbve/src/components/palworld/map/ReactPalworldMap.tsx
@@ -639,6 +639,51 @@ export default function ReactPalworldMap() {
 			rank?: number;
 			talents?: { hp: number; attack: number; defense: number };
 			passives?: string[];
+			hp?: number;
+			max_hp?: number;
+			sanity?: number;
+			hunger?: number;
+			lucky?: boolean;
+			sick?: string;
+			friendship?: number;
+			souls?: {
+				hp: number;
+				attack: number;
+				defense: number;
+				craft: number;
+			};
+		};
+		const palChip = (label: string, color: string) =>
+			`<span style="display:inline-block;padding:0 6px;margin-right:4px;border-radius:8px;` +
+			`border:1px solid ${color}55;color:${color};font-size:10px;line-height:1.6">${label}</span>`;
+		const palCondition = (p: BasePal) => {
+			const chips: string[] = [];
+			if (p.lucky) chips.push(palChip('Lucky', '#fbbf24'));
+			if (p.hp === 0) chips.push(palChip('Down', '#f87171'));
+			if (p.sick)
+				chips.push(
+					palChip(
+						esc(p.sick.replace(/([a-z])([A-Z])/g, '$1 $2')),
+						'#f87171',
+					),
+				);
+			if (p.hunger !== undefined && p.hunger <= 30)
+				chips.push(palChip(`Hungry ${p.hunger}%`, '#fb923c'));
+			if (p.sanity !== undefined && p.sanity < 70)
+				chips.push(palChip(`Sanity ${p.sanity}`, '#c084fc'));
+			if (p.souls) {
+				const s = p.souls;
+				const parts = [
+					s.hp ? `HP+${s.hp}` : '',
+					s.attack ? `ATK+${s.attack}` : '',
+					s.defense ? `DEF+${s.defense}` : '',
+					s.craft ? `WRK+${s.craft}` : '',
+				]
+					.filter(Boolean)
+					.join(' ');
+				if (parts) chips.push(palChip(parts, '#38bdf8'));
+			}
+			return chips.join('');
 		};
 		type BaseIntel = {
 			id: string;
@@ -711,6 +756,9 @@ export default function ReactPalworldMap() {
 							? ` · ${p.passives.map((s) => esc(s.replace(/_/g, ' '))).join(', ')}`
 							: '') +
 						`</div>`
+					: '') +
+				(palCondition(p)
+					? `<div style="margin-top:2px">${palCondition(p)}</div>`
 					: '') +
 				`</div>` +
 				`<span style="color:#34d399;font-variant-numeric:tabular-nums">Lv ${p.level}</span></div>`

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-palworld-savetool.mdx
@@ -14,7 +14,7 @@ tags:
 key: agones_palworld_savetool
 pipeline: docker
 app_name: agones-palworld-savetool
-version: "0.0.6"
+version: "0.0.7"
 source_path: apps/agones/palworld/savetool
 version_toml: apps/agones/palworld/savetool/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## What

Second enrichment pass over the base pal data — `/live/bases` pal entries gain (all optional, present only when the save carries them):

- `hp` / `max_hp` (FixedPoint64 ÷1000) — `hp: 0` = incapacitated
- `sanity` (rounded), `hunger` (percent of `MaxFullStomach`)
- `lucky` (`IsRarePal`), `sick` (`WorkerSick` enum tail, e.g. `DepressionSprain`)
- `friendship`, `souls` {hp, attack, defense, craft} (`Rank_*` enhancement levels, emitted only when any > 0)

The map's base modal renders compact status chips per pal: **Lucky** (gold), **Down** / sickness (red), **Hungry n%** (≤30), **Sanity n** (<70), and soul bonuses (`HP+5 ATK+3 WRK+10`). A healthy pal shows no chips — the row stays exactly as it was. Base ops at a glance: a stalled base now explains itself (starving, depressed, downed pals visible from the map).

## Verification

- savetool e2e fixture round-trips all condition fields through palsav codecs (asserts hp 183, sanity 62, hunger 30%, lucky, DepressionSprain, friendship 1250, souls hp+3)
- playwright modal check: chips render on decked-out and suffering fixtures, stat-less pal renders unchanged, escaping intact

MDX `0.0.6 → 0.0.7`, manifest regenerated.