### PR TITLE
fix(kbve): adjusting the graph for zoom levels

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -549,7 +549,7 @@
 		{
 			"key": "reel",
 			"app_name": "reel",
-			"version": "0.1.36",
+			"version": "0.1.37",
 			"version_toml": "apps/media/reel/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/reel.mdx",
 			"version_target": "apps/media/reel/Cargo.toml",

--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -344,6 +344,19 @@
 			"has_test": true
 		},
 		{
+			"key": "herbmail_server",
+			"app_name": "herbmail-server",
+			"version": "0.0.1",
+			"version_toml": "apps/agones/herbmail/server/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/herbmail-server.mdx",
+			"version_target": "apps/agones/herbmail/server/Cargo.toml",
+			"source_path": "apps/agones/herbmail/server",
+			"runner": "arc-runner-set",
+			"image": "kbve/herbmail-server",
+			"deployment_yaml": "apps/kube/agones/herbmail/manifests/fleet.yaml",
+			"has_test": false
+		},
+		{
 			"key": "iot_edge_worker",
 			"app_name": "iot-edge-worker",
 			"version": "0.0.1",
@@ -1418,7 +1431,7 @@
 		}
 	],
 	"summary": {
-		"docker": 40,
+		"docker": 41,
 		"npm": 4,
 		"crates": 27,
 		"python": 2,
@@ -1429,6 +1442,6 @@
 		"unreal_game": 4,
 		"bevy_game": 0,
 		"vite_game": 1,
-		"total": 107
+		"total": 108
 	}
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
  "glam_matrix_extras",
  "itertools 0.15.0",
  "obvhs",
- "parry3d",
+ "parry3d 0.27.0",
  "parry3d-f64",
  "serde",
  "smallvec",
@@ -8228,6 +8228,159 @@ dependencies = [
 
 [[package]]
 name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
@@ -8885,6 +9038,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "herbmail-server"
 version = "0.0.1"
+dependencies = [
+ "agones",
+ "async-trait",
+ "axum 0.8.9",
+ "bevy",
+ "jedi",
+ "simbody3d",
+ "simgrid",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -12246,7 +12411,41 @@ checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
+ "nalgebra-macros 0.2.2",
+ "num-complex 0.4.6",
+ "num-rational 0.4.2",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros 0.3.0",
  "num-complex 0.4.6",
  "num-rational 0.4.2",
  "num-traits",
@@ -12259,6 +12458,17 @@ name = "nalgebra-macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13558,7 +13768,7 @@ dependencies = [
  "either",
  "ena",
  "log",
- "nalgebra",
+ "nalgebra 0.33.3",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -13568,6 +13778,35 @@ dependencies = [
  "smallvec",
  "spade",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "parry3d"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99471b7b6870f7fe406d5611dd4b4c9b07aa3e5436b1d27e1515f9832bb0c6b"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.13.1",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "log",
+ "nalgebra 0.34.2",
+ "num-derive",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rstar",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "static_assertions",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -14492,6 +14731,19 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "proptest"
@@ -15080,7 +15332,7 @@ dependencies = [
  "crossbeam",
  "downcast-rs 1.2.1",
  "log",
- "nalgebra",
+ "nalgebra 0.33.3",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -15088,6 +15340,31 @@ dependencies = [
  "rustc-hash 2.1.3",
  "simba",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rapier3d"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd27b8eb36d0833fa0f2aea40164fabfad0fc34b9932286ae9e84f3452f5364"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "downcast-rs 2.0.2",
+ "log",
+ "nalgebra 0.34.2",
+ "num-derive",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "parry3d 0.25.3",
+ "profiling",
+ "rustc-hash 2.1.3",
+ "simba",
+ "static_assertions",
+ "thiserror 2.0.19",
+ "wide",
 ]
 
 [[package]]
@@ -16845,10 +17122,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
+ "libm",
  "num-complex 0.4.6",
  "num-traits",
  "paste",
  "wide",
+]
+
+[[package]]
+name = "simbody3d"
+version = "0.0.1"
+dependencies = [
+ "rapier3d",
 ]
 
 [[package]]

--- a/apps/agones/herbmail/server/Cargo.toml
+++ b/apps/agones/herbmail/server/Cargo.toml
@@ -11,4 +11,18 @@ description = "Herbmail game server — authoritative sim for the herbmail dunge
 name = "herbmail_server"
 path = "src/lib.rs"
 
+[[bin]]
+name = "herbmail-server"
+path = "src/main.rs"
+
 [dependencies]
+simgrid = { path = "../../../../packages/rust/simgrid" }
+simbody3d = { path = "../../../../packages/rust/simbody3d" }
+jedi = { path = "../../../../packages/rust/jedi" }
+async-trait = { workspace = true }
+bevy = { workspace = true, features = ["bevy_state"] }
+axum = { workspace = true, features = ["ws", "json", "http1", "tokio"] }
+tokio = { workspace = true, features = ["default", "rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["default", "env-filter", "fmt"] }
+agones = { workspace = true }

--- a/apps/agones/herbmail/server/Cargo.workspace.toml
+++ b/apps/agones/herbmail/server/Cargo.workspace.toml
@@ -1,67 +1,9 @@
-
 [workspace]
-resolver = '2'
+resolver = "2"
 members = [
-	'packages/rust/embeddb',
-	'packages/rust/embeddb-derive',
-	'packages/rust/kbve',
-	'packages/rust/erust',
-	'packages/rust/holy',
-	'packages/rust/jedi',
-	'apps/kbve/kilobase',
-	'packages/rust/q',
-'apps/herbmail/axum-herbmail',
-	'apps/memes/axum-memes',
-	'apps/irc/irc-gateway',
-	'apps/discordsh/axum-discordsh',
-	'apps/discordsh/discordsh-bot',
-	'apps/kbve/axum-kbve',
-	'apps/kbve/kbve-gate',
-	'apps/chuckrpg/axum-chuckrpg',
-	'apps/rentearth/axum-rentearth',
-	'apps/rareicon/axum-rareicon',
-	'apps/cryptothrone/axum-cryptothrone',
-	'apps/rows',
-	'apps/jobboard',
-	'apps/metrics',
-	'apps/kbve/isometric/src-tauri',
-	'packages/rust/bevy/bevy_inventory',
-	'packages/rust/bevy/bevy_statemachine',
-	'packages/rust/bevy/bevy_player',
-	'packages/rust/bevy/bevy_cam',
-	'packages/rust/bevy/bevy_kbve_net',
-	'packages/rust/bevy/bevy_items',
-	'packages/rust/bevy/bevy_spells',
-	'packages/rust/bevy/bevy_npc',
-	'packages/rust/bevy/bevy_mapdb',
-	'packages/rust/bevy/bevy_quests',
-	'packages/rust/bevy/bevy_battle',
-	'packages/rust/bevy/bevy_skills',
-	'packages/rust/bevy/bevy_tasker',
-	'packages/rust/bevy/bevy_db',
-	'packages/rust/bevy/bevy_supa',
-	'packages/rust/bevy/bevy_pathfinder',
-	'packages/rust/bevy/bevy_behavior',
-	'apps/vm/firecracker-ctl',
-	'apps/vm/factorio-ctl',
-	'apps/vm/kubectl',
-	'apps/mc/behavior_statetree',
-	'apps/mc/mc_auth',
-	'packages/rust/bevy/uniti',
-	'apps/agones/factorio/relay',
-	'apps/agones/palworld/relay',
-	'packages/rust/simgrid',
-	'packages/rust/simbody3d',
-	'apps/agones/cryptothrone/server',
-	'apps/agones/arpg/server',
-	'apps/agones/herbmail/server',
-	'packages/rust/kbve_wgpu',
-	'apps/media/reel',
-]
-
-exclude = [
-	'packages/rust/bevy/uniti/fuzz',
-	'apps/kbve/desktop-kbve/src-tauri',
+    "apps/agones/herbmail/server",
+    "packages/rust/simgrid",
+    "packages/rust/simbody3d",
 ]
 
 [workspace.package]
@@ -150,12 +92,9 @@ web-sys = "0.3"
 webpki-roots = "0.26"
 wgpu = "29"
 
-[profile.dev]
-opt-level = 1
-
 [profile.release]
 opt-level = 3
 lto = true
 strip = true
 codegen-units = 1
-panic = 'abort'
+panic = "abort"

--- a/apps/agones/herbmail/server/Dockerfile
+++ b/apps/agones/herbmail/server/Dockerfile
@@ -1,0 +1,92 @@
+# ============================================================================
+# herbmail-server — Herbmail game server (axum + tokio + simgrid)
+# ============================================================================
+
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+ENV CARGO_INCREMENTAL=0
+
+COPY apps/agones/herbmail/server/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+COPY apps/agones/herbmail/server/Cargo.toml apps/agones/herbmail/server/Cargo.toml
+COPY packages/rust/simgrid/Cargo.toml packages/rust/simgrid/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/simbody3d/Cargo.toml packages/rust/simbody3d/Cargo.toml
+
+RUN mkdir -p apps/agones/herbmail/server/src && \
+    echo "fn main() {}" > apps/agones/herbmail/server/src/main.rs && \
+    echo "" > apps/agones/herbmail/server/src/lib.rs && \
+    mkdir -p packages/rust/simgrid/src && \
+    echo "" > packages/rust/simgrid/src/lib.rs && \
+    mkdir -p packages/rust/jedi/src && \
+    echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/simbody3d/src && \
+    echo "" > packages/rust/simbody3d/src/lib.rs
+
+RUN cargo chef prepare --recipe-path recipe.json --bin herbmail-server
+
+# ============================================================================
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    --mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false \
+    if [ -n "${SCCACHE_REDIS_PASSWORD:-}" ]; then \
+        export SCCACHE_REDIS_ENDPOINT=tcp://valkey.valkey.svc.cluster.local:6379 \
+            SCCACHE_REDIS_USERNAME=default \
+            SCCACHE_REDIS_KEY_PREFIX=herbmail-server; \
+        echo "sccache: Redis backend enabled"; \
+    else \
+        echo "sccache: Redis password not provided, falling back to local disk cache"; \
+    fi && \
+    cargo chef cook --release --recipe-path recipe.json -p herbmail-server && \
+    (sccache --show-stats || true)
+
+# ============================================================================
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder
+ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY apps/agones/herbmail/server/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+COPY packages/rust/simgrid packages/rust/simgrid
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/simbody3d packages/rust/simbody3d
+COPY apps/agones/herbmail/server apps/agones/herbmail/server
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    --mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false \
+    if [ -n "${SCCACHE_REDIS_PASSWORD:-}" ]; then \
+        export SCCACHE_REDIS_ENDPOINT=tcp://valkey.valkey.svc.cluster.local:6379 \
+            SCCACHE_REDIS_USERNAME=default \
+            SCCACHE_REDIS_KEY_PREFIX=herbmail-server; \
+    fi && \
+    cargo build --release -p herbmail-server --bin herbmail-server && \
+    (sccache --show-stats || true) && \
+    strip target/release/herbmail-server
+
+# ============================================================================
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
+
+COPY --from=builder --chown=10001:10001 /app/target/release/herbmail-server /app/herbmail-server
+
+ENV HM_SERVER_ADDR=0.0.0.0:7979
+ENV RUST_LOG=info,herbmail_server=debug
+
+EXPOSE 7979
+
+ENTRYPOINT ["/app/herbmail-server"]

--- a/apps/agones/herbmail/server/e2e/boot.spec.ts
+++ b/apps/agones/herbmail/server/e2e/boot.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { dockerLogs, dockerRunning } from './helpers/docker';
+
+const host = process.env.HM_HOST ?? '127.0.0.1';
+const port = process.env.HM_PORT ?? '7979';
+
+describe('herbmail-server boot smoke', () => {
+	it('container is still running', () => {
+		expect(dockerRunning()).toBe(true);
+	});
+
+	it('healthz returns ok', () => {
+		const out = execSync(`curl -fsS http://${host}:${port}/healthz`, {
+			encoding: 'utf8',
+		}).trim();
+		expect(out).toBe('ok');
+	});
+
+	it('admits guests when no Supabase JWKS is configured', () => {
+		expect(dockerLogs()).toContain('guests only (no JWKS configured)');
+	});
+
+	it('reports that collision is not yet authoritative', () => {
+		expect(dockerLogs()).toContain('authoritative_collision=false');
+	});
+});

--- a/apps/agones/herbmail/server/e2e/helpers/docker.ts
+++ b/apps/agones/herbmail/server/e2e/helpers/docker.ts
@@ -1,0 +1,22 @@
+import { execSync } from 'child_process';
+
+const CONTAINER = process.env.HM_CONTAINER ?? 'herbmail-server-e2e';
+
+export function dockerLogs(container = CONTAINER): string {
+	return execSync(`docker logs ${container} 2>&1`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}
+
+export function dockerRunning(container = CONTAINER): boolean {
+	try {
+		const out = execSync(
+			`docker inspect -f '{{.State.Running}}' ${container}`,
+			{ encoding: 'utf8' },
+		).trim();
+		return out === 'true';
+	} catch {
+		return false;
+	}
+}

--- a/apps/agones/herbmail/server/project.json
+++ b/apps/agones/herbmail/server/project.json
@@ -1,0 +1,94 @@
+{
+	"name": "herbmail-server",
+	"$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/agones/herbmail/server/src",
+	"tags": ["rust", "game-server", "agones", "herbmail"],
+	"targets": {
+		"build": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo build -p herbmail-server"
+			},
+			"outputs": ["{workspaceRoot}/dist/target/debug/herbmail-server"]
+		},
+		"build-release": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo build --release -p herbmail-server"
+			},
+			"outputs": ["{workspaceRoot}/dist/target/release/herbmail-server"]
+		},
+		"run": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo run -p herbmail-server"
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo test -p herbmail-server"
+			}
+		},
+		"lint": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo clippy -p herbmail-server --all-targets -- -D warnings"
+			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["herbmail-server"],
+					"params": "forward"
+				}
+			],
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f herbmail-server-e2e 2>/dev/null || true",
+					"docker run -d --name herbmail-server-e2e -p 7979:7979 -e HM_SERVER_ADDR=0.0.0.0:7979 kbve/herbmail-server:latest",
+					"echo 'Waiting for herbmail-server...' && for i in $(seq 1 60); do if curl -fsS http://127.0.0.1:7979/healthz >/dev/null 2>&1; then echo 'ready after '\"$i\"'s'; break; fi; if [ $i -eq 60 ]; then echo 'did not start in 60s'; docker logs herbmail-server-e2e 2>&1 | tail -80; docker rm -f herbmail-server-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
+					"HM_HOST=127.0.0.1 HM_PORT=7979 npx vitest run; EC=$?; echo '--- container logs ---'; docker logs herbmail-server-e2e 2>&1 | tail -80; docker rm -f herbmail-server-e2e 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/agones/herbmail/server"
+			},
+			"configurations": {
+				"ci": {}
+			}
+		},
+		"container": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/agones/herbmail/server/Dockerfile",
+				"load": true,
+				"tags": ["kbve/herbmail-server:latest"]
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/herbmail-server:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/herbmail-server:latest"],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/herbmail-server:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/herbmail-server:buildcache,mode=max"
+					]
+				}
+			}
+		}
+	}
+}

--- a/apps/agones/herbmail/server/src/agones.rs
+++ b/apps/agones/herbmail/server/src/agones.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{error, info, warn};
+
+const HEALTH_PING_INTERVAL: Duration = Duration::from_secs(2);
+
+pub async fn run_health_loop() {
+    let mut sdk = match agones::Sdk::new(None, None).await {
+        Ok(sdk) => {
+            info!("[herbmail-server/agones] Connected to Agones SDK sidecar");
+            sdk
+        }
+        Err(e) => {
+            warn!(error = %e, "[herbmail-server/agones] Agones SDK unavailable — running outside Agones (local dev?)");
+            return;
+        }
+    };
+
+    if let Err(e) = sdk.ready().await {
+        error!(error = %e, "[herbmail-server/agones] Failed to mark gameserver Ready");
+        return;
+    }
+    info!("[herbmail-server/agones] GameServer marked Ready");
+
+    let health_tx = sdk.health_check();
+    let mut ticker = interval(HEALTH_PING_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        if health_tx.send(()).await.is_err() {
+            error!("[herbmail-server/agones] Health channel closed — sidecar gone");
+            return;
+        }
+    }
+}
+
+pub async fn shutdown() {
+    let mut sdk = match agones::Sdk::new(None, None).await {
+        Ok(sdk) => sdk,
+        Err(e) => {
+            warn!(error = %e, "[herbmail-server/agones] Skipping graceful Shutdown — SDK unreachable");
+            return;
+        }
+    };
+    if let Err(e) = sdk.shutdown().await {
+        warn!(error = %e, "[herbmail-server/agones] Shutdown call failed");
+    } else {
+        info!("[herbmail-server/agones] Shutdown signal sent to Agones");
+    }
+}

--- a/apps/agones/herbmail/server/src/auth.rs
+++ b/apps/agones/herbmail/server/src/auth.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use simgrid::auth::{TokenVerifier, VerifiedUser};
+
+pub const GUEST_PREFIX: &str = "guest-";
+
+/// Accepts Supabase tokens (HS256 + ES256/JWKS) and, when guests are enabled,
+/// mints a server-owned identity for an empty token.
+pub struct HerbmailVerifier {
+    inner: Option<jedi::jwks::JwtVerifier>,
+    allow_guests: bool,
+    next_guest: AtomicU64,
+}
+
+#[async_trait::async_trait]
+impl TokenVerifier for HerbmailVerifier {
+    async fn verify(&self, token: &str) -> Result<VerifiedUser, String> {
+        if token.is_empty() {
+            if !self.allow_guests {
+                return Err("missing session token".into());
+            }
+            let n = self.next_guest.fetch_add(1, Ordering::Relaxed);
+            return Ok(VerifiedUser {
+                sub: String::new(),
+                kbve_username: format!("{GUEST_PREFIX}{n:04}"),
+            });
+        }
+        let Some(inner) = &self.inner else {
+            return Err("no token verifier configured".into());
+        };
+        let claims: simgrid::auth::SupabaseClaims =
+            inner.verify(token).map_err(|e| e.to_string())?;
+        if claims.kbve_username.is_empty() {
+            return Err("token missing kbve_username".into());
+        }
+        if claims.kbve_username.starts_with(GUEST_PREFIX) {
+            return Err("account name may not use the guest prefix".into());
+        }
+        Ok(VerifiedUser {
+            sub: claims.sub,
+            kbve_username: claims.kbve_username,
+        })
+    }
+}
+
+#[cfg(test)]
+impl HerbmailVerifier {
+    fn guests_only() -> Self {
+        Self {
+            inner: None,
+            allow_guests: true,
+            next_guest: AtomicU64::new(1),
+        }
+    }
+
+    fn accounts_only() -> Self {
+        Self {
+            inner: None,
+            allow_guests: false,
+            next_guest: AtomicU64::new(1),
+        }
+    }
+}
+
+pub fn guests_enabled() -> bool {
+    std::env::var("HM_ALLOW_GUESTS")
+        .map(|v| !matches!(v.trim(), "0" | "false" | "off"))
+        .unwrap_or(true)
+}
+
+pub async fn build(allow_guests: bool) -> (Option<Arc<dyn TokenVerifier>>, &'static str) {
+    let jwks_uri = std::env::var("SUPABASE_JWKS_URI")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("SUPABASE_URL").ok().and_then(|u| {
+                let u = u.trim().trim_end_matches('/');
+                (!u.is_empty()).then(|| format!("{u}/auth/v1/.well-known/jwks.json"))
+            })
+        });
+
+    let inner = match jwks_uri {
+        Some(uri) => {
+            let secret = std::env::var("SUPABASE_JWT_SECRET")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let issuer = std::env::var("SUPABASE_JWT_ISSUER")
+                .ok()
+                .filter(|s| !s.trim().is_empty());
+            let v = jedi::jwks::JwtVerifier::new(
+                uri,
+                secret.as_deref().map(str::as_bytes),
+                issuer,
+                None,
+            );
+            v.start(std::time::Duration::from_secs(300)).await;
+            Some(v)
+        }
+        None => None,
+    };
+
+    let mode = match (inner.is_some(), allow_guests) {
+        (true, true) => "supabase accept-both + guests",
+        (true, false) => "supabase accept-both, accounts only",
+        (false, true) => "guests only (no JWKS configured)",
+        (false, false) => "dev-accept (no JWKS, guests disabled)",
+    };
+
+    if inner.is_none() && !allow_guests {
+        return (None, mode);
+    }
+
+    let verifier: Arc<dyn TokenVerifier> = Arc::new(HerbmailVerifier {
+        inner,
+        allow_guests,
+        next_guest: AtomicU64::new(1),
+    });
+    (Some(verifier), mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mints_a_distinct_guest_per_empty_token() {
+        let v = HerbmailVerifier::guests_only();
+        let a = v.verify("").await.expect("guest admitted");
+        let b = v.verify("").await.expect("guest admitted");
+        assert!(a.kbve_username.starts_with(GUEST_PREFIX));
+        assert!(b.kbve_username.starts_with(GUEST_PREFIX));
+        assert_ne!(a.kbve_username, b.kbve_username);
+    }
+
+    #[tokio::test]
+    async fn guest_identity_is_server_owned_not_client_supplied() {
+        let v = HerbmailVerifier::guests_only();
+        let user = v.verify("").await.expect("guest admitted");
+        assert!(user.sub.is_empty());
+        assert_eq!(user.kbve_username, format!("{GUEST_PREFIX}0001"));
+    }
+
+    #[tokio::test]
+    async fn rejects_an_empty_token_when_guests_are_disabled() {
+        let v = HerbmailVerifier::accounts_only();
+        assert!(v.verify("").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_real_token_when_no_verifier_is_configured() {
+        let v = HerbmailVerifier::guests_only();
+        assert!(v.verify("a.b.c").await.is_err());
+    }
+}

--- a/apps/agones/herbmail/server/src/game.rs
+++ b/apps/agones/herbmail/server/src/game.rs
@@ -1,0 +1,65 @@
+use simbody3d::{PhysicsWorld, SimbodyConfig, presets};
+use simgrid::proto::Tile;
+use simgrid::{KindRegistry, SimConfig, WalkableMap};
+
+pub const SECTOR: i32 = 8;
+pub const CELL: i32 = 6;
+pub const SECTOR_TILES: i32 = SECTOR * CELL;
+pub const DUNGEON_SEED: u64 = 1337;
+
+pub const MAX_PLAYERS: usize = 32;
+pub const PLAYER_HP: i32 = 100;
+pub const PLAYER_ATTACK: i32 = 5;
+pub const PLAYER_TICKS_PER_TILE: u8 = 3;
+pub const PLAYER_SPAWN: Tile = Tile::new(2, 2);
+pub const PLAYER_SAFE_RADIUS: i32 = 8;
+
+pub const PLAYER_REF: &str = "player";
+
+/// Bound on the mounted 3x3 sector ring, which is what the client streams.
+pub const MAP_SPAN_TILES: i32 = SECTOR_TILES * 3;
+
+pub fn registry() -> KindRegistry {
+    let mut reg = KindRegistry::new();
+    reg.register_npc(PLAYER_REF);
+    reg
+}
+
+pub fn config() -> SimConfig {
+    SimConfig {
+        player_kind: 0,
+        player_hp: PLAYER_HP,
+        player_attack: PLAYER_ATTACK,
+        spawn: PLAYER_SPAWN,
+        ticks_per_tile: PLAYER_TICKS_PER_TILE,
+        safe_radius: PLAYER_SAFE_RADIUS,
+        starting_inventory: Vec::new(),
+        corpse_kind: None,
+    }
+}
+
+/// Fully open until the seed-derived tile grid is ported — the server cannot
+/// reproduce the client's walls yet, so it must not claim to. simgrid's own
+/// grid map stays open; rapier is what will actually arbitrate movement.
+pub fn walkable_map() -> WalkableMap {
+    WalkableMap::open(MAP_SPAN_TILES, MAP_SPAN_TILES)
+}
+
+pub fn collision_is_authoritative() -> bool {
+    false
+}
+
+/// Herbmail's world scale, capsule and tile-bit mapping, declared once in
+/// simbody3d so a future wasm client build reads the same numbers.
+pub fn simbody_config() -> SimbodyConfig {
+    presets::herbmail()
+}
+
+/// The rapier world the server resolves movement against.
+///
+/// Returned empty: `SectorTiles` has to come from the ported tile-grid
+/// generator, and mounting anything else would put the server in a different
+/// dungeon than the client.
+pub fn physics_world() -> PhysicsWorld {
+    PhysicsWorld::new(simbody_config())
+}

--- a/apps/agones/herbmail/server/src/main.rs
+++ b/apps/agones/herbmail/server/src/main.rs
@@ -1,0 +1,114 @@
+mod agones;
+mod auth;
+mod game;
+
+use std::net::SocketAddr;
+
+use simgrid::net::ServerState;
+use simgrid::proto::ServerEvent;
+use simgrid::{build_app, run_sim_loop};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,herbmail_server=debug,simgrid=debug".into()),
+        )
+        .init();
+
+    let addr: SocketAddr = std::env::var("HM_SERVER_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:7979".into())
+        .parse()?;
+
+    let seed: u64 = std::env::var("HM_SERVER_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(game::DUNGEON_SEED);
+
+    let (out_tx, out_rx) = mpsc::unbounded_channel::<ServerEvent>();
+    let (input_tx, input_rx) = mpsc::unbounded_channel::<simgrid::SlotInput>();
+
+    let allow_guests = auth::guests_enabled();
+    let (verifier, auth_mode) = auth::build(allow_guests).await;
+
+    let registry = game::registry();
+    let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
+        .unwrap_or_default()
+        .into_bytes();
+
+    let state = ServerState::new(input_tx, seed, jwt_secret, true, game::MAX_PLAYERS)
+        .with_registry(registry.entries());
+    let state = match verifier {
+        Some(v) => state.with_verifier(v),
+        None => state,
+    };
+    let roster = state.roster.clone();
+    state.spawn_event_router(out_rx);
+
+    let config = game::config();
+    let map = game::walkable_map();
+    let physics = game::physics_world();
+
+    let sim_handle = tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("sim runtime");
+        let app = build_app(out_tx, input_rx, roster, seed, config, map, registry);
+        rt.block_on(run_sim_loop(app));
+    });
+
+    let router = simgrid::router(state);
+
+    tracing::info!(
+        %addr,
+        %seed,
+        auth = %auth_mode,
+        max_players = game::MAX_PLAYERS,
+        authoritative_collision = game::collision_is_authoritative(),
+        physics_colliders = physics.collider_count(),
+        "herbmail-server listening"
+    );
+
+    let listener = TcpListener::bind(addr).await?;
+    let agones_handle = tokio::spawn(agones::run_health_loop());
+
+    let serve = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal());
+
+    if let Err(e) = serve.await {
+        tracing::error!("serve error: {e}");
+    }
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), agones::shutdown()).await;
+    agones_handle.abort();
+    drop(sim_handle);
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        if let Ok(mut s) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            s.recv().await;
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+
+    tracing::info!("shutdown signal received");
+}

--- a/apps/agones/herbmail/server/version.toml
+++ b/apps/agones/herbmail/server/version.toml
@@ -1,0 +1,2 @@
+version = "0.0.1"
+publish = false

--- a/apps/agones/herbmail/server/vitest.config.ts
+++ b/apps/agones/herbmail/server/vitest.config.ts
@@ -1,0 +1,8 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 240_000,
+		fileParallelism: false,
+	},
+};

--- a/apps/herbmail/herbmail-game/server/DESIGN.md
+++ b/apps/herbmail/herbmail-game/server/DESIGN.md
@@ -1,0 +1,567 @@
+# herbmail-game — Authoritative Server Design
+
+Status: design proposal, nothing implemented.
+Author: research pass over `packages/rust/simgrid`, `apps/agones/{cryptothrone,arpg}/server`, `apps/herbmail/*`, `packages/data/codegen`, `packages/npm/laser`.
+
+---
+
+## 1. Executive summary
+
+**Verdict: depend on `simgrid`. Do not fork it. Do not run rapier on the server.**
+
+`packages/rust/simgrid` is already a game-agnostic, headless, grid-authoritative multiplayer core — bevy ECS sim loop, axum WebSocket + UDP transport, postcard wire, Supabase JWT admission, AOI interest management, client-prediction reconciliation, seed-derived endless dungeons, and persistence sinks. Two games already consume it as a library through a thin per-game adapter (`apps/agones/cryptothrone/server`, `apps/agones/arpg/server`). herbmail should be the third.
+
+The recommended architecture is a new binary crate, `herbmail-server`, that:
+
+- takes `simgrid` as a path dependency and hosts it exactly like `arpg-server` does (`build_app` + `run_sim_loop` on a blocking thread, `simgrid::router(state)` on axum, Agones health loop alongside);
+- supplies a herbmail-specific adapter module: `KindRegistry`, `SimConfig`, and a `WalkableMap` whose collision is a **Rust port of `dungeon/generate.ts` + `dungeon/sector.ts` + `dungeon/collision.ts`**, so only the seed crosses the wire;
+- ~~ships its own ~200-line `motor.rs` (a 1:1 port of `character/CharacterMotor.ts` + `collision.ts::makeMover`)~~ **superseded — see §5:** links `packages/rust/simbody3d`, which runs rapier3d's character controller against colliders built from the tile grid. `simgrid::float_move` is still not reused, for the reasons in §5, but nothing is transliterated either;
+- consumes the same `packages/data/codegen/generated/*-data.json` the client consumes, via `include_bytes!`, exactly as `cryptothrone-server` already does.
+
+On the browser side the client work is largely **already available**: `@kbve/laser` exports `GameClient`, `ReconnectingSocket`, the full postcard wire codec, the protocol types, and `mulberry32`/`mix32`/`rollPct` determinism mirrors — and `herbmail-game` already depends on `@kbve/laser`.
+
+### Three corrections to the brief, stated up front
+
+1. **`simgrid` does not use rapier.** Its own `Cargo.toml` description says so verbatim: *"No godot, no rapier, no lightyear."* There is no rapier dependency anywhere in it. Collision is tile occupancy; movement is float bodies with sub-stepped axis-separated resolution (`packages/rust/simgrid/src/float_move.rs`). The only rapier in the Rust workspace is `packages/rust/q` (rapier**2d**, optional feature, unrelated to this stack).
+
+2. **rapier already exists in the herbmail client, and it is cosmetic.** `apps/herbmail/herbmail-game/src/game/sab/sim.worker.ts` runs `@dimforge/rapier3d-compat`, but the player is a `RigidBodyDesc.kinematicPositionBased()` proxy driven from the main thread — rapier decides nothing about the player. Its only dynamic bodies are the six break-off panels spawned by `shatter()` (`BODY_PANEL`, `F_BREAKABLE`, `PANEL_TTL = 8`, `PANEL_FADE = 1.2`). It is a debris VFX sim. Replicating it server-side would buy nothing.
+
+3. **"MMORPG" and what this stack delivers are different things.** Both existing simgrid games run as a *single pod, single world* — `minReplicas: maxReplicas: 1` with `MAX_PLAYERS: 32`, because "a Service round-robins; multiple Ready pods would split players across separate worlds" (`apps/kube/agones/cryptothrone/README.md`). There is no sharding, no cross-server handoff and no zone service anywhere in this repo. This design gets herbmail to a solid 32-player shared world on well-trodden rails; going beyond that is an unsolved problem here and should be scoped separately.
+
+4. **`apps/herbmail/axum-herbmail` is a static file server.** Its routes are `/health`, `/_astro/{*path}`, `/`, and MIME overrides so `.ts` worker files are served as JS (`src/transport/https.rs`). No DB, no auth, no WebSocket handler, no game state. It should be left alone; the game server goes **beside** it, not inside it.
+
+### Recommended first milestone
+
+Two browser clients, authenticated with Supabase JWTs, connected to `herbmail-server` over WebSocket, seeing each other's nameplate + capsule move around **sector (0,0)** — with the sector's geometry derived independently on both sides from `DUNGEON_SEED = 1337`, and nothing but positions on the wire. Everything else (props, mining, combat, doors, goblins) stays exactly as it is, client-local, until later milestones.
+
+---
+
+## 2. What already exists (inventory of prior art)
+
+### 2.1 `packages/rust/simgrid` — 18,966 lines, 21 modules
+
+`packages/rust/simgrid/Cargo.toml` / `README.md`:
+
+> Headless grid-authoritative multiplayer sim core for KBVE games. bevy ECS (headless) + axum WebSocket transport + postcard wire format + Supabase HS256 JWT admission. No godot, no rapier, no lightyear — collision is tile occupancy, "physics" is integer grid math.
+
+The README's own layout note is out of date (`build_app` now takes a `KindRegistry`, and `ServerState::new` takes an input sender, not a snapshot broadcaster) — read `apps/agones/cryptothrone/server/src/main.rs` as the live reference instead.
+
+Modules relevant to herbmail:
+
+| Module | Lines | What it gives herbmail |
+| --- | --- | --- |
+| `proto.rs` | 1932 | `PROTOCOL_VERSION: u32 = 16`, `ClientMessage`, `Input`, `ServerEvent`, `Snapshot`, `EntityDelta`, COBS-framed postcard encode/decode, `UdpPacket` |
+| `sim.rs` | 6604 | `build_app`, `run_sim_loop`, `SIM_TICK_HZ = 20`, `SimSet` ordering, `Health`/`Inventory`/`Loot`/`XpState`/`Equipped`/`EnvObject`, persistence sinks |
+| `net.rs` | 869 | axum `/ws` + `/healthz` router, per-connection session loop, `Roster`, **AOI snapshot routing** |
+| `net_udp.rs` | 405 | `UdpLane` — token-authenticated UDP fastlane with automatic WS fallback |
+| `float_move.rs` | 395 | `FloatBody`, `step_float`, `step_steer`, sub-stepped axis-separated tile collision |
+| `arpg_dungeon.rs` | 414 | Endless chunk-streamed multi-floor dungeon, collision as a pure `is_floor(seed, x, y)` |
+| `dungeon.rs` | 333 | Bounded rooms+corridors generator, semantic `role` grid, `role_blocks` |
+| `grid.rs` | 627 | `WalkableMap` (bitset **or** pure-function collision + dynamic `blocked` overlay), `Floor`, `Stairs`, `StairGrace` |
+| `rng.rs` | 123 | `Mulberry32`, `mix32`, `stream`, `roll_pct`, domain tags incl. `LOOT` / `DUNGEON` — **byte-mirrored in TS** |
+| `data.rs` | 351 | `ItemDb`, `NpcDb`, `KindRegistry` loaded from codegen JSON |
+| `auth.rs` | 93 | Supabase JWT verification, trusts the `kbve_username` claim |
+
+**Is it game-agnostic?** Yes, demonstrably. `sim.rs` comments call the sim "content-agnostic"; `SimConfig` has a `corpse_kind: Option<u16>` field explicitly because "the sim is content-agnostic". Two very different games already ride it:
+
+- `cryptothrone-server` — bounded 50×50 Tiled map, town + casino + shops, `WalkableMap::from_blocked`.
+- `arpg-server` — endless seeded multi-floor dungeon, `WalkableMap::arpg_dungeon(DUNGEON_SEED, PATH_WINDOW)`, plus ~200KB of game-specific systems (`duel.rs`, `pets`, `creatures.rs`, `pilot.rs`) layered on top via `app.add_systems(...)`.
+
+`arpg-server` is the closer analogue to herbmail and proves the shape works for a seed-derived endless world.
+
+### 2.2 The extension seam
+
+`packages/rust/simgrid/src/sim.rs:1505`:
+
+```rust
+pub fn build_app(
+    tx: mpsc::UnboundedSender<ServerEvent>,
+    input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
+    roster: Arc<RwLock<Roster>>,
+    seed: u64,
+    config: SimConfig,
+    map: WalkableMap,
+    registry: KindRegistry,
+) -> App
+```
+
+There is no `GamePlugin` trait. The seam is that `build_app` returns a plain bevy `App` the host mutates, plus resource injection, plus `PendingX` command queues the host drains in its own systems. `SimSet` is a 7-stage chained pipeline in `Update`:
+
+```rust
+pub enum SimSet { Tick, Spawn, Index, Input, Ai, Movement, Snapshot }
+```
+
+The **one real trait** is `TokenVerifier` (`src/auth.rs:17`), whose doc comment states the design intent exactly:
+
+```rust
+#[async_trait::async_trait]
+pub trait TokenVerifier: Send + Sync {
+    async fn verify(&self, token: &str) -> Result<VerifiedUser, String>;
+}
+```
+
+> The sim is content/infra-agnostic, so a host (the arpg server) injects a verifier — typically the shared jedi GoTrue + LRU cache — without simgrid taking that dependency.
+
+So a game adapter supplies `SimConfig`, `WalkableMap`, `KindRegistry`, a `TokenVerifier`, and extra bevy systems inserted into a `SimSet` — and nothing else. From `apps/agones/cryptothrone/server/src/main.rs`:
+
+```rust
+let mut app = build_app(out_tx, input_rx, roster, seed, config, map, registry);
+app.insert_resource(game::consumables());
+app.insert_resource(game::item_prices());
+app.add_systems(Update, game::spawn_world.in_set(simgrid::SimSet::Spawn));
+rt.block_on(run_sim_loop(app));
+```
+
+That is the whole integration surface. It is small, and it is the reason "fork" is the wrong answer.
+
+### 2.3 Browser-side kit — `@kbve/laser`
+
+`packages/npm/laser/src/index.ts` already exports, from the root barrel:
+
+- `GameClient` (`lib/net/game-client.ts`) — join handshake, COBS/postcard decode, typed event bus (`snapshot`, `welcome`, `combat`, `inventory`, `floor`, `pickup`, `stats`, …), and a `private unackedMoves: MoveSample[]` buffer for reconciliation;
+- `ReconnectingSocket` (`lib/net/connection.ts`);
+- `encodeClientMessage` / `decodeServerEvent` and the full typed protocol mirror (`lib/net/protocol.ts`, `lib/net/postcard-wire.ts`, with `postcard-wire.spec.ts` pinning parity);
+- `Domain`, `mix32`, `mulberry32`, `stream`, `rollPct` (`lib/determ`) — the exact mirrors of `simgrid::rng`.
+
+`apps/herbmail/herbmail-game/vite.config.ts:286-298` already aliases `@kbve/laser/mecs`, `/ecs`, `/phaser`, `/r3f`. Adding the root import costs nothing. Note that `net` lives in the **root** barrel (`@kbve/laser`), not a subpath — consistent with the "peers never in the root barrel" rule, since the net module has no peer deps.
+
+### 2.4 Deployment precedent
+
+`apps/kube/agones/arpg/manifests/`:
+
+- `fleet.yaml` — Agones `Fleet` named `arpg-server`, `portPolicy: None` on both ports (no hostPort; traffic arrives via the Cilium gateway), `containerPort: 7979/TCP` (ws) and `7977/UDP`, health `periodSeconds: 10`, `runAsNonRoot: true`.
+- `fleet-autoscaler.yaml` — `Buffer` policy with **`minReplicas: 1, maxReplicas: 1`**.
+- `game-service.yaml` — plain `ClusterIP` + `sessionAffinity: ClientIP`.
+- `game-httproute.yaml` — Gateway API `HTTPRoute` on `arpg.kbve.com`; `/ws` → `arpg-game:7979` with `backendRequest: 3600s`, everything else → the static vite client.
+- `game-udp-service.yaml` — `LoadBalancer` with `lbipam.cilium.io/ips` + sharing key.
+
+**Important and non-obvious: there is no Agones Allocation step.** The fleet is pinned to exactly one replica and clients reach it through an ordinary Service. Agones is used for lifecycle, health and rolling updates — this is a **single persistent world shard**, not a match-allocated session game. herbmail should copy this exactly.
+
+---
+
+## 3. The herbmail client, as it stands
+
+### 3.1 Determinism from the seed — verified, and stronger than the brief claims
+
+`apps/herbmail/herbmail-game/src/game/dungeon/store.ts:28`:
+
+```ts
+export const DUNGEON_SEED = 1337;
+```
+
+There is **no `Math.random` anywhere in the generation path**. The entire world derives from a stateless integer hash, `src/game/geometry/rng.ts`:
+
+```ts
+export function hashInt(x: number, y: number, z = 0): number {
+	let h = Math.imul(x | 0, 374761393) + Math.imul(y | 0, 668265263) + Math.imul(z | 0, 1274126177);
+	h = Math.imul(h ^ (h >>> 13), 1274126177);
+	return (h ^ (h >>> 16)) >>> 0;
+}
+export function hash01(x, y, z = 0) { return hashInt(x, y, z) / 4294967295; }
+export function jitter(x, y, z, min, max) { return min + hash01(x, y, z) * (max - min); }
+```
+
+`Math.imul` is `i32` wrapping multiply and `>>>` is a logical shift, so this is a trivially exact Rust port (`wrapping_mul` on `i32`, shifts on `u32`). It is a **coordinate hash, not a stream** — which is better than `Mulberry32` for a server: draws are order-independent and can be evaluated for any tile in O(1) without generating anything else.
+
+`genSector(seed, sx, sy)` and `genSectorDesc(seed, sx, sy)` are pure functions of `(seed, sx, sy)` with no global reads and no neighbour generation. Cross-sector agreement is achieved with **symmetric unordered-pair hashes** (`borderPos`, `seamKept`, `edgeOpen`) so two adjacent sectors independently agree on their shared seam. Sectors are memoized lazily by coordinate in `DungeonWorld.ensureSector(sx, sy)` and evicted past `KEEP_ROOMS = 64`; revisiting regenerates an identical sector.
+
+Coordinate scheme (three nested levels):
+
+| Level | Constant | Value | Defined in |
+| --- | --- | --- | --- |
+| tile | `TILE` | 3 world units | `src/game/config.ts` |
+| cell | `CELL` | 6 tiles = 18 units | `src/game/dungeon/generate.ts` |
+| sector | `SECTOR` | 8 cells = 48 tiles = **144 world units** | `src/game/dungeon/sector.ts` |
+
+One caveat for the port: `sector.ts` also wraps `hashInt` in a **counter-based stream**:
+
+```ts
+function makeRng(seed) {
+  let i = 0;
+  const next = () => hashInt(seed | 0, i++, 0x9e3779b9) / 4294967295;
+  return { next, int: (min, max) => min + Math.floor(next() * (max - min + 1)) };
+}
+```
+
+This is draw-order dependent. Any reordering of `rng.next()` calls in `partition` / `carveCorridor` / `applyLocks` changes the map. The Rust port must reproduce the call order exactly. Everything decided by `hash01(x, y, salt)` (torches, columns, oases, doorway widths, decor, stone identity) is order-independent and safe.
+
+**Consequence: the wire carries a `u64` seed and nothing else about geometry.** No tile streaming, no chunk downloads. This is the single biggest asset herbmail brings to a multiplayer port, and it exactly matches how `arpg-server` already operates.
+
+### 3.2 Collision — and why the Y axis does not matter
+
+`src/game/dungeon/collision.ts::solidAtWorld(x, z)` takes **only X and Z**. Consulted in order:
+
+1. `DOORWAY` bit → `doorClosedAt(wc, wr)`, else a jittered opening half-width — the arch's *collision* geometry comes from the same hash as its rendered mesh:
+   ```ts
+   const openHW = jitter(lc, lr, 1 + desc.variant * ARCH_SALT, TILE * 0.28, TILE * 0.38);
+   const lat = ns ? z - (wr + 0.5) * TILE : x - (wc + 0.5) * TILE;
+   return Math.abs(lat) > openHW;
+   ```
+2. `PILLAR` → circle test, `COLUMN_R = 0.55`
+3. `SOLID` → true
+4. prop footprint via `colliderAt(wc, wr)` → AABB from `Collider.hx/hz`
+
+Vertical geometry is `floorYAtWorld(x, z)`, which returns exactly `0` or `-OASIS_DEPTH` depending on the `PIT` bit. That is the entire height model: two discrete planes, a pure function of tile.
+
+**Therefore jumping cannot bypass any wall, and swimming cannot reach anywhere walking cannot.** The Y axis is cosmetic and derivable. This is the finding that closes the rapier question: herbmail's *gameplay* space is already 2.5D, identical in shape to what simgrid models.
+
+`makeMover(radius, self, skipBodies, blockPits)` resolves motion by sub-stepped axis-separated sliding, then actor-vs-actor depenetration against a global `Set<Body>`:
+
+```ts
+const moveAxis = (pos, dx, dz) => {
+  if (dx !== 0 && !blocked(pos.x + dx + Math.sign(dx) * radius, pos.z)) pos.x += dx;
+  if (dz !== 0 && !blocked(pos.x, pos.z + dz + Math.sign(dz) * radius)) pos.z += dz;
+};
+const steps = Math.min(64, Math.max(1, Math.ceil(dist / radius)));
+```
+
+This is structurally the same algorithm as `simgrid::float_move::move_axis_sub`. The differences are enumerated in §5.
+
+### 3.3 Movement integration
+
+`src/game/character/CharacterMotor.ts`:
+
+```ts
+const k = 1 - Math.exp(-this.cfg.accel * dt);
+this.velocity.lerp(this.desired, k);
+```
+
+`simgrid::float_move::accelerate`:
+
+```rust
+let response = 1.0 - exp_decay(rate, dt);
+b.vx += (target_vx - b.vx) * response;
+```
+
+**These are the same equation.** herbmail already uses simgrid's acceleration model. `DEFAULT_MOTOR = { walkSpeed: 1.8, runSpeed: 4.5, accel: 12, turnLerp: 10, gravity: 22, jumpSpeed: 6 }`, body radius `0.35`.
+
+The one real mismatch is timestep: herbmail runs the motor from `useFrame` at variable `dt` clamped to 50 ms (`Character.tsx:681`), in two independent per-frame callbacks. A server sim is fixed at 20 Hz. Converting the client to a fixed-step accumulator for the *motor only* (render interpolation on top) is prerequisite work for prediction — see Milestone 1.
+
+### 3.4 Everywhere the client currently assumes authority
+
+Nothing in `herbmail-game` is persisted — there is no `localStorage`, no `fetch`, no Supabase, no network of any kind in the game bundle. All mutable state is module-global JS, wiped on reload. `src/game/profession/store.ts:3` says it plainly:
+
+> Session-only progression. Deliberately not persisted — profession state is runtime state each game owns, and herbmail has no save layer yet.
+
+The complete list of client-authority sites:
+
+| # | Site | What it decides unilaterally |
+| --- | --- | --- |
+| A | `character/mine.ts::mineHit` | node HP decrement, **loot roll**, **XP grant**, node destruction |
+| B | `profession/store.ts::grantXp` | XP and level-ups; backing store is a bare module-level `Map` |
+| C | `inventory/store.ts::addLoot` | item creation; backing store is `let items: PlacedItem[] = []` |
+| D | `character/useCrateBreak.ts` | crate HP, unconditional `addLoot('wood')` |
+| E | `prop/burn.ts::killByBurn` | DoT ticks and the resulting `addLoot('wood')` |
+| F | `combat/castSystem.ts::applyDamage` | all damage and all kills |
+| G | `combat/castSystem.ts` cone test | hit detection (`reach`/`arc`, no raycast, no server) |
+| H | `character/melee.ts` | crate hits sampled from **render skeleton bone positions** |
+| I | `door/doors.ts::unlockDoor` | door unlock, with **no key check at all** (`SEdge.keyId` is generated but never consulted) |
+| J | `prop/placed.ts` | placed/destroyed props, FIFO-capped at `CAP = 24` / `SUPPRESS_CAP = 4096` |
+| K | `npc/goblinSim.ts` | all NPC position, aggro, and death |
+| L | `npc/spawn.ts::enemyBudget` | enemy population, from **client session history** (`progress.maxDist`) |
+| M | `character/playerStats.ts` | HP/MP/EP/SP pools and regen |
+| N | `character/mine.ts::mineRefusal` | tool + level gating, read from client-only `isHeld()` / `levelOf()` |
+
+Two of these are easy wins because they are already deterministic and coordinate-derived:
+
+- **A's loot roll is a pure function of world tile.** `Stone.seed[eid] = hashInt(worldCol, worldRow, 0x570e)` (`prop/stone.ts`), and the roll is `hash01(seed, 0x10a7 + i * 0x3f, i + 1) >= chance`. A server can recompute the exact drop from `(wc, wr)` with no RNG synchronisation problem whatsoever. Only *whether the node is still there* needs authority.
+- **F/G have no RNG at all.** `Health.hp[t] -= Math.max(1, ability.damage - def)` with a deterministic cone test. Combat is trivially reproducible server-side and trivially predictable client-side.
+
+The genuinely hard one is **K**: `goblinSim.ts` is the only true nondeterminism in the game (`Math.random()` at lines 127, 273-274, 295-296, 300), its runtime state lives in an off-ECS plain JS `Map<eid, NpcRuntime>`, and **L** makes population a function of client session history rather than world coordinates. NPCs must be rewritten, not ported.
+
+`combat/castSystem.ts:26` shows the author already anticipated this:
+
+```ts
+// Input -> sim bridge. Player keydown (and, later, network commands) push here;
+```
+
+That intent queue is the correct seam.
+
+---
+
+## 4. Reuse verdict on simgrid
+
+**Depend, and extend upstream only where the extension is genuinely general.**
+
+Reasoning, concretely:
+
+- **Not "ignore"** — simgrid solves transport, framing, admission, roster, AOI, snapshot/delta, reconciliation, persistence sinks and the Agones host shape. Rebuilding that is months of work that two other games have already paid for and hardened with integration tests (`tests/ws_flow.rs`, `tests/udp_flow.rs`).
+- **Not "fork"** — the integration surface is seven arguments to `build_app` plus `app.add_systems`. `arpg-server` layers ~200KB of game-specific systems on top without touching simgrid. herbmail needs strictly less than that.
+- **"Extend" only for one thing** (see §5): a continuous-coordinate blocked predicate. Even that is better done *locally first* and upstreamed once proven.
+
+### What the herbmail adapter looks like
+
+A new binary crate, structured as a near-copy of `apps/agones/arpg/server`:
+
+```
+herbmail-server/
+  Cargo.toml            # simgrid + jedi + bevy + axum + tokio + agones
+  Cargo.workspace.toml  # slim workspace for the docker chef build
+  Dockerfile            # copy of arpg/cryptothrone, chisel-ubuntu-axum base
+  project.json          # nx targets: build, build-release, run, test, lint, e2e, container
+  src/
+    main.rs        # ~130 lines, near-identical to cryptothrone-server's main.rs
+    agones.rs      # verbatim copy of apps/agones/cryptothrone/server/src/agones.rs
+    auth.rs        # verbatim copy (jedi JWKS accept-both verifier)
+    db/            # verbatim copy (pg_cluster + kv_cache, both non-fatal)
+    game.rs        # KindRegistry + SimConfig + WalkableMap + spawn systems
+    hash.rs        # port of geometry/rng.ts   (hashInt / hash01 / jitter)
+    sector.rs      # port of dungeon/sector.ts (BSP, corridors, locks, connectors)
+    generate.rs    # port of dungeon/generate.ts (tile grid, doorways, oases, columns)
+    collide.rs     # port of dungeon/collision.ts::solidAtWorld
+    motor.rs       # port of CharacterMotor + makeMover  (see §5)
+    npc.rs         # goblin AI, rewritten deterministically
+```
+
+`game.rs` is the adapter proper. It provides:
+
+- `walkable_map() -> WalkableMap` — herbmail cannot use `WalkableMap::from_blocked` (the world is unbounded) and cannot use `WalkableMap::arpg_dungeon` (wrong generator). It needs a third `Collision` variant. `grid.rs` already models exactly this distinction:
+  ```rust
+  enum Collision {
+      Bitset(Vec<bool>),
+      Dungeon { seed: u32 },
+  }
+  ```
+  Adding `Collision::Herbmail { seed: u32 }` backed by `collide::solid_at(seed, x, z)` is a ~20-line upstream change and is the right kind of extension — it follows the pattern the module was built for. The dynamic `blocked: HashSet<(i32, Tile)>` overlay already exists and is exactly what player-placed props and closed doors need.
+- `registry() -> KindRegistry` — kind IDs for player, goblin, kurenai, stone node, crate, torch, door, ground item.
+- `config() -> SimConfig` — `spawn` from the ported `dungeonSpawn()`, `player_hp: 100`, `safe_radius` around the entrance room.
+- data resources loaded from codegen, mirroring `cryptothrone-server/src/game.rs:17-20`:
+  ```rust
+  const ITEMDB_JSON: &[u8] = include_bytes!(".../packages/data/codegen/generated/itemdb-data.json");
+  ```
+  arpg does the same with `.binpb` and typed decoders: `bevy_mapdb::MapDb::from_bytes(include_bytes!(".../mapdb-data.binpb"))`, `bevy_items::ItemDb::from_bytes(...)`, `simgrid::NpcDb::from_json(...)`. **One source of truth, two consumers, no schema duplication.**
+
+  herbmail additionally needs **professiondb** (mining actions, XP curves, `spawnWeight` tables) and **mapdb** (`objectDefs`, the join target for `resourceNodeRef`). mapdb already has a Rust decoder. **professiondb does not** — see §10; it is the one piece of genuinely new data-layer tooling this design requires.
+
+### Where the crate should live
+
+The brief specifies `apps/herbmail/herbmail-game/server/`. **Repo convention says otherwise**: every Agones game server in this monorepo lives at `apps/agones/<game>/server` (`cryptothrone`, `arpg`), is a member of the root `Cargo.toml` `[workspace] members` list, has a sibling `apps/agones/<game>/web`, and gets its k8s manifests at `apps/kube/agones/<game>/manifests`.
+
+Recommendation: put the crate at **`apps/agones/herbmail/server`** and keep `apps/herbmail/herbmail-game/` as the pure client. Deviating would make the Dockerfile's `Cargo.workspace.toml` trick, the nx tags (`["rust", "game-server", "agones", "herbmail"]`), and the CI dispatch manifest all one-off. This document lives at the requested path; the code should not follow it.
+
+Root `Cargo.toml` `[workspace] members` is an **explicit list, not a glob**, so the new crate must be added to it (one line, alongside `'apps/agones/arpg/server'`).
+
+---
+
+## 5. Rapier's role — REVERSED, 2026-08-06
+
+> **This section's original conclusion ("no rapier server-side") was overturned and the code now does the opposite.** It is kept below with the reasoning that failed, because two of the four arguments were factually wrong at the time of writing and the other two were weaker than they read. Implemented in `packages/rust/simbody3d`.
+>
+> **Argument 2 was simply false.** `sim.worker.ts` imports `@dimforge/rapier3d-compat` and runs a `KinematicCharacterController` for the authority capsule. The client *is* running rapier for movement.
+>
+> **The measured 24cm authority drift is the argument against the original plan, not for it.** That gap is rapier disagreeing with the tile motor over wall slides and body pushout. Server rapier + client tile motor makes it permanent and puts it inside the reconciliation loop. Both sides must run the same solver.
+>
+> **The argument this section missed:** one solver compiled twice beats two transliterations pinned by parity vectors. `@dimforge/rapier3d-compat` 0.19.3 is built from `rapier3d` 0.30.1 (read out of the shipped wasm), so pinning that crate makes both sides the same code — no draw-order fragility, no `Math.imul` vs `wrapping_mul`, no ulp chasing in `jitter`.
+>
+> **Argument 4 was wrong-shaped.** It assumed per-player geometry. The world is static and seed-derived, so colliders build per *sector* and are shared across all players; 32 kinematic capsules in one rapier world is negligible.
+>
+> **Argument 1 still stands and is why simgrid remains the right netcode host** — gameplay is XZ, Y is cosmetic. It is not a reason to avoid rapier, only a reason not to put Y on the wire.
+>
+> **Argument 3 still stands and is now the open cost.** The doorway rule is hash-derived and must become geometry. `addSectorFloor` emits floors and walls only; `openHW` is still unimplemented on both sides of the port.
+>
+> **What did not change:** M1 is still required. The server must build the same colliders, so the tile-grid generator still has to be ported to Rust. Rapier changes what consumes that output — colliders instead of a predicate — not whether the port is needed.
+
+### Original reasoning (superseded)
+
+The brief proposes "physics via rapier". The evidence says don't.
+
+**Argument 1 — herbmail's gameplay space has no vertical dimension.** `solidAtWorld(x, z)` never reads Y. `floorYAtWorld` returns `0` or `-OASIS_DEPTH` as a pure function of tile. Nothing can be jumped over, climbed onto, or fallen off. A 3D rigid-body solver would be simulating a degree of freedom that does not affect a single gameplay outcome.
+
+**Argument 2 — the client is not running rapier for movement either.** The player is `kinematicPositionBased()` in `sim.worker.ts`; the tile grid decides where it goes. Introducing server rapier would create a *new* disagreement between client tile-collision and server rigid-body collision that does not exist today.
+
+**Argument 3 — herbmail's collision is intentionally non-physical.** The doorway rule (`|lat| > openHW`, where `openHW = jitter(lc, lr, 1 + variant * ARCH_SALT, TILE*0.28, TILE*0.38)`) is a hash-derived gameplay constraint, not a mesh. Reproducing it as rapier colliders means baking per-arch geometry on the server and keeping it in sync with a hash the client evaluates lazily. Reproducing it as a predicate is four lines.
+
+**Argument 4 — cost.** rapier3d + a broadphase over streamed sector geometry for N players is materially more CPU and memory per shard than evaluating a coordinate hash on demand. `arpg-server` holds an unbounded world at zero geometry memory precisely because collision is a pure function.
+
+### So does herbmail reuse `simgrid::float_move`?
+
+> **Superseded.** The answer is still "no", but not for these reasons and not via a transliterated `motor.rs` — `simbody3d` replaces it with rapier's own character controller. The incompatibilities below remain accurate descriptions of why `float_move` does not fit.
+
+**No — port it into `herbmail-server/src/motor.rs` instead.** Three concrete incompatibilities:
+
+1. **Predicate signature.** `float_move` threads `is_blocked: &impl Fn(i32, i32) -> bool` — tile-discrete. herbmail's `solidAtWorld` is continuous in `(x, z)` because of doorway half-widths, pillar circles and prop AABBs. A tile-granular predicate would make every arch either fully open or fully closed.
+2. **Tile space.** `float_move::tile_at(v) = (v + 0.5).floor()` puts tile *centres* on integers, with `BODY_RADIUS = 0.34`. herbmail uses `Math.floor(x / TILE)` with `TILE = 3` and radius `0.35` (≈ 0.117 tiles). Different origin convention and a ~3× different body-to-tile ratio.
+3. **Actor depenetration.** herbmail pushes actors apart against a registered body set and routes the push back through `moveAxis` so it respects walls. `float_move` has no actor-vs-actor pass; simgrid handles crowding elsewhere.
+
+`motor.rs` will be roughly 200 lines and is a direct transliteration of two files the client already ships and tests (`collision.test.ts`, `doorwaySteer.test.ts`, `strafe.test.ts`). Keeping it in the herbmail crate lets it stay byte-identical to the TS without negotiating a general abstraction in simgrid.
+
+**Upstream later, once proven:** generalise `float_move` over a `Blocked` trait with `TileBlocked` and `PointBlocked` impls, so simgrid gets herbmail's continuous predicate without breaking cryptothrone/arpg. Do not attempt this before Milestone 3.
+
+### How client prediction and the server avoid disagreeing
+
+Same discipline `arpg-server` and `@kbve/laser` already use:
+
+- **One canonical algorithm, two transliterations, pinned by parity vectors.** `simgrid/src/heightfield.rs` shows exactly how this repo does it — a `PINNED_BITS` table asserted bit-exactly in Rust and mirrored in `heightAt.spec.ts`. herbmail should do the same for `hashInt`, `sectorSeed`, and a fingerprint of the generated tile grid for a fixed set of `(seed, sx, sy)`.
+- **There is a working precedent for the client half.** `apps/cryptothrone/astro-cryptothrone/src/components/game/systems/floatMotion.ts` is a line-by-line TS port of `float_move.rs` with the constants duplicated (`WALK_SPEED = 3.4`, `MOVE_ACCEL = 18`, `BODY_RADIUS = 0.34`, `MAX_MOVE_STEP = 0.2`) and `stepFloat`/`moveAxis` structurally identical to the Rust. Read it before writing herbmail's equivalent — including its two hard-won details: an immediate flush on the moving→idle **release edge** rather than waiting for the 50 ms send cadence, and an anti-fight guard that skips reconciliation entirely when the body is already moving toward the server position.
+- **Correction is smoothed, not snapped.** cryptothrone uses `RECONCILE_LERP = 0.25` per correction with a hard snap only past `RECONCILE_SNAP_DIST = 6` tiles, and seeds the replay with the server's reported velocity (`qvx/qvy`) so unacked inputs reproduce the authoritative coast. Replaying from rest leaves the body trailing. Copy this.
+- **Fixed timestep on both sides.** Server 20 Hz; the client motor must move to a 20 Hz (or 50 Hz, integer multiple) accumulator, with render interpolation on top. This is the only real refactor the client needs.
+- **Reconciliation via `input_ack`.** `EntityDelta` already carries `qx`, `qy`, `qvx`, `qvy` and `input_ack`; `GameClient` already keeps `unackedMoves`. On a snapshot the client snaps its authoritative body to the server position and replays unacked inputs.
+- **Divergence is bounded, not eliminated.** `f32` `exp()` differs between JS and Rust in the last bits. That is fine: reconciliation corrects sub-centimetre drift invisibly. The thing that must be *exact* is the tile grid and the loot/hash derivations, which use only integer ops.
+
+---
+
+## 6. Authority split
+
+### Server-authoritative
+
+| System | Notes |
+| --- | --- |
+| Player position | Server owns `FloatBody`; client predicts and reconciles. Y stays client-side cosmetic. |
+| NPC position, aggro, death | Full rewrite of `goblinSim.ts`; `Math.random` → `simgrid::rng::stream(root, WANDER, &[eid, tick])`. |
+| NPC population | Replace `enemyBudget()`'s client-history budget with a per-sector, seed-derived spawn table, so two players in the same sector see the same goblins. |
+| Combat damage and kills | `applyDamage` moves server-side verbatim (no RNG). Client predicts the swing and the hit-flash; server confirms HP. |
+| Hit detection | Server re-runs the cone test at the caster's *server* position. `melee.ts` bone-sampling cannot be authoritative — replace it with the same cone/reach model used for abilities. |
+| Loot | Server recomputes `hash01(stoneId(wc, wr), 0x10a7 + i*0x3f, i+1)`. Deterministic, so the client can *predict* the drop and be right every time. |
+| Node/crate depletion | The only genuinely stateful part of mining. Lives in simgrid's dynamic overlay + a persisted env log. |
+| Profession XP and levels | `grantXp` becomes a server event; client shows a server-sent `StatsEvent`. |
+| Inventory | Server owns the item list; client renders a synced view. `Input::MoveItem { from, to }` already exists in the protocol. |
+| Door unlock | Server checks `SEdge.keyId` against the player's keys — the check the client never does. Unlocked doors become entries in the dynamic blocked overlay. |
+| Placed / destroyed props | Server owns; `prop/placed.ts`'s FIFO caps disappear. simgrid already has `PersistedEnvObject` / `EnvPersistSink` for exactly this. |
+| Player pools (HP/MP/EP/SP) | Server regen; simgrid's `EntityDelta` already carries `mp/max_mp/energy/max_energy/stamina/max_stamina`. |
+
+### Client-predicted / client-only
+
+| System | Rationale |
+| --- | --- |
+| Player XZ movement | Predicted from local input, reconciled on `input_ack`. |
+| Player Y — jump, swim, pit descent | Purely cosmetic; cannot affect XZ collision. Do not put it on the wire. |
+| Yaw / turn lerp | Cosmetic; `EntityDelta.facing` is enough for remote players. |
+| Camera, targeting lock, HUD | `combat/targeting.ts` is UI state. |
+| Cast windup/active/recover phases | Predicted for responsiveness; server confirms damage. |
+| Break-off panel debris (`sim.worker.ts`) | Stays entirely client-side. Server sends "node destroyed", client plays `shatter()`. |
+| Torch flicker, fireflies, decor, embers | All `hash01`-derived or purely visual; derived locally from seed. |
+| Baked vertex lighting, occlusion, LOD | Rendering. |
+
+### Derived on both sides, never transmitted
+
+Sector layout, room/corridor topology, doorway positions and widths, pillar placement, oasis extents, torch and decor placement, stone node identity and its resource tier, crate placement, the spawn point. All are pure functions of `(DUNGEON_SEED, sector coords)` or `(world tile)`.
+
+---
+
+## 7. Protocol
+
+**Recommendation: adopt simgrid's protocol as-is. Do not design a new one.**
+
+- **Transport: WebSocket only. herbmail cannot use the UDP lane.** simgrid's `UdpLane` is real, tested (`tests/udp_flow.rs`) and wired into snapshot routing:
+  ```rust
+  if let Some(lane) = udp
+      && let Some(addr) = lane.bound_addr(h.slot)
+      && lane.try_send_snapshot(addr, &view) { continue; }
+  let frame = Arc::new(encode_frame(&proto::ServerEventRef::Snapshot(view)));
+  deliver(h.value(), frame);
+  ```
+  But **cryptothrone never calls `.with_udp()`** — `state.udp` is `None` and no `UDP_OFFER` is ever emitted, because a browser cannot open a raw UDP socket. Only `arpg-server` enables it, env-gated on `ARPG_UDP_ADDR`, for native clients. herbmail is browser-only, so plan for WS and **omit the UDP Service from the manifests** until a native client exists.
+
+  WebTransport is not used anywhere in this repo, and `apps/kbve/astro-kbve/src/content/docs/gdd/netcode.mdx:103` records a standing rule that WS and WT transports are never mixed in shared structs. If sub-WS latency is ever needed, `UdpPacket` / `UdpPacketRef` is already the right shape to port onto WebTransport — but that is out of scope here.
+
+  WS is also what the Cilium Gateway `HTTPRoute` already terminates, with the `backendRequest: 3600s` timeout configured for exactly this.
+
+- **The WS handshake itself is unauthenticated.** The JWT arrives inside the first postcard `JoinMatch` frame, not in a header or query param, so the edge cannot reject unauthorized connections — every client gets a socket and a decode before rejection. Inherited from simgrid; note it, don't fix it here.
+
+- **Framing: COBS-framed postcard.** `proto::encode`. Note the hard rule stated in `proto.rs`: postcard is positional, so **never** use `skip_serializing_if` on a wire field — a conditionally omitted field shifts every following byte. New fields are appended last, with `#[serde(default)]`.
+
+- **Versioning:** `PROTOCOL_VERSION: u32 = 16`, sent in `JoinMatch` and checked on admission. Bump when variants are added. Note the repeated comment convention in `Input`: *"Appended last so serde variant indices of the existing inputs are unchanged."*
+
+- **Tick rates:** `SIM_TICK_HZ = 20`, `SNAPSHOT_EVERY_N_TICKS = 2` (10 Hz snapshots), `KEYFRAME_EVERY_N_TICKS = 100` (5 s). `run_sim_loop` uses a tokio interval with `MissedTickBehavior::Skip` and feeds physics a constant `dt_ms = 1000.0 / SIM_TICK_HZ` — never wall-clock delta, so the sim is deterministic in tick count. These are good defaults for a dungeon crawler; no change needed.
+
+- **"Snapshot" is a full state broadcast, not a delta — despite the type name `EntityDelta`.** `emit_snapshot` maps *every* matching entity every time. `Snapshot.keyframe` is computed but nothing branches on it, `Snapshot.input_ack` is hardcoded `0` (the real ack rides per-entity `EntityDelta.input_ack`), and `destroyed` is always `false` — client despawn is by **absence from the snapshot**, which is why AOI culling and despawn are coupled. Do not design herbmail around a baseline/ack delta scheme that does not exist. If bandwidth becomes a problem, adding real delta encoding is an upstream simgrid project, not a herbmail one.
+
+- **Input handling: `IntentBuffer`, a per-player client-tick jitter buffer** (`sim.rs:2042-2178`). `INPUT_JITTER_BUFFER = 2` intents are primed before consumption starts; exactly one intent is consumed per server tick in client-tick order; on starvation the last intent is held for `INPUT_STARVE_GRACE = 2` ticks then zeroed, accumulating `debt` so a late stop lands next tick rather than replaying a burst. This is what makes "the release stops exactly when the client did" true, and it is the reason the client must stamp `Input::Move.tick`. herbmail gets it for free and must send `tick` correctly.
+
+- **Lag compensation already exists.** `PosHistory` is a 16-tile ring rewound by `LAG_COMP_TICKS: usize = 5` for hit resolution, so the shooter's view of a target is reconstructed. Relevant if herbmail ever adds PvP.
+
+- **Interest management:** `net.rs::route_snapshot_aoi` — per-connection encode, filtered to `e.z == me.z && aoi_chebyshev(e.tile, me.tile) <= AOI_RADIUS` with `AOI_RADIUS: i32 = 64`. herbmail's sector is 48 tiles, so 64 covers a bit over one sector. The client mounts a 3×3 sector ring (`store.ts::mountedSectorCoords`), i.e. ±72 tiles. **Raise `AOI_RADIUS` to 96 for herbmail** (or make it a `SimConfig` field — currently it is a module constant) so entities never pop in inside the mounted ring. This is a small, safe upstream change.
+
+- **Messages herbmail needs**, all of which already exist in `proto::Input`: `Move { seq, mx, my, run, tick }`, `Face`, `Action { id, target }`, `UseItem`, `DropItem`, `MoveItem`, `EquipItem`, `PlaceItem { item_ref, tile, rot }`, `PickupObject { tile }`, `Heartbeat { client_tick }`, `Leave`. Mining maps cleanly onto the existing `Fell { tile }` shape (arpg's tree-felling); herbmail should add `Input::Mine { tile }` appended last rather than overloading `Fell`. Door interaction needs one new variant, `Input::OpenDoor { tile }`.
+
+- **Server events herbmail needs**, already present: `Snapshot`, `Welcome`, plus the ephemeral channels `EPHEMERAL_COMBAT`, `EPHEMERAL_INVENTORY`, `EPHEMERAL_PICKUP`, `EPHEMERAL_STATS`, `EPHEMERAL_ITEM_PLACED`, `EPHEMERAL_EQUIPPED`. A new `EPHEMERAL_MINE` (node destroyed + yield) is the only genuinely new one.
+
+- **Coordinate encoding.** `EntityDelta` carries both `tile: Tile` (i32 pair) and `qx/qy: i32` + `qvx/qvy: i16` quantized floats (`POS_SCALE = 32`, i.e. 1/32 tile; `VEL_SCALE = 256`). herbmail should send positions in **tile units** (world units / `TILE`), matching simgrid's convention, and convert at the client boundary. Do not send world units — the AOI filter and the tile field both assume tile space.
+
+  **One thing herbmail must not copy from cryptothrone:** its client reads `qx/qy/qvx/qvy` only for `myEid` and renders *remote* players at tile granularity, letting gridEngine tween between 10 Hz tile steps. The sub-tile data is on the wire and thrown away. herbmail is a 3D third-person crawler where remote players sliding between tile centres would look broken — read `qx/qy/qvx/qvy` for every entity and interpolate continuously. The bandwidth is already being spent.
+
+---
+
+## 8. Deployment
+
+Copy the arpg pattern verbatim.
+
+1. **Crate** at `apps/agones/herbmail/server`, added to root `Cargo.toml` `[workspace] members`.
+2. **`Cargo.workspace.toml`** in the crate dir listing only `apps/agones/herbmail/server`, `packages/rust/simgrid`, `packages/rust/jedi` — this is the slim workspace the Dockerfile's `cargo chef` planner stage copies in as `Cargo.toml`.
+3. **Dockerfile** — copy of `apps/agones/cryptothrone/server/Dockerfile`: `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder`, cargo-chef planner/deps/builder split, mold linker, sccache with the Valkey backend.
+4. **`project.json`** — targets `build`, `build-release`, `run`, `test`, `lint`, `container` (`@nx-tools/nx-container:build`, `push: false`, `local`/`production` configurations with a ghcr buildcache), and `e2e` that `dependsOn` `container`, runs the image, polls `/healthz`, then drives it with vitest. Tags `["rust", "game-server", "agones", "herbmail"]`. Note the repo has **two Rust nx styles**: `axum-herbmail` uses `@monodon/rust:{build,test,lint,run}` executors, while the agones game servers use plain `nx:run-commands` wrapping `cargo ... -p <crate>`. Follow the agones style.
+5. **`version.toml`** in the crate dir, and a registration in `.github/ci-dispatch-manifest.json` (`version_toml`, `version_target`, `image`, `deployment_yaml`) alongside the existing `arpg_server` / `cryptothrone_server` / `herbmail` entries. There is also a CI guard for the Dockerfile stub trick: `.github/workflows/ci-cargo-stub-guard.yml`.
+6. **Manifests** at `apps/kube/agones/herbmail/manifests`: `namespace.yaml`, `fleet.yaml` (port 7979/TCP only — see §7 on UDP; `portPolicy: None`, `runAsNonRoot`, `readOnlyRootFilesystem: true`, drop ALL caps), `fleet-autoscaler.yaml` (`Buffer`, `minReplicas: 1, maxReplicas: 1`, with an ArgoCD `ignoreDifferences` on `/spec/replicas` since the Fleet declares `replicas: 0`), `game-service.yaml` (ClusterIP, `sessionAffinity: ClientIP`), `game-httproute.yaml` (`/ws` → game service with `backendRequest: 3600s`, `/` → the static client), `external-secrets.yaml` for `SUPABASE_JWT_SECRET` + `SUPABASE_JWKS_URI`, `game-certificate.yaml`, plus `application.yaml` one level up.
+7. **Agones integration** is just the health loop — copy `src/agones.rs` unchanged: `agones::Sdk::new(None, None)`, `sdk.ready()`, then a 2 s `health_check()` ping, and `sdk.shutdown()` on SIGTERM. It is deliberately non-fatal: on `Err` it logs "running outside Agones (local dev?)" and returns, so local dev needs no sidecar. The `agones = "1.57"` crate is already in the root `[workspace.dependencies]`.
+8. **No allocation path.** One shard, one persistent world, reached by a stable Service. The reason the autoscaler is pinned to 1 is recorded in `apps/kube/agones/cryptothrone/README.md`: *"A Service round-robins; multiple Ready pods would split players across separate worlds."* If herbmail later wants instanced dungeons, `apps/cryptothrone/axum-cryptothrone/src/agones.rs` is the template — `kube::Client::try_default()` + a POST to `/apis/allocation.agones.dev/v1/.../gameserverallocations`, exposed as `POST /api/join`, with `allocator-rbac.yaml` granting `create` on `gameserverallocations`. A richer version with retries and a circuit breaker lives in `apps/rows/src/agones/`. Note that `herbmail-sa` currently sets `automountServiceAccountToken: false`, so an allocator would need that flipped plus RBAC.
+9. **Versioning** is MDX-driven in this repo; the Fleet image tag tracks the crate version that the release pipeline publishes. Nothing in this design touches version files.
+10. **The Dockerfile must explicitly `COPY` the codegen blobs** it `include_bytes!`s, before `cargo build` — see the corresponding lines in arpg's Dockerfile for itemdb/mapdb/spelldb/npcdb.
+
+The static client already has a home: `astro-herbmail` / `axum-herbmail` serve the site today. The `HTTPRoute` should route `/ws` on the game hostname to the Fleet and everything else to the existing static path, mirroring `arpg-game-route`.
+
+---
+
+## 9. Migration path
+
+> **Amended 2026-08-06 for the rapier reversal in §5.** Wherever a milestone says "port `motor.rs`" or "`motor.rs`'s TS twin", read `simbody3d` instead: `packages/rust/simbody3d` already provides the collider builder and rapier character controller, generic over `SimbodyConfig`/`TileMask`, compiling both natively and to wasm. M1 is unchanged and still gates everything — the port now feeds *colliders* rather than a `solidAtWorld` predicate. M3's "`Blocked` trait generalisation upstream into `float_move`" is dropped: nothing transliterates `float_move` any more.
+>
+> Status: M0 done (fixed-step motor). M1 partially done — `rng.rs` hash layer ported and pinned on both sides; `sectorSeed` and the tile-grid generator are not. Server scaffolding, auth and deployment manifests exist ahead of M2, with collision explicitly non-authoritative until M1 completes.
+
+The rule for every milestone: **the single-player game keeps working**. Gate the whole thing behind a `?mp=1` / env flag so the offline path is untouched until the last step.
+
+**M0 — Fixed-step the client motor.** No server involved. Move `CharacterMotor.update` behind a 20 Hz accumulator with render interpolation; keep `goblinSim` and `castSystem` on the same clock. This is the only prerequisite refactor and it improves the single-player game on its own (currently a stalled tab silently loses sim time via the 50 ms clamp).
+
+**M1 — Geometry parity harness.** Port `hashInt`/`hash01`/`jitter`, `sectorSeed`, `sector.ts` and `generate.ts` to Rust. Add a pinned parity test in the style of `heightfield.rs::PINNED_BITS`: for a fixed list of `(seed, sx, sy)`, assert a fingerprint of the generated tile grid, and assert the same fingerprint from a TS spec in `herbmail-game`. **Nothing ships until this is green.** No server, no protocol, no client change.
+
+**M2 — Two capsules in one sector.** ← *the recommended first useful milestone.*
+Stand up `herbmail-server` with `SimConfig`, a `KindRegistry` containing only `PLAYER_KIND`, and a `WalkableMap` backed by the M1 collision port. Port `motor.rs`. Client: import `GameClient` from `@kbve/laser`, send `Input::Move` at the fixed tick, render remote players from `Snapshot.entities` as capsules with nameplates. No prediction yet — render the local player from the server position with interpolation, accepting the latency, to prove the loop end-to-end. Scope: sector (0,0) only.
+
+**M3 — Prediction and reconciliation.** Local player predicts with `motor.rs`'s TS twin; replay `unackedMoves` on each snapshot. Add the `Blocked` trait generalisation upstream if the local `motor.rs` has stabilised. Raise `AOI_RADIUS` and let players roam across sectors.
+
+**M4 — Combat server-authoritative.** Move `applyDamage` and the cone test server-side. Client predicts the cast phases and shows a provisional hit; server confirms via `EPHEMERAL_COMBAT`. Retire `melee.ts` bone-sampling in favour of the ability cone. PvE only at this point.
+
+**M5 — Goblins server-side.** Rewrite `goblinSim` in Rust with `simgrid::rng::stream(root, domain::WANDER, &[eid, tick])` replacing every `Math.random`. Replace `enemyBudget()`'s session-history budget with a seed-derived per-sector spawn table. Client becomes a pure renderer + interpolator for NPCs.
+
+**M6 — Mining, loot, XP, inventory.** Requires the professiondb Rust decoder from §10 (net-new). `Input::Mine { tile }`; server owns node HP and depletion, recomputes the (already deterministic) drop, grants XP against the professiondb curves, and owns the inventory list. Client predicts the drop — it will always be right, because the roll is a coordinate hash. Wire `PlayerPersistSink` to `jedi`'s Postgres pool so progression finally survives a reload.
+
+**M7 — Doors and placed props.** Door unlock with a real `keyId` check; unlocked doors and placed props enter simgrid's dynamic blocked overlay and `EnvPersistSink`. The FIFO caps in `prop/placed.ts` and `door/doors.ts` are deleted.
+
+**M8 — Deploy.** Fleet, autoscaler pinned to 1, ClusterIP Service, HTTPRoute, external secrets, ArgoCD app, `version.toml` + `ci-dispatch-manifest.json` registration. No UDP Service — the client is a browser (§7).
+
+Auth plumbing (getting a Supabase access token from `astro-herbmail`'s session into `GameClient`) is a prerequisite for M2 and is not currently anywhere in `herbmail-game`. `apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx` is the template: `initSupa()` → `authBridge.getSession()` → `usernameFromToken(accessToken)` → gate on a missing `kbve_username` → hand `{ jwt, username, wsUrl }` to the client.
+
+---
+
+## 10. Risks and open questions
+
+Separated deliberately from the recommendations above.
+
+### Risks
+
+- **`makeRng` draw-order fragility.** `sector.ts`'s counter-based stream means any refactor of `partition`/`carveCorridor`/`applyLocks` on either side silently changes the world. Mitigation: the M1 fingerprint test, run in CI on both sides. This is the single highest-risk item in the plan.
+- **Float parity in doorway widths.** `jitter()` divides by `4294967295` and multiplies by `TILE * 0.28 .. 0.38`. JS uses f64; Rust must too (`f64`, not `f32`) or arch half-widths will differ by ulps and a player could be blocked on one side and not the other. Use `f64` throughout the collision port and compare with a tolerance in tests, not bit-exactly.
+- **Two clocks in the client.** `Character.tsx` and `ThirdPersonPlayer.tsx` each run their own `useFrame` with independent 50 ms clamps, and `PropRenderer.tsx` runs `npcSystem` + `castSystem` on a third. M0 has to unify these or prediction will jitter.
+- **SAB seqlock has no reader retry.** `packages/npm/laser/src/lib/mecs/sab.ts` exposes `gen()` but no consumer retries on a torn read, and structural ops are non-atomic bit writes. Safe today because each world has exactly one structural writer. If networking introduces a second writer to the props world, this becomes a real bug.
+- ~~**Body radius mismatch.**~~ **Resolved by §5.** simgrid's `BODY_RADIUS` is irrelevant now that `float_move` is not in the path. The radius is declared once, in `simbody3d`'s `CharacterConfig` (`presets::herbmail()`), and both the server and a wasm client build read it from there — there is no second value to keep in sync. The underlying concern was correct: differing radii would clip differently through the `TILE * 0.28` doorway gaps, the tightest geometry in the game.
+- **`herbmail-game` has no auth at all.** Supabase exists at the site level (`astro-herbmail/src/lib/supa.ts`) but the game bundle has zero hooks into it. Getting a JWT into `GameClient` requires plumbing that does not exist yet and is not in any milestone above.
+- **No persistence model exists to migrate.** `prop/placed.ts` caps at 24 records; `unlocked` caps at 2048. A server introduces persistent world state for the first time, which means schema design, migration, and a `dbmate` story that this document does not cover.
+- **`combat/los.ts` and `flowField.ts` both sample `solidAtWorld` heavily.** Server-side BFS flow fields over a *computed* collision function are more expensive than over a bitset. `WalkableMap::arpg_dungeon` already accepts a `path_window` to bound BFS for this reason (`MAX_PATH_LEN = 64`); herbmail will need the same cap and should measure it.
+- **The TS wire mirror is hand-written and is the highest-maintenance surface in the stack.** `packages/npm/laser/src/lib/net/postcard.ts` (a hand-rolled postcard v1 + COBS codec) plus `postcard-wire.ts` (815 lines of field-by-field mirrors of `proto.rs`) plus `protocol.ts` — roughly 1000 lines kept in sync only by byte-exact hex fixtures asserted on both sides (e.g. `assert_eq!(hex, "0e01070301037fff0109180a050d00")` in `proto.rs`, mirrored in `postcard-wire.spec.ts`). Every new `Input` variant or `EntityDelta` field herbmail adds requires a matching hand edit in TS. Postcard is positional, so a mistake here is a silent byte-shift desync, not a type error. Budget for it, and add fixtures for every herbmail-specific message.
+- **Hard scaling ceiling: one pod, one world.** `minReplicas: maxReplicas: 1` + `MAX_PLAYERS: 32` + `sessionAffinity: ClientIP`. There is no sharding, no cross-server handoff, no zone service anywhere in this repo. "MMO" in the brief and what this stack can currently deliver are different things — herbmail would be a 32-player shared world, and going beyond that is unsolved here.
+- **Snapshot cost is O(connections × entities).** Per-recipient AOI means a fresh postcard allocation per connection per snapshot, 10×/second. Fine at 32 players; measure before assuming more.
+- **`simgrid` is structurally agnostic but materially leaky.** `proto.rs` and `sim.rs` have absorbed concrete gameplay from the other two games — blackjack (a full dealer engine), pet/JRPG battles, ship piloting and a "space instance", tree felling. herbmail will link all of it. That is dead weight, not a correctness problem, but it means the crate will keep growing under other games' requirements and herbmail inherits the churn.
+
+### Open questions
+
+- **Shard model.** One global persistent dungeon shared by everyone, or per-party instances? The arpg precedent (Fleet pinned to 1) assumes one world. herbmail's `DUNGEON_SEED = 1337` is a single hardcoded constant, which suggests one world was the intent — but a dungeon crawler usually wants instancing. This decision changes §8 substantially and should be settled before M2.
+- **Does herbmail need floors?** simgrid has `Floor`, `Stairs`, `StairLink`, `StairGrace`, and `EntityDelta.z`; arpg uses them. herbmail is currently single-level with pits. If vertical levels are ever wanted, adopting `Floor` from M2 is nearly free; retrofitting it later is not.
+- **Player-vs-player.** Is herbmail PvE-only? §6 assumes so. If PvP is wanted, simgrid's `PosHistory` / `LAG_COMP_TICKS = 5` rewind already exists and should be adopted rather than reinvented — but herbmail's hit shapes are cones, not projectiles, so the rewind integration is not a copy-paste.
+- **`AOI_RADIUS` as a constant.** Should it be promoted to a `SimConfig` field upstream, or should herbmail just raise the constant and accept the effect on arpg/cryptothrone? Recommend a `SimConfig` field.
+- ~~**Where does the `Blocked` trait generalisation land?**~~ **Moot.** There is no second copy of `float_move` to reconcile — `simbody3d` uses rapier's own controller. The generalisation that did land is `TileMask`, which lets any consumer map its own tile bitfield onto "blocks movement" / "no floor slab".
+- **`professiondb` in Rust — this one is confirmed net-new work.** There are Rust consumers of itemdb, mapdb, spelldb and npcdb (`bevy_mapdb::MapDb::from_bytes`, `bevy_items::ItemDb::from_bytes`, `simgrid::NpcDb::from_json`, all via `include_bytes!`), but **no Rust consumer of professiondb exists anywhere in the repo.** `professiondb-data.binpb` (proto wire, `profession.ProfessionRegistry`) is generated and is the cleanest target — a `bevy_professiondb` crate with a `prost`/`prost-build` `build.rs`, mirroring `bevy_mapdb`. Open question: does it live in `simgrid::data`, in a new `bevy_professiondb`, or local to `herbmail-server`?
+
+  **Watch the two views.** `gen-professiondb-data.mjs` emits both `professiondb-data.json` (canonical) and `professiondb-runtime.json` (slimmed, camelCase, Astro-only fields like `title` stripped, enum strings prefixed e.g. `PROFESSION_CATEGORY_`). The herbmail client reads the **runtime** view — `src/game/data/professiondb.ts` imports `@kbve/professiondb-data`, aliased in `tsconfig.json` to `professiondb-runtime.json`. A Rust proto decode of the `.binpb` yields the **canonical** view. Field-name and enum-representation parity must be checked before either side is trusted. Also note `RUNTIME_SYNC_TARGETS` in that generator currently lists only the Unity StreamingAssets dir; herbmail is not in it.
+
+  The join key matters too, and is documented in `professiondb.ts`: `professiondb.resourceNodeRef -> mapdb.objectDefs[].ref`, with `mapdb.professionActionRef` pointing back. The server needs both DBs to resolve a mining action.
+- **Kurenai.** `npc/KurenaiNpc.tsx` is 320 lines of retargeted-animation NPC with `NPC_KURENAI { hp: 60, power: 9, defense: 3 }`. Is it a scripted set-piece (stays client-side) or a world NPC (must move server-side in M5)?
+- **Nothing currently damages the player.** Grepping `Health.hp[` writes finds only crate DoT, player→NPC casts, crate break and mining. There is no incoming-damage path to port, which means M4 is partly *new feature work*, not migration.

--- a/apps/herbmail/herbmail-game/src/game/net/auth.ts
+++ b/apps/herbmail/herbmail-game/src/game/net/auth.ts
@@ -26,7 +26,7 @@ export const SUPABASE_URL = 'https://supabase.kbve.com';
 export const SUPABASE_ANON_KEY =
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg';
 
-const DEFAULT_WS_URL = 'wss://herbmail.kbve.com/ws';
+const DEFAULT_WS_URL = 'wss://game.herbmail.com/ws';
 
 type SupabaseLike = {
 	auth: {

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -688,10 +688,23 @@ export class ReelPlayer {
 			// up once repeated recovery attempts stop working.
 			let netRetries = 0;
 			let mediaRetries = 0;
+			let starveRetries = 0;
 			const MAX_RECOVER = 6;
+			// Live-edge starvation: the encoder simply hasn't produced the next
+			// segment yet, so frag/playlist loads fail while nothing is actually
+			// broken. That's buffering, not an error — wait and reload with a far
+			// larger budget than the real-error ladder.
+			const MAX_STARVE = 40;
+			const STARVATION_DETAILS = new Set<string>([
+				Hls.ErrorDetails.FRAG_LOAD_ERROR,
+				Hls.ErrorDetails.FRAG_LOAD_TIMEOUT,
+				Hls.ErrorDetails.LEVEL_LOAD_ERROR,
+				Hls.ErrorDetails.LEVEL_LOAD_TIMEOUT,
+			]);
 			hls.on(Hls.Events.FRAG_BUFFERED, () => {
 				netRetries = 0;
 				mediaRetries = 0;
+				starveRetries = 0;
 				this.resurrects = 0;
 			});
 			hls.on(Hls.Events.ERROR, (_evt, data) => {
@@ -700,6 +713,20 @@ export class ReelPlayer {
 				switch (data.type) {
 					case Hls.ErrorTypes.NETWORK_ERROR: {
 						const expired = data.response?.code === 401;
+						if (
+							!expired &&
+							STARVATION_DETAILS.has(data.details) &&
+							starveRetries++ < MAX_STARVE
+						) {
+							this.emit(
+								'playing',
+								'Buffering — waiting for stream data',
+							);
+							setTimeout(() => {
+								if (this.generation === gen) hls.startLoad();
+							}, 3000);
+							break;
+						}
 						const code: ReelStreamErrorCode = expired
 							? 'token-expired'
 							: 'network';

--- a/apps/kbve/astro-kbve/src/content/docs/project/herbmail-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/herbmail-server.mdx
@@ -1,0 +1,136 @@
+---
+title: Herbmail Server — Authoritative Axum + Bevy Dungeon Host
+description: Herbmail authoritative game server pairs an axum WebSocket router with the simgrid headless Bevy sim on tokio, on a chiseled Ubuntu Agones runtime.
+sem: 1
+sidebar:
+    label: Herbmail Server
+    order: 59
+tags:
+    - docker
+    - rust
+    - game-server
+    - herbmail
+key: herbmail_server
+pipeline: docker
+app_name: herbmail-server
+version: "0.0.1"
+source_path: apps/agones/herbmail/server
+version_toml: apps/agones/herbmail/server/version.toml
+version_target: apps/agones/herbmail/server/Cargo.toml
+runner: arc-runner-set
+image: kbve/herbmail-server
+deployment_yaml: apps/kube/agones/herbmail/manifests/fleet.yaml
+has_test: false
+author: h0lybyte
+license: MIT
+status: beta
+kube:
+    stack: agones
+    environment: dev
+    tier: server
+    owner: h0lybyte
+    criticality: low
+template: splash
+tableOfContents: false
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+jsonld:
+    faq:
+        - question: What is the Herbmail server?
+          answer: herbmail-server is the authoritative shared-world host for the Herbmail dungeon crawler. It pairs an axum WebSocket router with the simgrid headless Bevy simulation on a tokio multi-thread runtime, keeping movement validation and snapshot framing server-owned.
+        - question: Can players join without an account?
+          answer: Yes. When guests are enabled the server mints its own guest identity for a connection that presents no token, so the client can never choose its own guest name. Signed-in players are verified against Supabase via the jedi JWKS verifier, which accepts both HS256 and ES256.
+        - question: Is the server authoritative over collision yet?
+          answer: Not yet. The dungeon is a pure function of a seed and is never transmitted, so the server must derive byte-identical geometry before it can arbitrate walls. Until that port lands the server logs authoritative_collision=false and runs an open map.
+bento:
+    badge: game-server · rust · herbmail
+    title: Authoritative dungeon host
+    accent: Herbmail Server
+    lede: >-
+        The authoritative shared-world host for Herbmail — an axum WebSocket
+        router paired with the simgrid headless Bevy simulation on tokio, with
+        guest and Supabase-account admission.
+    ctas:
+        - label: View source
+          href: https://github.com/KBVE/kbve/tree/main/apps/agones/herbmail/server
+          primary: true
+          external: true
+        - label: Deployment
+          href: "#internals"
+    aside:
+        icon: server
+        title: Seed-derived world
+        body: >-
+            The dungeon is a pure function of <strong>DUNGEON_SEED</strong> and
+            is never transmitted. Server and client each derive it, pinned
+            against shared parity vectors.
+        points:
+            - <strong>Auth</strong> — Supabase JWKS (HS256 + ES256) or server-minted guests.
+            - <strong>Lifecycle</strong> — Agones Ready / Health / Shutdown.
+    stats:
+        - { label: App, value: herbmail-server, icon: server }
+        - { label: Stack, value: axum + Bevy, icon: rust }
+        - { label: Protocol, value: postcard over WS, icon: network }
+        - { label: Listen, value: "0.0.0.0:7979", icon: activity }
+    features:
+        - title: Terminate /ws + admit
+          icon: key
+          body: Terminates the WebSocket upgrade and admits either a Supabase-verified account or a server-minted guest identity.
+        - title: Drive the sim tick
+          icon: activity
+          body: Runs the simgrid sim tick at 20 Hz on a tokio multi-thread runtime, fanning out authoritative 10 Hz snapshots.
+        - title: Derive, never transmit
+          icon: map
+          body: The dungeon is generated from a seed on both sides and pinned by parity vectors, so no geometry crosses the wire.
+        - title: Agones lifecycle
+          icon: server
+          body: Runs the Agones SDK lifecycle (Ready / Health / Shutdown); degrades gracefully outside Agones for local dev.
+    related:
+        - title: Herbmail
+          href: /project/herbmail/
+          copy: The Herbmail site and mail stack this game lives under.
+          icon: mail
+        - title: CryptoThrone Server
+          href: /project/cryptothrone-server/
+          copy: Sibling simgrid host, grid-authoritative rather than continuous.
+          icon: server
+    related_heading: Related
+---
+
+import BentoDoc from '@/components/hero/BentoDoc.astro';
+import BentoProse from '@/components/hero/BentoProse.astro';
+
+<BentoDoc data={frontmatter.bento} faq={frontmatter.jsonld?.faq}>
+
+<BentoProse id="overview" eyebrow="Responsibilities" heading="Overview & layout">
+
+`herbmail-server` is the authoritative shared-world host for the **Herbmail** dungeon crawler. It pairs an `axum` WebSocket router with the `simgrid` headless bevy simulation, so movement validation and snapshot framing stay server-owned.
+
+### Responsibilities
+
+- Terminate the `/ws` WebSocket upgrade and admit either a Supabase-verified account or a server-minted guest.
+- Drive the `simgrid` sim tick (20 Hz) on a tokio multi-thread runtime, fanning out 10 Hz snapshots.
+- Derive the dungeon from `DUNGEON_SEED` rather than transmitting it, byte-identically with the client.
+- Run the Agones SDK lifecycle (`Ready` / `Health` / `Shutdown`); degrades gracefully outside Agones for local dev.
+
+</BentoProse>
+
+<BentoProse id="internals" eyebrow="Deployment" heading="Fleet & routing">
+
+An Agones `Fleet` in the `herbmail-game` namespace runs the GameServer pods behind a ClusterIP `Service` with `sessionAffinity: ClientIP`, reached through the Cilium gateway on `game.herbmail.com`. The autoscaler is pinned to a single replica: a Service round-robins, and multiple Ready pods would split players across separate worlds.
+
+There is no UDP lane. The Herbmail client is browser-only and cannot open a raw UDP socket, so only the TCP WebSocket port is exposed.
+
+### Guest identities
+
+A connection presenting an empty token is admitted as `guest-NNNN`, minted by the server. The client cannot choose its own guest name — the name a player sees comes back in `Snapshot.players`, keyed by the slot in `Welcome`. Account names carrying the `guest-` prefix are rejected outright, so a guest can never present as a signed-in player.
+
+### Not yet authoritative
+
+The server does not yet reproduce the client's seed-derived walls; it runs an open map and logs `authoritative_collision=false`. Collision arbitration waits on the geometry port and its parity harness.
+
+</BentoProse>
+
+</BentoDoc>

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.36"
+version: "0.1.37"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/kube/agones/herbmail/application.yaml
+++ b/apps/kube/agones/herbmail/application.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones-herbmail
+    namespace: argocd
+    labels:
+        app.kubernetes.io/part-of: herbmail
+    annotations:
+        kbve.com/source-path: kube/agones/herbmail
+        kbve.com/manifest-path: apps/kube/agones/herbmail/manifests
+        kbve.com/application-file: kube/agones/herbmail/application.yaml
+        kbve.com/managed-by: argocd
+        kbve.com/schema-version: v1
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/agones/herbmail/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: herbmail-game
+    ignoreDifferences:
+        - group: agones.dev
+          kind: Fleet
+          jsonPointers:
+              - /spec/replicas
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/agones/herbmail/manifests/external-secrets.yaml
+++ b/apps/kube/agones/herbmail/manifests/external-secrets.yaml
@@ -1,0 +1,66 @@
+# SecretStore + ExternalSecret rendering supabase-shared in the herbmail-game
+# namespace, mirroring the arpg / cryptothrone pattern. The herbmail server
+# needs only SUPABASE_JWT_SECRET + SUPABASE_URL — it has no Postgres or Valkey
+# dependency yet.
+#
+# Activation requires herbmail-game-external-secrets to appear in the
+# notification-bot-read-secrets RoleBinding subjects list in
+# apps/kube/kilobase/manifests/cross-namespace-rbac.yaml. Until that binding
+# lands the ExternalSecret fails to render; the fleet marks both secretKeyRefs
+# optional so the GameServer still boots guests-only rather than wedging in
+# CreateContainerConfigError.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: herbmail-game-external-secrets
+    namespace: herbmail-game
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: herbmail-game
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: herbmail-game-external-secrets
+                    namespace: herbmail-game
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: herbmail-game-supabase-secrets
+    namespace: herbmail-game
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                SUPABASE_URL: 'http://kong.kilobase.svc.cluster.local:8000'
+                SUPABASE_ANON_KEY: '{{ .anonkey }}'
+                SUPABASE_JWT_SECRET: '{{ .jwtsecret }}'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key

--- a/apps/kube/agones/herbmail/manifests/fleet-autoscaler.yaml
+++ b/apps/kube/agones/herbmail/manifests/fleet-autoscaler.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.agones.dev/v1
+kind: FleetAutoscaler
+metadata:
+    name: herbmail-server-autoscaler
+    namespace: herbmail-game
+    labels:
+        app: herbmail-server
+        app.kubernetes.io/part-of: herbmail
+spec:
+    fleetName: herbmail-server
+    policy:
+        type: Buffer
+        buffer:
+            bufferSize: 1
+            minReplicas: 1
+            maxReplicas: 1
+    sync:
+        type: FixedInterval
+        fixedInterval:
+            seconds: 30

--- a/apps/kube/agones/herbmail/manifests/fleet.yaml
+++ b/apps/kube/agones/herbmail/manifests/fleet.yaml
@@ -1,0 +1,111 @@
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+    name: herbmail-server
+    namespace: herbmail-game
+    labels:
+        app: herbmail-server
+        app.kubernetes.io/part-of: herbmail
+spec:
+    replicas: 0
+    scheduling: Packed
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    template:
+        metadata:
+            labels:
+                app: herbmail-server
+                app.kubernetes.io/part-of: herbmail
+        spec:
+            ports:
+                # No hostPort — clients reach the server through the Cilium
+                # gateway (HTTPRoute -> herbmail-game Service), so the pod
+                # stays compatible with baseline PodSecurity. No UDP lane: the
+                # herbmail client is browser-only.
+                - name: ws
+                  portPolicy: None
+                  containerPort: 7979
+                  protocol: TCP
+            health:
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                failureThreshold: 5
+            sdkServer:
+                logLevel: Info
+            template:
+                metadata:
+                    labels:
+                        app: herbmail-server
+                        app.kubernetes.io/part-of: herbmail
+                spec:
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 10001
+                        runAsGroup: 10001
+                        fsGroup: 10001
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: herbmail-server
+                          image: ghcr.io/kbve/herbmail-server:0.0.1
+                          imagePullPolicy: IfNotPresent
+                          env:
+                              - name: HM_SERVER_ADDR
+                                value: '0.0.0.0:7979'
+                              - name: HM_SERVER_SEED
+                                value: '1337'
+                              - name: HM_ALLOW_GUESTS
+                                value: 'true'
+                              - name: RUST_LOG
+                                value: 'info,herbmail_server=debug,simgrid=info'
+                              # Both optional: until the ExternalSecret renders,
+                              # the server boots guests-only instead of wedging
+                              # in CreateContainerConfigError. SUPABASE_URL is
+                              # what enables the jedi JWKS verifier (accept-both
+                              # HS256 + ES256) and therefore account logins.
+                              - name: SUPABASE_JWT_SECRET
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: SUPABASE_JWT_SECRET
+                                        optional: true
+                              - name: SUPABASE_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: SUPABASE_URL
+                                        optional: true
+                          ports:
+                              - name: ws
+                                containerPort: 7979
+                                protocol: TCP
+                          readinessProbe:
+                              httpGet:
+                                  path: /healthz
+                                  port: 7979
+                              initialDelaySeconds: 3
+                              periodSeconds: 5
+                              failureThreshold: 3
+                          livenessProbe:
+                              httpGet:
+                                  path: /healthz
+                                  port: 7979
+                              initialDelaySeconds: 10
+                              periodSeconds: 15
+                              failureThreshold: 5
+                          resources:
+                              requests:
+                                  cpu: '250m'
+                                  memory: '128Mi'
+                              limits:
+                                  cpu: '1500m'
+                                  memory: '512Mi'
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              readOnlyRootFilesystem: true
+                              capabilities:
+                                  drop:
+                                      - ALL

--- a/apps/kube/agones/herbmail/manifests/game-certificate.yaml
+++ b/apps/kube/agones/herbmail/manifests/game-certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: herbmail-game-tls
+    namespace: herbmail-game
+    labels:
+        app.kubernetes.io/part-of: herbmail
+spec:
+    secretName: herbmail-game-tls
+    dnsNames:
+        - game.herbmail.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io

--- a/apps/kube/agones/herbmail/manifests/game-httproute.yaml
+++ b/apps/kube/agones/herbmail/manifests/game-httproute.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: herbmail-game-route
+    namespace: herbmail-game
+    labels:
+        app.kubernetes.io/part-of: herbmail
+spec:
+    # parentRefs/backendRefs carry the API-server default group/kind (+ backendRef
+    # weight) EXPLICITLY — the Gateway API defaults them on the live object, so
+    # omitting them makes ArgoCD diff git-vs-live forever (perpetual OutOfSync).
+    parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - game.herbmail.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          timeouts:
+              # Long-lived WebSocket — override Envoy's ~15s default backend
+              # timeout so wss connections survive.
+              backendRequest: 3600s
+          backendRefs:
+              - group: ''
+                kind: Service
+                name: herbmail-game
+                port: 7979
+                weight: 1

--- a/apps/kube/agones/herbmail/manifests/game-service.yaml
+++ b/apps/kube/agones/herbmail/manifests/game-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: herbmail-game
+    namespace: herbmail-game
+    labels:
+        app: herbmail-server
+        app.kubernetes.io/part-of: herbmail
+        kbve.com/category: game-server
+        kbve.com/stack: agones
+        kbve.com/managed-by: argocd
+spec:
+    type: ClusterIP
+    selector:
+        app: herbmail-server
+    sessionAffinity: ClientIP
+    ports:
+        - name: ws
+          port: 7979
+          targetPort: 7979
+          protocol: TCP

--- a/apps/kube/agones/herbmail/manifests/namespace.yaml
+++ b/apps/kube/agones/herbmail/manifests/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: herbmail-game
+    labels:
+        app.kubernetes.io/part-of: herbmail
+        kbve.com/stack: agones

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -80,6 +80,9 @@ subjects:
     - kind: ServiceAccount
       name: firecracker-external-secrets
       namespace: firecracker
+    - kind: ServiceAccount
+      name: herbmail-game-external-secrets
+      namespace: herbmail-game
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -73,6 +73,7 @@ resources:
     - agones/mc/application.yaml
     - agones/cryptothrone/application.yaml
     - agones/arpg/application.yaml
+    # - agones/herbmail/application.yaml  # DISABLED: enable once ghcr.io/kbve/herbmail-server:<version> is published and game.herbmail.com resolves
     - agones/factorio/application.yaml
     - agones/palworld/application.yaml
     - chuckrpg/application.yaml

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -92,7 +92,7 @@ spec:
                       timeoutSeconds: 5
                       failureThreshold: 6
                   resources:
-                      requests: { cpu: '4', memory: 1Gi }
+                      requests: { cpu: '8', memory: 8Gi }
                       limits: { cpu: '16', memory: 8Gi }
                   volumeMounts:
                       - { name: data, mountPath: /data }

--- a/apps/media/reel/src/api.rs
+++ b/apps/media/reel/src/api.rs
@@ -14,6 +14,7 @@ pub struct AppState {
     pub stream_enabled: bool,
     pub hls: hls::HlsManager,
     pub ffprobe_bin: String,
+    pub hls_segment_wait_ms: u64,
 }
 
 #[derive(Clone)]
@@ -420,6 +421,19 @@ async fn manifest(
         delivery
     };
 
+    // The viewer's HLS encode and the background library transcode would split
+    // the same cores; at 2 CPUs that halves an already sub-realtime encode and
+    // starves the live edge. The viewer wins — kill the background job.
+    if delivery == transcode::Delivery::TranscodeHls
+        && matches!(
+            meta.transcode,
+            state::TranscodeStatus::Remuxing | state::TranscodeStatus::Encoding
+        )
+    {
+        tracing::info!(id = %id, "aborting background transcode; viewer HLS encode takes priority");
+        st.transcoder.abort(&id).await;
+    }
+
     let outcome = st.hls.request(&id, delivery).await;
     hls_outcome_response(&st.store, &id, outcome).await
 }
@@ -520,6 +534,7 @@ async fn hls_segment(
         &id,
         &segment,
         &method,
+        st.hls_segment_wait_ms,
     )
     .await
 }
@@ -792,6 +807,36 @@ async fn hls_outcome_response(
     }
 }
 
+/// While the HLS job is Live the encoder may simply not have written the
+/// requested segment yet — a slow encode or leech at the live edge. Waiting a
+/// few beats instead of an instant 404 turns edge starvation into a delayed
+/// response the player treats as buffering, not an error strike.
+async fn open_segment_waiting(
+    store: &state::StateStore,
+    id: &str,
+    path: &std::path::Path,
+    wait_ms: u64,
+) -> std::io::Result<tokio::fs::File> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(wait_ms);
+    loop {
+        match tokio::fs::File::open(path).await {
+            Ok(f) => return Ok(f),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let live = store
+                    .get(id)
+                    .map(|m| m.hls == state::HlsStatus::Live)
+                    .unwrap_or(false);
+                if !live || tokio::time::Instant::now() >= deadline {
+                    return Err(e);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn hls_segment_core(
     headers: &HeaderMap,
     query: Option<&str>,
@@ -800,6 +845,7 @@ pub(crate) async fn hls_segment_core(
     id: &str,
     segment: &str,
     method: &axum::http::Method,
+    segment_wait_ms: u64,
 ) -> axum::response::Response {
     if !check_auth_q(headers, query, token) {
         return StatusCode::UNAUTHORIZED.into_response();
@@ -835,7 +881,7 @@ pub(crate) async fn hls_segment_core(
         };
         return crate::stream::head_response(total, range, ct);
     }
-    let file = match tokio::fs::File::open(&path).await {
+    let file = match open_segment_waiting(store, id, &path, segment_wait_ms).await {
         Ok(f) => f,
         Err(e) => {
             tracing::warn!(id = %id, segment, path = %path.display(), error = %e, "hls segment open failed");
@@ -1642,6 +1688,7 @@ mod tests {
             "1",
             "seg-1.mp4",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -1657,6 +1704,7 @@ mod tests {
             "1",
             "seg00001.ts",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -1696,12 +1744,70 @@ mod tests {
             "1",
             "seg00001.ts",
             &Method::GET,
+            0,
         )
         .await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.headers().get("content-type").unwrap(), "video/mp2t");
         let body = res.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], b"tsdata");
+    }
+
+    #[tokio::test]
+    async fn hls_segment_waits_for_live_encoder() {
+        let dir = tempdir().unwrap();
+        let hls_dir = dir.path().join("hls");
+        std::fs::create_dir_all(&hls_dir).unwrap();
+        let s = StateStore::load(dir.path().join("s.json")).unwrap();
+        s.upsert(Metadata {
+            id: "1".into(),
+            name: "movie".into(),
+            path: "/lib/movie.mp4".into(),
+            size: 5,
+            completed_at: Some(10),
+            last_access: 10,
+            state: TorrentState::Seeding,
+            error: None,
+            active_path: None,
+            transcode: TranscodeStatus::None,
+            transcode_path: None,
+            transcode_error: None,
+            hls: HlsStatus::Live,
+            hls_dir: Some(hls_dir.display().to_string()),
+            hls_error: None,
+        })
+        .unwrap();
+        let seg = hls_dir.join("seg00007.ts");
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+            std::fs::write(seg, b"late").unwrap();
+        });
+        let res = hls_segment_core(
+            &HeaderMap::new(),
+            None,
+            &None,
+            &s,
+            "1",
+            "seg00007.ts",
+            &Method::GET,
+            3000,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK, "waited for the encoder");
+        std::mem::forget(dir);
+
+        let res = hls_segment_core(
+            &HeaderMap::new(),
+            None,
+            &None,
+            &s,
+            "1",
+            "seg99999.ts",
+            &Method::GET,
+            300,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "deadline still 404s");
     }
 
     #[tokio::test]

--- a/apps/media/reel/src/config.rs
+++ b/apps/media/reel/src/config.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub live_hls_enabled: bool,
     pub live_prebuffer_segments: usize,
     pub hls_segment_secs: u64,
+    pub hls_max_height: u32,
+    pub hls_segment_wait_ms: u64,
     pub bt_port_file: Option<PathBuf>,
     pub bt_port_wait_secs: u64,
     pub bt_port_stable_secs: u64,
@@ -210,6 +212,8 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         live_hls_enabled: env_bool("REEL_LIVE_HLS", true),
         live_prebuffer_segments: env_u64("REEL_LIVE_PREBUFFER_SEGMENTS", 3)?.max(1) as usize,
         hls_segment_secs: env_u64("REEL_HLS_SEGMENT_SECS", 4)?,
+        hls_max_height: env_u64("REEL_HLS_MAX_HEIGHT", 1080)?.min(u32::MAX as u64) as u32,
+        hls_segment_wait_ms: env_u64("REEL_HLS_SEGMENT_WAIT_MS", 5000)?,
         bt_port_file: match std::env::var("REEL_BT_PORT_FILE") {
             Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v.trim())),
             _ => None,
@@ -263,6 +267,8 @@ mod tests {
             "REEL_LIVE_HLS",
             "REEL_LIVE_PREBUFFER_SEGMENTS",
             "REEL_HLS_SEGMENT_SECS",
+            "REEL_HLS_MAX_HEIGHT",
+            "REEL_HLS_SEGMENT_WAIT_MS",
             "REEL_BT_PORT_FILE",
             "REEL_BT_PORT_WAIT_SECS",
             "REEL_BT_PORT_WATCH_RESTART",
@@ -496,13 +502,19 @@ mod tests {
         assert!(c.live_hls_enabled);
         assert_eq!(c.live_prebuffer_segments, 3);
         assert_eq!(c.hls_segment_secs, 4);
+        assert_eq!(c.hls_max_height, 1080);
+        assert_eq!(c.hls_segment_wait_ms, 5000);
         std::env::set_var("REEL_HLS_ENABLED", "false");
         std::env::set_var("REEL_LIVE_HLS", "false");
         std::env::set_var("REEL_HLS_SEGMENT_SECS", "8");
+        std::env::set_var("REEL_HLS_MAX_HEIGHT", "0");
+        std::env::set_var("REEL_HLS_SEGMENT_WAIT_MS", "0");
         let c2 = load_from_env().unwrap();
         assert!(!c2.hls_enabled);
         assert!(!c2.live_hls_enabled);
         assert_eq!(c2.hls_segment_secs, 8);
+        assert_eq!(c2.hls_max_height, 0);
+        assert_eq!(c2.hls_segment_wait_ms, 0);
         clear();
     }
 }

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -35,6 +35,15 @@ mod tests {
         assert!(valid_segment_name("stream_00.vtt"));
     }
     #[test]
+    fn scale_filter_caps_and_disables() {
+        assert_eq!(
+            scale_filter(1080).as_deref(),
+            Some("scale=-2:min(1080\\,ih)")
+        );
+        assert_eq!(scale_filter(0), None);
+    }
+
+    #[test]
     fn rejects_traversal() {
         for n in [
             "../x",
@@ -71,6 +80,13 @@ fn count_ts_segments(dir: &std::path::Path) -> usize {
                 .count()
         })
         .unwrap_or(0)
+}
+
+/// Scale filter capping output height so a 4K source encodes at a rate the
+/// player can keep up with. `min(h, ih)` never upscales; `-2` keeps the width
+/// even. 0 disables the cap.
+pub fn scale_filter(max_height: u32) -> Option<String> {
+    (max_height > 0).then(|| format!("scale=-2:min({max_height}\\,ih)"))
 }
 
 fn delivery_label(d: Delivery) -> &'static str {
@@ -150,6 +166,7 @@ pub struct HlsManager {
     live_enabled: bool,
     live_prebuffer_segments: usize,
     encode_threads: usize,
+    max_height: u32,
     children: Arc<Mutex<HashMap<String, Child>>>,
     delivery_cache: Arc<Mutex<HashMap<String, Delivery>>>,
 }
@@ -166,6 +183,7 @@ impl HlsManager {
         live_enabled: bool,
         live_prebuffer_segments: usize,
         encode_threads: usize,
+        max_height: u32,
     ) -> Self {
         let this = Self {
             store,
@@ -177,6 +195,7 @@ impl HlsManager {
             live_enabled,
             live_prebuffer_segments: live_prebuffer_segments.max(1),
             encode_threads,
+            max_height,
             children: Arc::new(Mutex::new(HashMap::new())),
             delivery_cache: Arc::new(Mutex::new(HashMap::new())),
         };
@@ -329,6 +348,10 @@ impl HlsManager {
                 args.push("libx264".into());
                 args.push("-preset".into());
                 args.push("veryfast".into());
+                if let Some(vf) = scale_filter(self.max_height) {
+                    args.push("-vf".into());
+                    args.push(vf);
+                }
                 if self.encode_threads > 0 {
                     args.push("-threads".into());
                     args.push(self.encode_threads.to_string());
@@ -604,6 +627,10 @@ impl HlsManager {
             args.push("libx264".into());
             args.push("-preset".into());
             args.push("veryfast".into());
+            if let Some(vf) = scale_filter(self.max_height) {
+                args.push("-vf".into());
+                args.push(vf);
+            }
             if self.encode_threads > 0 {
                 args.push("-threads".into());
                 args.push(self.encode_threads.to_string());
@@ -803,6 +830,7 @@ mod mgr_tests {
             true,
             3,
             1,
+            1080,
         );
         mgr.abort("unknown-id").await;
         assert!(mgr.take_child("unknown-id").is_none());
@@ -822,6 +850,7 @@ mod mgr_tests {
             true,
             3,
             1,
+            1080,
         );
         assert_eq!(mgr.cached_delivery("1"), None);
         mgr.cache_delivery("1", Delivery::RemuxHls);

--- a/apps/media/reel/src/main.rs
+++ b/apps/media/reel/src/main.rs
@@ -41,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.live_hls_enabled,
         cfg.live_prebuffer_segments,
         cfg.encode_threads,
+        cfg.hls_max_height,
     );
 
     tokio::spawn(reaper::reap_loop(
@@ -93,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
         stream_enabled: cfg.stream_enabled,
         hls,
         ffprobe_bin: cfg.ffprobe_bin.clone(),
+        hls_segment_wait_ms: cfg.hls_segment_wait_ms,
     });
     let listener = tokio::net::TcpListener::bind(&cfg.api_addr).await?;
     tracing::info!(addr = %cfg.api_addr, "reel listening");

--- a/apps/media/reel/src/transcode.rs
+++ b/apps/media/reel/src/transcode.rs
@@ -687,9 +687,16 @@ async fn extract_subtitles(
 }
 
 /// A finished download that has not been made playable yet. Failed transcodes
-/// are left alone (no auto-retry loop); the user can retry manually.
+/// are left alone (no auto-retry loop); the user can retry manually. An entry
+/// with an active HLS job is skipped — a background encode racing the viewer's
+/// HLS encode for the same cores starves the live stream.
 pub fn should_auto_transcode(m: &crate::state::Metadata) -> bool {
-    m.state == crate::state::TorrentState::Seeding && m.transcode == TranscodeStatus::None
+    m.state == crate::state::TorrentState::Seeding
+        && m.transcode == TranscodeStatus::None
+        && !matches!(
+            m.hls,
+            crate::state::HlsStatus::Starting | crate::state::HlsStatus::Live
+        )
 }
 
 /// Makes every completed download playable on its own — no manual transcode
@@ -984,6 +991,15 @@ mod transcoder_tests {
         let mut leech = meta("e", TranscodeStatus::None);
         leech.state = TorrentState::Leeching;
         assert!(!should_auto_transcode(&leech));
+        let mut watching = meta("f", TranscodeStatus::None);
+        watching.hls = crate::state::HlsStatus::Live;
+        assert!(!should_auto_transcode(&watching));
+        let mut starting = meta("g", TranscodeStatus::None);
+        starting.hls = crate::state::HlsStatus::Starting;
+        assert!(!should_auto_transcode(&starting));
+        let mut done = meta("h", TranscodeStatus::None);
+        done.hls = crate::state::HlsStatus::Ready;
+        assert!(should_auto_transcode(&done), "finished HLS does not block");
     }
 
     #[test]

--- a/apps/media/reel/tests/hls_integration.rs
+++ b/apps/media/reel/tests/hls_integration.rs
@@ -58,6 +58,7 @@ async fn hls_transcode_integration() {
         true,
         3,
         1,
+        1080,
     );
     let outcome = mgr
         .request("test-hls", reel::transcode::Delivery::TranscodeHls)

--- a/packages/rust/simbody3d/Cargo.toml
+++ b/packages/rust/simbody3d/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "simbody3d"
+authors = ["kbve", "h0lybyte"]
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+license = "MIT"
+description = "Tile-derived 3D collision and kinematic character movement on rapier3d — the physics complement to simgrid, built to compile natively and to wasm from one source."
+homepage = "https://kbve.com/"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/simbody3d"
+keywords = ["rapier", "physics", "multiplayer", "gamedev", "character-controller"]
+categories = ["game-development", "simulation"]
+
+[lib]
+name = "simbody3d"
+path = "src/lib.rs"
+
+[dependencies]
+rapier3d = "0.30.1"
+
+[features]
+default = ["presets"]
+# Shipped world/character configurations. Kept in this crate rather than in a
+# consumer so a native server and a wasm client build read the same numbers
+# instead of each declaring their own.
+presets = []
+# Cross-platform determinism at the cost of SIMD. Only meaningful once every
+# consumer builds from this crate — enabling it on one side while the other
+# runs a differently-configured rapier would make the two diverge, not agree.
+enhanced-determinism = ["rapier3d/enhanced-determinism"]

--- a/packages/rust/simbody3d/project.json
+++ b/packages/rust/simbody3d/project.json
@@ -1,0 +1,33 @@
+{
+	"name": "simbody3d",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/rust/simbody3d/src",
+	"tags": ["rust", "physics", "rapier"],
+	"targets": {
+		"build": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo build -p simbody3d"
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo test -p simbody3d"
+			}
+		},
+		"lint": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo clippy -p simbody3d --all-targets --all-features -- -D warnings"
+			}
+		},
+		"check-wasm": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo check -p simbody3d --target wasm32-unknown-unknown"
+			}
+		}
+	}
+}

--- a/packages/rust/simbody3d/src/config.rs
+++ b/packages/rust/simbody3d/src/config.rs
@@ -1,0 +1,96 @@
+use crate::tiles::TileMask;
+
+/// World scale and static geometry dimensions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WorldConfig {
+    /// Edge length of one tile in world units.
+    pub tile: f32,
+    /// Height of a solid tile's wall block.
+    pub wall_height: f32,
+    /// Half-thickness of a floor slab. The slab's top face sits at y=0 for any
+    /// value, so this is a robustness knob rather than a gameplay one.
+    pub floor_half: f32,
+}
+
+impl Default for WorldConfig {
+    fn default() -> Self {
+        Self {
+            tile: 1.0,
+            wall_height: 3.0,
+            floor_half: 0.5,
+        }
+    }
+}
+
+/// Capsule dimensions and kinematic character controller tuning.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CharacterConfig {
+    /// Capsule half-height, excluding the end caps.
+    pub half_height: f32,
+    pub radius: f32,
+    /// Controller skin width; the capsule rests this far off a surface.
+    pub offset: f32,
+    pub autostep_max_height: f32,
+    pub autostep_min_width: f32,
+    pub autostep_dynamic_bodies: bool,
+    /// `None` disables snap-to-ground.
+    pub snap_to_ground: Option<f32>,
+    pub gravity: f32,
+    /// Exponential approach rate toward the desired horizontal velocity.
+    pub accel: f32,
+    pub walk_speed: f32,
+    pub run_speed: f32,
+}
+
+impl CharacterConfig {
+    /// Distance from the reported foot position up to the capsule's centre.
+    #[inline]
+    pub fn centre_offset(&self) -> f32 {
+        self.half_height + self.radius
+    }
+}
+
+impl Default for CharacterConfig {
+    fn default() -> Self {
+        Self {
+            half_height: 0.6,
+            radius: 0.35,
+            offset: 0.02,
+            autostep_max_height: 0.5,
+            autostep_min_width: 0.2,
+            autostep_dynamic_bodies: true,
+            snap_to_ground: Some(0.5),
+            gravity: 22.0,
+            accel: 12.0,
+            walk_speed: 1.8,
+            run_speed: 4.5,
+        }
+    }
+}
+
+/// Fixed simulation step. Keep `dt` shorter than a display frame: at exactly
+/// 1/60 a 60Hz frame straddles the boundary and takes 0 or 2 steps, which reads
+/// as judder.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StepConfig {
+    pub dt: f32,
+    pub max_steps: u32,
+}
+
+impl Default for StepConfig {
+    fn default() -> Self {
+        Self {
+            dt: 1.0 / 120.0,
+            max_steps: 8,
+        }
+    }
+}
+
+/// Everything a [`crate::PhysicsWorld`] needs to interpret a tile buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct SimbodyConfig {
+    pub world: WorldConfig,
+    pub character: CharacterConfig,
+    pub step: StepConfig,
+    pub mask: TileMask,
+}

--- a/packages/rust/simbody3d/src/lib.rs
+++ b/packages/rust/simbody3d/src/lib.rs
@@ -1,0 +1,32 @@
+//! Tile-derived 3D collision and kinematic character movement on rapier3d.
+//!
+//! The physics complement to `simgrid`, which owns the wire, roster and grid
+//! sim but has no physics engine of its own. A game links both: simgrid for
+//! netcode, this for where a body may actually go.
+//!
+//! Built to be the *only* implementation of that for a given game. It compiles
+//! natively for an authoritative server and to wasm for a browser client, so
+//! prediction and authority run the same solver rather than two
+//! transliterations pinned by parity vectors. `simgrid` cannot follow it to
+//! wasm — it depends on bevy, axum and multi-threaded tokio.
+//!
+//! Nothing here is game-specific: world scale, capsule dimensions, controller
+//! tuning and the meaning of tile bits all arrive via [`SimbodyConfig`].
+//! Shipped configurations live in `presets`.
+//!
+//! rapier is pinned to 0.30.1 because that is what
+//! `@dimforge/rapier3d-compat` 0.19.3 is built from, so a client still using
+//! the npm package runs the same solver version.
+
+pub mod config;
+pub mod motor;
+pub mod tiles;
+pub mod world;
+
+#[cfg(feature = "presets")]
+pub mod presets;
+
+pub use config::{CharacterConfig, SimbodyConfig, StepConfig, WorldConfig};
+pub use motor::{FixedStep, approach};
+pub use tiles::{SectorTiles, TileMask};
+pub use world::{CharacterHandle, PhysicsWorld, sector_colliders};

--- a/packages/rust/simbody3d/src/motor.rs
+++ b/packages/rust/simbody3d/src/motor.rs
@@ -1,0 +1,63 @@
+use crate::config::StepConfig;
+
+/// Exponential approach toward a target.
+///
+/// Consumers that also predict this motion client-side must use this exact
+/// curve — two copies of a formula this small is how authoritative and
+/// predicted motion quietly diverge.
+#[inline]
+pub fn approach(current: f32, target: f32, accel: f32, dt: f32) -> f32 {
+    current + (target - current) * (1.0 - (-accel * dt).exp())
+}
+
+/// Turns a variable frame delta into whole simulation steps, so travel is a
+/// function of elapsed time rather than of how often the caller ticks.
+pub struct FixedStep {
+    acc: f32,
+    pub dt: f32,
+    pub max_steps: u32,
+}
+
+impl Default for FixedStep {
+    fn default() -> Self {
+        Self::from_config(StepConfig::default())
+    }
+}
+
+impl FixedStep {
+    pub fn new(dt: f32, max_steps: u32) -> Self {
+        Self {
+            acc: 0.0,
+            dt,
+            max_steps,
+        }
+    }
+
+    pub fn from_config(cfg: StepConfig) -> Self {
+        Self::new(cfg.dt, cfg.max_steps)
+    }
+
+    /// Runs whole steps for the elapsed time; returns how many ran. Past
+    /// `max_steps` the backlog is dropped rather than repaid in one burst.
+    pub fn run(&mut self, frame_dt: f32, mut step: impl FnMut(f32)) -> u32 {
+        self.acc += frame_dt;
+        let mut n = 0;
+        while self.acc >= self.dt && n < self.max_steps {
+            self.acc -= self.dt;
+            step(self.dt);
+            n += 1;
+        }
+        if n >= self.max_steps {
+            self.acc = 0.0;
+        }
+        n
+    }
+
+    pub fn pending(&self) -> f32 {
+        self.acc
+    }
+
+    pub fn reset(&mut self) {
+        self.acc = 0.0;
+    }
+}

--- a/packages/rust/simbody3d/src/presets.rs
+++ b/packages/rust/simbody3d/src/presets.rs
@@ -1,0 +1,56 @@
+use crate::config::{CharacterConfig, SimbodyConfig, StepConfig, WorldConfig};
+use crate::tiles::TileMask;
+
+/// Herbmail's tile bitfield, mirroring `game/geometry/grid.ts`. Only SOLID and
+/// PIT reach collision; the rest are rendering concerns listed so the mapping is
+/// checkable against the client.
+pub mod herbmail_tiles {
+    pub const SOLID: u8 = 1 << 0;
+    pub const OCCLUDES: u8 = 1 << 1;
+    pub const DOORWAY: u8 = 1 << 2;
+    pub const PILLAR: u8 = 1 << 3;
+    pub const PIT: u8 = 1 << 4;
+    pub const OPEN: u8 = 1 << 5;
+
+    pub const FLOOR: u8 = 0;
+    pub const WALL: u8 = SOLID | OCCLUDES;
+    pub const ARCH: u8 = DOORWAY;
+    pub const COLUMN: u8 = SOLID | PILLAR;
+    pub const OASIS: u8 = PIT;
+}
+
+/// Herbmail's world and character dimensions.
+///
+/// These are the numbers the client's physics worker already runs with, and the
+/// single place they are declared for any consumer of this crate — a second
+/// declaration is how an authoritative and a predicted body quietly diverge.
+pub fn herbmail() -> SimbodyConfig {
+    SimbodyConfig {
+        world: WorldConfig {
+            tile: 3.0,
+            wall_height: 9.0,
+            floor_half: 0.5,
+        },
+        character: CharacterConfig {
+            half_height: 0.6,
+            radius: 0.35,
+            offset: 0.02,
+            autostep_max_height: 0.5,
+            autostep_min_width: 0.2,
+            autostep_dynamic_bodies: true,
+            snap_to_ground: Some(0.5),
+            gravity: 22.0,
+            accel: 12.0,
+            walk_speed: 1.8,
+            run_speed: 4.5,
+        },
+        step: StepConfig {
+            dt: 1.0 / 120.0,
+            max_steps: 8,
+        },
+        mask: TileMask {
+            solid: herbmail_tiles::SOLID,
+            no_floor: herbmail_tiles::PIT,
+        },
+    }
+}

--- a/packages/rust/simbody3d/src/tiles.rs
+++ b/packages/rust/simbody3d/src/tiles.rs
@@ -1,0 +1,85 @@
+/// How a consumer's tile bitfield maps onto the only two properties this crate
+/// cares about. Everything else a game encodes in a tile — occlusion, doorways,
+/// lighting, ownership — is irrelevant to collision and is never read here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TileMask {
+    /// Bits that make a tile block movement and grow a wall block.
+    pub solid: u8,
+    /// Bits that suppress the floor slab, so a character walks in and falls.
+    pub no_floor: u8,
+}
+
+impl Default for TileMask {
+    fn default() -> Self {
+        Self {
+            solid: 1 << 0,
+            no_floor: 1 << 1,
+        }
+    }
+}
+
+impl TileMask {
+    #[inline]
+    pub fn is_solid(&self, tile: u8) -> bool {
+        tile & self.solid != 0
+    }
+
+    /// A slab is emitted only where the tile is neither solid nor explicitly
+    /// floorless.
+    #[inline]
+    pub fn has_floor(&self, tile: u8) -> bool {
+        tile & (self.solid | self.no_floor) == 0
+    }
+}
+
+/// One rectangular block of tiles, positioned in world tile coordinates.
+#[derive(Clone, Debug)]
+pub struct SectorTiles {
+    pub cols: i32,
+    pub rows: i32,
+    pub origin_col: i32,
+    pub origin_row: i32,
+    pub tiles: Vec<u8>,
+}
+
+impl SectorTiles {
+    pub fn new(cols: i32, rows: i32, origin_col: i32, origin_row: i32, tiles: Vec<u8>) -> Self {
+        assert_eq!(
+            tiles.len(),
+            (cols * rows) as usize,
+            "tile buffer must be cols*rows"
+        );
+        Self {
+            cols,
+            rows,
+            origin_col,
+            origin_row,
+            tiles,
+        }
+    }
+
+    pub fn filled(cols: i32, rows: i32, origin_col: i32, origin_row: i32, tile: u8) -> Self {
+        Self::new(
+            cols,
+            rows,
+            origin_col,
+            origin_row,
+            vec![tile; (cols * rows) as usize],
+        )
+    }
+
+    /// Out of bounds reads as all-bits-set so every mask treats it as solid: a
+    /// sector edge must not silently become walkable when a neighbour is not
+    /// mounted.
+    #[inline]
+    pub fn at(&self, col: i32, row: i32) -> u8 {
+        if col < 0 || row < 0 || col >= self.cols || row >= self.rows {
+            return u8::MAX;
+        }
+        self.tiles[(row * self.cols + col) as usize]
+    }
+
+    pub fn set(&mut self, col: i32, row: i32, tile: u8) {
+        self.tiles[(row * self.cols + col) as usize] = tile;
+    }
+}

--- a/packages/rust/simbody3d/src/world.rs
+++ b/packages/rust/simbody3d/src/world.rs
@@ -1,0 +1,464 @@
+use std::collections::HashMap;
+
+use rapier3d::control::{CharacterAutostep, CharacterLength, KinematicCharacterController};
+use rapier3d::parry::query::DefaultQueryDispatcher;
+use rapier3d::prelude::*;
+
+use crate::config::{SimbodyConfig, WorldConfig};
+use crate::tiles::{SectorTiles, TileMask};
+
+/// Static colliders for one block of tiles.
+///
+/// Walls are one cuboid per solid tile. Floors are merged into per-row runs
+/// first: a collider per open tile would be ~2300 for a 48x48 sector and ~18k
+/// across a resident 3x3 ring, and rooms are typically rectangular so runs
+/// collapse that to a handful of boxes per row.
+pub fn sector_colliders(d: &SectorTiles, world: &WorldConfig, mask: &TileMask) -> Vec<Collider> {
+    let mut out = Vec::new();
+    let tile = world.tile;
+    let hx = tile / 2.0;
+    let hy = world.wall_height / 2.0;
+
+    for r in 0..d.rows {
+        for c in 0..d.cols {
+            if !mask.is_solid(d.at(c, r)) {
+                continue;
+            }
+            out.push(
+                ColliderBuilder::cuboid(hx, hy, hx)
+                    .translation(vector![
+                        (d.origin_col + c) as f32 * tile + hx,
+                        hy,
+                        (d.origin_row + r) as f32 * tile + hx
+                    ])
+                    .build(),
+            );
+        }
+    }
+
+    for r in 0..d.rows {
+        let mut c = 0;
+        while c < d.cols {
+            if !mask.has_floor(d.at(c, r)) {
+                c += 1;
+                continue;
+            }
+            let mut end = c;
+            while end + 1 < d.cols && mask.has_floor(d.at(end + 1, r)) {
+                end += 1;
+            }
+            let len = (end - c + 1) as f32;
+            out.push(
+                ColliderBuilder::cuboid(len * tile / 2.0, world.floor_half, tile / 2.0)
+                    .translation(vector![
+                        ((d.origin_col + c) as f32 + len / 2.0) * tile,
+                        -world.floor_half,
+                        (d.origin_row + r) as f32 * tile + tile / 2.0
+                    ])
+                    .build(),
+            );
+            c = end + 1;
+        }
+    }
+
+    out
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CharacterHandle {
+    pub body: RigidBodyHandle,
+    pub collider: ColliderHandle,
+    grounded: bool,
+}
+
+impl CharacterHandle {
+    pub fn grounded(&self) -> bool {
+        self.grounded
+    }
+}
+
+/// Static tile geometry plus kinematic character capsules, resolved by rapier's
+/// character controller.
+pub struct PhysicsWorld {
+    config: SimbodyConfig,
+    bodies: RigidBodySet,
+    colliders: ColliderSet,
+    islands: IslandManager,
+    broad_phase: BroadPhaseBvh,
+    narrow_phase: NarrowPhase,
+    impulse_joints: ImpulseJointSet,
+    multibody_joints: MultibodyJointSet,
+    ccd_solver: CCDSolver,
+    pipeline: PhysicsPipeline,
+    integration: IntegrationParameters,
+    dispatcher: DefaultQueryDispatcher,
+    controller: KinematicCharacterController,
+    sectors: HashMap<(i32, i32), RigidBodyHandle>,
+}
+
+impl PhysicsWorld {
+    pub fn new(config: SimbodyConfig) -> Self {
+        let ch = &config.character;
+        let controller = KinematicCharacterController {
+            offset: CharacterLength::Absolute(ch.offset),
+            snap_to_ground: ch.snap_to_ground.map(CharacterLength::Absolute),
+            autostep: Some(CharacterAutostep {
+                max_height: CharacterLength::Absolute(ch.autostep_max_height),
+                min_width: CharacterLength::Absolute(ch.autostep_min_width),
+                include_dynamic_bodies: ch.autostep_dynamic_bodies,
+            }),
+            ..Default::default()
+        };
+
+        Self {
+            config,
+            bodies: RigidBodySet::new(),
+            colliders: ColliderSet::new(),
+            islands: IslandManager::new(),
+            broad_phase: BroadPhaseBvh::new(),
+            narrow_phase: NarrowPhase::new(),
+            impulse_joints: ImpulseJointSet::new(),
+            multibody_joints: MultibodyJointSet::new(),
+            ccd_solver: CCDSolver::new(),
+            pipeline: PhysicsPipeline::new(),
+            integration: IntegrationParameters::default(),
+            dispatcher: DefaultQueryDispatcher,
+            controller,
+            sectors: HashMap::new(),
+        }
+    }
+
+    pub fn config(&self) -> &SimbodyConfig {
+        &self.config
+    }
+
+    pub fn add_sector(&mut self, key: (i32, i32), d: &SectorTiles) {
+        if self.sectors.contains_key(&key) {
+            return;
+        }
+        let body = self.bodies.insert(RigidBodyBuilder::fixed().build());
+        for collider in sector_colliders(d, &self.config.world, &self.config.mask) {
+            self.colliders
+                .insert_with_parent(collider, body, &mut self.bodies);
+        }
+        self.sectors.insert(key, body);
+        self.settle();
+    }
+
+    pub fn remove_sector(&mut self, key: (i32, i32)) {
+        let Some(body) = self.sectors.remove(&key) else {
+            return;
+        };
+        self.bodies.remove(
+            body,
+            &mut self.islands,
+            &mut self.colliders,
+            &mut self.impulse_joints,
+            &mut self.multibody_joints,
+            true,
+        );
+        self.settle();
+    }
+
+    pub fn collider_count(&self) -> usize {
+        self.colliders.len()
+    }
+
+    pub fn sector_count(&self) -> usize {
+        self.sectors.len()
+    }
+
+    /// Spawns a character capsule with its feet at `foot`.
+    pub fn spawn_character(&mut self, foot: Vector<f32>) -> CharacterHandle {
+        let ch = &self.config.character;
+        let body = self.bodies.insert(
+            RigidBodyBuilder::kinematic_position_based()
+                .translation(vector![foot.x, foot.y + ch.centre_offset(), foot.z])
+                .build(),
+        );
+        let collider = self.colliders.insert_with_parent(
+            ColliderBuilder::capsule_y(ch.half_height, ch.radius).build(),
+            body,
+            &mut self.bodies,
+        );
+        self.settle();
+        CharacterHandle {
+            body,
+            collider,
+            grounded: false,
+        }
+    }
+
+    /// One substep of character movement. `desired_x`/`desired_z` are horizontal
+    /// velocities; gravity is applied here. Kinematic bodies are excluded from
+    /// the sweep so two characters never shove each other.
+    pub fn step_character(
+        &mut self,
+        ch: &mut CharacterHandle,
+        desired_x: f32,
+        desired_z: f32,
+        dt: f32,
+    ) {
+        let translation = *self.bodies[ch.body].translation();
+        let wanted = vector![
+            desired_x * dt,
+            -self.config.character.gravity * dt,
+            desired_z * dt
+        ];
+        let shape = self.colliders[ch.collider].shared_shape().clone();
+
+        let queries = self.broad_phase.as_query_pipeline(
+            &self.dispatcher,
+            &self.bodies,
+            &self.colliders,
+            QueryFilter::exclude_kinematic(),
+        );
+
+        let movement = self.controller.move_shape(
+            dt,
+            &queries,
+            shape.as_ref(),
+            &Isometry::from(translation),
+            wanted,
+            |_| {},
+        );
+
+        ch.grounded = movement.grounded;
+        // Teleport rather than setting a next kinematic target: the target only
+        // lands on the next physics step, so a second substep in the same step
+        // would read the same stale translation and overwrite the first's
+        // result instead of accumulating it, silently halving the speed.
+        self.bodies[ch.body].set_translation(translation + movement.translation, true);
+        self.settle();
+    }
+
+    /// Foot position of a character.
+    pub fn foot_position(&self, ch: &CharacterHandle) -> Vector<f32> {
+        let t = self.bodies[ch.body].translation();
+        vector![
+            t.x,
+            t.y - self.config.character.centre_offset(),
+            t.z
+        ]
+    }
+
+    pub fn teleport_character(&mut self, ch: &CharacterHandle, foot: Vector<f32>) {
+        let centre = self.config.character.centre_offset();
+        self.bodies[ch.body].set_translation(vector![foot.x, foot.y + centre, foot.z], true);
+        self.settle();
+    }
+
+    /// Advances the pipeline with a zero timestep so the broad-phase BVH picks
+    /// up inserted, removed or teleported colliders before the next query.
+    fn settle(&mut self) {
+        let mut params = self.integration;
+        params.dt = 0.0;
+        self.pipeline.step(
+            &vector![0.0, 0.0, 0.0],
+            &params,
+            &mut self.islands,
+            &mut self.broad_phase,
+            &mut self.narrow_phase,
+            &mut self.bodies,
+            &mut self.colliders,
+            &mut self.impulse_joints,
+            &mut self.multibody_joints,
+            &mut self.ccd_solver,
+            &(),
+            &(),
+        );
+    }
+}
+
+#[cfg(all(test, feature = "presets"))]
+mod tests {
+    use super::*;
+    use crate::motor::{FixedStep, approach};
+    use crate::presets::herbmail_tiles::{FLOOR, PIT, WALL};
+    use crate::presets::herbmail;
+
+    const N: i32 = 8;
+
+    fn open_sector() -> SectorTiles {
+        SectorTiles::filled(N, N, 0, 0, FLOOR)
+    }
+
+    fn world() -> PhysicsWorld {
+        PhysicsWorld::new(herbmail())
+    }
+
+    /// Walks the capsule for `secs` at a constant horizontal intent, using the
+    /// configured substep cadence and acceleration curve.
+    fn walk(world: &mut PhysicsWorld, ch: &mut CharacterHandle, vx: f32, vz: f32, secs: f32) {
+        let cfg = *world.config();
+        let mut stepper = FixedStep::from_config(cfg.step);
+        let mut vel = (0.0f32, 0.0f32);
+        let frames = (secs / (1.0 / 60.0)).round() as i32;
+        for _ in 0..frames {
+            stepper.run(1.0 / 60.0, |dt| {
+                vel.0 = approach(vel.0, vx, cfg.character.accel, dt);
+                vel.1 = approach(vel.1, vz, cfg.character.accel, dt);
+                world.step_character(ch, vel.0, vel.1, dt);
+            });
+        }
+    }
+
+    #[test]
+    fn floors_merge_into_row_runs_not_per_tile_colliders() {
+        let cfg = herbmail();
+        let colliders = sector_colliders(&open_sector(), &cfg.world, &cfg.mask);
+        // One run per row, no walls. Per-tile would be N*N = 64.
+        assert_eq!(colliders.len(), N as usize);
+    }
+
+    #[test]
+    fn a_floorless_tile_splits_a_row_run_and_emits_no_slab_over_it() {
+        let cfg = herbmail();
+        let mut d = open_sector();
+        d.set(4, 0, PIT);
+        let runs = sector_colliders(&d, &cfg.world, &cfg.mask).len();
+        // Row 0 splits into two runs; the other N-1 rows stay whole.
+        assert_eq!(runs, (N + 1) as usize);
+    }
+
+    #[test]
+    fn a_solid_tile_emits_a_wall_cuboid_at_the_tile_centre() {
+        let cfg = herbmail();
+        let mut d = open_sector();
+        d.set(3, 5, WALL);
+        let colliders = sector_colliders(&d, &cfg.world, &cfg.mask);
+        let wall = colliders
+            .iter()
+            .find(|c| c.translation().y > 0.0)
+            .expect("a wall collider sits above the floor slabs");
+        assert!((wall.translation().x - 10.5).abs() < 1e-4);
+        assert!((wall.translation().z - 16.5).abs() < 1e-4);
+        assert!((wall.translation().y - 4.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn the_tile_mask_decides_what_blocks_rather_than_a_fixed_flag_set() {
+        // A consumer whose bitfield puts "solid" on a different bit gets walls
+        // there and nowhere else. This is what makes the crate reusable.
+        let mut cfg = herbmail();
+        cfg.mask = TileMask {
+            solid: 1 << 7,
+            no_floor: 1 << 6,
+        };
+        let mut d = SectorTiles::filled(N, N, 0, 0, 0);
+        // herbmail's SOLID bit must now mean nothing.
+        d.set(2, 2, 1 << 0);
+        let walls = sector_colliders(&d, &cfg.world, &cfg.mask)
+            .iter()
+            .filter(|c| c.translation().y > 0.0)
+            .count();
+        assert_eq!(walls, 0);
+
+        d.set(2, 2, 1 << 7);
+        let walls = sector_colliders(&d, &cfg.world, &cfg.mask)
+            .iter()
+            .filter(|c| c.translation().y > 0.0)
+            .count();
+        assert_eq!(walls, 1);
+    }
+
+    #[test]
+    fn the_capsule_rests_on_the_floor_instead_of_sinking_or_hovering() {
+        let mut w = world();
+        w.add_sector((0, 0), &open_sector());
+        let mut ch = w.spawn_character(vector![4.5, 0.0, 4.5]);
+        walk(&mut w, &mut ch, 0.0, 0.0, 1.0);
+        let foot = w.foot_position(&ch);
+        assert!(
+            foot.y.abs() < 0.05,
+            "foot drifted off the floor plane: y = {}",
+            foot.y
+        );
+        assert!(ch.grounded(), "capsule should report grounded on a slab");
+    }
+
+    #[test]
+    fn constant_intent_travels_about_the_expected_distance() {
+        let mut w = world();
+        w.add_sector((0, 0), &open_sector());
+        let mut ch = w.spawn_character(vector![4.5, 0.0, 4.5]);
+        walk(&mut w, &mut ch, 1.8, 0.0, 2.0);
+        let travelled = w.foot_position(&ch).x - 4.5;
+        // 2s at 1.8 m/s minus the acceleration ramp, which costs well under one
+        // step's worth at accel 12.
+        assert!(
+            travelled > 3.3 && travelled < 3.6,
+            "expected ~3.5m of travel, got {travelled}"
+        );
+    }
+
+    #[test]
+    fn a_wall_stops_the_capsule_at_its_radius_plus_the_controller_offset() {
+        let mut d = open_sector();
+        for r in 0..N {
+            d.set(4, r, WALL);
+        }
+        let mut w = world();
+        w.add_sector((0, 0), &d);
+        let mut ch = w.spawn_character(vector![4.5, 0.0, 4.5]);
+        walk(&mut w, &mut ch, 4.5, 0.0, 4.0);
+
+        // Literal, not recomputed from the config under test: wall face at
+        // x=12.0, capsule radius 0.35, controller offset 0.02. Deriving it from
+        // the config would make the assertion move with the bug.
+        let expected = 11.63;
+        let x = w.foot_position(&ch).x;
+        assert!(
+            (x - expected).abs() < 0.05,
+            "expected to stop at {expected}, stopped at {x}"
+        );
+    }
+
+    #[test]
+    fn a_floorless_region_is_walked_into_and_fallen_through_rather_than_blocked() {
+        let mut d = open_sector();
+        for r in 0..N {
+            for c in 4..N {
+                d.set(c, r, PIT);
+            }
+        }
+        let mut w = world();
+        w.add_sector((0, 0), &d);
+        let mut ch = w.spawn_character(vector![4.5, 0.0, 4.5]);
+        walk(&mut w, &mut ch, 4.5, 0.0, 3.0);
+
+        let foot = w.foot_position(&ch);
+        assert!(
+            foot.x > 12.0,
+            "should have crossed into the pit at x=12, stopped at {}",
+            foot.x
+        );
+        assert!(foot.y < -1.0, "should have fallen, y = {}", foot.y);
+        assert!(!ch.grounded(), "should not report grounded over a pit");
+    }
+
+    #[test]
+    fn sectors_can_be_added_and_removed_without_leaking_colliders() {
+        let mut w = world();
+        assert_eq!(w.collider_count(), 0);
+        w.add_sector((0, 0), &open_sector());
+        let with_one = w.collider_count();
+        assert_eq!(with_one, N as usize);
+        w.add_sector((1, 0), &SectorTiles::filled(N, N, N, 0, FLOOR));
+        assert_eq!(w.collider_count(), with_one * 2);
+        assert_eq!(w.sector_count(), 2);
+        w.remove_sector((1, 0));
+        assert_eq!(w.collider_count(), with_one);
+        assert_eq!(w.sector_count(), 1);
+    }
+
+    #[test]
+    fn an_unmounted_neighbour_reads_as_solid_rather_than_walkable() {
+        // Out-of-bounds must not become a hole a player can walk out through.
+        let cfg = herbmail();
+        let d = open_sector();
+        assert!(cfg.mask.is_solid(d.at(-1, 0)));
+        assert!(cfg.mask.is_solid(d.at(N, 0)));
+        assert!(!cfg.mask.has_floor(d.at(-1, 0)));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed graph pan/zoom interaction bug where zooming in and dragging to pan would cause unwanted zoom-out behavior
- Added user interaction state tracking to prevent automatic directory loading during manual pan/zoom operations
- Updated CLAUDE.md with Nx best practices and workspace-specific patterns

## Technical Changes

### Graph Interaction Fix
The graph explorer was automatically switching directories based on the viewport center during manual pan operations, causing the view to snap/zoom unexpectedly.

**Solution:**
- Added `isUserInteracting` ref to track when the user is actively dragging/panning
- Enhanced MapControls event listeners to set interaction state on `start` and clear on `end`
- Guarded the automatic directory-loading logic to only run when NOT manually interacting

**Files Changed:**
- [TieredGraphScene.tsx](apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/TieredGraphScene.tsx#L135-L154) - Added interaction tracking
- [TieredGraphScene.tsx](apps/kbve/astro-kbve/src/components/dashboard/graphExplorer/TieredGraphScene.tsx#L326) - Guarded auto-load logic

### Documentation Improvements
- Added "Common Pitfalls" section to CLAUDE.md with Nx cache/affected/dependency warnings
- Added "Workspace-Specific Patterns" with monorepo navigation best practices
- Noted current graph performance optimization work in progress

## Test Plan
- [x] Manually tested zoom in + pan behavior - no unwanted zoom-out
- [x] Verified automatic directory loading still works after interaction completes
- [x] Confirmed smooth pan interaction while zoomed in
- [x] Branch builds successfully

## Related Issues
Fixes graph pan/zoom UX issue reported during graph performance optimization work

🤖 Generated with [Claude Code](https://claude.com/claude-code)