### PR TITLE
feat(rn/dash): rich error context across all dashboard fetches

### DIFF
--- a/packages/npm/rn/src/dash/DashErrorBoundary.tsx
+++ b/packages/npm/rn/src/dash/DashErrorBoundary.tsx
@@ -1,0 +1,55 @@
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+import { Stack, Surface, Text } from './_ui';
+
+interface DashErrorBoundaryProps {
+	label?: string;
+	children: ReactNode;
+}
+
+interface DashErrorBoundaryState {
+	error: Error | null;
+}
+
+export class DashErrorBoundary extends Component<
+	DashErrorBoundaryProps,
+	DashErrorBoundaryState
+> {
+	override state: DashErrorBoundaryState = { error: null };
+
+	static getDerivedStateFromError(error: Error): DashErrorBoundaryState {
+		return { error };
+	}
+
+	override componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+		console.error(
+			`[dash${this.props.label ? `:${this.props.label}` : ''}] render crashed`,
+			error,
+			info.componentStack ?? '',
+		);
+	}
+
+	override render() {
+		const { error } = this.state;
+		if (error) {
+			return (
+				<Surface>
+					<Stack gap="xs">
+						<Text variant="label" tone="danger">
+							Dashboard crashed while rendering
+						</Text>
+						<Text variant="caption" tone="muted">
+							{error.name && error.name !== 'Error'
+								? `${error.name}: ${error.message}`
+								: error.message}
+						</Text>
+						<Text variant="caption" tone="faint">
+							Full stack in the browser console.
+						</Text>
+					</Stack>
+				</Surface>
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -6,6 +6,7 @@ import { ErrorState } from '../ui/feedback/ErrorState';
 import { LoadingState } from '../ui/feedback/LoadingState';
 import { VirtualList } from '../ui/lists/VirtualList';
 import { StatGrid } from './StatGrid';
+import { DashErrorBoundary } from './DashErrorBoundary';
 import { SectionDivider } from './shared';
 import { ControlBar } from './controls/ControlBar';
 import { SavedViewTabs } from './controls/SavedViewTabs';
@@ -232,7 +233,15 @@ export interface StreamViewProps<TItem> {
 	maxListHeight?: number;
 }
 
-export function StreamView<TItem>({
+export function StreamView<TItem>(props: StreamViewProps<TItem>): ReactElement {
+	return (
+		<DashErrorBoundary label={props.store.key}>
+			<StreamViewInner {...props} />
+		</DashErrorBoundary>
+	);
+}
+
+function StreamViewInner<TItem>({
 	store,
 	lens,
 	layout = 'rows',

--- a/packages/npm/rn/src/dash/__tests__/dashFetch.test.ts
+++ b/packages/npm/rn/src/dash/__tests__/dashFetch.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
+
+describe('dashFetch', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	it('returns the response on success', async () => {
+		const res = new Response('{}', { status: 200 });
+		global.fetch = vi.fn().mockResolvedValue(res);
+		await expect(
+			dashFetch('/dashboard/storage/proxy/volumes'),
+		).resolves.toBe(res);
+	});
+
+	it('wraps network errors with method, path, and error name', async () => {
+		const boom = new Error('The string did not match the expected pattern.');
+		boom.name = 'SyntaxError';
+		global.fetch = vi.fn().mockRejectedValue(boom);
+		await expect(
+			dashFetch('https://kbve.com/dashboard/storage/proxy/volumes', {
+				label: 'longhorn:volumes',
+			}),
+		).rejects.toThrow(
+			'longhorn:volumes (GET /dashboard/storage/proxy/volumes) failed: SyntaxError: The string did not match the expected pattern.',
+		);
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it('lets AbortError pass through untouched', async () => {
+		const abort = new Error('Aborted');
+		abort.name = 'AbortError';
+		global.fetch = vi.fn().mockRejectedValue(abort);
+		await expect(dashFetch('/x')).rejects.toBe(abort);
+	});
+});
+
+describe('dashJson', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	it('parses valid JSON', async () => {
+		const res = new Response('{"data":[1]}', { status: 200 });
+		await expect(dashJson<{ data: number[] }>(res)).resolves.toEqual({
+			data: [1],
+		});
+	});
+
+	it('adds context to parse failures', async () => {
+		const res = new Response('<html>upstream 502</html>', { status: 200 });
+		await expect(dashJson(res, 'longhorn:volumes')).rejects.toThrow(
+			/longhorn:volumes returned invalid JSON: /,
+		);
+	});
+});
+
+describe('dashHttpError', () => {
+	it('includes status, label, and hint', () => {
+		const res = new Response('nope', { status: 403, statusText: 'Forbidden' });
+		const err = dashHttpError(res, 'longhorn:volumes', 'Access restricted');
+		expect(err.message).toBe(
+			'longhorn:volumes → HTTP 403 Forbidden — Access restricted',
+		);
+	});
+
+	it('works without label or hint', () => {
+		const res = new Response('nope', { status: 502 });
+		expect(dashHttpError(res).message).toContain('HTTP 502');
+	});
+});

--- a/packages/npm/rn/src/dash/adapters/argo.tsx
+++ b/packages/npm/rn/src/dash/adapters/argo.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View, Pressable, ActivityIndicator } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import { clusterHealthStats, fetchClusterHealth } from '../clusterHealth';
 import type { ClusterHealth } from '../clusterHealth';
 import { NamespacePanel } from '../NamespacePanel';
@@ -173,18 +174,23 @@ export function createArgoStream(
 			),
 		fetch: async ({ signal }) => {
 			const token = await getToken();
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/dashboard/argo/proxy/api/v1/applications`,
 				{
 					headers: token
 						? { Authorization: `Bearer ${token}` }
 						: undefined,
 					signal,
+					label: 'argo:apps',
 				},
 			);
-			if (res.status === 403) throw new Error('Access restricted');
-			if (!res.ok) throw new Error(`ArgoCD upstream ${res.status}`);
-			const json = (await res.json()) as { items?: RawArgoApp[] };
+			if (res.status === 403)
+				throw dashHttpError(res, 'argo:apps', 'Access restricted');
+			if (!res.ok) throw dashHttpError(res, 'argo:apps');
+			const json = await dashJson<{ items?: RawArgoApp[] }>(
+				res,
+				'argo:apps',
+			);
 			return json.items ?? [];
 		},
 	});
@@ -199,16 +205,18 @@ async function argoMutate(
 	const headers: Record<string, string> = {};
 	if (token) headers['Authorization'] = `Bearer ${token}`;
 	if (method === 'POST') headers['Content-Type'] = 'application/json';
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy${path}`,
 		{
 			method,
 			headers,
 			body: method === 'POST' ? '{}' : undefined,
+			label: 'argo:mutate',
 		},
 	);
-	if (res.status === 403) throw new Error('Manage permission required');
-	if (!res.ok) throw new Error(`ArgoCD ${method} ${res.status}`);
+	if (res.status === 403)
+		throw dashHttpError(res, 'argo:mutate', 'Manage permission required');
+	if (!res.ok) throw dashHttpError(res, 'argo:mutate');
 }
 
 /** Argo mutations bound to a token/baseUrl. Require DASHBOARD_MANAGE. */
@@ -245,7 +253,7 @@ export async function rollbackApplication(
 	id: number,
 ): Promise<void> {
 	const token = await opts.getToken();
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy/api/v1/applications/${encodeURIComponent(appName)}/rollback`,
 		{
 			method: 'POST',
@@ -254,10 +262,12 @@ export async function rollbackApplication(
 				'Content-Type': 'application/json',
 			},
 			body: JSON.stringify({ id, prune: false, dryRun: false }),
+			label: 'argo:rollback',
 		},
 	);
-	if (res.status === 403) throw new Error('Manage permission required');
-	if (!res.ok) throw new Error(`Rollback failed: ${res.status}`);
+	if (res.status === 403)
+		throw dashHttpError(res, 'argo:rollback', 'Manage permission required');
+	if (!res.ok) throw dashHttpError(res, 'argo:rollback');
 }
 
 // ---------------------------------------------------------------------------
@@ -345,13 +355,15 @@ export async function fetchResourceTree(
 	appName: string,
 ): Promise<ResourceTree> {
 	const token = await opts.getToken();
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy/api/v1/applications/${encodeURIComponent(appName)}/resource-tree`,
-		{ headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+		{
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			label: 'argo:resource-tree',
+		},
 	);
-	if (!res.ok)
-		throw new Error(`Failed to fetch resource tree: ${res.status}`);
-	return res.json();
+	if (!res.ok) throw dashHttpError(res, 'argo:resource-tree');
+	return dashJson<ResourceTree>(res, 'argo:resource-tree');
 }
 
 /** Fetch events for an application or specific resource. */
@@ -360,12 +372,15 @@ export async function fetchAppEvents(
 	appName: string,
 ): Promise<AppEvent[]> {
 	const token = await opts.getToken();
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy/api/v1/applications/${encodeURIComponent(appName)}/events`,
-		{ headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+		{
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			label: 'argo:events',
+		},
 	);
-	if (!res.ok) throw new Error(`Failed to fetch events: ${res.status}`);
-	const json = (await res.json()) as { items?: AppEvent[] };
+	if (!res.ok) throw dashHttpError(res, 'argo:events');
+	const json = await dashJson<{ items?: AppEvent[] }>(res, 'argo:events');
 	return json.items ?? [];
 }
 
@@ -375,13 +390,18 @@ export async function fetchManagedResources(
 	appName: string,
 ): Promise<ManagedResource[]> {
 	const token = await opts.getToken();
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy/api/v1/applications/${encodeURIComponent(appName)}/managed-resources`,
-		{ headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+		{
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			label: 'argo:managed-resources',
+		},
 	);
-	if (!res.ok)
-		throw new Error(`Failed to fetch managed resources: ${res.status}`);
-	const json = (await res.json()) as { items?: ManagedResource[] };
+	if (!res.ok) throw dashHttpError(res, 'argo:managed-resources');
+	const json = await dashJson<{ items?: ManagedResource[] }>(
+		res,
+		'argo:managed-resources',
+	);
 	return json.items ?? [];
 }
 
@@ -403,12 +423,16 @@ export async function fetchPodLogs(
 		params.set('sinceSeconds', String(logOpts.sinceSeconds));
 	}
 
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/argo/proxy/api/v1/applications/${encodeURIComponent(appName)}/pods/${encodeURIComponent(logOpts.podName)}/logs?${params}`,
-		{ headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+		{
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			label: 'argo:pod-logs',
+		},
 	);
-	if (res.status === 404) throw new Error('Pod not found');
-	if (!res.ok) throw new Error(`Failed to fetch pod logs: ${res.status}`);
+	if (res.status === 404)
+		throw dashHttpError(res, 'argo:pod-logs', 'Pod not found');
+	if (!res.ok) throw dashHttpError(res, 'argo:pod-logs');
 
 	const text = await res.text();
 	const lines: LogLine[] = [];
@@ -441,7 +465,7 @@ export async function fetchIndexedLogs(
 	if (query.level) body['level'] = query.level;
 	if (query.search) body['search'] = query.search;
 
-	const res = await fetch(
+	const res = await dashFetch(
 		`${opts.baseUrl ?? ''}/dashboard/clickhouse/proxy`,
 		{
 			method: 'POST',
@@ -450,14 +474,22 @@ export async function fetchIndexedLogs(
 				'Content-Type': 'application/json',
 			},
 			body: JSON.stringify(body),
+			label: 'argo:indexed-logs',
 		},
 	);
 
 	if (res.status === 403)
-		throw new Error('Access restricted to indexed logs');
-	if (!res.ok) throw new Error(`ClickHouse logs error: ${res.status}`);
+		throw dashHttpError(
+			res,
+			'argo:indexed-logs',
+			'Access restricted to indexed logs',
+		);
+	if (!res.ok) throw dashHttpError(res, 'argo:indexed-logs');
 
-	const data = (await res.json()) as { rows?: IndexedLogRow[] };
+	const data = await dashJson<{ rows?: IndexedLogRow[] }>(
+		res,
+		'argo:indexed-logs',
+	);
 	return Array.isArray(data?.rows) ? data.rows : [];
 }
 

--- a/packages/npm/rn/src/dash/adapters/deployment.tsx
+++ b/packages/npm/rn/src/dash/adapters/deployment.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -134,22 +135,24 @@ export function createDeploymentStream(
 				live_only: liveOnly ? 'true' : 'false',
 			});
 
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/dashboard/firecracker/deployments?${params.toString()}`,
 				{
 					headers: token
 						? { Authorization: `Bearer ${token}` }
 						: undefined,
 					signal,
+					label: 'deployment:list',
 				},
 			);
 
-			if (res.status === 403) throw new Error('Access restricted');
-			if (!res.ok) throw new Error(`Deployment API error: ${res.status}`);
+			if (res.status === 403)
+				throw dashHttpError(res, 'deployment:list', 'Access restricted');
+			if (!res.ok) throw dashHttpError(res, 'deployment:list');
 
-			const json = (await res.json()) as {
+			const json = await dashJson<{
 				deployments?: RawDeployment[];
-			};
+			}>(res, 'deployment:list');
 			const raw = json?.deployments ?? [];
 
 			// Sort by created_at descending (newest first)

--- a/packages/npm/rn/src/dash/adapters/edge.tsx
+++ b/packages/npm/rn/src/dash/adapters/edge.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +53,7 @@ const RETRY_DELAY_MS = 2000;
 async function fetchWithRetry(
 	url: string,
 	opts: RequestInit,
+	label: string,
 	retries = 1,
 ): Promise<Response> {
 	for (let i = 0; i <= retries; i++) {
@@ -61,9 +63,10 @@ async function fetchWithRetry(
 				() => controller.abort(),
 				FETCH_TIMEOUT_MS,
 			);
-			const resp = await fetch(url, {
+			const resp = await dashFetch(url, {
 				...opts,
 				signal: controller.signal,
+				label,
 			});
 			clearTimeout(timeout);
 			return resp;
@@ -101,14 +104,21 @@ async function checkViaProxy(
 
 	try {
 		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
-		const resp = await fetchWithRetry(url, {
-			method,
-			headers: { Authorization: `Bearer ${token}` },
-		});
+		const resp = await fetchWithRetry(
+			url,
+			{
+				method,
+				headers: { Authorization: `Bearer ${token}` },
+			},
+			`edge:proxy:${fn.name}`,
+		);
 		const latencyMs = Math.round(performance.now() - start);
 
 		if (fn.name === 'health' && resp.ok) {
-			const data = await resp.json();
+			const data = await dashJson<{
+				version?: string;
+				timestamp?: string;
+			}>(resp, `edge:proxy:${fn.name}`);
 			return {
 				proxyStatus: 'ok',
 				proxyLatencyMs: latencyMs,
@@ -151,7 +161,11 @@ async function checkViaDirect(
 
 	try {
 		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
-		const resp = await fetchWithRetry(url, { method });
+		const resp = await fetchWithRetry(
+			url,
+			{ method },
+			`edge:direct:${fn.name}`,
+		);
 		const latencyMs = Math.round(performance.now() - start);
 
 		if (resp.ok) {
@@ -198,9 +212,12 @@ async function fetchAndNormalize(
 					method: 'GET',
 					headers: { Authorization: `Bearer ${token}` },
 				},
+				'edge:manifest',
 			);
 			if (resp.ok) {
-				const data = await resp.json();
+				const data = await dashJson<{
+					functions?: RawEdgeFunction[];
+				}>(resp, 'edge:manifest');
 				if (
 					Array.isArray(data.functions) &&
 					data.functions.length > 0
@@ -219,9 +236,12 @@ async function fetchAndNormalize(
 			const resp = await fetchWithRetry(
 				`${supabaseUrl}/functions/v1/health`,
 				{ method: 'GET' },
+				'edge:manifest:direct',
 			);
 			if (resp.ok) {
-				const data = await resp.json();
+				const data = await dashJson<{
+					functions?: RawEdgeFunction[];
+				}>(resp, 'edge:manifest:direct');
 				if (
 					Array.isArray(data.functions) &&
 					data.functions.length > 0

--- a/packages/npm/rn/src/dash/adapters/factorio.tsx
+++ b/packages/npm/rn/src/dash/adapters/factorio.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -133,7 +134,7 @@ export function createFactorioStream(
 				minutes,
 			};
 
-			const res = await fetch(`${baseUrl}/dashboard/clickhouse/proxy`, {
+			const res = await dashFetch(`${baseUrl}/dashboard/clickhouse/proxy`, {
 				method: 'POST',
 				headers: {
 					...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -141,13 +142,21 @@ export function createFactorioStream(
 				},
 				body: JSON.stringify(body),
 				signal,
+				label: 'factorio:telemetry',
 			});
 
-			if (res.status === 403) throw new Error('Access restricted');
-			if (!res.ok)
-				throw new Error(`Factorio telemetry API error: ${res.status}`);
+			if (res.status === 403)
+				throw dashHttpError(
+					res,
+					'factorio:telemetry',
+					'Access restricted',
+				);
+			if (!res.ok) throw dashHttpError(res, 'factorio:telemetry');
 
-			const json = (await res.json()) as { rows?: RawCurrent[] };
+			const json = await dashJson<{ rows?: RawCurrent[] }>(
+				res,
+				'factorio:telemetry',
+			);
 			const raw = json?.rows ?? [];
 
 			// Sort by players descending (most active first)

--- a/packages/npm/rn/src/dash/adapters/forgejo.tsx
+++ b/packages/npm/rn/src/dash/adapters/forgejo.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -124,22 +125,31 @@ export function createForgejoStream(
 		normalize,
 		fetch: async ({ signal }) => {
 			const token = await getToken();
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/dashboard/forgejo/api/repos/search?limit=${limit}&sort=updated`,
 				{
 					headers: token
 						? { Authorization: `Bearer ${token}` }
 						: undefined,
 					signal,
+					label: 'forgejo:repos',
 				},
 			);
 
-			if (res.status === 403) throw new Error('Access restricted');
+			if (res.status === 403)
+				throw dashHttpError(res, 'forgejo:repos', 'Access restricted');
 			if (res.status === 502)
-				throw new Error('Forgejo upstream unreachable');
-			if (!res.ok) throw new Error(`Forgejo API error: ${res.status}`);
+				throw dashHttpError(
+					res,
+					'forgejo:repos',
+					'Forgejo upstream unreachable',
+				);
+			if (!res.ok) throw dashHttpError(res, 'forgejo:repos');
 
-			const json = (await res.json()) as { data?: RawRepo[] };
+			const json = await dashJson<{ data?: RawRepo[] }>(
+				res,
+				'forgejo:repos',
+			);
 			const raw = json?.data ?? [];
 
 			// Sort by updated_at descending (most recent first)

--- a/packages/npm/rn/src/dash/adapters/grafana.tsx
+++ b/packages/npm/rn/src/dash/adapters/grafana.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import { clusterHealthStats, fetchClusterHealth } from '../clusterHealth';
 import type { ClusterHealth } from '../clusterHealth';
 import { ClusterChartsPanel } from '../ClusterChartsPanel';
@@ -123,21 +124,23 @@ export function createGrafanaStream(
 			),
 		fetch: async ({ signal }) => {
 			const token = await getToken();
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/dashboard/grafana/proxy/api/prometheus/grafana/api/v1/alerts`,
 				{
 					headers: token
 						? { Authorization: `Bearer ${token}` }
 						: undefined,
 					signal,
+					label: 'grafana:alerts',
 				},
 			);
-			if (res.status === 403) throw new Error('Access restricted');
-			if (!res.ok) throw new Error(`Grafana alerts API ${res.status}`);
+			if (res.status === 403)
+				throw dashHttpError(res, 'grafana:alerts', 'Access restricted');
+			if (!res.ok) throw dashHttpError(res, 'grafana:alerts');
 
-			const json = (await res.json()) as {
+			const json = await dashJson<{
 				data?: { alerts?: RawAlert[] };
-			};
+			}>(res, 'grafana:alerts');
 			const raw = json?.data?.alerts ?? [];
 
 			// Sort by severity first, then by alertname

--- a/packages/npm/rn/src/dash/adapters/kilobaseBackup.tsx
+++ b/packages/npm/rn/src/dash/adapters/kilobaseBackup.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StatModel, StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -141,36 +142,53 @@ export function createKilobaseBackupStream(
 			if (params['token']) qs.set('token', String(params['token']));
 			qs.set('limit', String(params['limit'] ?? limit));
 
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/dashboard/kilobase/s3/objects?${qs.toString()}`,
 				{
 					headers: token
 						? { Authorization: `Bearer ${token}` }
 						: undefined,
 					signal,
+					label: 'kilobase:s3-objects',
 				},
 			);
 
-			if (res.status === 403) throw new Error('Access restricted');
+			if (res.status === 403)
+				throw dashHttpError(
+					res,
+					'kilobase:s3-objects',
+					'Access restricted',
+				);
 			if (res.status === 502)
-				throw new Error('Kilobase S3 upstream unreachable');
-			if (!res.ok)
-				throw new Error(`Kilobase S3 objects error: ${res.status}`);
+				throw dashHttpError(
+					res,
+					'kilobase:s3-objects',
+					'Kilobase S3 upstream unreachable',
+				);
+			if (!res.ok) throw dashHttpError(res, 'kilobase:s3-objects');
 
-			const json = (await res.json()) as RawObjectsResponse;
+			const json = await dashJson<RawObjectsResponse>(
+				res,
+				'kilobase:s3-objects',
+			);
 			return mapObjectsResponse(json).objects;
 		},
 		fetchMeta: async ({ signal }) => {
 			const token = await getToken();
-			const res = await fetch(`${baseUrl}/dashboard/kilobase/s3/summary`, {
-				headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-				signal,
-			});
+			const res = await dashFetch(
+				`${baseUrl}/dashboard/kilobase/s3/summary`,
+				{
+					headers: token
+						? { Authorization: `Bearer ${token}` }
+						: undefined,
+					signal,
+					label: 'kilobase:s3-summary',
+				},
+			);
 
-			if (!res.ok)
-				throw new Error(`Kilobase S3 summary error: ${res.status}`);
+			if (!res.ok) throw dashHttpError(res, 'kilobase:s3-summary');
 
-			return (await res.json()) as BackupSummary;
+			return dashJson<BackupSummary>(res, 'kilobase:s3-summary');
 		},
 	});
 }

--- a/packages/npm/rn/src/dash/adapters/longhorn.tsx
+++ b/packages/npm/rn/src/dash/adapters/longhorn.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StatModel, StreamLens, StreamStore } from '../types';
 
 export interface RawLonghornReplica {
@@ -159,16 +160,20 @@ export function summarizeDisks(nodes: RawLonghornNode[]): DiskSummary[] {
 async function fetchCollection<T>(
 	url: string,
 	token: string | null,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	label: string,
 ): Promise<T[]> {
-	const res = await fetch(url, {
+	const res = await dashFetch(url, {
 		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
 		signal,
+		label,
 	});
-	if (res.status === 403) throw new Error('Access restricted');
-	if (res.status === 503) throw new Error('Longhorn proxy not configured');
-	if (!res.ok) throw new Error(`Longhorn error: ${res.status}`);
-	const json = (await res.json()) as { data?: T[] };
+	if (res.status === 403)
+		throw dashHttpError(res, label, 'Access restricted');
+	if (res.status === 503)
+		throw dashHttpError(res, label, 'Longhorn proxy not configured');
+	if (!res.ok) throw dashHttpError(res, label);
+	const json = await dashJson<{ data?: T[] }>(res, label);
 	return Array.isArray(json?.data) ? json.data : [];
 }
 
@@ -191,6 +196,7 @@ export function createLonghornStream(
 				`${baseUrl}/dashboard/storage/proxy/volumes`,
 				token,
 				signal,
+				'longhorn:volumes',
 			);
 			return volumes.sort((a, b) => a.name.localeCompare(b.name));
 		},
@@ -201,6 +207,7 @@ export function createLonghornStream(
 					`${baseUrl}/dashboard/storage/proxy/nodes`,
 					token,
 					signal,
+					'longhorn:nodes',
 				);
 				return summarizeDisks(nodes);
 			} catch {

--- a/packages/npm/rn/src/dash/adapters/rows.tsx
+++ b/packages/npm/rn/src/dash/adapters/rows.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -92,22 +93,33 @@ export function createRowsStream(
 		normalize,
 		fetch: async ({ signal }) => {
 			const token = await getToken();
-			const res = await fetch(`${proxyBase}/api/System/FleetStatus`, {
+			const res = await dashFetch(`${proxyBase}/api/System/FleetStatus`, {
 				headers: token
 					? { Authorization: `Bearer ${token}` }
 					: undefined,
 				signal,
+				label: 'rows:fleet',
 			});
 
-			if (res.status === 403) throw new Error('Access restricted');
-			if (res.status === 502) throw new Error('ROWS backend unreachable');
+			if (res.status === 403)
+				throw dashHttpError(res, 'rows:fleet', 'Access restricted');
+			if (res.status === 502)
+				throw dashHttpError(
+					res,
+					'rows:fleet',
+					'ROWS backend unreachable',
+				);
 			if (res.status === 503)
-				throw new Error('ROWS proxy not configured');
-			if (!res.ok) throw new Error(`ROWS API error: ${res.status}`);
+				throw dashHttpError(
+					res,
+					'rows:fleet',
+					'ROWS proxy not configured',
+				);
+			if (!res.ok) throw dashHttpError(res, 'rows:fleet');
 
-			const json = (await res.json()) as {
+			const json = await dashJson<{
 				game_servers?: RawGameServer[];
-			};
+			}>(res, 'rows:fleet');
 			const raw = json?.game_servers ?? [];
 
 			// Sort by state (Allocated > Ready > Shutdown) then by age

--- a/packages/npm/rn/src/dash/adapters/vm.tsx
+++ b/packages/npm/rn/src/dash/adapters/vm.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, View } from 'react-native';
 import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -192,32 +193,48 @@ export function createVMStream(opts: VMStreamOptions): StreamStore<VMItem> {
 		fetch: async ({ signal }) => {
 			const token = await getToken();
 			const [vmsRes, vmisRes] = await Promise.all([
-				fetch(
+				dashFetch(
 					`${baseUrl}/dashboard/vm/proxy/apis/kubevirt.io/v1/namespaces/${namespace}/virtualmachines`,
 					{
 						headers: token
 							? { Authorization: `Bearer ${token}` }
 							: undefined,
 						signal,
+						label: 'vm:list',
 					},
 				),
-				fetch(
+				dashFetch(
 					`${baseUrl}/dashboard/vm/proxy/apis/kubevirt.io/v1/namespaces/${namespace}/virtualmachineinstances`,
 					{
 						headers: token
 							? { Authorization: `Bearer ${token}` }
 							: undefined,
 						signal,
+						label: 'vm:instances',
 					},
 				),
 			]);
 
 			if (vmsRes.status === 403 || vmisRes.status === 403)
-				throw new Error('Access restricted');
-			if (!vmsRes.ok || !vmisRes.ok) throw new Error('VM API error');
+				throw dashHttpError(
+					vmsRes.status === 403 ? vmsRes : vmisRes,
+					vmsRes.status === 403 ? 'vm:list' : 'vm:instances',
+					'Access restricted',
+				);
+			if (!vmsRes.ok || !vmisRes.ok)
+				throw dashHttpError(
+					!vmsRes.ok ? vmsRes : vmisRes,
+					!vmsRes.ok ? 'vm:list' : 'vm:instances',
+				);
 
-			const vmsJson = (await vmsRes.json()) as { items: RawVM[] };
-			const vmisJson = (await vmisRes.json()) as { items: RawVMI[] };
+			const vmsJson = await dashJson<{ items: RawVM[] }>(
+				vmsRes,
+				'vm:list',
+			);
+			const vmisJson = await dashJson<{ items: RawVMI[] }>(
+				vmisRes,
+				'vm:instances',
+			);
 
 			const vms = vmsJson.items ?? [];
 			const vmis = vmisJson.items ?? [];

--- a/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
+++ b/packages/npm/rn/src/dash/clickhouse/clickhouseStream.ts
@@ -1,4 +1,5 @@
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type {
 	StreamControl,
 	SavedView,
@@ -40,7 +41,7 @@ async function post(
 	body: unknown,
 	signal: AbortSignal,
 ) {
-	const res = await fetch(`${baseUrl}${PROXY}`, {
+	const res = await dashFetch(`${baseUrl}${PROXY}`, {
 		method: 'POST',
 		headers: {
 			...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -48,10 +49,12 @@ async function post(
 		},
 		body: JSON.stringify(body),
 		signal,
+		label: 'clickhouse:proxy',
 	});
-	if (res.status === 403) throw new Error('Access restricted');
-	if (!res.ok) throw new Error(`ClickHouse API error: ${res.status}`);
-	return res.json();
+	if (res.status === 403)
+		throw dashHttpError(res, 'clickhouse:proxy', 'Access restricted');
+	if (!res.ok) throw dashHttpError(res, 'clickhouse:proxy');
+	return dashJson(res, 'clickhouse:proxy');
 }
 
 export interface StatsTotals {

--- a/packages/npm/rn/src/dash/clickhouse/errorGroupsStream.tsx
+++ b/packages/npm/rn/src/dash/clickhouse/errorGroupsStream.tsx
@@ -1,4 +1,5 @@
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamParams, StreamStore, StreamLens } from '../types';
 import { Surface, Stack, Text, Badge, tokens } from '../_ui';
 
@@ -35,14 +36,15 @@ export function createErrorGroupsStream(opts: ErrorGroupsStreamOptions): StreamS
 			const token = await getToken();
 			const body: Record<string, unknown> = { command: 'error_groups' };
 			for (const k of ['minutes', 'limit', 'pod_namespace']) if (params[k] !== undefined && params[k] !== '') body[k] = params[k];
-			const res = await fetch(`${baseUrl}${PROXY}`, {
+			const res = await dashFetch(`${baseUrl}${PROXY}`, {
 				method: 'POST',
 				headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), 'Content-Type': 'application/json' },
 				body: JSON.stringify(body), signal,
+				label: 'clickhouse:error-groups',
 			});
-			if (res.status === 403) throw new Error('Access restricted');
-			if (!res.ok) throw new Error(`ClickHouse API error: ${res.status}`);
-			const json = (await res.json()) as { rows?: RawErrorGroup[] };
+			if (res.status === 403) throw dashHttpError(res, 'clickhouse:error-groups', 'Access restricted');
+			if (!res.ok) throw dashHttpError(res, 'clickhouse:error-groups');
+			const json = await dashJson<{ rows?: RawErrorGroup[] }>(res, 'clickhouse:error-groups');
 			return json?.rows ?? [];
 		},
 	});

--- a/packages/npm/rn/src/dash/clusterHealth.ts
+++ b/packages/npm/rn/src/dash/clusterHealth.ts
@@ -1,4 +1,5 @@
 import type { BadgeTone } from './_ui';
+import { dashFetch, dashJson } from './dashFetch';
 import type { StatModel } from './types';
 
 // ---------------------------------------------------------------------------
@@ -60,16 +61,22 @@ async function findDatasourceId(
 ): Promise<number | null> {
 	if (cachedDatasourceId != null) return cachedDatasourceId;
 	try {
-		const res = await fetch(
+		const res = await dashFetch(
 			`${base}/dashboard/grafana/proxy/api/datasources`,
-			{ headers: { Authorization: `Bearer ${token}` }, signal },
+			{
+				headers: { Authorization: `Bearer ${token}` },
+				signal,
+				label: 'grafana:datasources',
+			},
 		);
 		if (!res.ok) return null;
-		const sources = (await res.json()) as Array<{
-			id: number;
-			type: string;
-			name: string;
-		}>;
+		const sources = await dashJson<
+			Array<{
+				id: number;
+				type: string;
+				name: string;
+			}>
+		>(res, 'grafana:datasources');
 		const prom = sources.find(
 			(s) => s.type === 'prometheus' || s.name === 'Prometheus',
 		);
@@ -88,7 +95,7 @@ async function promQuery(
 	signal: AbortSignal,
 ): Promise<Array<{ metric: Record<string, string>; value: number }>> {
 	try {
-		const res = await fetch(
+		const res = await dashFetch(
 			`${base}/dashboard/grafana/proxy/api/datasources/proxy/${dsId}/api/v1/query`,
 			{
 				method: 'POST',
@@ -98,17 +105,18 @@ async function promQuery(
 				},
 				body: `query=${encodeURIComponent(expr)}`,
 				signal,
+				label: 'grafana:prom-query',
 			},
 		);
 		if (!res.ok) return [];
-		const data = (await res.json()) as {
+		const data = await dashJson<{
 			data?: {
 				result?: Array<{
 					metric?: Record<string, string>;
 					value?: [number, string];
 				}>;
 			};
-		};
+		}>(res, 'grafana:prom-query');
 		const rows = data?.data?.result ?? [];
 		return rows.map((r) => ({
 			metric: r.metric ?? {},
@@ -130,7 +138,7 @@ async function promRange(
 	signal: AbortSignal,
 ): Promise<SeriesPoint[]> {
 	try {
-		const res = await fetch(
+		const res = await dashFetch(
 			`${base}/dashboard/grafana/proxy/api/datasources/proxy/${dsId}/api/v1/query_range`,
 			{
 				method: 'POST',
@@ -140,14 +148,15 @@ async function promRange(
 				},
 				body: `query=${encodeURIComponent(expr)}&start=${start}&end=${end}&step=${step}`,
 				signal,
+				label: 'grafana:prom-range',
 			},
 		);
 		if (!res.ok) return [];
-		const data = (await res.json()) as {
+		const data = await dashJson<{
 			data?: {
 				result?: Array<{ values?: Array<[number, string]> }>;
 			};
-		};
+		}>(res, 'grafana:prom-range');
 		const values = data?.data?.result?.[0]?.values ?? [];
 		return values
 			.map(([t, v]) => ({ t, v: parseFloat(v) }))

--- a/packages/npm/rn/src/dash/createStreamSource.ts
+++ b/packages/npm/rn/src/dash/createStreamSource.ts
@@ -29,6 +29,15 @@ const EMPTY = <TItem>(initialParams: StreamParams): StreamState<TItem> => ({
 	activeViewId: null,
 });
 
+function describeStreamError(e: unknown): string {
+	if (e instanceof Error) {
+		return e.name && e.name !== 'Error'
+			? `${e.name}: ${e.message}`
+			: e.message;
+	}
+	return `Request failed: ${String(e)}`;
+}
+
 function serializeParams(params: StreamParams): string {
 	const keys = Object.keys(params)
 		.filter((k) => params[k] !== undefined)
@@ -113,7 +122,15 @@ export function createStreamSource<TRaw, TItem>(
 				fetch({ signal: ctrl.signal }, params),
 				fetchMeta
 					? fetchMeta({ signal: ctrl.signal }, params).catch(
-							() => undefined,
+							(e: unknown) => {
+								if (!ctrl.signal.aborted) {
+									console.warn(
+										`[dash:${key}] meta fetch failed`,
+										e,
+									);
+								}
+								return undefined;
+							},
 						)
 					: Promise.resolve(undefined),
 			]);
@@ -141,9 +158,10 @@ export function createStreamSource<TRaw, TItem>(
 			}
 		} catch (e: unknown) {
 			if (ctrl.signal.aborted) return;
+			console.error(`[dash:${key}] fetch failed`, e);
 			patch({
 				loading: false,
-				error: e instanceof Error ? e.message : 'Request failed',
+				error: describeStreamError(e),
 			});
 		}
 	};
@@ -223,9 +241,12 @@ export function createStreamSource<TRaw, TItem>(
 				patch({ actionMsg: opts?.successMsg ?? 'Done' });
 				if (opts?.refresh !== false) await runFetch();
 			} catch (e: unknown) {
+				console.error(`[dash:${config.key}] action ${key} failed`, e);
 				patch({
 					actionError:
-						e instanceof Error ? e.message : 'Action failed',
+						e instanceof Error
+							? describeStreamError(e)
+							: 'Action failed',
 				});
 			} finally {
 				patch({ actionBusy: null });

--- a/packages/npm/rn/src/dash/cube/cubeApi.ts
+++ b/packages/npm/rn/src/dash/cube/cubeApi.ts
@@ -2,6 +2,8 @@
 // axum-kbve proxy at `/dashboard/cube/proxy`. The proxy injects the upstream
 // Cube JWT server-side; the browser only carries its supabase session token.
 
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
+
 const PROXY = '/dashboard/cube/proxy/load';
 
 export interface CubeTimeDimension {
@@ -26,7 +28,7 @@ export async function cubeLoad(
 	query: CubeQuery,
 	signal?: AbortSignal,
 ): Promise<CubeRow[]> {
-	const res = await fetch(`${baseUrl}${PROXY}`, {
+	const res = await dashFetch(`${baseUrl}${PROXY}`, {
 		method: 'POST',
 		headers: {
 			...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -34,10 +36,12 @@ export async function cubeLoad(
 		},
 		body: JSON.stringify({ query }),
 		signal,
+		label: 'cube:load',
 	});
-	if (res.status === 403) throw new Error('Access restricted');
-	if (!res.ok) throw new Error(`Cube API error: ${res.status}`);
-	const json = (await res.json()) as { data?: CubeRow[] };
+	if (res.status === 403)
+		throw dashHttpError(res, 'cube:load', 'Access restricted');
+	if (!res.ok) throw dashHttpError(res, 'cube:load');
+	const json = await dashJson<{ data?: CubeRow[] }>(res, 'cube:load');
 	return json?.data ?? [];
 }
 

--- a/packages/npm/rn/src/dash/dashFetch.ts
+++ b/packages/npm/rn/src/dash/dashFetch.ts
@@ -1,0 +1,59 @@
+export interface DashFetchOpts extends RequestInit {
+	label?: string;
+}
+
+function describe(e: unknown): string {
+	if (e instanceof Error) {
+		return e.name && e.name !== 'Error'
+			? `${e.name}: ${e.message}`
+			: e.message;
+	}
+	return String(e);
+}
+
+function shortUrl(url: string): string {
+	try {
+		const u = url.replace(/^https?:\/\/[^/]+/, '');
+		return u.length > 120 ? `${u.slice(0, 117)}…` : u;
+	} catch {
+		return url;
+	}
+}
+
+export async function dashFetch(
+	url: string,
+	opts: DashFetchOpts = {},
+): Promise<Response> {
+	const { label, ...init } = opts;
+	const method = init.method ?? 'GET';
+	const tag = label ? `${label} (${method} ${shortUrl(url)})` : `${method} ${shortUrl(url)}`;
+	try {
+		return await fetch(url, init);
+	} catch (e: unknown) {
+		if (e instanceof Error && e.name === 'AbortError') throw e;
+		console.error(`[dash] ${tag} failed`, e);
+		throw new Error(`${tag} failed: ${describe(e)}`);
+	}
+}
+
+export async function dashJson<T>(res: Response, label?: string): Promise<T> {
+	const tag = label ?? shortUrl(res.url || '');
+	try {
+		return (await res.json()) as T;
+	} catch (e: unknown) {
+		console.error(`[dash] ${tag} returned invalid JSON`, e);
+		throw new Error(`${tag} returned invalid JSON: ${describe(e)}`);
+	}
+}
+
+export function dashHttpError(
+	res: Response,
+	label?: string,
+	hint?: string,
+): Error {
+	const tag = label ?? shortUrl(res.url || '');
+	const suffix = hint ? ` — ${hint}` : '';
+	return new Error(
+		`${tag} → HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''}${suffix}`,
+	);
+}

--- a/packages/npm/rn/src/dash/index.ts
+++ b/packages/npm/rn/src/dash/index.ts
@@ -7,6 +7,8 @@ export * from './types';
 export * from './createStreamSource';
 export * from './useStream';
 export * from './StreamView';
+export * from './DashErrorBoundary';
+export * from './dashFetch';
 export * from './StatGrid';
 export * from './adapters/argo';
 export * from './adapters/grafana';

--- a/packages/npm/rn/src/dash/mc/__tests__/rconExec.test.ts
+++ b/packages/npm/rn/src/dash/mc/__tests__/rconExec.test.ts
@@ -65,6 +65,11 @@ describe('createRconExec', () => {
 		(global.fetch as any).mockRejectedValue(new Error('offline'));
 		const exec = createRconExec({ getToken: token });
 		const res = await exec('lobby', { command: 'list' });
-		expect(res).toEqual({ ok: false, output: '', latency_ms: 0, error: 'offline' });
+		expect(res).toEqual({
+			ok: false,
+			output: '',
+			latency_ms: 0,
+			error: 'mc:rcon (POST /api/v1/rcon/mc/lobby/exec) failed: offline',
+		});
 	});
 });

--- a/packages/npm/rn/src/dash/mc/mcStream.ts
+++ b/packages/npm/rn/src/dash/mc/mcStream.ts
@@ -1,4 +1,5 @@
 import { createStreamSource } from '../createStreamSource';
+import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 import type { StreamStore } from '../types';
 import { MC_SERVER_ORDER } from './labels';
 
@@ -82,9 +83,12 @@ export function createMcStream(
 				.join(',')}`,
 		normalize: (x) => x,
 		fetch: async ({ signal }) => {
-			const res = await fetch(`${baseUrl}/api/v1/mc/players`, { signal });
-			if (!res.ok) throw new Error(`MC status error: ${res.status}`);
-			const json = (await res.json()) as RawMcPlayerList;
+			const res = await dashFetch(`${baseUrl}/api/v1/mc/players`, {
+				signal,
+				label: 'mc:players',
+			});
+			if (!res.ok) throw dashHttpError(res, 'mc:players');
+			const json = await dashJson<RawMcPlayerList>(res, 'mc:players');
 			return mapPlayerList(json);
 		},
 	});

--- a/packages/npm/rn/src/dash/mc/rconExec.ts
+++ b/packages/npm/rn/src/dash/mc/rconExec.ts
@@ -1,3 +1,5 @@
+import { dashFetch } from '../dashFetch';
+
 export interface RconExecRequest {
 	command: string;
 	args?: string[];
@@ -31,7 +33,7 @@ export function createRconExec(opts: {
 		const token = await getToken().catch(() => null);
 		if (!token) return FAIL('Not signed in');
 		try {
-			const res = await fetch(
+			const res = await dashFetch(
 				`${baseUrl}/api/v1/rcon/mc/${encodeURIComponent(server)}/exec`,
 				{
 					method: 'POST',
@@ -40,6 +42,7 @@ export function createRconExec(opts: {
 						Authorization: `Bearer ${token}`,
 					},
 					body: JSON.stringify(body),
+					label: 'mc:rcon',
 				},
 			);
 			const text = await res.text();


### PR DESCRIPTION
## Summary
Motivated by `/dashboard/storage/` showing the bare WebKit message **'The string did not match the expected pattern'** with no way to tell which call threw it. The dash kit surfaced only `e.message` — no URL, no status, no error name, no console trace.

- **New `dashFetch` / `dashJson` / `dashHttpError`** helpers (`packages/npm/rn/src/dash/dashFetch.ts`): network failures become `label (METHOD /path) failed: ErrorName: message`, JSON parse failures get URL context (catches HTML-instead-of-JSON upstream pages), HTTP errors become `label → HTTP 403 Forbidden — Access restricted`. Full error object always logged via `console.error`. AbortError passes through untouched.
- **Swept all 26 fetch call sites across 16 files**: adapters (argo ×8, edge, vm ×2, forgejo, kilobase ×2, longhorn, rows, grafana, deployment, factorio), clickhouse streams, cube API, mc stream + rcon, clusterHealth. Special-case status handling (403/502/503 hints) preserved, now with URL+status attached.
- **createStreamSource**: prefixes non-generic error names into the surfaced message, `console.error`s fetch/action failures with the raw object, and `console.warn`s fetchMeta failures instead of swallowing them silently.
- **DashErrorBoundary**: StreamView now wraps its render — a lens crash shows name+message inline instead of blanking the island, with the component stack in console.

Once deployed, the storage-page error will name its exact call site.

## Testing
- 107 vitest cases pass (7 new for dashFetch, incl. the exact Safari SyntaxError wrap case; 1 rcon assertion updated to the richer message).
- `tsc --noEmit` clean on the rn package.