### PR TITLE
refactor(arpg-web): share the projectile aim logic, and test it

### DIFF
--- a/apps/agones/arpg/web/src/game/systems/aim.spec.ts
+++ b/apps/agones/arpg/web/src/game/systems/aim.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { coneTarget, rayTarget, type AimCandidate } from './aim';
+import { worldToScreen, type TileXY } from '../iso';
+
+/**
+ * Candidates are built through the real iso projection rather than hardcoded
+ * pixels, so these stay honest if TILE_W/TILE_H ever change. `lift` raises the
+ * sprite above its ground tile the way a hovering flyer is drawn.
+ */
+function cand(id: number, x: number, y: number, lift = 0): AimCandidate {
+	const s = worldToScreen(x, y);
+	return { id, tile: { x, y }, screen: { x: s.x, y: s.y - lift } };
+}
+
+const ORIGIN: TileXY = { x: 0, y: 0 };
+const WIDE = { halfPx: 55, range: 15 };
+
+describe('coneTarget', () => {
+	it('returns null with no candidates', () => {
+		expect(coneTarget([], ORIGIN, { x: 5, y: 0 }, WIDE)).toBeNull();
+	});
+
+	it('returns null when the aim line is degenerate', () => {
+		// Aiming at your own feet has no direction to project onto.
+		expect(coneTarget([cand(1, 3, 0)], ORIGIN, ORIGIN, WIDE)).toBeNull();
+	});
+
+	it('picks the candidate closest to the aim line, not the nearest one', () => {
+		const onLine = cand(1, 8, 0);
+		const closerButOffAxis = cand(2, 3, 3);
+		const target = coneTarget(
+			[closerButOffAxis, onLine],
+			ORIGIN,
+			{ x: 10, y: 0 },
+			WIDE,
+		);
+		expect(target).toBe(1);
+	});
+
+	it('ignores candidates behind the shooter', () => {
+		const behind = cand(1, -5, 0);
+		expect(coneTarget([behind], ORIGIN, { x: 5, y: 0 }, WIDE)).toBeNull();
+	});
+
+	it('ignores candidates beyond range', () => {
+		const far = cand(1, 20, 0);
+		expect(
+			coneTarget(
+				[far],
+				ORIGIN,
+				{ x: 25, y: 0 },
+				{ halfPx: 55, range: 15 },
+			),
+		).toBeNull();
+		// Same candidate, unbounded range.
+		expect(
+			coneTarget(
+				[far],
+				ORIGIN,
+				{ x: 25, y: 0 },
+				{ halfPx: 55, range: 0 },
+			),
+		).toBe(1);
+	});
+
+	it('treats a negative range as unbounded', () => {
+		expect(
+			coneTarget(
+				[cand(1, 30, 0)],
+				ORIGIN,
+				{ x: 40, y: 0 },
+				{ halfPx: 55, range: -1 },
+			),
+		).toBe(1);
+	});
+
+	it('ignores candidates outside the cone half-width', () => {
+		const off = cand(1, 4, 4);
+		// On the (1,1) diagonal the sprite is far off a due-east screen line.
+		expect(
+			coneTarget(
+				[off],
+				ORIGIN,
+				{ x: 10, y: 0 },
+				{ halfPx: 4, range: 15 },
+			),
+		).toBeNull();
+		expect(
+			coneTarget(
+				[off],
+				ORIGIN,
+				{ x: 10, y: 0 },
+				{ halfPx: 400, range: 15 },
+			),
+		).toBe(1);
+	});
+
+	it('skips a candidate that has no sprite drawn yet', () => {
+		const invisible: AimCandidate = { id: 1, tile: { x: 5, y: 0 } };
+		expect(
+			coneTarget([invisible], ORIGIN, { x: 10, y: 0 }, WIDE),
+		).toBeNull();
+	});
+
+	it('connects with a hovering flyer that a tile-space ray sails over', () => {
+		// The wyvern's TILE is well off the aim line, but it is DRAWN high enough
+		// that its sprite sits right on the on-screen line — which is what the
+		// player is pointing at. This is the whole reason the cone is screen-space.
+		const flyerTile = { x: 6, y: 2 };
+		const aim = { x: 10, y: 0 };
+		// Lift chosen so the sprite lands on the screen line to the aim point.
+		const lift =
+			worldToScreen(flyerTile.x, flyerTile.y).y -
+			worldToScreen(aim.x, aim.y).y *
+				(worldToScreen(flyerTile.x, flyerTile.y).x /
+					worldToScreen(aim.x, aim.y).x);
+		const flyer = cand(1, flyerTile.x, flyerTile.y, lift);
+
+		expect(coneTarget([flyer], ORIGIN, aim, WIDE)).toBe(1);
+		// The tile-space ray, given the same geometry, misses it entirely.
+		expect(
+			rayTarget([flyer], ORIGIN, aim, { perp: 0.75, range: 15 }),
+		).toBeNull();
+	});
+
+	it('excludes a candidate sitting exactly at the half-width', () => {
+		// The comparison is strict (`perp < bestPerp`), so the boundary is a miss.
+		const c = cand(1, 4, 0);
+		const a = worldToScreen(0, 0);
+		const s = c.screen!;
+		const b = worldToScreen(10, 0);
+		const nx = (b.x - a.x) / Math.hypot(b.x - a.x, b.y - a.y);
+		const ny = (b.y - a.y) / Math.hypot(b.x - a.x, b.y - a.y);
+		const perp = Math.abs((s.x - a.x) * ny - (s.y - a.y) * nx);
+		expect(
+			coneTarget(
+				[c],
+				ORIGIN,
+				{ x: 10, y: 0 },
+				{ halfPx: perp, range: 15 },
+			),
+		).toBeNull();
+		expect(
+			coneTarget(
+				[c],
+				ORIGIN,
+				{ x: 10, y: 0 },
+				{ halfPx: perp + 1e-6, range: 15 },
+			),
+		).toBe(1);
+	});
+});
+
+describe('rayTarget', () => {
+	const RAY = { perp: 0.75, range: 15 };
+
+	it('returns null with no candidates', () => {
+		expect(rayTarget([], ORIGIN, { x: 5, y: 0 }, RAY)).toBeNull();
+	});
+
+	it('returns null when the aim is degenerate', () => {
+		expect(rayTarget([cand(1, 3, 0)], ORIGIN, ORIGIN, RAY)).toBeNull();
+	});
+
+	it('picks the nearest along the ray, not the closest to the line', () => {
+		const near = cand(1, 3, 0.5);
+		const farButDeadOn = cand(2, 9, 0);
+		expect(
+			rayTarget([farButDeadOn, near], ORIGIN, { x: 12, y: 0 }, RAY),
+		).toBe(1);
+	});
+
+	it('ignores candidates behind the caster', () => {
+		expect(
+			rayTarget([cand(1, -4, 0)], ORIGIN, { x: 5, y: 0 }, RAY),
+		).toBeNull();
+	});
+
+	it('ignores candidates beyond range', () => {
+		const far = cand(1, 20, 0);
+		expect(rayTarget([far], ORIGIN, { x: 25, y: 0 }, RAY)).toBeNull();
+		expect(
+			rayTarget([far], ORIGIN, { x: 25, y: 0 }, { perp: 0.75, range: 0 }),
+		).toBe(1);
+	});
+
+	it('rejects candidates further than perp off the centerline', () => {
+		const off = cand(1, 5, 2);
+		expect(rayTarget([off], ORIGIN, { x: 10, y: 0 }, RAY)).toBeNull();
+		expect(
+			rayTarget([off], ORIGIN, { x: 10, y: 0 }, { perp: 3, range: 15 }),
+		).toBe(1);
+	});
+
+	it('includes a candidate sitting exactly at the perp limit', () => {
+		// This comparison is `> perp` (not `>=`), so the boundary is a hit —
+		// the opposite of the cone's strict half-width.
+		const c = cand(1, 5, 2);
+		const perp = Math.abs(2 * 1 - 0 * 0) / 1; // dx*ny - dy*nx with aim +x
+		expect(
+			rayTarget([c], ORIGIN, { x: 10, y: 0 }, { perp, range: 15 }),
+		).toBe(1);
+	});
+
+	it('counts a candidate with no sprite, unlike the cone', () => {
+		const invisible: AimCandidate = { id: 1, tile: { x: 5, y: 0 } };
+		expect(rayTarget([invisible], ORIGIN, { x: 10, y: 0 }, RAY)).toBe(1);
+		expect(
+			coneTarget([invisible], ORIGIN, { x: 10, y: 0 }, WIDE),
+		).toBeNull();
+	});
+});

--- a/apps/agones/arpg/web/src/game/systems/aim.ts
+++ b/apps/agones/arpg/web/src/game/systems/aim.ts
@@ -1,0 +1,117 @@
+import { worldToScreen, type TileXY } from '../iso';
+
+/**
+ * Target acquisition for projectiles, shared by the bow and by targeted spells.
+ *
+ * Both weapons pick their target the same way and only differ in constants, so
+ * the geometry lives here once. Nothing in this module touches Phaser or the
+ * entity store — callers adapt whatever they have into `AimCandidate`s — which
+ * is what makes the aim rules testable without a renderer.
+ */
+
+/** A hostile the caller has already filtered down and resolved a sprite for. */
+export interface AimCandidate {
+	id: number;
+	/** Ground tile, used for range and for the tile-space ray. */
+	tile: TileXY;
+	/**
+	 * On-screen sprite position, for the screen-space cone. Absent when the
+	 * entity has no sprite drawn yet — such a candidate is invisible, so the
+	 * cone skips it while the tile-space ray still counts it.
+	 */
+	screen?: { x: number; y: number };
+}
+
+export interface ConeOptions {
+	/** Cone half-width in SCREEN px. */
+	halfPx: number;
+	/** Max tile distance from the shooter. <= 0 means unbounded. */
+	range: number;
+}
+
+export interface RayOptions {
+	/** Max perpendicular offset from the centerline, in TILES. */
+	perp: number;
+	/** Max tile distance along the ray. <= 0 means unbounded. */
+	range: number;
+}
+
+const cap = (range: number) => (range > 0 ? range : Infinity);
+
+/**
+ * Closest candidate to the shooter→aim line in SCREEN space, among those in
+ * front of the shooter, in range, and inside the cone.
+ *
+ * Screen space rather than tile space is the point: a flyer is drawn above its
+ * ground tile, so a tile-space ray sails over the wyvern the player is plainly
+ * pointing at. Matching sprite to on-screen aim line is what the player sees.
+ *
+ * Returns null when the aim line is degenerate (aiming at your own feet) so the
+ * caller can choose its own fallback.
+ */
+export function coneTarget(
+	candidates: Iterable<AimCandidate>,
+	from: TileXY,
+	aim: TileXY,
+	opts: ConeOptions,
+): number | null {
+	const a = worldToScreen(from.x, from.y);
+	const b = worldToScreen(aim.x, aim.y);
+	const dx = b.x - a.x;
+	const dy = b.y - a.y;
+	const len = Math.hypot(dx, dy);
+	if (len < 1e-3) return null;
+	const nx = dx / len;
+	const ny = dy / len;
+	const maxTiles = cap(opts.range);
+	let best: number | null = null;
+	let bestPerp = opts.halfPx;
+	for (const c of candidates) {
+		if (!c.screen) continue;
+		if (Math.hypot(c.tile.x - from.x, c.tile.y - from.y) > maxTiles)
+			continue;
+		const rx = c.screen.x - a.x;
+		const ry = c.screen.y - a.y;
+		if (rx * nx + ry * ny <= 0) continue;
+		const perp = Math.abs(rx * ny - ry * nx);
+		if (perp < bestPerp) {
+			bestPerp = perp;
+			best = c.id;
+		}
+	}
+	return best;
+}
+
+/**
+ * Nearest candidate along the aim ray in TILE space: the plain projectile model
+ * — it flies where aimed and hits the first thing in its path, or nothing.
+ * Used as the fallback when the screen-space cone comes up empty.
+ */
+export function rayTarget(
+	candidates: Iterable<AimCandidate>,
+	from: TileXY,
+	aim: TileXY,
+	opts: RayOptions,
+): number | null {
+	const adx = aim.x - from.x;
+	const ady = aim.y - from.y;
+	const amag = Math.hypot(adx, ady);
+	if (amag < 1e-3) return null;
+	const nx = adx / amag;
+	const ny = ady / amag;
+	const maxTiles = cap(opts.range);
+	let best: number | null = null;
+	let bestAlong = Infinity;
+	for (const c of candidates) {
+		const dx = c.tile.x - from.x;
+		const dy = c.tile.y - from.y;
+		const along = dx * nx + dy * ny;
+		if (along <= 0 || along > maxTiles) continue;
+		if (Math.abs(dx * ny - dy * nx) > opts.perp) continue;
+		if (along < bestAlong) {
+			bestAlong = along;
+			best = c.id;
+		}
+	}
+	return best;
+}

--- a/apps/agones/arpg/web/src/game/systems/combat.ts
+++ b/apps/agones/arpg/web/src/game/systems/combat.ts
@@ -13,7 +13,8 @@ import {
 	type BowShot,
 } from '../entities/projectiles/arrows/bow';
 import { setCreaturePose, type EntityRefs } from '../entities/sprites';
-import { worldToScreen, type TileXY } from '../iso';
+import type { TileXY } from '../iso';
+import { coneTarget, type AimCandidate } from './aim';
 
 // Aim-assist cone half-width (screen px) for bow targeting: a hostile whose
 // on-screen SPRITE sits within this of the player→aim screen line is a hit.
@@ -193,46 +194,31 @@ export function fireBowAt(
 	);
 }
 
+/** Hostiles with a drawn sprite, as aim candidates. */
+function* bowCandidates(deps: CombatDeps): Generator<AimCandidate> {
+	for (const [serverEid, , refs] of deps.store.entries()) {
+		if (!deps.isHostile(serverEid)) continue;
+		const tile = deps.store.tile(serverEid);
+		if (!tile) continue;
+		const sprite = refs.sprite;
+		if (!sprite) continue;
+		yield { id: serverEid, tile, screen: { x: sprite.x, y: sprite.y } };
+	}
+}
+
 /**
- * Acquire the hostile the arrow will hit with sprite-space aim-assist: among
- * hostiles in FRONT of the shot (along the player→aim SCREEN line), in range,
- * and within BOW_AIM_HALF_PX of that line, pick the one CLOSEST to the line.
- * Matches the on-screen sprite to the on-screen aim line, so a shot aimed at a
- * hovering flyer (drawn above its ground tile) connects — a tile-space ray
- * misses it. Mirrors acquireSpellTarget; falls back to null (clean miss).
+ * Acquire the hostile the arrow will hit. Screen-space cone (see aim.ts) so a
+ * shot aimed at a hovering flyer connects; null is a clean miss.
  */
 export function acquireBowTarget(
 	deps: CombatDeps,
 	from: TileXY,
 	aim: TileXY,
-): number | undefined {
-	const a = worldToScreen(from.x, from.y);
-	const b = worldToScreen(aim.x, aim.y);
-	const dx = b.x - a.x;
-	const dy = b.y - a.y;
-	const len = Math.hypot(dx, dy);
-	if (len < 1e-3) return undefined;
-	const nx = dx / len;
-	const ny = dy / len;
-	let best: number | undefined;
-	let bestPerp = BOW_AIM_HALF_PX;
-	for (const [serverEid, , refs] of deps.store.entries()) {
-		if (!deps.isHostile(serverEid)) continue;
-		const t = deps.store.tile(serverEid);
-		if (!t) continue;
-		if (Math.hypot(t.x - from.x, t.y - from.y) > ARROW_MAX_RANGE) continue;
-		const sprite = refs.sprite;
-		if (!sprite) continue;
-		const rx = sprite.x - a.x;
-		const ry = sprite.y - a.y;
-		if (rx * nx + ry * ny <= 0) continue; // behind the shooter
-		const perp = Math.abs(rx * ny - ry * nx);
-		if (perp < bestPerp) {
-			bestPerp = perp;
-			best = serverEid;
-		}
-	}
-	return best;
+): number | null {
+	return coneTarget(bowCandidates(deps), from, aim, {
+		halfPx: BOW_AIM_HALF_PX,
+		range: ARROW_MAX_RANGE,
+	});
 }
 
 /**

--- a/apps/agones/arpg/web/src/game/systems/spells.ts
+++ b/apps/agones/arpg/web/src/game/systems/spells.ts
@@ -8,12 +8,9 @@ import {
 	castStormVfx,
 } from '../entities/projectiles/spells/spellVfx';
 import type { EntityRefs } from '../entities/sprites';
-import {
-	worldToScreen,
-	screenToWorldF,
-	type TileXY,
-} from '../iso';
+import { worldToScreen, screenToWorldF, type TileXY } from '../iso';
 import type { InterpBuffer } from './interp';
+import { coneTarget, rayTarget, type AimCandidate } from './aim';
 
 /**
  * Spell loadout + casting. Loadout is the first 9 spells from spelldb (keys 1-9,
@@ -209,42 +206,33 @@ export function acquireSpellTarget(
 	aim: TileXY,
 	range: number,
 ): number | null {
-	const a = worldToScreen(from.x, from.y);
-	const b = worldToScreen(aim.x, aim.y);
-	const dx = b.x - a.x;
-	const dy = b.y - a.y;
-	const len = Math.hypot(dx, dy);
-	if (len < 1e-3) return aimHostile(deps, from, aim, range);
-	const nx = dx / len;
-	const ny = dy / len;
-	const cap = range > 0 ? range : Infinity;
-	let best: number | null = null;
-	let bestPerp = SPELL_AIM_HALF_PX;
+	const candidates = [...spellCandidates(deps)];
+	return (
+		coneTarget(candidates, from, aim, {
+			halfPx: SPELL_AIM_HALF_PX,
+			range,
+		}) ?? rayTarget(candidates, from, aim, { perp: AIM_PERP, range })
+	);
+}
+
+/** Hostile NPCs as aim candidates; `screen` is absent until a sprite exists. */
+function* spellCandidates(deps: SpellDeps): Generator<AimCandidate> {
 	for (const sid of deps.store.serverIdsWith(Cat.Npc)) {
 		if (!deps.isHostile(sid)) continue;
-		const t = deps.store.tile(sid);
-		if (!t) continue;
-		if (Math.hypot(t.x - from.x, t.y - from.y) > cap) continue;
+		const tile = deps.store.tile(sid);
+		if (!tile) continue;
 		const sprite = deps.store.refs(sid)?.sprite;
-		if (!sprite) continue;
-		const rx = sprite.x - a.x;
-		const ry = sprite.y - a.y;
-		if (rx * nx + ry * ny <= 0) continue; // behind the caster
-		const perp = Math.abs(rx * ny - ry * nx);
-		if (perp < bestPerp) {
-			bestPerp = perp;
-			best = sid;
-		}
+		yield {
+			id: sid,
+			tile,
+			screen: sprite ? { x: sprite.x, y: sprite.y } : undefined,
+		};
 	}
-	return best ?? aimHostile(deps, from, aim, range);
 }
 
 /**
- * First hostile NPC along the aim ray from `from` toward `aim`, within `range`
- * tiles (0 = unbounded). Marches the direction and returns the nearest hostile
- * whose center sits within AIM_PERP of the centerline — the projectile model
- * shared with the bow: the spell flies where aimed and hits the first thing in
- * its path, or null (clean miss). The server is authoritative on the landing.
+ * First hostile NPC along the aim ray — the plain projectile model, kept as the
+ * fallback when nothing is inside the aim-assist cone.
  */
 export function aimHostile(
 	deps: SpellDeps,
@@ -252,28 +240,8 @@ export function aimHostile(
 	aim: TileXY,
 	range: number,
 ): number | null {
-	const adx = aim.x - from.x;
-	const ady = aim.y - from.y;
-	const amag = Math.hypot(adx, ady);
-	if (amag < 1e-3) return null;
-	const nx = adx / amag;
-	const ny = ady / amag;
-	const cap = range > 0 ? range : Infinity;
-	let best: number | null = null;
-	let bestAlong = Infinity;
-	for (const sid of deps.store.serverIdsWith(Cat.Npc)) {
-		if (!deps.isHostile(sid)) continue;
-		const t = deps.store.tile(sid);
-		if (!t) continue;
-		const dx = t.x - from.x;
-		const dy = t.y - from.y;
-		const along = dx * nx + dy * ny;
-		if (along <= 0 || along > cap) continue;
-		if (Math.abs(dx * ny - dy * nx) > AIM_PERP) continue;
-		if (along < bestAlong) {
-			bestAlong = along;
-			best = sid;
-		}
-	}
-	return best;
+	return rayTarget(spellCandidates(deps), from, aim, {
+		perp: AIM_PERP,
+		range,
+	});
 }


### PR DESCRIPTION
Follow-up to #15430, which flagged `combat.ts` and `spells.ts` as the next-biggest untested logic but blocked on their top-level `import Phaser`.

## The duplication

`acquireBowTarget` and `acquireSpellTarget` were **the same screen-space cone algorithm written twice** — normalise the shooter→aim screen line, reject anything behind, keep the candidate with the smallest perpendicular offset. They differed only in:

| | bow | spell |
|---|---|---|
| half-width | 55px | 110px |
| candidates | `store.entries()` | `store.serverIdsWith(Cat.Npc)` |
| range | `ARROW_MAX_RANGE` | spell meta, `0` = unbounded |
| miss | `undefined` | falls back to `aimHostile` |

Both lived behind a Phaser import, so neither was reachable from the node-env vitest — which is why the logic deciding **every shot the player takes** had no tests.

## The extraction

New [`systems/aim.ts`](apps/agones/arpg/web/src/game/systems/aim.ts): `coneTarget` and `rayTarget` over a plain `AimCandidate` list. It imports nothing but the iso projection. `combat.ts` and `spells.ts` each supply candidates and their own constants; `aimHostile` becomes a thin call to `rayTarget`.

`screen` is **optional** on a candidate, because the two searches genuinely differ there: the cone needs a drawn sprite (matching what the player sees is its entire purpose), the tile-space ray does not. That asymmetry was implicit in the duplicated code — now it's stated and tested both ways.

## Behaviour-preserving — verified, not asserted

I kept the pre-refactor implementations around and fuzzed them against the extracted ones: **20,000 random cases** over varying candidate counts, missing sprites, degenerate aims, and zero/negative ranges. Identical results on both functions. The harness was throwaway and is not in this PR.

## Tests

[`aim.spec.ts`](apps/agones/arpg/web/src/game/systems/aim.spec.ts) — 18 tests. Candidates are built through the real `worldToScreen`, so the fixtures stay honest if `TILE_W`/`TILE_H` change. Includes the case the cone exists for: a wyvern whose *tile* is well off the aim line but whose *sprite* sits on it is a **hit for the cone and a miss for the ray**.

Both boundary conventions are pinned, since they differ and that is easy to "tidy" wrongly later: the cone is strict (`perp < halfPx`, boundary is a miss), the ray is not (`> perp` rejects, boundary is a hit).

Mutation-checked — all 7 injected defects fail the suite:

| Injected defect | Result |
|---|---|
| cone: allow candidates behind the shooter | 1 failed |
| cone: stop skipping sprite-less candidates | 2 failed |
| cone: `<=` at the half-width boundary | 1 failed |
| `range <= 0` no longer unbounded | 3 failed |
| ray: allow candidates behind | 1 failed |
| ray: pick farthest instead of nearest | 5 failed |
| ray: `>=` at the perp limit | 1 failed |

## Verified

- `arpg-web:test` — 92 passed / 8 files (was 74 / 7)
- `arpg-web:typecheck` and `arpg-web:build` (app + embed + discord) — clean