### PR TITLE
fix(reel): keep live HLS ahead of the player on transcode-heavy sources

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -688,10 +688,23 @@ export class ReelPlayer {
 			// up once repeated recovery attempts stop working.
 			let netRetries = 0;
 			let mediaRetries = 0;
+			let starveRetries = 0;
 			const MAX_RECOVER = 6;
+			// Live-edge starvation: the encoder simply hasn't produced the next
+			// segment yet, so frag/playlist loads fail while nothing is actually
+			// broken. That's buffering, not an error — wait and reload with a far
+			// larger budget than the real-error ladder.
+			const MAX_STARVE = 40;
+			const STARVATION_DETAILS = new Set<string>([
+				Hls.ErrorDetails.FRAG_LOAD_ERROR,
+				Hls.ErrorDetails.FRAG_LOAD_TIMEOUT,
+				Hls.ErrorDetails.LEVEL_LOAD_ERROR,
+				Hls.ErrorDetails.LEVEL_LOAD_TIMEOUT,
+			]);
 			hls.on(Hls.Events.FRAG_BUFFERED, () => {
 				netRetries = 0;
 				mediaRetries = 0;
+				starveRetries = 0;
 				this.resurrects = 0;
 			});
 			hls.on(Hls.Events.ERROR, (_evt, data) => {
@@ -700,6 +713,20 @@ export class ReelPlayer {
 				switch (data.type) {
 					case Hls.ErrorTypes.NETWORK_ERROR: {
 						const expired = data.response?.code === 401;
+						if (
+							!expired &&
+							STARVATION_DETAILS.has(data.details) &&
+							starveRetries++ < MAX_STARVE
+						) {
+							this.emit(
+								'playing',
+								'Buffering — waiting for stream data',
+							);
+							setTimeout(() => {
+								if (this.generation === gen) hls.startLoad();
+							}, 3000);
+							break;
+						}
 						const code: ReelStreamErrorCode = expired
 							? 'token-expired'
 							: 'network';

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.36"
+version: "0.1.37"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -92,7 +92,7 @@ spec:
                       timeoutSeconds: 5
                       failureThreshold: 6
                   resources:
-                      requests: { cpu: '8', memory: 2Gi }
+                      requests: { cpu: '8', memory: 8Gi }
                       limits: { cpu: '16', memory: 8Gi }
                   volumeMounts:
                       - { name: data, mountPath: /data }

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -92,7 +92,7 @@ spec:
                       timeoutSeconds: 5
                       failureThreshold: 6
                   resources:
-                      requests: { cpu: '4', memory: 1Gi }
+                      requests: { cpu: '8', memory: 2Gi }
                       limits: { cpu: '16', memory: 8Gi }
                   volumeMounts:
                       - { name: data, mountPath: /data }

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -14,6 +14,7 @@ pub struct AppState {
     pub stream_enabled: bool,
     pub hls: hls::HlsManager,
     pub ffprobe_bin: String,
+    pub hls_segment_wait_ms: u64,
 }
 
 #[derive(Clone)]
@@ -420,6 +421,19 @@ async fn manifest(
         delivery
     };
 
+    // The viewer's HLS encode and the background library transcode would split
+    // the same cores; at 2 CPUs that halves an already sub-realtime encode and
+    // starves the live edge. The viewer wins — kill the background job.
+    if delivery == transcode::Delivery::TranscodeHls
+        && matches!(
+            meta.transcode,
+            state::TranscodeStatus::Remuxing | state::TranscodeStatus::Encoding
+        )
+    {
+        tracing::info!(id = %id, "aborting background transcode; viewer HLS encode takes priority");
+        st.transcoder.abort(&id).await;
+    }
+
     let outcome = st.hls.request(&id, delivery).await;
     hls_outcome_response(&st.store, &id, outcome).await
 }
@@ -520,6 +534,7 @@ async fn hls_segment(
         &id,
         &segment,
         &method,
+        st.hls_segment_wait_ms,
     )
     .await
 }
@@ -792,6 +807,36 @@ async fn hls_outcome_response(
     }
 }
 
+/// While the HLS job is Live the encoder may simply not have written the
+/// requested segment yet — a slow encode or leech at the live edge. Waiting a
+/// few beats instead of an instant 404 turns edge starvation into a delayed
+/// response the player treats as buffering, not an error strike.
+async fn open_segment_waiting(
+    store: &state::StateStore,
+    id: &str,
+    path: &std::path::Path,
+    wait_ms: u64,
+) -> std::io::Result<tokio::fs::File> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(wait_ms);
+    loop {
+        match tokio::fs::File::open(path).await {
+            Ok(f) => return Ok(f),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let live = store
+                    .get(id)
+                    .map(|m| m.hls == state::HlsStatus::Live)
+                    .unwrap_or(false);
+                if !live || tokio::time::Instant::now() >= deadline {
+                    return Err(e);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn hls_segment_core(
     headers: &HeaderMap,
     query: Option<&str>,
@@ -800,6 +845,7 @@ pub(crate) async fn hls_segment_core(
     id: &str,
     segment: &str,
     method: &axum::http::Method,
+    segment_wait_ms: u64,
 ) -> axum::response::Response {
     if !check_auth_q(headers, query, token) {
         return StatusCode::UNAUTHORIZED.into_response();
@@ -835,7 +881,7 @@ pub(crate) async fn hls_segment_core(
         };
         return crate::stream::head_response(total, range, ct);
     }
-    let file = match tokio::fs::File::open(&path).await {
+    let file = match open_segment_waiting(store, id, &path, segment_wait_ms).await {
         Ok(f) => f,
         Err(e) => {
             tracing::warn!(id = %id, segment, path = %path.display(), error = %e, "hls segment open failed");
@@ -1642,6 +1688,7 @@ mod tests {
             "1",
             "seg-1.mp4",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -1657,6 +1704,7 @@ mod tests {
             "1",
             "seg00001.ts",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -1696,12 +1744,70 @@ mod tests {
             "1",
             "seg00001.ts",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.headers().get("content-type").unwrap(), "video/mp2t");
         let body = res.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], b"tsdata");
+    }
+
+    #[tokio::test]
+    async fn hls_segment_waits_for_live_encoder() {
+        let dir = tempdir().unwrap();
+        let hls_dir = dir.path().join("hls");
+        std::fs::create_dir_all(&hls_dir).unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: "/lib/movie.mp4".into(),
+            size: 5,
+            completed_at: Some(10),
+            last_access: 10,
+            state: TorrentState::Seeding,
+            error: None,
+            active_path: None,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::Live,
+            hls_dir: Some(hls_dir.display().to_string()),
+            hls_error: None,
+        })
+        .unwrap();
+        let seg = hls_dir.join("seg00007.ts");
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+            std::fs::write(seg, b"late").unwrap();
+        });
+        let res = hls_segment_core(
+            &HeaderMap::new(),
+            None,
+            &None,
+            &s,
+            "1",
+            "seg00007.ts",
+            &Method::GET,
+            3000,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK, "waited for the encoder");
+        std::mem::forget(dir);
+
+        let res = hls_segment_core(
+            &HeaderMap::new(),
+            None,
+            &None,
+            &s,
+            "1",
+            "seg99999.ts",
+            &Method::GET,
+            300,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "deadline still 404s");
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub live_hls_enabled: bool,
     pub live_prebuffer_segments: usize,
     pub hls_segment_secs: u64,
+    pub hls_max_height: u32,
+    pub hls_segment_wait_ms: u64,
     pub bt_port_file: Option<PathBuf>,
     pub bt_port_wait_secs: u64,
     pub bt_port_stable_secs: u64,
@@ -210,6 +212,8 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         live_hls_enabled: env_bool("REEL_LIVE_HLS", true),
         live_prebuffer_segments: env_u64("REEL_LIVE_PREBUFFER_SEGMENTS", 3)?.max(1) as usize,
         hls_segment_secs: env_u64("REEL_HLS_SEGMENT_SECS", 4)?,
+        hls_max_height: env_u64("REEL_HLS_MAX_HEIGHT", 1080)?.min(u32::MAX as u64) as u32,
+        hls_segment_wait_ms: env_u64("REEL_HLS_SEGMENT_WAIT_MS", 5000)?,
         bt_port_file: match std::env::var("REEL_BT_PORT_FILE") {
             Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v.trim())),
             _ => None,
@@ -263,6 +267,8 @@ mod tests {
             "REEL_LIVE_HLS",
             "REEL_LIVE_PREBUFFER_SEGMENTS",
             "REEL_HLS_SEGMENT_SECS",
+            "REEL_HLS_MAX_HEIGHT",
+            "REEL_HLS_SEGMENT_WAIT_MS",
             "REEL_BT_PORT_FILE",
             "REEL_BT_PORT_WAIT_SECS",
             "REEL_BT_PORT_WATCH_RESTART",
@@ -496,13 +502,19 @@ mod tests {
         assert!(c.live_hls_enabled);
         assert_eq!(c.live_prebuffer_segments, 3);
         assert_eq!(c.hls_segment_secs, 4);
+        assert_eq!(c.hls_max_height, 1080);
+        assert_eq!(c.hls_segment_wait_ms, 5000);
         std::env::set_var("REEL_HLS_ENABLED", "false");
         std::env::set_var("REEL_LIVE_HLS", "false");
         std::env::set_var("REEL_HLS_SEGMENT_SECS", "8");
+        std::env::set_var("REEL_HLS_MAX_HEIGHT", "0");
+        std::env::set_var("REEL_HLS_SEGMENT_WAIT_MS", "0");
         let c2 = load_from_env().unwrap();
         assert!(!c2.hls_enabled);
         assert!(!c2.live_hls_enabled);
         assert_eq!(c2.hls_segment_secs, 8);
+        assert_eq!(c2.hls_max_height, 0);
+        assert_eq!(c2.hls_segment_wait_ms, 0);
         clear();
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -35,6 +35,15 @@ mod tests {
         assert!(valid_segment_name("stream_00.vtt"));
     }
     #[test]
+    fn scale_filter_caps_and_disables() {
+        assert_eq!(
+            scale_filter(1080).as_deref(),
+            Some("scale=-2:min(1080\\,ih)")
+        );
+        assert_eq!(scale_filter(0), None);
+    }
+
+    #[test]
     fn rejects_traversal() {
         for n in [
             "../x",
@@ -71,6 +80,13 @@ fn count_ts_segments(dir: &std::path::Path) -> usize {
                 .count()
         })
         .unwrap_or(0)
+}
+
+/// Scale filter capping output height so a 4K source encodes at a rate the
+/// player can keep up with. `min(h, ih)` never upscales; `-2` keeps the width
+/// even. 0 disables the cap.
+pub fn scale_filter(max_height: u32) -> Option<String> {
+    (max_height > 0).then(|| format!("scale=-2:min({max_height}\\,ih)"))
 }
 
 fn delivery_label(d: Delivery) -> &'static str {
@@ -150,6 +166,7 @@ pub struct HlsManager {
     live_enabled: bool,
     live_prebuffer_segments: usize,
     encode_threads: usize,
+    max_height: u32,
     children: Arc<Mutex<HashMap<String, Child>>>,
     delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
 }
@@ -166,6 +183,7 @@ impl HlsManager {
         live_enabled: bool,
         live_prebuffer_segments: usize,
         encode_threads: usize,
+        max_height: u32,
     ) -> Self {
         let this = Self {
             store,
@@ -177,6 +195,7 @@ impl HlsManager {
             live_enabled,
             live_prebuffer_segments: live_prebuffer_segments.max(1),
             encode_threads,
+            max_height,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
         };
@@ -329,6 +348,10 @@ impl HlsManager {
                 args.push("libx264".into());
                 args.push("-preset".into());
                 args.push("veryfast".into());
+                if let Some(vf) = scale_filter(self.max_height) {
+                    args.push("-vf".into());
+                    args.push(vf);
+                }
                 if self.encode_threads > 0 {
                     args.push("-threads".into());
                     args.push(self.encode_threads.to_string());
@@ -604,6 +627,10 @@ impl HlsManager {
             args.push("libx264".into());
             args.push("-preset".into());
             args.push("veryfast".into());
+            if let Some(vf) = scale_filter(self.max_height) {
+                args.push("-vf".into());
+                args.push(vf);
+            }
             if self.encode_threads > 0 {
                 args.push("-threads".into());
                 args.push(self.encode_threads.to_string());
@@ -803,6 +830,7 @@ mod mgr_tests {
             true,
             3,
             1,
+            1080,
         );
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
@@ -822,6 +850,7 @@ mod mgr_tests {
             true,
             3,
             1,
+            1080,
         );
         assert_eq!(mgr.cached_delivery("1"), None);
         mgr.cache_delivery("1", Delivery::RemuxHls);

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -41,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.live_hls_enabled,
         cfg.live_prebuffer_segments,
         cfg.encode_threads,
+        cfg.hls_max_height,
     );
 
     tokio::spawn(reaper::reap_loop(
@@ -93,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
         stream_enabled: cfg.stream_enabled,
         hls,
         ffprobe_bin: cfg.ffprobe_bin.clone(),
+        hls_segment_wait_ms: cfg.hls_segment_wait_ms,
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -687,9 +687,16 @@ async fn extract_subtitles(
 }
 
 /// A finished download that has not been made playable yet. Failed transcodes
-/// are left alone (no auto-retry loop); the user can retry manually.
+/// are left alone (no auto-retry loop); the user can retry manually. An entry
+/// with an active HLS job is skipped — a background encode racing the viewer's
+/// HLS encode for the same cores starves the live stream.
 pub fn should_auto_transcode(m: &crate::state::Metadata) -> bool {
-    m.state == crate::state::TorrentState::Seeding && m.transcode == TranscodeStatus::None
+    m.state == crate::state::TorrentState::Seeding
+        && m.transcode == TranscodeStatus::None
+        && !matches!(
+            m.hls,
+            crate::state::HlsStatus::Starting | crate::state::HlsStatus::Live
+        )
 }
 
 /// Makes every completed download playable on its own — no manual transcode
@@ -984,6 +991,15 @@ mod transcoder_tests {
         let mut leech = meta("e", TranscodeStatus::None);
         leech.state = TorrentState::Leeching;
         assert!(!should_auto_transcode(&leech));
+        let mut watching = meta("f", TranscodeStatus::None);
+        watching.hls = crate::state::HlsStatus::Live;
+        assert!(!should_auto_transcode(&watching));
+        let mut starting = meta("g", TranscodeStatus::None);
+        starting.hls = crate::state::HlsStatus::Starting;
+        assert!(!should_auto_transcode(&starting));
+        let mut done = meta("h", TranscodeStatus::None);
+        done.hls = crate::state::HlsStatus::Ready;
+        assert!(should_auto_transcode(&done), "finished HLS does not block");
     }
 
     #[test]

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -58,6 +58,7 @@ async fn hls_transcode_integration() {
         true,
         3,
         1,
+        1080,
     );
     let outcome = mgr
         .request("test-hls", reel::transcode::Delivery::TranscodeHls)


### PR DESCRIPTION
## Problem

Streaming a 4K hevc source: probe correctly routes `transcode_hls` (full libx264 re-encode), but the encode runs ~0.4× realtime on the 2-CPU pod — made worse by the background library transcode of the same file racing it for the cores. The player burns through produced segments, hits the live edge, exhausts the hls.js fatal-error ladder, and the stream dies ("off air") instead of buffering.

## Fix (four layers)

**Attack the encode rate**
- `REEL_HLS_MAX_HEIGHT` (default 1080, 0=off): HLS transcode/live-encode adds `-vf scale=-2:min(1080\,ih)` — never upscales; a 2160p source encodes ~4× fewer pixels. The library `.reel.mp4` transcode stays full-res.
- Viewer priority: the manifest handler aborts an in-flight background transcode of the same torrent before starting a `TranscodeHls` job, and `should_auto_transcode` skips entries whose HLS job is Starting/Live. No more two ffmpeg encodes splitting the same cores.

**Attack death-instead-of-buffer**
- `REEL_HLS_SEGMENT_WAIT_MS` (default 5000): while HLS is Live, a missing segment waits for the encoder (250ms polls) before 404ing — edge starvation becomes a delayed response, not an error strike.
- Player (reelService.ts): fatal frag/level load failures get their own 40-retry buffering budget (reset on FRAG_BUFFERED) with a 'Buffering — waiting for stream data' status, instead of consuming the 6-strike fatal ladder. 401/manifest errors keep the existing recovery paths.

## Tests
- `cargo test -p reel`: 162 passed (was 158) — scale filter, auto-transcode HLS gate, segment wait/deadline, config defaults
- clippy clean (2 pre-existing warnings untouched)
- `astro check`: 0 errors in media components (26 repo-wide pre-existing)

mdx 0.1.36 → 0.1.37