### PR TITLE
perf(herbmail-game): build room geometry on a worker

### DIFF
--- a/apps/herbmail/herbmail-game/src/game/dungeon/geoBridge.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/geoBridge.ts
@@ -1,0 +1,103 @@
+import type { GeoRequest, GeoResult } from './geoWorker';
+import type { RoomDesc } from './generate';
+
+// Owns the geometry worker and the in-flight request table. Kept separate from
+// roomGeometry so that module stays testable in node, where Worker does not
+// exist and `new URL(..., import.meta.url)` has nothing to resolve against.
+
+type Ready = (r: GeoResult) => void;
+
+let worker: Worker | null = null;
+let nextId = 1;
+const inFlight = new Map<number, string>();
+const bySignature = new Map<string, number>();
+let onReady: Ready = () => undefined;
+let failed = false;
+
+export function geoWorkerAvailable(): boolean {
+	return !failed && typeof Worker !== 'undefined';
+}
+
+export function setGeoReadyHandler(cb: Ready): void {
+	onReady = cb;
+}
+
+function ensure(): Worker | null {
+	if (failed || typeof Worker === 'undefined') return null;
+	if (worker) return worker;
+	try {
+		worker = new Worker(new URL('./geoWorker.ts', import.meta.url), {
+			type: 'module',
+		});
+		worker.onmessage = (e: MessageEvent<GeoResult>) => {
+			inFlight.delete(e.data.id);
+			bySignature.delete(e.data.signature);
+			onReady(e.data);
+		};
+		// A worker that dies must not strand the queue: fall back to building on
+		// the main thread for the rest of the session rather than never producing
+		// geometry at all.
+		worker.onerror = (e) => {
+			console.warn(
+				'[geo] worker failed, building on main thread',
+				e.message,
+			);
+			failed = true;
+			worker?.terminate();
+			worker = null;
+			inFlight.clear();
+			bySignature.clear();
+		};
+	} catch (err) {
+		console.warn('[geo] worker unavailable, building on main thread', err);
+		failed = true;
+		worker = null;
+	}
+	return worker;
+}
+
+export function requestRoom(
+	desc: RoomDesc,
+	wantFloor: boolean,
+	wantCeiling: boolean,
+): boolean {
+	const w = ensure();
+	if (!w) return false;
+	if (bySignature.has(desc.signature)) return true;
+	const id = nextId++;
+	inFlight.set(id, desc.signature);
+	bySignature.set(desc.signature, id);
+	const req: GeoRequest = { id, desc, wantFloor, wantCeiling };
+	w.postMessage(req);
+	return true;
+}
+
+export function isGeoInFlight(signature: string): boolean {
+	return bySignature.has(signature);
+}
+
+// Dropping the claim (not the worker's work) so a room the player reached first
+// is rebuilt on the main thread and the late result is discarded rather than
+// overwriting a set already handed to the scene.
+export function forgetGeoRequest(signature: string): void {
+	const id = bySignature.get(signature);
+	if (id !== undefined) {
+		bySignature.delete(signature);
+		inFlight.delete(id);
+	}
+}
+
+export function geoBridgeStats(): {
+	inFlight: number;
+	failed: boolean;
+	active: boolean;
+} {
+	return { inFlight: bySignature.size, failed, active: worker !== null };
+}
+
+export function stopGeoWorker(): void {
+	worker?.terminate();
+	worker = null;
+	inFlight.clear();
+	bySignature.clear();
+}

--- a/apps/herbmail/herbmail-game/src/game/dungeon/geoTransfer.test.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/geoTransfer.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { toPayload, fromPayload, transfersOf } from './geoTransfer';
+
+function sample(): THREE.BufferGeometry {
+	const g = new THREE.BufferGeometry();
+	g.setAttribute(
+		'position',
+		new THREE.BufferAttribute(
+			new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0]),
+			3,
+		),
+	);
+	g.setAttribute(
+		'normal',
+		new THREE.BufferAttribute(
+			new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]),
+			3,
+		),
+	);
+	g.setAttribute(
+		'uv',
+		new THREE.BufferAttribute(
+			new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]),
+			2,
+		),
+	);
+	g.setIndex(
+		new THREE.BufferAttribute(new Uint16Array([0, 1, 2, 2, 1, 3]), 1),
+	);
+	return g;
+}
+
+describe('geoTransfer', () => {
+	it('round-trips every attribute and the index', () => {
+		const src = sample();
+		const out = fromPayload(toPayload(src));
+		for (const name of ['position', 'normal', 'uv']) {
+			expect(Array.from(out.attributes[name].array)).toEqual(
+				Array.from(src.attributes[name].array),
+			);
+			expect(out.attributes[name].itemSize).toBe(
+				src.attributes[name].itemSize,
+			);
+		}
+		expect(Array.from(out.index!.array)).toEqual(
+			Array.from(src.index!.array),
+		);
+	});
+
+	it('preserves index integer width', () => {
+		const g = sample();
+		g.setIndex(new THREE.BufferAttribute(new Uint32Array([0, 1, 2]), 1));
+		expect(fromPayload(toPayload(g)).index!.array).toBeInstanceOf(
+			Uint32Array,
+		);
+		expect(fromPayload(toPayload(sample())).index!.array).toBeInstanceOf(
+			Uint16Array,
+		);
+	});
+
+	// A geometry with no index is normal for the diced chunks, so it must not
+	// be treated as a malformed payload.
+	it('handles geometry without an index', () => {
+		const g = sample();
+		g.setIndex(null);
+		const out = fromPayload(toPayload(g));
+		expect(out.index).toBeNull();
+		expect(out.attributes.position.count).toBe(4);
+	});
+
+	// Attributes that view part of a larger buffer must be copied out, not
+	// handed over whole: transferring the shared backing store would detach it
+	// from every other attribute still using it.
+	it('copies out attributes that are views into a shared buffer', () => {
+		const backing = new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2, 9, 9, 9]);
+		const g = new THREE.BufferGeometry();
+		g.setAttribute(
+			'position',
+			new THREE.BufferAttribute(backing.subarray(0, 9), 3),
+		);
+		const p = toPayload(g);
+		expect(p.attrs.position.array.byteLength).toBe(9 * 4);
+		expect(Array.from(fromPayload(p).attributes.position.array)).toEqual([
+			0, 0, 0, 1, 1, 1, 2, 2, 2,
+		]);
+	});
+
+	it('lists each buffer once for the transfer list', () => {
+		const list = transfersOf([toPayload(sample()), toPayload(sample())]);
+		expect(new Set(list).size).toBe(list.length);
+		expect(list.every((b) => b instanceof ArrayBuffer)).toBe(true);
+		// 3 attributes + 1 index, twice.
+		expect(list.length).toBe(8);
+	});
+
+	it('rejects array types it cannot faithfully reproduce', () => {
+		const g = new THREE.BufferGeometry();
+		g.setAttribute(
+			'position',
+			new THREE.BufferAttribute(new Int16Array([0, 1, 2]), 3),
+		);
+		expect(() => toPayload(g)).toThrow(/unsupported array/);
+	});
+});

--- a/apps/herbmail/herbmail-game/src/game/dungeon/geoTransfer.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/geoTransfer.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three';
+
+// Geometry crosses the worker boundary as raw typed arrays. BufferGeometry
+// itself is not cloneable — it carries prototypes, a uuid and cached bounding
+// volumes — but every attribute underneath it is a typed array over an
+// ArrayBuffer, which transfers with no copy at all.
+
+export interface AttrPayload {
+	array: ArrayBuffer;
+	kind: 'f32' | 'u32' | 'u16';
+	itemSize: number;
+	normalized: boolean;
+}
+
+export interface GeoPayload {
+	attrs: Record<string, AttrPayload>;
+	index: AttrPayload | null;
+}
+
+function kindOf(a: ArrayBufferView): AttrPayload['kind'] {
+	if (a instanceof Float32Array) return 'f32';
+	if (a instanceof Uint32Array) return 'u32';
+	if (a instanceof Uint16Array) return 'u16';
+	throw new Error(`geoTransfer: unsupported array ${a.constructor.name}`);
+}
+
+function viewOf(p: AttrPayload): THREE.TypedArray {
+	if (p.kind === 'f32') return new Float32Array(p.array);
+	if (p.kind === 'u32') return new Uint32Array(p.array);
+	return new Uint16Array(p.array);
+}
+
+// The attribute may be a view over a larger buffer (three's interleaved and
+// sliced attributes are), so the exact byte range is copied out rather than
+// handing over the whole backing store — transferring that would detach data
+// another attribute is still using.
+function packAttr(a: THREE.BufferAttribute): AttrPayload {
+	const src = a.array as ArrayBufferView & {
+		slice(a: number, b: number): unknown;
+	};
+	const exact =
+		src.byteOffset === 0 && src.byteLength === src.buffer.byteLength
+			? (src.buffer as ArrayBuffer)
+			: ((
+					src.slice(
+						0,
+						(src as unknown as { length: number }).length,
+					) as ArrayBufferView
+				).buffer as ArrayBuffer);
+	return {
+		array: exact,
+		kind: kindOf(a.array as ArrayBufferView),
+		itemSize: a.itemSize,
+		normalized: a.normalized,
+	};
+}
+
+export function toPayload(geo: THREE.BufferGeometry): GeoPayload {
+	const attrs: Record<string, AttrPayload> = {};
+	for (const name of Object.keys(geo.attributes)) {
+		attrs[name] = packAttr(geo.attributes[name] as THREE.BufferAttribute);
+	}
+	return { attrs, index: geo.index ? packAttr(geo.index) : null };
+}
+
+export function fromPayload(p: GeoPayload): THREE.BufferGeometry {
+	const geo = new THREE.BufferGeometry();
+	for (const name of Object.keys(p.attrs)) {
+		const a = p.attrs[name];
+		geo.setAttribute(
+			name,
+			new THREE.BufferAttribute(viewOf(a), a.itemSize, a.normalized),
+		);
+	}
+	if (p.index) geo.setIndex(new THREE.BufferAttribute(viewOf(p.index), 1));
+	return geo;
+}
+
+// Every ArrayBuffer in the payload, for postMessage's transfer list. Collected
+// through a Set because two attributes can legitimately share a buffer and
+// listing one twice is a DataCloneError.
+export function transfersOf(payloads: GeoPayload[]): ArrayBuffer[] {
+	const out = new Set<ArrayBuffer>();
+	for (const p of payloads) {
+		for (const name of Object.keys(p.attrs)) out.add(p.attrs[name].array);
+		if (p.index) out.add(p.index.array);
+	}
+	return [...out];
+}

--- a/apps/herbmail/herbmail-game/src/game/dungeon/geoWorker.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/geoWorker.ts
@@ -1,0 +1,126 @@
+import {
+	buildArches,
+	buildTrims,
+	buildBays,
+	buildCeiling,
+	buildCeilingWithHoles,
+	buildOasisDomes,
+	buildCornerCoves,
+	buildCoves,
+	buildFloor,
+	buildFloorWithHoles,
+	buildWalls,
+	buildColumns,
+} from '../geometry';
+import { makeLocalGrid, type RoomDesc } from './generate';
+import { toPayload, transfersOf, type GeoPayload } from './geoTransfer';
+
+// Room geometry runs here rather than on the main thread. The builders are pure
+// mesh maths over three's geometry classes — BufferGeometry, ExtrudeGeometry,
+// LatheGeometry, Shape/Path, Matrix4 — none of which touch a renderer, a
+// texture or the DOM, so they run in a worker unchanged.
+//
+// What stays on the main thread is everything that needs GPU or scene context:
+// dicing into chunks, the bake pool, BVH queueing, and the shared floor/ceiling
+// singletons. This only moves the arithmetic.
+
+export interface GeoRequest {
+	id: number;
+	desc: RoomDesc;
+	// Rooms that bake get their own floor/ceiling slab; the ones that do not
+	// share a singleton the main thread already holds, so building them here
+	// would be wasted work and a wasted transfer.
+	wantFloor: boolean;
+	wantCeiling: boolean;
+}
+
+export interface GeoResult {
+	id: number;
+	signature: string;
+	walls: GeoPayload[];
+	columns: GeoPayload[];
+	floor: GeoPayload | null;
+	ceiling: GeoPayload | null;
+	arch: GeoPayload;
+	trim: GeoPayload;
+	cove: GeoPayload;
+	corner: GeoPayload;
+	domes: GeoPayload | null;
+	bayFrames: GeoPayload;
+	bayBacks: GeoPayload;
+}
+
+export function buildRoom(req: GeoRequest): {
+	result: GeoResult;
+	transfer: ArrayBuffer[];
+} {
+	const { desc } = req;
+	const g = makeLocalGrid(desc);
+	const v = desc.variant;
+
+	const walls = buildWalls(g, v).map(toPayload);
+	const columns = buildColumns(desc.columns).map(toPayload);
+	const arch = toPayload(buildArches(g, v));
+	const trim = toPayload(buildTrims(g, v));
+	const cove = toPayload(buildCoves(g));
+	const corner = toPayload(buildCornerCoves(g, v));
+	const domes = desc.oases.length
+		? toPayload(buildOasisDomes(g, desc.oases))
+		: null;
+	const bays = buildBays(g, v);
+	const bayFrames = toPayload(bays.frames);
+	const bayBacks = toPayload(bays.backs);
+
+	const floor = req.wantFloor
+		? toPayload(desc.oases.length ? buildFloorWithHoles(g) : buildFloor(g))
+		: null;
+	const ceiling = req.wantCeiling
+		? toPayload(
+				desc.oases.length ? buildCeilingWithHoles(g) : buildCeiling(g),
+			)
+		: null;
+
+	const result: GeoResult = {
+		id: req.id,
+		signature: desc.signature,
+		walls,
+		columns,
+		floor,
+		ceiling,
+		arch,
+		trim,
+		cove,
+		corner,
+		domes,
+		bayFrames,
+		bayBacks,
+	};
+
+	const all = [
+		...walls,
+		...columns,
+		arch,
+		trim,
+		cove,
+		corner,
+		bayFrames,
+		bayBacks,
+	];
+	if (floor) all.push(floor);
+	if (ceiling) all.push(ceiling);
+	if (domes) all.push(domes);
+
+	return { result, transfer: transfersOf(all) };
+}
+
+// globalThis rather than self, matching bakeWorker: `self` is a restricted
+// global in this workspace. Guarded so buildRoom stays importable from tests,
+// where there is no worker scope to install a handler on.
+const ctx = globalThis as unknown as Worker;
+
+if (typeof ctx.postMessage === 'function' && !('document' in globalThis)) {
+	ctx.onmessage = (e: MessageEvent<GeoRequest>) => {
+		const { result, transfer } = buildRoom(e.data);
+		ctx.postMessage(result, transfer);
+	};
+}

--- a/apps/herbmail/herbmail-game/src/game/dungeon/roomGeometry.ts
+++ b/apps/herbmail/herbmail-game/src/game/dungeon/roomGeometry.ts
@@ -16,6 +16,15 @@ import {
 import { makeLocalGrid, type RoomDesc } from './generate';
 import { chunkGeometry } from './chunkGeometry';
 import { queueBVH, cancelBVH } from '../render/bvh';
+import { fromPayload, type GeoPayload } from './geoTransfer';
+import type { GeoResult } from './geoWorker';
+import {
+	forgetGeoRequest,
+	isGeoInFlight,
+	requestRoom,
+	setGeoReadyHandler,
+	geoBridgeStats,
+} from './geoBridge';
 import {
 	forgetSector,
 	releaseBaked,
@@ -221,6 +230,7 @@ if (import.meta.env?.DEV) {
 		stats: () => geoBuildStats(),
 		ticks: () => geoTickStats(),
 		depth: () => geoPrefetchDepth(),
+		worker: () => geoBridgeStats(),
 		reset: () => resetGeoBuildStats(),
 	};
 }
@@ -231,26 +241,95 @@ if (import.meta.env?.DEV) {
 const pending = new Map<string, BuildJob>();
 const queue: string[] = [];
 
-function commit(job: BuildJob): RoomGeoSet {
-	pending.delete(job.desc.signature);
-	buildMs.push(job.ms);
-	cache.set(job.desc.signature, job.set);
+// The worker is handed a desc and answers with a signature, so the desc has to
+// be held until the payloads come back to rebuild against.
+const descBySignature = new Map<string, RoomDesc>();
+
+setGeoReadyHandler((res) => adoptResult(res));
+
+function store(key: string, set: RoomGeoSet): RoomGeoSet {
+	cache.set(key, set);
 	if (cache.size > CACHE_CAP) {
 		const oldest = cache.keys().next().value as string;
 		const evicted = cache.get(oldest);
 		cache.delete(oldest);
 		if (evicted) disposeSet(evicted);
 	}
-	return job.set;
+	return set;
+}
+
+function commit(job: BuildJob): RoomGeoSet {
+	pending.delete(job.desc.signature);
+	buildMs.push(job.ms);
+	return store(job.desc.signature, job.set);
 }
 
 /** Queue a sector to be built in the background. No-op if it is already built
  * or queued. Safe to call every time the mount set changes. */
 export function prefetchRoomGeoSet(desc: RoomDesc): void {
 	const key = desc.signature;
-	if (cache.has(key) || pending.has(key)) return;
+	if (cache.has(key) || pending.has(key) || isGeoInFlight(key)) return;
+	// Off-thread when the worker is alive. The builders are the expensive part
+	// and they are pure maths, so they run there and come back as typed arrays;
+	// only dicing, baking and BVH queueing stay here. Main-thread slicing is
+	// kept as the fallback for a worker that never started or died.
+	const ctx = sectorBakeCtx(desc);
+	if (
+		requestRoom(desc, needsOwnFloor(desc, ctx), needsOwnCeiling(desc, ctx))
+	) {
+		descBySignature.set(key, desc);
+		return;
+	}
 	pending.set(key, makeJob(desc));
 	queue.push(key);
+}
+
+// A baked sector needs its own slab; the rest share a singleton this thread
+// already holds, so there is no point building or transferring one.
+function needsOwnFloor(desc: RoomDesc, ctx: SectorBakeCtx | null): boolean {
+	return desc.oases.length > 0 || ctx !== null || sharedFloor === null;
+}
+function needsOwnCeiling(desc: RoomDesc, ctx: SectorBakeCtx | null): boolean {
+	return desc.oases.length > 0 || ctx !== null || sharedCeiling === null;
+}
+
+// Rebuild the worker's payloads into the set the scene mounts. This is the work
+// that genuinely has to be here: dicing produces the chunks the culler and the
+// BVH operate on, and both the bake pool and the BVH queue are main-thread.
+function adoptResult(res: GeoResult): void {
+	const key = res.signature;
+	if (cache.has(key)) return;
+	const desc = descBySignature.get(key);
+	if (!desc) return;
+	descBySignature.delete(key);
+	const ctx = sectorBakeCtx(desc);
+	const set = emptySet(key);
+	const cut = (p: GeoPayload) => dice(fromPayload(p), ctx);
+
+	set.walls = res.walls.map(cut);
+	set.columns = res.columns.map(cut);
+	set.arch = cut(res.arch);
+	set.trim = cut(res.trim);
+	set.cove = cut(res.cove);
+	set.corner = cut(res.corner);
+	set.domes = res.domes ? cut(res.domes) : [];
+	set.bays.frames = cut(res.bayFrames);
+	set.bays.backs = cut(res.bayBacks);
+
+	if (res.floor) set.floor = cut(res.floor);
+	else {
+		if (!sharedFloor)
+			sharedFloor = dice(buildFloor(makeLocalGrid(desc)), null);
+		set.floor = sharedFloor;
+	}
+	if (res.ceiling) set.ceiling = cut(res.ceiling);
+	else {
+		if (!sharedCeiling)
+			sharedCeiling = dice(buildCeiling(makeLocalGrid(desc)), null);
+		set.ceiling = sharedCeiling;
+	}
+
+	store(key, set);
 }
 
 const tickMs: number[] = [];
@@ -302,6 +381,10 @@ export function getRoomGeoSet(desc: RoomDesc): RoomGeoSet {
 	}
 	// Arrived before the prefetcher finished (or never prefetched at all) —
 	// drain the remaining steps now so a mount is never handed a partial set.
+	// Any worker request for this room is abandoned first: its payloads would
+	// otherwise land later and replace a set the scene is already showing.
+	forgetGeoRequest(key);
+	descBySignature.delete(key);
 	const job = pending.get(key) ?? makeJob(desc);
 	const i = queue.indexOf(key);
 	if (i >= 0) queue.splice(i, 1);


### PR DESCRIPTION
Fixes the hitch when walking into a new area.

## Diagnosis

Not SharedArrayBuffer — that layer is healthy:

```
crossOriginIsolated: true    SharedArrayBuffer: true
COOP: same-origin            COEP: require-corp
coi-serviceworker.js shipped for the itch/static-host case
2428 light bakes ran on the bake worker
```

The cause was [roomGeometry.ts](apps/herbmail/herbmail-game/src/game/dungeon/roomGeometry.ts). The prefetcher sliced room construction at 4 ms/frame, but `getRoomGeoSet` called `runJob(job, 0)` — **unbounded** — whenever the player reached a room the prefetcher had not finished, running the entire remainder in one frame.

**Measured worst single room build: 42 ms.** Self-reinforcing, too: moving faster leaves the prefetcher less lead time, so the faster you walk the more likely you eat the unbounded path.

## The change

The builders are pure mesh maths over three's geometry classes — `BufferGeometry`, `ExtrudeGeometry`, `LatheGeometry`, `Shape`/`Path`, `Matrix4` — touching no renderer, no texture, no DOM. They run in a worker unchanged, and `RoomDesc` is plain data that clones as-is.

Geometry crosses back as raw typed arrays. `BufferGeometry` is not cloneable, but every attribute under it is a typed array that transfers with **no copy**.

**Subtlety worth flagging:** attributes that view part of a larger buffer are copied out rather than handed over whole. Transferring a shared backing store would detach it from every other attribute still using it. There is a test for exactly that case.

What stays on the main thread is what needs scene or GPU context: dicing into chunks, the bake pool, BVH queueing, and the shared floor/ceiling singletons. Rooms that share those singletons don't ask the worker to build them, so nothing is built or transferred twice.

## Fallbacks preserved

- A worker that never starts or dies falls back to main-thread slicing for the rest of the session.
- Arriving before the payloads land still builds synchronously — but the in-flight request is **abandoned first**, or the late result would replace a set the scene is already showing.

## Verification

In-browser, after load:

```
geoWorker: { active: true, failed: false, inFlight: 0 }
geoTicks:  { ticks: 0 }        ← main-thread slicer never ran
wallChunks 279   floorChunks 110   emptyGeoms 0
BVH 2428 built   bakes 2428    ← unchanged
```

Chunk counts, BVH and bake totals match the pre-change audit exactly. The 4 remaining synchronous builds are the spawn rooms at mount, which have no prefetch lead by definition — startup, not the walking hitch.

180 unit tests (6 new on the transfer layer), 12 e2e, lint clean.

**Not verified end to end:** headless can't drive a sector crossing — pointer-lock look doesn't engage, so the character wedges against a wall. The mechanism and the instrumentation are confirmed; whether the felt hitch is gone needs real play. `__geo.worker()` and `__geo.ticks()` are exposed for that.