### PR TITLE
fix(reel): terminate dead-encoder streams + guarantee encode pod resources

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -565,11 +565,14 @@ export class ReelPlayer {
 
 	// A stall watchdog: if the playhead stops advancing while playback is
 	// intended and the buffer is starved (readyState below HAVE_FUTURE_DATA),
-	// kick the active recovery path. Runs until torn down, so a stream that
-	// hangs at the download edge resumes on its own without a manual refresh.
+	// kick the active recovery path. A frozen EVENT playlist (dead encoder)
+	// never errors — playlist reloads keep returning 200 — so repeated
+	// no-progress kicks escalate to a full resurrect instead of kicking forever.
 	private startWatchdog(video: HTMLVideoElement, gen: number): void {
 		this.stopWatchdog();
 		this.lastPos = video.currentTime;
+		let stalledKicks = 0;
+		const MAX_STALL_KICKS = 6;
 		this.stallTimer = setInterval(() => {
 			if (this.generation !== gen) return;
 			const v = this.video;
@@ -582,9 +585,54 @@ export class ReelPlayer {
 			// HAVE_FUTURE_DATA (3) or more means it can play on; below that while
 			// the clock isn't moving is a genuine stall.
 			if (advanced < 0.05 && v.readyState < 3) {
+				if (++stalledKicks >= MAX_STALL_KICKS && this.currentId) {
+					void this.resurrect(
+						v,
+						this.currentId,
+						gen,
+						'network',
+						'no playback progress — restarting stream',
+					);
+					return;
+				}
 				this.recover?.();
+			} else {
+				stalledKicks = 0;
 			}
 		}, 5000);
+	}
+
+	// A failed encoder now finalizes its playlist with EXT-X-ENDLIST, so the
+	// player "ends" mid-movie instead of hanging. Tell a real end apart from a
+	// dead encoder by asking the server: HLS Failed means restart the stream.
+	private watchEndedEarly(
+		video: HTMLVideoElement,
+		id: string,
+		gen: number,
+	): void {
+		video.addEventListener(
+			'ended',
+			() => {
+				if (this.generation !== gen) return;
+				void authedApiFetch<ReelDetail>(
+					`${REEL_PATH}/torrents/${encodeURIComponent(id)}`,
+				)
+					.then((detail) => {
+						if (this.generation !== gen) return;
+						if (detail?.hls === 'Failed') {
+							void this.resurrect(
+								video,
+								id,
+								gen,
+								'network',
+								'encoder failed mid-stream — restarting',
+							);
+						}
+					})
+					.catch(() => undefined);
+			},
+			{ once: true },
+		);
 	}
 
 	private stopWatchdog(): void {
@@ -789,6 +837,7 @@ export class ReelPlayer {
 				void video.play().catch(() => undefined);
 			};
 			this.startWatchdog(video, gen);
+			this.watchEndedEarly(video, id, gen);
 			void video.play().catch(() => undefined);
 			return;
 		}
@@ -819,6 +868,7 @@ export class ReelPlayer {
 				void video.play().catch(() => undefined);
 			};
 			this.startWatchdog(video, gen);
+			this.watchEndedEarly(video, id, gen);
 			void video.play().catch(() => undefined);
 			return;
 		}

--- a/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/reel.mdx
@@ -13,7 +13,7 @@ tags:
 key: reel
 pipeline: docker
 app_name: reel
-version: "0.1.37"
+version: "0.1.38"
 source_path: apps/media/reel
 version_toml: apps/media/reel/version.toml
 version_target: apps/media/reel/Cargo.toml

--- a/apps/media/reel/src/hls.rs
+++ b/apps/media/reel/src/hls.rs
@@ -35,6 +35,31 @@ mod tests {
         assert!(valid_segment_name("stream_00.vtt"));
     }
     #[test]
+    fn finalize_appends_endlist_only_to_media_playlists() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        std::fs::write(
+            d.join("index.m3u8"),
+            "#EXTM3U\n#EXTINF:4.0,\nseg00000.ts\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("master.m3u8"),
+            "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nstream_0.m3u8\n",
+        )
+        .unwrap();
+        std::fs::write(d.join("seg00000.ts"), b"x").unwrap();
+        finalize_event_playlists(d);
+        let media = std::fs::read_to_string(d.join("index.m3u8")).unwrap();
+        assert!(media.ends_with("#EXT-X-ENDLIST\n"));
+        let master = std::fs::read_to_string(d.join("master.m3u8")).unwrap();
+        assert!(!master.contains("ENDLIST"), "master playlist untouched");
+        finalize_event_playlists(d);
+        let again = std::fs::read_to_string(d.join("index.m3u8")).unwrap();
+        assert_eq!(again.matches("ENDLIST").count(), 1, "idempotent");
+    }
+
+    #[test]
     fn scale_filter_caps_and_disables() {
         assert_eq!(
             scale_filter(1080).as_deref(),
@@ -69,6 +94,34 @@ mod tests {
         std::fs::write(d.join("index.m3u8"), b"m").unwrap();
         assert_eq!(count_ts_segments(d), 2, "m3u8 not counted");
         assert_eq!(count_ts_segments(&d.join("missing")), 0, "missing dir -> 0");
+    }
+}
+
+/// A dead or killed encoder leaves EVENT playlists without `#EXT-X-ENDLIST`;
+/// players then poll the frozen playlist forever instead of ending. Append the
+/// tag to every media playlist (the ones carrying `#EXTINF`) so the stream
+/// terminates deterministically and the client can re-probe.
+pub(crate) fn finalize_event_playlists(dir: &std::path::Path) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("m3u8") {
+            continue;
+        }
+        let Ok(body) = std::fs::read_to_string(&p) else {
+            continue;
+        };
+        if !body.contains("#EXTINF") || body.contains("#EXT-X-ENDLIST") {
+            continue;
+        }
+        let mut out = body;
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("#EXT-X-ENDLIST\n");
+        let _ = std::fs::write(&p, out);
     }
 }
 
@@ -201,6 +254,9 @@ impl HlsManager {
         };
         for m in this.store.list() {
             if matches!(m.hls, HlsStatus::Starting | HlsStatus::Live) {
+                if let Some(dir) = &m.hls_dir {
+                    finalize_event_playlists(std::path::Path::new(dir));
+                }
                 let _ = this.store.update(&m.id, |m| {
                     m.hls = HlsStatus::Failed;
                     m.hls_error = Some("interrupted by restart".into());
@@ -468,6 +524,7 @@ impl HlsManager {
                 Some(Ok(status)) => {
                     let reason = format!("ffmpeg exited: {status}: {}", ffmpeg_tail(&errbuf));
                     crate::telemetry::hls_failed(&id, &reason);
+                    finalize_event_playlists(&hls_dir);
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Failed;
                         m.hls_error = Some(reason.clone());
@@ -477,6 +534,7 @@ impl HlsManager {
                 Some(Err(e)) => {
                     let reason = e.to_string();
                     crate::telemetry::hls_failed(&id, &reason);
+                    finalize_event_playlists(&hls_dir);
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Failed;
                         m.hls_error = Some(reason.clone());
@@ -484,6 +542,7 @@ impl HlsManager {
                     });
                 }
                 None => {
+                    finalize_event_playlists(&hls_dir);
                     let _ = this.store.update(&id, |m| {
                         m.hls = HlsStatus::Failed;
                         m.hls_error = Some("aborted".into());


### PR DESCRIPTION
## Summary

Follow-up to #15451 — that squash-merge captured the HLS rate fixes and both resource bumps, so after a rebase this PR carries only the **dead-encoder termination** work (plus its release bump):

- **server** (`hls.rs`): a crashed/killed HLS ffmpeg left an EVENT playlist without `#EXT-X-ENDLIST`, so the (now patient) player polled a frozen playlist forever. `finalize_event_playlists` appends the tag to media playlists (skips master, idempotent) on every failure/abort path and on restart reconcile.
- **player** (`reelService.ts`): stall watchdog escalates to a full resurrect after 6 consecutive no-progress kicks (~30s) instead of kicking `startLoad` forever; on `ended` the client checks server HLS status — `Failed` → restart the stream rather than presenting a mid-movie end as finished.
- **mdx** 0.1.37 → 0.1.38 (reel image change → release bump).

## Tests
`cargo test -p reel`: 163 passed (adds finalize idempotency/master-skip test); astro check 0 media errors.