### PR TITLE
feat(embeddb): offline read path, embedder abstraction, and HTTP embedding provider

### DIFF
--- a/packages/rust/embeddb/Cargo.toml
+++ b/packages/rust/embeddb/Cargo.toml
@@ -13,11 +13,15 @@ duckdb = { version = "1", features = ["bundled"] }
 tokio = { workspace = true, features = ["default", "rt", "rt-multi-thread", "macros"] }
 thiserror = { workspace = true }
 embeddb-derive = { version = "0.1.0", path = "../embeddb-derive", optional = true }
+reqwest = { workspace = true, features = ["json", "rustls"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["derive"]
 derive = ["dep:embeddb-derive"]
 vector = []
+embed-api = ["vector", "dep:reqwest", "dep:serde", "dep:serde_json"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
@@ -34,4 +38,8 @@ required-features = ["derive"]
 
 [[test]]
 name = "e2e_vector"
+required-features = ["vector"]
+
+[[test]]
+name = "e2e_offline"
 required-features = ["vector"]

--- a/packages/rust/embeddb/src/embed.rs
+++ b/packages/rust/embeddb/src/embed.rs
@@ -1,0 +1,254 @@
+use crate::{EmbedDb, EmbedError, Result, VectorFilter, VectorHit, VectorSpace};
+use std::future::Future;
+use std::pin::Pin;
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+pub trait Embedder: Send + Sync {
+    fn provider(&self) -> &str;
+
+    fn model(&self) -> &str;
+
+    fn dim(&self) -> usize;
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, Result<Vec<Vec<f32>>>>;
+
+    fn space(&self) -> VectorSpace {
+        VectorSpace::new(self.provider(), self.model(), self.dim())
+    }
+}
+
+fn check_batch(embedder: &dyn Embedder, texts: &[String], got: &[Vec<f32>]) -> Result<()> {
+    if got.len() != texts.len() {
+        return Err(EmbedError::Embedder(format!(
+            "embedder returned {} vectors for {} inputs",
+            got.len(),
+            texts.len()
+        )));
+    }
+    for v in got {
+        if v.len() != embedder.dim() {
+            return Err(EmbedError::VectorDim { expected: embedder.dim(), actual: v.len() });
+        }
+    }
+    Ok(())
+}
+
+impl EmbedDb {
+    pub async fn vector_upsert_text(
+        &self,
+        embedder: &dyn Embedder,
+        ref_kind: &str,
+        ref_id: &str,
+        text: &str,
+    ) -> Result<()> {
+        let inputs = vec![text.to_string()];
+        let vectors = embedder.embed(&inputs).await?;
+        check_batch(embedder, &inputs, &vectors)?;
+        self.vector_upsert(&embedder.space(), ref_kind, ref_id, &vectors[0]).await
+    }
+
+    pub async fn vector_upsert_texts(
+        &self,
+        embedder: &dyn Embedder,
+        items: &[(String, String, String)],
+    ) -> Result<u64> {
+        if items.is_empty() {
+            return Ok(0);
+        }
+        let inputs: Vec<String> = items.iter().map(|(_, _, text)| text.clone()).collect();
+        let vectors = embedder.embed(&inputs).await?;
+        check_batch(embedder, &inputs, &vectors)?;
+        let rows: Vec<(String, String, Vec<f32>)> = items
+            .iter()
+            .zip(vectors)
+            .map(|((kind, id, _), v)| (kind.clone(), id.clone(), v))
+            .collect();
+        self.vector_upsert_batch(&embedder.space(), &rows).await
+    }
+
+    pub async fn vector_search_text(
+        &self,
+        embedder: &dyn Embedder,
+        query: &str,
+        k: usize,
+        filter: Option<&VectorFilter>,
+    ) -> Result<Vec<VectorHit>> {
+        let inputs = vec![query.to_string()];
+        let vectors = embedder.embed(&inputs).await?;
+        check_batch(embedder, &inputs, &vectors)?;
+        self.vector_search(&embedder.space(), &vectors[0], k, filter).await
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub(crate) struct HashEmbedder {
+        pub dim: usize,
+        pub model: String,
+        pub calls: AtomicUsize,
+    }
+
+    impl HashEmbedder {
+        pub(crate) fn new(model: &str, dim: usize) -> Self {
+            HashEmbedder { dim, model: model.to_string(), calls: AtomicUsize::new(0) }
+        }
+    }
+
+    impl Embedder for HashEmbedder {
+        fn provider(&self) -> &str {
+            "test"
+        }
+        fn model(&self) -> &str {
+            &self.model
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, Result<Vec<Vec<f32>>>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(texts
+                    .iter()
+                    .map(|t| {
+                        let mut v = vec![0.0_f32; self.dim];
+                        for (i, byte) in t.bytes().enumerate() {
+                            v[i % self.dim] += f32::from(byte) / 255.0;
+                        }
+                        if v.iter().all(|x| *x == 0.0) {
+                            v[0] = 1.0;
+                        }
+                        v
+                    })
+                    .collect())
+            })
+        }
+    }
+
+    pub(crate) struct BrokenEmbedder {
+        pub dim: usize,
+        pub emit: usize,
+        pub emit_dim: usize,
+    }
+
+    impl Embedder for BrokenEmbedder {
+        fn provider(&self) -> &str {
+            "test"
+        }
+        fn model(&self) -> &str {
+            "broken"
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn embed<'a>(&'a self, _texts: &'a [String]) -> BoxFuture<'a, Result<Vec<Vec<f32>>>> {
+            let out = vec![vec![1.0_f32; self.emit_dim]; self.emit];
+            Box::pin(async move { Ok(out) })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testing::*;
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    async fn open(name: &str) -> (tempfile::TempDir, EmbedDb) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join(name)).await.unwrap();
+        db.vector_init().await.unwrap();
+        (dir, db)
+    }
+
+    #[tokio::test]
+    async fn space_is_derived_from_the_embedder() {
+        let e = HashEmbedder::new("m1", 8);
+        let space = e.space();
+        assert_eq!(space.provider, "test");
+        assert_eq!(space.model, "m1");
+        assert_eq!(space.dim, 8);
+    }
+
+    #[tokio::test]
+    async fn upsert_and_search_by_text_round_trip() {
+        let (_d, db) = open("embed_text.db").await;
+        let e = HashEmbedder::new("m1", 16);
+
+        db.vector_upsert_text(&e, "message", "a", "deploy the cluster").await.unwrap();
+        db.vector_upsert_text(&e, "message", "b", "lunch at noon").await.unwrap();
+
+        let hits = db.vector_search_text(&e, "deploy the cluster", 1, None).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].ref_id, "a");
+        assert!((hits[0].score - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn batch_text_upsert_issues_one_embedder_call() {
+        let (_d, db) = open("embed_batch.db").await;
+        let e = HashEmbedder::new("m1", 16);
+        let items = vec![
+            ("message".to_string(), "a".to_string(), "first".to_string()),
+            ("message".to_string(), "b".to_string(), "second".to_string()),
+            ("message".to_string(), "c".to_string(), "third".to_string()),
+        ];
+
+        let n = db.vector_upsert_texts(&e, &items).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(e.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(db.vector_count("m1").await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn empty_batch_does_not_call_the_embedder() {
+        let (_d, db) = open("embed_empty.db").await;
+        let e = HashEmbedder::new("m1", 16);
+        assert_eq!(db.vector_upsert_texts(&e, &[]).await.unwrap(), 0);
+        assert_eq!(e.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn two_embedders_cannot_contaminate_each_other() {
+        let (_d, db) = open("embed_isolation.db").await;
+        let a = HashEmbedder::new("model-a", 16);
+        let b = HashEmbedder::new("model-b", 16);
+
+        db.vector_upsert_text(&a, "message", "x", "shared text").await.unwrap();
+        db.vector_upsert_text(&b, "message", "y", "shared text").await.unwrap();
+
+        let hits = db.vector_search_text(&a, "shared text", 10, None).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].ref_id, "x");
+    }
+
+    #[tokio::test]
+    async fn wrong_vector_count_is_rejected() {
+        let (_d, db) = open("embed_count.db").await;
+        let e = BrokenEmbedder { dim: 4, emit: 2, emit_dim: 4 };
+        let items = vec![("message".to_string(), "a".to_string(), "one".to_string())];
+        let err = db.vector_upsert_texts(&e, &items).await.unwrap_err();
+        assert!(matches!(err, EmbedError::Embedder(_)), "{err}");
+        assert_eq!(db.vector_count("broken").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn wrong_vector_dim_is_rejected() {
+        let (_d, db) = open("embed_dim.db").await;
+        let e = BrokenEmbedder { dim: 4, emit: 1, emit_dim: 3 };
+        let err = db.vector_upsert_text(&e, "message", "a", "one").await.unwrap_err();
+        assert!(matches!(err, EmbedError::VectorDim { expected: 4, actual: 3 }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn embedder_is_usable_behind_dyn() {
+        let (_d, db) = open("embed_dyn.db").await;
+        let boxed: Box<dyn Embedder> = Box::new(HashEmbedder::new("m1", 8));
+        db.vector_upsert_text(boxed.as_ref(), "message", "a", "text").await.unwrap();
+        let hits = db.vector_search_text(boxed.as_ref(), "text", 1, None).await.unwrap();
+        assert_eq!(hits[0].ref_id, "a");
+    }
+}

--- a/packages/rust/embeddb/src/embed_api.rs
+++ b/packages/rust/embeddb/src/embed_api.rs
@@ -1,0 +1,280 @@
+use crate::embed::{BoxFuture, Embedder};
+use crate::{EmbedError, Result};
+
+#[derive(Debug, Clone)]
+pub struct ApiEmbedderConfig {
+    pub base_url: String,
+    pub api_key: Option<String>,
+    pub provider: String,
+    pub model: String,
+    pub dim: usize,
+    pub timeout: std::time::Duration,
+}
+
+impl ApiEmbedderConfig {
+    pub fn new(base_url: impl Into<String>, model: impl Into<String>, dim: usize) -> Self {
+        ApiEmbedderConfig {
+            base_url: base_url.into(),
+            api_key: None,
+            provider: "api".to_string(),
+            model: model.into(),
+            dim,
+            timeout: std::time::Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+pub struct ApiEmbedder {
+    config: ApiEmbedderConfig,
+    client: reqwest::Client,
+    endpoint: String,
+}
+
+impl std::fmt::Debug for ApiEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiEmbedder")
+            .field("endpoint", &self.endpoint)
+            .field("model", &self.config.model)
+            .field("dim", &self.config.dim)
+            .field("api_key", &self.config.api_key.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+impl ApiEmbedder {
+    pub fn new(config: ApiEmbedderConfig) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| EmbedError::Embedder(format!("building http client: {e}")))?;
+        let endpoint = format!("{}/embeddings", config.base_url.trim_end_matches('/'));
+        Ok(ApiEmbedder { config, client, endpoint })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    async fn request(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let body = serde_json::json!({ "model": self.config.model, "input": texts });
+        let mut req = self.client.post(&self.endpoint).json(&body);
+        if let Some(key) = &self.config.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        let res = req
+            .send()
+            .await
+            .map_err(|e| EmbedError::Embedder(format!("embedding request failed: {e}")))?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            let body = body.chars().take(500).collect::<String>();
+            return Err(EmbedError::Embedder(format!(
+                "embedding endpoint returned {status}: {body}"
+            )));
+        }
+
+        let parsed: EmbeddingResponse = res
+            .json()
+            .await
+            .map_err(|e| EmbedError::Embedder(format!("decoding embedding response: {e}")))?;
+
+        let mut items = parsed.data;
+        items.sort_by_key(|d| d.index);
+        Ok(items.into_iter().map(|d| d.embedding).collect())
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingItem>,
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingItem {
+    #[serde(default)]
+    index: usize,
+    embedding: Vec<f32>,
+}
+
+impl Embedder for ApiEmbedder {
+    fn provider(&self) -> &str {
+        &self.config.provider
+    }
+
+    fn model(&self) -> &str {
+        &self.config.model
+    }
+
+    fn dim(&self) -> usize {
+        self.config.dim
+    }
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, Result<Vec<Vec<f32>>>> {
+        Box::pin(async move {
+            if texts.is_empty() {
+                return Ok(Vec::new());
+            }
+            self.request(texts).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    struct StubServer {
+        base_url: String,
+        requests: Arc<tokio::sync::Mutex<Vec<String>>>,
+    }
+
+    async fn stub(status: &'static str, body: &'static str) -> StubServer {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let sink = requests.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else { return };
+                let sink = sink.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0_u8; 8192];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    sink.lock().await.push(String::from_utf8_lossy(&buf[..n]).into_owned());
+                    let response = format!(
+                        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.flush().await;
+                });
+            }
+        });
+
+        StubServer { base_url: format!("http://{addr}/v1"), requests }
+    }
+
+    fn embedder(server: &StubServer, dim: usize) -> ApiEmbedder {
+        ApiEmbedder::new(
+            ApiEmbedderConfig::new(&server.base_url, "test-model", dim)
+                .with_api_key("secret-key")
+                .with_provider("stub"),
+        )
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn endpoint_is_built_without_duplicate_slashes() {
+        let a = ApiEmbedder::new(ApiEmbedderConfig::new("http://h/v1", "m", 2)).unwrap();
+        let b = ApiEmbedder::new(ApiEmbedderConfig::new("http://h/v1/", "m", 2)).unwrap();
+        assert_eq!(a.endpoint(), "http://h/v1/embeddings");
+        assert_eq!(b.endpoint(), "http://h/v1/embeddings");
+    }
+
+    #[tokio::test]
+    async fn successful_response_maps_to_vectors() {
+        let server = stub(
+            "200 OK",
+            r#"{"data":[{"index":0,"embedding":[1.0,0.0]},{"index":1,"embedding":[0.0,1.0]}]}"#,
+        )
+            .await;
+        let e = embedder(&server, 2);
+
+        let out = e.embed(&["a".to_string(), "b".to_string()]).await.unwrap();
+        assert_eq!(out, vec![vec![1.0, 0.0], vec![0.0, 1.0]]);
+
+        let seen = server.requests.lock().await;
+        assert!(seen[0].contains("POST /v1/embeddings"));
+        assert!(seen[0].contains("Bearer secret-key"));
+        assert!(seen[0].contains("\"model\":\"test-model\""));
+    }
+
+    #[tokio::test]
+    async fn out_of_order_response_is_reordered_by_index() {
+        let server = stub(
+            "200 OK",
+            r#"{"data":[{"index":1,"embedding":[0.0,1.0]},{"index":0,"embedding":[1.0,0.0]}]}"#,
+        )
+            .await;
+        let out = embedder(&server, 2)
+            .embed(&["a".to_string(), "b".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(out, vec![vec![1.0, 0.0], vec![0.0, 1.0]]);
+    }
+
+    #[tokio::test]
+    async fn empty_input_short_circuits_without_a_request() {
+        let server = stub("200 OK", r#"{"data":[]}"#).await;
+        let out = embedder(&server, 2).embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+        assert!(server.requests.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn error_status_surfaces_the_body() {
+        let server = stub("429 Too Many Requests", r#"{"error":"rate limited"}"#).await;
+        let err = embedder(&server, 2).embed(&["a".to_string()]).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("429"), "{msg}");
+        assert!(msg.contains("rate limited"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn malformed_body_is_a_decode_error() {
+        let server = stub("200 OK", "not json at all").await;
+        let err = embedder(&server, 2).embed(&["a".to_string()]).await.unwrap_err();
+        assert!(err.to_string().contains("decoding embedding response"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn unreachable_host_is_a_request_error() {
+        let e = ApiEmbedder::new(
+            ApiEmbedderConfig::new("http://127.0.0.1:1/v1", "m", 2)
+                .with_timeout(std::time::Duration::from_millis(500)),
+        )
+            .unwrap();
+        let err = e.embed(&["a".to_string()]).await.unwrap_err();
+        assert!(err.to_string().contains("embedding request failed"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn debug_output_does_not_leak_the_api_key() {
+        let server = stub("200 OK", r#"{"data":[]}"#).await;
+        let rendered = format!("{:?}", embedder(&server, 2));
+        assert!(!rendered.contains("secret-key"), "{rendered}");
+        assert!(rendered.contains("redacted"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn embedder_metadata_comes_from_config() {
+        let server = stub("200 OK", r#"{"data":[]}"#).await;
+        let e = embedder(&server, 7);
+        assert_eq!(e.provider(), "stub");
+        assert_eq!(e.model(), "test-model");
+        assert_eq!(e.dim(), 7);
+        assert_eq!(e.space().dim, 7);
+    }
+}

--- a/packages/rust/embeddb/src/error.rs
+++ b/packages/rust/embeddb/src/error.rs
@@ -19,6 +19,9 @@ pub enum EmbedError {
     #[cfg(feature = "vector")]
     #[error("vector blob error: {0}")]
     VectorBlob(String),
+    #[cfg(feature = "vector")]
+    #[error("embedder error: {0}")]
+    Embedder(String),
     #[error("{0}")]
     Other(String),
 }

--- a/packages/rust/embeddb/src/lib.rs
+++ b/packages/rust/embeddb/src/lib.rs
@@ -10,8 +10,13 @@ mod migrate;
 mod query;
 mod pool;
 mod convert;
+mod read;
 #[cfg(feature = "vector")]
 mod vector;
+#[cfg(feature = "vector")]
+mod embed;
+#[cfg(feature = "embed-api")]
+mod embed_api;
 
 pub use error::{EmbedError, Result};
 pub use db::EmbedDb;
@@ -22,6 +27,14 @@ pub use config::EmbedConfig;
 pub use query::QueryResult;
 pub use query::FromEmbedRow;
 pub use convert::FromEmbedValue;
+
+pub use read::params_from_values;
+
+#[cfg(feature = "vector")]
+pub use embed::{BoxFuture, Embedder};
+
+#[cfg(feature = "embed-api")]
+pub use embed_api::{ApiEmbedder, ApiEmbedderConfig};
 
 #[cfg(feature = "vector")]
 pub use vector::{

--- a/packages/rust/embeddb/src/read.rs
+++ b/packages/rust/embeddb/src/read.rs
@@ -1,0 +1,346 @@
+use crate::{EmbedDb, EmbedRow, EmbedValue, QueryResult, Result};
+
+pub(crate) fn value_from_turso(v: turso::Value) -> EmbedValue {
+    match v {
+        turso::Value::Null => EmbedValue::Null,
+        turso::Value::Integer(n) => EmbedValue::Int(n),
+        turso::Value::Real(n) => EmbedValue::Float(n),
+        turso::Value::Text(s) => EmbedValue::Text(s),
+        turso::Value::Blob(b) => EmbedValue::Blob(b),
+    }
+}
+
+pub fn params_from_values(values: Vec<EmbedValue>) -> Vec<turso::Value> {
+    values.into_iter().map(value_to_turso).collect()
+}
+
+pub(crate) fn value_to_turso(v: EmbedValue) -> turso::Value {
+    match v {
+        EmbedValue::Null => turso::Value::Null,
+        EmbedValue::Int(n) => turso::Value::Integer(n),
+        EmbedValue::Float(n) => turso::Value::Real(n),
+        EmbedValue::Text(s) => turso::Value::Text(s),
+        EmbedValue::Blob(b) => turso::Value::Blob(b),
+        EmbedValue::Bool(b) => turso::Value::Integer(i64::from(b)),
+        EmbedValue::HugeInt(n) => turso::Value::Text(n.to_string()),
+        EmbedValue::Timestamp(n) => turso::Value::Integer(n),
+        EmbedValue::Date(n) => turso::Value::Integer(i64::from(n)),
+        EmbedValue::Time(n) => turso::Value::Integer(n),
+    }
+}
+
+impl EmbedDb {
+    pub async fn query(&self, sql: &str, params: impl turso::IntoParams) -> Result<QueryResult> {
+        let mut rows = self.conn().query(sql, params).await?;
+        let columns = rows.column_names();
+        let ncols = columns.len();
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let mut vals = Vec::with_capacity(ncols);
+            for i in 0..ncols {
+                vals.push(value_from_turso(row.get_value(i)?));
+            }
+            out.push(EmbedRow(vals));
+        }
+        Ok(QueryResult { columns, rows: out })
+    }
+
+    pub async fn query_rows(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+    ) -> Result<Vec<EmbedRow>> {
+        Ok(self.query(sql, params).await?.rows)
+    }
+
+    pub async fn query_one(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+    ) -> Result<Option<EmbedRow>> {
+        Ok(self.query(sql, params).await?.rows.into_iter().next())
+    }
+
+    pub async fn query_as<T: crate::FromEmbedRow>(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+    ) -> Result<Vec<T>> {
+        let q = self.query(sql, params).await?;
+        let mut out = Vec::with_capacity(q.rows.len());
+        for row in &q.rows {
+            out.push(T::from_row(row, &q.columns)?);
+        }
+        Ok(out)
+    }
+
+    pub async fn query_for_each<F>(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+        mut f: F,
+    ) -> Result<u64>
+    where
+        F: FnMut(&EmbedRow),
+    {
+        let mut rows = self.conn().query(sql, params).await?;
+        let ncols = rows.column_count();
+        let mut count = 0_u64;
+        while let Some(row) = rows.next().await? {
+            let mut vals = Vec::with_capacity(ncols);
+            for i in 0..ncols {
+                vals.push(value_from_turso(row.get_value(i)?));
+            }
+            f(&EmbedRow(vals));
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    pub async fn query_scalar_i64(&self, sql: &str, params: impl turso::IntoParams) -> Result<i64> {
+        self.scalar(sql, params, "i64", |v| match v {
+            EmbedValue::Int(n) => Some(*n),
+            _ => None,
+        })
+            .await
+    }
+
+    pub async fn query_scalar_f64(&self, sql: &str, params: impl turso::IntoParams) -> Result<f64> {
+        self.scalar(sql, params, "f64", |v| match v {
+            EmbedValue::Float(n) => Some(*n),
+            EmbedValue::Int(n) => Some(*n as f64),
+            _ => None,
+        })
+            .await
+    }
+
+    pub async fn query_scalar_string(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+    ) -> Result<String> {
+        self.scalar(sql, params, "string", |v| match v {
+            EmbedValue::Text(s) => Some(s.clone()),
+            _ => None,
+        })
+            .await
+    }
+
+    async fn scalar<T, F>(
+        &self,
+        sql: &str,
+        params: impl turso::IntoParams,
+        expected: &str,
+        pick: F,
+    ) -> Result<T>
+    where
+        F: Fn(&EmbedValue) -> Option<T>,
+    {
+        let row = self.query_one(sql, params).await?.ok_or_else(|| {
+            crate::EmbedError::Other(format!("expected one {expected} row, query returned none"))
+        })?;
+        let value = row
+            .get(0)
+            .ok_or_else(|| crate::EmbedError::Other(format!("expected {expected}, no columns")))?;
+        pick(value).ok_or_else(|| {
+            crate::EmbedError::Other(format!("expected {expected}, got {value:?}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open(name: &str) -> (tempfile::TempDir, EmbedDb) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = EmbedDb::open(dir.path().join(name)).await.unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn turso_value_maps_both_directions() {
+        let cases = [
+            (turso::Value::Null, EmbedValue::Null),
+            (turso::Value::Integer(7), EmbedValue::Int(7)),
+            (turso::Value::Real(1.5), EmbedValue::Float(1.5)),
+            (turso::Value::Text("x".into()), EmbedValue::Text("x".into())),
+            (turso::Value::Blob(vec![1, 2]), EmbedValue::Blob(vec![1, 2])),
+        ];
+        for (turso_value, embed_value) in cases {
+            assert_eq!(value_from_turso(turso_value.clone()), embed_value);
+            assert_eq!(value_to_turso(embed_value), turso_value);
+        }
+    }
+
+    #[test]
+    fn richer_values_narrow_to_sqlite_storage_classes() {
+        assert_eq!(value_to_turso(EmbedValue::Bool(true)), turso::Value::Integer(1));
+        assert_eq!(value_to_turso(EmbedValue::Bool(false)), turso::Value::Integer(0));
+        assert_eq!(value_to_turso(EmbedValue::Timestamp(99)), turso::Value::Integer(99));
+        assert_eq!(value_to_turso(EmbedValue::Date(5)), turso::Value::Integer(5));
+        assert_eq!(value_to_turso(EmbedValue::Time(6)), turso::Value::Integer(6));
+        assert_eq!(
+            value_to_turso(EmbedValue::HugeInt(170141183460469231731687303715884105727)),
+            turso::Value::Text("170141183460469231731687303715884105727".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn query_returns_columns_and_rows() {
+        let (_d, db) = open("read_query.db").await;
+        db.execute("CREATE TABLE t (id INTEGER, label TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'one')", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (2, 'two')", ()).await.unwrap();
+
+        let q = db.query("SELECT id, label FROM t ORDER BY id", ()).await.unwrap();
+        assert_eq!(q.columns, vec!["id".to_string(), "label".to_string()]);
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.get(1, "label"), Some(&EmbedValue::Text("two".into())));
+    }
+
+    #[tokio::test]
+    async fn query_binds_parameters() {
+        let (_d, db) = open("read_params.db").await;
+        db.execute("CREATE TABLE t (name TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", ("o'brien",)).await.unwrap();
+        db.execute("INSERT INTO t VALUES (?)", ("other",)).await.unwrap();
+
+        let rows = db.query_rows("SELECT name FROM t WHERE name = ?", ("o'brien",)).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].as_str(0), Some("o'brien"));
+    }
+
+    #[tokio::test]
+    async fn dynamic_params_bind_from_embed_values() {
+        let (_d, db) = open("read_dynamic.db").await;
+        db.execute("CREATE TABLE t (a INTEGER, b TEXT)", ()).await.unwrap();
+        let params = params_from_values(vec![EmbedValue::Int(1), EmbedValue::Text("x".into())]);
+        db.execute("INSERT INTO t VALUES (?, ?)", params).await.unwrap();
+
+        let probe = params_from_values(vec![EmbedValue::Int(1)]);
+        let row = db.query_one("SELECT b FROM t WHERE a = ?", probe).await.unwrap().unwrap();
+        assert_eq!(row.as_str(0), Some("x"));
+    }
+
+    #[tokio::test]
+    async fn query_one_returns_none_on_empty() {
+        let (_d, db) = open("read_one.db").await;
+        db.execute("CREATE TABLE t (id INTEGER)", ()).await.unwrap();
+        assert!(db.query_one("SELECT id FROM t", ()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn scalars_read_without_duckdb() {
+        let (_d, db) = open("read_scalar.db").await;
+        db.execute("CREATE TABLE t (n INTEGER, f REAL, s TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (3, 2.5, 'hi')", ()).await.unwrap();
+
+        assert_eq!(db.query_scalar_i64("SELECT n FROM t", ()).await.unwrap(), 3);
+        assert_eq!(db.query_scalar_f64("SELECT f FROM t", ()).await.unwrap(), 2.5);
+        assert_eq!(db.query_scalar_f64("SELECT n FROM t", ()).await.unwrap(), 3.0);
+        assert_eq!(db.query_scalar_string("SELECT s FROM t", ()).await.unwrap(), "hi");
+    }
+
+    #[tokio::test]
+    async fn scalar_reports_missing_row_and_wrong_type() {
+        let (_d, db) = open("read_scalar_err.db").await;
+        db.execute("CREATE TABLE t (s TEXT)", ()).await.unwrap();
+
+        let err = db.query_scalar_i64("SELECT s FROM t", ()).await.unwrap_err();
+        assert!(err.to_string().contains("returned none"), "{err}");
+
+        db.execute("INSERT INTO t VALUES ('nope')", ()).await.unwrap();
+        let err = db.query_scalar_i64("SELECT s FROM t", ()).await.unwrap_err();
+        assert!(err.to_string().contains("expected i64"), "{err}");
+        assert!(db.query_scalar_string("SELECT rowid FROM t", ()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn query_for_each_streams_every_row() {
+        let (_d, db) = open("read_stream.db").await;
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        let rows: Vec<(i64,)> = (0..50).map(|i| (i,)).collect();
+        db.execute_batch("INSERT INTO t VALUES (?)", rows).await.unwrap();
+
+        let mut sum = 0_i64;
+        let n = db
+            .query_for_each("SELECT v FROM t", (), |row| sum += row.as_i64(0).unwrap_or(0))
+            .await
+            .unwrap();
+        assert_eq!(n, 50);
+        assert_eq!(sum, (0..50).sum::<i64>());
+    }
+
+    #[tokio::test]
+    async fn query_as_maps_into_structs() {
+        let (_d, db) = open("read_as.db").await;
+        db.execute("CREATE TABLE t (id INTEGER, label TEXT)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1, 'one')", ()).await.unwrap();
+
+        struct Rec {
+            id: i64,
+            label: String,
+        }
+        impl crate::FromEmbedRow for Rec {
+            fn from_row(row: &EmbedRow, columns: &[String]) -> Result<Self> {
+                let idx = |name: &str| columns.iter().position(|c| c == name).unwrap();
+                Ok(Rec {
+                    id: row.as_i64(idx("id")).unwrap(),
+                    label: row.as_str(idx("label")).unwrap().to_string(),
+                })
+            }
+        }
+
+        let recs: Vec<Rec> = db.query_as("SELECT id, label FROM t", ()).await.unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].id, 1);
+        assert_eq!(recs[0].label, "one");
+    }
+
+    #[tokio::test]
+    async fn reads_see_uncommitted_writes_from_the_same_connection() {
+        let (_d, db) = open("read_tx.db").await;
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+
+        let tx = db.begin().await.unwrap();
+        tx.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        assert_eq!(db.query_scalar_i64("SELECT count(*) FROM t", ()).await.unwrap(), 1);
+        tx.rollback().await.unwrap();
+        assert_eq!(db.query_scalar_i64("SELECT count(*) FROM t", ()).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn invalid_sql_errors() {
+        let (_d, db) = open("read_bad.db").await;
+        assert!(db.query("NOT SQL", ()).await.is_err());
+        assert!(db.query_rows("SELECT * FROM missing", ()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn reads_discharge_a_deferred_rollback() {
+        let (_d, db) = open("read_dangling.db").await;
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+
+        {
+            let tx = db.begin().await.unwrap();
+            tx.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        }
+
+        assert_eq!(db.query_scalar_i64("SELECT count(*) FROM t", ()).await.unwrap(), 0);
+        db.execute("INSERT INTO t VALUES (2)", ()).await.unwrap();
+        let rows = db.query_rows("SELECT v FROM t", ()).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].as_i64(0), Some(2));
+    }
+
+    #[tokio::test]
+    async fn repeated_queries_are_stable() {
+        let (_d, db) = open("read_repeat.db").await;
+        db.execute("CREATE TABLE t (v INTEGER)", ()).await.unwrap();
+        db.execute("INSERT INTO t VALUES (1)", ()).await.unwrap();
+        for _ in 0..100 {
+            assert_eq!(db.query_scalar_i64("SELECT count(*) FROM t", ()).await.unwrap(), 1);
+        }
+    }
+}

--- a/packages/rust/embeddb/tests/e2e_offline.rs
+++ b/packages/rust/embeddb/tests/e2e_offline.rs
@@ -1,0 +1,264 @@
+use embeddb::{EmbedConfig, EmbedDb, EmbedValue, VectorFilter, VectorSpace};
+
+const SCHEMA: &str = "CREATE TABLE messages (\
+ id TEXT PRIMARY KEY, channel TEXT NOT NULL, author TEXT NOT NULL, body TEXT NOT NULL)";
+
+async fn open_without_duckdb(dir: &tempfile::TempDir, name: &str) -> EmbedDb {
+    let broken = dir.path().join("extension_dir_is_a_file");
+    std::fs::write(&broken, b"x").unwrap();
+    let config = EmbedConfig {
+        duckdb_extension_dir: Some(broken),
+        ..EmbedConfig::default()
+    };
+    let db = EmbedDb::open_with(dir.path().join(name), config).await.unwrap();
+    db.migrate(&[SCHEMA]).await.unwrap();
+    db.vector_init().await.unwrap();
+    db
+}
+
+fn space() -> VectorSpace {
+    VectorSpace::new("local", "offline-model", 4)
+}
+
+fn embed(text: &str) -> Vec<f32> {
+    let mut v = vec![0.0_f32; 4];
+    for (i, byte) in text.bytes().enumerate() {
+        v[i % 4] += f32::from(byte) / 255.0;
+    }
+    if v.iter().all(|x| *x == 0.0) {
+        v[0] = 1.0;
+    }
+    v
+}
+
+#[tokio::test]
+async fn full_recall_flow_works_with_duckdb_unavailable() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_recall.db").await;
+    let space = space();
+
+    let corpus = [
+        ("m1", "general", "ada", "the deploy failed on the staging cluster"),
+        ("m2", "general", "grace", "lunch plans for tomorrow"),
+        ("m3", "random", "alan", "staging cluster is back up"),
+    ];
+
+    for (id, channel, author, body) in &corpus {
+        db.execute(
+            "INSERT INTO messages (id, channel, author, body) VALUES (?, ?, ?, ?)",
+            (*id, *channel, *author, *body),
+        )
+            .await
+            .unwrap();
+        db.vector_upsert(&space, "message", id, &embed(body)).await.unwrap();
+    }
+
+    assert!(
+        db.analytics_scalar_i64("SELECT count(*) FROM messages").await.is_err(),
+        "this test is only meaningful when the DuckDB reader cannot be built"
+    );
+
+    let hits = db
+        .vector_search(&space, &embed("the deploy failed on the staging cluster"), 2, None)
+        .await
+        .unwrap();
+    assert_eq!(hits[0].ref_id, "m1");
+
+    let row = db
+        .query_one("SELECT author, body FROM messages WHERE id = ?", (hits[0].ref_id.as_str(),))
+        .await
+        .unwrap()
+        .expect("recalled message must be readable without duckdb");
+    assert_eq!(row.as_str(0), Some("ada"));
+    assert_eq!(row.as_str(1), Some("the deploy failed on the staging cluster"));
+
+    let count = db.query_scalar_i64("SELECT count(*) FROM messages", ()).await.unwrap();
+    assert_eq!(count, 3);
+
+    let channel_rows = db
+        .query_rows("SELECT id FROM messages WHERE channel = ? ORDER BY id", ("general",))
+        .await
+        .unwrap();
+    assert_eq!(channel_rows.len(), 2);
+}
+
+#[tokio::test]
+async fn recalled_ids_hydrate_back_into_full_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_hydrate.db").await;
+    let space = space();
+
+    for i in 0..20 {
+        let id = format!("m{i}");
+        let body = format!("message number {i} about clusters");
+        db.execute(
+            "INSERT INTO messages (id, channel, author, body) VALUES (?, ?, ?, ?)",
+            (id.as_str(), "general", "ada", body.as_str()),
+        )
+            .await
+            .unwrap();
+        db.vector_upsert(&space, "message", &id, &embed(&body)).await.unwrap();
+    }
+
+    let hits = db
+        .vector_search(&space, &embed("message number 7 about clusters"), 3, None)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 3);
+
+    let mut bodies = Vec::new();
+    for hit in &hits {
+        let row = db
+            .query_one("SELECT body FROM messages WHERE id = ?", (hit.ref_id.as_str(),))
+            .await
+            .unwrap()
+            .unwrap();
+        bodies.push(row.as_str(0).unwrap().to_string());
+    }
+    assert_eq!(bodies.len(), 3);
+    assert!(bodies[0].contains("number 7"), "closest hit should be the exact message: {bodies:?}");
+}
+
+#[tokio::test]
+async fn token_ledger_aggregates_without_duckdb() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_ledger.db").await;
+
+    db.execute(
+        "CREATE TABLE token_usage (id INTEGER PRIMARY KEY AUTOINCREMENT, model TEXT, \
+         prompt_tokens INTEGER, completion_tokens INTEGER)",
+        (),
+    )
+        .await
+        .unwrap();
+
+    db.execute_batch(
+        "INSERT INTO token_usage (model, prompt_tokens, completion_tokens) VALUES (?, ?, ?)",
+        vec![
+            ("gpt", 100_i64, 50_i64),
+            ("gpt", 200_i64, 75_i64),
+            ("other", 10_i64, 5_i64),
+        ],
+    )
+        .await
+        .unwrap();
+
+    let total = db
+        .query_scalar_i64(
+            "SELECT sum(prompt_tokens + completion_tokens) FROM token_usage WHERE model = ?",
+            ("gpt",),
+        )
+        .await
+        .unwrap();
+    assert_eq!(total, 425);
+
+    let rows = db
+        .query_rows(
+            "SELECT model, sum(prompt_tokens) FROM token_usage GROUP BY model ORDER BY model",
+            (),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].as_str(0), Some("gpt"));
+    assert_eq!(rows[0].as_i64(1), Some(300));
+}
+
+#[tokio::test]
+async fn filtered_recall_then_hydrate_by_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_kind.db").await;
+    let space = space();
+
+    db.execute(
+        "INSERT INTO messages (id, channel, author, body) VALUES ('m1', 'general', 'ada', 'cluster status')",
+        (),
+    )
+        .await
+        .unwrap();
+    db.vector_upsert(&space, "message", "m1", &embed("cluster status")).await.unwrap();
+    db.vector_upsert(&space, "document", "d1", &embed("cluster status")).await.unwrap();
+
+    let hits = db
+        .vector_search(&space, &embed("cluster status"), 5, Some(&VectorFilter::kind("message")))
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].ref_kind, "message");
+
+    let row = db
+        .query_one("SELECT body FROM messages WHERE id = ?", (hits[0].ref_id.as_str(),))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.as_str(0), Some("cluster status"));
+}
+
+#[tokio::test]
+async fn writes_and_reads_agree_across_a_transaction_without_duckdb() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_tx.db").await;
+
+    let tx = db.begin().await.unwrap();
+    tx.execute(
+        "INSERT INTO messages (id, channel, author, body) VALUES ('t1', 'c', 'a', 'body')",
+        (),
+    )
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+    assert_eq!(db.query_scalar_i64("SELECT count(*) FROM messages", ()).await.unwrap(), 0);
+
+    let tx = db.begin().await.unwrap();
+    tx.execute(
+        "INSERT INTO messages (id, channel, author, body) VALUES ('t2', 'c', 'a', 'body')",
+        (),
+    )
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(db.query_scalar_i64("SELECT count(*) FROM messages", ()).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn dynamic_parameters_drive_a_runtime_built_query() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_without_duckdb(&dir, "offline_dynamic.db").await;
+
+    db.execute(
+        "INSERT INTO messages (id, channel, author, body) VALUES ('m1', 'general', 'ada', 'one')",
+        (),
+    )
+        .await
+        .unwrap();
+
+    let filters: Vec<EmbedValue> =
+        vec![EmbedValue::Text("general".into()), EmbedValue::Text("ada".into())];
+    let rows = db
+        .query_rows(
+            "SELECT body FROM messages WHERE channel = ? AND author = ?",
+            embeddb::params_from_values(filters),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].as_str(0), Some("one"));
+}
+
+#[tokio::test]
+async fn analytics_still_works_when_duckdb_is_available() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbedDb::open(dir.path().join("offline_control.db")).await.unwrap();
+    db.migrate(&[SCHEMA]).await.unwrap();
+    db.execute(
+        "INSERT INTO messages (id, channel, author, body) VALUES ('m1', 'general', 'ada', 'one')",
+        (),
+    )
+        .await
+        .unwrap();
+
+    let via_turso = db.query_scalar_i64("SELECT count(*) FROM messages", ()).await.unwrap();
+    let via_duckdb = db.analytics_scalar_i64("SELECT count(*) FROM messages").await.unwrap();
+    assert_eq!(via_turso, via_duckdb);
+    assert_eq!(via_turso, 1);
+}


### PR DESCRIPTION
Closes the three gaps found auditing the crate after #15336. One of them made the vector tier unusable in the environment it was built for.

## Gap 1: reads required DuckDB, so recall could not complete

Every read went through the DuckDB reader, and `open_reader` runs this unconditionally:

```rust
conn.execute_batch("INSTALL sqlite; LOAD sqlite;")?;
```

That is a network fetch unless the extension is pre-staged. The Turso connection was `pub(crate)`, used only by `vector_search`.

So a distroless or egress-denied consumer could write rows and run vector searches, but **could not run a plain SELECT**. Vector search returns `ref_id`s and there was no supported way to turn those back into message rows. The dependency-free claim covered writing and scoring but not reading your own data.

`read.rs` adds `query`, `query_rows`, `query_one`, `query_as::<T>`, `query_for_each`, and `query_scalar_i64/f64/string` over the Turso connection. No new dependencies. The lazy DuckDB reader is still never built for consumers that do not call `analytics_*`.

The two readers differ in type fidelity, deliberately: Turso returns SQLite's five storage classes, DuckDB reports booleans, decimals, and temporal types. Callers needing the richer mapping keep using `analytics_*`. `params_from_values` converts `EmbedValue` into bindable params for runtime-built queries — `IntoParams` is sealed upstream, so this wraps the supported path rather than implementing the trait.

`tests/e2e_offline.rs` proves the gap is closed by pointing `duckdb_extension_dir` at a file so the reader cannot build, asserting `analytics_*` fails, and then running the whole discord.sh-shaped flow anyway: store messages, embed, recall by similarity, hydrate ref_ids back into full rows, and aggregate a token ledger.

## Gap 2: embedder abstraction and a provider

`Embedder` is dyn-compatible and dependency-free — boxed futures instead of an `async-trait` dependency — so the trait lives in the dep-free tier and providers layer above it.

`vector_upsert_text`, `vector_upsert_texts`, and `vector_search_text` derive the `VectorSpace` from the embedder. A caller cannot pair a query embedding with another model's stored vectors, because they never construct the space by hand. This makes the cross-model footgun structurally unreachable rather than merely documented. Batch text upsert issues exactly one embedder call, and vector count and dimension are both validated before anything is written.

`embed-api` adds `ApiEmbedder` against the OpenAI-compatible `/embeddings` shape, which also covers Groq, Together, and local shims. Responses are reordered by `index` rather than trusting arrival order. Debug output redacts the API key. reqwest uses `["json", "rustls"]`, matching jedi and kbve — `rustls-tls` no longer exists in 0.13.

Tests run against a local stub HTTP server, so the suite makes no outbound requests and needs no key.

## Gap 3: statement caching attempted, then reverted as unsafe

turso exposes `prepare_cached`, and `Connection::execute`/`::query` do not use it, so routing writes through it looked like a free win.

It is not safe. `maybe_handle_dangling_tx` is `pub(crate)` and runs **only** inside `execute` and `query`. Preparing directly skips it, so a dropped uncommitted transaction is never rolled back and the next write silently joins the aborted transaction. The existing `batch_write_rolls_back_entirely_on_failure` E2E from #15311 caught this on the first run.

Reads therefore use `Connection::query` and take column names from `Rows`, keeping the safe entry point. A regression test now pins the behavior: after dropping an uncommitted transaction, a read must observe the rollback. Real statement caching needs an upstream change to expose the dangling-tx discharge.

WASM stays out of scope — neither turso nor duckdb targets wasm32 here.

## Verification

199 tests pass (was 161). Clippy clean with `--all-features --all-targets`. Feature matrix verified: default, `--no-default-features`, `vector`, `embed-api`, and `embed-api` without defaults.

Coverage 98.41% to **98.46%** of lines across a substantially larger surface — `read.rs` 99.36%, `embed_api.rs` 99.04%, `embed.rs` 96.50%, `vector.rs` now 100%.

No version bump; release is a separate MDX-only follow-up as before.