### PR TITLE
feat(desktop-kbve): port Handy devops pillar (Claude Code agent orchestration)

### DIFF
--- a/apps/kbve/desktop-kbve/package.json
+++ b/apps/kbve/desktop-kbve/package.json
@@ -20,6 +20,7 @@
 		"@xterm/addon-web-links": "^0.11.0",
 		"@xterm/addon-webgl": "^0.18.0",
 		"@xterm/xterm": "^5.5.0",
+		"lucide-react": "^0.542.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
 		"react-native-web": "^0.21.0",

--- a/apps/kbve/desktop-kbve/pnpm-lock.yaml
+++ b/apps/kbve/desktop-kbve/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      lucide-react:
+        specifier: ^0.542.0
+        version: 0.542.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -836,6 +839,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.542.0:
+    resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1627,6 +1635,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.542.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:

--- a/apps/kbve/desktop-kbve/src-tauri/Cargo.lock
+++ b/apps/kbve/desktop-kbve/src-tauri/Cargo.lock
@@ -178,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2365,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gray_matter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
+dependencies = [
+ "serde",
+ "thiserror 2.0.19",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2533,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3085,6 +3122,8 @@ dependencies = [
  "ferrous-opencc",
  "flate2",
  "futures-util",
+ "gray_matter",
+ "hostname",
  "hound",
  "log",
  "natural",
@@ -4634,7 +4673,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5093,7 +5132,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8473,6 +8512,17 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yoke"

--- a/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
+++ b/apps/kbve/desktop-kbve/src-tauri/Cargo.toml
@@ -104,6 +104,8 @@ anyhow = "1.0"
 log = "0.4"
 once_cell = "1"
 chrono = "0.4"
+gray_matter = "0.3"
+hostname = "0.4"
 regex = "1"
 tempfile = "3.8"
 

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/devops.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/devops.rs
@@ -1,0 +1,1443 @@
+//! DevOps-related Tauri commands.
+
+use crate::devops::{
+    DevOpsDependencies, check_all_dependencies,
+    github::{
+        self, GhAuthStatus, GitHubComment, GitHubIssue, GitHubPullRequest, IssueAgentMetadata,
+        IssueWithAgent, PrStatus,
+    },
+    operations::agent_lifecycle::PrDetectionResult,
+    orchestrator::{
+        self, AgentStatus, CompleteWorkResult, SpawnConfig, SpawnResult, WorkflowConfig,
+    },
+    tmux::{self, AgentMetadata, RecoveredSession, RecoveryResult, TmuxSession},
+    worktree::{self, CollisionCheck, WorktreeConfig, WorktreeCreateResult, WorktreeInfo},
+};
+use crate::settings;
+use tauri::{AppHandle, Emitter};
+
+/// Check if required DevOps dependencies (gh, tmux) are installed.
+/// Runs in a blocking task to avoid freezing the UI.
+#[tauri::command]
+#[specta::specta]
+pub async fn check_devops_dependencies() -> Result<DevOpsDependencies, String> {
+    tokio::task::spawn_blocking(check_all_dependencies)
+        .await
+        .map_err(|e| format!("Failed to check dependencies: {}", e))
+}
+
+/// Launch authentication flow for a CLI tool by creating a tmux session.
+/// Returns the session name so the user can attach to it.
+#[tauri::command]
+#[specta::specta]
+pub fn launch_cli_auth(tool_name: String) -> Result<String, String> {
+    // Use the same socket name as other Handy tmux sessions
+    const SOCKET_NAME: &str = "handy";
+
+    let session_name = format!("handy-auth-{}", tool_name);
+
+    // Determine the command to run based on the tool
+    let auth_command = match tool_name.as_str() {
+        "gh" => "gh auth login",
+        "claude" => "claude",
+        _ => return Err(format!("Unknown tool: {}", tool_name)),
+    };
+
+    // Create a tmux session that runs the auth command
+    // The session will stay open so the user can complete the OAuth flow
+    let result = std::process::Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET_NAME,
+            "new-session",
+            "-d",
+            "-s",
+            &session_name,
+            "-x",
+            "120",
+            "-y",
+            "30",
+            auth_command,
+        ])
+        .output();
+
+    match result {
+        Ok(output) => {
+            if output.status.success() {
+                // Open Terminal.app and attach to the session
+                let _ = std::process::Command::new("open")
+                    .args(["-a", "Terminal"])
+                    .spawn();
+
+                // Give Terminal a moment to open, then attach
+                std::thread::sleep(std::time::Duration::from_millis(500));
+
+                // Attach using the same socket
+                let _ = std::process::Command::new("osascript")
+                    .args([
+                        "-e",
+                        &format!(
+                            "tell application \"Terminal\" to do script \"tmux -L {} attach-session -t {}\"",
+                            SOCKET_NAME,
+                            session_name
+                        ),
+                    ])
+                    .spawn();
+
+                Ok(session_name)
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(format!("Failed to create auth session: {}", stderr))
+            }
+        }
+        Err(e) => Err(format!("Failed to run tmux: {}", e)),
+    }
+}
+
+/// Attach to an existing tmux session by opening Terminal.app.
+#[tauri::command]
+#[specta::specta]
+pub fn attach_tmux_session(session_name: String) -> Result<(), String> {
+    const SOCKET_NAME: &str = "handy";
+
+    // Open Terminal.app
+    let _ = std::process::Command::new("open")
+        .args(["-a", "Terminal"])
+        .spawn();
+
+    // Give Terminal a moment to open, then attach
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Attach to the session using the handy socket
+    let result = std::process::Command::new("osascript")
+        .args([
+            "-e",
+            &format!(
+                "tell application \"Terminal\" to do script \"tmux -L {} attach-session -t {}\"",
+                SOCKET_NAME, session_name
+            ),
+        ])
+        .output();
+
+    match result {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(format!("Failed to attach to session: {}", stderr))
+            }
+        }
+        Err(e) => Err(format!("Failed to run osascript: {}", e)),
+    }
+}
+
+/// List all Handy agent tmux sessions.
+#[tauri::command]
+#[specta::specta]
+pub fn list_tmux_sessions() -> Result<Vec<TmuxSession>, String> {
+    tmux::list_sessions()
+}
+
+/// Get metadata for a specific tmux session.
+#[tauri::command]
+#[specta::specta]
+pub fn get_tmux_session_metadata(session_name: String) -> Result<AgentMetadata, String> {
+    tmux::get_session_metadata(&session_name)
+}
+
+/// Create a new tmux session with metadata.
+#[tauri::command]
+#[specta::specta]
+pub fn create_tmux_session(
+    session_name: String,
+    working_dir: Option<String>,
+    issue_ref: Option<String>,
+    repo: Option<String>,
+    agent_type: String,
+) -> Result<(), String> {
+    let metadata = AgentMetadata {
+        session: session_name.clone(),
+        issue_ref,
+        repo,
+        worktree: working_dir.clone(),
+        agent_type,
+        machine_id: hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "unknown".to_string()),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    tmux::create_session(&session_name, working_dir.as_deref(), &metadata)
+}
+
+/// Kill a tmux session.
+#[tauri::command]
+#[specta::specta]
+pub fn kill_tmux_session(session_name: String) -> Result<(), String> {
+    tmux::kill_session(&session_name)
+}
+
+/// Get recent output from a tmux session.
+#[tauri::command]
+#[specta::specta]
+pub fn get_tmux_session_output(session_name: String, lines: Option<u32>) -> Result<String, String> {
+    tmux::get_session_output(&session_name, lines)
+}
+
+/// Send a command to a tmux session (appends Enter key).
+/// If command is empty, sends just Enter key.
+#[tauri::command]
+#[specta::specta]
+pub fn send_tmux_command(session_name: String, command: String) -> Result<(), String> {
+    tmux::send_command(&session_name, &command)
+}
+
+/// Send raw keys to a tmux session without appending Enter.
+/// Use for special keys: Enter, Escape, Tab, Space, BSpace, Up, Down, Left, Right, C-c, etc.
+#[tauri::command]
+#[specta::specta]
+pub fn send_tmux_keys(session_name: String, keys: String) -> Result<(), String> {
+    tmux::send_keys(&session_name, &keys)
+}
+
+/// Recover agent sessions on startup.
+#[tauri::command]
+#[specta::specta]
+pub fn recover_tmux_sessions() -> Result<Vec<RecoveredSession>, String> {
+    tmux::recover_sessions()
+}
+
+/// Restart an agent in an existing tmux session.
+///
+/// Use this for recovery when a session exists but the agent process has stopped.
+/// This reads the session metadata and restarts the appropriate agent command.
+#[tauri::command]
+#[specta::specta]
+pub fn restart_agent_in_session(session_name: String) -> Result<(), String> {
+    tmux::restart_agent(&session_name)
+}
+
+/// Recover all sessions that need attention.
+///
+/// - `auto_restart`: If true, automatically restart agents in stopped sessions
+/// - `auto_cleanup`: If true, automatically kill orphaned sessions (no worktree)
+///
+/// Returns results for each session that was processed.
+#[tauri::command]
+#[specta::specta]
+pub fn recover_all_agent_sessions(
+    auto_restart: bool,
+    auto_cleanup: bool,
+) -> Result<Vec<RecoveryResult>, String> {
+    tmux::recover_all_sessions(auto_restart, auto_cleanup)
+}
+
+/// Check if tmux server is running.
+#[tauri::command]
+#[specta::specta]
+pub fn is_tmux_running() -> bool {
+    tmux::is_tmux_running()
+}
+
+/// Ensure a master tmux session exists for orchestration.
+/// Returns true if the session was created, false if it already exists.
+#[tauri::command]
+#[specta::specta]
+pub fn ensure_master_tmux_session() -> Result<bool, String> {
+    tmux::ensure_master_session()
+}
+
+// ============================================================================
+// Git Worktree Commands
+// ============================================================================
+
+/// List all git worktrees in a repository.
+#[tauri::command]
+#[specta::specta]
+pub fn list_git_worktrees(repo_path: String) -> Result<Vec<WorktreeInfo>, String> {
+    worktree::list_worktrees(&repo_path)
+}
+
+/// Get information about a specific worktree.
+#[tauri::command]
+#[specta::specta]
+pub fn get_git_worktree_info(
+    repo_path: String,
+    worktree_path: String,
+) -> Result<WorktreeInfo, String> {
+    worktree::get_worktree_info(&repo_path, &worktree_path)
+}
+
+/// Check for collisions before creating a worktree.
+#[tauri::command]
+#[specta::specta]
+pub fn check_worktree_collision(
+    repo_path: String,
+    worktree_path: String,
+    branch_name: String,
+) -> Result<CollisionCheck, String> {
+    worktree::check_collision(&repo_path, &worktree_path, &branch_name)
+}
+
+/// Create a new git worktree with a new branch.
+#[tauri::command]
+#[specta::specta]
+pub fn create_git_worktree(
+    repo_path: String,
+    name: String,
+    prefix: Option<String>,
+    base_path: Option<String>,
+    base_branch: Option<String>,
+) -> Result<WorktreeCreateResult, String> {
+    let config = WorktreeConfig {
+        prefix: prefix.unwrap_or_default(),
+        base_path,
+        delete_branch_on_merge: true,
+    };
+    worktree::create_worktree(&repo_path, &name, &config, base_branch.as_deref())
+}
+
+/// Create a worktree using an existing branch.
+#[tauri::command]
+#[specta::specta]
+pub fn create_git_worktree_existing_branch(
+    repo_path: String,
+    branch_name: String,
+    prefix: Option<String>,
+    base_path: Option<String>,
+) -> Result<WorktreeCreateResult, String> {
+    let config = WorktreeConfig {
+        prefix: prefix.unwrap_or_default(),
+        base_path,
+        delete_branch_on_merge: true,
+    };
+    worktree::create_worktree_existing_branch(&repo_path, &branch_name, &config)
+}
+
+/// Remove a git worktree.
+#[tauri::command]
+#[specta::specta]
+pub fn remove_git_worktree(
+    repo_path: String,
+    worktree_path: String,
+    force: bool,
+    delete_branch: bool,
+) -> Result<(), String> {
+    worktree::remove_worktree(&repo_path, &worktree_path, force, delete_branch)
+}
+
+/// Prune stale worktree entries.
+#[tauri::command]
+#[specta::specta]
+pub fn prune_git_worktrees(repo_path: String) -> Result<(), String> {
+    worktree::prune_worktrees(&repo_path)
+}
+
+/// Get the root directory of a git repository.
+#[tauri::command]
+#[specta::specta]
+pub fn get_git_repo_root(path: String) -> Result<String, String> {
+    worktree::get_repo_root(&path)
+}
+
+/// Get the default branch of a repository.
+#[tauri::command]
+#[specta::specta]
+pub fn get_git_default_branch(repo_path: String) -> Result<String, String> {
+    worktree::get_default_branch(&repo_path)
+}
+
+/// Suggest local paths for a GitHub repository.
+/// Searches common locations for cloned repos matching the given owner/repo format.
+#[tauri::command]
+#[specta::specta]
+pub fn suggest_local_repo_path(github_repo: String) -> Vec<String> {
+    let mut suggestions = Vec::new();
+
+    // Extract repo name from "owner/repo" format
+    let repo_name = github_repo.split('/').last().unwrap_or(&github_repo);
+
+    // Get home directory using std::env
+    let home = match std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+    {
+        Ok(h) => h,
+        Err(_) => return suggestions,
+    };
+
+    // Common locations to search
+    let search_paths = vec![
+        home.join("Documents/GitHub"),
+        home.join("Documents"),
+        home.join("Projects"),
+        home.join("Code"),
+        home.join("repos"),
+        home.join("Developer"),
+        home.join("dev"),
+        home.clone(),
+    ];
+
+    for base_path in search_paths {
+        if !base_path.exists() {
+            continue;
+        }
+
+        // Check direct match
+        let direct = base_path.join(repo_name);
+        if direct.exists() && direct.join(".git").exists() {
+            suggestions.push(direct.to_string_lossy().to_string());
+        }
+
+        // Also check with owner prefix (e.g., KBVE/kbve -> kbve)
+        if github_repo.contains('/') {
+            let with_owner = base_path.join(&github_repo.replace('/', "-"));
+            if with_owner.exists() && with_owner.join(".git").exists() {
+                suggestions.push(with_owner.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    // Also add current working directory if it's a git repo
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join(".git").exists() {
+            let cwd_str = cwd.to_string_lossy().to_string();
+            if !suggestions.contains(&cwd_str) {
+                suggestions.push(cwd_str);
+            }
+        }
+    }
+
+    suggestions
+}
+
+// ============================================================================
+// GitHub Issue Commands
+// ============================================================================
+
+/// Check GitHub CLI authentication status.
+#[tauri::command]
+#[specta::specta]
+pub fn check_gh_auth() -> GhAuthStatus {
+    github::check_auth_status()
+}
+
+/// List issues from a GitHub repository.
+#[tauri::command]
+#[specta::specta]
+pub fn list_github_issues(
+    repo: String,
+    state: Option<String>,
+    labels: Option<Vec<String>>,
+    limit: Option<u32>,
+) -> Result<Vec<GitHubIssue>, String> {
+    let state_ref = state.as_deref();
+    let labels_ref: Option<Vec<&str>> = labels
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    github::list_issues(&repo, state_ref, labels_ref, limit)
+}
+
+/// Get details of a specific GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn get_github_issue(repo: String, number: u64) -> Result<GitHubIssue, String> {
+    github::get_issue(&repo, number)
+}
+
+/// Get issue with agent metadata.
+#[tauri::command]
+#[specta::specta]
+pub fn get_github_issue_with_agent(repo: String, number: u64) -> Result<IssueWithAgent, String> {
+    github::get_issue_with_agent(&repo, number)
+}
+
+/// Create a new GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn create_github_issue(
+    repo: String,
+    title: String,
+    body: Option<String>,
+    labels: Option<Vec<String>>,
+) -> Result<GitHubIssue, String> {
+    let body_ref = body.as_deref();
+    let labels_ref: Option<Vec<&str>> = labels
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    github::create_issue(&repo, &title, body_ref, labels_ref)
+}
+
+/// Add a comment to a GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn comment_on_github_issue(repo: String, number: u64, body: String) -> Result<(), String> {
+    github::add_comment(&repo, number, &body)
+}
+
+/// Assign an agent to a GitHub issue (adds metadata comment).
+#[tauri::command]
+#[specta::specta]
+pub fn assign_agent_to_issue(
+    repo: String,
+    number: u64,
+    session: String,
+    agent_type: String,
+    worktree: Option<String>,
+) -> Result<(), String> {
+    let metadata = IssueAgentMetadata {
+        session,
+        machine_id: hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "unknown".to_string()),
+        worktree,
+        agent_type,
+        started_at: chrono::Utc::now().to_rfc3339(),
+        status: "working".to_string(),
+    };
+    github::add_agent_metadata_comment(&repo, number, &metadata)
+}
+
+/// List comments on a GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn list_github_issue_comments(repo: String, number: u64) -> Result<Vec<GitHubComment>, String> {
+    github::list_comments(&repo, number)
+}
+
+/// Update labels on a GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn update_github_issue_labels(
+    repo: String,
+    number: u64,
+    add_labels: Vec<String>,
+    remove_labels: Vec<String>,
+) -> Result<(), String> {
+    let add_refs: Vec<&str> = add_labels.iter().map(|s| s.as_str()).collect();
+    let remove_refs: Vec<&str> = remove_labels.iter().map(|s| s.as_str()).collect();
+    github::update_labels(&repo, number, add_refs, remove_refs)
+}
+
+/// Close a GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn close_github_issue(
+    repo: String,
+    number: u64,
+    comment: Option<String>,
+) -> Result<(), String> {
+    github::close_issue(&repo, number, comment.as_deref())
+}
+
+/// Reopen a closed GitHub issue.
+#[tauri::command]
+#[specta::specta]
+pub fn reopen_github_issue(repo: String, number: u64) -> Result<(), String> {
+    github::reopen_issue(&repo, number)
+}
+
+// ============================================================================
+// GitHub Pull Request Commands
+// ============================================================================
+
+/// List pull requests from a GitHub repository.
+#[tauri::command]
+#[specta::specta]
+pub fn list_github_prs(
+    repo: String,
+    state: Option<String>,
+    base: Option<String>,
+    limit: Option<u32>,
+) -> Result<Vec<GitHubPullRequest>, String> {
+    let state_ref = state.as_deref();
+    let base_ref = base.as_deref();
+    github::list_prs(&repo, state_ref, base_ref, limit)
+}
+
+/// Get details of a specific GitHub pull request.
+#[tauri::command]
+#[specta::specta]
+pub fn get_github_pr(repo: String, number: u64) -> Result<GitHubPullRequest, String> {
+    github::get_pr(&repo, number)
+}
+
+/// Get full status of a pull request (PR + checks + reviews).
+#[tauri::command]
+#[specta::specta]
+pub fn get_github_pr_status(repo: String, number: u64) -> Result<PrStatus, String> {
+    github::get_pr_status(&repo, number)
+}
+
+/// Create a new GitHub pull request.
+#[tauri::command]
+#[specta::specta]
+pub fn create_github_pr(
+    repo: String,
+    title: String,
+    body: Option<String>,
+    base: String,
+    head: Option<String>,
+    draft: bool,
+) -> Result<GitHubPullRequest, String> {
+    let body_ref = body.as_deref();
+    let head_ref = head.as_deref();
+    github::create_pr(&repo, &title, body_ref, &base, head_ref, draft)
+}
+
+/// Merge a GitHub pull request.
+#[tauri::command]
+#[specta::specta]
+pub fn merge_github_pr(
+    repo: String,
+    number: u64,
+    method: Option<String>,
+    delete_branch: bool,
+) -> Result<(), String> {
+    github::merge_pr(&repo, number, method.as_deref(), delete_branch)
+}
+
+/// Close a GitHub pull request without merging.
+#[tauri::command]
+#[specta::specta]
+pub fn close_github_pr(repo: String, number: u64, comment: Option<String>) -> Result<(), String> {
+    github::close_pr(&repo, number, comment.as_deref())
+}
+
+// ============================================================================
+// Agent Orchestration Commands
+// ============================================================================
+
+/// Spawn a new agent to work on an issue.
+///
+/// Creates a worktree, tmux session (or Docker container if sandbox enabled),
+/// and updates the issue with metadata.
+#[tauri::command]
+#[specta::specta]
+pub fn spawn_agent(
+    app: AppHandle,
+    repo: String,
+    issue_number: u64,
+    agent_type: String,
+    repo_path: String,
+    session_name: Option<String>,
+    worktree_prefix: Option<String>,
+    working_labels: Option<Vec<String>>,
+    use_sandbox: Option<bool>,
+) -> Result<SpawnResult, String> {
+    // Get sandbox setting from app settings if not explicitly provided
+    let sandbox_enabled = use_sandbox.unwrap_or_else(|| {
+        let app_settings = settings::get_settings(&app);
+        app_settings.sandbox_enabled
+    });
+
+    let config = SpawnConfig {
+        repo,
+        issue_number,
+        agent_type,
+        session_name,
+        worktree_prefix,
+        working_labels: working_labels.unwrap_or_default(),
+        use_sandbox: sandbox_enabled,
+        sandbox_ports: vec![], // Auto-detect ports from project
+    };
+    orchestrator::spawn_agent(&config, &repo_path)
+}
+
+/// Get status of all active agents.
+#[tauri::command]
+#[specta::specta]
+pub fn list_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    orchestrator::list_agent_statuses()
+}
+
+/// Clean up an agent's resources after work is complete.
+#[tauri::command]
+#[specta::specta]
+pub fn cleanup_agent(
+    session_name: String,
+    repo_path: String,
+    remove_worktree: bool,
+    delete_branch: bool,
+) -> Result<(), String> {
+    orchestrator::cleanup_agent(&session_name, &repo_path, remove_worktree, delete_branch)
+}
+
+/// Create a PR from an agent's work.
+#[tauri::command]
+#[specta::specta]
+pub fn create_pr_from_agent(
+    session_name: String,
+    title: String,
+    body: Option<String>,
+    draft: bool,
+) -> Result<GitHubPullRequest, String> {
+    orchestrator::create_pr_from_agent(&session_name, &title, body.as_deref(), draft)
+}
+
+/// Complete an agent's work with workflow automation.
+///
+/// Creates PR, updates issue with link, manages labels.
+#[tauri::command]
+#[specta::specta]
+pub fn complete_agent_work(
+    session_name: String,
+    pr_title: String,
+    pr_body: Option<String>,
+    working_labels: Vec<String>,
+    pr_labels: Vec<String>,
+    draft_pr: bool,
+) -> Result<CompleteWorkResult, String> {
+    let config = WorkflowConfig {
+        working_labels,
+        pr_labels,
+        draft_pr,
+        close_on_merge: true,
+    };
+    orchestrator::complete_agent_work(&session_name, &pr_title, pr_body.as_deref(), &config)
+}
+
+/// Check if a PR has been merged and cleanup resources if so.
+#[tauri::command]
+#[specta::specta]
+pub fn check_and_cleanup_merged_pr(
+    session_name: String,
+    repo_path: String,
+    pr_number: u64,
+) -> Result<bool, String> {
+    orchestrator::check_and_cleanup_merged_pr(&session_name, &repo_path, pr_number)
+}
+
+/// Get current machine identifier.
+#[tauri::command]
+#[specta::specta]
+pub fn get_current_machine_id() -> String {
+    orchestrator::get_current_machine_id()
+}
+
+/// List only agents running on this machine.
+#[tauri::command]
+#[specta::specta]
+pub fn list_local_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    orchestrator::list_local_agent_statuses()
+}
+
+/// List agents from other machines (potentially orphaned).
+#[tauri::command]
+#[specta::specta]
+pub fn list_remote_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    orchestrator::list_remote_agent_statuses()
+}
+
+/// Toggle an agent type on/off.
+#[tauri::command]
+#[specta::specta]
+pub fn toggle_agent_enabled(
+    app: AppHandle,
+    agent_type: String,
+    enabled: bool,
+) -> Result<Vec<String>, String> {
+    let mut app_settings = settings::get_settings(&app);
+
+    if enabled {
+        // Add to enabled list if not already present
+        if !app_settings.enabled_agents.contains(&agent_type) {
+            app_settings.enabled_agents.push(agent_type);
+        }
+    } else {
+        // Remove from enabled list
+        app_settings.enabled_agents.retain(|a| a != &agent_type);
+    }
+
+    let result = app_settings.enabled_agents.clone();
+    settings::write_settings(&app, app_settings);
+    Ok(result)
+}
+
+/// Get list of enabled agents.
+#[tauri::command]
+#[specta::specta]
+pub fn get_enabled_agents(app: AppHandle) -> Vec<String> {
+    let app_settings = settings::get_settings(&app);
+    app_settings.enabled_agents
+}
+
+/// Set the list of enabled agents (bulk update).
+#[tauri::command]
+#[specta::specta]
+pub fn set_enabled_agents(app: AppHandle, agents: Vec<String>) -> Vec<String> {
+    let mut app_settings = settings::get_settings(&app);
+    app_settings.enabled_agents = agents;
+    let result = app_settings.enabled_agents.clone();
+    settings::write_settings(&app, app_settings);
+    result
+}
+
+/// Get whether sandbox mode is enabled for agent spawning.
+#[tauri::command]
+#[specta::specta]
+pub fn get_sandbox_enabled(app: AppHandle) -> bool {
+    let app_settings = settings::get_settings(&app);
+    app_settings.sandbox_enabled
+}
+
+/// Set whether sandbox mode is enabled for agent spawning.
+#[tauri::command]
+#[specta::specta]
+pub fn set_sandbox_enabled(app: AppHandle, enabled: bool) -> bool {
+    let mut app_settings = settings::get_settings(&app);
+    app_settings.sandbox_enabled = enabled;
+    settings::write_settings(&app, app_settings);
+    enabled
+}
+
+/// Clean up orphaned Docker containers from sandbox execution.
+///
+/// Finds and removes containers that match `handy-sandbox-*` or `handy-support-sandbox-*`
+/// but don't have a corresponding active tmux session.
+///
+/// Emits `orphan-container-cleaned` events for each cleaned container (for toast notifications).
+#[tauri::command]
+#[specta::specta]
+pub fn cleanup_orphaned_containers(
+    app: AppHandle,
+) -> Result<crate::devops::docker::OrphanCleanupResult, String> {
+    let result = crate::devops::docker::cleanup_orphaned_containers()?;
+
+    // Emit events for each cleaned orphan so UI can show toast notifications
+    for orphan in &result.cleaned_orphans {
+        let _ = app.emit("orphan-container-cleaned", orphan.clone());
+    }
+
+    Ok(result)
+}
+
+/// Check the status of the Claude Code authentication volume.
+///
+/// Returns information about whether the volume exists and has credentials.
+#[tauri::command]
+#[specta::specta]
+pub fn check_claude_auth_volume() -> Result<crate::devops::docker::ClaudeAuthVolumeStatus, String> {
+    crate::devops::docker::check_claude_auth_volume()
+}
+
+/// Launch an interactive container for Claude Code authentication.
+///
+/// Opens a new Terminal window with a container where the user can run `claude /login`.
+/// Credentials are saved to a persistent Docker volume for future sandbox use.
+#[tauri::command]
+#[specta::specta]
+pub fn launch_claude_auth_setup() -> Result<String, String> {
+    crate::devops::docker::launch_claude_auth_in_terminal()
+}
+
+// ===== Epic Workflow Operations =====
+
+/// Create a new epic issue with standardized structure
+#[tauri::command]
+#[specta::specta]
+pub async fn create_epic(
+    config: crate::devops::operations::EpicConfig,
+) -> Result<crate::devops::operations::EpicInfo, String> {
+    crate::devops::operations::create_epic(config).await
+}
+
+/// Create multiple sub-issues for an epic in batch
+#[tauri::command]
+#[specta::specta]
+pub async fn create_sub_issues(
+    epic_number: u32,
+    epic_repo: String,
+    epic_work_repo: String,
+    sub_issues: Vec<crate::devops::operations::SubIssueConfig>,
+) -> Result<Vec<crate::devops::operations::SubIssueInfo>, String> {
+    crate::devops::operations::create_sub_issues(epic_number, epic_repo, epic_work_repo, sub_issues)
+        .await
+}
+
+/// Update epic issue progress based on sub-issue completion
+#[tauri::command]
+#[specta::specta]
+pub async fn update_epic_progress(
+    epic_number: u32,
+    epic_repo: String,
+) -> Result<crate::devops::operations::EpicProgress, String> {
+    crate::devops::operations::update_epic_progress(epic_number, epic_repo).await
+}
+
+/// Spawn an agent for a GitHub issue
+#[tauri::command]
+#[specta::specta]
+pub async fn spawn_agent_from_issue(
+    config: crate::devops::operations::SpawnAgentConfig,
+) -> Result<crate::devops::operations::AgentSpawnResult, String> {
+    crate::devops::operations::spawn_agent_from_issue(config).await
+}
+
+/// Complete agent work by creating a PR
+#[tauri::command]
+#[specta::specta]
+pub async fn complete_agent_work_with_pr(
+    session: String,
+    pr_title: Option<String>,
+) -> Result<crate::devops::operations::AgentCompletionResult, String> {
+    crate::devops::operations::complete_agent_work(session, pr_title).await
+}
+
+/// Plan an Epic from a markdown file using AI agent
+#[tauri::command]
+#[specta::specta]
+pub async fn plan_epic_from_markdown(
+    app: AppHandle,
+    config: crate::devops::operations::PlanFromMarkdownConfig,
+) -> Result<crate::devops::operations::PlanResult, String> {
+    // Get enabled agents from settings
+    let app_settings = crate::settings::get_settings(&app);
+    let enabled_agents = app_settings.enabled_agents;
+
+    crate::devops::operations::plan_from_markdown(config, enabled_agents).await
+}
+
+/// List all available Epic plan templates from docs/plans directory
+#[tauri::command]
+#[specta::specta]
+pub fn list_epic_plan_templates(
+    app: AppHandle,
+) -> Result<Vec<crate::devops::operations::PlanTemplate>, String> {
+    // In dev mode, look relative to current directory (project root)
+    // In production, look relative to the app's resource directory
+    #[cfg(debug_assertions)]
+    let repo_root = {
+        // In dev mode, go up from src-tauri to project root
+        let current = std::env::current_dir()
+            .map_err(|e| format!("Failed to get current directory: {}", e))?;
+
+        // Check if we're in src-tauri directory
+        if current.ends_with("src-tauri") {
+            current
+                .parent()
+                .ok_or_else(|| "Could not find parent directory".to_string())?
+                .to_path_buf()
+        } else {
+            current
+        }
+    };
+
+    #[cfg(not(debug_assertions))]
+    let repo_root = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("Failed to get resource directory: {}", e))?;
+
+    crate::devops::operations::list_plan_templates(&repo_root)
+}
+
+// ===== Epic Orchestration Commands =====
+
+/// Start orchestration for an epic - creates sub-issues and optionally spawns agents
+#[tauri::command]
+#[specta::specta]
+pub async fn start_epic_orchestration(
+    epic: crate::devops::operations::EpicInfo,
+    config: crate::devops::operations::StartOrchestrationConfig,
+) -> Result<crate::devops::operations::OrchestrationResult, String> {
+    crate::devops::operations::start_orchestration(&epic, config).await
+}
+
+/// Get status of all phases in an epic
+#[tauri::command]
+#[specta::specta]
+pub async fn get_epic_phase_status(
+    epic_number: u32,
+    epic_repo: String,
+    phases: Vec<crate::devops::operations::PhaseConfig>,
+) -> Result<Vec<crate::devops::operations::PhaseStatus>, String> {
+    crate::devops::operations::get_epic_phase_status(epic_number, &epic_repo, &phases).await
+}
+
+/// Load an existing epic from GitHub by issue number
+///
+/// Parses the epic's body to extract phases and metadata for orchestration.
+#[tauri::command]
+#[specta::specta]
+pub async fn load_epic(
+    repo: String,
+    epic_number: u32,
+) -> Result<crate::devops::operations::EpicInfo, String> {
+    crate::devops::operations::load_epic(repo, epic_number).await
+}
+
+/// Update the Epic issue on GitHub with current phase status.
+///
+/// Call this after phases complete to keep the Epic issue body in sync.
+#[tauri::command]
+#[specta::specta]
+pub async fn update_epic_phase_status_on_github(
+    epic_repo: String,
+    epic_number: u32,
+    phase_statuses: Vec<crate::devops::operations::PhaseStatus>,
+) -> Result<(), String> {
+    crate::devops::operations::update_epic_phase_status_on_github(
+        &epic_repo,
+        epic_number,
+        &phase_statuses,
+    )
+    .await
+}
+
+/// Load an existing epic with full recovery information
+///
+/// Fetches the epic, all its sub-issues, and determines what work remains.
+/// Useful for recovering/continuing orchestration on an existing epic.
+#[tauri::command]
+#[specta::specta]
+pub async fn load_epic_for_recovery(
+    repo: String,
+    epic_number: u32,
+) -> Result<crate::devops::operations::EpicRecoveryInfo, String> {
+    crate::devops::operations::load_epic_for_recovery(repo, epic_number).await
+}
+
+/// Manually mark a phase's status on GitHub.
+///
+/// Use this for phases that were completed manually (without sub-issues)
+/// or for recovery when the Epic body status doesn't match actual state.
+#[tauri::command]
+#[specta::specta]
+pub async fn mark_epic_phase_status(
+    epic_repo: String,
+    epic_number: u32,
+    phase_number: u32,
+    new_status: String,
+) -> Result<(), String> {
+    crate::devops::operations::mark_phase_status(&epic_repo, epic_number, phase_number, &new_status)
+        .await
+}
+
+// ===== Epic State Persistence Commands =====
+
+/// Get the currently active Epic state (persisted across app restarts).
+#[tauri::command]
+#[specta::specta]
+pub fn get_active_epic_state(
+    app: AppHandle,
+) -> Option<crate::devops::orchestration::ActiveEpicState> {
+    crate::devops::orchestration::get_active_epic(&app)
+}
+
+/// Set the active Epic from an EpicInfo (when linking an Epic).
+#[tauri::command]
+#[specta::specta]
+pub fn set_active_epic_state(
+    app: AppHandle,
+    epic_info: crate::devops::operations::EpicInfo,
+) -> crate::devops::orchestration::ActiveEpicState {
+    crate::devops::orchestration::set_active_epic(&app, &epic_info)
+}
+
+/// Set the active Epic from recovery info (more complete data with sub-issues).
+#[tauri::command]
+#[specta::specta]
+pub fn set_active_epic_from_recovery(
+    app: AppHandle,
+    recovery: crate::devops::operations::EpicRecoveryInfo,
+) -> crate::devops::orchestration::ActiveEpicState {
+    crate::devops::orchestration::set_active_epic_from_recovery(&app, &recovery)
+}
+
+/// Clear the active Epic state. If archive is true, moves to history.
+#[tauri::command]
+#[specta::specta]
+pub fn clear_active_epic_state(
+    app: AppHandle,
+    archive: bool,
+) -> Option<crate::devops::orchestration::ActiveEpicState> {
+    crate::devops::orchestration::clear_active_epic(&app, archive)
+}
+
+/// Sync the active Epic state with GitHub to get latest sub-issue status.
+#[tauri::command]
+#[specta::specta]
+pub async fn sync_active_epic_state(
+    app: AppHandle,
+) -> Result<Option<crate::devops::orchestration::ActiveEpicState>, String> {
+    crate::devops::orchestration::sync_active_epic(&app).await
+}
+
+/// Update a sub-issue's agent assignment in the active Epic.
+#[tauri::command]
+#[specta::specta]
+pub fn update_epic_sub_issue_agent(
+    app: AppHandle,
+    issue_number: u32,
+    session_name: Option<String>,
+    agent_type: Option<String>,
+) -> Result<(), String> {
+    crate::devops::orchestration::update_epic_sub_issue_agent(
+        &app,
+        issue_number,
+        session_name.as_deref(),
+        agent_type.as_deref(),
+    )
+}
+
+/// Update the local repository path for the active Epic.
+///
+/// This path is used when spawning agents to know where to create worktrees.
+#[tauri::command]
+#[specta::specta]
+pub fn set_epic_local_repo_path(app: AppHandle, local_repo_path: String) -> Result<(), String> {
+    crate::devops::orchestration::set_epic_local_repo_path(&app, &local_repo_path)
+}
+
+/// Handle pipeline item completion and optionally update Epic on GitHub.
+///
+/// Call this when a sub-issue is completed (PR merged, issue closed).
+/// It syncs Epic state and optionally updates the Epic issue on GitHub
+/// with the new phase progress.
+#[tauri::command]
+#[specta::specta]
+pub async fn on_pipeline_item_complete(
+    app: AppHandle,
+    issue_number: u32,
+    update_github: bool,
+) -> Result<(), String> {
+    crate::devops::orchestration::on_pipeline_item_complete(&app, issue_number, update_github).await
+}
+
+/// Merge a PR for a sub-issue that's in "Ready" state
+///
+/// This command:
+/// 1. Finds the PR associated with the sub-issue
+/// 2. Merges the PR (squash merge by default)
+/// 3. Syncs the Epic state to update status
+/// 4. Returns info about whether next phase can start
+#[tauri::command]
+#[specta::specta]
+pub async fn merge_ready_pr(
+    app: AppHandle,
+    issue_number: u32,
+    merge_method: Option<String>,
+    delete_branch: bool,
+) -> Result<crate::devops::orchestration::MergeResult, String> {
+    crate::devops::orchestration::merge_ready_pr(
+        &app,
+        issue_number,
+        merge_method.as_deref(),
+        delete_branch,
+    )
+    .await
+}
+
+/// Process all "Ready" sub-issues for the active Epic
+///
+/// This command finds all sub-issues with PRs (Ready state) and merges them.
+/// After each merge, it checks if the phase is complete and can start the next phase.
+#[tauri::command]
+#[specta::specta]
+pub async fn process_ready_prs(
+    app: AppHandle,
+    merge_method: Option<String>,
+    delete_branch: bool,
+    auto_start_next_phase: bool,
+) -> Result<crate::devops::orchestration::ProcessReadyResult, String> {
+    crate::devops::orchestration::process_ready_prs(
+        &app,
+        merge_method.as_deref(),
+        delete_branch,
+        auto_start_next_phase,
+    )
+    .await
+}
+
+// ============================================================================
+// Docker Sandbox Commands
+// ============================================================================
+
+/// Check if Docker is available and daemon is running
+#[tauri::command]
+#[specta::specta]
+pub fn is_docker_available() -> bool {
+    crate::devops::docker::is_docker_available()
+}
+
+/// Spawn a sandboxed agent in a Docker container
+///
+/// This creates an isolated container where the agent can run with
+/// auto-accept permissions safely. The container has:
+/// - The worktree mounted at /workspace
+/// - GitHub and Anthropic credentials passed as env vars
+/// - Resource limits applied
+#[tauri::command]
+#[specta::specta]
+pub fn spawn_sandbox(
+    config: crate::devops::docker::SandboxConfig,
+) -> Result<crate::devops::docker::SandboxResult, String> {
+    crate::devops::docker::spawn_sandbox(&config)
+}
+
+/// Get status of a sandbox container
+#[tauri::command]
+#[specta::specta]
+pub fn get_sandbox_status(
+    container_name: String,
+) -> Result<crate::devops::docker::SandboxStatus, String> {
+    crate::devops::docker::get_sandbox_status(&container_name)
+}
+
+/// Get logs from a sandbox container
+#[tauri::command]
+#[specta::specta]
+pub fn get_sandbox_logs(container_name: String, tail: Option<u32>) -> Result<String, String> {
+    crate::devops::docker::get_sandbox_logs(&container_name, tail)
+}
+
+/// Stop a sandbox container
+#[tauri::command]
+#[specta::specta]
+pub fn stop_sandbox(container_name: String) -> Result<(), String> {
+    crate::devops::docker::stop_sandbox(&container_name)
+}
+
+/// Remove a sandbox container
+#[tauri::command]
+#[specta::specta]
+pub fn remove_sandbox(container_name: String, force: bool) -> Result<(), String> {
+    crate::devops::docker::remove_sandbox(&container_name, force)
+}
+
+/// List all Handy sandbox containers
+#[tauri::command]
+#[specta::specta]
+pub fn list_sandboxes() -> Result<Vec<crate::devops::docker::SandboxStatus>, String> {
+    crate::devops::docker::list_sandboxes()
+}
+
+/// Check if devcontainer CLI is available
+#[tauri::command]
+#[specta::specta]
+pub fn is_devcontainer_cli_available() -> bool {
+    crate::devops::docker::is_devcontainer_cli_available()
+}
+
+/// Setup a devcontainer configuration for a worktree
+///
+/// Creates a .devcontainer/devcontainer.json file with the official
+/// Anthropic Claude Code feature configured.
+#[tauri::command]
+#[specta::specta]
+pub fn setup_devcontainer(
+    worktree_path: String,
+    issue_ref: String,
+    gh_token: Option<String>,
+    anthropic_key: Option<String>,
+) -> Result<String, String> {
+    crate::devops::docker::setup_devcontainer_for_worktree(
+        &worktree_path,
+        &issue_ref,
+        gh_token.as_deref(),
+        anthropic_key.as_deref(),
+    )
+}
+
+/// Start a devcontainer for a workspace
+///
+/// Uses the devcontainer CLI to build and start the container.
+#[tauri::command]
+#[specta::specta]
+pub fn start_devcontainer(worktree_path: String) -> Result<String, String> {
+    crate::devops::docker::start_devcontainer(&worktree_path)
+}
+
+/// Execute a command inside a running devcontainer
+#[tauri::command]
+#[specta::specta]
+pub fn exec_in_devcontainer(worktree_path: String, command: String) -> Result<String, String> {
+    crate::devops::docker::exec_in_devcontainer(&worktree_path, &command)
+}
+
+/// Ensure the shared agent network exists for inter-container communication
+///
+/// Creates the 'handy-agents' Docker network if it doesn't exist.
+/// Agents on this network can communicate using container names as hostnames.
+#[tauri::command]
+#[specta::specta]
+pub fn ensure_agent_network() -> Result<(), String> {
+    crate::devops::docker::ensure_agent_network()
+}
+
+/// Get network information for a sandboxed agent
+///
+/// Returns the allocated port range and network hostname for the agent.
+/// Use this to know which ports are available and how other agents can reach this one.
+#[tauri::command]
+#[specta::specta]
+pub fn get_agent_network_info(
+    issue_number: u64,
+    container_ports: Vec<u16>,
+) -> crate::devops::docker::AgentNetworkInfo {
+    crate::devops::docker::get_agent_network_info(issue_number, &container_ports)
+}
+
+/// List all containers on the agent network
+///
+/// Returns container names that can be used as hostnames for inter-container communication.
+#[tauri::command]
+#[specta::specta]
+pub fn list_network_containers() -> Result<Vec<String>, String> {
+    crate::devops::docker::list_network_containers()
+}
+
+// ===== Pipeline Orchestration Commands =====
+
+/// Assign an issue to an agent, creating worktree and tmux session.
+#[tauri::command]
+#[specta::specta]
+pub fn assign_issue_to_agent_pipeline(
+    app: AppHandle,
+    config: crate::devops::orchestration::AssignIssueConfig,
+) -> Result<crate::devops::orchestration::AssignIssueResult, String> {
+    crate::devops::orchestration::assign_issue_to_agent(&app, &config)
+}
+
+/// Skip an issue and update its labels.
+#[tauri::command]
+#[specta::specta]
+pub fn skip_issue(
+    app: AppHandle,
+    config: crate::devops::orchestration::SkipIssueConfig,
+) -> Result<crate::devops::pipeline::PipelineItem, String> {
+    crate::devops::orchestration::skip_issue(&app, &config)
+}
+
+/// List all pipeline items, aggregating from multiple sources.
+#[tauri::command]
+#[specta::specta]
+pub fn list_pipeline_items(
+    app: AppHandle,
+    work_repo: Option<String>,
+) -> Result<Vec<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::list_pipeline_items(&app, work_repo.as_deref())
+}
+
+/// Get pipeline history (completed items).
+#[tauri::command]
+#[specta::specta]
+pub fn get_pipeline_history(
+    app: AppHandle,
+    limit: Option<usize>,
+) -> Vec<crate::devops::pipeline::PipelineItem> {
+    crate::devops::orchestration::get_pipeline_history(&app, limit)
+}
+
+/// Get pipeline summary statistics.
+#[tauri::command]
+#[specta::specta]
+pub fn get_pipeline_summary(app: AppHandle) -> crate::devops::orchestration::PipelineSummary {
+    crate::devops::orchestration::get_pipeline_summary(&app)
+}
+
+/// Detect and link PRs to pipeline items.
+#[tauri::command]
+#[specta::specta]
+pub fn detect_and_link_prs(
+    app: AppHandle,
+    work_repo: String,
+) -> Result<Vec<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::detect_and_link_prs(&app, &work_repo)
+}
+
+/// Sync PR status for all pipeline items with PRs.
+#[tauri::command]
+#[specta::specta]
+pub fn sync_all_pr_statuses(
+    app: AppHandle,
+) -> Result<Vec<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::sync_all_pr_statuses(&app)
+}
+
+/// Update a specific pipeline item's PR status.
+#[tauri::command]
+#[specta::specta]
+pub fn update_pipeline_item_pr_status(
+    app: AppHandle,
+    item_id: String,
+) -> Result<Option<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::update_pipeline_item_pr_status(&app, &item_id)
+}
+
+/// Get a pipeline item by ID.
+#[tauri::command]
+#[specta::specta]
+pub fn get_pipeline_item(
+    app: AppHandle,
+    item_id: String,
+) -> Option<crate::devops::pipeline::PipelineItem> {
+    crate::devops::orchestration::get_pipeline_item(&app, &item_id)
+}
+
+/// Find a pipeline item by issue.
+#[tauri::command]
+#[specta::specta]
+pub fn find_pipeline_item_by_issue(
+    app: AppHandle,
+    repo: String,
+    issue_number: u64,
+) -> Option<crate::devops::pipeline::PipelineItem> {
+    crate::devops::orchestration::find_pipeline_item_by_issue(&app, &repo, issue_number)
+}
+
+/// Find a pipeline item by session name.
+#[tauri::command]
+#[specta::specta]
+pub fn find_pipeline_item_by_session(
+    app: AppHandle,
+    session_name: String,
+) -> Option<crate::devops::pipeline::PipelineItem> {
+    crate::devops::orchestration::find_pipeline_item_by_session(&app, &session_name)
+}
+
+/// Link a PR to a pipeline item.
+#[tauri::command]
+#[specta::specta]
+pub fn link_pr_to_pipeline_item(
+    app: AppHandle,
+    item_id: String,
+    pr_number: u64,
+    work_repo: String,
+) -> Result<crate::devops::pipeline::PipelineItem, String> {
+    // Fetch the PR first
+    let pr = github::get_pr(&work_repo, pr_number)?;
+    crate::devops::orchestration::link_pr_to_pipeline_item(&app, &item_id, &pr)
+}
+
+/// Archive a completed pipeline item.
+#[tauri::command]
+#[specta::specta]
+pub fn archive_pipeline_item(
+    app: AppHandle,
+    item_id: String,
+) -> Result<Option<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::archive_pipeline_item(&app, &item_id)
+}
+
+/// Remove a pipeline item (for cleanup).
+#[tauri::command]
+#[specta::specta]
+pub fn remove_pipeline_item(
+    app: AppHandle,
+    item_id: String,
+) -> Result<Option<crate::devops::pipeline::PipelineItem>, String> {
+    crate::devops::orchestration::remove_pipeline_item(&app, &item_id)
+}
+
+/// Check all active agent sessions for PR creation.
+///
+/// Returns a list of PR detection results for all active sessions.
+/// Each result indicates whether a PR was found and if it's newly detected.
+#[tauri::command]
+#[specta::specta]
+pub async fn check_sessions_for_prs(app: AppHandle) -> Result<Vec<PrDetectionResult>, String> {
+    crate::devops::orchestration::check_sessions_for_prs(&app).await
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod devops;
 pub mod memory;
 pub mod models;
 pub mod onichan;

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/dependencies.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/dependencies.rs
@@ -1,0 +1,436 @@
+//! Dependency detection for DevOps features.
+//!
+//! Checks for required CLI tools: gh (GitHub CLI), tmux, and claude (Claude Code CLI).
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::process::Command;
+
+/// Status of a single dependency
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DependencyStatus {
+    /// Name of the dependency
+    pub name: String,
+    /// Whether the dependency is installed
+    pub installed: bool,
+    /// Whether the dependency is authenticated (for tools that require auth)
+    pub authenticated: Option<bool>,
+    /// Username/account if authenticated
+    pub auth_user: Option<String>,
+    /// Authentication hint URL if not authenticated
+    pub auth_hint_url: Option<String>,
+    /// Version string if installed
+    pub version: Option<String>,
+    /// Path to the executable if installed
+    pub path: Option<String>,
+    /// Installation instructions if not installed
+    pub install_hint: String,
+}
+
+/// Status of all DevOps dependencies
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DevOpsDependencies {
+    /// GitHub CLI status (required)
+    pub gh: DependencyStatus,
+    /// tmux status (required)
+    pub tmux: DependencyStatus,
+    /// Docker status (optional, enables sandboxed agents)
+    pub docker: DependencyStatus,
+    /// Claude Code CLI status
+    pub claude: DependencyStatus,
+    /// Aider CLI status
+    pub aider: DependencyStatus,
+    /// Gemini CLI status (Google AI)
+    pub gemini: DependencyStatus,
+    /// Ollama status (local LLM server)
+    pub ollama: DependencyStatus,
+    /// vLLM status (high-performance inference)
+    pub vllm: DependencyStatus,
+    /// Whether all required dependencies are installed (gh + tmux + at least one agent)
+    pub all_satisfied: bool,
+    /// List of available agent types that are installed
+    pub available_agents: Vec<String>,
+    /// Whether sandboxed (Docker) agents are available
+    pub sandbox_available: bool,
+}
+
+/// Check if a command exists and get its version
+fn check_command(name: &str, version_args: &[&str]) -> (bool, Option<String>, Option<String>) {
+    // First check if command exists using `which`
+    let which_result = Command::new("which").arg(name).output();
+
+    let path = match which_result {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => return (false, None, None),
+    };
+
+    // Get version
+    let version_result = Command::new(name).args(version_args).output();
+
+    let version = match version_result {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Some tools output to stderr
+            let output_str = if stdout.trim().is_empty() {
+                stderr.to_string()
+            } else {
+                stdout.to_string()
+            };
+            // Extract first line and clean up
+            output_str.lines().next().map(|s| s.trim().to_string())
+        }
+        _ => None,
+    };
+
+    (true, version, Some(path))
+}
+
+/// Run a command with a timeout, returning stdout if successful
+fn run_command_with_timeout(
+    name: &str,
+    args: &[&str],
+    timeout_secs: u64,
+) -> Option<(bool, String)> {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let name = name.to_string();
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let result = Command::new(&name).args(&args).output();
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            Some((output.status.success(), stdout))
+        }
+        _ => None,
+    }
+}
+
+/// Check if GitHub CLI is authenticated and get the username
+fn check_gh_auth() -> (bool, Option<String>) {
+    // Use a 5 second timeout to prevent hanging
+    match run_command_with_timeout("gh", &["auth", "status"], 5) {
+        Some((success, _)) => {
+            if success {
+                // Get the authenticated username
+                if let Some((_, stdout)) =
+                    run_command_with_timeout("gh", &["api", "user", "-q", ".login"], 3)
+                {
+                    let username = stdout.trim().to_string();
+                    if !username.is_empty() {
+                        return (true, Some(username));
+                    }
+                }
+                (true, None)
+            } else {
+                (false, None)
+            }
+        }
+        None => (false, None),
+    }
+}
+
+/// Check GitHub CLI (gh) status
+fn check_gh() -> DependencyStatus {
+    let (installed, version, path) = check_command("gh", &["--version"]);
+
+    // Parse version from "gh version 2.40.0 (2024-01-01)" format
+    let version = version.and_then(|v| {
+        v.split_whitespace()
+            .nth(2)
+            .map(|s| s.trim_end_matches(',').to_string())
+    });
+
+    // Check authentication status if installed
+    let (authenticated, auth_user) = if installed {
+        let (is_auth, user) = check_gh_auth();
+        (Some(is_auth), user)
+    } else {
+        (None, None)
+    };
+
+    DependencyStatus {
+        name: "gh".to_string(),
+        installed,
+        authenticated,
+        auth_user,
+        auth_hint_url: Some("https://kbve.com/application/git#gh".to_string()),
+        version,
+        path,
+        install_hint: "brew install gh".to_string(),
+    }
+}
+
+/// Check tmux status
+fn check_tmux() -> DependencyStatus {
+    let (installed, version, path) = check_command("tmux", &["-V"]);
+
+    // Parse version from "tmux 3.4" format
+    let version = version.and_then(|v| v.split_whitespace().nth(1).map(|s| s.to_string()));
+
+    DependencyStatus {
+        name: "tmux".to_string(),
+        installed,
+        authenticated: None,
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "brew install tmux".to_string(),
+    }
+}
+
+/// Check if Claude Code CLI is authenticated and get the email
+fn check_claude_auth() -> (bool, Option<String>) {
+    // Method 1: Check for ANTHROPIC_API_KEY environment variable (highest priority auth method)
+    if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
+        if !api_key.is_empty() {
+            return (true, Some("API Key".to_string()));
+        }
+    }
+
+    // Method 2: Read ~/.claude.json and check for oauthAccount
+    if let Ok(home) = std::env::var("HOME") {
+        let claude_config = std::path::PathBuf::from(&home).join(".claude.json");
+        if claude_config.exists() {
+            if let Ok(contents) = std::fs::read_to_string(&claude_config) {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
+                    // Check for oauthAccount which contains email and other auth info
+                    if let Some(oauth) = json.get("oauthAccount") {
+                        if let Some(email) = oauth.get("emailAddress").and_then(|e| e.as_str()) {
+                            if !email.is_empty() {
+                                return (true, Some(email.to_string()));
+                            }
+                        }
+                        // Has oauth account but no email - still authenticated
+                        return (true, None);
+                    }
+                }
+            }
+        }
+    }
+
+    (false, None)
+}
+
+/// Check Claude Code CLI status
+fn check_claude() -> DependencyStatus {
+    let (installed, version, path) = check_command("claude", &["--version"]);
+
+    // Version output format may vary, just use the first line
+    let version = version.map(|v| v.trim().to_string());
+
+    // Check authentication status if installed
+    let (authenticated, auth_user) = if installed {
+        let (is_auth, user) = check_claude_auth();
+        (Some(is_auth), user)
+    } else {
+        (None, None)
+    };
+
+    DependencyStatus {
+        name: "claude".to_string(),
+        installed,
+        authenticated,
+        auth_user,
+        auth_hint_url: Some("https://kbve.com/application/ml/#claude".to_string()),
+        version,
+        path,
+        install_hint: "npm install -g @anthropic-ai/claude-code".to_string(),
+    }
+}
+
+/// Check Aider CLI status
+fn check_aider() -> DependencyStatus {
+    let (installed, version, path) = check_command("aider", &["--version"]);
+
+    // Parse version from aider output
+    let version = version.map(|v| v.trim().to_string());
+
+    DependencyStatus {
+        name: "aider".to_string(),
+        installed,
+        authenticated: None,
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "pip install aider-chat".to_string(),
+    }
+}
+
+/// Check Gemini CLI status (Google AI Studio)
+fn check_gemini() -> DependencyStatus {
+    let (installed, version, path) = check_command("gemini", &["--version"]);
+
+    let version = version.map(|v| v.trim().to_string());
+
+    DependencyStatus {
+        name: "gemini".to_string(),
+        installed,
+        authenticated: None,
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "pip install google-generativeai".to_string(),
+    }
+}
+
+/// Check Ollama status (local LLM server)
+fn check_ollama() -> DependencyStatus {
+    let (installed, version, path) = check_command("ollama", &["--version"]);
+
+    // Parse version from ollama output
+    let version = version.and_then(|v| {
+        v.split_whitespace()
+            .find(|s| {
+                s.chars()
+                    .next()
+                    .map(|c| c.is_ascii_digit())
+                    .unwrap_or(false)
+            })
+            .map(|s| s.to_string())
+    });
+
+    DependencyStatus {
+        name: "ollama".to_string(),
+        installed,
+        authenticated: None,
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "brew install ollama".to_string(),
+    }
+}
+
+/// Check vLLM status (high-performance inference server)
+fn check_vllm() -> DependencyStatus {
+    // vLLM is typically run as a server, check for python module
+    let (installed, version, path) = check_command("vllm", &["--version"]);
+
+    let version = version.map(|v| v.trim().to_string());
+
+    DependencyStatus {
+        name: "vllm".to_string(),
+        installed,
+        authenticated: None,
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "pip install vllm".to_string(),
+    }
+}
+
+/// Check Docker status
+fn check_docker() -> DependencyStatus {
+    let (installed, version, path) = check_command("docker", &["--version"]);
+
+    // Parse version from "Docker version 24.0.7, build afdd53b" format
+    let version = version.and_then(|v| {
+        v.split_whitespace()
+            .nth(2)
+            .map(|s| s.trim_end_matches(',').to_string())
+    });
+
+    // Check if Docker daemon is running
+    let daemon_running = if installed {
+        run_command_with_timeout("docker", &["info"], 5)
+            .map(|(success, _)| success)
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    DependencyStatus {
+        name: "docker".to_string(),
+        installed,
+        // Use authenticated field to indicate daemon is running
+        authenticated: if installed {
+            Some(daemon_running)
+        } else {
+            None
+        },
+        auth_user: None,
+        auth_hint_url: None,
+        version,
+        path,
+        install_hint: "Install Docker Desktop from https://docker.com".to_string(),
+    }
+}
+
+/// Check all DevOps dependencies
+pub fn check_all_dependencies() -> DevOpsDependencies {
+    let gh = check_gh();
+    let tmux = check_tmux();
+    let docker = check_docker();
+    let claude = check_claude();
+    let aider = check_aider();
+    let gemini = check_gemini();
+    let ollama = check_ollama();
+    let vllm = check_vllm();
+
+    // Build list of available agents
+    let mut available_agents = Vec::new();
+    if claude.installed {
+        available_agents.push("claude".to_string());
+    }
+    if aider.installed {
+        available_agents.push("aider".to_string());
+    }
+    if gemini.installed {
+        available_agents.push("gemini".to_string());
+    }
+    if ollama.installed {
+        available_agents.push("ollama".to_string());
+    }
+    if vllm.installed {
+        available_agents.push("vllm".to_string());
+    }
+
+    // All satisfied if gh + tmux + at least one agent
+    let has_agent = !available_agents.is_empty();
+    let all_satisfied = gh.installed && tmux.installed && has_agent;
+
+    // Sandbox is available if Docker is installed and daemon is running
+    let sandbox_available = docker.installed && docker.authenticated.unwrap_or(false);
+
+    DevOpsDependencies {
+        gh,
+        tmux,
+        docker,
+        claude,
+        aider,
+        gemini,
+        ollama,
+        vllm,
+        all_satisfied,
+        available_agents,
+        sandbox_available,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_dependencies() {
+        let deps = check_all_dependencies();
+        // Just verify it doesn't panic and returns valid structure
+        assert!(!deps.gh.name.is_empty());
+        assert!(!deps.tmux.name.is_empty());
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/docker.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/docker.rs
@@ -1,0 +1,1443 @@
+//! Docker and Dev Container management for sandboxed agent execution.
+//!
+//! This module provides two approaches for running agents in isolation:
+//!
+//! 1. **Dev Containers** (recommended): Uses VS Code Dev Container spec with
+//!    Anthropic's official devcontainer feature for Claude Code. This creates
+//!    a reproducible, versioned environment as part of the repo.
+//!
+//! 2. **Direct Docker**: Simpler approach using Docker directly for quick
+//!    sandboxing when a full devcontainer setup isn't needed.
+//!
+//! The Dev Container approach is preferred because:
+//! - Official Anthropic support via `ghcr.io/anthropics/devcontainer-features/claude-code`
+//! - Versioned environment (`.devcontainer/devcontainer.json` in repo)
+//! - VS Code compatibility
+//! - Proper toolchain configuration
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::process::Command;
+
+/// Anthropic's official devcontainer feature for Claude Code
+const CLAUDE_DEVCONTAINER_FEATURE: &str =
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0";
+
+/// Regex patterns for sanitizing sensitive data from error messages and logs
+static SENSITIVE_PATTERNS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(sk-ant-[a-zA-Z0-9\-_]+|ghp_[a-zA-Z0-9]+|gho_[a-zA-Z0-9]+|github_pat_[a-zA-Z0-9_]+|ANTHROPIC_API_KEY=[^\s]+|GH_TOKEN=[^\s]+|GITHUB_TOKEN=[^\s]+|Bearer\s+[a-zA-Z0-9\-_.]+)").unwrap()
+});
+
+/// Sanitize a string to remove sensitive credentials before logging or displaying.
+///
+/// This removes:
+/// - Anthropic API keys (sk-ant-*)
+/// - GitHub tokens (ghp_*, gho_*, github_pat_*)
+/// - Environment variable assignments with sensitive values
+/// - Bearer tokens
+/// - Home directory paths (replaced with ~)
+pub fn sanitize_sensitive_data(content: &str) -> String {
+    // First, redact known sensitive patterns
+    let sanitized = SENSITIVE_PATTERNS.replace_all(content, "[REDACTED]");
+
+    // Replace home directory with ~ to avoid leaking username
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return sanitized.replace(&home, "~");
+        }
+    }
+
+    sanitized.to_string()
+}
+
+/// Sanitize Docker command output for safe display/logging
+fn sanitize_docker_error(stderr: &str) -> String {
+    sanitize_sensitive_data(stderr)
+}
+
+/// Default Docker image for direct Docker mode (Node.js based for Claude Code CLI)
+const DEFAULT_AGENT_IMAGE: &str = "node:20-bookworm";
+
+/// Container name prefix for Handy agent containers
+const CONTAINER_PREFIX: &str = "handy-sandbox-";
+
+/// Docker network name for inter-agent communication
+const AGENT_NETWORK: &str = "handy-agents";
+
+/// Base port for agent port range allocation
+const PORT_RANGE_BASE: u16 = 30000;
+
+/// Size of each agent's port range (agent 0 gets 30000-30099, agent 1 gets 30100-30199, etc.)
+const PORT_RANGE_SIZE: u16 = 100;
+
+/// Sandbox mode - how to run the isolated agent
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Default)]
+pub enum SandboxMode {
+    /// Use Dev Container (recommended) - creates .devcontainer/devcontainer.json
+    /// and uses the official Anthropic devcontainer feature
+    #[default]
+    DevContainer,
+    /// Use direct Docker container (simpler but less integrated)
+    DirectDocker,
+}
+
+/// Configuration for spawning a sandboxed agent container
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SandboxConfig {
+    /// Sandbox mode - DevContainer (recommended) or DirectDocker
+    pub mode: SandboxMode,
+    /// Docker image to use (for DirectDocker mode)
+    pub image: Option<String>,
+    /// Working directory to mount (the worktree path)
+    pub workdir: String,
+    /// GitHub token for API access (passed as env var)
+    pub gh_token: Option<String>,
+    /// Anthropic API key for Claude (passed as env var)
+    pub anthropic_api_key: Option<String>,
+    /// Issue reference (org/repo#number)
+    pub issue_ref: String,
+    /// Agent type (claude, aider, etc.)
+    pub agent_type: String,
+    /// Whether to auto-accept all operations (safe in sandbox)
+    pub auto_accept: bool,
+    /// Memory limit (e.g., "4g")
+    pub memory_limit: Option<String>,
+    /// CPU limit (e.g., "2")
+    pub cpu_limit: Option<String>,
+    /// Network mode: "bridge" (default), "none" (air-gapped), or "host"
+    pub network_mode: Option<String>,
+}
+
+/// Result of spawning a sandboxed container
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SandboxResult {
+    /// Container ID
+    pub container_id: String,
+    /// Container name
+    pub container_name: String,
+    /// Whether the container started successfully
+    pub started: bool,
+}
+
+/// Status of a running sandbox container
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SandboxStatus {
+    /// Container ID
+    pub container_id: String,
+    /// Container name
+    pub container_name: String,
+    /// Whether container is running
+    pub running: bool,
+    /// Exit code if stopped
+    pub exit_code: Option<i32>,
+    /// Container status string
+    pub status: String,
+}
+
+/// Check if Docker is available and daemon is running
+pub fn is_docker_available() -> bool {
+    Command::new("docker")
+        .args(["info"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Check if the handy-agents network exists
+pub fn network_exists() -> bool {
+    Command::new("docker")
+        .args(["network", "inspect", AGENT_NETWORK])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Create the handy-agents Docker network for inter-container communication
+///
+/// This network allows sandboxed agents to communicate with each other using
+/// container names as hostnames (e.g., `handy-sandbox-123:3000`).
+pub fn ensure_agent_network() -> Result<(), String> {
+    if network_exists() {
+        return Ok(());
+    }
+
+    let output = Command::new("docker")
+        .args(["network", "create", "--driver", "bridge", AGENT_NETWORK])
+        .output()
+        .map_err(|e| format!("Failed to create network: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Ignore "already exists" error (race condition)
+        if !stderr.contains("already exists") {
+            return Err(format!("Failed to create network: {}", stderr));
+        }
+    }
+
+    log::info!("Created Docker network: {}", AGENT_NETWORK);
+    Ok(())
+}
+
+/// Get the Docker network name for agent containers
+pub fn get_agent_network_name() -> &'static str {
+    AGENT_NETWORK
+}
+
+/// Allocate a unique port range for an agent based on issue number
+///
+/// Each agent gets a range of PORT_RANGE_SIZE ports to avoid conflicts.
+/// Port ranges are deterministic based on issue number modulo 100.
+///
+/// Returns (base_port, end_port) tuple, e.g., (30000, 30099) for slot 0
+pub fn allocate_port_range(issue_number: u64) -> (u16, u16) {
+    // Use issue number modulo 100 to determine slot (supports 100 concurrent agents)
+    let slot = (issue_number % 100) as u16;
+    let base = PORT_RANGE_BASE + (slot * PORT_RANGE_SIZE);
+    let end = base + PORT_RANGE_SIZE - 1;
+    (base, end)
+}
+
+/// Remap a container port to a unique host port within the agent's allocated range
+///
+/// For example, if an agent needs port 3000 and has range 30100-30199,
+/// this maps container:3000 -> host:30100
+pub fn remap_port_to_range(container_port: u16, issue_number: u64) -> u16 {
+    let (base, _end) = allocate_port_range(issue_number);
+    // Map container port to range: 3000 -> base + (3000 % PORT_RANGE_SIZE)
+    // This keeps relative port offsets consistent
+    base + (container_port % PORT_RANGE_SIZE)
+}
+
+/// Information about an agent's network configuration
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AgentNetworkInfo {
+    /// The Docker network name
+    pub network_name: String,
+    /// Container hostname (can be used by other containers to connect)
+    pub container_hostname: String,
+    /// Allocated host port range (base, end)
+    pub host_port_range: (u16, u16),
+    /// Port mappings from container port to host port
+    pub port_mappings: Vec<(u16, u16)>,
+}
+
+/// Get network info for a sandboxed agent
+pub fn get_agent_network_info(issue_number: u64, container_ports: &[u16]) -> AgentNetworkInfo {
+    let container_name = container_name_for_issue(issue_number);
+    let (base, end) = allocate_port_range(issue_number);
+
+    let port_mappings: Vec<(u16, u16)> = container_ports
+        .iter()
+        .map(|&cp| (cp, remap_port_to_range(cp, issue_number)))
+        .collect();
+
+    AgentNetworkInfo {
+        network_name: AGENT_NETWORK.to_string(),
+        container_hostname: container_name,
+        host_port_range: (base, end),
+        port_mappings,
+    }
+}
+
+/// List all containers on the handy-agents network
+pub fn list_network_containers() -> Result<Vec<String>, String> {
+    if !network_exists() {
+        return Ok(vec![]);
+    }
+
+    let output = Command::new("docker")
+        .args([
+            "network",
+            "inspect",
+            AGENT_NETWORK,
+            "--format",
+            "{{range .Containers}}{{.Name}} {{end}}",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to inspect network: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to inspect network: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let containers: Vec<String> = stdout
+        .split_whitespace()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+
+    Ok(containers)
+}
+
+/// Get the GitHub token from gh CLI
+fn get_gh_token() -> Option<String> {
+    Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Get the Anthropic API key from environment
+fn get_anthropic_key() -> Option<String> {
+    std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Generate a container name for an issue
+pub fn container_name_for_issue(issue_number: u64) -> String {
+    format!("{}{}", CONTAINER_PREFIX, issue_number)
+}
+
+/// Spawn a sandboxed agent container
+///
+/// This creates and starts a Docker container with:
+/// - The worktree mounted at /workspace
+/// - GitHub and Anthropic credentials passed as env vars
+/// - Resource limits applied
+/// - The agent command started with auto-accept flags
+/// - A non-root user (required for Claude Code's --dangerously-skip-permissions)
+pub fn spawn_sandbox(config: &SandboxConfig) -> Result<SandboxResult, String> {
+    // Parse issue number from issue_ref
+    let issue_number = config
+        .issue_ref
+        .split('#')
+        .last()
+        .and_then(|n| n.parse::<u64>().ok())
+        .ok_or("Invalid issue reference format")?;
+
+    let container_name = container_name_for_issue(issue_number);
+
+    // Pre-check: Remove any existing container with this name to avoid conflicts
+    // This handles orphaned containers that weren't cleaned up properly
+    if let Some(existing) = container_exists_for_issue(issue_number as u32) {
+        log::warn!(
+            "Found existing container {} for issue #{}, removing before spawn",
+            existing,
+            issue_number
+        );
+        if let Err(e) = stop_and_remove_container(&existing) {
+            log::warn!("Failed to remove existing container: {}", e);
+            // Continue anyway - docker run will fail if container exists
+        }
+    }
+
+    let image = config
+        .image
+        .clone()
+        .unwrap_or_else(|| DEFAULT_AGENT_IMAGE.to_string());
+
+    // Build docker run command
+    let mut args = vec![
+        "run".to_string(),
+        "-d".to_string(), // Detached
+        "--name".to_string(),
+        container_name.clone(),
+        // Mount worktree as /workspace
+        "-v".to_string(),
+        format!("{}:/workspace", config.workdir),
+        "-w".to_string(),
+        "/workspace".to_string(),
+    ];
+
+    // Mount the persistent Claude auth volume
+    // This volume contains credentials from the one-time auth setup container
+    // The volume is mounted directly to the user's .claude directory
+    args.push("-v".to_string());
+    args.push(format!("{}:/tmp/claude-auth:ro", CLAUDE_AUTH_VOLUME));
+
+    // Mount GitHub CLI auth from host (if available) - gh tokens work fine from host
+    if let Ok(home) = std::env::var("HOME") {
+        let gh_dir = format!("{}/.config/gh", home);
+        if std::path::Path::new(&gh_dir).exists() {
+            args.push("-v".to_string());
+            args.push(format!("{}:/tmp/host-auth/.config/gh:ro", gh_dir));
+        }
+    }
+
+    // Add resource limits
+    if let Some(ref mem) = config.memory_limit {
+        args.push("-m".to_string());
+        args.push(mem.clone());
+    }
+    if let Some(ref cpu) = config.cpu_limit {
+        args.push("--cpus".to_string());
+        args.push(cpu.clone());
+    }
+
+    // Add network mode
+    let network = config
+        .network_mode
+        .clone()
+        .unwrap_or_else(|| "bridge".to_string());
+    args.push("--network".to_string());
+    args.push(network);
+
+    // Add GitHub token
+    let gh_token = config.gh_token.clone().or_else(get_gh_token);
+    if let Some(token) = gh_token {
+        args.push("-e".to_string());
+        args.push(format!("GH_TOKEN={}", token));
+        args.push("-e".to_string());
+        args.push(format!("GITHUB_TOKEN={}", token));
+    }
+
+    // Add Anthropic API key
+    let anthropic_key = config.anthropic_api_key.clone().or_else(get_anthropic_key);
+    if let Some(key) = anthropic_key {
+        args.push("-e".to_string());
+        args.push(format!("ANTHROPIC_API_KEY={}", key));
+    }
+
+    // Add issue context as env vars
+    args.push("-e".to_string());
+    args.push(format!("HANDY_ISSUE_REF={}", config.issue_ref));
+    args.push("-e".to_string());
+    args.push(format!("HANDY_AGENT_TYPE={}", config.agent_type));
+
+    // Add the image
+    args.push(image);
+
+    // Build the agent command based on type, wrapped in a setup script
+    // that creates a non-root user (required for --dangerously-skip-permissions)
+    let agent_cmd =
+        build_sandboxed_agent_command(&config.agent_type, &config.issue_ref, config.auto_accept)?;
+    let setup_script = build_nonroot_setup_script(&agent_cmd);
+
+    // Add command as shell execution
+    args.push("sh".to_string());
+    args.push("-c".to_string());
+    args.push(setup_script);
+
+    // Log the docker command (sanitized - hide sensitive env vars)
+    let safe_args: Vec<String> = args
+        .iter()
+        .map(|arg| {
+            if arg.contains("GH_TOKEN=")
+                || arg.contains("GITHUB_TOKEN=")
+                || arg.contains("ANTHROPIC_API_KEY=")
+            {
+                "[REDACTED_ENV_VAR]".to_string()
+            } else {
+                arg.clone()
+            }
+        })
+        .collect();
+    log::debug!("Spawning sandbox container: docker {}", safe_args.join(" "));
+
+    // Run docker command
+    let output = Command::new("docker")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to run docker: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Docker failed: {}", sanitize_docker_error(&stderr)));
+    }
+
+    let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    Ok(SandboxResult {
+        container_id,
+        container_name,
+        started: true,
+    })
+}
+
+/// Build a setup script that creates a non-root user and runs the agent command
+///
+/// This is required because Claude Code's --dangerously-skip-permissions flag
+/// refuses to run with root/sudo privileges for security reasons.
+///
+/// The script always creates a non-root 'agent' user (or reuses 'node' if it exists
+/// in node-based images). On macOS with Docker Desktop/OrbStack, mounted volumes
+/// may appear as root-owned, so we can't rely on workspace UID detection.
+///
+/// IMPORTANT: We use `exec gosu` to completely replace the shell process with
+/// the non-root user's process. This ensures Claude Code sees a clean non-root
+/// environment without any sudo/su context in the process tree.
+///
+/// Authentication is loaded from:
+/// - /tmp/claude-auth - Persistent Docker volume with Claude Code credentials
+/// - /tmp/host-auth/.config/gh - GitHub CLI auth from host
+fn build_nonroot_setup_script(agent_cmd: &str) -> String {
+    format!(
+        r#"
+set -e
+
+# Always use a non-root user for Claude Code
+# On macOS with Docker Desktop/OrbStack, mounted volumes may appear as root-owned,
+# so we can't rely on workspace UID detection.
+
+# Check if 'node' user exists (common in node:* images) and use it
+# Otherwise create an 'agent' user
+if id "node" &>/dev/null; then
+    AGENT_USER="node"
+    AGENT_HOME=$(getent passwd "node" | cut -d: -f6)
+    echo "Using existing 'node' user"
+else
+    AGENT_USER="agent"
+    AGENT_HOME="/home/agent"
+
+    # Create agent group and user (ignore errors if they exist)
+    groupadd agent 2>/dev/null || true
+    useradd -m -s /bin/bash -g agent agent 2>/dev/null || true
+
+    echo "Created 'agent' user"
+fi
+
+# Ensure home directory structure exists
+mkdir -p "$AGENT_HOME/.config"
+mkdir -p "$AGENT_HOME/.claude"
+
+# Copy Claude Code auth from persistent volume (set up via one-time auth container)
+if [ -d /tmp/claude-auth ] && [ "$(ls -A /tmp/claude-auth 2>/dev/null)" ]; then
+    echo "Copying Claude Code credentials from auth volume..."
+    cp -r /tmp/claude-auth/* "$AGENT_HOME/.claude/" 2>/dev/null || true
+else
+    echo "WARNING: No Claude auth found in volume. Run 'Setup Auth' in Handy DevOps settings."
+fi
+
+# Copy GitHub CLI auth from host (if mounted)
+if [ -d /tmp/host-auth/.config/gh ]; then
+    mkdir -p "$AGENT_HOME/.config/gh"
+    cp -r /tmp/host-auth/.config/gh/* "$AGENT_HOME/.config/gh/" 2>/dev/null || true
+    echo "Copied GitHub CLI auth from host"
+fi
+
+# Fix ownership of home directory
+chown -R "$AGENT_USER:$AGENT_USER" "$AGENT_HOME" 2>/dev/null || true
+
+# Give the user ownership of the workspace
+# This is safe because we're in an isolated container
+chown -R "$AGENT_USER:$AGENT_USER" /workspace 2>/dev/null || true
+
+# Install gh CLI, gosu, and expect (for automating the interactive prompt)
+apt-get update && apt-get install -y gh gosu expect > /dev/null 2>&1 || true
+
+# Install Claude Code globally (as root, so it's available to all users)
+npm install -g @anthropic-ai/claude-code
+
+# Create expect script file to automate the bypass permissions warning dialog
+# Use a here-doc with Tcl's format command to create the escape character
+cat > /tmp/auto-accept.exp << 'EXPECT_SCRIPT'
+#!/usr/bin/expect -f
+set timeout -1
+set cmd [lindex $argv 0]
+
+# Define the escape sequence for down arrow using Tcl format (char 27 = ESC)
+set DOWN_ARROW [format "%c\[B" 27]
+
+spawn -noecho {{*}}$cmd
+expect {{
+    "No, exit" {{
+        send $DOWN_ARROW
+        sleep 0.2
+        send "\r"
+        exp_continue
+    }}
+    eof
+}}
+wait
+EXPECT_SCRIPT
+chmod +x /tmp/auto-accept.exp
+
+# Create wrapper script that runs Claude via expect
+# Use unquoted heredoc so CLAUDE_CMD variable expands
+CLAUDE_CMD='{agent_cmd}'
+cat > /tmp/run-agent.sh << AGENT_SCRIPT
+#!/bin/bash
+cd /workspace
+exec /tmp/auto-accept.exp "$CLAUDE_CMD"
+AGENT_SCRIPT
+chmod +x /tmp/run-agent.sh
+chown "$AGENT_USER:$AGENT_USER" /tmp/run-agent.sh /tmp/auto-accept.exp
+
+# Use gosu to exec as the user - this replaces the current process entirely
+# Unlike su/sudo, gosu doesn't leave any privileged process in the chain
+exec gosu "$AGENT_USER" /tmp/run-agent.sh
+"#,
+        agent_cmd = agent_cmd.replace('\'', "'\\''"),
+    )
+}
+
+/// Build the command to run inside the sandbox container
+fn build_sandboxed_agent_command(
+    agent_type: &str,
+    issue_ref: &str,
+    auto_accept: bool,
+) -> Result<String, String> {
+    let (repo, issue_number) = parse_issue_ref(issue_ref)?;
+
+    let command = match agent_type.to_lowercase().as_str() {
+        "claude" => {
+            if auto_accept {
+                // In sandbox, we can safely use --dangerously-skip-permissions
+                // This works because we run as a non-root user
+                format!(
+                    "claude --dangerously-skip-permissions 'Work on GitHub issue {}#{}: Implement the requirements described in the issue. When done, commit your changes and create a PR.'",
+                    repo, issue_number
+                )
+            } else {
+                format!(
+                    "claude 'Work on GitHub issue {}#{}: Implement the requirements described in the issue. When done, commit your changes and create a PR.'",
+                    repo, issue_number
+                )
+            }
+        }
+        "aider" => {
+            if auto_accept {
+                format!(
+                    "aider --yes-always --message 'Work on GitHub issue {}#{}. Implement the requirements and commit when done.'",
+                    repo, issue_number
+                )
+            } else {
+                format!(
+                    "aider --message 'Work on GitHub issue {}#{}. Implement the requirements and commit when done.'",
+                    repo, issue_number
+                )
+            }
+        }
+        _ => {
+            return Err(format!(
+                "Agent type '{}' is not supported for sandboxed execution. Supported: claude, aider",
+                agent_type
+            ));
+        }
+    };
+
+    Ok(command)
+}
+
+/// Parse issue reference like "org/repo#123" into (repo, number)
+fn parse_issue_ref(issue_ref: &str) -> Result<(String, u64), String> {
+    let parts: Vec<&str> = issue_ref.split('#').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid issue reference: {}. Expected format: org/repo#123",
+            issue_ref
+        ));
+    }
+
+    let repo = parts[0].to_string();
+    let number = parts[1]
+        .parse::<u64>()
+        .map_err(|_| format!("Invalid issue number: {}", parts[1]))?;
+
+    Ok((repo, number))
+}
+
+/// Get status of a sandbox container
+pub fn get_sandbox_status(container_name: &str) -> Result<SandboxStatus, String> {
+    let output = Command::new("docker")
+        .args([
+            "inspect",
+            "--format",
+            "{{.Id}}\t{{.State.Running}}\t{{.State.ExitCode}}\t{{.State.Status}}",
+            container_name,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to inspect container: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!("Container '{}' not found", container_name));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parts: Vec<&str> = stdout.trim().split('\t').collect();
+
+    if parts.len() < 4 {
+        return Err("Invalid docker inspect output".to_string());
+    }
+
+    Ok(SandboxStatus {
+        container_id: parts[0].to_string(),
+        container_name: container_name.to_string(),
+        running: parts[1] == "true",
+        exit_code: parts[2].parse().ok(),
+        status: parts[3].to_string(),
+    })
+}
+
+/// Get logs from a sandbox container
+pub fn get_sandbox_logs(container_name: &str, tail: Option<u32>) -> Result<String, String> {
+    let mut args = vec!["logs".to_string()];
+
+    if let Some(n) = tail {
+        args.push("--tail".to_string());
+        args.push(n.to_string());
+    }
+
+    args.push(container_name.to_string());
+
+    let output = Command::new("docker")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to get logs: {}", e))?;
+
+    // Docker logs outputs to stderr for stderr, stdout for stdout
+    // Combine both
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    Ok(format!("{}{}", stdout, stderr))
+}
+
+/// Stop a sandbox container
+pub fn stop_sandbox(container_name: &str) -> Result<(), String> {
+    let output = Command::new("docker")
+        .args(["stop", container_name])
+        .output()
+        .map_err(|e| format!("Failed to stop container: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to stop container: {}", stderr));
+    }
+
+    Ok(())
+}
+
+/// Remove a sandbox container
+pub fn remove_sandbox(container_name: &str, force: bool) -> Result<(), String> {
+    let mut args = vec!["rm".to_string()];
+    if force {
+        args.push("-f".to_string());
+    }
+    args.push(container_name.to_string());
+
+    let output = Command::new("docker")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to remove container: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to remove container: {}", stderr));
+    }
+
+    Ok(())
+}
+
+/// List all Handy sandbox containers
+pub fn list_sandboxes() -> Result<Vec<SandboxStatus>, String> {
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name={}", CONTAINER_PREFIX),
+            "--format",
+            "{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Status}}",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to list containers: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Docker failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut sandboxes = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() >= 4 {
+            sandboxes.push(SandboxStatus {
+                container_id: parts[0].to_string(),
+                container_name: parts[1].to_string(),
+                running: parts[2] == "running",
+                exit_code: None, // Would need separate inspect call
+                status: parts[3].to_string(),
+            });
+        }
+    }
+
+    Ok(sandboxes)
+}
+
+/// Information about a cleaned up orphan container
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct CleanedOrphanInfo {
+    /// Container name
+    pub container_name: String,
+    /// Issue number associated with this container (if parseable)
+    pub issue_number: Option<u32>,
+}
+
+/// Result of cleaning up orphaned containers
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OrphanCleanupResult {
+    /// Number of orphaned containers found
+    pub found: usize,
+    /// Number of containers successfully removed
+    pub removed: usize,
+    /// Container names that were removed
+    pub removed_containers: Vec<String>,
+    /// Detailed info about cleaned containers (includes issue numbers for toasts)
+    pub cleaned_orphans: Vec<CleanedOrphanInfo>,
+    /// Any errors encountered
+    pub errors: Vec<String>,
+}
+
+/// Check if a Docker container exists for a given issue number
+///
+/// Checks for both `handy-sandbox-{issue}` and `handy-support-sandbox-{issue}` patterns.
+/// Returns the container name if it exists, None otherwise.
+pub fn container_exists_for_issue(issue_number: u32) -> Option<String> {
+    let patterns = [
+        format!("handy-sandbox-{}", issue_number),
+        format!("handy-support-sandbox-{}", issue_number),
+    ];
+
+    for container_name in &patterns {
+        let output = Command::new("docker")
+            .args(["inspect", "--format", "{{.State.Running}}", container_name])
+            .output();
+
+        if let Ok(output) = output {
+            if output.status.success() {
+                // Container exists
+                return Some(container_name.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Stop and remove a container by name
+///
+/// Returns Ok(()) if the container was removed or didn't exist.
+/// Returns Err if the removal failed.
+pub fn stop_and_remove_container(container_name: &str) -> Result<(), String> {
+    let output = Command::new("docker")
+        .args(["rm", "-f", container_name])
+        .output()
+        .map_err(|e| format!("Failed to run docker rm: {}", e))?;
+
+    if output.status.success() {
+        log::info!("Removed container: {}", container_name);
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // "No such container" is fine - it's already gone
+        if stderr.contains("No such container") {
+            Ok(())
+        } else {
+            Err(format!(
+                "Failed to remove container {}: {}",
+                container_name,
+                sanitize_docker_error(&stderr)
+            ))
+        }
+    }
+}
+
+/// Find and remove orphaned Handy Docker containers
+///
+/// An orphaned container is one that:
+/// - Has a name matching `handy-sandbox-*` or `handy-support-sandbox-*`
+/// - Does not have a corresponding active tmux session
+///
+/// This helps clean up containers that were left behind when:
+/// - The app crashed
+/// - A tmux session was killed externally
+/// - Docker containers outlived their sessions
+pub fn cleanup_orphaned_containers() -> Result<OrphanCleanupResult, String> {
+    use super::tmux;
+
+    // Get all Handy-related containers (both sandbox and support-sandbox)
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "name=handy-sandbox-",
+            "--filter",
+            "name=handy-support-sandbox-",
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to list containers: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // If docker is not running, that's fine - no orphans to clean
+        if stderr.contains("Cannot connect to the Docker daemon") {
+            return Ok(OrphanCleanupResult {
+                found: 0,
+                removed: 0,
+                removed_containers: vec![],
+                cleaned_orphans: vec![],
+                errors: vec![],
+            });
+        }
+        return Err(format!("Docker failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let container_names: Vec<&str> = stdout.lines().filter(|s| !s.is_empty()).collect();
+
+    if container_names.is_empty() {
+        return Ok(OrphanCleanupResult {
+            found: 0,
+            removed: 0,
+            removed_containers: vec![],
+            cleaned_orphans: vec![],
+            errors: vec![],
+        });
+    }
+
+    // Get active tmux sessions to compare against
+    let active_sessions = tmux::list_sessions().unwrap_or_default();
+
+    // Build a set of issue numbers that have active sessions
+    let active_issue_numbers: std::collections::HashSet<u32> = active_sessions
+        .iter()
+        .filter_map(|s| {
+            s.metadata.as_ref().and_then(|m| {
+                m.issue_ref
+                    .as_ref()
+                    .and_then(|ref_str| ref_str.split('#').last().and_then(|n| n.parse().ok()))
+            })
+        })
+        .collect();
+
+    let mut result = OrphanCleanupResult {
+        found: 0,
+        removed: 0,
+        removed_containers: vec![],
+        cleaned_orphans: vec![],
+        errors: vec![],
+    };
+
+    for container_name in container_names {
+        // Extract issue number from container name
+        // Patterns: handy-sandbox-123, handy-support-sandbox-123
+        let issue_num: Option<u32> = container_name
+            .trim_start_matches("handy-support-sandbox-")
+            .trim_start_matches("handy-sandbox-")
+            .parse()
+            .ok();
+
+        let is_orphan = match issue_num {
+            Some(num) => !active_issue_numbers.contains(&num),
+            None => true, // Can't parse issue number, consider it orphaned
+        };
+
+        if is_orphan {
+            result.found += 1;
+            log::info!("Found orphaned container: {}", container_name);
+
+            // Try to remove the container
+            match Command::new("docker")
+                .args(["rm", "-f", container_name])
+                .output()
+            {
+                Ok(rm_output) => {
+                    if rm_output.status.success() {
+                        result.removed += 1;
+                        result.removed_containers.push(container_name.to_string());
+                        result.cleaned_orphans.push(CleanedOrphanInfo {
+                            container_name: container_name.to_string(),
+                            issue_number: issue_num,
+                        });
+                        log::info!("Removed orphaned container: {}", container_name);
+                    } else {
+                        let err = String::from_utf8_lossy(&rm_output.stderr).to_string();
+                        result.errors.push(format!("{}: {}", container_name, err));
+                        log::warn!("Failed to remove container {}: {}", container_name, err);
+                    }
+                }
+                Err(e) => {
+                    result.errors.push(format!("{}: {}", container_name, e));
+                    log::warn!("Failed to remove container {}: {}", container_name, e);
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Configuration for a devcontainer.json file
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DevContainerConfig {
+    /// Name for the devcontainer
+    pub name: String,
+    /// Base image to use
+    pub image: String,
+    /// Features to include (like claude-code)
+    pub features: Vec<DevContainerFeature>,
+    /// Environment variables
+    pub container_env: std::collections::HashMap<String, String>,
+    /// Post-create command to run
+    pub post_create_command: Option<String>,
+}
+
+/// A devcontainer feature reference
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DevContainerFeature {
+    /// Feature identifier (e.g., "ghcr.io/anthropics/devcontainer-features/claude-code:1.0")
+    pub id: String,
+    /// Feature options as key-value string pairs (values are JSON strings)
+    pub options: std::collections::HashMap<String, String>,
+}
+
+impl Default for DevContainerConfig {
+    fn default() -> Self {
+        let mut features = Vec::new();
+
+        // Add the official Anthropic Claude Code feature
+        features.push(DevContainerFeature {
+            id: CLAUDE_DEVCONTAINER_FEATURE.to_string(),
+            options: std::collections::HashMap::new(),
+        });
+
+        Self {
+            name: "Handy Agent Sandbox".to_string(),
+            image: "mcr.microsoft.com/devcontainers/base:ubuntu".to_string(),
+            features,
+            container_env: std::collections::HashMap::new(),
+            post_create_command: None,
+        }
+    }
+}
+
+/// Generate devcontainer.json content for a sandboxed agent
+pub fn generate_devcontainer_json(config: &DevContainerConfig) -> String {
+    let mut features_map = serde_json::Map::new();
+    for feature in &config.features {
+        if feature.options.is_empty() {
+            features_map.insert(feature.id.clone(), serde_json::json!({}));
+        } else {
+            // Convert string options to JSON values
+            let options_obj: serde_json::Map<String, serde_json::Value> = feature
+                .options
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect();
+            features_map.insert(feature.id.clone(), serde_json::Value::Object(options_obj));
+        }
+    }
+
+    let devcontainer = serde_json::json!({
+        "name": config.name,
+        "image": config.image,
+        "features": features_map,
+        "containerEnv": config.container_env,
+        "postCreateCommand": config.post_create_command,
+        "customizations": {
+            "vscode": {
+                "extensions": [
+                    "anthropics.claude-code"
+                ]
+            }
+        }
+    });
+
+    serde_json::to_string_pretty(&devcontainer).unwrap_or_default()
+}
+
+/// Create a devcontainer configuration for an issue worktree
+///
+/// This creates a .devcontainer/devcontainer.json in the worktree directory
+/// with the official Anthropic Claude Code feature configured.
+pub fn setup_devcontainer_for_worktree(
+    worktree_path: &str,
+    issue_ref: &str,
+    gh_token: Option<&str>,
+    anthropic_key: Option<&str>,
+) -> Result<String, String> {
+    use std::fs;
+    use std::path::Path;
+
+    let devcontainer_dir = Path::new(worktree_path).join(".devcontainer");
+    let devcontainer_file = devcontainer_dir.join("devcontainer.json");
+
+    // Create .devcontainer directory if it doesn't exist
+    fs::create_dir_all(&devcontainer_dir)
+        .map_err(|e| format!("Failed to create .devcontainer directory: {}", e))?;
+
+    // Build the config
+    let mut config = DevContainerConfig::default();
+    config.name = format!("Handy Agent - {}", issue_ref);
+
+    // Add environment variables for credentials
+    if let Some(token) = gh_token {
+        config
+            .container_env
+            .insert("GH_TOKEN".to_string(), token.to_string());
+        config
+            .container_env
+            .insert("GITHUB_TOKEN".to_string(), token.to_string());
+    }
+    if let Some(key) = anthropic_key {
+        config
+            .container_env
+            .insert("ANTHROPIC_API_KEY".to_string(), key.to_string());
+    }
+
+    // Add issue context
+    config
+        .container_env
+        .insert("HANDY_ISSUE_REF".to_string(), issue_ref.to_string());
+
+    // Generate and write the devcontainer.json
+    let json_content = generate_devcontainer_json(&config);
+    fs::write(&devcontainer_file, &json_content)
+        .map_err(|e| format!("Failed to write devcontainer.json: {}", e))?;
+
+    Ok(devcontainer_file.to_string_lossy().to_string())
+}
+
+/// Check if devcontainer CLI is available
+pub fn is_devcontainer_cli_available() -> bool {
+    Command::new("devcontainer")
+        .args(["--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Start a devcontainer for the given workspace
+///
+/// Uses the devcontainer CLI to build and start the container.
+/// Falls back to VS Code if CLI is not available.
+pub fn start_devcontainer(worktree_path: &str) -> Result<String, String> {
+    if !is_devcontainer_cli_available() {
+        return Err(
+            "devcontainer CLI not found. Install with: npm install -g @devcontainers/cli"
+                .to_string(),
+        );
+    }
+
+    // Start the devcontainer
+    let output = Command::new("devcontainer")
+        .args(["up", "--workspace-folder", worktree_path])
+        .output()
+        .map_err(|e| format!("Failed to start devcontainer: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to start devcontainer: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.to_string())
+}
+
+/// Execute a command inside a running devcontainer
+pub fn exec_in_devcontainer(worktree_path: &str, command: &str) -> Result<String, String> {
+    if !is_devcontainer_cli_available() {
+        return Err("devcontainer CLI not found".to_string());
+    }
+
+    let output = Command::new("devcontainer")
+        .args([
+            "exec",
+            "--workspace-folder",
+            worktree_path,
+            "sh",
+            "-c",
+            command,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to exec in devcontainer: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        return Err(format!("Command failed: {}{}", stdout, stderr));
+    }
+
+    Ok(format!("{}{}", stdout, stderr))
+}
+
+/// Volume name for persistent Claude Code authentication
+const CLAUDE_AUTH_VOLUME: &str = "handy-claude-auth";
+
+/// Status of the Claude Code authentication volume
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ClaudeAuthVolumeStatus {
+    /// Whether the volume exists
+    pub exists: bool,
+    /// Whether the volume has authentication data
+    pub has_auth: bool,
+    /// Volume name
+    pub volume_name: String,
+    /// Last authentication time (if known)
+    pub last_auth: Option<String>,
+}
+
+/// Check if the Claude Code authentication volume exists and has credentials
+pub fn check_claude_auth_volume() -> Result<ClaudeAuthVolumeStatus, String> {
+    // Check if volume exists
+    let output = Command::new("docker")
+        .args(["volume", "inspect", CLAUDE_AUTH_VOLUME])
+        .output()
+        .map_err(|e| format!("Failed to inspect volume: {}", e))?;
+
+    let exists = output.status.success();
+
+    if !exists {
+        return Ok(ClaudeAuthVolumeStatus {
+            exists: false,
+            has_auth: false,
+            volume_name: CLAUDE_AUTH_VOLUME.to_string(),
+            last_auth: None,
+        });
+    }
+
+    // Check if volume has auth data by running a quick container to check for .credentials.json
+    // Claude Code stores credentials in .credentials.json (not .claude.json as previously thought)
+    let check_output = Command::new("docker")
+        .args([
+            "run", "--rm",
+            "-v", &format!("{}:/claude-auth:ro", CLAUDE_AUTH_VOLUME),
+            "alpine:latest",
+            "sh", "-c",
+            "test -f /claude-auth/.credentials.json && cat /claude-auth/.credentials.json | head -1 || echo 'NO_AUTH'"
+        ])
+        .output()
+        .map_err(|e| format!("Failed to check auth data: {}", e))?;
+
+    let check_result = String::from_utf8_lossy(&check_output.stdout)
+        .trim()
+        .to_string();
+    let has_auth = check_output.status.success()
+        && !check_result.contains("NO_AUTH")
+        && check_result.starts_with('{');
+
+    // Try to get last modified time of auth file
+    let last_auth = if has_auth {
+        let stat_output = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "-v",
+                &format!("{}:/claude-auth:ro", CLAUDE_AUTH_VOLUME),
+                "alpine:latest",
+                "stat",
+                "-c",
+                "%y",
+                "/claude-auth/.credentials.json",
+            ])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+        stat_output
+    } else {
+        None
+    };
+
+    Ok(ClaudeAuthVolumeStatus {
+        exists,
+        has_auth,
+        volume_name: CLAUDE_AUTH_VOLUME.to_string(),
+        last_auth,
+    })
+}
+
+/// Create the Claude Code authentication volume if it doesn't exist
+pub fn ensure_claude_auth_volume() -> Result<(), String> {
+    let output = Command::new("docker")
+        .args(["volume", "create", CLAUDE_AUTH_VOLUME])
+        .output()
+        .map_err(|e| format!("Failed to create volume: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Ignore "already exists" error
+        if !stderr.contains("already exists") {
+            return Err(format!("Failed to create volume: {}", stderr));
+        }
+    }
+
+    log::info!("Ensured Claude auth volume exists: {}", CLAUDE_AUTH_VOLUME);
+    Ok(())
+}
+
+/// Launch an interactive container for Claude Code authentication
+///
+/// This starts a one-time container that:
+/// 1. Mounts the persistent auth volume
+/// 2. Installs Claude Code
+/// 3. Opens a shell where the user can run `claude /login`
+/// 4. Saves credentials to the volume for future use
+///
+/// Returns the container name so the caller can track it.
+pub fn launch_claude_auth_container() -> Result<String, String> {
+    // Ensure the auth volume exists
+    ensure_claude_auth_volume()?;
+
+    let container_name = "handy-claude-auth-setup";
+
+    // Remove any existing auth container
+    let _ = Command::new("docker")
+        .args(["rm", "-f", container_name])
+        .output();
+
+    // Launch interactive container with the auth volume mounted
+    // We use node:20-bookworm as it has npm for installing claude-code
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "-it",
+            "--rm",
+            "--name",
+            container_name,
+            "-v",
+            &format!("{}:/home/node/.claude", CLAUDE_AUTH_VOLUME),
+            "-e",
+            "HOME=/home/node",
+            "-w",
+            "/home/node",
+            "node:20-bookworm",
+            "bash",
+            "-c",
+            r#"
+echo "=================================================="
+echo "   Claude Code Authentication Setup"
+echo "=================================================="
+echo ""
+echo "Installing Claude Code..."
+npm install -g @anthropic-ai/claude-code > /dev/null 2>&1
+echo "✅ Claude Code installed"
+echo ""
+echo "Now run: claude /login"
+echo ""
+echo "After authenticating, your credentials will be saved"
+echo "for all future Handy sandbox containers."
+echo ""
+echo "Type 'exit' when done."
+echo "=================================================="
+exec bash
+"#,
+        ])
+        .spawn()
+        .map_err(|e| format!("Failed to launch auth container: {}", e))?;
+
+    // Note: spawn() returns immediately, the container runs in foreground
+    // The calling code should handle this appropriately (e.g., open in terminal)
+
+    Ok(container_name.to_string())
+}
+
+/// Launch Claude auth container in Terminal.app
+///
+/// This writes a shell script to /tmp and opens Terminal to run it.
+/// The script runs an interactive Docker container for Claude Code authentication.
+pub fn launch_claude_auth_in_terminal() -> Result<String, String> {
+    // Ensure the auth volume exists
+    ensure_claude_auth_volume()?;
+
+    let container_name = "handy-claude-auth-setup";
+
+    // Remove any existing auth container first
+    let _ = Command::new("docker")
+        .args(["rm", "-f", container_name])
+        .output();
+
+    // Write a shell script that runs the docker command
+    let script_path = "/tmp/handy-claude-auth-setup.sh";
+    let script_content = format!(
+        r#"#!/bin/bash
+echo "=================================================="
+echo "   Claude Code Authentication Setup"
+echo "=================================================="
+echo ""
+echo "Starting Docker container..."
+docker run -it --rm \
+    --name {container_name} \
+    -v {volume}:/home/node/.claude \
+    -e HOME=/home/node \
+    -w /home/node \
+    node:20-bookworm \
+    bash -c '
+        echo "Installing Claude Code..."
+        npm install -g @anthropic-ai/claude-code > /dev/null 2>&1
+        echo "[OK] Claude Code installed"
+        echo ""
+        echo "Now run: claude /login"
+        echo ""
+        echo "After authenticating, your credentials will be saved"
+        echo "for all future Handy sandbox containers."
+        echo ""
+        echo "Type exit when done."
+        echo "=================================================="
+        exec bash
+    '
+echo ""
+echo "Done. You can close this window."
+"#,
+        container_name = container_name,
+        volume = CLAUDE_AUTH_VOLUME
+    );
+
+    // Write the script
+    std::fs::write(script_path, &script_content)
+        .map_err(|e| format!("Failed to write script: {}", e))?;
+
+    // Make it executable
+    let _ = Command::new("chmod").args(["+x", script_path]).output();
+
+    // Open Terminal and run the script
+    let result = Command::new("open")
+        .args(["-a", "Terminal", script_path])
+        .output();
+
+    match result {
+        Ok(output) => {
+            if output.status.success() {
+                log::info!("Launched Claude auth container via Terminal");
+                Ok(container_name.to_string())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(format!("Failed to open Terminal: {}", stderr))
+            }
+        }
+        Err(e) => Err(format!("Failed to run open command: {}", e)),
+    }
+}
+
+/// Get the volume name for Claude authentication
+pub fn get_claude_auth_volume_name() -> &'static str {
+    CLAUDE_AUTH_VOLUME
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_container_name_for_issue() {
+        assert_eq!(container_name_for_issue(123), "handy-sandbox-123");
+    }
+
+    #[test]
+    fn test_parse_issue_ref() {
+        let (repo, num) = parse_issue_ref("org/repo#456").unwrap();
+        assert_eq!(repo, "org/repo");
+        assert_eq!(num, 456);
+    }
+
+    #[test]
+    fn test_parse_issue_ref_invalid() {
+        assert!(parse_issue_ref("invalid").is_err());
+        assert!(parse_issue_ref("org/repo").is_err());
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/github.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/github.rs
@@ -1,0 +1,1515 @@
+//! GitHub CLI integration for issue management.
+//!
+//! Uses the `gh` CLI to interact with GitHub issues, providing
+//! task queue functionality for coding agents.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::process::Command;
+
+/// Regex patterns for sanitizing sensitive data from content before posting to GitHub.
+static SENSITIVE_PATTERNS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(sk-ant-[a-zA-Z0-9\-_]+|ghp_[a-zA-Z0-9]+|gho_[a-zA-Z0-9]+|github_pat_[a-zA-Z0-9_]+|ANTHROPIC_API_KEY=[^\s]+|GH_TOKEN=[^\s]+|GITHUB_TOKEN=[^\s]+|Bearer\s+[a-zA-Z0-9\-_.]+)").unwrap()
+});
+
+/// Sanitize content before posting to GitHub issues or comments.
+///
+/// This removes sensitive data that could leak credentials:
+/// - Anthropic API keys (sk-ant-*)
+/// - GitHub tokens (ghp_*, gho_*, github_pat_*)
+/// - Environment variable assignments with sensitive values
+/// - Bearer tokens
+/// - Home directory paths (replaced with ~)
+///
+/// This function should be called on any content derived from error messages,
+/// logs, or other system output before posting to GitHub.
+pub fn sanitize_for_github(content: &str) -> String {
+    // Redact known sensitive patterns
+    let sanitized = SENSITIVE_PATTERNS.replace_all(content, "[REDACTED]");
+
+    // Replace home directory with ~ to avoid leaking username
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return sanitized.replace(&home, "~");
+        }
+    }
+
+    sanitized.to_string()
+}
+
+/// GitHub authentication status.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct GhAuthStatus {
+    /// Whether the user is authenticated
+    pub authenticated: bool,
+    /// Username if authenticated
+    pub username: Option<String>,
+    /// Scopes available
+    pub scopes: Vec<String>,
+    /// Error message if not authenticated
+    pub error: Option<String>,
+}
+
+/// A GitHub issue.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct GitHubIssue {
+    /// Issue number
+    pub number: u64,
+    /// Issue title
+    pub title: String,
+    /// Issue body/description
+    pub body: Option<String>,
+    /// Issue state (open, closed)
+    pub state: String,
+    /// Issue URL
+    pub url: String,
+    /// Labels on the issue
+    pub labels: Vec<String>,
+    /// Assignees
+    pub assignees: Vec<String>,
+    /// Author username
+    pub author: String,
+    /// Created timestamp
+    pub created_at: String,
+    /// Updated timestamp
+    pub updated_at: String,
+    /// Repository in owner/repo format
+    pub repo: String,
+}
+
+/// A GitHub issue comment.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct GitHubComment {
+    /// Comment ID
+    pub id: u64,
+    /// Comment body
+    pub body: String,
+    /// Author username
+    pub author: String,
+    /// Created timestamp
+    pub created_at: String,
+}
+
+/// Agent metadata stored in issue comments.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct IssueAgentMetadata {
+    /// Session name
+    pub session: String,
+    /// Machine ID
+    pub machine_id: String,
+    /// Worktree path
+    pub worktree: Option<String>,
+    /// Agent type
+    pub agent_type: String,
+    /// Started timestamp
+    pub started_at: String,
+    /// Current status
+    pub status: String,
+}
+
+/// Parsed issue with agent metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct IssueWithAgent {
+    /// The issue
+    pub issue: GitHubIssue,
+    /// Agent metadata if assigned
+    pub agent: Option<IssueAgentMetadata>,
+}
+
+const METADATA_START: &str = "<!-- HANDY_AGENT_METADATA";
+const METADATA_END: &str = "-->";
+
+/// Check GitHub CLI authentication status.
+pub fn check_auth_status() -> GhAuthStatus {
+    let output = Command::new("gh")
+        .args(["auth", "status", "--show-token"])
+        .output();
+
+    match output {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let combined = format!("{}{}", stdout, stderr);
+
+            if output.status.success() || combined.contains("Logged in to") {
+                // Parse username from output
+                let username = combined
+                    .lines()
+                    .find(|line| line.contains("Logged in to"))
+                    .and_then(|line| {
+                        // Format: "✓ Logged in to github.com account username (keyring)"
+                        line.split("account ")
+                            .nth(1)
+                            .map(|s| s.split_whitespace().next().unwrap_or("").to_string())
+                    });
+
+                // Parse scopes
+                let scopes = combined
+                    .lines()
+                    .find(|line| line.contains("Token scopes:"))
+                    .map(|line| {
+                        line.split("Token scopes:")
+                            .nth(1)
+                            .unwrap_or("")
+                            .split(',')
+                            .map(|s| s.trim().trim_matches('\'').to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                GhAuthStatus {
+                    authenticated: true,
+                    username,
+                    scopes,
+                    error: None,
+                }
+            } else {
+                GhAuthStatus {
+                    authenticated: false,
+                    username: None,
+                    scopes: vec![],
+                    error: Some(combined.trim().to_string()),
+                }
+            }
+        }
+        Err(e) => GhAuthStatus {
+            authenticated: false,
+            username: None,
+            scopes: vec![],
+            error: Some(format!("Failed to run gh: {}", e)),
+        },
+    }
+}
+
+/// List issues from a repository.
+pub fn list_issues(
+    repo: &str,
+    state: Option<&str>,
+    labels: Option<Vec<&str>>,
+    limit: Option<u32>,
+) -> Result<Vec<GitHubIssue>, String> {
+    let mut args = vec![
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,state,url,labels,assignees,author,createdAt,updatedAt",
+    ];
+
+    let state_str;
+    if let Some(s) = state {
+        state_str = s.to_string();
+        args.push("--state");
+        args.push(&state_str);
+    }
+
+    let labels_str;
+    if let Some(l) = labels {
+        labels_str = l.join(",");
+        args.push("--label");
+        args.push(&labels_str);
+    }
+
+    let limit_str;
+    if let Some(l) = limit {
+        limit_str = l.to_string();
+        args.push("--limit");
+        args.push(&limit_str);
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    // Parse the JSON response
+    #[derive(Deserialize)]
+    struct GhIssue {
+        number: u64,
+        title: String,
+        body: Option<String>,
+        state: String,
+        url: String,
+        labels: Vec<GhLabel>,
+        assignees: Vec<GhUser>,
+        author: GhUser,
+        #[serde(rename = "createdAt")]
+        created_at: String,
+        #[serde(rename = "updatedAt")]
+        updated_at: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhLabel {
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+
+    let gh_issues: Vec<GhIssue> =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(gh_issues
+        .into_iter()
+        .map(|i| GitHubIssue {
+            number: i.number,
+            title: i.title,
+            body: i.body,
+            state: i.state,
+            url: i.url,
+            labels: i.labels.into_iter().map(|l| l.name).collect(),
+            assignees: i.assignees.into_iter().map(|a| a.login).collect(),
+            author: i.author.login,
+            created_at: i.created_at,
+            updated_at: i.updated_at,
+            repo: repo.to_string(),
+        })
+        .collect())
+}
+
+/// Get details of a specific issue.
+pub fn get_issue(repo: &str, number: u64) -> Result<GitHubIssue, String> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,url,labels,assignees,author,createdAt,updatedAt",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhIssue {
+        number: u64,
+        title: String,
+        body: Option<String>,
+        state: String,
+        url: String,
+        labels: Vec<GhLabel>,
+        assignees: Vec<GhUser>,
+        author: GhUser,
+        #[serde(rename = "createdAt")]
+        created_at: String,
+        #[serde(rename = "updatedAt")]
+        updated_at: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhLabel {
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+
+    let gh_issue: GhIssue =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(GitHubIssue {
+        number: gh_issue.number,
+        title: gh_issue.title,
+        body: gh_issue.body,
+        state: gh_issue.state,
+        url: gh_issue.url,
+        labels: gh_issue.labels.into_iter().map(|l| l.name).collect(),
+        assignees: gh_issue.assignees.into_iter().map(|a| a.login).collect(),
+        author: gh_issue.author.login,
+        created_at: gh_issue.created_at,
+        updated_at: gh_issue.updated_at,
+        repo: repo.to_string(),
+    })
+}
+
+/// Create a new issue.
+pub fn create_issue(
+    repo: &str,
+    title: &str,
+    body: Option<&str>,
+    labels: Option<Vec<&str>>,
+) -> Result<GitHubIssue, String> {
+    let mut args = vec!["issue", "create", "--repo", repo, "--title", title];
+
+    let body_str;
+    if let Some(b) = body {
+        body_str = b.to_string();
+        args.push("--body");
+        args.push(&body_str);
+    }
+
+    let labels_str;
+    if let Some(l) = labels {
+        labels_str = l.join(",");
+        args.push("--label");
+        args.push(&labels_str);
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue create failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Output is the issue URL, parse the number from it
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let number = url
+        .split('/')
+        .last()
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| "Failed to parse issue number from URL".to_string())?;
+
+    // Fetch the full issue details
+    get_issue(repo, number)
+}
+
+/// Add a comment to an issue.
+pub fn add_comment(repo: &str, number: u64, body: &str) -> Result<(), String> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "comment",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--body",
+            body,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue comment failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Add agent metadata comment to an issue.
+pub fn add_agent_metadata_comment(
+    repo: &str,
+    number: u64,
+    metadata: &IssueAgentMetadata,
+) -> Result<(), String> {
+    let metadata_json = serde_json::to_string(metadata)
+        .map_err(|e| format!("Failed to serialize metadata: {}", e))?;
+
+    let body = format!(
+        r#"{}
+{}
+{}
+🤖 **Agent Assigned**
+- Session: `{}`
+- Type: {}
+- Machine: {}
+- Started: {}"#,
+        METADATA_START,
+        metadata_json,
+        METADATA_END,
+        metadata.session,
+        metadata.agent_type,
+        metadata.machine_id,
+        metadata.started_at
+    );
+
+    add_comment(repo, number, &body)
+}
+
+/// List comments on an issue.
+pub fn list_comments(repo: &str, number: u64) -> Result<Vec<GitHubComment>, String> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "comments",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhComments {
+        comments: Vec<GhComment>,
+    }
+
+    #[derive(Deserialize)]
+    struct GhComment {
+        id: String,
+        body: String,
+        author: GhUser,
+        #[serde(rename = "createdAt")]
+        created_at: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+
+    let gh_comments: GhComments =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(gh_comments
+        .comments
+        .into_iter()
+        .map(|c| GitHubComment {
+            id: c.id.parse().unwrap_or(0),
+            body: c.body,
+            author: c.author.login,
+            created_at: c.created_at,
+        })
+        .collect())
+}
+
+/// Parse agent metadata from issue comments.
+pub fn parse_agent_metadata(comments: &[GitHubComment]) -> Option<IssueAgentMetadata> {
+    for comment in comments.iter().rev() {
+        if let Some(metadata) = extract_metadata_from_comment(&comment.body) {
+            return Some(metadata);
+        }
+    }
+    None
+}
+
+/// Extract metadata from a comment body.
+fn extract_metadata_from_comment(body: &str) -> Option<IssueAgentMetadata> {
+    let start_idx = body.find(METADATA_START)?;
+    let end_idx = body[start_idx..].find(METADATA_END)?;
+
+    let json_start = start_idx + METADATA_START.len();
+    let json_end = start_idx + end_idx;
+    let json_str = body[json_start..json_end].trim();
+
+    serde_json::from_str(json_str).ok()
+}
+
+/// Get issue with agent metadata.
+pub fn get_issue_with_agent(repo: &str, number: u64) -> Result<IssueWithAgent, String> {
+    let issue = get_issue(repo, number)?;
+    let comments = list_comments(repo, number)?;
+    let agent = parse_agent_metadata(&comments);
+
+    Ok(IssueWithAgent { issue, agent })
+}
+
+/// Update issue labels.
+/// Labels that don't exist in the repo are silently skipped.
+pub fn update_labels(
+    repo: &str,
+    number: u64,
+    add: Vec<&str>,
+    remove: Vec<&str>,
+) -> Result<(), String> {
+    // Add labels one at a time, skipping any that don't exist
+    for label in &add {
+        let output = Command::new("gh")
+            .args([
+                "issue",
+                "edit",
+                &number.to_string(),
+                "--repo",
+                repo,
+                "--add-label",
+                label,
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Skip labels that don't exist in the repo
+            if stderr.contains("not found") {
+                eprintln!("Warning: label '{}' not found in repo, skipping", label);
+                continue;
+            }
+            return Err(format!(
+                "gh issue edit (add label '{}') failed: {}",
+                label, stderr
+            ));
+        }
+    }
+
+    // Remove labels one at a time, skipping any that don't exist
+    for label in &remove {
+        let output = Command::new("gh")
+            .args([
+                "issue",
+                "edit",
+                &number.to_string(),
+                "--repo",
+                repo,
+                "--remove-label",
+                label,
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Skip labels that don't exist in the repo
+            if stderr.contains("not found") {
+                eprintln!("Warning: label '{}' not found in repo, skipping", label);
+                continue;
+            }
+            return Err(format!(
+                "gh issue edit (remove label '{}') failed: {}",
+                label, stderr
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Close an issue with an optional comment.
+pub fn close_issue(repo: &str, number: u64, comment: Option<&str>) -> Result<(), String> {
+    // Add closing comment if provided
+    if let Some(c) = comment {
+        add_comment(repo, number, c)?;
+    }
+
+    let output = Command::new("gh")
+        .args(["issue", "close", &number.to_string(), "--repo", repo])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue close failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Reopen a closed issue.
+pub fn reopen_issue(repo: &str, number: u64) -> Result<(), String> {
+    let output = Command::new("gh")
+        .args(["issue", "reopen", &number.to_string(), "--repo", repo])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue reopen failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Pull Request Functions
+// ============================================================================
+
+/// A GitHub Pull Request.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct GitHubPullRequest {
+    /// PR number
+    pub number: u64,
+    /// PR title
+    pub title: String,
+    /// PR body/description
+    pub body: Option<String>,
+    /// PR state (open, closed, merged)
+    pub state: String,
+    /// PR URL
+    pub url: String,
+    /// Source branch
+    pub head_branch: String,
+    /// Target branch
+    pub base_branch: String,
+    /// Is the PR a draft
+    pub is_draft: bool,
+    /// Is the PR mergeable
+    pub mergeable: Option<bool>,
+    /// Labels on the PR
+    pub labels: Vec<String>,
+    /// Author username
+    pub author: String,
+    /// Created timestamp
+    pub created_at: String,
+    /// Updated timestamp
+    pub updated_at: String,
+    /// Repository in owner/repo format
+    pub repo: String,
+}
+
+/// PR check status.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PrCheckStatus {
+    /// Overall status (pending, success, failure)
+    pub state: String,
+    /// Number of passing checks
+    pub passing: u32,
+    /// Number of failing checks
+    pub failing: u32,
+    /// Number of pending checks
+    pub pending: u32,
+    /// Total number of checks
+    pub total: u32,
+}
+
+/// PR review status.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PrReviewStatus {
+    /// Number of approvals
+    pub approved: u32,
+    /// Number of changes requested
+    pub changes_requested: u32,
+    /// Number of reviews pending
+    pub pending: u32,
+}
+
+/// Full PR status including checks and reviews.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PrStatus {
+    /// The PR
+    pub pr: GitHubPullRequest,
+    /// Check status
+    pub checks: PrCheckStatus,
+    /// Review status
+    pub reviews: PrReviewStatus,
+}
+
+/// List pull requests from a repository.
+pub fn list_prs(
+    repo: &str,
+    state: Option<&str>,
+    base: Option<&str>,
+    limit: Option<u32>,
+) -> Result<Vec<GitHubPullRequest>, String> {
+    let mut args = vec![
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,state,url,headRefName,baseRefName,isDraft,mergeable,labels,author,createdAt,updatedAt",
+    ];
+
+    let state_str;
+    if let Some(s) = state {
+        state_str = s.to_string();
+        args.push("--state");
+        args.push(&state_str);
+    }
+
+    let base_str;
+    if let Some(b) = base {
+        base_str = b.to_string();
+        args.push("--base");
+        args.push(&base_str);
+    }
+
+    let limit_str;
+    if let Some(l) = limit {
+        limit_str = l.to_string();
+        args.push("--limit");
+        args.push(&limit_str);
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhPr {
+        number: u64,
+        title: String,
+        body: Option<String>,
+        state: String,
+        url: String,
+        #[serde(rename = "headRefName")]
+        head_ref_name: String,
+        #[serde(rename = "baseRefName")]
+        base_ref_name: String,
+        #[serde(rename = "isDraft")]
+        is_draft: bool,
+        mergeable: Option<String>,
+        labels: Vec<GhLabel>,
+        author: GhUser,
+        #[serde(rename = "createdAt")]
+        created_at: String,
+        #[serde(rename = "updatedAt")]
+        updated_at: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhLabel {
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+
+    let gh_prs: Vec<GhPr> =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(gh_prs
+        .into_iter()
+        .map(|p| GitHubPullRequest {
+            number: p.number,
+            title: p.title,
+            body: p.body,
+            state: p.state,
+            url: p.url,
+            head_branch: p.head_ref_name,
+            base_branch: p.base_ref_name,
+            is_draft: p.is_draft,
+            mergeable: p.mergeable.map(|m| m == "MERGEABLE"),
+            labels: p.labels.into_iter().map(|l| l.name).collect(),
+            author: p.author.login,
+            created_at: p.created_at,
+            updated_at: p.updated_at,
+            repo: repo.to_string(),
+        })
+        .collect())
+}
+
+/// Get details of a specific pull request.
+pub fn get_pr(repo: &str, number: u64) -> Result<GitHubPullRequest, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,url,headRefName,baseRefName,isDraft,mergeable,labels,author,createdAt,updatedAt",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhPr {
+        number: u64,
+        title: String,
+        body: Option<String>,
+        state: String,
+        url: String,
+        #[serde(rename = "headRefName")]
+        head_ref_name: String,
+        #[serde(rename = "baseRefName")]
+        base_ref_name: String,
+        #[serde(rename = "isDraft")]
+        is_draft: bool,
+        mergeable: Option<String>,
+        labels: Vec<GhLabel>,
+        author: GhUser,
+        #[serde(rename = "createdAt")]
+        created_at: String,
+        #[serde(rename = "updatedAt")]
+        updated_at: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhLabel {
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+
+    let gh_pr: GhPr =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(GitHubPullRequest {
+        number: gh_pr.number,
+        title: gh_pr.title,
+        body: gh_pr.body,
+        state: gh_pr.state,
+        url: gh_pr.url,
+        head_branch: gh_pr.head_ref_name,
+        base_branch: gh_pr.base_ref_name,
+        is_draft: gh_pr.is_draft,
+        mergeable: gh_pr.mergeable.map(|m| m == "MERGEABLE"),
+        labels: gh_pr.labels.into_iter().map(|l| l.name).collect(),
+        author: gh_pr.author.login,
+        created_at: gh_pr.created_at,
+        updated_at: gh_pr.updated_at,
+        repo: repo.to_string(),
+    })
+}
+
+/// Create a new pull request.
+pub fn create_pr(
+    repo: &str,
+    title: &str,
+    body: Option<&str>,
+    base: &str,
+    head: Option<&str>,
+    draft: bool,
+) -> Result<GitHubPullRequest, String> {
+    let mut args = vec![
+        "pr", "create", "--repo", repo, "--title", title, "--base", base,
+    ];
+
+    let body_str;
+    if let Some(b) = body {
+        body_str = b.to_string();
+        args.push("--body");
+        args.push(&body_str);
+    }
+
+    let head_str;
+    if let Some(h) = head {
+        head_str = h.to_string();
+        args.push("--head");
+        args.push(&head_str);
+    }
+
+    if draft {
+        args.push("--draft");
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr create failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Output is the PR URL, parse the number from it
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let number = url
+        .split('/')
+        .last()
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| "Failed to parse PR number from URL".to_string())?;
+
+    // Fetch the full PR details
+    get_pr(repo, number)
+}
+
+/// Get PR check status.
+pub fn get_pr_checks(repo: &str, number: u64) -> Result<PrCheckStatus, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "checks",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "name,state,conclusion",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    // gh pr checks returns non-zero if checks are failing, so we parse regardless
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhCheck {
+        #[allow(dead_code)]
+        name: String,
+        state: String,
+        conclusion: Option<String>,
+    }
+
+    let checks: Vec<GhCheck> = if json_str.trim().is_empty() {
+        vec![]
+    } else {
+        serde_json::from_str(&json_str).unwrap_or_default()
+    };
+
+    let mut passing = 0u32;
+    let mut failing = 0u32;
+    let mut pending = 0u32;
+
+    for check in &checks {
+        match check.state.as_str() {
+            "COMPLETED" => {
+                if check.conclusion.as_deref() == Some("SUCCESS") {
+                    passing += 1;
+                } else {
+                    failing += 1;
+                }
+            }
+            "IN_PROGRESS" | "QUEUED" | "PENDING" => pending += 1,
+            _ => {}
+        }
+    }
+
+    let total = checks.len() as u32;
+    let state = if failing > 0 {
+        "failure".to_string()
+    } else if pending > 0 {
+        "pending".to_string()
+    } else if passing > 0 {
+        "success".to_string()
+    } else {
+        "unknown".to_string()
+    };
+
+    Ok(PrCheckStatus {
+        state,
+        passing,
+        failing,
+        pending,
+        total,
+    })
+}
+
+/// Get PR review status.
+pub fn get_pr_reviews(repo: &str, number: u64) -> Result<PrReviewStatus, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "reviews",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhReviews {
+        reviews: Vec<GhReview>,
+    }
+
+    #[derive(Deserialize)]
+    struct GhReview {
+        state: String,
+    }
+
+    let reviews: GhReviews =
+        serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    let mut approved = 0u32;
+    let mut changes_requested = 0u32;
+    let mut pending = 0u32;
+
+    for review in &reviews.reviews {
+        match review.state.as_str() {
+            "APPROVED" => approved += 1,
+            "CHANGES_REQUESTED" => changes_requested += 1,
+            "PENDING" => pending += 1,
+            _ => {}
+        }
+    }
+
+    Ok(PrReviewStatus {
+        approved,
+        changes_requested,
+        pending,
+    })
+}
+
+/// Get full PR status including checks and reviews.
+pub fn get_pr_status(repo: &str, number: u64) -> Result<PrStatus, String> {
+    let pr = get_pr(repo, number)?;
+    let checks = get_pr_checks(repo, number)?;
+    let reviews = get_pr_reviews(repo, number)?;
+
+    Ok(PrStatus {
+        pr,
+        checks,
+        reviews,
+    })
+}
+
+/// Merge a pull request.
+pub fn merge_pr(
+    repo: &str,
+    number: u64,
+    method: Option<&str>,
+    delete_branch: bool,
+) -> Result<(), String> {
+    let number_str = number.to_string();
+    let mut args = vec!["pr", "merge", &number_str, "--repo", repo];
+
+    match method {
+        Some("squash") => args.push("--squash"),
+        Some("rebase") => args.push("--rebase"),
+        _ => args.push("--merge"),
+    }
+
+    if delete_branch {
+        args.push("--delete-branch");
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr merge failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Close a pull request without merging.
+pub fn close_pr(repo: &str, number: u64, comment: Option<&str>) -> Result<(), String> {
+    if let Some(c) = comment {
+        // Add comment first
+        let comment_output = Command::new("gh")
+            .args([
+                "pr",
+                "comment",
+                &number.to_string(),
+                "--repo",
+                repo,
+                "--body",
+                c,
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+        if !comment_output.status.success() {
+            return Err(format!(
+                "gh pr comment failed: {}",
+                String::from_utf8_lossy(&comment_output.stderr)
+            ));
+        }
+    }
+
+    let output = Command::new("gh")
+        .args(["pr", "close", &number.to_string(), "--repo", repo])
+        .output()
+        .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr close failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+// ===== Async Wrappers for Operations Module =====
+
+/// Async wrapper for add labels (using update_labels)
+pub async fn add_labels_async(
+    repo: &str,
+    issue_number: u32,
+    labels: &[String],
+) -> Result<(), String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let labels: Vec<String> = labels.to_vec();
+        move || {
+            let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+            update_labels(&repo, issue_number as u64, label_refs, vec![])
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for add_comment
+pub async fn add_issue_comment_async(
+    repo: &str,
+    issue_number: u32,
+    comment: &str,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let comment = comment.to_string();
+        move || add_comment(&repo, issue_number as u64, &comment)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for get_issue
+pub async fn get_issue_async(repo: &str, issue_number: u32) -> Result<GitHubIssue, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        move || get_issue(&repo, issue_number as u64)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for list_issues
+pub async fn list_issues_async(
+    repo: &str,
+    labels: Vec<String>,
+) -> Result<Vec<GitHubIssue>, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        move || {
+            let label_strs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+            list_issues(
+                &repo,
+                None,
+                if label_strs.is_empty() {
+                    None
+                } else {
+                    Some(label_strs)
+                },
+                None,
+            )
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for list_issues that includes ALL issues (open and closed)
+/// Used for Epic tracking to maintain historical context
+pub async fn list_all_issues_async(
+    repo: &str,
+    labels: Vec<String>,
+) -> Result<Vec<GitHubIssue>, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        move || {
+            let label_strs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+            list_issues(
+                &repo,
+                Some("all"), // Include both open and closed issues
+                if label_strs.is_empty() {
+                    None
+                } else {
+                    Some(label_strs)
+                },
+                None,
+            )
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for create_issue
+pub async fn create_issue_async(repo: &str, title: &str, body: &str) -> Result<u32, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let title = title.to_string();
+        let body = body.to_string();
+        move || {
+            let issue = create_issue(&repo, &title, Some(&body), None)?;
+            Ok::<u32, String>(issue.number as u32)
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Update issue body (currently not in existing code, so we'll implement it)
+pub async fn update_issue_body_async(
+    repo: &str,
+    issue_number: u32,
+    body: &str,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let body = body.to_string();
+        move || {
+            // Use gh CLI to edit issue body
+            let output = std::process::Command::new("gh")
+                .args([
+                    "issue",
+                    "edit",
+                    &issue_number.to_string(),
+                    "--repo",
+                    &repo,
+                    "--body",
+                    &body,
+                ])
+                .output()
+                .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+            if !output.status.success() {
+                return Err(format!(
+                    "gh issue edit failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Async wrapper for create_pr
+pub async fn create_pr_async(
+    repo: &str,
+    title: &str,
+    body: &str,
+    base: &str,
+    head: &str,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let title = title.to_string();
+        let body = body.to_string();
+        let base = base.to_string();
+        let head = head.to_string();
+        move || {
+            let pr = create_pr(&repo, &title, Some(&body), &base, Some(&head), false)?;
+            Ok::<String, String>(pr.url)
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Add labels to a PR (currently not in existing code)
+pub async fn add_pr_labels_async(
+    repo: &str,
+    pr_url: &str,
+    labels: Vec<String>,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let pr_url = pr_url.to_string();
+        move || {
+            // Extract PR number from URL
+            let pr_number = pr_url
+                .split('/')
+                .last()
+                .and_then(|s| s.parse::<u64>().ok())
+                .ok_or_else(|| format!("Invalid PR URL: {}", pr_url))?;
+
+            // Add each label
+            for label in &labels {
+                let output = std::process::Command::new("gh")
+                    .args([
+                        "pr",
+                        "edit",
+                        &pr_number.to_string(),
+                        "--repo",
+                        &repo,
+                        "--add-label",
+                        label,
+                    ])
+                    .output()
+                    .map_err(|e| format!("Failed to execute gh: {}", e))?;
+
+                if !output.status.success() {
+                    return Err(format!(
+                        "gh pr edit failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Find PRs that reference a specific issue number (async)
+///
+/// Searches PR bodies for references like "Fixes #123", "Closes #123", "Resolves #123",
+/// or simple "#123" references. Returns all matching PRs.
+pub async fn find_prs_for_issue_async(
+    repo: &str,
+    issue_number: u32,
+) -> Result<Vec<GitHubPullRequest>, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        move || {
+            let mut found_prs = Vec::new();
+            let issue_ref = format!("#{}", issue_number);
+
+            // Check open PRs
+            if let Ok(open_prs) = list_prs(&repo, Some("open"), None, Some(100)) {
+                for pr in open_prs {
+                    if let Some(body) = &pr.body {
+                        if body.contains(&issue_ref) {
+                            found_prs.push(pr);
+                        }
+                    }
+                }
+            }
+
+            // Check merged PRs (in case we're looking at historical data)
+            if let Ok(merged_prs) = list_prs(&repo, Some("merged"), None, Some(50)) {
+                for pr in merged_prs {
+                    if let Some(body) = &pr.body {
+                        if body.contains(&issue_ref)
+                            && !found_prs.iter().any(|p| p.number == pr.number)
+                        {
+                            found_prs.push(pr);
+                        }
+                    }
+                }
+            }
+
+            Ok(found_prs)
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Find a PR by head branch name (async)
+///
+/// Returns the first PR found that matches the given head branch name.
+/// Searches both open and merged PRs.
+pub async fn find_pr_by_branch_async(
+    repo: &str,
+    branch_name: &str,
+) -> Result<Option<GitHubPullRequest>, String> {
+    tokio::task::spawn_blocking({
+        let repo = repo.to_string();
+        let branch_name = branch_name.to_string();
+        move || {
+            // First check open PRs
+            let open_prs = list_prs(&repo, Some("open"), None, Some(100))?;
+            if let Some(pr) = open_prs
+                .into_iter()
+                .find(|pr| pr.head_branch == branch_name)
+            {
+                return Ok(Some(pr));
+            }
+
+            // Then check merged PRs
+            let merged_prs = list_prs(&repo, Some("merged"), None, Some(50))?;
+            if let Some(pr) = merged_prs
+                .into_iter()
+                .find(|pr| pr.head_branch == branch_name)
+            {
+                return Ok(Some(pr));
+            }
+
+            // Finally check closed (but not merged) PRs
+            let closed_prs = list_prs(&repo, Some("closed"), None, Some(50))?;
+            if let Some(pr) = closed_prs
+                .into_iter()
+                .find(|pr| pr.head_branch == branch_name)
+            {
+                return Ok(Some(pr));
+            }
+
+            Ok(None)
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_metadata() {
+        let comment = r#"<!-- HANDY_AGENT_METADATA
+{"session":"handy-agent-42","machine_id":"test-mac","worktree":null,"agent_type":"claude","started_at":"2024-01-15T10:30:00Z","status":"working"}
+-->
+🤖 **Agent Assigned**"#;
+
+        let metadata = extract_metadata_from_comment(comment);
+        assert!(metadata.is_some());
+        let m = metadata.unwrap();
+        assert_eq!(m.session, "handy-agent-42");
+        assert_eq!(m.machine_id, "test-mac");
+    }
+
+    #[test]
+    fn test_no_metadata() {
+        let comment = "Just a regular comment without metadata";
+        let metadata = extract_metadata_from_comment(comment);
+        assert!(metadata.is_none());
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/mod.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/mod.rs
@@ -1,0 +1,22 @@
+//! DevOps module for multi-agent coding assistant functionality.
+//!
+//! This module provides:
+//! - Dependency detection (gh, tmux, docker)
+//! - tmux session management
+//! - Docker sandbox containers for isolated agent execution
+//! - Git worktree management
+//! - GitHub issue integration
+//! - Agent orchestration
+//! - Pipeline state tracking
+
+mod dependencies;
+pub mod docker;
+pub mod github;
+pub mod operations;
+pub mod orchestration;
+pub mod orchestrator;
+pub mod pipeline;
+pub mod tmux;
+pub mod worktree;
+
+pub use dependencies::*;

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations.rs
@@ -1,0 +1,24 @@
+//! High-level Epic Workflow operations.
+//!
+//! This module implements the Epic → Sub-Issue → Agent pattern defined in EPIC_WORKFLOW_SOP.md.
+//! It provides reusable operations for:
+//! - Creating and managing epics
+//! - Creating sub-issues in batch
+//! - Spawning agents from GitHub issues
+//! - Completing agent work with PR creation
+//! - Recovery from crashes/reboots
+//! - Planning epics from markdown files (AI-assisted)
+//! - Orchestrating epic execution (auto-start phases)
+
+pub mod agent_lifecycle;
+pub mod epic;
+pub mod orchestration;
+pub mod plan;
+pub mod plan_parser;
+
+// Re-export for convenience
+pub use agent_lifecycle::*;
+pub use epic::*;
+pub use orchestration::*;
+pub use plan::*;
+pub use plan_parser::*;

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/agent_lifecycle.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/agent_lifecycle.rs
@@ -1,0 +1,953 @@
+//! Agent lifecycle operations: spawn, complete, cleanup.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::devops::{github, tmux, worktree};
+
+/// Configuration for spawning an agent from a GitHub issue
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SpawnAgentConfig {
+    /// Issue reference (e.g., "org/Handy#101")
+    pub issue_ref: String,
+    /// Override agent type (if not specified in issue body)
+    pub agent_type: Option<String>,
+    /// Custom session name (if not auto-generated)
+    pub session_name: Option<String>,
+    /// Work repository (where code lives and agent works)
+    /// If None, extracts from issue body or uses issue_ref repo
+    pub work_repo: Option<String>,
+}
+
+/// Result of spawning an agent
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AgentSpawnResult {
+    /// tmux session name
+    pub session: String,
+    /// Issue number
+    pub issue_number: u32,
+    /// Worktree path
+    pub worktree: String,
+    /// Agent type used
+    pub agent_type: String,
+    /// Agent metadata
+    pub metadata: tmux::AgentMetadata,
+}
+
+/// Result of completing agent work
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AgentCompletionResult {
+    /// PR URL
+    pub pr_url: String,
+    /// Issue number
+    pub issue_number: u32,
+    /// Session name
+    pub session: String,
+    /// Status
+    pub status: String,
+}
+
+/// Result of PR detection for an agent session
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PrDetectionResult {
+    /// tmux session name
+    pub session: String,
+    /// Issue number the agent is working on
+    pub issue_number: u32,
+    /// Repository (org/repo format)
+    pub repo: String,
+    /// PR URL if found
+    pub pr_url: Option<String>,
+    /// PR number if found
+    pub pr_number: Option<u64>,
+    /// Branch name that was checked
+    pub branch_name: String,
+    /// Whether this is a newly detected PR (first time seeing it)
+    pub is_new: bool,
+}
+
+/// Spawn an agent for a GitHub issue
+///
+/// This function:
+/// 1. Fetches the issue from GitHub
+/// 2. Extracts agent type and epic reference
+/// 3. Creates a git worktree
+/// 4. Creates a tmux session
+/// 5. Sets metadata in tmux env vars
+/// 6. Posts metadata comment to GitHub
+/// 7. Adds "agent-assigned" label
+pub async fn spawn_agent_from_issue(config: SpawnAgentConfig) -> Result<AgentSpawnResult, String> {
+    // Parse issue reference
+    let (repo, issue_number) = parse_issue_ref(&config.issue_ref)?;
+
+    // Fetch issue from GitHub
+    let issue = github::get_issue_async(&repo, issue_number).await?;
+
+    // Extract agent type from issue body or use override
+    let issue_body = issue.body.as_deref().unwrap_or("");
+    let agent_type = config
+        .agent_type
+        .or_else(|| extract_agent_type(issue_body))
+        .ok_or_else(|| {
+            "Agent type not specified in config or issue body. \
+             Add '**Agent Type**: <type>' to issue or provide agent_type in config"
+                .to_string()
+        })?;
+
+    // Extract epic reference from issue body (optional)
+    let epic_ref = extract_epic_ref(issue_body);
+
+    // Extract work_repo from config, issue body, or default to issue_ref repo
+    let work_repo = config
+        .work_repo
+        .or_else(|| extract_work_repo(issue_body))
+        .unwrap_or_else(|| repo.clone());
+
+    // Generate session name
+    let session_name = config
+        .session_name
+        .unwrap_or_else(|| format!("handy-agent-{}", issue_number));
+
+    // Get repo path from current directory
+    // NOTE: This assumes we're running from the work_repo directory
+    // In the future, we may want to clone work_repo if it's different from tracking repo
+    let repo_path = std::env::current_dir().map_err(|e| e.to_string())?;
+
+    // Create worktree (blocking operation)
+    let branch_name = format!("issue-{}", issue_number);
+    let repo_path_str = repo_path.to_string_lossy().to_string();
+    let worktree_result = tokio::task::spawn_blocking({
+        let repo_path = repo_path_str.clone();
+        let branch_name = branch_name.clone();
+        move || {
+            let config = worktree::WorktreeConfig::default();
+            worktree::create_worktree(&repo_path, &branch_name, &config, None)
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to create worktree: {}", e))?;
+
+    let worktree_path = worktree_result.path.clone();
+
+    // Build metadata
+    let machine_id = get_machine_id()?;
+    let metadata = tmux::AgentMetadata {
+        session: session_name.clone(),
+        issue_ref: Some(config.issue_ref.clone()),
+        repo: Some(repo.clone()),
+        worktree: Some(worktree_path.clone()),
+        agent_type: agent_type.clone(),
+        machine_id: machine_id.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    // Create tmux session in the worktree (blocking operation)
+    tokio::task::spawn_blocking({
+        let session_name = session_name.clone();
+        let worktree_path = worktree_path.clone();
+        let metadata = metadata.clone();
+        move || tmux::create_session(&session_name, Some(&worktree_path), &metadata)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to create tmux session: {}", e))?;
+
+    // Start the agent in the tmux session (blocking operation)
+    let issue_title_for_agent = issue.title.clone();
+    tokio::task::spawn_blocking({
+        let session_name = session_name.clone();
+        let agent_type = agent_type.clone();
+        let repo = repo.clone();
+        move || {
+            tmux::start_agent_in_session(
+                &session_name,
+                &agent_type,
+                &repo,
+                issue_number as u64,
+                Some(&issue_title_for_agent),
+            )
+        }
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to start agent in session: {}", e))?;
+
+    // Post metadata comment to GitHub
+    let comment_body = format_agent_metadata_comment(&metadata, &issue.title, epic_ref.as_deref());
+    github::add_issue_comment_async(&repo, issue_number, &comment_body)
+        .await
+        .map_err(|e| format!("Failed to add GitHub comment: {}", e))?;
+
+    // Add "agent-assigned" label
+    github::add_labels_async(&repo, issue_number, &vec!["agent-assigned".to_string()])
+        .await
+        .map_err(|e| format!("Failed to add labels: {}", e))?;
+
+    Ok(AgentSpawnResult {
+        session: session_name,
+        issue_number,
+        worktree: worktree_path,
+        agent_type,
+        metadata,
+    })
+}
+
+/// Complete agent work by creating a PR
+///
+/// This function:
+/// 1. Gets agent status from tmux
+/// 2. Pushes the branch to remote
+/// 3. Creates a PR via GitHub CLI
+/// 4. Adds labels to PR
+/// 5. Comments on issue with PR link
+/// 6. Updates epic progress if applicable
+pub async fn complete_agent_work(
+    session: String,
+    pr_title: Option<String>,
+) -> Result<AgentCompletionResult, String> {
+    // Get agent metadata from tmux (blocking operation)
+    let metadata = tokio::task::spawn_blocking({
+        let session = session.clone();
+        move || tmux::get_session_metadata(&session)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to get session metadata: {}", e))?;
+
+    // Clone values from metadata that we'll use later
+    let issue_ref = metadata
+        .issue_ref
+        .as_ref()
+        .ok_or_else(|| "Agent has no issue reference".to_string())?
+        .clone();
+    let worktree_path = metadata
+        .worktree
+        .as_ref()
+        .ok_or_else(|| "Agent has no worktree path".to_string())?
+        .clone();
+
+    let (repo, issue_number) = parse_issue_ref(&issue_ref)?;
+
+    // Get issue details
+    let issue = github::get_issue_async(&repo, issue_number).await?;
+
+    let branch_name = format!("issue-{}", issue_number);
+
+    // Push branch (blocking operation)
+    tokio::task::spawn_blocking({
+        let worktree_path = worktree_path.clone();
+        let branch_name = branch_name.clone();
+        move || push_branch(&worktree_path, &branch_name)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to push branch: {}", e))?;
+
+    // Create PR
+    let pr_title = pr_title.unwrap_or_else(|| issue.title.clone());
+    let pr_body = format_pr_body(&issue.title, issue_number, &metadata);
+
+    let pr_url = github::create_pr_async(&repo, &pr_title, &pr_body, "main", &branch_name)
+        .await
+        .map_err(|e| format!("Failed to create PR: {}", e))?;
+
+    // Add labels to PR
+    github::add_pr_labels_async(&repo, &pr_url, vec!["agent-created".to_string()])
+        .await
+        .ok(); // Non-critical, continue even if fails
+
+    // Comment on issue
+    let completion_comment = format!(
+        "✅ **Work Complete**\n\nPR created: {}\n\nAgent `{}` has finished implementation.",
+        pr_url, session
+    );
+    github::add_issue_comment_async(&repo, issue_number, &completion_comment)
+        .await
+        .ok(); // Non-critical
+
+    // Update epic progress if epic exists
+    // Epic ref is stored in GitHub comment metadata, would need to parse from issue comments
+    // For now, skip this feature - will implement when adding epic tracking
+
+    Ok(AgentCompletionResult {
+        pr_url,
+        issue_number,
+        session,
+        status: "completed".to_string(),
+    })
+}
+
+/// Detect if a PR exists for an agent's branch
+///
+/// This function:
+/// 1. Gets agent metadata from the tmux session
+/// 2. Extracts the issue number to determine the branch name (issue-{number})
+/// 3. Queries GitHub for PRs with that head branch
+/// 4. Returns PR info if found
+pub async fn detect_pr_for_agent(session: &str) -> Result<Option<PrDetectionResult>, String> {
+    // Get agent metadata from tmux (blocking operation)
+    let metadata = tokio::task::spawn_blocking({
+        let session = session.to_string();
+        move || tmux::get_session_metadata(&session)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to get session metadata: {}", e))?;
+
+    // Get issue reference from metadata
+    let issue_ref = metadata
+        .issue_ref
+        .as_ref()
+        .ok_or_else(|| "Agent has no issue reference".to_string())?;
+
+    let (repo, issue_number) = parse_issue_ref(issue_ref)?;
+
+    // Branch name follows our convention: issue-{number}
+    let branch_name = format!("issue-{}", issue_number);
+
+    // Check GitHub for a PR with this branch
+    let pr = github::find_pr_by_branch_async(&repo, &branch_name).await?;
+
+    match pr {
+        Some(pr_info) => Ok(Some(PrDetectionResult {
+            session: session.to_string(),
+            issue_number,
+            repo,
+            pr_url: Some(pr_info.url),
+            pr_number: Some(pr_info.number),
+            branch_name,
+            is_new: false, // Caller will determine if it's new
+        })),
+        None => Ok(Some(PrDetectionResult {
+            session: session.to_string(),
+            issue_number,
+            repo,
+            pr_url: None,
+            pr_number: None,
+            branch_name,
+            is_new: false,
+        })),
+    }
+}
+
+/// Parse issue reference like "org/repo#123" into (repo, number)
+fn parse_issue_ref(issue_ref: &str) -> Result<(String, u32), String> {
+    let parts: Vec<&str> = issue_ref.split('#').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid issue reference: {}. Expected format: org/repo#123",
+            issue_ref
+        ));
+    }
+
+    let repo = parts[0].to_string();
+    let number = parts[1]
+        .parse::<u32>()
+        .map_err(|_| format!("Invalid issue number: {}", parts[1]))?;
+
+    Ok((repo, number))
+}
+
+/// Extract agent type from issue body
+/// Looks for pattern: "**Agent Type**: <type>"
+fn extract_agent_type(issue_body: &str) -> Option<String> {
+    let re = regex::Regex::new(r"\*\*Agent Type\*\*:\s*(\w+)").ok()?;
+    re.captures(issue_body)?
+        .get(1)
+        .map(|m| m.as_str().to_string())
+}
+
+/// Extract epic reference from issue body
+/// Looks for pattern: "**Epic**: #<number>"
+fn extract_epic_ref(issue_body: &str) -> Option<String> {
+    let re = regex::Regex::new(r"\*\*Epic\*\*:\s*#(\d+)").ok()?;
+    re.captures(issue_body)?
+        .get(1)
+        .map(|m| format!("#{}", m.as_str()))
+}
+
+/// Extract work repository from issue body
+/// Looks for pattern: "**Work Repository**: <org/repo>"
+fn extract_work_repo(issue_body: &str) -> Option<String> {
+    let re = regex::Regex::new(r"\*\*Work Repository\*\*:\s*([\w-]+/[\w-]+)").ok()?;
+    re.captures(issue_body)?
+        .get(1)
+        .map(|m| m.as_str().to_string())
+}
+
+/// Get machine ID (hostname)
+fn get_machine_id() -> Result<String, String> {
+    hostname::get()
+        .map_err(|e| format!("Failed to get hostname: {}", e))?
+        .to_string_lossy()
+        .to_string()
+        .pipe(Ok)
+}
+
+/// Format agent metadata comment for GitHub
+fn format_agent_metadata_comment(
+    metadata: &tmux::AgentMetadata,
+    issue_title: &str,
+    epic_ref: Option<&str>,
+) -> String {
+    let metadata_json = serde_json::to_string_pretty(metadata).unwrap_or_else(|_| "{}".to_string());
+
+    let epic_line = if let Some(epic) = epic_ref {
+        format!("- **Epic**: {}\n", epic)
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"<!-- HANDY_AGENT_METADATA
+{}
+-->
+
+🤖 **Agent Assigned**
+- **Session**: `{}`
+- **Type**: {}
+- **Worktree**: `{}`
+- **Machine**: {}
+{}- **Started**: {}
+
+Agent is now working on: {}
+
+Will update with progress.
+"#,
+        metadata_json,
+        metadata.session,
+        metadata.agent_type,
+        metadata
+            .worktree
+            .as_ref()
+            .and_then(|w| w.split('/').last())
+            .unwrap_or("unknown"),
+        metadata.machine_id,
+        epic_line,
+        metadata.started_at,
+        issue_title,
+    )
+}
+
+/// Format PR body with standard template
+fn format_pr_body(issue_title: &str, issue_number: u32, metadata: &tmux::AgentMetadata) -> String {
+    format!(
+        r#"## Summary
+{}
+
+## Changes
+Implementation of #{} via DevOps agent.
+
+## Testing
+```bash
+# Run tests to verify changes
+cargo test  # For Rust
+bun run test  # For TypeScript
+```
+
+## Related Issues
+Closes #{}
+
+---
+
+🤖 Generated by {} agent `{}`
+"#,
+        issue_title, issue_number, issue_number, metadata.agent_type, metadata.session,
+    )
+}
+
+/// Push git branch to remote
+fn push_branch(worktree_path: &str, branch_name: &str) -> Result<(), String> {
+    use std::process::Command;
+
+    let output = Command::new("git")
+        .args(&["push", "-u", "origin", branch_name])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git push: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git push failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Configuration for spawning a support worker agent for a specific task
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SupportWorkerConfig {
+    /// Repository in org/repo format
+    pub repo: String,
+    /// Issue number the work relates to (for tracking)
+    pub issue_number: u32,
+    /// PR number to work on (for merge tasks)
+    pub pr_number: Option<u64>,
+    /// The task description for the agent
+    pub task: String,
+    /// Task type (merge, review, etc.)
+    pub task_type: String,
+    /// Merge method if this is a merge task
+    pub merge_method: Option<String>,
+    /// Whether to delete the branch after merging
+    pub delete_branch: bool,
+    /// Whether to run in a sandboxed Docker container
+    pub sandboxed: bool,
+    /// Worktree path (required for sandboxed execution to resolve merge conflicts)
+    pub worktree_path: Option<String>,
+}
+
+/// Result of spawning a support worker
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SupportWorkerResult {
+    /// tmux session name
+    pub session: String,
+    /// Issue number
+    pub issue_number: u32,
+    /// PR number if applicable
+    pub pr_number: Option<u64>,
+    /// Task type
+    pub task_type: String,
+    /// Status of the spawn
+    pub status: String,
+}
+
+/// Spawn a support worker agent to handle a specific task
+///
+/// Support workers are lightweight agents that handle specific tasks like:
+/// - Merging PRs after review
+/// - Running CI checks
+/// - Updating issue labels
+///
+/// When `sandboxed` is true and a `worktree_path` is provided, the support worker
+/// runs inside a Docker container with the worktree mounted, allowing it to
+/// resolve merge conflicts locally.
+pub async fn spawn_support_worker(
+    config: SupportWorkerConfig,
+) -> Result<SupportWorkerResult, String> {
+    let session_name = format!("handy-support-{}-{}", config.task_type, config.issue_number);
+
+    // Get machine ID
+    let machine_id = get_machine_id()?;
+
+    // Build metadata for the support worker session
+    let metadata = tmux::AgentMetadata {
+        session: session_name.clone(),
+        issue_ref: Some(format!("{}#{}", config.repo, config.issue_number)),
+        repo: Some(config.repo.clone()),
+        worktree: config.worktree_path.clone(),
+        agent_type: format!("support-{}", config.task_type),
+        machine_id: machine_id.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    // Determine working directory:
+    // - If sandboxed with worktree, use worktree path (will be mounted in container)
+    // - Otherwise, use home directory
+    let working_dir = if config.sandboxed {
+        config.worktree_path.clone().ok_or_else(|| {
+            "Worktree path required for sandboxed support worker execution".to_string()
+        })?
+    } else {
+        std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string())
+    };
+
+    // Create tmux session
+    tokio::task::spawn_blocking({
+        let session_name = session_name.clone();
+        let metadata = metadata.clone();
+        let working_dir = working_dir.clone();
+        move || tmux::create_session(&session_name, Some(&working_dir), &metadata)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to create tmux session: {}", e))?;
+
+    // Build the inner command based on task type
+    // Pass sandboxed flag so we can add --dangerously-skip-permissions in sandbox
+    let inner_command = build_support_worker_command(&config, config.sandboxed)?;
+
+    // If sandboxed, wrap the command in a Docker container
+    let command = if config.sandboxed {
+        let worktree_path = config.worktree_path.as_ref().ok_or_else(|| {
+            "Worktree path required for sandboxed support worker execution".to_string()
+        })?;
+
+        build_sandboxed_support_worker_command(
+            &inner_command,
+            worktree_path,
+            &config.repo,
+            config.issue_number,
+        )?
+    } else {
+        inner_command
+    };
+
+    // Send the command to the tmux session
+    tokio::task::spawn_blocking({
+        let session_name = session_name.clone();
+        move || tmux::send_command(&session_name, &command)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+    .map_err(|e| format!("Failed to start support worker: {}", e))?;
+
+    // Post comment to issue about support worker activity
+    let sandbox_note = if config.sandboxed { " (sandboxed)" } else { "" };
+    let comment = format!(
+        "🔧 **Support Worker Spawned**{}\n\n\
+        - **Task**: {}\n\
+        - **Session**: `{}`\n\
+        - **PR**: #{}\n\
+        - **Machine**: {}\n\n\
+        Support worker is handling this task.",
+        sandbox_note,
+        config.task_type,
+        session_name,
+        config.pr_number.unwrap_or(0),
+        machine_id
+    );
+    github::add_issue_comment_async(&config.repo, config.issue_number, &comment)
+        .await
+        .ok(); // Non-critical
+
+    Ok(SupportWorkerResult {
+        session: session_name,
+        issue_number: config.issue_number,
+        pr_number: config.pr_number,
+        task_type: config.task_type,
+        status: "spawned".to_string(),
+    })
+}
+
+/// Build the inner command for a support worker based on task type
+///
+/// When `sandboxed` is true, adds `--dangerously-skip-permissions` flag since
+/// the Docker container provides isolation and we want fully autonomous execution.
+fn build_support_worker_command(
+    config: &SupportWorkerConfig,
+    sandboxed: bool,
+) -> Result<String, String> {
+    // In sandbox mode, use --dangerously-skip-permissions for autonomous execution
+    let auto_flag = if sandboxed {
+        " --dangerously-skip-permissions"
+    } else {
+        ""
+    };
+
+    match config.task_type.as_str() {
+        "merge" => {
+            // Build gh pr merge command with Claude for conflict resolution
+            let merge_method = config.merge_method.as_deref().unwrap_or("squash");
+            let pr_number = config
+                .pr_number
+                .ok_or("PR number required for merge task")?;
+            let delete_flag = if config.delete_branch {
+                " --delete-branch"
+            } else {
+                ""
+            };
+
+            // Use Claude to handle the merge, including conflict resolution if needed
+            Ok(format!(
+                r#"claude{auto_flag} "You are a Support Worker agent tasked with merging PR #{pr_number} in {repo}.
+
+Your task:
+1. First, view the PR details: gh pr view {pr_number} --repo {repo}
+2. Check PR status and CI: gh pr checks {pr_number} --repo {repo}
+3. Attempt to merge the PR: gh pr merge {pr_number} --repo {repo} --{merge_method}{delete_flag}
+
+If the merge fails due to merge conflicts:
+1. Checkout the PR branch locally
+2. Pull the latest main branch
+3. Merge main into the PR branch
+4. Resolve any conflicts by examining the code and making intelligent decisions
+5. Commit the resolved conflicts
+6. Push the updated branch
+7. Retry the merge
+
+If CI checks are failing, analyze the failures and determine if they are blocking. Report back with what you find.
+
+Start by viewing the PR and attempting the merge.""#,
+                auto_flag = auto_flag,
+                pr_number = pr_number,
+                repo = config.repo,
+                merge_method = merge_method,
+                delete_flag = delete_flag,
+            ))
+        }
+        "review" => {
+            let pr_number = config
+                .pr_number
+                .ok_or("PR number required for review task")?;
+            Ok(format!(
+                r#"claude{} "Review the PR #{} in {} and provide feedback. Check the diff, look for issues, and approve or request changes." --repo {}"#,
+                auto_flag, pr_number, config.repo, config.repo
+            ))
+        }
+        _ => {
+            // Generic task - let Claude handle it
+            Ok(format!(
+                r#"claude{} "{}""#,
+                auto_flag,
+                config.task.replace('"', "\\\"")
+            ))
+        }
+    }
+}
+
+/// Build a Docker command that runs the support worker inside a container
+///
+/// This wraps the support worker command in a Docker container with:
+/// - The worktree mounted at /workspace
+/// - GitHub and Anthropic credentials passed from host auth configs
+/// - Resource limits applied
+/// - A non-root user (required for --dangerously-skip-permissions)
+fn build_sandboxed_support_worker_command(
+    inner_command: &str,
+    worktree_path: &str,
+    repo: &str,
+    issue_number: u32,
+) -> Result<String, String> {
+    use crate::devops::docker::{container_exists_for_issue, stop_and_remove_container};
+
+    let container_name = format!("handy-support-sandbox-{}", issue_number);
+    let image = "node:20-bookworm"; // Base image with Node.js for Claude Code
+
+    // Pre-check: Remove any existing container with this issue number to avoid conflicts
+    // This handles both regular sandbox and support-sandbox containers
+    if let Some(existing) = container_exists_for_issue(issue_number) {
+        log::warn!(
+            "Found existing container {} for issue #{}, removing before spawning support worker",
+            existing,
+            issue_number
+        );
+        if let Err(e) = stop_and_remove_container(&existing) {
+            log::warn!("Failed to remove existing container: {}", e);
+            // Continue anyway - docker run will fail if container exists
+        }
+    }
+
+    let mut docker_args = vec![
+        "docker run --rm -it".to_string(),
+        format!("--name {}", container_name),
+        format!("-v {}:/workspace", worktree_path),
+        "-w /workspace".to_string(),
+    ];
+
+    // Mount the persistent Claude auth volume
+    // This volume contains credentials from the one-time auth setup container
+    docker_args.push(format!(
+        "-v {}:/tmp/claude-auth:ro",
+        crate::devops::docker::get_claude_auth_volume_name()
+    ));
+
+    // Mount GitHub CLI auth from host (if available) - gh tokens work fine from host
+    if let Ok(home) = std::env::var("HOME") {
+        let gh_dir = format!("{}/.config/gh", home);
+        if std::path::Path::new(&gh_dir).exists() {
+            docker_args.push(format!("-v {}:/tmp/host-auth/.config/gh:ro", gh_dir));
+        }
+    }
+
+    // Pass through credentials from host environment (fallback)
+    docker_args.push("-e GH_TOKEN".to_string());
+    docker_args.push("-e GITHUB_TOKEN".to_string());
+
+    // Add context env vars
+    docker_args.push(format!("-e HANDY_ISSUE_REF={}#{}", repo, issue_number));
+    docker_args.push("-e HANDY_AGENT_TYPE=support-worker".to_string());
+    docker_args.push(format!("-e HANDY_CONTAINER_NAME={}", container_name));
+
+    // Add image
+    docker_args.push(image.to_string());
+    docker_args.push("sh -c".to_string());
+
+    // Build the setup script that:
+    // 1. Uses the 'node' user if it exists (common in node:* images), otherwise creates 'agent' user
+    // 2. Copies auth from persistent volume to the user's home
+    // 3. Installs Claude Code globally
+    // 4. Uses gosu to exec as the non-root user (completely replacing the process)
+    //
+    // We need to run as non-root because Claude Code's --dangerously-skip-permissions
+    // flag refuses to run with root/sudo privileges for security reasons.
+    //
+    // NOTE: On macOS with Docker Desktop/OrbStack, mounted volumes may appear as root-owned,
+    // so we can't rely on workspace UID detection. We always use a non-root user.
+    //
+    // IMPORTANT: We use `exec gosu` to completely replace the shell process with
+    // the non-root user's process. This ensures Claude Code sees a clean non-root
+    // environment without any sudo/su context in the process tree.
+    let setup_script = format!(
+        r#"
+set -e
+
+# Always use a non-root user for Claude Code
+# On macOS with Docker Desktop/OrbStack, mounted volumes may appear as root-owned,
+# so we can't rely on workspace UID detection.
+
+# Check if 'node' user exists (common in node:* images) and use it
+# Otherwise create an 'agent' user
+if id "node" &>/dev/null; then
+    AGENT_USER="node"
+    AGENT_HOME=$(getent passwd "node" | cut -d: -f6)
+    echo "Using existing 'node' user"
+else
+    AGENT_USER="agent"
+    AGENT_HOME="/home/agent"
+
+    # Create agent group and user (ignore errors if they exist)
+    groupadd agent 2>/dev/null || true
+    useradd -m -s /bin/bash -g agent agent 2>/dev/null || true
+
+    echo "Created 'agent' user"
+fi
+
+# Ensure home directory structure exists
+mkdir -p "$AGENT_HOME/.config"
+mkdir -p "$AGENT_HOME/.claude"
+
+# Copy Claude Code auth from persistent volume (set up via one-time auth container)
+if [ -d /tmp/claude-auth ] && [ "$(ls -A /tmp/claude-auth 2>/dev/null)" ]; then
+    echo "Copying Claude Code credentials from auth volume..."
+    cp -r /tmp/claude-auth/* "$AGENT_HOME/.claude/" 2>/dev/null || true
+else
+    echo "WARNING: No Claude auth found in volume. Run 'Setup Auth' in Handy DevOps settings."
+fi
+
+# Copy GitHub CLI auth from host (if mounted)
+if [ -d /tmp/host-auth/.config/gh ]; then
+    mkdir -p "$AGENT_HOME/.config/gh"
+    cp -r /tmp/host-auth/.config/gh/* "$AGENT_HOME/.config/gh/" 2>/dev/null || true
+    echo "Copied GitHub CLI auth from host"
+fi
+
+# Fix ownership of home directory
+chown -R "$AGENT_USER:$AGENT_USER" "$AGENT_HOME" 2>/dev/null || true
+
+# Give the user ownership of the workspace
+# This is safe because we're in an isolated container
+chown -R "$AGENT_USER:$AGENT_USER" /workspace 2>/dev/null || true
+
+# Install gh CLI, gosu, and expect (for automating the interactive prompt)
+apt-get update && apt-get install -y gh gosu expect > /dev/null 2>&1 || true
+
+# Install Claude Code globally (as root, so it's available to all users)
+npm install -g @anthropic-ai/claude-code
+
+# Create expect script file to automate the bypass permissions warning dialog
+# Use a here-doc with Tcl's format command to create the escape character
+cat > /tmp/auto-accept.exp << 'EXPECT_SCRIPT'
+#!/usr/bin/expect -f
+set timeout -1
+set cmd [lindex $argv 0]
+
+# Define the escape sequence for down arrow using Tcl format (char 27 = ESC)
+set DOWN_ARROW [format "%c\[B" 27]
+
+spawn -noecho {{*}}$cmd
+expect {{
+    "No, exit" {{
+        send $DOWN_ARROW
+        sleep 0.2
+        send "\r"
+        exp_continue
+    }}
+    eof
+}}
+wait
+EXPECT_SCRIPT
+chmod +x /tmp/auto-accept.exp
+
+# Create wrapper script that runs Claude via expect
+# Use unquoted heredoc so CLAUDE_CMD variable expands
+CLAUDE_CMD='{inner_command}'
+cat > /tmp/run-agent.sh << AGENT_SCRIPT
+#!/bin/bash
+cd /workspace
+exec /tmp/auto-accept.exp "$CLAUDE_CMD"
+AGENT_SCRIPT
+chmod +x /tmp/run-agent.sh
+chown "$AGENT_USER:$AGENT_USER" /tmp/run-agent.sh /tmp/auto-accept.exp
+
+# Use gosu to exec as the user - this replaces the current process entirely
+# Unlike su/sudo, gosu doesn't leave any privileged process in the chain
+exec gosu "$AGENT_USER" /tmp/run-agent.sh
+"#,
+        inner_command = inner_command.replace('\'', "'\\''"),
+    );
+
+    docker_args.push(format!("'{}'", setup_script.replace('\'', "'\\''")));
+
+    Ok(docker_args.join(" "))
+}
+
+// Helper trait for .pipe()
+trait Pipe: Sized {
+    fn pipe<F, R>(self, f: F) -> R
+    where
+        F: FnOnce(Self) -> R,
+    {
+        f(self)
+    }
+}
+
+impl<T> Pipe for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_issue_ref() {
+        let (repo, number) = parse_issue_ref("org/Handy#101").unwrap();
+        assert_eq!(repo, "org/Handy");
+        assert_eq!(number, 101);
+    }
+
+    #[test]
+    fn test_parse_issue_ref_invalid() {
+        assert!(parse_issue_ref("invalid").is_err());
+        assert!(parse_issue_ref("org/repo").is_err());
+        assert!(parse_issue_ref("org/repo#abc").is_err());
+    }
+
+    #[test]
+    fn test_extract_agent_type() {
+        let body = "Some text\n**Agent Type**: claude\nMore text";
+        assert_eq!(extract_agent_type(body), Some("claude".to_string()));
+    }
+
+    #[test]
+    fn test_extract_agent_type_not_found() {
+        let body = "Some text without agent type";
+        assert_eq!(extract_agent_type(body), None);
+    }
+
+    #[test]
+    fn test_extract_epic_ref() {
+        let body = "Some text\n**Epic**: #100\nMore text";
+        assert_eq!(extract_epic_ref(body), Some("#100".to_string()));
+    }
+
+    #[test]
+    fn test_extract_epic_ref_not_found() {
+        let body = "Some text without epic";
+        assert_eq!(extract_epic_ref(body), None);
+    }
+
+    #[test]
+    fn test_extract_work_repo() {
+        let body = "Some text\n**Work Repository**: user/my-project\nMore text";
+        assert_eq!(extract_work_repo(body), Some("user/my-project".to_string()));
+    }
+
+    #[test]
+    fn test_extract_work_repo_not_found() {
+        let body = "Some text without work repo";
+        assert_eq!(extract_work_repo(body), None);
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/epic.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/epic.rs
@@ -1,0 +1,794 @@
+//! Epic creation and management operations.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::devops::github;
+
+/// Configuration for creating a new epic issue
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct EpicConfig {
+    /// Epic title (without [EPIC] prefix - added automatically)
+    pub title: String,
+    /// Tracking repository where Epic/Sub-issues are created (e.g., "org/Handy")
+    pub repo: String,
+    /// Work repository where code lives and agents work (e.g., "user/project")
+    /// If None, defaults to same as repo
+    pub work_repo: Option<String>,
+    /// Epic description/goal (1-2 sentences)
+    pub goal: String,
+    /// Success metrics (checkbox list)
+    pub success_metrics: Vec<String>,
+    /// Phases with descriptions
+    pub phases: Vec<PhaseConfig>,
+    /// Labels to add to epic (epic label added automatically)
+    pub labels: Vec<String>,
+}
+
+/// Phase configuration within an epic
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PhaseConfig {
+    /// Phase name (e.g., "Foundation", "Integration Tests")
+    pub name: String,
+    /// Phase description
+    pub description: String,
+    /// Approach: "manual", "agent-assisted", or "automated"
+    pub approach: String,
+    /// Key tasks for this phase (each becomes a sub-issue)
+    #[serde(default)]
+    pub tasks: Vec<String>,
+    /// Files to modify (optional context for agents)
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// Dependencies - names of phases that must complete first
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+}
+
+/// Information about a created epic
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct EpicInfo {
+    /// Epic issue number
+    pub epic_number: u32,
+    /// Tracking repository (where Epic is created)
+    pub repo: String,
+    /// Work repository (where code lives)
+    pub work_repo: String,
+    /// Epic title
+    pub title: String,
+    /// GitHub issue URL
+    pub url: String,
+    /// Phases from config
+    pub phases: Vec<PhaseConfig>,
+}
+
+/// Configuration for creating a sub-issue
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SubIssueConfig {
+    /// Sub-issue title (e.g., "Implement test_agent_spawning.rs")
+    pub title: String,
+    /// Phase number (1-indexed)
+    pub phase: u32,
+    /// Estimated time (e.g., "6 hours", "2 days")
+    pub estimated_time: String,
+    /// Dependencies (other sub-issue titles or "None")
+    pub dependencies: String,
+    /// Goal description (1-2 sentences)
+    pub goal: String,
+    /// Detailed task breakdown (markdown)
+    pub tasks: String,
+    /// Acceptance criteria (checkbox list)
+    pub acceptance_criteria: Vec<String>,
+    /// Recommended agent type
+    pub agent_type: String,
+    /// Work repository (where agent will work)
+    /// If None, inherits from Epic
+    pub work_repo: Option<String>,
+}
+
+/// Information about a created sub-issue
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SubIssueInfo {
+    /// Issue number
+    pub issue_number: u32,
+    /// Issue title
+    pub title: String,
+    /// Phase number
+    pub phase: u32,
+    /// Recommended agent type
+    pub agent_type: String,
+    /// Work repository (where agent will work)
+    pub work_repo: String,
+    /// GitHub issue URL
+    pub url: String,
+}
+
+/// Epic progress statistics
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct EpicProgress {
+    /// Total sub-issues
+    pub total: usize,
+    /// Completed sub-issues
+    pub completed: usize,
+    /// Percentage complete
+    pub percentage: usize,
+    /// Remaining sub-issues
+    pub remaining: usize,
+}
+
+/// Create a new epic issue with standardized structure
+pub async fn create_epic(config: EpicConfig) -> Result<EpicInfo, String> {
+    // Determine work_repo (default to tracking repo if not specified)
+    let work_repo = config
+        .work_repo
+        .clone()
+        .unwrap_or_else(|| config.repo.clone());
+
+    // Format epic body from template (including work_repo info)
+    let body = format_epic_body(&config, &work_repo);
+
+    // Create GitHub issue
+    let issue_number =
+        github::create_issue_async(&config.repo, &format!("[EPIC] {}", config.title), &body)
+            .await?;
+
+    // Add labels (include "epic" automatically)
+    let mut labels = config.labels.clone();
+    if !labels.contains(&"epic".to_string()) {
+        labels.push("epic".to_string());
+    }
+    github::add_labels_async(&config.repo, issue_number, &labels).await?;
+
+    // Return epic info
+    Ok(EpicInfo {
+        epic_number: issue_number,
+        repo: config.repo.clone(),
+        work_repo,
+        title: config.title,
+        url: format!("https://github.com/{}/issues/{}", config.repo, issue_number),
+        phases: config.phases,
+    })
+}
+
+/// Format epic issue body using standard template
+fn format_epic_body(config: &EpicConfig, work_repo: &str) -> String {
+    let metrics = config
+        .success_metrics
+        .iter()
+        .map(|m| format!("- [ ] {}", m))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let phases = config
+        .phases
+        .iter()
+        .enumerate()
+        .map(|(i, phase)| {
+            format!(
+                "### Phase {}: {}\n{}\n\n**Approach**: {}\n**Status**: ⏸️ Not Started\n",
+                i + 1,
+                phase.name,
+                phase.description,
+                phase.approach
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Show work repo if different from tracking repo
+    let work_repo_line = if work_repo != config.repo {
+        format!("\n**Work Repository**: {}\n", work_repo)
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"# {}
+
+## Goal
+{}
+{}
+## Success Metrics
+{}
+
+## Phases
+
+{}
+
+## Progress
+0/TBD sub-issues completed (0%)
+
+## Notes
+Created via Handy DevOps Epic Workflow
+"#,
+        config.title, config.goal, work_repo_line, metrics, phases
+    )
+}
+
+/// Create multiple sub-issues for an epic in batch
+pub async fn create_sub_issues(
+    epic_number: u32,
+    epic_repo: String,
+    epic_work_repo: String,
+    sub_issues: Vec<SubIssueConfig>,
+) -> Result<Vec<SubIssueInfo>, String> {
+    let mut created = Vec::new();
+
+    for config in sub_issues.iter() {
+        // Determine work_repo for this sub-issue (inherit from epic if not specified)
+        let work_repo = config
+            .work_repo
+            .clone()
+            .unwrap_or_else(|| epic_work_repo.clone());
+
+        // Format sub-issue body (including work_repo)
+        let body = format_sub_issue_body(epic_number, &epic_repo, &work_repo, config);
+
+        // Create GitHub issue
+        let issue_number = github::create_issue_async(&epic_repo, &config.title, &body).await?;
+
+        // Add labels - only use standard labels that exist in the repo
+        // Phase info is tracked in the issue body, not via labels
+        let labels = vec!["todo".to_string()];
+        if let Err(e) = github::add_labels_async(&epic_repo, issue_number, &labels).await {
+            eprintln!(
+                "Warning: Failed to add labels to issue #{}: {}",
+                issue_number, e
+            );
+            // Continue anyway - labels are nice to have but not critical
+        }
+
+        created.push(SubIssueInfo {
+            issue_number,
+            title: config.title.clone(),
+            phase: config.phase,
+            agent_type: config.agent_type.clone(),
+            work_repo,
+            url: format!("https://github.com/{}/issues/{}", epic_repo, issue_number),
+        });
+    }
+
+    Ok(created)
+}
+
+/// Format sub-issue body using standard template
+fn format_sub_issue_body(
+    epic_number: u32,
+    epic_repo: &str,
+    work_repo: &str,
+    config: &SubIssueConfig,
+) -> String {
+    let criteria = config
+        .acceptance_criteria
+        .iter()
+        .map(|c| format!("- [ ] {}", c))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Show work repo if different from tracking repo
+    let work_repo_line = if work_repo != epic_repo {
+        format!("**Work Repository**: {}\n", work_repo)
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"# {}
+
+**Epic**: #{}
+**Phase**: {}
+**Estimated Time**: {}
+**Dependencies**: {}
+{}
+## Goal
+{}
+
+## Tasks
+{}
+
+## Acceptance Criteria
+{}
+- [ ] Code follows style guide (cargo fmt, clippy, eslint)
+- [ ] Tests passing locally
+- [ ] PR created referencing this issue
+
+## Agent Assignment
+**Agent Type**: {}
+**Session**: handy-agent-TBD
+**Worktree**: handy-worktrees/issue-TBD
+**Started**: [Will be filled when agent spawns]
+"#,
+        config.title,
+        epic_number,
+        config.phase,
+        config.estimated_time,
+        config.dependencies,
+        work_repo_line,
+        config.goal,
+        config.tasks,
+        criteria,
+        config.agent_type,
+    )
+}
+
+/// Update epic issue progress section based on sub-issue completion
+pub async fn update_epic_progress(
+    epic_number: u32,
+    epic_repo: String,
+) -> Result<EpicProgress, String> {
+    // Get epic issue
+    let epic = github::get_issue_async(&epic_repo, epic_number).await?;
+
+    // Find all sub-issues (issues that reference this epic) - include closed for accurate counts
+    let all_issues = github::list_all_issues_async(&epic_repo, vec![]).await?;
+    let sub_issues: Vec<_> = all_issues
+        .into_iter()
+        .filter(|issue| {
+            issue
+                .body
+                .as_ref()
+                .map(|b| b.contains(&format!("Epic**: #{}", epic_number)))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    // Count completed (use case-insensitive comparison since GitHub returns uppercase)
+    let total = sub_issues.len();
+    let completed = sub_issues
+        .iter()
+        .filter(|i| i.state.eq_ignore_ascii_case("closed"))
+        .count();
+    let percentage = if total > 0 {
+        (completed * 100) / total
+    } else {
+        0
+    };
+
+    // Update epic body (replace progress section)
+    let epic_body = epic.body.as_deref().unwrap_or("");
+    let updated_body = update_progress_section(epic_body, completed, total, percentage);
+    github::update_issue_body_async(&epic_repo, epic_number, &updated_body).await?;
+
+    Ok(EpicProgress {
+        total,
+        completed,
+        percentage,
+        remaining: total - completed,
+    })
+}
+
+/// Replace progress section in epic body with updated stats
+fn update_progress_section(
+    body: &str,
+    completed: usize,
+    total: usize,
+    percentage: usize,
+) -> String {
+    // Find and replace "## Progress\n<line>" with updated stats
+    let lines: Vec<&str> = body.lines().collect();
+    let mut result = Vec::new();
+    let mut skip_next = false;
+
+    for line in lines.iter() {
+        if skip_next {
+            skip_next = false;
+            // Replace this line with updated progress
+            result.push(format!(
+                "{}/{} sub-issues completed ({}%)",
+                completed, total, percentage
+            ));
+            continue;
+        }
+
+        if line.starts_with("## Progress") {
+            result.push(line.to_string());
+            skip_next = true;
+        } else {
+            result.push(line.to_string());
+        }
+    }
+
+    result.join("\n")
+}
+
+/// Load an existing epic from GitHub by issue number
+///
+/// Parses the epic's body to extract phases and metadata.
+/// Returns an EpicInfo that can be used for orchestration.
+pub async fn load_epic(repo: String, epic_number: u32) -> Result<EpicInfo, String> {
+    // Fetch the issue from GitHub
+    let issue = github::get_issue_async(&repo, epic_number).await?;
+
+    // Verify it's an epic (has [EPIC] prefix or epic label)
+    let is_epic = issue.title.starts_with("[EPIC]")
+        || issue.labels.iter().any(|l| l.eq_ignore_ascii_case("epic"));
+
+    if !is_epic {
+        return Err(format!(
+            "Issue #{} is not an epic (missing [EPIC] prefix or 'epic' label)",
+            epic_number
+        ));
+    }
+
+    // Extract title (remove [EPIC] prefix if present)
+    let title = issue.title.trim_start_matches("[EPIC]").trim().to_string();
+
+    // Parse body to extract work_repo and phases
+    let body = issue.body.as_deref().unwrap_or("");
+    let work_repo = extract_work_repo_from_body(body).unwrap_or_else(|| repo.clone());
+    let phases = extract_phases_from_body(body);
+
+    Ok(EpicInfo {
+        epic_number,
+        repo: repo.clone(),
+        work_repo,
+        title,
+        url: issue.url,
+        phases,
+    })
+}
+
+/// Information about an existing sub-issue linked to an epic
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ExistingSubIssue {
+    /// Issue number
+    pub issue_number: u32,
+    /// Issue title
+    pub title: String,
+    /// Phase number (extracted from labels)
+    pub phase: Option<u32>,
+    /// Current state (open/closed)
+    pub state: String,
+    /// Labels on the issue
+    pub labels: Vec<String>,
+    /// URL to the issue
+    pub url: String,
+    /// Whether an agent is currently working on it
+    pub has_agent_working: bool,
+    /// PR URL if a PR has been created for this issue
+    pub pr_url: Option<String>,
+    /// PR number if a PR has been created
+    pub pr_number: Option<u64>,
+}
+
+/// Recovery information for an epic
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct EpicRecoveryInfo {
+    /// The epic info
+    pub epic: EpicInfo,
+    /// The raw Epic issue body (for reading phase statuses)
+    pub epic_body: String,
+    /// Existing sub-issues for this epic
+    pub sub_issues: Vec<ExistingSubIssue>,
+    /// Progress statistics
+    pub progress: EpicProgress,
+    /// Phases that have no sub-issues yet
+    pub phases_without_issues: Vec<u32>,
+    /// Sub-issues that are ready for agents (have todo label, not closed)
+    pub ready_for_agents: Vec<ExistingSubIssue>,
+    /// Sub-issues that have agents actively working
+    pub in_progress: Vec<ExistingSubIssue>,
+}
+
+/// Load an existing epic with full recovery information
+///
+/// This fetches the epic, all its sub-issues, and determines what work
+/// remains to be done. Useful for recovering/continuing orchestration.
+pub async fn load_epic_for_recovery(
+    repo: String,
+    epic_number: u32,
+) -> Result<EpicRecoveryInfo, String> {
+    // Fetch the Epic issue to get the body
+    let epic_issue = github::get_issue_async(&repo, epic_number).await?;
+    let epic_body = epic_issue.body.clone().unwrap_or_default();
+
+    // Load basic epic info
+    let epic = load_epic(repo.clone(), epic_number).await?;
+
+    // Find all sub-issues that reference this epic (include closed for historical context)
+    let all_issues = github::list_all_issues_async(&repo, vec![]).await?;
+
+    // First pass: collect basic issue info
+    let basic_sub_issues: Vec<_> = all_issues
+        .into_iter()
+        .filter(|issue| {
+            issue
+                .body
+                .as_ref()
+                .map(|b| b.contains(&format!("Epic**: #{}", epic_number)))
+                .unwrap_or(false)
+        })
+        .map(|issue| {
+            // Extract phase number from body (e.g., "**Phase**: 1")
+            let phase = issue.body.as_ref().and_then(|body| {
+                // Look for "**Phase**: N" pattern
+                body.lines()
+                    .find(|line| line.contains("**Phase**:"))
+                    .and_then(|line| {
+                        line.split("**Phase**:")
+                            .nth(1)
+                            .and_then(|s| s.trim().parse().ok())
+                    })
+            });
+
+            let has_agent_working = issue.labels.iter().any(|l| l == "staging");
+
+            (
+                issue.number as u32,
+                issue.title,
+                phase,
+                issue.state,
+                issue.labels,
+                issue.url,
+                has_agent_working,
+            )
+        })
+        .collect();
+
+    // Second pass: look up PRs for open sub-issues (to detect "Ready" state)
+    // We use the work_repo for PR lookups since PRs are created there
+    let work_repo = &epic.work_repo;
+    let mut sub_issues: Vec<ExistingSubIssue> = Vec::new();
+
+    for (issue_number, title, phase, state, labels, url, has_agent_working) in basic_sub_issues {
+        // Only look up PRs for open issues (closed issues are already done)
+        let (pr_url, pr_number) = if state.eq_ignore_ascii_case("open") {
+            // Try to find a PR that references this issue
+            match github::find_prs_for_issue_async(work_repo, issue_number).await {
+                Ok(prs) if !prs.is_empty() => {
+                    // Take the first (most recent) PR
+                    let pr = &prs[0];
+                    (Some(pr.url.clone()), Some(pr.number))
+                }
+                _ => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        sub_issues.push(ExistingSubIssue {
+            issue_number,
+            title,
+            phase,
+            state,
+            labels,
+            url,
+            has_agent_working,
+            pr_url,
+            pr_number,
+        });
+    }
+
+    // Calculate progress (use case-insensitive comparison since GitHub returns uppercase)
+    let total = sub_issues.len();
+    let completed = sub_issues
+        .iter()
+        .filter(|i| i.state.eq_ignore_ascii_case("closed"))
+        .count();
+    let percentage = if total > 0 {
+        (completed * 100) / total
+    } else {
+        0
+    };
+
+    let progress = EpicProgress {
+        total,
+        completed,
+        percentage,
+        remaining: total - completed,
+    };
+
+    // Find phases that have no sub-issues
+    let phases_with_issues: std::collections::HashSet<u32> =
+        sub_issues.iter().filter_map(|i| i.phase).collect();
+
+    let phases_without_issues: Vec<u32> = (1..=epic.phases.len() as u32)
+        .filter(|p| !phases_with_issues.contains(p))
+        .collect();
+
+    // Find issues ready for agents (use case-insensitive comparison)
+    let ready_for_agents: Vec<ExistingSubIssue> = sub_issues
+        .iter()
+        .filter(|i| {
+            i.state.eq_ignore_ascii_case("open")
+                && i.labels.iter().any(|l| l == "todo")
+                && !i.has_agent_working
+        })
+        .cloned()
+        .collect();
+
+    // Find issues with agents in progress
+    let in_progress: Vec<ExistingSubIssue> = sub_issues
+        .iter()
+        .filter(|i| i.has_agent_working)
+        .cloned()
+        .collect();
+
+    Ok(EpicRecoveryInfo {
+        epic,
+        epic_body,
+        sub_issues,
+        progress,
+        phases_without_issues,
+        ready_for_agents,
+        in_progress,
+    })
+}
+
+/// Extract work repository from epic body
+fn extract_work_repo_from_body(body: &str) -> Option<String> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("**Work Repository**:") {
+            let repo = trimmed
+                .trim_start_matches("**Work Repository**:")
+                .trim()
+                .to_string();
+            if !repo.is_empty() {
+                return Some(repo);
+            }
+        }
+    }
+    None
+}
+
+/// Extract phases from epic body
+fn extract_phases_from_body(body: &str) -> Vec<PhaseConfig> {
+    let mut phases = Vec::new();
+    let mut in_phases = false;
+    let mut current_phase: Option<PhaseConfig> = None;
+    let mut current_description = Vec::new();
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        // Start of phases section
+        if trimmed == "## Phases" {
+            in_phases = true;
+            continue;
+        }
+
+        if !in_phases {
+            continue;
+        }
+
+        // Stop at next top-level section
+        if trimmed.starts_with("## ") && trimmed != "## Phases" {
+            break;
+        }
+
+        // Phase heading: "### Phase N: Name"
+        if trimmed.starts_with("### ") {
+            // Save previous phase
+            if let Some(mut phase) = current_phase.take() {
+                phase.description = current_description.join(" ").trim().to_string();
+                phases.push(phase);
+                current_description.clear();
+            }
+
+            // Extract phase name (after "Phase N: ")
+            let name = trimmed
+                .trim_start_matches("###")
+                .trim()
+                .split(':')
+                .last()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+
+            current_phase = Some(PhaseConfig {
+                name,
+                description: String::new(),
+                approach: "manual".to_string(),
+                tasks: Vec::new(),
+                files: Vec::new(),
+                dependencies: Vec::new(),
+            });
+            continue;
+        }
+
+        // Extract approach
+        if trimmed.starts_with("**Approach**:") {
+            if let Some(ref mut phase) = current_phase {
+                phase.approach = trimmed
+                    .trim_start_matches("**Approach**:")
+                    .trim()
+                    .to_lowercase();
+            }
+            continue;
+        }
+
+        // Skip metadata lines and horizontal rules
+        if trimmed.starts_with("**") || trimmed == "---" || trimmed.is_empty() {
+            continue;
+        }
+
+        // Accumulate description
+        if current_phase.is_some() {
+            current_description.push(trimmed);
+        }
+    }
+
+    // Save last phase
+    if let Some(mut phase) = current_phase {
+        phase.description = current_description.join(" ").trim().to_string();
+        phases.push(phase);
+    }
+
+    phases
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_epic_body() {
+        let config = EpicConfig {
+            title: "Test Epic".to_string(),
+            repo: "org/repo".to_string(),
+            work_repo: None,
+            goal: "Test goal".to_string(),
+            success_metrics: vec!["Metric 1".to_string(), "Metric 2".to_string()],
+            phases: vec![PhaseConfig {
+                name: "Phase 1".to_string(),
+                description: "Test phase".to_string(),
+                approach: "manual".to_string(),
+                tasks: vec![],
+                files: vec![],
+                dependencies: vec![],
+            }],
+            labels: vec![],
+        };
+
+        let body = format_epic_body(&config, "org/repo");
+
+        assert!(body.contains("# Test Epic"));
+        assert!(body.contains("## Goal"));
+        assert!(body.contains("Test goal"));
+        assert!(body.contains("- [ ] Metric 1"));
+        assert!(body.contains("- [ ] Metric 2"));
+        assert!(body.contains("### Phase 1: Phase 1"));
+        assert!(body.contains("**Approach**: manual"));
+    }
+
+    #[test]
+    fn test_format_sub_issue_body() {
+        let config = SubIssueConfig {
+            title: "Test Task".to_string(),
+            phase: 1,
+            estimated_time: "2 hours".to_string(),
+            dependencies: "None".to_string(),
+            goal: "Test goal".to_string(),
+            tasks: "- Task 1\n- Task 2".to_string(),
+            acceptance_criteria: vec!["Criterion 1".to_string()],
+            agent_type: "claude".to_string(),
+            work_repo: None,
+        };
+
+        let body = format_sub_issue_body(100, "org/repo", "org/repo", &config);
+
+        assert!(body.contains("**Epic**: #100"));
+        assert!(body.contains("**Phase**: 1"));
+        assert!(body.contains("**Estimated Time**: 2 hours"));
+        assert!(body.contains("- [ ] Criterion 1"));
+        assert!(body.contains("**Agent Type**: claude"));
+    }
+
+    #[test]
+    fn test_update_progress_section() {
+        let original = r#"# Epic Title
+
+## Progress
+0/10 sub-issues completed (0%)
+
+## Notes
+Some notes
+"#;
+
+        let updated = update_progress_section(original, 5, 10, 50);
+
+        assert!(updated.contains("5/10 sub-issues completed (50%)"));
+        assert!(updated.contains("## Notes"));
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/orchestration.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/orchestration.rs
@@ -1,0 +1,673 @@
+//! Epic orchestration operations.
+//!
+//! This module handles the automated workflow of starting epic execution:
+//! - Creating sub-issues from phase tasks
+//! - Spawning agents for agent-assisted phases
+//! - Managing phase progression
+
+use super::{EpicInfo, PhaseConfig, SubIssueConfig, SubIssueInfo, create_sub_issues};
+use crate::devops::orchestrator;
+
+/// Maximum length for issue titles - keep them concise and readable
+const MAX_TITLE_LENGTH: usize = 100;
+
+/// Truncate a title to be concise, breaking at word boundaries
+fn truncate_title(title: &str) -> String {
+    let title = title.trim();
+    if title.len() <= MAX_TITLE_LENGTH {
+        return title.to_string();
+    }
+
+    // Find last space before the limit to break at word boundary
+    let truncate_at = title[..MAX_TITLE_LENGTH - 3]
+        .rfind(' ')
+        .unwrap_or(MAX_TITLE_LENGTH - 3);
+
+    format!("{}...", &title[..truncate_at])
+}
+
+/// Result of starting orchestration for an epic
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct OrchestrationResult {
+    /// Epic number
+    pub epic_number: u32,
+    /// Created sub-issues
+    pub sub_issues: Vec<SubIssueInfo>,
+    /// Spawned agents (for agent-assisted phases)
+    pub spawned_agents: Vec<SpawnedAgentInfo>,
+    /// Phases that were started
+    pub started_phases: Vec<u32>,
+    /// Any warnings during orchestration
+    pub warnings: Vec<String>,
+}
+
+/// Information about a spawned agent
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct SpawnedAgentInfo {
+    /// Issue number the agent is working on
+    pub issue_number: u32,
+    /// Session name (tmux)
+    pub session_name: String,
+    /// Worktree path
+    pub worktree_path: String,
+    /// Agent type (claude, aider, etc.)
+    pub agent_type: String,
+}
+
+/// Configuration for starting orchestration
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct StartOrchestrationConfig {
+    /// Which phases to start (1-indexed). If empty, starts Phase 1.
+    pub phases: Vec<u32>,
+    /// Whether to auto-spawn agents for agent-assisted phases
+    pub auto_spawn_agents: bool,
+    /// Default agent type for spawning
+    pub default_agent_type: String,
+    /// Local filesystem path to git repository for creating worktrees.
+    /// Must be a valid git repository path (e.g., "/Users/me/projects/MyRepo").
+    /// If empty or invalid, agent spawning will be skipped but issues will still be created.
+    pub worktree_base: String,
+}
+
+/// Start orchestration for an epic
+///
+/// This creates sub-issues for the specified phases and optionally spawns agents.
+/// If a phase already has an issue, it will skip creation and reuse the existing one.
+pub async fn start_orchestration(
+    epic: &EpicInfo,
+    config: StartOrchestrationConfig,
+) -> Result<OrchestrationResult, String> {
+    use crate::devops::github;
+
+    let mut result = OrchestrationResult {
+        epic_number: epic.epic_number,
+        sub_issues: Vec::new(),
+        spawned_agents: Vec::new(),
+        started_phases: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    // Determine which phases to process (default to Phase 1)
+    let phases_to_start: Vec<u32> = if config.phases.is_empty() {
+        vec![1]
+    } else {
+        config.phases.clone()
+    };
+
+    // First, check for existing sub-issues for this epic (include closed to avoid re-creating)
+    let existing_issues = github::list_all_issues_async(&epic.repo, vec![])
+        .await
+        .unwrap_or_default();
+    let existing_phase_issues: std::collections::HashMap<u32, _> = existing_issues
+        .iter()
+        .filter(|issue| {
+            issue
+                .body
+                .as_ref()
+                .map(|b| b.contains(&format!("Epic**: #{}", epic.epic_number)))
+                .unwrap_or(false)
+        })
+        .filter_map(|issue| {
+            // Extract phase number from body
+            issue
+                .body
+                .as_ref()
+                .and_then(|body| {
+                    body.lines()
+                        .find(|line| line.contains("**Phase**:"))
+                        .and_then(|line| {
+                            line.split("**Phase**:")
+                                .nth(1)
+                                .and_then(|s| s.trim().parse::<u32>().ok())
+                        })
+                })
+                .map(|phase| (phase, issue))
+        })
+        .collect();
+
+    // Generate ONE sub-issue per phase (agent will break down further if needed)
+    let mut sub_issue_configs: Vec<SubIssueConfig> = Vec::new();
+
+    for phase_num in &phases_to_start {
+        let phase_idx = (*phase_num as usize).saturating_sub(1);
+        if phase_idx >= epic.phases.len() {
+            result.warnings.push(format!(
+                "Phase {} does not exist (epic has {} phases)",
+                phase_num,
+                epic.phases.len()
+            ));
+            continue;
+        }
+
+        // Check if issue already exists for this phase
+        if let Some(existing) = existing_phase_issues.get(phase_num) {
+            result.warnings.push(format!(
+                "Phase {} already has issue #{} - skipping creation",
+                phase_num, existing.number
+            ));
+            result.started_phases.push(*phase_num);
+            // Add existing issue to result
+            result.sub_issues.push(SubIssueInfo {
+                issue_number: existing.number as u32,
+                title: existing.title.clone(),
+                phase: *phase_num,
+                agent_type: config.default_agent_type.clone(),
+                work_repo: epic.work_repo.clone(),
+                url: existing.url.clone(),
+            });
+            continue;
+        }
+
+        let phase = &epic.phases[phase_idx];
+
+        // Check dependencies
+        if !phase.dependencies.is_empty() {
+            result.warnings.push(format!(
+                "Phase {} has dependencies: {:?}. Proceeding anyway.",
+                phase_num, phase.dependencies
+            ));
+        }
+
+        // Create a single issue for the phase - agent will handle task breakdown
+        let phase_issue = create_phase_issue(
+            *phase_num,
+            phase,
+            &epic.work_repo,
+            &config.default_agent_type,
+        );
+
+        sub_issue_configs.push(phase_issue);
+        result.started_phases.push(*phase_num);
+    }
+
+    // Create sub-issues in GitHub
+    if !sub_issue_configs.is_empty() {
+        match create_sub_issues(
+            epic.epic_number,
+            epic.repo.clone(),
+            epic.work_repo.clone(),
+            sub_issue_configs,
+        )
+        .await
+        {
+            Ok(created) => {
+                result.sub_issues = created;
+            }
+            Err(e) => {
+                return Err(format!("Failed to create sub-issues: {}", e));
+            }
+        }
+    }
+
+    // Spawn agents for agent-assisted sub-issues if requested
+    if config.auto_spawn_agents {
+        // Validate worktree_base is a valid git repository path
+        let worktree_path = std::path::Path::new(&config.worktree_base);
+        let is_valid_git_repo =
+            worktree_path.exists() && worktree_path.is_dir() && worktree_path.join(".git").exists();
+
+        if !is_valid_git_repo {
+            result.warnings.push(format!(
+                "Cannot spawn agents: worktree_base '{}' is not a valid git repository. \
+                 Please provide a local filesystem path to a git repo (e.g., '/Users/me/projects/MyRepo').",
+                config.worktree_base
+            ));
+        } else {
+            for sub_issue in &result.sub_issues {
+                // Only spawn for agent-assisted (not "manual")
+                if sub_issue.agent_type == "manual" {
+                    continue;
+                }
+
+                // Spawn agent
+                match spawn_agent_for_issue(
+                    &epic.repo,
+                    sub_issue.issue_number,
+                    &sub_issue.agent_type,
+                    &sub_issue.work_repo,
+                    &config.worktree_base,
+                ) {
+                    Ok(agent_info) => {
+                        result.spawned_agents.push(agent_info);
+                    }
+                    Err(e) => {
+                        result.warnings.push(format!(
+                            "Failed to spawn agent for issue #{}: {}",
+                            sub_issue.issue_number, e
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Create a single issue for a phase
+///
+/// Instead of creating many small issues from tasks, we create one issue per phase.
+/// The agent working on this phase will handle task breakdown and can create
+/// follow-up issues if needed.
+fn create_phase_issue(
+    phase_num: u32,
+    phase: &PhaseConfig,
+    work_repo: &str,
+    default_agent_type: &str,
+) -> SubIssueConfig {
+    // Create a concise title: "Phase N: Name"
+    let title = truncate_title(&format!("Phase {}: {}", phase_num, phase.name));
+
+    // Determine agent type based on approach
+    let agent_type = match phase.approach.as_str() {
+        "agent-assisted" => default_agent_type.to_string(),
+        "automated" => "automated".to_string(),
+        _ => "manual".to_string(),
+    };
+
+    // Build comprehensive tasks list from phase
+    let tasks_text = if phase.tasks.is_empty() {
+        phase.description.clone()
+    } else {
+        let task_list = phase
+            .tasks
+            .iter()
+            .map(|t| format!("- {}", t))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        if phase.files.is_empty() {
+            task_list
+        } else {
+            let files_list = phase
+                .files
+                .iter()
+                .map(|f| format!("- `{}`", f))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("{}\n\n**Relevant files**:\n{}", task_list, files_list)
+        }
+    };
+
+    // Build acceptance criteria
+    let mut criteria = vec![
+        "All tasks completed".to_string(),
+        "Tests pass".to_string(),
+        "Code reviewed".to_string(),
+    ];
+    if !phase.tasks.is_empty() {
+        criteria.insert(0, format!("{} tasks completed", phase.tasks.len()));
+    }
+
+    SubIssueConfig {
+        title,
+        phase: phase_num,
+        estimated_time: estimate_phase_time(phase),
+        dependencies: if phase.dependencies.is_empty() {
+            "None".to_string()
+        } else {
+            phase.dependencies.join(", ")
+        },
+        goal: phase.description.clone(),
+        tasks: tasks_text,
+        acceptance_criteria: criteria,
+        agent_type,
+        work_repo: Some(work_repo.to_string()),
+    }
+}
+
+/// Estimate time for a phase based on number of tasks
+fn estimate_phase_time(phase: &PhaseConfig) -> String {
+    let task_count = phase.tasks.len();
+    if task_count == 0 {
+        "2-4 hours".to_string()
+    } else if task_count <= 3 {
+        "4-8 hours".to_string()
+    } else if task_count <= 6 {
+        "1-2 days".to_string()
+    } else {
+        "2-3 days".to_string()
+    }
+}
+
+/// Spawn an agent for a specific issue
+fn spawn_agent_for_issue(
+    repo: &str,
+    issue_number: u32,
+    agent_type: &str,
+    work_repo: &str,
+    worktree_base: &str,
+) -> Result<SpawnedAgentInfo, String> {
+    // Use the orchestrator to spawn the agent
+    let config = orchestrator::SpawnConfig {
+        repo: repo.to_string(),
+        issue_number: issue_number as u64,
+        agent_type: agent_type.to_string(),
+        session_name: None,
+        worktree_prefix: Some("handy-agent".to_string()),
+        working_labels: vec!["staging".to_string()],
+        use_sandbox: false,    // TODO: Pass from config
+        sandbox_ports: vec![], // Auto-detect ports from project
+    };
+
+    let spawn_result = orchestrator::spawn_agent(&config, worktree_base)?;
+
+    Ok(SpawnedAgentInfo {
+        issue_number,
+        session_name: spawn_result.session_name,
+        worktree_path: spawn_result.worktree.path,
+        agent_type: agent_type.to_string(),
+    })
+}
+
+/// Get phase status for an epic (how many sub-issues complete per phase)
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct PhaseStatus {
+    pub phase_number: u32,
+    pub phase_name: String,
+    pub approach: String,
+    pub total_issues: u32,
+    pub completed_issues: u32,
+    pub in_progress_issues: u32,
+    pub status: String, // "not_started", "in_progress", "completed"
+}
+
+/// Get detailed status of all phases in an epic
+pub async fn get_epic_phase_status(
+    epic_number: u32,
+    epic_repo: &str,
+    phases: &[PhaseConfig],
+) -> Result<Vec<PhaseStatus>, String> {
+    use crate::devops::github;
+
+    // Get the Epic issue to read its current phase status from the body
+    let epic_issue = github::get_issue_async(epic_repo, epic_number).await?;
+    let epic_body = epic_issue.body.unwrap_or_default();
+    let body_statuses = extract_phase_statuses_from_body(&epic_body);
+
+    // Get all issues that reference this epic (include closed to count completions)
+    let all_issues = github::list_all_issues_async(epic_repo, vec![]).await?;
+
+    let mut phase_statuses = Vec::new();
+
+    for (idx, phase) in phases.iter().enumerate() {
+        let phase_num = (idx + 1) as u32;
+
+        // Filter issues for this phase by checking body content
+        let phase_issues: Vec<_> = all_issues
+            .iter()
+            .filter(|issue| {
+                let body = issue.body.as_deref().unwrap_or("");
+
+                // Must reference the epic
+                let refs_epic = body.contains(&format!("Epic**: #{}", epic_number));
+
+                // Must be for this phase (check body for "**Phase**: N")
+                let is_this_phase = body.contains(&format!("**Phase**: {}", phase_num));
+
+                refs_epic && is_this_phase
+            })
+            .collect();
+
+        let total = phase_issues.len() as u32;
+        let completed = phase_issues.iter().filter(|i| i.state == "closed").count() as u32;
+        let in_progress = phase_issues
+            .iter()
+            .filter(|i| i.state == "open" && i.labels.iter().any(|l| l == "staging"))
+            .count() as u32;
+
+        // Determine status:
+        // 1. If there are sub-issues, use their status
+        // 2. If no sub-issues, check the Epic body for status (handles manual completions)
+        let status = if total > 0 {
+            if completed == total {
+                "completed".to_string()
+            } else {
+                "in_progress".to_string()
+            }
+        } else {
+            // No sub-issues - check Epic body for status (e.g., manually completed phase)
+            body_statuses
+                .get(&phase_num)
+                .cloned()
+                .unwrap_or_else(|| "not_started".to_string())
+        };
+
+        phase_statuses.push(PhaseStatus {
+            phase_number: phase_num,
+            phase_name: phase.name.clone(),
+            approach: phase.approach.clone(),
+            total_issues: total,
+            completed_issues: completed,
+            in_progress_issues: in_progress,
+            status,
+        });
+    }
+
+    Ok(phase_statuses)
+}
+
+/// Update the Epic issue body on GitHub with current phase status.
+///
+/// This rewrites the Phases section with updated status indicators:
+/// - ⏸️ Not Started
+/// - 🔄 In Progress
+/// - ✅ Complete
+/// - ⏭️ Skipped
+pub async fn update_epic_phase_status_on_github(
+    epic_repo: &str,
+    epic_number: u32,
+    phase_statuses: &[PhaseStatus],
+) -> Result<(), String> {
+    use crate::devops::github;
+
+    // First, get the current Epic issue body
+    let issue = github::get_issue_async(epic_repo, epic_number).await?;
+    let body = issue.body.unwrap_or_default();
+
+    // Parse the body and update phase statuses
+    let updated_body = update_phases_in_body(&body, phase_statuses);
+
+    // Also update the progress section
+    let total_issues: u32 = phase_statuses.iter().map(|p| p.total_issues).sum();
+    let completed_issues: u32 = phase_statuses.iter().map(|p| p.completed_issues).sum();
+    let percentage = if total_issues > 0 {
+        (completed_issues as f64 / total_issues as f64 * 100.0) as u32
+    } else {
+        0
+    };
+
+    let updated_body =
+        update_progress_in_body(&updated_body, completed_issues, total_issues, percentage);
+
+    // Update the issue
+    github::update_issue_body_async(epic_repo, epic_number, &updated_body).await
+}
+
+/// Update phase status indicators in the Epic body.
+fn update_phases_in_body(body: &str, phase_statuses: &[PhaseStatus]) -> String {
+    let mut result = body.to_string();
+
+    for status in phase_statuses {
+        // Pattern to match the phase header and status line
+        let phase_pattern = format!("### Phase {}: {}", status.phase_number, status.phase_name);
+
+        // Find the phase section and update its status
+        if let Some(phase_start) = result.find(&phase_pattern) {
+            // Find the status line within this phase
+            let phase_section = &result[phase_start..];
+            if let Some(status_pos) = phase_section.find("**Status**:") {
+                let abs_status_pos = phase_start + status_pos;
+
+                // Find the end of the status line (next newline)
+                let after_status = &result[abs_status_pos..];
+                if let Some(line_end) = after_status.find('\n') {
+                    // Replace the status line
+                    let new_status = format_phase_status(status);
+                    let before = &result[..abs_status_pos];
+                    let after = &result[abs_status_pos + line_end..];
+                    result = format!("{}{}{}", before, new_status, after);
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Format a phase status indicator.
+fn format_phase_status(status: &PhaseStatus) -> String {
+    let (icon, text) = match status.status.as_str() {
+        "completed" => ("✅", "Complete"),
+        "ready" => ("🟡", "Ready"),
+        "in_progress" => ("🔄", "In Progress"),
+        "not_started" => ("⏸️", "Not Started"),
+        "skipped" => ("⏭️", "Skipped"),
+        _ => ("⏸️", "Not Started"),
+    };
+
+    if status.total_issues > 0 {
+        format!(
+            "**Status**: {} {} ({}/{} issues)",
+            icon, text, status.completed_issues, status.total_issues
+        )
+    } else {
+        format!("**Status**: {} {}", icon, text)
+    }
+}
+
+/// Update the progress section in the Epic body.
+fn update_progress_in_body(body: &str, completed: u32, total: u32, percentage: u32) -> String {
+    // Find the progress section
+    if let Some(progress_start) = body.find("## Progress") {
+        let after_header = &body[progress_start..];
+        if let Some(line_start) = after_header.find('\n') {
+            let after_newline = &after_header[line_start + 1..];
+            if let Some(line_end) = after_newline.find('\n') {
+                // Replace the progress line
+                let progress_line = format!(
+                    "{}/{} sub-issues completed ({}%)",
+                    completed, total, percentage
+                );
+                let before = &body[..progress_start + line_start + 1];
+                let after = &after_newline[line_end..];
+                return format!("{}{}{}", before, progress_line, after);
+            }
+        }
+    }
+    body.to_string()
+}
+
+/// Extract phase status from the Epic issue body.
+///
+/// Looks for lines like "**Status**: ✅ Complete" within each phase section.
+/// Returns a map from phase number to status string.
+fn extract_phase_statuses_from_body(body: &str) -> std::collections::HashMap<u32, String> {
+    let mut statuses = std::collections::HashMap::new();
+    let mut current_phase: Option<u32> = None;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        // Look for phase headers: "### Phase N: Name"
+        if trimmed.starts_with("### Phase ") {
+            // Extract phase number
+            let after_phase = trimmed.trim_start_matches("### Phase ");
+            if let Some(num_end) = after_phase.find(':') {
+                if let Ok(num) = after_phase[..num_end].trim().parse::<u32>() {
+                    current_phase = Some(num);
+                }
+            }
+            continue;
+        }
+
+        // Look for status line: "**Status**: ✅ Complete" or similar
+        if trimmed.starts_with("**Status**:") {
+            if let Some(phase_num) = current_phase {
+                let status_text = trimmed.trim_start_matches("**Status**:").trim();
+                let status = if status_text.contains("Complete") || status_text.contains("✅") {
+                    "completed"
+                } else if status_text.contains("Ready") || status_text.contains("🟡") {
+                    "ready"
+                } else if status_text.contains("In Progress") || status_text.contains("🔄") {
+                    "in_progress"
+                } else if status_text.contains("Skipped") || status_text.contains("⏭️") {
+                    "skipped"
+                } else {
+                    "not_started"
+                };
+                statuses.insert(phase_num, status.to_string());
+            }
+        }
+
+        // Reset phase when we hit a new top-level section
+        if trimmed.starts_with("## ") && !trimmed.starts_with("### ") {
+            current_phase = None;
+        }
+    }
+
+    statuses
+}
+
+/// Mark a single phase's status directly on GitHub.
+///
+/// This is useful for phases that were completed manually (without sub-issues)
+/// or for recovery when the Epic body status doesn't match the actual state.
+///
+/// # Arguments
+/// * `epic_repo` - The repository where the Epic issue lives (e.g., "KBVE/kbve")
+/// * `epic_number` - The Epic issue number
+/// * `phase_number` - The phase to mark (1-indexed)
+/// * `new_status` - The new status: "completed", "in_progress", "not_started", or "skipped"
+pub async fn mark_phase_status(
+    epic_repo: &str,
+    epic_number: u32,
+    phase_number: u32,
+    new_status: &str,
+) -> Result<(), String> {
+    use crate::devops::github;
+
+    // Get the current Epic issue
+    let issue = github::get_issue_async(epic_repo, epic_number).await?;
+    let body = issue.body.unwrap_or_default();
+
+    // Extract phase name from the Epic body
+    let phase_name = extract_phase_name_from_body(&body, phase_number)
+        .ok_or_else(|| format!("Phase {} not found in Epic body", phase_number))?;
+
+    // Create a PhaseStatus with the new status
+    let phase_status = PhaseStatus {
+        phase_number,
+        phase_name,
+        approach: String::new(), // Not needed for status update
+        status: new_status.to_string(),
+        total_issues: 0, // Manual phases typically have no sub-issues
+        completed_issues: 0,
+        in_progress_issues: 0,
+    };
+
+    // Update just this phase in the body
+    let updated_body = update_phases_in_body(&body, &[phase_status]);
+
+    // Update the issue on GitHub
+    github::update_issue_body_async(epic_repo, epic_number, &updated_body).await
+}
+
+/// Extract a phase name from the Epic body by phase number.
+fn extract_phase_name_from_body(body: &str, phase_number: u32) -> Option<String> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        // Look for "### Phase N: Name"
+        if trimmed.starts_with("### Phase ") {
+            let after_phase = trimmed.trim_start_matches("### Phase ");
+            if let Some(colon_pos) = after_phase.find(':') {
+                if let Ok(num) = after_phase[..colon_pos].trim().parse::<u32>() {
+                    if num == phase_number {
+                        return Some(after_phase[colon_pos + 1..].trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan.rs
@@ -1,0 +1,328 @@
+//! Epic planning operations: parse markdown plans and generate Epic + Sub-issues.
+//!
+//! This module uses an AI agent (via claude-code, aider, etc.) to:
+//! 1. Read a project plan markdown file
+//! 2. Analyze the plan and extract Epic structure
+//! 3. Generate Epic issue configuration
+//! 4. Generate N sub-issue configurations
+//! 5. Create Epic + Sub-issues on GitHub
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::devops::operations;
+
+/// Helper: Determine which agent to use for planning
+fn determine_planning_agent(
+    config: &PlanFromMarkdownConfig,
+    enabled_agents: &[String],
+) -> Result<String, String> {
+    // If user specified an agent, check if it's enabled
+    if let Some(requested_agent) = &config.planning_agent {
+        if !enabled_agents.contains(requested_agent) {
+            return Err(format!(
+                "Agent '{}' is not enabled. Enable it in DevOps settings first. Enabled agents: {}",
+                requested_agent,
+                enabled_agents.join(", ")
+            ));
+        }
+        return Ok(requested_agent.clone());
+    }
+
+    // Otherwise, use first enabled agent
+    enabled_agents.first().cloned().ok_or_else(|| {
+        "No agents enabled. Enable at least one agent (claude, aider, etc.) in DevOps settings."
+            .to_string()
+    })
+}
+
+/// Configuration for planning an Epic from a markdown file
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PlanFromMarkdownConfig {
+    /// Path to the markdown plan file
+    pub plan_file_path: String,
+    /// Tracking repository where Epic/Sub-issues are created (e.g., "KBVE/Handy")
+    pub repo: String,
+    /// Work repository where code lives and agents work (e.g., "user/project")
+    /// If None, defaults to same as repo
+    pub work_repo: Option<String>,
+    /// Optional: Override epic title
+    pub title_override: Option<String>,
+    /// Optional: Agent to use for planning (default: claude)
+    pub planning_agent: Option<String>,
+}
+
+/// Result of the planning operation
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PlanResult {
+    /// Created Epic info
+    pub epic: operations::EpicInfo,
+    /// Created sub-issues
+    pub sub_issues: Vec<operations::SubIssueInfo>,
+    /// Agent used for planning
+    pub planning_agent: String,
+    /// Summary of what was created
+    pub summary: String,
+}
+
+/// Plan an Epic from a markdown file using an AI agent
+///
+/// This function:
+/// 1. Reads the markdown plan file
+/// 2. Spawns a planning agent (claude/aider) to analyze it
+/// 3. Agent extracts Epic structure (title, phases, sub-issues)
+/// 4. Creates Epic issue on GitHub
+/// 5. Creates all sub-issues referencing the Epic
+/// 6. Returns complete plan result
+pub async fn plan_from_markdown(
+    config: PlanFromMarkdownConfig,
+    enabled_agents: Vec<String>,
+) -> Result<PlanResult, String> {
+    // Step 1: Determine which agent to use
+    let agent_type = determine_planning_agent(&config, &enabled_agents)?;
+
+    // Step 2: Read the markdown file
+    let plan_content = std::fs::read_to_string(&config.plan_file_path)
+        .map_err(|e| format!("Failed to read plan file: {}", e))?;
+
+    // Step 3: Prepare planning prompt for the agent
+    let planning_prompt = format!(
+        r#"Analyze this project plan and generate Epic structure:
+
+# Project Plan
+{}
+
+# Task
+Extract from this plan:
+1. Epic title (if not provided, use: {})
+2. Epic goal (1-2 sentences)
+3. Success metrics (checkbox list)
+4. Phases with approach (manual/agent-assisted/automated)
+5. Sub-issues for each phase with:
+   - Title
+   - Goal
+   - Tasks breakdown
+   - Acceptance criteria
+   - Recommended agent type
+   - Estimated time
+   - Dependencies
+
+# Output Format
+Return ONLY valid JSON in this exact structure (no markdown, no explanation):
+{{
+  "epic": {{
+    "title": "...",
+    "goal": "...",
+    "success_metrics": ["...", "..."],
+    "phases": [
+      {{"name": "...", "description": "...", "approach": "manual"}}
+    ],
+    "labels": ["...", "..."]
+  }},
+  "sub_issues": [
+    {{
+      "title": "...",
+      "phase": 1,
+      "estimated_time": "...",
+      "dependencies": "...",
+      "goal": "...",
+      "tasks": "...",
+      "acceptance_criteria": ["...", "..."],
+      "agent_type": "claude"
+    }}
+  ]
+}}
+"#,
+        plan_content,
+        config
+            .title_override
+            .as_deref()
+            .unwrap_or("Extracted from plan")
+    );
+
+    // Step 4: Spawn planning agent to analyze the plan
+    let agent_output = spawn_planning_agent(&planning_prompt, &agent_type).await?;
+
+    // Step 4: Parse agent's JSON output
+    let plan_structure = parse_agent_output(&agent_output)?;
+
+    // Step 5: Convert to Epic and SubIssue configurations
+    let epic_config = operations::EpicConfig {
+        title: plan_structure.epic.title.clone(),
+        repo: config.repo.clone(),
+        work_repo: config.work_repo.clone(),
+        goal: plan_structure.epic.goal,
+        success_metrics: plan_structure.epic.success_metrics,
+        phases: plan_structure.epic.phases,
+        labels: plan_structure.epic.labels,
+    };
+
+    let sub_issue_configs: Vec<operations::SubIssueConfig> = plan_structure
+        .sub_issues
+        .iter()
+        .map(|sub| operations::SubIssueConfig {
+            title: sub.title.clone(),
+            phase: sub.phase,
+            estimated_time: sub.estimated_time.clone(),
+            dependencies: sub.dependencies.clone(),
+            goal: sub.goal.clone(),
+            tasks: sub.tasks.clone(),
+            acceptance_criteria: sub.acceptance_criteria.clone(),
+            agent_type: sub.agent_type.clone(),
+            work_repo: None, // Will inherit from epic
+        })
+        .collect();
+
+    // Step 6: Create Epic issue on GitHub
+    let epic = operations::create_epic(epic_config).await?;
+
+    // Step 7: Create all sub-issues (pass work_repo from epic)
+    let sub_issues = operations::create_sub_issues(
+        epic.epic_number,
+        epic.repo.clone(),
+        epic.work_repo.clone(),
+        sub_issue_configs,
+    )
+    .await?;
+
+    // Step 8: Generate summary
+    let summary = format!(
+        "Created Epic #{} '{}' with {} sub-issues using {} agent",
+        epic.epic_number,
+        plan_structure.epic.title,
+        sub_issues.len(),
+        agent_type
+    );
+
+    Ok(PlanResult {
+        epic,
+        sub_issues,
+        planning_agent: agent_type.to_string(),
+        summary,
+    })
+}
+
+/// Helper: Parse agent output (JSON) into Epic and SubIssue configs
+#[derive(Debug, Deserialize)]
+struct PlanStructure {
+    epic: EpicStructure,
+    sub_issues: Vec<SubIssueStructure>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EpicStructure {
+    title: String,
+    goal: String,
+    success_metrics: Vec<String>,
+    phases: Vec<operations::PhaseConfig>,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubIssueStructure {
+    title: String,
+    phase: u32,
+    estimated_time: String,
+    dependencies: String,
+    goal: String,
+    tasks: String,
+    acceptance_criteria: Vec<String>,
+    agent_type: String,
+}
+
+/// Helper: Spawn a planning agent and get its output
+///
+/// NOTE: This is a placeholder for the full agent integration.
+/// Currently returns an error with instructions to use the agent system manually.
+///
+/// Future implementation will:
+/// 1. Create a temporary planning issue with the prompt
+/// 2. Spawn the agent using spawn_agent_from_issue()
+/// 3. Wait for agent completion
+/// 4. Extract JSON from agent's work
+/// 5. Delete temporary issue
+async fn spawn_planning_agent(_prompt: &str, agent_type: &str) -> Result<String, String> {
+    // TODO: Integrate with existing agent spawning system
+    // For now, return an error with manual instructions
+
+    Err(format!(
+        "Automated AI planning not yet implemented.\n\
+         \n\
+         To plan your Epic manually:\n\
+         1. Read your markdown plan file\n\
+         2. Create a planning GitHub issue with the plan content\n\
+         3. Spawn a {} agent for that issue using spawn_agent_from_issue()\n\
+         4. Agent analyzes plan and generates Epic structure JSON\n\
+         5. Use the JSON output to create Epic + Sub-issues\n\
+         \n\
+         Full integration coming soon! For now, use the predefined Epic templates\n\
+         in 'Epic Workflow - Predefined Plans' section.",
+        agent_type
+    ))
+}
+
+/// Helper: Parse agent output and extract JSON
+fn parse_agent_output(output: &str) -> Result<PlanStructure, String> {
+    // Try to extract JSON from markdown code blocks if present
+    let json_str = if let Some(start) = output.find("```json") {
+        let after_start = &output[start + 7..];
+        if let Some(end) = after_start.find("```") {
+            after_start[..end].trim()
+        } else {
+            output.trim()
+        }
+    } else if let Some(start) = output.find("```") {
+        let after_start = &output[start + 3..];
+        if let Some(end) = after_start.find("```") {
+            after_start[..end].trim()
+        } else {
+            output.trim()
+        }
+    } else {
+        output.trim()
+    };
+
+    // Parse JSON
+    serde_json::from_str::<PlanStructure>(json_str).map_err(|e| {
+        format!(
+            "Failed to parse agent output as JSON: {}\n\nOutput was:\n{}",
+            e, json_str
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plan_structure_deserialization() {
+        let json = r#"{
+            "epic": {
+                "title": "Test Epic",
+                "goal": "Test goal",
+                "success_metrics": ["Metric 1"],
+                "phases": [
+                    {"name": "Phase 1", "description": "Test", "approach": "manual"}
+                ],
+                "labels": ["test"]
+            },
+            "sub_issues": [
+                {
+                    "title": "Sub-issue 1",
+                    "phase": 1,
+                    "estimated_time": "2 hours",
+                    "dependencies": "None",
+                    "goal": "Test goal",
+                    "tasks": "- Task 1",
+                    "acceptance_criteria": ["Criterion 1"],
+                    "agent_type": "claude"
+                }
+            ]
+        }"#;
+
+        let plan: PlanStructure = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.epic.title, "Test Epic");
+        assert_eq!(plan.sub_issues.len(), 1);
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan_parser.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan_parser.rs
@@ -1,0 +1,523 @@
+//! Epic plan template parsing from markdown files with frontmatter.
+//!
+//! This module reads markdown files from `docs/plans/` directory, extracts
+//! frontmatter metadata (title, description, labels), and parses the markdown
+//! body to extract Epic structure (goal, success metrics, phases).
+
+use gray_matter::engine::YAML;
+use gray_matter::{Matter, ParsedEntity};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::fs;
+use std::path::Path;
+
+use super::{EpicConfig, PhaseConfig};
+
+/// Metadata from plan template frontmatter
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PlanFrontmatter {
+    title: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    labels: Vec<String>,
+    /// Repository for tracking issues (e.g., "KBVE/KBVE")
+    #[serde(default)]
+    tracking_repo: Option<String>,
+    /// Repository for working/implementation (e.g., "KBVE/Handy")
+    #[serde(default)]
+    working_repo: Option<String>,
+}
+
+/// Parsed plan template ready for use
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PlanTemplate {
+    /// Template identifier (filename without extension)
+    pub id: String,
+    /// Template title from frontmatter
+    pub title: String,
+    /// Template description from frontmatter
+    pub description: String,
+    /// Labels from frontmatter
+    pub labels: Vec<String>,
+    /// Repository for tracking issues (e.g., "KBVE/KBVE")
+    pub tracking_repo: Option<String>,
+    /// Repository for working/implementation (e.g., "KBVE/Handy")
+    pub working_repo: Option<String>,
+    /// Epic goal extracted from markdown
+    pub goal: String,
+    /// Success metrics extracted from markdown
+    pub success_metrics: Vec<String>,
+    /// Phases extracted from markdown
+    pub phases: Vec<PhaseConfig>,
+}
+
+/// List all available plan templates from docs/plans directory
+pub fn list_plan_templates(repo_root: &Path) -> Result<Vec<PlanTemplate>, String> {
+    let plans_dir = repo_root.join("docs/plans");
+
+    if !plans_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut templates = Vec::new();
+
+    let entries =
+        fs::read_dir(&plans_dir).map_err(|e| format!("Failed to read plans directory: {}", e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        // Only process .md files
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+
+        // Skip README.md
+        if path.file_name().and_then(|s| s.to_str()) == Some("README.md") {
+            continue;
+        }
+
+        match parse_plan_template(&path) {
+            Ok(template) => templates.push(template),
+            Err(e) => {
+                eprintln!("Warning: Failed to parse {}: {}", path.display(), e);
+                continue;
+            }
+        }
+    }
+
+    // Sort by title
+    templates.sort_by(|a, b| a.title.cmp(&b.title));
+
+    Ok(templates)
+}
+
+/// Parse a single plan template markdown file
+fn parse_plan_template(path: &Path) -> Result<PlanTemplate, String> {
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+
+    let matter = Matter::<YAML>::new();
+    let result: ParsedEntity<PlanFrontmatter> = matter
+        .parse(&content)
+        .map_err(|e| format!("Failed to parse markdown: {}", e))?;
+
+    // Extract frontmatter
+    let frontmatter = result
+        .data
+        .ok_or_else(|| "No frontmatter found".to_string())?;
+
+    let markdown = result.content;
+
+    // Extract goal, success metrics, and phases from markdown
+    let goal = extract_goal(&markdown)?;
+    let success_metrics = extract_success_metrics(&markdown);
+    let phases = extract_phases(&markdown)?;
+
+    let id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| "Invalid filename".to_string())?
+        .to_string();
+
+    Ok(PlanTemplate {
+        id,
+        title: frontmatter.title,
+        description: frontmatter.description,
+        labels: frontmatter.labels,
+        tracking_repo: frontmatter.tracking_repo,
+        working_repo: frontmatter.working_repo,
+        goal,
+        success_metrics,
+        phases,
+    })
+}
+
+/// Extract goal from "## Goal" section
+fn extract_goal(markdown: &str) -> Result<String, String> {
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut in_goal = false;
+    let mut goal_lines = Vec::new();
+
+    for line in lines {
+        if line.trim() == "## Goal" {
+            in_goal = true;
+            continue;
+        }
+
+        if in_goal {
+            // Stop at next heading
+            if line.trim().starts_with("##") {
+                break;
+            }
+
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                goal_lines.push(trimmed);
+            }
+        }
+    }
+
+    if goal_lines.is_empty() {
+        return Err("No goal found in plan".to_string());
+    }
+
+    Ok(goal_lines.join(" "))
+}
+
+/// Extract success metrics from "## Success Metrics" section
+fn extract_success_metrics(markdown: &str) -> Vec<String> {
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut in_metrics = false;
+    let mut metrics = Vec::new();
+
+    for line in lines {
+        if line.trim() == "## Success Metrics" {
+            in_metrics = true;
+            continue;
+        }
+
+        if in_metrics {
+            // Stop at next heading
+            if line.trim().starts_with("##") {
+                break;
+            }
+
+            let trimmed = line.trim();
+            // Extract list items (with or without checkbox)
+            if trimmed.starts_with("- ") {
+                let metric = trimmed
+                    .trim_start_matches("- ")
+                    .trim_start_matches("[ ] ")
+                    .trim();
+                if !metric.is_empty() {
+                    metrics.push(metric.to_string());
+                }
+            }
+        }
+    }
+
+    metrics
+}
+
+/// Extract phases from "## Phases" section
+fn extract_phases(markdown: &str) -> Result<Vec<PhaseConfig>, String> {
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut in_phases = false;
+    let mut phases = Vec::new();
+    let mut current_phase: Option<PhaseConfig> = None;
+    let mut current_description = Vec::new();
+    let mut current_tasks = Vec::new();
+    let mut current_files = Vec::new();
+    let mut current_deps = Vec::new();
+    let mut in_tasks = false;
+    let mut in_files = false;
+    let mut in_deps = false;
+
+    for line in lines {
+        if line.trim() == "## Phases" {
+            in_phases = true;
+            continue;
+        }
+
+        if !in_phases {
+            continue;
+        }
+
+        // Stop at next top-level heading
+        if line.trim().starts_with("## ") && line.trim() != "## Phases" {
+            break;
+        }
+
+        let trimmed = line.trim();
+
+        // Phase heading: "### Phase N: Name" or "### Name"
+        if trimmed.starts_with("### ") {
+            // Save previous phase if exists
+            if let Some(mut phase) = current_phase.take() {
+                phase.description = current_description.join(" ").trim().to_string();
+                phase.tasks = current_tasks.clone();
+                phase.files = current_files.clone();
+                phase.dependencies = current_deps.clone();
+                phases.push(phase);
+                current_description.clear();
+                current_tasks.clear();
+                current_files.clear();
+                current_deps.clear();
+            }
+
+            // Reset section flags
+            in_tasks = false;
+            in_files = false;
+            in_deps = false;
+
+            // Extract phase name
+            let name = trimmed
+                .trim_start_matches("###")
+                .trim()
+                .split(':')
+                .last()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+
+            current_phase = Some(PhaseConfig {
+                name,
+                description: String::new(),
+                approach: "manual".to_string(),
+                tasks: Vec::new(),
+                files: Vec::new(),
+                dependencies: Vec::new(),
+            });
+            continue;
+        }
+
+        // Extract approach if specified
+        if trimmed.starts_with("**Approach**:") {
+            if let Some(ref mut phase) = current_phase {
+                let approach = trimmed
+                    .trim_start_matches("**Approach**:")
+                    .trim()
+                    .to_lowercase();
+                phase.approach = approach;
+            }
+            in_tasks = false;
+            in_files = false;
+            in_deps = false;
+            continue;
+        }
+
+        // Detect section headers
+        if trimmed.starts_with("**Key Tasks**:") || trimmed.starts_with("**Tasks**:") {
+            in_tasks = true;
+            in_files = false;
+            in_deps = false;
+            continue;
+        }
+        if trimmed.starts_with("**Files**:") {
+            in_tasks = false;
+            in_files = true;
+            in_deps = false;
+            continue;
+        }
+        if trimmed.starts_with("**Dependencies**:") {
+            in_tasks = false;
+            in_files = false;
+            in_deps = true;
+            // Check for inline "None"
+            let dep_value = trimmed.trim_start_matches("**Dependencies**:").trim();
+            if dep_value.eq_ignore_ascii_case("none") {
+                current_deps.clear();
+                in_deps = false;
+            }
+            continue;
+        }
+
+        // Skip horizontal rules and empty lines for description
+        if trimmed == "---" || trimmed.is_empty() {
+            // Empty line ends the current section
+            if in_tasks || in_files || in_deps {
+                in_tasks = false;
+                in_files = false;
+                in_deps = false;
+            }
+            continue;
+        }
+
+        // Skip other ** metadata fields
+        if trimmed.starts_with("**") {
+            in_tasks = false;
+            in_files = false;
+            in_deps = false;
+            continue;
+        }
+
+        // Collect list items based on current section
+        if trimmed.starts_with("- ") {
+            let item = trimmed.trim_start_matches("- ").trim().to_string();
+            if in_tasks && current_phase.is_some() {
+                current_tasks.push(item);
+            } else if in_files && current_phase.is_some() {
+                // Clean up file paths (remove backticks)
+                let file = item.trim_matches('`').to_string();
+                current_files.push(file);
+            } else if in_deps && current_phase.is_some() {
+                current_deps.push(item);
+            } else if current_phase.is_some() {
+                // Regular description list items
+                current_description.push(trimmed);
+            }
+            continue;
+        }
+
+        // Accumulate description lines (only if not in a specific section)
+        if current_phase.is_some() && !in_tasks && !in_files && !in_deps {
+            current_description.push(trimmed);
+        }
+    }
+
+    // Save last phase
+    if let Some(mut phase) = current_phase {
+        phase.description = current_description.join(" ").trim().to_string();
+        phase.tasks = current_tasks;
+        phase.files = current_files;
+        phase.dependencies = current_deps;
+        phases.push(phase);
+    }
+
+    if phases.is_empty() {
+        return Err("No phases found in plan".to_string());
+    }
+
+    Ok(phases)
+}
+
+/// Convert a plan template to EpicConfig
+///
+/// Uses template's tracking_repo and working_repo if specified,
+/// otherwise falls back to provided defaults.
+pub fn template_to_config(
+    template: &PlanTemplate,
+    default_repo: String,
+    default_work_repo: Option<String>,
+) -> EpicConfig {
+    // Use template repos if specified, otherwise use defaults
+    let repo = template.tracking_repo.clone().unwrap_or(default_repo);
+    let work_repo = template.working_repo.clone().or(default_work_repo);
+
+    EpicConfig {
+        title: template.title.clone(),
+        repo,
+        work_repo,
+        goal: template.goal.clone(),
+        success_metrics: template.success_metrics.clone(),
+        phases: template.phases.clone(),
+        labels: template.labels.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_goal() {
+        let markdown = r#"
+# Epic Title
+
+## Goal
+
+This is the goal.
+It spans multiple lines.
+
+## Success Metrics
+"#;
+        let goal = extract_goal(markdown).unwrap();
+        assert_eq!(goal, "This is the goal. It spans multiple lines.");
+    }
+
+    #[test]
+    fn test_extract_success_metrics() {
+        let markdown = r#"
+## Success Metrics
+
+- Metric 1
+- [ ] Metric 2
+- Metric 3
+
+## Phases
+"#;
+        let metrics = extract_success_metrics(markdown);
+        assert_eq!(metrics, vec!["Metric 1", "Metric 2", "Metric 3"]);
+    }
+
+    #[test]
+    fn test_extract_phases() {
+        let markdown = r#"
+## Phases
+
+### Phase 1: Foundation
+
+**Approach**: manual
+
+Build test utilities and infrastructure.
+
+---
+
+### Phase 2: Integration
+
+**Approach**: agent-assisted
+
+Comprehensive tests for workflows.
+
+## Next Section
+"#;
+        let phases = extract_phases(markdown).unwrap();
+        assert_eq!(phases.len(), 2);
+        assert_eq!(phases[0].name, "Foundation");
+        assert_eq!(phases[0].approach, "manual");
+        assert!(phases[0].description.contains("Build test utilities"));
+        assert_eq!(phases[1].name, "Integration");
+        assert_eq!(phases[1].approach, "agent-assisted");
+    }
+
+    #[test]
+    fn test_extract_phases_with_tasks_and_files() {
+        let markdown = r#"
+## Phases
+
+### Phase 1: Core Infrastructure
+
+**Approach**: manual
+
+Build backend infrastructure for pipeline state tracking.
+
+**Key Tasks**:
+- Create `PipelineItem` struct linking issue → session → worktree → PR
+- Add `list_pipeline_items` command to aggregate current state
+- Store pipeline state in persistent storage
+
+**Files**:
+- `src-tauri/src/devops/pipeline.rs` (new)
+- `src-tauri/src/commands/devops.rs` (add commands)
+
+**Dependencies**: None
+
+---
+
+### Phase 2: Frontend
+
+**Approach**: agent-assisted
+
+Build the Orchestration tab UI.
+
+**Key Tasks**:
+- Add "Orchestration" tab to DevOpsLayout
+- Create OrchestrationTab component
+
+**Dependencies**: Phase 1 complete
+
+## Design
+"#;
+        let phases = extract_phases(markdown).unwrap();
+        assert_eq!(phases.len(), 2);
+
+        // Phase 1
+        assert_eq!(phases[0].name, "Core Infrastructure");
+        assert_eq!(phases[0].approach, "manual");
+        assert_eq!(phases[0].tasks.len(), 3);
+        assert!(phases[0].tasks[0].contains("PipelineItem"));
+        assert_eq!(phases[0].files.len(), 2);
+        assert!(phases[0].files[0].contains("pipeline.rs"));
+        assert!(phases[0].dependencies.is_empty()); // "None" should result in empty vec
+
+        // Phase 2
+        assert_eq!(phases[1].name, "Frontend");
+        assert_eq!(phases[1].approach, "agent-assisted");
+        assert_eq!(phases[1].tasks.len(), 2);
+        assert!(phases[1].tasks[0].contains("Orchestration"));
+        assert_eq!(phases[1].dependencies.len(), 1);
+        assert!(phases[1].dependencies[0].contains("Phase 1"));
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/orchestration.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/orchestration.rs
@@ -1,0 +1,1478 @@
+//! Pipeline orchestration for agent workflows.
+//!
+//! This module provides high-level orchestration functions for managing
+//! the agent pipeline, including issue assignment, PR detection, and state management.
+//! Also provides Epic state persistence for tracking active Epic workflows.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_store::StoreExt;
+
+use super::github::{self, GitHubPullRequest};
+use super::operations::agent_lifecycle::{
+    PrDetectionResult, SupportWorkerConfig, detect_pr_for_agent, spawn_support_worker,
+};
+use super::operations::epic::{EpicInfo, EpicRecoveryInfo, ExistingSubIssue};
+use super::orchestrator::{self, SpawnConfig, SpawnResult};
+use super::pipeline::{PipelineItem, PipelineState, PipelineStatus};
+use super::tmux;
+
+/// Store path for pipeline state.
+pub const PIPELINE_STORE_PATH: &str = "pipeline_store.json";
+
+/// Store path for Epic state.
+pub const EPIC_STORE_PATH: &str = "epic_store.json";
+
+/// Configuration for assigning an issue to an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AssignIssueConfig {
+    /// Repository where the issue exists (tracking repo)
+    pub tracking_repo: String,
+    /// Repository where work will be done
+    pub work_repo: String,
+    /// Issue number to assign
+    pub issue_number: u64,
+    /// Agent type to use
+    pub agent_type: String,
+    /// Local path to the work repository
+    pub repo_path: String,
+    /// Labels to add when work starts
+    #[serde(default)]
+    pub start_labels: Vec<String>,
+    /// Labels to remove when work starts
+    #[serde(default)]
+    pub remove_labels: Vec<String>,
+}
+
+/// Result of assigning an issue to an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AssignIssueResult {
+    /// The pipeline item created
+    pub pipeline_item: PipelineItem,
+    /// The spawn result from orchestrator
+    pub spawn_result: SpawnResult,
+}
+
+/// Configuration for skipping an issue.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SkipIssueConfig {
+    /// Repository where the issue exists
+    pub repo: String,
+    /// Issue number to skip
+    pub issue_number: u64,
+    /// Optional reason for skipping
+    pub reason: Option<String>,
+    /// Labels to add (defaults to "agent-skipped")
+    #[serde(default)]
+    pub add_labels: Vec<String>,
+    /// Labels to remove (defaults to "agent-todo")
+    #[serde(default)]
+    pub remove_labels: Vec<String>,
+}
+
+/// Summary of pipeline items for display.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PipelineSummary {
+    /// Total items in pipeline
+    pub total: usize,
+    /// Items queued (not started)
+    pub queued: usize,
+    /// Items in progress
+    pub in_progress: usize,
+    /// Items with PRs pending review
+    pub pr_pending: usize,
+    /// Completed items
+    pub completed: usize,
+    /// Skipped items
+    pub skipped: usize,
+    /// Failed items
+    pub failed: usize,
+}
+
+/// Load pipeline state from persistent storage.
+pub fn load_pipeline_state(app: &AppHandle) -> PipelineState {
+    let store = match app.store(PIPELINE_STORE_PATH) {
+        Ok(s) => s,
+        Err(_) => return PipelineState::new(),
+    };
+
+    if let Some(state_value) = store.get("pipeline") {
+        serde_json::from_value::<PipelineState>(state_value)
+            .unwrap_or_else(|_| PipelineState::new())
+    } else {
+        PipelineState::new()
+    }
+}
+
+/// Save pipeline state to persistent storage.
+pub fn save_pipeline_state(app: &AppHandle, state: &PipelineState) {
+    if let Ok(store) = app.store(PIPELINE_STORE_PATH) {
+        if let Ok(value) = serde_json::to_value(state) {
+            let _ = store.set("pipeline", value);
+        }
+    }
+}
+
+/// Assign an issue to an agent.
+///
+/// This creates a worktree, spawns a tmux session, updates labels,
+/// and creates a pipeline item to track the work.
+pub fn assign_issue_to_agent(
+    app: &AppHandle,
+    config: &AssignIssueConfig,
+) -> Result<AssignIssueResult, String> {
+    // 1. Fetch the issue to ensure it exists
+    let issue = github::get_issue(&config.tracking_repo, config.issue_number)?;
+
+    // 2. Create spawn config
+    let settings = crate::settings::get_settings(app);
+    let spawn_config = SpawnConfig {
+        repo: config.work_repo.clone(),
+        issue_number: config.issue_number,
+        agent_type: config.agent_type.clone(),
+        session_name: None,
+        worktree_prefix: Some("handy".to_string()),
+        working_labels: config.start_labels.clone(),
+        use_sandbox: settings.sandbox_enabled,
+        sandbox_ports: vec![], // Auto-detect ports from project
+    };
+
+    // 3. Spawn the agent (creates worktree and session)
+    let spawn_result = orchestrator::spawn_agent(&spawn_config, &config.repo_path)?;
+
+    // 4. Create pipeline item
+    let mut pipeline_item = PipelineItem::from_issue(
+        &issue,
+        &config.tracking_repo,
+        &config.work_repo,
+        &config.agent_type,
+    );
+
+    // 5. Update pipeline item with session details
+    pipeline_item.start_work(
+        &spawn_result.session_name,
+        &spawn_result.worktree.path,
+        &spawn_result.worktree.branch,
+        &spawn_result.machine_id,
+    );
+
+    // 6. Update labels on the issue
+    if !config.remove_labels.is_empty() {
+        let remove_refs: Vec<&str> = config.remove_labels.iter().map(|s| s.as_str()).collect();
+        let _ = github::update_labels(
+            &config.tracking_repo,
+            config.issue_number,
+            vec![],
+            remove_refs,
+        );
+    }
+
+    // 7. Save to pipeline state
+    let mut state = load_pipeline_state(app);
+    state.add_item(pipeline_item.clone());
+    save_pipeline_state(app, &state);
+
+    Ok(AssignIssueResult {
+        pipeline_item,
+        spawn_result,
+    })
+}
+
+/// Skip an issue and update its labels.
+pub fn skip_issue(app: &AppHandle, config: &SkipIssueConfig) -> Result<PipelineItem, String> {
+    // 1. Fetch the issue
+    let issue = github::get_issue(&config.repo, config.issue_number)?;
+
+    // 2. Create a pipeline item to record the skip
+    let mut pipeline_item = PipelineItem::from_issue(&issue, &config.repo, &config.repo, "none");
+    pipeline_item.skip();
+
+    if let Some(reason) = &config.reason {
+        pipeline_item.error = Some(reason.clone());
+    }
+
+    // 3. Update labels
+    let add_labels = if config.add_labels.is_empty() {
+        vec!["agent-skipped"]
+    } else {
+        config.add_labels.iter().map(|s| s.as_str()).collect()
+    };
+
+    let remove_labels = if config.remove_labels.is_empty() {
+        vec!["agent-todo"]
+    } else {
+        config.remove_labels.iter().map(|s| s.as_str()).collect()
+    };
+
+    github::update_labels(&config.repo, config.issue_number, add_labels, remove_labels)?;
+
+    // 4. Add comment if reason provided (sanitized to prevent credential leaks)
+    if let Some(reason) = &config.reason {
+        let sanitized_reason = github::sanitize_for_github(reason);
+        let comment = format!(
+            "🚫 **Issue Skipped**\n\n\
+            This issue was skipped by the automation system.\n\n\
+            **Reason:** {}\n\n\
+            The issue has been marked with `agent-skipped` label.",
+            sanitized_reason
+        );
+        let _ = github::add_comment(&config.repo, config.issue_number, &comment);
+    }
+
+    // 5. Save to history
+    let mut state = load_pipeline_state(app);
+    state.history.push(pipeline_item.clone());
+    save_pipeline_state(app, &state);
+
+    Ok(pipeline_item)
+}
+
+/// List all pipeline items, aggregating from multiple sources.
+pub fn list_pipeline_items(
+    app: &AppHandle,
+    work_repo: Option<&str>,
+) -> Result<Vec<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+
+    // Get active sessions
+    let sessions = orchestrator::list_agent_statuses().unwrap_or_default();
+
+    // Aggregate pipeline state with session data
+    let work_repo = work_repo.unwrap_or("");
+    let items = super::pipeline::aggregate_pipeline_state(&state, &sessions, work_repo);
+
+    // Update state with aggregated items
+    for item in &items {
+        if let Some(existing) = state.items.get_mut(&item.id) {
+            existing.session_name = item.session_name.clone();
+            existing.worktree_path = item.worktree_path.clone();
+            existing.machine_id = item.machine_id.clone();
+            existing.status = item.status;
+        }
+    }
+
+    save_pipeline_state(app, &state);
+    Ok(items)
+}
+
+/// Get pipeline history (completed items).
+pub fn get_pipeline_history(app: &AppHandle, limit: Option<usize>) -> Vec<PipelineItem> {
+    let state = load_pipeline_state(app);
+    state.get_history(limit).into_iter().cloned().collect()
+}
+
+/// Get pipeline summary statistics.
+pub fn get_pipeline_summary(app: &AppHandle) -> PipelineSummary {
+    let state = load_pipeline_state(app);
+
+    let mut summary = PipelineSummary {
+        total: state.items.len(),
+        queued: 0,
+        in_progress: 0,
+        pr_pending: 0,
+        completed: 0,
+        skipped: 0,
+        failed: 0,
+    };
+
+    for item in state.items.values() {
+        match item.status {
+            PipelineStatus::Queued => summary.queued += 1,
+            PipelineStatus::InProgress => summary.in_progress += 1,
+            PipelineStatus::PrPending | PipelineStatus::PrReview => summary.pr_pending += 1,
+            PipelineStatus::Completed => summary.completed += 1,
+            PipelineStatus::Skipped => summary.skipped += 1,
+            PipelineStatus::Failed => summary.failed += 1,
+        }
+    }
+
+    summary
+}
+
+/// Detect and link PRs to pipeline items.
+///
+/// This checks for any PRs that match pipeline item branches
+/// and links them automatically.
+pub fn detect_and_link_prs(app: &AppHandle, work_repo: &str) -> Result<Vec<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+    let mut updated_items = Vec::new();
+
+    // Get open PRs for the repo
+    let prs = github::list_prs(work_repo, Some("open"), None, Some(100))?;
+
+    // Check each active item without a PR
+    for item in state.items.values_mut() {
+        if item.pr_number.is_none() && item.branch_name.is_some() {
+            if let Some(pr) = super::pipeline::detect_pr_for_item(item, &prs) {
+                item.link_pr(&pr);
+                updated_items.push(item.clone());
+            }
+        }
+    }
+
+    // Save updated state
+    if !updated_items.is_empty() {
+        save_pipeline_state(app, &state);
+    }
+
+    Ok(updated_items)
+}
+
+/// Sync PR status for all pipeline items with PRs.
+pub fn sync_all_pr_statuses(app: &AppHandle) -> Result<Vec<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+    let mut updated_items = Vec::new();
+
+    for item in state.items.values_mut() {
+        if item.pr_number.is_some() {
+            let repo = item.work_repo.clone();
+            if super::pipeline::sync_pr_status(item, &repo).unwrap_or(false) {
+                updated_items.push(item.clone());
+            }
+        }
+    }
+
+    // Save updated state
+    if !updated_items.is_empty() {
+        save_pipeline_state(app, &state);
+    }
+
+    // Archive completed items
+    state.archive_completed();
+    save_pipeline_state(app, &state);
+
+    Ok(updated_items)
+}
+
+/// Update a specific pipeline item's PR status.
+pub fn update_pipeline_item_pr_status(
+    app: &AppHandle,
+    item_id: &str,
+) -> Result<Option<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+
+    if let Some(item) = state.items.get_mut(item_id) {
+        if item.pr_number.is_some() {
+            let repo = item.work_repo.clone();
+            super::pipeline::sync_pr_status(item, &repo)?;
+            let updated_item = item.clone();
+            save_pipeline_state(app, &state);
+            return Ok(Some(updated_item));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Link a PR to a pipeline item.
+pub fn link_pr_to_pipeline_item(
+    app: &AppHandle,
+    item_id: &str,
+    pr: &GitHubPullRequest,
+) -> Result<PipelineItem, String> {
+    let mut state = load_pipeline_state(app);
+
+    if let Some(item) = state.items.get_mut(item_id) {
+        item.link_pr(pr);
+        let updated_item = item.clone();
+        save_pipeline_state(app, &state);
+        Ok(updated_item)
+    } else {
+        Err(format!("Pipeline item not found: {}", item_id))
+    }
+}
+
+/// Get a pipeline item by ID.
+pub fn get_pipeline_item(app: &AppHandle, item_id: &str) -> Option<PipelineItem> {
+    let state = load_pipeline_state(app);
+    state.get_item(item_id).cloned()
+}
+
+/// Find a pipeline item by issue.
+pub fn find_pipeline_item_by_issue(
+    app: &AppHandle,
+    repo: &str,
+    issue_number: u64,
+) -> Option<PipelineItem> {
+    let state = load_pipeline_state(app);
+    state.find_by_issue(repo, issue_number).cloned()
+}
+
+/// Find a pipeline item by session name.
+pub fn find_pipeline_item_by_session(app: &AppHandle, session_name: &str) -> Option<PipelineItem> {
+    let state = load_pipeline_state(app);
+    state.find_by_session(session_name).cloned()
+}
+
+/// Archive a completed pipeline item.
+pub fn archive_pipeline_item(
+    app: &AppHandle,
+    item_id: &str,
+) -> Result<Option<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+    let archived = state.archive_item(item_id);
+    save_pipeline_state(app, &state);
+    Ok(archived)
+}
+
+/// Remove a pipeline item (for cleanup).
+pub fn remove_pipeline_item(
+    app: &AppHandle,
+    item_id: &str,
+) -> Result<Option<PipelineItem>, String> {
+    let mut state = load_pipeline_state(app);
+    let removed = state.remove_item(item_id);
+    save_pipeline_state(app, &state);
+    Ok(removed)
+}
+
+// ========== Epic State Management ==========
+
+/// Status of a phase within an Epic (for persisted tracking)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackedPhaseStatus {
+    /// Phase not started
+    NotStarted,
+    /// Phase is in progress (agents working)
+    InProgress,
+    /// Phase is ready (all sub-issues have PRs, waiting for merge)
+    Ready,
+    /// Phase is completed (all sub-issues closed)
+    Completed,
+    /// Phase was skipped
+    Skipped,
+}
+
+impl Default for TrackedPhaseStatus {
+    fn default() -> Self {
+        Self::NotStarted
+    }
+}
+
+/// Tracked state for a phase
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct TrackedPhase {
+    /// Phase number (1-indexed)
+    pub phase_number: u32,
+    /// Phase name
+    pub name: String,
+    /// Phase status
+    pub status: TrackedPhaseStatus,
+    /// Sub-issue numbers assigned to this phase
+    pub sub_issues: Vec<u32>,
+    /// Count of completed sub-issues
+    pub completed_count: usize,
+    /// Total sub-issues for this phase
+    pub total_count: usize,
+}
+
+/// Persisted state for an active Epic workflow
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ActiveEpicState {
+    /// Epic issue number
+    pub epic_number: u32,
+    /// Tracking repository (where Epic issue lives)
+    pub tracking_repo: String,
+    /// Work repository (where code is written)
+    pub work_repo: String,
+    /// Local filesystem path to the repository (for agent spawning)
+    #[serde(default)]
+    pub local_repo_path: Option<String>,
+    /// Epic title
+    pub title: String,
+    /// Epic URL
+    pub url: String,
+    /// Phases with their tracked state
+    pub phases: Vec<TrackedPhase>,
+    /// All sub-issues for this epic
+    pub sub_issues: Vec<TrackedSubIssue>,
+    /// When this Epic was linked/loaded
+    pub linked_at: String,
+    /// Last time state was synced with GitHub
+    pub last_synced_at: Option<String>,
+}
+
+/// Tracked state for a sub-issue
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct TrackedSubIssue {
+    /// Issue number
+    pub issue_number: u32,
+    /// Issue title
+    pub title: String,
+    /// Phase number this belongs to
+    pub phase: Option<u32>,
+    /// Current state (open/closed)
+    pub state: String,
+    /// Agent type assigned
+    pub agent_type: Option<String>,
+    /// Session name if agent is working
+    pub session_name: Option<String>,
+    /// tmux session name for the agent (if assigned)
+    #[serde(default)]
+    pub agent_session: Option<String>,
+    /// Whether an agent is currently working
+    pub has_agent_working: bool,
+    /// URL to the issue
+    pub url: String,
+    /// PR URL if agent created one
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    /// PR number if agent created one
+    #[serde(default)]
+    pub pr_number: Option<u64>,
+}
+
+/// Full Epic store state (can track multiple epics, though typically one active)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
+pub struct EpicStoreState {
+    /// Currently active Epic (the one being orchestrated)
+    pub active_epic: Option<ActiveEpicState>,
+    /// History of completed epics (for reference)
+    pub history: Vec<ActiveEpicState>,
+    /// Maximum history to keep
+    #[serde(default = "default_epic_history")]
+    pub max_history: usize,
+}
+
+fn default_epic_history() -> usize {
+    10
+}
+
+impl EpicStoreState {
+    pub fn new() -> Self {
+        Self {
+            active_epic: None,
+            history: Vec::new(),
+            max_history: default_epic_history(),
+        }
+    }
+}
+
+/// Load Epic state from persistent storage.
+pub fn load_epic_state(app: &AppHandle) -> EpicStoreState {
+    let store = match app.store(EPIC_STORE_PATH) {
+        Ok(s) => s,
+        Err(_) => return EpicStoreState::new(),
+    };
+
+    if let Some(state_value) = store.get("epic_state") {
+        serde_json::from_value::<EpicStoreState>(state_value)
+            .unwrap_or_else(|_| EpicStoreState::new())
+    } else {
+        EpicStoreState::new()
+    }
+}
+
+/// Save Epic state to persistent storage.
+pub fn save_epic_state(app: &AppHandle, state: &EpicStoreState) {
+    if let Ok(store) = app.store(EPIC_STORE_PATH) {
+        if let Ok(value) = serde_json::to_value(state) {
+            let _ = store.set("epic_state", value);
+        }
+    }
+}
+
+/// Set the active Epic from an EpicInfo (when first linking an Epic).
+pub fn set_active_epic(app: &AppHandle, epic_info: &EpicInfo) -> ActiveEpicState {
+    let mut state = load_epic_state(app);
+
+    // Convert phases to tracked phases
+    let tracked_phases: Vec<TrackedPhase> = epic_info
+        .phases
+        .iter()
+        .enumerate()
+        .map(|(i, phase)| TrackedPhase {
+            phase_number: (i + 1) as u32,
+            name: phase.name.clone(),
+            status: TrackedPhaseStatus::NotStarted,
+            sub_issues: Vec::new(),
+            completed_count: 0,
+            total_count: 0,
+        })
+        .collect();
+
+    // Preserve existing local_repo_path if we're re-linking the same epic
+    let existing_local_path = state
+        .active_epic
+        .as_ref()
+        .filter(|e| e.epic_number == epic_info.epic_number)
+        .and_then(|e| e.local_repo_path.clone());
+
+    let active = ActiveEpicState {
+        epic_number: epic_info.epic_number,
+        tracking_repo: epic_info.repo.clone(),
+        work_repo: epic_info.work_repo.clone(),
+        local_repo_path: existing_local_path,
+        title: epic_info.title.clone(),
+        url: epic_info.url.clone(),
+        phases: tracked_phases,
+        sub_issues: Vec::new(),
+        linked_at: chrono::Utc::now().to_rfc3339(),
+        last_synced_at: None,
+    };
+
+    state.active_epic = Some(active.clone());
+    save_epic_state(app, &state);
+
+    active
+}
+
+/// Extract phase status from the Epic issue body.
+/// Returns a map from phase number to status.
+fn extract_phase_statuses_from_body(
+    body: &str,
+) -> std::collections::HashMap<u32, TrackedPhaseStatus> {
+    let mut statuses = std::collections::HashMap::new();
+    let mut current_phase: Option<u32> = None;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        // Look for phase headers: "### Phase N: Name"
+        if trimmed.starts_with("### Phase ") {
+            let after_phase = trimmed.trim_start_matches("### Phase ");
+            if let Some(num_end) = after_phase.find(':') {
+                if let Ok(num) = after_phase[..num_end].trim().parse::<u32>() {
+                    current_phase = Some(num);
+                }
+            }
+            continue;
+        }
+
+        // Look for status line: "**Status**: ✅ Complete" or similar
+        if trimmed.starts_with("**Status**:") {
+            if let Some(phase_num) = current_phase {
+                let status_text = trimmed.trim_start_matches("**Status**:").trim();
+                let status = if status_text.contains("Complete") || status_text.contains("✅") {
+                    TrackedPhaseStatus::Completed
+                } else if status_text.contains("Ready") || status_text.contains("🟡") {
+                    TrackedPhaseStatus::Ready
+                } else if status_text.contains("In Progress") || status_text.contains("🔄") {
+                    TrackedPhaseStatus::InProgress
+                } else if status_text.contains("Skipped") || status_text.contains("⏭️") {
+                    TrackedPhaseStatus::Skipped
+                } else {
+                    TrackedPhaseStatus::NotStarted
+                };
+                statuses.insert(phase_num, status);
+            }
+        }
+
+        // Reset phase when we hit a new top-level section
+        if trimmed.starts_with("## ") && !trimmed.starts_with("### ") {
+            current_phase = None;
+        }
+    }
+
+    statuses
+}
+
+/// Set the active Epic from recovery info (more complete data).
+///
+/// This also cross-references with active tmux sessions to populate
+/// has_agent_working more accurately.
+pub fn set_active_epic_from_recovery(
+    app: &AppHandle,
+    recovery: &EpicRecoveryInfo,
+) -> ActiveEpicState {
+    let mut state = load_epic_state(app);
+
+    // Extract phase statuses from the Epic body (for manually completed phases)
+    let body_statuses = extract_phase_statuses_from_body(&recovery.epic_body);
+
+    // Get active tmux sessions to cross-reference agent assignments
+    let active_sessions = tmux::list_sessions().unwrap_or_default();
+    let issue_to_session: std::collections::HashMap<u32, String> = active_sessions
+        .iter()
+        .filter_map(|s| {
+            s.metadata.as_ref().and_then(|m| {
+                m.issue_ref.as_ref().and_then(|ref_str| {
+                    // Parse issue number from ref like "owner/repo#123"
+                    ref_str
+                        .split('#')
+                        .nth(1)
+                        .and_then(|num| num.parse::<u32>().ok())
+                        .map(|num| (num, s.name.clone()))
+                })
+            })
+        })
+        .collect();
+
+    // Group sub-issues by phase
+    let mut phase_issues: std::collections::HashMap<u32, Vec<&ExistingSubIssue>> =
+        std::collections::HashMap::new();
+    for sub in &recovery.sub_issues {
+        if let Some(phase) = sub.phase {
+            phase_issues.entry(phase).or_default().push(sub);
+        }
+    }
+
+    // Build tracked phases with sub-issue info
+    let tracked_phases: Vec<TrackedPhase> = recovery
+        .epic
+        .phases
+        .iter()
+        .enumerate()
+        .map(|(i, phase)| {
+            let phase_num = (i + 1) as u32;
+            let phase_subs = phase_issues
+                .get(&phase_num)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            // Use case-insensitive comparison since GitHub returns uppercase state
+            let completed = phase_subs
+                .iter()
+                .filter(|s| s.state.eq_ignore_ascii_case("closed"))
+                .count();
+
+            // Count open sub-issues
+            let open_subs: Vec<_> = phase_subs
+                .iter()
+                .filter(|s| s.state.eq_ignore_ascii_case("open"))
+                .collect();
+
+            // Check for active agents: either has_agent_working from labels OR has active session
+            // But NOT if the sub-issue already has a PR (agent work is done)
+            let has_active_agent = phase_subs.iter().any(|s| {
+                let is_open = s.state.eq_ignore_ascii_case("open");
+                let has_pr = s.pr_url.is_some();
+                let has_agent =
+                    s.has_agent_working || issue_to_session.contains_key(&s.issue_number);
+                // Only count as active if open, has agent, but no PR yet
+                is_open && has_agent && !has_pr
+            });
+
+            // Check if all open sub-issues have PRs (phase is "ready" for merge)
+            let all_open_have_prs =
+                !open_subs.is_empty() && open_subs.iter().all(|s| s.pr_url.is_some());
+
+            // Determine status:
+            // 1. If there are sub-issues, use their status
+            // 2. If no sub-issues, check the Epic body for status (handles manual completions)
+            let status = if !phase_subs.is_empty() {
+                if completed == phase_subs.len() {
+                    TrackedPhaseStatus::Completed
+                } else if all_open_have_prs {
+                    // All remaining open issues have PRs - phase is ready for merge
+                    TrackedPhaseStatus::Ready
+                } else if has_active_agent {
+                    TrackedPhaseStatus::InProgress
+                } else if open_subs.is_empty() && completed > 0 {
+                    // All sub-issues are closed
+                    TrackedPhaseStatus::Completed
+                } else if !open_subs.is_empty() {
+                    // Has open issues but no agent working - still in progress
+                    TrackedPhaseStatus::InProgress
+                } else {
+                    TrackedPhaseStatus::NotStarted
+                }
+            } else {
+                // No sub-issues - check Epic body for status
+                body_statuses
+                    .get(&phase_num)
+                    .cloned()
+                    .unwrap_or(TrackedPhaseStatus::NotStarted)
+            };
+
+            TrackedPhase {
+                phase_number: phase_num,
+                name: phase.name.clone(),
+                status,
+                sub_issues: phase_subs.iter().map(|s| s.issue_number).collect(),
+                completed_count: completed,
+                total_count: phase_subs.len(),
+            }
+        })
+        .collect();
+
+    // Convert sub-issues to tracked format, enriching with session info
+    let tracked_sub_issues: Vec<TrackedSubIssue> = recovery
+        .sub_issues
+        .iter()
+        .map(|s| {
+            let session_name = issue_to_session.get(&s.issue_number).cloned();
+            // Only mark as having agent if issue is open - closed issues don't need agents
+            let is_closed = s.state.eq_ignore_ascii_case("closed");
+            // If PR exists, agent work is done (even if session still exists)
+            let has_pr = s.pr_url.is_some();
+            let has_agent =
+                !is_closed && !has_pr && (s.has_agent_working || session_name.is_some());
+
+            TrackedSubIssue {
+                issue_number: s.issue_number,
+                title: s.title.clone(),
+                phase: s.phase,
+                state: s.state.to_lowercase(), // Normalize to lowercase for consistent comparison
+                agent_type: None,              // Will be filled when agent is assigned
+                session_name: if is_closed {
+                    None
+                } else {
+                    session_name.clone()
+                },
+                agent_session: if is_closed { None } else { session_name },
+                has_agent_working: has_agent,
+                url: s.url.clone(),
+                pr_url: s.pr_url.clone(),
+                pr_number: s.pr_number,
+            }
+        })
+        .collect();
+
+    // Preserve existing local_repo_path if we're re-loading the same epic
+    let existing_local_path = state
+        .active_epic
+        .as_ref()
+        .filter(|e| e.epic_number == recovery.epic.epic_number)
+        .and_then(|e| e.local_repo_path.clone());
+
+    let active = ActiveEpicState {
+        epic_number: recovery.epic.epic_number,
+        tracking_repo: recovery.epic.repo.clone(),
+        work_repo: recovery.epic.work_repo.clone(),
+        local_repo_path: existing_local_path,
+        title: recovery.epic.title.clone(),
+        url: recovery.epic.url.clone(),
+        phases: tracked_phases,
+        sub_issues: tracked_sub_issues,
+        linked_at: chrono::Utc::now().to_rfc3339(),
+        last_synced_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+
+    state.active_epic = Some(active.clone());
+    save_epic_state(app, &state);
+
+    active
+}
+
+/// Get the currently active Epic state.
+pub fn get_active_epic(app: &AppHandle) -> Option<ActiveEpicState> {
+    let state = load_epic_state(app);
+    state.active_epic
+}
+
+/// Update the local repository path for the active Epic.
+pub fn set_epic_local_repo_path(app: &AppHandle, local_repo_path: &str) -> Result<(), String> {
+    let mut state = load_epic_state(app);
+
+    if let Some(ref mut active) = state.active_epic {
+        active.local_repo_path = Some(local_repo_path.to_string());
+        save_epic_state(app, &state);
+        log::info!("Updated Epic local_repo_path to: {}", local_repo_path);
+        Ok(())
+    } else {
+        Err("No active Epic to update".to_string())
+    }
+}
+
+/// Clear the active Epic (move to history if completed).
+pub fn clear_active_epic(app: &AppHandle, archive: bool) -> Option<ActiveEpicState> {
+    let mut state = load_epic_state(app);
+
+    if let Some(active) = state.active_epic.take() {
+        if archive {
+            state.history.push(active.clone());
+            // Trim history
+            while state.history.len() > state.max_history {
+                state.history.remove(0);
+            }
+        }
+        save_epic_state(app, &state);
+        return Some(active);
+    }
+
+    None
+}
+
+/// Update a sub-issue's agent assignment in the active Epic.
+pub fn update_epic_sub_issue_agent(
+    app: &AppHandle,
+    issue_number: u32,
+    session_name: Option<&str>,
+    agent_type: Option<&str>,
+) -> Result<(), String> {
+    let mut state = load_epic_state(app);
+
+    if let Some(ref mut active) = state.active_epic {
+        if let Some(sub) = active
+            .sub_issues
+            .iter_mut()
+            .find(|s| s.issue_number == issue_number)
+        {
+            sub.session_name = session_name.map(|s| s.to_string());
+            sub.agent_session = session_name.map(|s| s.to_string()); // Also set agent_session for PR tracking
+            sub.agent_type = agent_type.map(|s| s.to_string());
+            sub.has_agent_working = session_name.is_some();
+            save_epic_state(app, &state);
+            return Ok(());
+        }
+    }
+
+    Err(format!(
+        "Sub-issue {} not found in active epic",
+        issue_number
+    ))
+}
+
+/// Sync the active Epic state with GitHub.
+///
+/// This preserves locally-tracked state (pr_url, agent_session, etc.) while
+/// updating GitHub-sourced state (issue state, labels, etc.).
+pub async fn sync_active_epic(app: &AppHandle) -> Result<Option<ActiveEpicState>, String> {
+    let state = load_epic_state(app);
+
+    if let Some(active) = &state.active_epic {
+        // Save local-only state before reload
+        let local_state: std::collections::HashMap<
+            u32,
+            (Option<String>, Option<u64>, Option<String>, Option<String>),
+        > = active
+            .sub_issues
+            .iter()
+            .map(|s| {
+                (
+                    s.issue_number,
+                    (
+                        s.pr_url.clone(),
+                        s.pr_number,
+                        s.agent_session.clone(),
+                        s.agent_type.clone(),
+                    ),
+                )
+            })
+            .collect();
+
+        // Reload from GitHub
+        let recovery = super::operations::epic::load_epic_for_recovery(
+            active.tracking_repo.clone(),
+            active.epic_number,
+        )
+        .await?;
+
+        // Update with fresh data (this recreates sub_issues)
+        let mut updated = set_active_epic_from_recovery(app, &recovery);
+
+        // Restore local-only state that GitHub doesn't know about
+        for sub_issue in &mut updated.sub_issues {
+            if let Some((pr_url, pr_number, agent_session, agent_type)) =
+                local_state.get(&sub_issue.issue_number)
+            {
+                // Preserve PR info
+                if sub_issue.pr_url.is_none() {
+                    sub_issue.pr_url = pr_url.clone();
+                }
+                if sub_issue.pr_number.is_none() {
+                    sub_issue.pr_number = *pr_number;
+                }
+                // Preserve agent session info
+                if sub_issue.agent_session.is_none() {
+                    sub_issue.agent_session = agent_session.clone();
+                }
+                if sub_issue.agent_type.is_none() {
+                    sub_issue.agent_type = agent_type.clone();
+                }
+            }
+        }
+
+        // Save the merged state
+        let mut final_state = load_epic_state(app);
+        final_state.active_epic = Some(updated.clone());
+        save_epic_state(app, &final_state);
+
+        Ok(Some(updated))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Handle pipeline item completion and update Epic if applicable.
+///
+/// This should be called when a pipeline item transitions to Completed/Failed/Skipped.
+/// It will:
+/// 1. Update the Epic's sub-issue tracking
+/// 2. Update phase status if all sub-issues in a phase are complete
+/// 3. Optionally update the Epic issue on GitHub
+pub async fn on_pipeline_item_complete(
+    app: &AppHandle,
+    issue_number: u32,
+    update_github: bool,
+) -> Result<(), String> {
+    let state = load_epic_state(app);
+
+    if let Some(active) = &state.active_epic {
+        // Check if this issue belongs to the active Epic
+        let belongs_to_epic = active
+            .sub_issues
+            .iter()
+            .any(|s| s.issue_number == issue_number);
+
+        if belongs_to_epic {
+            log::info!(
+                "Pipeline item #{} completed, belongs to Epic #{}",
+                issue_number,
+                active.epic_number
+            );
+
+            // Sync Epic state with GitHub to get latest status
+            let updated = sync_active_epic(app).await?;
+
+            // Optionally update the Epic issue on GitHub with new phase status
+            if update_github {
+                if let Some(updated_state) = updated {
+                    // Build phase statuses from the updated state
+                    let phase_statuses: Vec<super::operations::PhaseStatus> = updated_state
+                        .phases
+                        .iter()
+                        .map(|p| super::operations::PhaseStatus {
+                            phase_number: p.phase_number,
+                            phase_name: p.name.clone(),
+                            approach: match p.status {
+                                TrackedPhaseStatus::Completed => "manual".to_string(),
+                                _ => "agent-assisted".to_string(),
+                            },
+                            total_issues: p.total_count as u32,
+                            completed_issues: p.completed_count as u32,
+                            in_progress_issues: 0, // Would need to calculate from sub_issues
+                            status: match p.status {
+                                TrackedPhaseStatus::Completed => "completed".to_string(),
+                                TrackedPhaseStatus::Ready => "ready".to_string(),
+                                TrackedPhaseStatus::InProgress => "in_progress".to_string(),
+                                TrackedPhaseStatus::NotStarted => "not_started".to_string(),
+                                TrackedPhaseStatus::Skipped => "skipped".to_string(),
+                            },
+                        })
+                        .collect();
+
+                    // Update Epic issue on GitHub
+                    super::operations::update_epic_phase_status_on_github(
+                        &updated_state.tracking_repo,
+                        updated_state.epic_number,
+                        &phase_statuses,
+                    )
+                    .await?;
+
+                    log::info!(
+                        "Updated Epic #{} on GitHub with phase status",
+                        updated_state.epic_number
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check all active agent sessions for PR creation
+///
+/// This function:
+/// 1. Gets all active tmux sessions (agents working on issues)
+/// 2. For each session, checks if a PR exists for its branch
+/// 3. Compares with previously detected PRs to identify new ones
+/// 4. Returns list of detection results with is_new flag set appropriately
+///
+/// Used by the Epic monitor to detect when agents have completed work
+/// by creating PRs, enabling automatic Epic progress updates.
+pub async fn check_sessions_for_prs(app: &AppHandle) -> Result<Vec<PrDetectionResult>, String> {
+    // Get all active sessions
+    let sessions = tokio::task::spawn_blocking(tmux::list_sessions)
+        .await
+        .map_err(|e| format!("Task join error: {}", e))?
+        .map_err(|e| format!("Failed to list sessions: {}", e))?;
+
+    // Filter to only agent sessions (those with issue_ref metadata)
+    let agent_sessions: Vec<_> = sessions
+        .into_iter()
+        .filter(|s| {
+            s.metadata
+                .as_ref()
+                .map(|m| m.issue_ref.is_some())
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if agent_sessions.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // Load previously detected PRs from state (track by issue number, not session)
+    let state = load_epic_state(app);
+    let known_pr_issues: std::collections::HashSet<u32> = state
+        .active_epic
+        .as_ref()
+        .map(|e| {
+            e.sub_issues
+                .iter()
+                .filter(|s| s.pr_url.is_some())
+                .map(|s| s.issue_number)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut results = Vec::new();
+
+    // Check each session for PRs
+    for session in agent_sessions {
+        match detect_pr_for_agent(&session.name).await {
+            Ok(Some(mut result)) => {
+                // Check if this is a newly detected PR (by issue number)
+                if result.pr_url.is_some() {
+                    result.is_new = !known_pr_issues.contains(&result.issue_number);
+
+                    // If new PR detected, update Epic state and emit event
+                    if result.is_new {
+                        if let Some(pr_url) = &result.pr_url {
+                            // Update the sub-issue in Epic state with PR info
+                            update_sub_issue_pr_url(
+                                app,
+                                result.issue_number,
+                                pr_url,
+                                result.pr_number,
+                            );
+
+                            log::info!(
+                                "New PR detected for session {}: {} (issue #{})",
+                                session.name,
+                                pr_url,
+                                result.issue_number
+                            );
+
+                            // Emit event for real-time UI updates
+                            let _ = app.emit(
+                                "agent-pr-created",
+                                serde_json::json!({
+                                    "session": session.name,
+                                    "issue_number": result.issue_number,
+                                    "pr_url": pr_url,
+                                    "pr_number": result.pr_number,
+                                    "repo": result.repo,
+                                }),
+                            );
+                        }
+                    }
+                }
+                results.push(result);
+            }
+            Ok(None) => {
+                // Session exists but no PR info (shouldn't happen with current impl)
+            }
+            Err(e) => {
+                log::warn!("Failed to detect PR for session {}: {}", session.name, e);
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Update a sub-issue's PR URL in the Epic state
+fn update_sub_issue_pr_url(
+    app: &AppHandle,
+    issue_number: u32,
+    pr_url: &str,
+    pr_number: Option<u64>,
+) {
+    let mut state = load_epic_state(app);
+
+    if let Some(ref mut active) = state.active_epic {
+        // Find and update the sub-issue
+        for sub_issue in &mut active.sub_issues {
+            if sub_issue.issue_number == issue_number {
+                sub_issue.pr_url = Some(pr_url.to_string());
+                sub_issue.pr_number = pr_number;
+                log::info!(
+                    "Updated sub-issue #{} with PR URL: {}",
+                    issue_number,
+                    pr_url
+                );
+                break;
+            }
+        }
+
+        save_epic_state(app, &state);
+    }
+}
+
+// ============================================================================
+// PR Merge Commands for Ready State
+// ============================================================================
+
+/// Result of merging a single PR
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct MergeResult {
+    /// Issue number that was merged
+    pub issue_number: u32,
+    /// PR number that was merged
+    pub pr_number: u64,
+    /// PR URL
+    pub pr_url: String,
+    /// Whether the support worker was spawned successfully
+    pub success: bool,
+    /// Error message if spawn failed
+    pub error: Option<String>,
+    /// Phase this issue belongs to
+    pub phase: Option<u32>,
+    /// Support worker session name (for tracking)
+    pub support_worker_session: Option<String>,
+    /// Whether this phase is now complete (all issues closed)
+    /// Note: This is only accurate after the merge completes
+    pub phase_complete: bool,
+    /// Next phase number if phase is complete and there's more work
+    pub next_phase: Option<u32>,
+}
+
+/// Result of processing all ready PRs
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ProcessReadyResult {
+    /// Individual merge results
+    pub merges: Vec<MergeResult>,
+    /// Phases that are now complete
+    pub completed_phases: Vec<u32>,
+    /// Next phase to work on (if any)
+    pub next_phase: Option<u32>,
+    /// Whether agents were auto-started for next phase
+    pub agents_started: bool,
+}
+
+/// Merge a PR for a sub-issue that's in "Ready" state
+///
+/// This spawns a Support Worker agent to handle the merge process.
+/// The support worker will:
+/// 1. View the PR details
+/// 2. Check PR status and CI results
+/// 3. Merge the PR using the specified method
+/// 4. Delete the branch if requested
+///
+/// When sandbox mode is enabled, the support worker runs inside a Docker container
+/// with the worktree mounted, allowing it to resolve merge conflicts locally.
+pub async fn merge_ready_pr(
+    app: &AppHandle,
+    issue_number: u32,
+    merge_method: Option<&str>,
+    delete_branch: bool,
+) -> Result<MergeResult, String> {
+    let state = load_epic_state(app);
+    let settings = crate::settings::get_settings(app);
+
+    let active = state.active_epic.as_ref().ok_or("No active Epic")?;
+
+    // Find the sub-issue
+    let sub_issue = active
+        .sub_issues
+        .iter()
+        .find(|s| s.issue_number == issue_number)
+        .ok_or_else(|| format!("Sub-issue #{} not found in active Epic", issue_number))?;
+
+    // Check it has a PR
+    let pr_url = sub_issue
+        .pr_url
+        .as_ref()
+        .ok_or_else(|| format!("Sub-issue #{} has no PR to merge", issue_number))?;
+
+    let pr_number = sub_issue
+        .pr_number
+        .ok_or_else(|| format!("Sub-issue #{} has no PR number", issue_number))?;
+
+    let phase = sub_issue.phase;
+    let work_repo = active.work_repo.clone();
+
+    // Get worktree path for sandboxed execution
+    // Try to get it from the agent session metadata, or construct it from the Epic's local repo path
+    let worktree_path = if settings.sandbox_enabled {
+        // First try to get from tmux session metadata
+        let session_worktree = if let Some(session_name) = &sub_issue.agent_session {
+            tokio::task::spawn_blocking({
+                let session_name = session_name.clone();
+                move || {
+                    tmux::get_session_metadata(&session_name)
+                        .ok()
+                        .and_then(|m| m.worktree)
+                }
+            })
+            .await
+            .ok()
+            .flatten()
+        } else {
+            None
+        };
+
+        // If no session worktree, try to construct from Epic's local repo path
+        session_worktree.or_else(|| {
+            active.local_repo_path.as_ref().map(|repo_path| {
+                // Worktrees are typically at <repo>/../handy-worktrees/issue-<number>
+                let base = std::path::Path::new(repo_path)
+                    .parent()
+                    .unwrap_or(std::path::Path::new(repo_path));
+                base.join("handy-worktrees")
+                    .join(format!("issue-{}", issue_number))
+                    .to_string_lossy()
+                    .to_string()
+            })
+        })
+    } else {
+        None
+    };
+
+    log::info!(
+        "Spawning support worker to merge PR #{} for issue #{} (sandbox: {}, worktree: {:?})",
+        pr_number,
+        issue_number,
+        settings.sandbox_enabled,
+        worktree_path
+    );
+
+    // Spawn a support worker to handle the merge
+    let support_config = SupportWorkerConfig {
+        repo: work_repo.clone(),
+        issue_number,
+        pr_number: Some(pr_number),
+        task: format!("Merge PR #{} for issue #{}", pr_number, issue_number),
+        task_type: "merge".to_string(),
+        merge_method: merge_method.map(|s| s.to_string()),
+        delete_branch,
+        sandboxed: settings.sandbox_enabled && worktree_path.is_some(),
+        worktree_path,
+    };
+
+    match spawn_support_worker(support_config).await {
+        Ok(result) => {
+            log::info!(
+                "Support worker spawned: {} for PR #{}",
+                result.session,
+                pr_number
+            );
+
+            // Emit event so frontend can track the merge
+            let _ = app.emit(
+                "support-worker-spawned",
+                serde_json::json!({
+                    "session": result.session,
+                    "issue_number": issue_number,
+                    "pr_number": pr_number,
+                    "task_type": "merge",
+                }),
+            );
+
+            // Note: Phase completion will be detected on next sync after merge completes
+            // For now, return success with the session info
+            Ok(MergeResult {
+                issue_number,
+                pr_number,
+                pr_url: pr_url.clone(),
+                success: true,
+                error: None,
+                phase,
+                support_worker_session: Some(result.session),
+                phase_complete: false, // Will be updated on next sync
+                next_phase: None,
+            })
+        }
+        Err(e) => {
+            log::error!(
+                "Failed to spawn support worker for PR #{}: {}",
+                pr_number,
+                e
+            );
+            Ok(MergeResult {
+                issue_number,
+                pr_number,
+                pr_url: pr_url.clone(),
+                success: false,
+                error: Some(e),
+                phase,
+                support_worker_session: None,
+                phase_complete: false,
+                next_phase: None,
+            })
+        }
+    }
+}
+
+/// Process all "Ready" sub-issues for the active Epic
+pub async fn process_ready_prs(
+    app: &AppHandle,
+    merge_method: Option<&str>,
+    delete_branch: bool,
+    auto_start_next_phase: bool,
+) -> Result<ProcessReadyResult, String> {
+    // First sync to ensure we have latest state
+    sync_active_epic(app).await?;
+
+    let state = load_epic_state(app);
+    let active = state.active_epic.as_ref().ok_or("No active Epic")?;
+
+    // Find all sub-issues in "Ready" state (open with PR)
+    let ready_issues: Vec<u32> = active
+        .sub_issues
+        .iter()
+        .filter(|s| s.state.eq_ignore_ascii_case("open") && s.pr_url.is_some())
+        .map(|s| s.issue_number)
+        .collect();
+
+    log::info!("Found {} ready PRs to process", ready_issues.len());
+
+    let mut merges = Vec::new();
+    let mut completed_phases = Vec::new();
+
+    for issue_number in ready_issues {
+        let result = merge_ready_pr(app, issue_number, merge_method, delete_branch).await?;
+
+        if result.success && result.phase_complete {
+            if let Some(phase) = result.phase {
+                if !completed_phases.contains(&phase) {
+                    completed_phases.push(phase);
+                }
+            }
+        }
+
+        merges.push(result);
+    }
+
+    // Find next phase to work on
+    let state = load_epic_state(app);
+    let next_phase = if let Some(active) = &state.active_epic {
+        active
+            .phases
+            .iter()
+            .find(|ph| ph.status == TrackedPhaseStatus::NotStarted)
+            .map(|ph| ph.phase_number)
+    } else {
+        None
+    };
+
+    // Optionally auto-start agents for next phase
+    let agents_started = if auto_start_next_phase && next_phase.is_some() {
+        log::info!("Auto-starting agents for phase {:?}", next_phase);
+        // TODO: Implement auto-start logic - spawn agents for queued issues in next phase
+        false // Not implemented yet
+    } else {
+        false
+    };
+
+    Ok(ProcessReadyResult {
+        merges,
+        completed_phases,
+        next_phase,
+        agents_started,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_issue_config_defaults() {
+        let config = SkipIssueConfig {
+            repo: "test/repo".to_string(),
+            issue_number: 123,
+            reason: None,
+            add_labels: vec![],
+            remove_labels: vec![],
+        };
+
+        assert!(config.add_labels.is_empty());
+        assert!(config.remove_labels.is_empty());
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/orchestrator.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/orchestrator.rs
@@ -1,0 +1,740 @@
+//! Agent orchestration for multi-agent workflows.
+//!
+//! This module coordinates the spawning and management of coding agents,
+//! tying together issues, worktrees, and tmux sessions.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::docker;
+use super::github::{self, GitHubIssue, IssueAgentMetadata};
+use super::tmux::{self, AgentMetadata, PortMapping, SandboxedAgentConfig};
+use super::worktree::{self, WorktreeConfig, WorktreeCreateResult};
+use std::path::Path;
+
+/// Configuration for spawning an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SpawnConfig {
+    /// Repository in owner/repo format
+    pub repo: String,
+    /// Issue number to work on
+    pub issue_number: u64,
+    /// Agent type (e.g., "claude", "gpt", "codex")
+    pub agent_type: String,
+    /// Optional custom session name (auto-generated if not provided)
+    pub session_name: Option<String>,
+    /// Optional worktree prefix
+    pub worktree_prefix: Option<String>,
+    /// Labels to add when agent starts working
+    pub working_labels: Vec<String>,
+    /// Whether to run in Docker sandbox (if available)
+    #[serde(default)]
+    pub use_sandbox: bool,
+    /// Optional manual port mappings (host:container format, e.g., ["3000:3000", "8080:80"])
+    /// If not specified, ports are auto-detected from project files
+    #[serde(default)]
+    pub sandbox_ports: Vec<String>,
+}
+
+/// Result of spawning an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SpawnResult {
+    /// The issue being worked on
+    pub issue: GitHubIssue,
+    /// The created worktree
+    pub worktree: WorktreeCreateResult,
+    /// The tmux session name (or container name if sandboxed)
+    pub session_name: String,
+    /// Machine ID where agent is running
+    pub machine_id: String,
+    /// Whether agent is running in Docker sandbox
+    #[serde(default)]
+    pub is_sandboxed: bool,
+    /// Container ID if sandboxed
+    pub container_id: Option<String>,
+}
+
+/// Status of an active agent.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AgentStatus {
+    /// Session name
+    pub session: String,
+    /// Issue reference (owner/repo#number)
+    pub issue_ref: Option<String>,
+    /// Repository
+    pub repo: Option<String>,
+    /// Issue number
+    pub issue_number: Option<u64>,
+    /// Worktree path
+    pub worktree: Option<String>,
+    /// Agent type
+    pub agent_type: String,
+    /// Machine ID
+    pub machine_id: String,
+    /// Started timestamp
+    pub started_at: String,
+    /// Whether session is attached
+    pub is_attached: bool,
+    /// Whether this agent is on the current machine
+    pub is_local: bool,
+}
+
+/// Result of completing agent work.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct CompleteWorkResult {
+    /// The created pull request
+    pub pull_request: github::GitHubPullRequest,
+    /// Whether the issue was updated with PR link
+    pub issue_updated: bool,
+    /// Whether working labels were removed
+    pub labels_updated: bool,
+}
+
+/// Configuration for workflow automation.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct WorkflowConfig {
+    /// Labels to remove when work is complete
+    pub working_labels: Vec<String>,
+    /// Labels to add when PR is created
+    pub pr_labels: Vec<String>,
+    /// Whether to create PR as draft
+    pub draft_pr: bool,
+    /// Whether to auto-close issue when PR merges
+    pub close_on_merge: bool,
+}
+
+/// Get the current machine's identifier.
+pub fn get_current_machine_id() -> String {
+    hostname::get()
+        .map(|h| h.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Common development ports by project type
+const COMMON_PORTS: &[(u16, &str)] = &[
+    (3000, "React/Next.js/Node.js"),
+    (3001, "React dev server alternate"),
+    (4200, "Angular"),
+    (5000, "Flask/Python"),
+    (5173, "Vite"),
+    (5174, "Vite HMR"),
+    (8000, "Django/FastAPI"),
+    (8080, "Generic web server"),
+    (8081, "Metro bundler (React Native)"),
+    (9000, "PHP-FPM"),
+    (19000, "Expo"),
+    (19001, "Expo DevTools"),
+    (24678, "Vite HMR WebSocket"),
+];
+
+/// Parse port mapping strings into PortMapping structs.
+///
+/// Accepts formats:
+/// - "3000" - same port on host and container
+/// - "3000:3000" - explicit host:container
+/// - "8080:80" - different host and container ports
+/// - "3000:3000/udp" - with protocol
+fn parse_port_mappings(port_strings: &[String]) -> Vec<PortMapping> {
+    let mut ports = Vec::new();
+
+    for port_str in port_strings {
+        let port_str = port_str.trim();
+        if port_str.is_empty() {
+            continue;
+        }
+
+        // Check for protocol suffix
+        let (port_part, protocol) = if port_str.contains('/') {
+            let parts: Vec<&str> = port_str.splitn(2, '/').collect();
+            (parts[0], Some(parts.get(1).unwrap_or(&"tcp").to_string()))
+        } else {
+            (port_str, None)
+        };
+
+        // Parse host:container or just port
+        if port_part.contains(':') {
+            let parts: Vec<&str> = port_part.splitn(2, ':').collect();
+            if let (Ok(host), Ok(container)) = (parts[0].parse::<u16>(), parts[1].parse::<u16>()) {
+                ports.push(PortMapping {
+                    host_port: host,
+                    container_port: container,
+                    protocol,
+                });
+            }
+        } else if let Ok(port) = port_part.parse::<u16>() {
+            ports.push(PortMapping {
+                host_port: port,
+                container_port: port,
+                protocol,
+            });
+        }
+    }
+
+    ports
+}
+
+/// Detect common development ports based on project files.
+///
+/// This examines the worktree for common configuration files and
+/// returns appropriate port mappings for the detected project type.
+fn detect_project_ports(worktree_path: &str) -> Vec<PortMapping> {
+    let path = Path::new(worktree_path);
+    let mut ports = Vec::new();
+
+    // Check for package.json (Node.js projects)
+    let package_json = path.join("package.json");
+    if package_json.exists() {
+        if let Ok(content) = std::fs::read_to_string(&package_json) {
+            // Next.js / React
+            if content.contains("\"next\"") {
+                ports.push(PortMapping::new(3000));
+            }
+            // Vite
+            if content.contains("\"vite\"") {
+                ports.push(PortMapping::new(5173));
+                ports.push(PortMapping::new(5174)); // HMR
+                ports.push(PortMapping::new(24678)); // WebSocket
+            }
+            // Create React App
+            if content.contains("\"react-scripts\"") {
+                ports.push(PortMapping::new(3000));
+            }
+            // Angular
+            if content.contains("\"@angular/core\"") {
+                ports.push(PortMapping::new(4200));
+            }
+            // Expo (React Native)
+            if content.contains("\"expo\"") {
+                ports.push(PortMapping::new(19000));
+                ports.push(PortMapping::new(19001));
+                ports.push(PortMapping::new(8081)); // Metro
+            }
+            // Generic Node.js server
+            if ports.is_empty()
+                && (content.contains("\"express\"")
+                    || content.contains("\"fastify\"")
+                    || content.contains("\"koa\""))
+            {
+                ports.push(PortMapping::new(3000));
+            }
+        }
+    }
+
+    // Check for Python projects
+    let pyproject = path.join("pyproject.toml");
+    let requirements = path.join("requirements.txt");
+    let manage_py = path.join("manage.py");
+
+    if manage_py.exists() {
+        // Django
+        ports.push(PortMapping::new(8000));
+    } else if pyproject.exists() || requirements.exists() {
+        // Check for FastAPI or Flask
+        let check_files = [pyproject, requirements];
+        for file in &check_files {
+            if file.exists() {
+                if let Ok(content) = std::fs::read_to_string(file) {
+                    if content.contains("fastapi") || content.contains("uvicorn") {
+                        ports.push(PortMapping::new(8000));
+                        break;
+                    }
+                    if content.contains("flask") {
+                        ports.push(PortMapping::new(5000));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Check for Go projects
+    let go_mod = path.join("go.mod");
+    if go_mod.exists() {
+        // Go web servers commonly use 8080
+        ports.push(PortMapping::new(8080));
+    }
+
+    // Check for Rust projects with Tauri
+    let cargo_toml = path.join("Cargo.toml");
+    if cargo_toml.exists() {
+        if let Ok(content) = std::fs::read_to_string(&cargo_toml) {
+            if content.contains("tauri") {
+                // Tauri typically uses Vite or another bundler
+                ports.push(PortMapping::new(1420)); // Tauri dev server
+                ports.push(PortMapping::new(5173)); // Vite
+            }
+            // Actix/Axum/Rocket web frameworks
+            if content.contains("actix") || content.contains("axum") || content.contains("rocket") {
+                ports.push(PortMapping::new(8080));
+            }
+        }
+    }
+
+    // Check for docker-compose.yml for additional ports
+    let docker_compose = path.join("docker-compose.yml");
+    let docker_compose_yaml = path.join("docker-compose.yaml");
+    for compose_file in &[docker_compose, docker_compose_yaml] {
+        if compose_file.exists() {
+            if let Ok(content) = std::fs::read_to_string(compose_file) {
+                // Simple regex-free port extraction (looks for "ports:" sections)
+                // Format: - "3000:3000" or - 3000:3000
+                for line in content.lines() {
+                    let trimmed = line.trim().trim_start_matches('-').trim();
+                    if trimmed.starts_with('"')
+                        || trimmed.chars().next().map_or(false, |c| c.is_ascii_digit())
+                    {
+                        let port_str = trimmed.trim_matches('"');
+                        if let Some((host, _container)) = port_str.split_once(':') {
+                            if let Ok(port) = host.parse::<u16>() {
+                                // Don't duplicate
+                                if !ports.iter().any(|p| p.host_port == port) {
+                                    ports.push(PortMapping::new(port));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Deduplicate
+    let mut seen = std::collections::HashSet::new();
+    ports.retain(|p| seen.insert(p.host_port));
+
+    log::info!(
+        "Detected {} ports for project at {}: {:?}",
+        ports.len(),
+        worktree_path,
+        ports.iter().map(|p| p.host_port).collect::<Vec<_>>()
+    );
+
+    ports
+}
+
+/// Spawn a new agent to work on an issue.
+///
+/// This creates a worktree and a tmux session. If sandbox mode is enabled
+/// and Docker is available, the agent runs inside a Docker container
+/// within the tmux session (allowing attach/detach and visibility).
+pub fn spawn_agent(config: &SpawnConfig, repo_path: &str) -> Result<SpawnResult, String> {
+    // 1. Fetch the issue to ensure it exists
+    let issue = github::get_issue(&config.repo, config.issue_number)?;
+
+    // 2. Generate session name if not provided
+    let session_name = config.session_name.clone().unwrap_or_else(|| {
+        format!(
+            "handy-issue-{}-{}",
+            config.issue_number,
+            chrono::Utc::now().timestamp()
+        )
+    });
+
+    // 3. Create worktree for isolated work
+    let worktree_name = format!("issue-{}", config.issue_number);
+    let worktree_config = WorktreeConfig {
+        prefix: config.worktree_prefix.clone().unwrap_or_default(),
+        base_path: None,
+        delete_branch_on_merge: true,
+    };
+    let worktree = worktree::create_worktree(repo_path, &worktree_name, &worktree_config, None)?;
+
+    // 4. Get machine ID
+    let machine_id = hostname::get()
+        .map(|h| h.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    // 5. Create tmux session (always - for both sandboxed and non-sandboxed)
+    let metadata = AgentMetadata {
+        session: session_name.clone(),
+        issue_ref: Some(format!("{}#{}", config.repo, config.issue_number)),
+        repo: Some(config.repo.clone()),
+        worktree: Some(worktree.path.clone()),
+        agent_type: config.agent_type.clone(),
+        machine_id: machine_id.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    tmux::create_session(&session_name, Some(&worktree.path), &metadata)?;
+
+    // 6. Start agent in the tmux session (sandboxed or direct)
+    let is_sandboxed = config.use_sandbox && docker::is_docker_available();
+
+    if is_sandboxed {
+        // Sandbox mode: run agent inside Docker container within tmux
+        // Use manual ports if provided, otherwise auto-detect from project files
+        let ports = if !config.sandbox_ports.is_empty() {
+            parse_port_mappings(&config.sandbox_ports)
+        } else {
+            detect_project_ports(&worktree.path)
+        };
+
+        let sandbox_config = SandboxedAgentConfig {
+            worktree_path: worktree.path.clone(),
+            memory_limit: Some("4g".to_string()),
+            cpu_limit: Some("2".to_string()),
+            auto_accept: true, // Safe in sandbox
+            ports,
+            auto_detect_ports: config.sandbox_ports.is_empty(),
+            use_agent_network: true, // Enable inter-container communication
+            remap_ports: true,       // Avoid port conflicts between agents
+        };
+
+        tmux::start_sandboxed_agent_in_session(
+            &session_name,
+            &config.agent_type,
+            &config.repo,
+            config.issue_number,
+            Some(&issue.title),
+            &sandbox_config,
+        )?;
+    } else {
+        // Direct mode: run agent directly in tmux
+        tmux::start_agent_in_session(
+            &session_name,
+            &config.agent_type,
+            &config.repo,
+            config.issue_number,
+            Some(&issue.title),
+        )?;
+    }
+
+    // 7. Add agent metadata comment to the issue
+    let issue_metadata = IssueAgentMetadata {
+        session: session_name.clone(),
+        machine_id: machine_id.clone(),
+        worktree: Some(worktree.path.clone()),
+        agent_type: config.agent_type.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+        status: if is_sandboxed {
+            "working (sandboxed)".to_string()
+        } else {
+            "working".to_string()
+        },
+    };
+    github::add_agent_metadata_comment(&config.repo, config.issue_number, &issue_metadata)?;
+
+    // 8. Add working labels to the issue
+    if !config.working_labels.is_empty() {
+        let labels_refs: Vec<&str> = config.working_labels.iter().map(|s| s.as_str()).collect();
+        github::update_labels(&config.repo, config.issue_number, labels_refs, vec![])?;
+    }
+
+    Ok(SpawnResult {
+        issue,
+        worktree,
+        session_name,
+        machine_id,
+        is_sandboxed,
+        container_id: None, // Container is managed by tmux session now
+    })
+}
+
+/// Get status of all active agents.
+pub fn list_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    // list_sessions() returns error if tmux isn't running, treat as empty list
+    let sessions = tmux::list_sessions().unwrap_or_else(|_| vec![]);
+    let current_machine = get_current_machine_id();
+    let mut statuses = Vec::new();
+
+    for session in sessions {
+        // Try to get metadata for each session
+        let metadata = tmux::get_session_metadata(&session.name).ok();
+
+        let agent_machine_id = metadata
+            .as_ref()
+            .map(|m| m.machine_id.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let status = AgentStatus {
+            session: session.name.clone(),
+            issue_ref: metadata.as_ref().and_then(|m| m.issue_ref.clone()),
+            repo: metadata.as_ref().and_then(|m| m.repo.clone()),
+            issue_number: metadata.as_ref().and_then(|m| {
+                m.issue_ref
+                    .as_ref()
+                    .and_then(|r| r.split('#').last().and_then(|n| n.parse().ok()))
+            }),
+            worktree: metadata.as_ref().and_then(|m| m.worktree.clone()),
+            agent_type: metadata
+                .as_ref()
+                .map(|m| m.agent_type.clone())
+                .unwrap_or_else(|| "unknown".to_string()),
+            machine_id: agent_machine_id.clone(),
+            started_at: metadata
+                .as_ref()
+                .map(|m| m.started_at.clone())
+                .unwrap_or_else(|| "unknown".to_string()),
+            is_attached: session.attached,
+            is_local: agent_machine_id == current_machine,
+        };
+
+        statuses.push(status);
+    }
+
+    Ok(statuses)
+}
+
+/// Get status of agents on the current machine only.
+pub fn list_local_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    let all_statuses = list_agent_statuses()?;
+    Ok(all_statuses.into_iter().filter(|s| s.is_local).collect())
+}
+
+/// Get status of agents from other machines (potentially orphaned).
+pub fn list_remote_agent_statuses() -> Result<Vec<AgentStatus>, String> {
+    let all_statuses = list_agent_statuses()?;
+    Ok(all_statuses.into_iter().filter(|s| !s.is_local).collect())
+}
+
+/// Clean up an agent's resources after work is complete.
+///
+/// This kills the tmux session and optionally removes the worktree.
+pub fn cleanup_agent(
+    session_name: &str,
+    repo_path: &str,
+    remove_worktree: bool,
+    delete_branch: bool,
+) -> Result<(), String> {
+    // Get session metadata to find the worktree
+    let metadata = tmux::get_session_metadata(session_name).ok();
+
+    // Kill the tmux session
+    tmux::kill_session(session_name)?;
+
+    // Remove worktree if requested
+    if remove_worktree {
+        if let Some(ref meta) = metadata {
+            if let Some(ref worktree_path) = meta.worktree {
+                worktree::remove_worktree(repo_path, worktree_path, true, delete_branch)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Create a PR from an agent's work.
+pub fn create_pr_from_agent(
+    session_name: &str,
+    title: &str,
+    body: Option<&str>,
+    draft: bool,
+) -> Result<github::GitHubPullRequest, String> {
+    // Get session metadata
+    let metadata = tmux::get_session_metadata(session_name)?;
+
+    let repo = metadata
+        .repo
+        .ok_or("Session has no associated repository")?;
+    let worktree_path = metadata
+        .worktree
+        .ok_or("Session has no associated worktree")?;
+
+    // Get worktree info to find the branch
+    let worktree_info = worktree::get_worktree_info(&worktree_path, &worktree_path)?;
+    let branch = worktree_info.branch.ok_or("Worktree has no branch")?;
+
+    // Get default branch for base
+    let default_branch = worktree::get_default_branch(&worktree_path)?;
+
+    // Create PR
+    github::create_pr(&repo, title, body, &default_branch, Some(&branch), draft)
+}
+
+/// Complete an agent's work by creating a PR and updating the issue.
+///
+/// This is the main workflow automation function that:
+/// 1. Creates a PR from the agent's branch
+/// 2. Updates the issue with a link to the PR
+/// 3. Updates labels (removes working labels, adds PR labels)
+/// 4. Adds a completion comment to the issue
+pub fn complete_agent_work(
+    session_name: &str,
+    pr_title: &str,
+    pr_body: Option<&str>,
+    workflow_config: &WorkflowConfig,
+) -> Result<CompleteWorkResult, String> {
+    // Get session metadata
+    let metadata = tmux::get_session_metadata(session_name)?;
+
+    let repo = metadata
+        .repo
+        .clone()
+        .ok_or("Session has no associated repository")?;
+    let worktree_path = metadata
+        .worktree
+        .clone()
+        .ok_or("Session has no associated worktree")?;
+    let issue_ref = metadata.issue_ref.clone();
+
+    // Extract issue number from issue_ref (format: owner/repo#number)
+    let issue_number = issue_ref
+        .as_ref()
+        .and_then(|r| r.split('#').last())
+        .and_then(|n| n.parse::<u64>().ok());
+
+    // Get worktree info to find the branch
+    let worktree_info = worktree::get_worktree_info(&worktree_path, &worktree_path)?;
+    let branch = worktree_info.branch.ok_or("Worktree has no branch")?;
+
+    // Get default branch for base
+    let default_branch = worktree::get_default_branch(&worktree_path)?;
+
+    // Build PR body with issue reference if available
+    let full_pr_body = if let Some(num) = issue_number {
+        let issue_link = format!("\n\nCloses #{}", num);
+        match pr_body {
+            Some(body) => format!("{}{}", body, issue_link),
+            None => format!("Automated PR for issue #{}{}", num, issue_link),
+        }
+    } else {
+        pr_body.map(|s| s.to_string()).unwrap_or_default()
+    };
+
+    // 1. Create PR
+    let pull_request = github::create_pr(
+        &repo,
+        pr_title,
+        Some(&full_pr_body),
+        &default_branch,
+        Some(&branch),
+        workflow_config.draft_pr,
+    )?;
+
+    let mut issue_updated = false;
+    let mut labels_updated = false;
+
+    // 2. Update issue with PR link and labels
+    if let Some(num) = issue_number {
+        // Add comment linking to the PR
+        let comment = format!(
+            "🤖 **Agent Work Complete**\n\n\
+            Pull request created: #{}\n\n\
+            **Session:** `{}`\n\
+            **Machine:** `{}`\n\
+            **Branch:** `{}`",
+            pull_request.number, session_name, metadata.machine_id, branch
+        );
+        if github::add_comment(&repo, num, &comment).is_ok() {
+            issue_updated = true;
+        }
+
+        // Update labels
+        let add_labels: Vec<&str> = workflow_config
+            .pr_labels
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let remove_labels: Vec<&str> = workflow_config
+            .working_labels
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+
+        if !add_labels.is_empty() || !remove_labels.is_empty() {
+            if github::update_labels(&repo, num, add_labels, remove_labels).is_ok() {
+                labels_updated = true;
+            }
+        }
+    }
+
+    Ok(CompleteWorkResult {
+        pull_request,
+        issue_updated,
+        labels_updated,
+    })
+}
+
+/// Check if a PR has been merged and cleanup if so.
+///
+/// Returns true if cleanup was performed.
+pub fn check_and_cleanup_merged_pr(
+    session_name: &str,
+    repo_path: &str,
+    pr_number: u64,
+) -> Result<bool, String> {
+    // Get session metadata
+    let metadata = tmux::get_session_metadata(session_name)?;
+    let repo = metadata
+        .repo
+        .clone()
+        .ok_or("Session has no associated repository")?;
+
+    // Check PR status
+    let pr_status = github::get_pr_status(&repo, pr_number)?;
+
+    // Check if PR state indicates it was merged
+    if pr_status.pr.state == "merged" {
+        // PR is merged, cleanup the agent
+        cleanup_agent(session_name, repo_path, true, true)?;
+
+        // Update issue if linked
+        if let Some(issue_ref) = &metadata.issue_ref {
+            if let Some(issue_num) = issue_ref
+                .split('#')
+                .last()
+                .and_then(|n| n.parse::<u64>().ok())
+            {
+                let comment = format!(
+                    "✅ **PR Merged & Cleanup Complete**\n\n\
+                    The pull request #{} has been merged.\n\
+                    Agent session `{}` and worktree have been cleaned up.",
+                    pr_number, session_name
+                );
+                let _ = github::add_comment(&repo, issue_num, &comment);
+            }
+        }
+
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spawn_config_default_session_name() {
+        let config = SpawnConfig {
+            repo: "KBVE/kbve".to_string(),
+            issue_number: 123,
+            agent_type: "claude".to_string(),
+            session_name: None,
+            worktree_prefix: None,
+            working_labels: vec![],
+            use_sandbox: false,
+            sandbox_ports: vec![],
+        };
+        assert!(config.session_name.is_none());
+    }
+
+    #[test]
+    fn test_parse_port_mappings() {
+        // Simple port
+        let ports = parse_port_mappings(&["3000".to_string()]);
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].host_port, 3000);
+        assert_eq!(ports[0].container_port, 3000);
+
+        // Host:container
+        let ports = parse_port_mappings(&["8080:80".to_string()]);
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].host_port, 8080);
+        assert_eq!(ports[0].container_port, 80);
+
+        // With protocol
+        let ports = parse_port_mappings(&["53:53/udp".to_string()]);
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].protocol, Some("udp".to_string()));
+
+        // Multiple
+        let ports = parse_port_mappings(&[
+            "3000".to_string(),
+            "8080:80".to_string(),
+            "5432:5432".to_string(),
+        ]);
+        assert_eq!(ports.len(), 3);
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/pipeline.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/pipeline.rs
@@ -1,0 +1,511 @@
+//! Pipeline state tracking for agent workflows.
+//!
+//! This module provides infrastructure for tracking the lifecycle of agent work items,
+//! from issue assignment through session/worktree creation to PR completion.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::HashMap;
+
+use super::github::{self, GitHubIssue, GitHubPullRequest};
+use super::orchestrator::AgentStatus;
+
+/// Status of a PR in the pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PrPipelineStatus {
+    /// No PR has been created yet
+    None,
+    /// PR is in draft state
+    Draft,
+    /// PR is ready for review
+    Ready,
+    /// PR needs review (has reviewers assigned)
+    NeedsReview,
+    /// PR has been approved
+    Approved,
+    /// PR has been merged
+    Merged,
+    /// PR was closed without merging
+    Closed,
+}
+
+impl Default for PrPipelineStatus {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Status of a pipeline item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PipelineStatus {
+    /// Issue is queued but not assigned
+    Queued,
+    /// Issue is assigned to an agent and work is in progress
+    InProgress,
+    /// Agent has completed work and PR is pending
+    PrPending,
+    /// PR has been created and is being reviewed
+    PrReview,
+    /// PR has been merged, work is complete
+    Completed,
+    /// Issue was skipped
+    Skipped,
+    /// Work failed or was abandoned
+    Failed,
+}
+
+impl Default for PipelineStatus {
+    fn default() -> Self {
+        Self::Queued
+    }
+}
+
+/// A pipeline item linking issue -> session -> worktree -> PR.
+///
+/// This struct tracks the full lifecycle of an agent's work on an issue.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct PipelineItem {
+    /// Unique identifier for this pipeline item
+    pub id: String,
+    /// Repository in owner/repo format (tracking repo where issue exists)
+    pub tracking_repo: String,
+    /// Repository where work is done (may be different from tracking_repo)
+    pub work_repo: String,
+    /// Issue number being worked on
+    pub issue_number: u64,
+    /// Issue title
+    pub issue_title: String,
+    /// Issue URL
+    pub issue_url: String,
+    /// Agent type (e.g., "claude", "aider")
+    pub agent_type: String,
+    /// tmux session name (if active)
+    pub session_name: Option<String>,
+    /// Worktree path (if created)
+    pub worktree_path: Option<String>,
+    /// Branch name for the work
+    pub branch_name: Option<String>,
+    /// Machine ID where agent is running
+    pub machine_id: Option<String>,
+    /// PR number (if created)
+    pub pr_number: Option<u64>,
+    /// PR URL (if created)
+    pub pr_url: Option<String>,
+    /// Current PR status
+    pub pr_status: PrPipelineStatus,
+    /// Overall pipeline status
+    pub status: PipelineStatus,
+    /// When the item was created/queued
+    pub created_at: String,
+    /// When work started (agent assigned)
+    pub started_at: Option<String>,
+    /// When work completed (PR merged or skipped)
+    pub completed_at: Option<String>,
+    /// Any error message if failed
+    pub error: Option<String>,
+}
+
+impl PipelineItem {
+    /// Create a new pipeline item from an issue.
+    pub fn from_issue(
+        issue: &GitHubIssue,
+        tracking_repo: &str,
+        work_repo: &str,
+        agent_type: &str,
+    ) -> Self {
+        let id = format!(
+            "{}-{}-{}",
+            work_repo.replace('/', "-"),
+            issue.number,
+            chrono::Utc::now().timestamp()
+        );
+        Self {
+            id,
+            tracking_repo: tracking_repo.to_string(),
+            work_repo: work_repo.to_string(),
+            issue_number: issue.number,
+            issue_title: issue.title.clone(),
+            issue_url: issue.url.clone(),
+            agent_type: agent_type.to_string(),
+            session_name: None,
+            worktree_path: None,
+            branch_name: None,
+            machine_id: None,
+            pr_number: None,
+            pr_url: None,
+            pr_status: PrPipelineStatus::None,
+            status: PipelineStatus::Queued,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            started_at: None,
+            completed_at: None,
+            error: None,
+        }
+    }
+
+    /// Mark the item as in progress with session details.
+    pub fn start_work(
+        &mut self,
+        session_name: &str,
+        worktree_path: &str,
+        branch_name: &str,
+        machine_id: &str,
+    ) {
+        self.session_name = Some(session_name.to_string());
+        self.worktree_path = Some(worktree_path.to_string());
+        self.branch_name = Some(branch_name.to_string());
+        self.machine_id = Some(machine_id.to_string());
+        self.status = PipelineStatus::InProgress;
+        self.started_at = Some(chrono::Utc::now().to_rfc3339());
+    }
+
+    /// Link a PR to this pipeline item.
+    pub fn link_pr(&mut self, pr: &GitHubPullRequest) {
+        self.pr_number = Some(pr.number);
+        self.pr_url = Some(pr.url.clone());
+        self.pr_status = if pr.state == "merged" {
+            PrPipelineStatus::Merged
+        } else if pr.state == "closed" {
+            PrPipelineStatus::Closed
+        } else if pr.is_draft {
+            PrPipelineStatus::Draft
+        } else {
+            PrPipelineStatus::Ready
+        };
+        self.status = if self.pr_status == PrPipelineStatus::Merged {
+            PipelineStatus::Completed
+        } else {
+            PipelineStatus::PrReview
+        };
+    }
+
+    /// Update PR status from a GitHubPullRequest.
+    pub fn update_pr_status(
+        &mut self,
+        pr: &GitHubPullRequest,
+        has_reviewers: bool,
+        is_approved: bool,
+    ) {
+        self.pr_status = if pr.state == "merged" || pr.state == "MERGED" {
+            PrPipelineStatus::Merged
+        } else if pr.state == "closed" || pr.state == "CLOSED" {
+            PrPipelineStatus::Closed
+        } else if is_approved {
+            PrPipelineStatus::Approved
+        } else if has_reviewers {
+            PrPipelineStatus::NeedsReview
+        } else if pr.is_draft {
+            PrPipelineStatus::Draft
+        } else {
+            PrPipelineStatus::Ready
+        };
+
+        // Update overall status based on PR status
+        self.status = match self.pr_status {
+            PrPipelineStatus::Merged => {
+                self.completed_at = Some(chrono::Utc::now().to_rfc3339());
+                PipelineStatus::Completed
+            }
+            PrPipelineStatus::Closed => {
+                self.completed_at = Some(chrono::Utc::now().to_rfc3339());
+                PipelineStatus::Failed
+            }
+            _ => PipelineStatus::PrReview,
+        };
+    }
+
+    /// Mark as skipped.
+    pub fn skip(&mut self) {
+        self.status = PipelineStatus::Skipped;
+        self.completed_at = Some(chrono::Utc::now().to_rfc3339());
+    }
+
+    /// Mark as failed with an error message.
+    pub fn fail(&mut self, error: &str) {
+        self.status = PipelineStatus::Failed;
+        self.error = Some(error.to_string());
+        self.completed_at = Some(chrono::Utc::now().to_rfc3339());
+    }
+
+    /// Check if this item is active (in progress or PR pending).
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self.status,
+            PipelineStatus::InProgress | PipelineStatus::PrPending | PipelineStatus::PrReview
+        )
+    }
+
+    /// Check if this item is complete (finished or skipped/failed).
+    pub fn is_complete(&self) -> bool {
+        matches!(
+            self.status,
+            PipelineStatus::Completed | PipelineStatus::Skipped | PipelineStatus::Failed
+        )
+    }
+}
+
+/// Storage for pipeline state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
+pub struct PipelineState {
+    /// Active pipeline items (keyed by item ID)
+    pub items: HashMap<String, PipelineItem>,
+    /// Completed pipeline items (for history, keyed by item ID)
+    pub history: Vec<PipelineItem>,
+    /// Maximum history items to keep
+    #[serde(default = "default_max_history")]
+    pub max_history: usize,
+}
+
+fn default_max_history() -> usize {
+    100
+}
+
+impl PipelineState {
+    /// Create a new empty pipeline state.
+    pub fn new() -> Self {
+        Self {
+            items: HashMap::new(),
+            history: Vec::new(),
+            max_history: default_max_history(),
+        }
+    }
+
+    /// Add a new pipeline item.
+    pub fn add_item(&mut self, item: PipelineItem) {
+        self.items.insert(item.id.clone(), item);
+    }
+
+    /// Get a pipeline item by ID.
+    pub fn get_item(&self, id: &str) -> Option<&PipelineItem> {
+        self.items.get(id)
+    }
+
+    /// Get a mutable pipeline item by ID.
+    pub fn get_item_mut(&mut self, id: &str) -> Option<&mut PipelineItem> {
+        self.items.get_mut(id)
+    }
+
+    /// Find a pipeline item by issue.
+    pub fn find_by_issue(&self, repo: &str, issue_number: u64) -> Option<&PipelineItem> {
+        self.items.values().find(|item| {
+            (item.tracking_repo == repo || item.work_repo == repo)
+                && item.issue_number == issue_number
+        })
+    }
+
+    /// Find a pipeline item by session name.
+    pub fn find_by_session(&self, session_name: &str) -> Option<&PipelineItem> {
+        self.items
+            .values()
+            .find(|item| item.session_name.as_deref() == Some(session_name))
+    }
+
+    /// Find a pipeline item by PR.
+    pub fn find_by_pr(&self, repo: &str, pr_number: u64) -> Option<&PipelineItem> {
+        self.items
+            .values()
+            .find(|item| item.work_repo == repo && item.pr_number == Some(pr_number))
+    }
+
+    /// Find a pipeline item by branch name.
+    pub fn find_by_branch(&self, branch_name: &str) -> Option<&PipelineItem> {
+        self.items
+            .values()
+            .find(|item| item.branch_name.as_deref() == Some(branch_name))
+    }
+
+    /// Move a completed item to history.
+    pub fn archive_item(&mut self, id: &str) -> Option<PipelineItem> {
+        if let Some(item) = self.items.remove(id) {
+            if item.is_complete() {
+                self.history.push(item.clone());
+                // Trim history if needed
+                while self.history.len() > self.max_history {
+                    self.history.remove(0);
+                }
+            }
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    /// Get all active pipeline items.
+    pub fn get_active_items(&self) -> Vec<&PipelineItem> {
+        self.items
+            .values()
+            .filter(|item| item.is_active())
+            .collect()
+    }
+
+    /// Get all items (active and complete but not archived).
+    pub fn get_all_items(&self) -> Vec<&PipelineItem> {
+        self.items.values().collect()
+    }
+
+    /// Get pipeline history.
+    pub fn get_history(&self, limit: Option<usize>) -> Vec<&PipelineItem> {
+        let limit = limit.unwrap_or(self.history.len());
+        self.history.iter().rev().take(limit).collect()
+    }
+
+    /// Remove a pipeline item.
+    pub fn remove_item(&mut self, id: &str) -> Option<PipelineItem> {
+        self.items.remove(id)
+    }
+
+    /// Clear completed items from active list and archive them.
+    pub fn archive_completed(&mut self) {
+        let completed_ids: Vec<String> = self
+            .items
+            .iter()
+            .filter(|(_, item)| item.is_complete())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in completed_ids {
+            self.archive_item(&id);
+        }
+    }
+}
+
+/// Aggregate pipeline state from multiple sources.
+///
+/// This function combines data from:
+/// - Active tmux sessions
+/// - GitHub issues with agent metadata
+/// - Known worktrees
+/// - Existing pipeline state
+pub fn aggregate_pipeline_state(
+    existing_state: &PipelineState,
+    sessions: &[AgentStatus],
+    work_repo: &str,
+) -> Vec<PipelineItem> {
+    let mut items: HashMap<String, PipelineItem> = existing_state.items.clone();
+
+    // Update existing items with session status
+    for session in sessions {
+        if let Some(issue_number) = session.issue_number {
+            let repo = session.repo.as_deref().unwrap_or(work_repo);
+
+            // Find or create pipeline item for this session
+            let item = items.values_mut().find(|item| {
+                item.issue_number == issue_number
+                    && (item.tracking_repo == repo || item.work_repo == repo)
+            });
+
+            if let Some(item) = item {
+                // Update session info
+                item.session_name = Some(session.session.clone());
+                item.worktree_path = session.worktree.clone();
+                item.machine_id = Some(session.machine_id.clone());
+
+                // Update status based on session state
+                if !item.is_complete() {
+                    item.status = PipelineStatus::InProgress;
+                }
+            }
+        }
+    }
+
+    items.into_values().collect()
+}
+
+/// Detect if a PR was created for a pipeline item by checking branches.
+///
+/// This is used to auto-link PRs to pipeline items.
+pub fn detect_pr_for_item(
+    item: &PipelineItem,
+    prs: &[GitHubPullRequest],
+) -> Option<GitHubPullRequest> {
+    if let Some(branch) = &item.branch_name {
+        for pr in prs {
+            if pr.head_branch == *branch {
+                return Some(pr.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Sync pipeline item with GitHub PR status.
+pub fn sync_pr_status(item: &mut PipelineItem, repo: &str) -> Result<bool, String> {
+    if let Some(pr_number) = item.pr_number {
+        let pr_status = github::get_pr_status(repo, pr_number)?;
+
+        let has_reviewers = pr_status.reviews.pending > 0
+            || pr_status.reviews.approved > 0
+            || pr_status.reviews.changes_requested > 0;
+        let is_approved =
+            pr_status.reviews.approved > 0 && pr_status.reviews.changes_requested == 0;
+
+        item.update_pr_status(&pr_status.pr, has_reviewers, is_approved);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pipeline_item_lifecycle() {
+        let issue = GitHubIssue {
+            number: 123,
+            title: "Test Issue".to_string(),
+            body: None,
+            state: "open".to_string(),
+            url: "https://github.com/test/repo/issues/123".to_string(),
+            labels: vec![],
+            assignees: vec![],
+            author: "testuser".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            repo: "test/repo".to_string(),
+        };
+
+        let mut item = PipelineItem::from_issue(&issue, "test/tracking", "test/repo", "claude");
+        assert_eq!(item.status, PipelineStatus::Queued);
+        assert!(!item.is_active());
+        assert!(!item.is_complete());
+
+        item.start_work("session-1", "/tmp/worktree", "issue-123", "machine-1");
+        assert_eq!(item.status, PipelineStatus::InProgress);
+        assert!(item.is_active());
+        assert!(!item.is_complete());
+
+        item.skip();
+        assert_eq!(item.status, PipelineStatus::Skipped);
+        assert!(!item.is_active());
+        assert!(item.is_complete());
+    }
+
+    #[test]
+    fn test_pipeline_state() {
+        let mut state = PipelineState::new();
+
+        let issue = GitHubIssue {
+            number: 123,
+            title: "Test Issue".to_string(),
+            body: None,
+            state: "open".to_string(),
+            url: "https://github.com/test/repo/issues/123".to_string(),
+            labels: vec![],
+            assignees: vec![],
+            author: "testuser".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            repo: "test/repo".to_string(),
+        };
+
+        let item = PipelineItem::from_issue(&issue, "test/tracking", "test/repo", "claude");
+        let item_id = item.id.clone();
+
+        state.add_item(item);
+        assert!(state.get_item(&item_id).is_some());
+        assert!(state.find_by_issue("test/repo", 123).is_some());
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/tmux.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/tmux.rs
@@ -1,0 +1,1008 @@
+//! tmux session management for DevOps agent sessions.
+//!
+//! Sessions persist independently in the tmux server, surviving app restarts.
+//! Metadata is stored in tmux environment variables for recovery.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Session naming prefix for all Handy agent sessions
+const SESSION_PREFIX: &str = "handy-agent-";
+
+/// Base prefix for all Handy-related tmux sessions (includes master)
+const HANDY_PREFIX: &str = "handy-";
+
+/// Custom socket name to avoid macOS /private/tmp permission issues
+const SOCKET_NAME: &str = "handy";
+
+/// Environment variable keys stored in tmux sessions
+const ENV_ISSUE_REF: &str = "HANDY_ISSUE_REF";
+const ENV_REPO: &str = "HANDY_REPO";
+const ENV_WORKTREE: &str = "HANDY_WORKTREE";
+const ENV_AGENT_TYPE: &str = "HANDY_AGENT_TYPE";
+const ENV_MACHINE_ID: &str = "HANDY_MACHINE_ID";
+const ENV_STARTED_AT: &str = "HANDY_STARTED_AT";
+
+/// Status of an agent session
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq)]
+pub enum SessionStatus {
+    /// Session is running and agent is active
+    Running,
+    /// Session exists but agent process has exited
+    Stopped,
+    /// Session was recovered from metadata (tmux or GitHub)
+    Recovered,
+}
+
+/// Metadata stored with each agent session
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct AgentMetadata {
+    /// Session name (e.g., "handy-agent-42")
+    pub session: String,
+    /// GitHub issue reference (e.g., "org/repo#42")
+    pub issue_ref: Option<String>,
+    /// Repository being worked on
+    pub repo: Option<String>,
+    /// Path to the worktree
+    pub worktree: Option<String>,
+    /// Type of agent (e.g., "claude", "aider")
+    pub agent_type: String,
+    /// Machine identifier for multi-machine disambiguation
+    pub machine_id: String,
+    /// ISO timestamp when session started
+    pub started_at: String,
+}
+
+/// Information about a tmux session
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct TmuxSession {
+    /// Session name
+    pub name: String,
+    /// Whether the session is attached
+    pub attached: bool,
+    /// Number of windows in the session
+    pub windows: u32,
+    /// Session creation time (Unix timestamp)
+    pub created: u64,
+    /// Agent metadata if this is a Handy session
+    pub metadata: Option<AgentMetadata>,
+    /// Current status
+    pub status: SessionStatus,
+}
+
+/// Source of recovered session information
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub enum RecoverySource {
+    /// Found in tmux, normal operation
+    Tmux,
+    /// Recovered from GitHub issue comment
+    GitHubIssue,
+    /// Confirmed by both sources
+    Both,
+}
+
+/// Recommended action for a recovered session
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub enum RecoveryAction {
+    /// tmux alive, continue monitoring
+    Resume,
+    /// tmux dead but work incomplete, offer restart
+    Restart,
+    /// orphan session, offer to kill/remove
+    Cleanup,
+    /// completed normally, nothing to do
+    None,
+}
+
+/// A session recovered during startup
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct RecoveredSession {
+    pub metadata: AgentMetadata,
+    pub source: RecoverySource,
+    pub tmux_alive: bool,
+    pub worktree_exists: bool,
+    pub recommended_action: RecoveryAction,
+}
+
+/// Check if tmux server is running
+pub fn is_tmux_running() -> bool {
+    Command::new("tmux")
+        .args(["-L", SOCKET_NAME, "list-sessions"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Get the current machine's hostname for identification
+fn get_machine_id() -> String {
+    Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// List all tmux sessions, filtering for Handy agent sessions
+pub fn list_sessions() -> Result<Vec<TmuxSession>, String> {
+    // Format: session_name, attached, windows, created
+    let output = Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET_NAME,
+            "list-sessions",
+            "-F",
+            "#{session_name}\t#{session_attached}\t#{session_windows}\t#{session_created}",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to list tmux sessions: {}", e))?;
+
+    if !output.status.success() {
+        // No sessions or tmux not running
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("no server running") || stderr.contains("no sessions") {
+            return Ok(vec![]);
+        }
+        return Err(format!("tmux error: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut sessions = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() >= 4 {
+            let name = parts[0].to_string();
+            let attached = parts[1] == "1";
+            let windows = parts[2].parse().unwrap_or(1);
+            let created = parts[3].parse().unwrap_or(0);
+
+            // Only include Handy sessions (agents and master)
+            if name.starts_with(HANDY_PREFIX) {
+                let metadata = get_session_metadata(&name).ok();
+                let status = if check_session_has_active_process(&name) {
+                    SessionStatus::Running
+                } else {
+                    SessionStatus::Stopped
+                };
+
+                sessions.push(TmuxSession {
+                    name,
+                    attached,
+                    windows,
+                    created,
+                    metadata,
+                    status,
+                });
+            }
+        }
+    }
+
+    Ok(sessions)
+}
+
+/// Check if a session has an active process running in its pane
+fn check_session_has_active_process(session_name: &str) -> bool {
+    // Get the command running in the session's active pane
+    Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET_NAME,
+            "list-panes",
+            "-t",
+            session_name,
+            "-F",
+            "#{pane_current_command}",
+        ])
+        .output()
+        .map(|o| {
+            if o.status.success() {
+                let cmd = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                // Check if it's not just a shell prompt
+                !cmd.is_empty() && cmd != "bash" && cmd != "zsh" && cmd != "sh" && cmd != "fish"
+            } else {
+                false
+            }
+        })
+        .unwrap_or(false)
+}
+
+/// Get metadata for a specific session from its environment variables
+pub fn get_session_metadata(session_name: &str) -> Result<AgentMetadata, String> {
+    let output = Command::new("tmux")
+        .args(["-L", SOCKET_NAME, "show-environment", "-t", session_name])
+        .output()
+        .map_err(|e| format!("Failed to get session environment: {}", e))?;
+
+    if !output.status.success() {
+        return Err("Session not found or no environment set".to_string());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut env_vars: HashMap<String, String> = HashMap::new();
+
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            if key.starts_with("HANDY_") {
+                env_vars.insert(key.to_string(), value.to_string());
+            }
+        }
+    }
+
+    Ok(AgentMetadata {
+        session: session_name.to_string(),
+        issue_ref: env_vars.get(ENV_ISSUE_REF).cloned(),
+        repo: env_vars.get(ENV_REPO).cloned(),
+        worktree: env_vars.get(ENV_WORKTREE).cloned(),
+        agent_type: env_vars
+            .get(ENV_AGENT_TYPE)
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string()),
+        machine_id: env_vars
+            .get(ENV_MACHINE_ID)
+            .cloned()
+            .unwrap_or_else(get_machine_id),
+        started_at: env_vars
+            .get(ENV_STARTED_AT)
+            .cloned()
+            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
+    })
+}
+
+/// Create a new tmux session with metadata
+pub fn create_session(
+    session_name: &str,
+    working_dir: Option<&str>,
+    metadata: &AgentMetadata,
+) -> Result<(), String> {
+    // Validate session name - must start with handy- prefix (agents or master)
+    if !session_name.starts_with(HANDY_PREFIX) {
+        return Err(format!("Session name must start with '{}'", HANDY_PREFIX));
+    }
+
+    // Check if session already exists
+    let existing = list_sessions()?;
+    if existing.iter().any(|s| s.name == session_name) {
+        return Err(format!("Session '{}' already exists", session_name));
+    }
+
+    // Build the create command
+    let mut args = vec!["new-session", "-d", "-s", session_name];
+
+    if let Some(dir) = working_dir {
+        args.push("-c");
+        args.push(dir);
+    }
+
+    // Prepend -L flag for custom socket
+    let mut full_args = vec!["-L", SOCKET_NAME];
+    full_args.extend_from_slice(&args);
+
+    let output = Command::new("tmux")
+        .args(&full_args)
+        .output()
+        .map_err(|e| format!("Failed to create session: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Set environment variables for metadata
+    set_session_env(session_name, ENV_AGENT_TYPE, &metadata.agent_type)?;
+    set_session_env(session_name, ENV_MACHINE_ID, &metadata.machine_id)?;
+    set_session_env(session_name, ENV_STARTED_AT, &metadata.started_at)?;
+
+    if let Some(ref issue_ref) = metadata.issue_ref {
+        set_session_env(session_name, ENV_ISSUE_REF, issue_ref)?;
+    }
+    if let Some(ref repo) = metadata.repo {
+        set_session_env(session_name, ENV_REPO, repo)?;
+    }
+    if let Some(ref worktree) = metadata.worktree {
+        set_session_env(session_name, ENV_WORKTREE, worktree)?;
+    }
+
+    Ok(())
+}
+
+/// Set an environment variable in a tmux session
+fn set_session_env(session_name: &str, key: &str, value: &str) -> Result<(), String> {
+    let output = Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET_NAME,
+            "set-environment",
+            "-t",
+            session_name,
+            key,
+            value,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to set environment: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to set {}: {}",
+            key,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Kill a tmux session and any associated Docker containers
+pub fn kill_session(session_name: &str) -> Result<(), String> {
+    // First, try to get the session metadata to find associated containers
+    // We'll try to kill containers before killing the session
+    if let Ok(metadata) = get_session_metadata(session_name) {
+        // Extract issue number from issue_ref (e.g., "org/repo#123" -> 123)
+        if let Some(issue_ref) = &metadata.issue_ref {
+            if let Some(issue_num) = issue_ref
+                .split('#')
+                .last()
+                .and_then(|n| n.parse::<u32>().ok())
+            {
+                // Try to kill sandbox containers (both agent and support worker patterns)
+                let container_patterns = [
+                    format!("handy-sandbox-{}", issue_num),
+                    format!("handy-support-sandbox-{}", issue_num),
+                ];
+
+                for container_name in &container_patterns {
+                    // Force remove the container (ignore errors - container may not exist)
+                    let _ = Command::new("docker")
+                        .args(["rm", "-f", container_name])
+                        .output();
+                    log::debug!("Attempted to remove Docker container: {}", container_name);
+                }
+            }
+        }
+    }
+
+    // Now kill the tmux session
+    let output = Command::new("tmux")
+        .args(["-L", SOCKET_NAME, "kill-session", "-t", session_name])
+        .output()
+        .map_err(|e| format!("Failed to kill session: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Get recent output from a session's pane
+pub fn get_session_output(session_name: &str, lines: Option<u32>) -> Result<String, String> {
+    let line_count = lines.unwrap_or(100).to_string();
+
+    let output = Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET_NAME,
+            "capture-pane",
+            "-t",
+            session_name,
+            "-p",
+            "-S",
+            &format!("-{}", line_count),
+        ])
+        .output()
+        .map_err(|e| format!("Failed to capture pane: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Send a command to a session
+/// If the command is empty, sends just Enter key
+/// Special key sequences: Enter, Escape, Tab, Space, BSpace, Up, Down, Left, Right, etc.
+pub fn send_command(session_name: &str, command: &str) -> Result<(), String> {
+    let mut args = vec!["-L", SOCKET_NAME, "send-keys", "-t", session_name];
+
+    // If empty command, just send Enter
+    if command.is_empty() {
+        args.push("Enter");
+    } else {
+        args.push(command);
+        args.push("Enter");
+    }
+
+    let output = Command::new("tmux")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to send command: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Send raw keys to a session without appending Enter
+/// Use this for special keys like Escape, Tab, or partial input
+pub fn send_keys(session_name: &str, keys: &str) -> Result<(), String> {
+    let output = Command::new("tmux")
+        .args(["-L", SOCKET_NAME, "send-keys", "-t", session_name, keys])
+        .output()
+        .map_err(|e| format!("Failed to send keys: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Recover agent sessions on startup
+pub fn recover_sessions() -> Result<Vec<RecoveredSession>, String> {
+    let current_machine = get_machine_id();
+    let sessions = list_sessions()?;
+    let mut recovered = Vec::new();
+
+    for session in sessions {
+        if let Some(metadata) = session.metadata {
+            // Only recover sessions from this machine
+            if metadata.machine_id != current_machine {
+                continue;
+            }
+
+            let worktree_exists = metadata
+                .worktree
+                .as_ref()
+                .map(|p| std::path::Path::new(p).exists())
+                .unwrap_or(false);
+
+            let tmux_alive = session.status == SessionStatus::Running;
+
+            let recommended_action = match (tmux_alive, worktree_exists) {
+                (true, _) => RecoveryAction::Resume,
+                (false, true) => RecoveryAction::Restart,
+                (false, false) => RecoveryAction::Cleanup,
+            };
+
+            recovered.push(RecoveredSession {
+                metadata,
+                source: RecoverySource::Tmux,
+                tmux_alive,
+                worktree_exists,
+                recommended_action,
+            });
+        }
+    }
+
+    Ok(recovered)
+}
+
+/// Result of attempting to recover/restart sessions
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct RecoveryResult {
+    /// Session name
+    pub session: String,
+    /// Whether recovery was successful
+    pub success: bool,
+    /// Action that was taken
+    pub action: RecoveryAction,
+    /// Error message if recovery failed
+    pub error: Option<String>,
+}
+
+/// Attempt to recover all sessions that need attention.
+///
+/// For sessions with `RecoveryAction::Restart`, this will restart the agent.
+/// For sessions with `RecoveryAction::Cleanup`, this will kill the session.
+/// Sessions with `RecoveryAction::Resume` are left as-is (already running).
+///
+/// Also cleans up any orphaned Docker containers (containers without corresponding tmux sessions).
+///
+/// Returns results for each session that was processed.
+pub fn recover_all_sessions(
+    auto_restart: bool,
+    auto_cleanup: bool,
+) -> Result<Vec<RecoveryResult>, String> {
+    let sessions = recover_sessions()?;
+    let mut results = Vec::new();
+
+    for session in sessions {
+        let result = match session.recommended_action {
+            RecoveryAction::Resume => {
+                // Already running, nothing to do
+                RecoveryResult {
+                    session: session.metadata.session.clone(),
+                    success: true,
+                    action: RecoveryAction::Resume,
+                    error: None,
+                }
+            }
+            RecoveryAction::Restart => {
+                if auto_restart {
+                    match restart_agent(&session.metadata.session) {
+                        Ok(()) => RecoveryResult {
+                            session: session.metadata.session.clone(),
+                            success: true,
+                            action: RecoveryAction::Restart,
+                            error: None,
+                        },
+                        Err(e) => RecoveryResult {
+                            session: session.metadata.session.clone(),
+                            success: false,
+                            action: RecoveryAction::Restart,
+                            error: Some(e),
+                        },
+                    }
+                } else {
+                    RecoveryResult {
+                        session: session.metadata.session.clone(),
+                        success: false,
+                        action: RecoveryAction::Restart,
+                        error: Some("Auto-restart disabled".to_string()),
+                    }
+                }
+            }
+            RecoveryAction::Cleanup => {
+                if auto_cleanup {
+                    match kill_session(&session.metadata.session) {
+                        Ok(()) => RecoveryResult {
+                            session: session.metadata.session.clone(),
+                            success: true,
+                            action: RecoveryAction::Cleanup,
+                            error: None,
+                        },
+                        Err(e) => RecoveryResult {
+                            session: session.metadata.session.clone(),
+                            success: false,
+                            action: RecoveryAction::Cleanup,
+                            error: Some(e),
+                        },
+                    }
+                } else {
+                    RecoveryResult {
+                        session: session.metadata.session.clone(),
+                        success: false,
+                        action: RecoveryAction::Cleanup,
+                        error: Some("Auto-cleanup disabled".to_string()),
+                    }
+                }
+            }
+            RecoveryAction::None => {
+                // Nothing to do
+                RecoveryResult {
+                    session: session.metadata.session.clone(),
+                    success: true,
+                    action: RecoveryAction::None,
+                    error: None,
+                }
+            }
+        };
+
+        results.push(result);
+    }
+
+    // Also clean up orphaned Docker containers
+    // This catches containers that were left behind when tmux sessions were killed externally
+    if let Ok(orphan_result) = super::docker::cleanup_orphaned_containers() {
+        if orphan_result.removed > 0 {
+            log::info!(
+                "Cleaned up {} orphaned Docker containers during session recovery",
+                orphan_result.removed
+            );
+        }
+    }
+
+    Ok(results)
+}
+
+/// Port mapping configuration for container
+#[derive(Debug, Clone)]
+pub struct PortMapping {
+    /// Host port to bind
+    pub host_port: u16,
+    /// Container port to expose
+    pub container_port: u16,
+    /// Protocol (tcp or udp), defaults to tcp
+    pub protocol: Option<String>,
+}
+
+impl PortMapping {
+    /// Create a new port mapping (same port on host and container)
+    pub fn new(port: u16) -> Self {
+        Self {
+            host_port: port,
+            container_port: port,
+            protocol: None,
+        }
+    }
+
+    /// Create a port mapping with different host and container ports
+    pub fn mapped(host_port: u16, container_port: u16) -> Self {
+        Self {
+            host_port,
+            container_port,
+            protocol: None,
+        }
+    }
+
+    /// Format as Docker -p argument
+    pub fn to_docker_arg(&self) -> String {
+        match &self.protocol {
+            Some(proto) => format!("-p {}:{}/{}", self.host_port, self.container_port, proto),
+            None => format!("-p {}:{}", self.host_port, self.container_port),
+        }
+    }
+}
+
+/// Configuration for sandboxed agent execution
+#[derive(Debug, Clone)]
+pub struct SandboxedAgentConfig {
+    /// Path to the worktree (will be mounted in container)
+    pub worktree_path: String,
+    /// Container memory limit (e.g., "4g")
+    pub memory_limit: Option<String>,
+    /// Container CPU limit (e.g., "2")
+    pub cpu_limit: Option<String>,
+    /// Whether to use --dangerously-skip-permissions (safe in sandbox)
+    pub auto_accept: bool,
+    /// Port mappings for the container (host:container)
+    pub ports: Vec<PortMapping>,
+    /// Whether to auto-detect common development ports from the project
+    pub auto_detect_ports: bool,
+    /// Whether to join the shared agent network for inter-container communication
+    pub use_agent_network: bool,
+    /// Whether to remap ports to unique ranges (avoids conflicts between agents)
+    pub remap_ports: bool,
+}
+
+/// Build a Docker command that runs the agent inside a container
+///
+/// This wraps the agent command in a Docker container with:
+/// - The worktree mounted at /workspace
+/// - GitHub and Anthropic credentials passed from environment
+/// - Resource limits applied
+/// - Shared network for inter-container communication (optional)
+/// - Port remapping to unique ranges (optional, avoids conflicts)
+fn build_sandboxed_agent_command(
+    agent_type: &str,
+    repo: &str,
+    issue_number: u64,
+    issue_title: Option<&str>,
+    config: &SandboxedAgentConfig,
+) -> Result<String, String> {
+    use super::docker;
+
+    // First get the base agent command
+    let inner_command = build_agent_command_inner(
+        agent_type,
+        repo,
+        issue_number,
+        issue_title,
+        config.auto_accept,
+    )?;
+
+    // Build docker run command
+    let container_name = format!("handy-sandbox-{}", issue_number);
+    let image = "node:20-bookworm"; // Base image with Node.js for Claude Code
+
+    let mut docker_args = vec![
+        "docker run --rm -it".to_string(),
+        format!("--name {}", container_name),
+        format!("-v {}:/workspace", config.worktree_path),
+        "-w /workspace".to_string(),
+    ];
+
+    // Join the shared agent network if enabled
+    // This allows containers to communicate via container names as hostnames
+    if config.use_agent_network {
+        // Ensure network exists (will be created if needed)
+        if let Err(e) = docker::ensure_agent_network() {
+            log::warn!("Failed to create agent network: {}", e);
+        } else {
+            docker_args.push(format!("--network {}", docker::get_agent_network_name()));
+            // Set hostname to container name for easy discovery
+            docker_args.push(format!("--hostname {}", container_name));
+        }
+    }
+
+    // Add resource limits
+    if let Some(ref mem) = config.memory_limit {
+        docker_args.push(format!("-m {}", mem));
+    }
+    if let Some(ref cpu) = config.cpu_limit {
+        docker_args.push(format!("--cpus {}", cpu));
+    }
+
+    // Add port mappings (with optional remapping to unique ranges)
+    if config.remap_ports {
+        // Remap ports to unique ranges to avoid conflicts between agents
+        for port_mapping in &config.ports {
+            let host_port = docker::remap_port_to_range(port_mapping.container_port, issue_number);
+            let remapped = PortMapping {
+                host_port,
+                container_port: port_mapping.container_port,
+                protocol: port_mapping.protocol.clone(),
+            };
+            docker_args.push(remapped.to_docker_arg());
+        }
+    } else {
+        // Use ports as-is
+        for port_mapping in &config.ports {
+            docker_args.push(port_mapping.to_docker_arg());
+        }
+    }
+
+    // Pass through credentials from host environment
+    docker_args.push("-e GH_TOKEN".to_string());
+    docker_args.push("-e GITHUB_TOKEN".to_string());
+    docker_args.push("-e ANTHROPIC_API_KEY".to_string());
+
+    // Add context env vars
+    docker_args.push(format!("-e HANDY_ISSUE_REF={}#{}", repo, issue_number));
+    docker_args.push(format!("-e HANDY_AGENT_TYPE={}", agent_type));
+    docker_args.push(format!("-e HANDY_CONTAINER_NAME={}", container_name));
+
+    // Add port range info so the agent knows which ports it can use
+    if config.remap_ports {
+        let (base, end) = docker::allocate_port_range(issue_number);
+        docker_args.push(format!("-e HANDY_PORT_RANGE_BASE={}", base));
+        docker_args.push(format!("-e HANDY_PORT_RANGE_END={}", end));
+    }
+
+    // Add image and command
+    docker_args.push(image.to_string());
+    docker_args.push("sh -c".to_string());
+
+    // Install Claude Code and run the agent command
+    let install_and_run = format!("npm install -g @anthropic/claude-code && {}", inner_command);
+    docker_args.push(format!("'{}'", install_and_run.replace('\'', "'\\''")));
+
+    Ok(docker_args.join(" "))
+}
+
+/// Build the inner agent command (used both directly and inside containers)
+fn build_agent_command_inner(
+    agent_type: &str,
+    repo: &str,
+    issue_number: u64,
+    issue_title: Option<&str>,
+    auto_accept: bool,
+) -> Result<String, String> {
+    let title_arg = issue_title
+        .map(|t| {
+            let escaped = t.replace('\'', "'\\''");
+            format!(" --title '{}'", escaped)
+        })
+        .unwrap_or_default();
+
+    let command = match agent_type.to_lowercase().as_str() {
+        "claude" => {
+            if auto_accept {
+                // In sandbox, we can safely skip permissions
+                format!(
+                    "claude --dangerously-skip-permissions 'Work on GitHub issue {}#{}: Implement the requirements described in the issue. When done, commit your changes and create a PR.'",
+                    repo, issue_number
+                )
+            } else {
+                format!(
+                    "claude 'Work on GitHub issue {}#{}: Implement the requirements described in the issue. When done, commit your changes and create a PR.'",
+                    repo, issue_number
+                )
+            }
+        }
+        "aider" => {
+            format!(
+                "aider --message 'Work on GitHub issue {}#{}{}. Implement the requirements and commit when done.'",
+                repo, issue_number, title_arg
+            )
+        }
+        "codex" | "openai" => {
+            format!(
+                "codex 'Implement GitHub issue {}#{}{}'",
+                repo, issue_number, title_arg
+            )
+        }
+        "gemini" => {
+            format!(
+                "gemini-cli 'Work on GitHub issue {}#{}{}'",
+                repo, issue_number, title_arg
+            )
+        }
+        "ollama" | "local" => {
+            format!(
+                "ollama run codellama 'Implement GitHub issue {}#{}{}'",
+                repo, issue_number, title_arg
+            )
+        }
+        "manual" => {
+            format!(
+                "echo '🔧 Manual work session for issue {}#{}. The worktree is ready for you to work in.'",
+                repo, issue_number
+            )
+        }
+        _ => {
+            return Err(format!(
+                "Unknown agent type '{}'. Supported types: claude, aider, codex, gemini, ollama, manual",
+                agent_type
+            ));
+        }
+    };
+
+    Ok(command)
+}
+
+/// Build the command to start an agent based on type and context
+///
+/// Returns the shell command that should be sent to the tmux session
+/// to start the appropriate agent with the issue context.
+/// This is for non-sandboxed execution (auto_accept = false).
+pub fn build_agent_command(
+    agent_type: &str,
+    repo: &str,
+    issue_number: u64,
+    issue_title: Option<&str>,
+) -> Result<String, String> {
+    // Non-sandboxed mode: don't auto-accept
+    build_agent_command_inner(agent_type, repo, issue_number, issue_title, false)
+}
+
+/// Start an agent in an existing tmux session
+///
+/// This sends the appropriate command to the session to start the agent.
+/// Call this after create_session() to actually begin agent work.
+pub fn start_agent_in_session(
+    session_name: &str,
+    agent_type: &str,
+    repo: &str,
+    issue_number: u64,
+    issue_title: Option<&str>,
+) -> Result<(), String> {
+    let command = build_agent_command(agent_type, repo, issue_number, issue_title)?;
+    send_command(session_name, &command)
+}
+
+/// Start an agent in a Docker container inside a tmux session
+///
+/// This runs the agent inside a Docker container, which provides:
+/// - Filesystem isolation (worktree mounted at /workspace)
+/// - Resource limits (memory, CPU)
+/// - Safe auto-accept mode (--dangerously-skip-permissions is safe in sandbox)
+/// - Credential pass-through from host environment
+///
+/// The tmux session allows:
+/// - Attaching to see agent progress
+/// - Recovery if the container stops
+/// - Consistent management with non-sandboxed agents
+pub fn start_sandboxed_agent_in_session(
+    session_name: &str,
+    agent_type: &str,
+    repo: &str,
+    issue_number: u64,
+    issue_title: Option<&str>,
+    sandbox_config: &SandboxedAgentConfig,
+) -> Result<(), String> {
+    let command =
+        build_sandboxed_agent_command(agent_type, repo, issue_number, issue_title, sandbox_config)?;
+    send_command(session_name, &command)
+}
+
+/// Restart an agent in an existing session
+///
+/// Use this for recovery when a session exists but the agent process has stopped.
+/// This will attempt to restart the agent with the same context.
+pub fn restart_agent(session_name: &str) -> Result<(), String> {
+    // Get metadata to rebuild the agent command
+    let metadata = get_session_metadata(session_name)?;
+
+    let repo = metadata
+        .repo
+        .ok_or("Session has no repository metadata - cannot restart")?;
+
+    let issue_number = metadata
+        .issue_ref
+        .as_ref()
+        .and_then(|r| r.split('#').last())
+        .and_then(|n| n.parse::<u64>().ok())
+        .ok_or("Session has no valid issue reference - cannot restart")?;
+
+    // Start the agent with the stored metadata
+    start_agent_in_session(
+        session_name,
+        &metadata.agent_type,
+        &repo,
+        issue_number,
+        None, // We don't store the title in metadata, agent will fetch from GitHub
+    )
+}
+
+/// Generate a session name for an issue
+pub fn session_name_for_issue(issue_number: u32) -> String {
+    format!("{}{}", SESSION_PREFIX, issue_number)
+}
+
+/// Generate a session name for a manual (non-issue) session
+pub fn session_name_manual(suffix: &str) -> String {
+    format!("{}manual-{}", SESSION_PREFIX, suffix)
+}
+
+/// Ensure a master tmux session exists for orchestration and management.
+/// This session serves as a persistent handler for background tasks.
+/// Returns Ok(true) if the session was created, Ok(false) if it already exists.
+pub fn ensure_master_session() -> Result<bool, String> {
+    const MASTER_SESSION: &str = "handy-master";
+
+    // Check if master session already exists
+    // list_sessions() will fail if tmux server isn't running, which is fine
+    if let Ok(sessions) = list_sessions() {
+        let exists = sessions.iter().any(|s| s.name == MASTER_SESSION);
+        if exists {
+            return Ok(false);
+        }
+    }
+    // If list_sessions() failed, tmux server isn't running - we'll create the master session
+
+    // Create master session directly (bypassing create_session to avoid list_sessions check)
+    let output = Command::new("tmux")
+        .args(["-L", SOCKET_NAME, "new-session", "-d", "-s", MASTER_SESSION])
+        .output()
+        .map_err(|e| format!("Failed to create master session: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "tmux error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Set metadata for the master session
+    let machine_id = get_machine_id();
+    let started_at = chrono::Utc::now().to_rfc3339();
+    set_session_env(MASTER_SESSION, ENV_AGENT_TYPE, "master")?;
+    set_session_env(MASTER_SESSION, ENV_MACHINE_ID, &machine_id)?;
+    set_session_env(MASTER_SESSION, ENV_STARTED_AT, &started_at)?;
+
+    log::info!("Created master tmux session: {}", MASTER_SESSION);
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_name_generation() {
+        assert_eq!(session_name_for_issue(42), "handy-agent-42");
+        assert_eq!(session_name_manual("test"), "handy-agent-manual-test");
+    }
+
+    #[test]
+    fn test_is_tmux_running() {
+        // Just ensure it doesn't panic
+        let _ = is_tmux_running();
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/worktree.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/worktree.rs
@@ -1,0 +1,547 @@
+//! Git worktree management for isolated agent development environments.
+//!
+//! Enables creating, listing, and removing git worktrees with collision detection.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Configuration for worktree creation.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct WorktreeConfig {
+    /// Prefix for worktree directories (e.g., "Handy-" -> "Handy-feature-1")
+    pub prefix: String,
+    /// Base directory for worktrees (default: parent of repo)
+    pub base_path: Option<String>,
+    /// Auto-delete branch after merge
+    pub delete_branch_on_merge: bool,
+}
+
+impl Default for WorktreeConfig {
+    fn default() -> Self {
+        Self {
+            prefix: String::new(),
+            base_path: None,
+            delete_branch_on_merge: true,
+        }
+    }
+}
+
+/// Information about a git worktree.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct WorktreeInfo {
+    /// Absolute path to the worktree
+    pub path: String,
+    /// Branch name checked out in this worktree
+    pub branch: Option<String>,
+    /// Commit SHA of HEAD
+    pub head: String,
+    /// Whether this is the main worktree
+    pub is_main: bool,
+    /// Whether the worktree is locked
+    pub is_locked: bool,
+    /// Whether the worktree is prunable (missing)
+    pub is_prunable: bool,
+}
+
+/// Result of a worktree creation attempt.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct WorktreeCreateResult {
+    /// Path to the created worktree
+    pub path: String,
+    /// Branch name
+    pub branch: String,
+    /// Whether a new branch was created
+    pub branch_created: bool,
+}
+
+/// Collision check result.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct CollisionCheck {
+    /// Whether any collision was detected
+    pub has_collision: bool,
+    /// Path collision: directory already exists
+    pub path_exists: bool,
+    /// Branch collision: branch already exists
+    pub branch_exists: bool,
+    /// Worktree collision: worktree at path already exists
+    pub worktree_exists: bool,
+    /// Details about the collision
+    pub details: Option<String>,
+}
+
+/// Get the root directory of the git repository.
+pub fn get_repo_root(repo_path: &str) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Not a git repository: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Get the project name from the repository root.
+pub fn get_project_name(repo_path: &str) -> Result<String, String> {
+    let root = get_repo_root(repo_path)?;
+    let path = Path::new(&root);
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Could not determine project name".to_string())
+}
+
+/// Get the default branch (main or master).
+pub fn get_default_branch(repo_path: &str) -> Result<String, String> {
+    // Try to get the default branch from remote
+    let output = Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+        .current_dir(repo_path)
+        .output();
+
+    if let Ok(output) = output {
+        if output.status.success() {
+            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            // Remove "origin/" prefix
+            if let Some(name) = branch.strip_prefix("origin/") {
+                return Ok(name.to_string());
+            }
+            return Ok(branch);
+        }
+    }
+
+    // Fallback: check if main or master exists
+    for branch in &["main", "master"] {
+        let output = Command::new("git")
+            .args(["rev-parse", "--verify", branch])
+            .current_dir(repo_path)
+            .output();
+
+        if let Ok(output) = output {
+            if output.status.success() {
+                return Ok(branch.to_string());
+            }
+        }
+    }
+
+    Err("Could not determine default branch".to_string())
+}
+
+/// List all git worktrees in a repository.
+pub fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>, String> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git worktree list: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut worktrees = Vec::new();
+    let mut current = WorktreeInfo {
+        path: String::new(),
+        branch: None,
+        head: String::new(),
+        is_main: false,
+        is_locked: false,
+        is_prunable: false,
+    };
+    let mut is_first = true;
+
+    for line in stdout.lines() {
+        if line.starts_with("worktree ") {
+            if !current.path.is_empty() {
+                worktrees.push(current.clone());
+            }
+            current = WorktreeInfo {
+                path: line.strip_prefix("worktree ").unwrap_or("").to_string(),
+                branch: None,
+                head: String::new(),
+                is_main: is_first,
+                is_locked: false,
+                is_prunable: false,
+            };
+            is_first = false;
+        } else if line.starts_with("HEAD ") {
+            current.head = line.strip_prefix("HEAD ").unwrap_or("").to_string();
+        } else if line.starts_with("branch ") {
+            let branch = line.strip_prefix("branch ").unwrap_or("");
+            // Remove refs/heads/ prefix
+            current.branch = Some(
+                branch
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(branch)
+                    .to_string(),
+            );
+        } else if line == "locked" {
+            current.is_locked = true;
+        } else if line == "prunable" {
+            current.is_prunable = true;
+        } else if line == "detached" {
+            // Detached HEAD, no branch
+            current.branch = None;
+        }
+    }
+
+    // Don't forget the last worktree
+    if !current.path.is_empty() {
+        worktrees.push(current);
+    }
+
+    Ok(worktrees)
+}
+
+/// Check for collisions before creating a worktree.
+pub fn check_collision(
+    repo_path: &str,
+    worktree_path: &str,
+    branch_name: &str,
+) -> Result<CollisionCheck, String> {
+    let mut result = CollisionCheck {
+        has_collision: false,
+        path_exists: false,
+        branch_exists: false,
+        worktree_exists: false,
+        details: None,
+    };
+
+    // Check if path exists
+    if Path::new(worktree_path).exists() {
+        result.path_exists = true;
+        result.has_collision = true;
+        result.details = Some(format!("Directory already exists: {}", worktree_path));
+    }
+
+    // Check if branch exists
+    let branch_check = Command::new("git")
+        .args(["rev-parse", "--verify", branch_name])
+        .current_dir(repo_path)
+        .output();
+
+    if let Ok(output) = branch_check {
+        if output.status.success() {
+            result.branch_exists = true;
+            result.has_collision = true;
+            let msg = format!("Branch already exists: {}", branch_name);
+            result.details = Some(
+                result
+                    .details
+                    .map_or(msg.clone(), |d| format!("{}; {}", d, msg)),
+            );
+        }
+    }
+
+    // Check if worktree already exists at path
+    let worktrees = list_worktrees(repo_path)?;
+    for wt in worktrees {
+        if wt.path == worktree_path {
+            result.worktree_exists = true;
+            result.has_collision = true;
+            let msg = format!("Worktree already exists at: {}", worktree_path);
+            result.details = Some(
+                result
+                    .details
+                    .map_or(msg.clone(), |d| format!("{}; {}", d, msg)),
+            );
+        }
+    }
+
+    Ok(result)
+}
+
+/// Create a new git worktree with a new branch.
+///
+/// # Arguments
+/// * `repo_path` - Path to the git repository
+/// * `name` - Name for the worktree (will be used in path and branch name)
+/// * `config` - Worktree configuration (prefix, base path)
+/// * `base_branch` - Branch to create from (default: main/master)
+///
+/// # Returns
+/// Result with the created worktree info or an error
+pub fn create_worktree(
+    repo_path: &str,
+    name: &str,
+    config: &WorktreeConfig,
+    base_branch: Option<&str>,
+) -> Result<WorktreeCreateResult, String> {
+    let repo_root = get_repo_root(repo_path)?;
+    let project_name = get_project_name(repo_path)?;
+
+    // Determine base branch
+    let base = match base_branch {
+        Some(b) => b.to_string(),
+        None => get_default_branch(repo_path)?,
+    };
+
+    // Build the worktree path and branch name
+    let prefix = if config.prefix.is_empty() {
+        format!("{}-", project_name)
+    } else {
+        config.prefix.clone()
+    };
+
+    let worktree_name = format!("{}{}", prefix, name);
+    let branch_name = worktree_name.clone();
+
+    // Determine worktree directory
+    let base_path = config.base_path.clone().unwrap_or_else(|| {
+        Path::new(&repo_root)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| repo_root.clone())
+    });
+
+    let worktree_path = PathBuf::from(&base_path).join(&worktree_name);
+    let worktree_path_str = worktree_path.to_string_lossy().to_string();
+
+    // Check for collisions
+    let collision = check_collision(repo_path, &worktree_path_str, &branch_name)?;
+    if collision.has_collision {
+        return Err(format!(
+            "Cannot create worktree: {}",
+            collision
+                .details
+                .unwrap_or_else(|| "collision detected".to_string())
+        ));
+    }
+
+    // Create the worktree with a new branch
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            &branch_name,
+            &worktree_path_str,
+            &base,
+        ])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git worktree add: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(WorktreeCreateResult {
+        path: worktree_path_str,
+        branch: branch_name,
+        branch_created: true,
+    })
+}
+
+/// Create a worktree using an existing branch.
+pub fn create_worktree_existing_branch(
+    repo_path: &str,
+    branch_name: &str,
+    config: &WorktreeConfig,
+) -> Result<WorktreeCreateResult, String> {
+    let repo_root = get_repo_root(repo_path)?;
+    let project_name = get_project_name(repo_path)?;
+
+    // Build the worktree path
+    let prefix = if config.prefix.is_empty() {
+        format!("{}-", project_name)
+    } else {
+        config.prefix.clone()
+    };
+
+    let worktree_name = format!("{}{}", prefix, branch_name);
+
+    // Determine worktree directory
+    let base_path = config.base_path.clone().unwrap_or_else(|| {
+        Path::new(&repo_root)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| repo_root.clone())
+    });
+
+    let worktree_path = PathBuf::from(&base_path).join(&worktree_name);
+    let worktree_path_str = worktree_path.to_string_lossy().to_string();
+
+    // Check if path exists
+    if Path::new(&worktree_path_str).exists() {
+        return Err(format!("Directory already exists: {}", worktree_path_str));
+    }
+
+    // Create the worktree using existing branch
+    let output = Command::new("git")
+        .args(["worktree", "add", &worktree_path_str, branch_name])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git worktree add: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(WorktreeCreateResult {
+        path: worktree_path_str,
+        branch: branch_name.to_string(),
+        branch_created: false,
+    })
+}
+
+/// Remove a git worktree.
+///
+/// # Arguments
+/// * `repo_path` - Path to the main repository
+/// * `worktree_path` - Path to the worktree to remove
+/// * `force` - Force removal even if there are uncommitted changes
+/// * `delete_branch` - Also delete the associated branch
+pub fn remove_worktree(
+    repo_path: &str,
+    worktree_path: &str,
+    force: bool,
+    delete_branch: bool,
+) -> Result<(), String> {
+    // Get branch name before removing worktree (if we need to delete it)
+    let branch_to_delete = if delete_branch {
+        let worktrees = list_worktrees(repo_path)?;
+        worktrees
+            .iter()
+            .find(|wt| wt.path == worktree_path)
+            .and_then(|wt| wt.branch.clone())
+    } else {
+        None
+    };
+
+    // Remove the worktree
+    let mut args = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    args.push(worktree_path);
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git worktree remove: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree remove failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Delete the branch if requested
+    if let Some(branch) = branch_to_delete {
+        let delete_args = if force {
+            vec!["branch", "-D", &branch]
+        } else {
+            vec!["branch", "-d", &branch]
+        };
+
+        let output = Command::new("git")
+            .args(&delete_args)
+            .current_dir(repo_path)
+            .output()
+            .map_err(|e| format!("Failed to delete branch: {}", e))?;
+
+        if !output.status.success() {
+            // Branch deletion failure is not critical, just log it
+            eprintln!(
+                "Warning: Could not delete branch {}: {}",
+                branch,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Get information about a specific worktree.
+pub fn get_worktree_info(repo_path: &str, worktree_path: &str) -> Result<WorktreeInfo, String> {
+    let worktrees = list_worktrees(repo_path)?;
+    worktrees
+        .into_iter()
+        .find(|wt| wt.path == worktree_path)
+        .ok_or_else(|| format!("Worktree not found: {}", worktree_path))
+}
+
+/// Prune stale worktree entries.
+pub fn prune_worktrees(repo_path: &str) -> Result<(), String> {
+    let output = Command::new("git")
+        .args(["worktree", "prune"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git worktree prune: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree prune failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a path is inside a git worktree or repository.
+pub fn is_inside_worktree(path: &str) -> Result<bool, String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                Ok(result == "true")
+            } else {
+                Ok(false)
+            }
+        }
+        Err(_) => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collision_check_structure() {
+        let check = CollisionCheck {
+            has_collision: false,
+            path_exists: false,
+            branch_exists: false,
+            worktree_exists: false,
+            details: None,
+        };
+        assert!(!check.has_collision);
+    }
+
+    #[test]
+    fn test_worktree_config_default() {
+        let config = WorktreeConfig::default();
+        assert!(config.prefix.is_empty());
+        assert!(config.base_path.is_none());
+        assert!(config.delete_branch_on_merge);
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod audio_toolkit;
 pub mod auth;
 pub mod clipboard;
 pub mod commands;
+pub mod devops;
 pub mod helpers;
 pub mod input;
 pub mod local_llm;
@@ -218,6 +219,128 @@ fn specta_builder() -> Builder<tauri::Wry> {
         // onichan: sidecar quick-config
         commands::sidecar_config::get_sidecar_quick_config,
         commands::sidecar_config::set_sidecar_quick_config_field,
+        // devops: dependencies + auth
+        commands::devops::check_devops_dependencies,
+        commands::devops::launch_cli_auth,
+        // devops: tmux
+        commands::devops::attach_tmux_session,
+        commands::devops::list_tmux_sessions,
+        commands::devops::get_tmux_session_metadata,
+        commands::devops::create_tmux_session,
+        commands::devops::kill_tmux_session,
+        commands::devops::get_tmux_session_output,
+        commands::devops::send_tmux_command,
+        commands::devops::send_tmux_keys,
+        commands::devops::recover_tmux_sessions,
+        commands::devops::restart_agent_in_session,
+        commands::devops::recover_all_agent_sessions,
+        commands::devops::is_tmux_running,
+        commands::devops::ensure_master_tmux_session,
+        // devops: git worktrees
+        commands::devops::list_git_worktrees,
+        commands::devops::get_git_worktree_info,
+        commands::devops::check_worktree_collision,
+        commands::devops::create_git_worktree,
+        commands::devops::create_git_worktree_existing_branch,
+        commands::devops::remove_git_worktree,
+        commands::devops::prune_git_worktrees,
+        commands::devops::get_git_repo_root,
+        commands::devops::get_git_default_branch,
+        commands::devops::suggest_local_repo_path,
+        // devops: github
+        commands::devops::check_gh_auth,
+        commands::devops::list_github_issues,
+        commands::devops::get_github_issue,
+        commands::devops::get_github_issue_with_agent,
+        commands::devops::create_github_issue,
+        commands::devops::comment_on_github_issue,
+        commands::devops::assign_agent_to_issue,
+        commands::devops::list_github_issue_comments,
+        commands::devops::update_github_issue_labels,
+        commands::devops::close_github_issue,
+        commands::devops::reopen_github_issue,
+        commands::devops::list_github_prs,
+        commands::devops::get_github_pr,
+        commands::devops::get_github_pr_status,
+        commands::devops::create_github_pr,
+        commands::devops::merge_github_pr,
+        commands::devops::close_github_pr,
+        // devops: agent orchestration
+        commands::devops::spawn_agent,
+        commands::devops::list_agent_statuses,
+        commands::devops::cleanup_agent,
+        commands::devops::create_pr_from_agent,
+        commands::devops::complete_agent_work,
+        commands::devops::check_and_cleanup_merged_pr,
+        commands::devops::get_current_machine_id,
+        commands::devops::list_local_agent_statuses,
+        commands::devops::list_remote_agent_statuses,
+        commands::devops::toggle_agent_enabled,
+        commands::devops::get_enabled_agents,
+        commands::devops::set_enabled_agents,
+        commands::devops::get_sandbox_enabled,
+        commands::devops::set_sandbox_enabled,
+        // devops: epics
+        commands::devops::create_epic,
+        commands::devops::create_sub_issues,
+        commands::devops::update_epic_progress,
+        commands::devops::spawn_agent_from_issue,
+        commands::devops::complete_agent_work_with_pr,
+        commands::devops::plan_epic_from_markdown,
+        commands::devops::list_epic_plan_templates,
+        commands::devops::start_epic_orchestration,
+        commands::devops::get_epic_phase_status,
+        commands::devops::load_epic,
+        commands::devops::load_epic_for_recovery,
+        commands::devops::update_epic_phase_status_on_github,
+        commands::devops::mark_epic_phase_status,
+        // devops: epic state persistence
+        commands::devops::get_active_epic_state,
+        commands::devops::set_active_epic_state,
+        commands::devops::set_active_epic_from_recovery,
+        commands::devops::clear_active_epic_state,
+        commands::devops::sync_active_epic_state,
+        commands::devops::update_epic_sub_issue_agent,
+        commands::devops::set_epic_local_repo_path,
+        commands::devops::on_pipeline_item_complete,
+        commands::devops::merge_ready_pr,
+        commands::devops::process_ready_prs,
+        // devops: docker sandbox
+        commands::devops::is_docker_available,
+        commands::devops::spawn_sandbox,
+        commands::devops::get_sandbox_status,
+        commands::devops::get_sandbox_logs,
+        commands::devops::stop_sandbox,
+        commands::devops::remove_sandbox,
+        commands::devops::list_sandboxes,
+        // devops: devcontainer
+        commands::devops::is_devcontainer_cli_available,
+        commands::devops::setup_devcontainer,
+        commands::devops::start_devcontainer,
+        commands::devops::exec_in_devcontainer,
+        // devops: agent network
+        commands::devops::ensure_agent_network,
+        commands::devops::get_agent_network_info,
+        commands::devops::list_network_containers,
+        // devops: pipeline
+        commands::devops::assign_issue_to_agent_pipeline,
+        commands::devops::skip_issue,
+        commands::devops::list_pipeline_items,
+        commands::devops::get_pipeline_history,
+        commands::devops::get_pipeline_summary,
+        commands::devops::detect_and_link_prs,
+        commands::devops::sync_all_pr_statuses,
+        commands::devops::update_pipeline_item_pr_status,
+        commands::devops::get_pipeline_item,
+        commands::devops::find_pipeline_item_by_issue,
+        commands::devops::find_pipeline_item_by_session,
+        commands::devops::link_pr_to_pipeline_item,
+        commands::devops::archive_pipeline_item,
+        commands::devops::remove_pipeline_item,
+        commands::devops::check_sessions_for_prs,
+        commands::devops::cleanup_orphaned_containers,
+        commands::devops::check_claude_auth_volume,
+        commands::devops::launch_claude_auth_setup,
     ])
 }
 
@@ -423,6 +546,11 @@ pub fn run() {
 
             // Hidden recording overlay window (shown during record/transcribe).
             utils::create_recording_overlay(&dict_handle);
+
+            // Master tmux session for DevOps agent orchestration (optional).
+            if let Err(e) = devops::tmux::ensure_master_session() {
+                log::warn!("Failed to create master tmux session: {}", e);
+            }
 
             Ok(())
         })

--- a/apps/kbve/desktop-kbve/src/App.tsx
+++ b/apps/kbve/desktop-kbve/src/App.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from './stores/app';
 import { getView } from './engine';
 import { useAuthStore } from './stores/auth';
 import { SignIn } from './components/SignIn';
+import { ToastContainer } from './components/common/ToastContainer';
 
 export default function App() {
 	const phase = useAuthStore((s) => s.phase);
@@ -29,6 +30,7 @@ export default function App() {
 				<Header />
 				<ViewHost />
 			</main>
+			<ToastContainer />
 		</div>
 	);
 }

--- a/apps/kbve/desktop-kbve/src/app.css
+++ b/apps/kbve/desktop-kbve/src/app.css
@@ -1,6 +1,39 @@
 @import 'tailwindcss';
 @source "./**/*.{ts,tsx}";
 
+/* Handy-compat tokens: upstream devops components use these class names. */
+@theme inline {
+	--color-mid-gray: var(--color-text-muted);
+	--color-logo-primary: var(--color-accent);
+	--color-logo-secondary: var(--color-accent-hover);
+	--color-logo-stroke: var(--color-border);
+	--color-text-stroke: var(--color-border);
+	--color-accent-cyan: #22d3ee;
+	--color-accent-purple: #a78bfa;
+	--animate-slide-in-right: slideInRight 0.3s ease-out;
+	--animate-fade-out: fadeOut 0.2s ease-out;
+}
+
+@keyframes slideInRight {
+	0% {
+		transform: translateX(100%);
+		opacity: 0;
+	}
+	100% {
+		transform: translateX(0);
+		opacity: 1;
+	}
+}
+
+@keyframes fadeOut {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
 /* ─── Font ────────────────────────────────────────────────────────────────── */
 
 @font-face {

--- a/apps/kbve/desktop-kbve/src/bindings.ts
+++ b/apps/kbve/desktop-kbve/src/bindings.ts
@@ -975,6 +975,1962 @@ export const commands = {
 			else return { status: 'error', error: e as any };
 		}
 	},
+	/**
+	 * Check if required DevOps dependencies (gh, tmux) are installed.
+	 * Runs in a blocking task to avoid freezing the UI.
+	 */
+	async checkDevopsDependencies(): Promise<
+		Result<DevOpsDependencies, string>
+	> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('check_devops_dependencies'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Launch authentication flow for a CLI tool by creating a tmux session.
+	 * Returns the session name so the user can attach to it.
+	 */
+	async launchCliAuth(toolName: string): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('launch_cli_auth', { toolName }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Attach to an existing tmux session by opening Terminal.app.
+	 */
+	async attachTmuxSession(
+		sessionName: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('attach_tmux_session', {
+					sessionName,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List all Handy agent tmux sessions.
+	 */
+	async listTmuxSessions(): Promise<Result<TmuxSession[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_tmux_sessions'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get metadata for a specific tmux session.
+	 */
+	async getTmuxSessionMetadata(
+		sessionName: string,
+	): Promise<Result<AgentMetadata, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_tmux_session_metadata', {
+					sessionName,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a new tmux session with metadata.
+	 */
+	async createTmuxSession(
+		sessionName: string,
+		workingDir: string | null,
+		issueRef: string | null,
+		repo: string | null,
+		agentType: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_tmux_session', {
+					sessionName,
+					workingDir,
+					issueRef,
+					repo,
+					agentType,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Kill a tmux session.
+	 */
+	async killTmuxSession(sessionName: string): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('kill_tmux_session', { sessionName }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get recent output from a tmux session.
+	 */
+	async getTmuxSessionOutput(
+		sessionName: string,
+		lines: number | null,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_tmux_session_output', {
+					sessionName,
+					lines,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Send a command to a tmux session (appends Enter key).
+	 * If command is empty, sends just Enter key.
+	 */
+	async sendTmuxCommand(
+		sessionName: string,
+		command: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('send_tmux_command', {
+					sessionName,
+					command,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Send raw keys to a tmux session without appending Enter.
+	 * Use for special keys: Enter, Escape, Tab, Space, BSpace, Up, Down, Left, Right, C-c, etc.
+	 */
+	async sendTmuxKeys(
+		sessionName: string,
+		keys: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('send_tmux_keys', {
+					sessionName,
+					keys,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Recover agent sessions on startup.
+	 */
+	async recoverTmuxSessions(): Promise<Result<RecoveredSession[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('recover_tmux_sessions'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Restart an agent in an existing tmux session.
+	 *
+	 * Use this for recovery when a session exists but the agent process has stopped.
+	 * This reads the session metadata and restarts the appropriate agent command.
+	 */
+	async restartAgentInSession(
+		sessionName: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('restart_agent_in_session', {
+					sessionName,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Recover all sessions that need attention.
+	 *
+	 * - `auto_restart`: If true, automatically restart agents in stopped sessions
+	 * - `auto_cleanup`: If true, automatically kill orphaned sessions (no worktree)
+	 *
+	 * Returns results for each session that was processed.
+	 */
+	async recoverAllAgentSessions(
+		autoRestart: boolean,
+		autoCleanup: boolean,
+	): Promise<Result<RecoveryResult[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('recover_all_agent_sessions', {
+					autoRestart,
+					autoCleanup,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check if tmux server is running.
+	 */
+	async isTmuxRunning(): Promise<boolean> {
+		return await TAURI_INVOKE('is_tmux_running');
+	},
+	/**
+	 * Ensure a master tmux session exists for orchestration.
+	 * Returns true if the session was created, false if it already exists.
+	 */
+	async ensureMasterTmuxSession(): Promise<Result<boolean, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('ensure_master_tmux_session'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List all git worktrees in a repository.
+	 */
+	async listGitWorktrees(
+		repoPath: string,
+	): Promise<Result<WorktreeInfo[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_git_worktrees', { repoPath }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get information about a specific worktree.
+	 */
+	async getGitWorktreeInfo(
+		repoPath: string,
+		worktreePath: string,
+	): Promise<Result<WorktreeInfo, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_git_worktree_info', {
+					repoPath,
+					worktreePath,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check for collisions before creating a worktree.
+	 */
+	async checkWorktreeCollision(
+		repoPath: string,
+		worktreePath: string,
+		branchName: string,
+	): Promise<Result<CollisionCheck, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('check_worktree_collision', {
+					repoPath,
+					worktreePath,
+					branchName,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a new git worktree with a new branch.
+	 */
+	async createGitWorktree(
+		repoPath: string,
+		name: string,
+		prefix: string | null,
+		basePath: string | null,
+		baseBranch: string | null,
+	): Promise<Result<WorktreeCreateResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_git_worktree', {
+					repoPath,
+					name,
+					prefix,
+					basePath,
+					baseBranch,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a worktree using an existing branch.
+	 */
+	async createGitWorktreeExistingBranch(
+		repoPath: string,
+		branchName: string,
+		prefix: string | null,
+		basePath: string | null,
+	): Promise<Result<WorktreeCreateResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE(
+					'create_git_worktree_existing_branch',
+					{ repoPath, branchName, prefix, basePath },
+				),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Remove a git worktree.
+	 */
+	async removeGitWorktree(
+		repoPath: string,
+		worktreePath: string,
+		force: boolean,
+		deleteBranch: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('remove_git_worktree', {
+					repoPath,
+					worktreePath,
+					force,
+					deleteBranch,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Prune stale worktree entries.
+	 */
+	async pruneGitWorktrees(repoPath: string): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('prune_git_worktrees', { repoPath }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get the root directory of a git repository.
+	 */
+	async getGitRepoRoot(path: string): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_git_repo_root', { path }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get the default branch of a repository.
+	 */
+	async getGitDefaultBranch(
+		repoPath: string,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_git_default_branch', {
+					repoPath,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Suggest local paths for a GitHub repository.
+	 * Searches common locations for cloned repos matching the given owner/repo format.
+	 */
+	async suggestLocalRepoPath(githubRepo: string): Promise<string[]> {
+		return await TAURI_INVOKE('suggest_local_repo_path', { githubRepo });
+	},
+	/**
+	 * Check GitHub CLI authentication status.
+	 */
+	async checkGhAuth(): Promise<GhAuthStatus> {
+		return await TAURI_INVOKE('check_gh_auth');
+	},
+	/**
+	 * List issues from a GitHub repository.
+	 */
+	async listGithubIssues(
+		repo: string,
+		state: string | null,
+		labels: string[] | null,
+		limit: number | null,
+	): Promise<Result<GitHubIssue[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_github_issues', {
+					repo,
+					state,
+					labels,
+					limit,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get details of a specific GitHub issue.
+	 */
+	async getGithubIssue(
+		repo: string,
+		number: number,
+	): Promise<Result<GitHubIssue, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_github_issue', { repo, number }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get issue with agent metadata.
+	 */
+	async getGithubIssueWithAgent(
+		repo: string,
+		number: number,
+	): Promise<Result<IssueWithAgent, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_github_issue_with_agent', {
+					repo,
+					number,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a new GitHub issue.
+	 */
+	async createGithubIssue(
+		repo: string,
+		title: string,
+		body: string | null,
+		labels: string[] | null,
+	): Promise<Result<GitHubIssue, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_github_issue', {
+					repo,
+					title,
+					body,
+					labels,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Add a comment to a GitHub issue.
+	 */
+	async commentOnGithubIssue(
+		repo: string,
+		number: number,
+		body: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('comment_on_github_issue', {
+					repo,
+					number,
+					body,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Assign an agent to a GitHub issue (adds metadata comment).
+	 */
+	async assignAgentToIssue(
+		repo: string,
+		number: number,
+		session: string,
+		agentType: string,
+		worktree: string | null,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('assign_agent_to_issue', {
+					repo,
+					number,
+					session,
+					agentType,
+					worktree,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List comments on a GitHub issue.
+	 */
+	async listGithubIssueComments(
+		repo: string,
+		number: number,
+	): Promise<Result<GitHubComment[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_github_issue_comments', {
+					repo,
+					number,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update labels on a GitHub issue.
+	 */
+	async updateGithubIssueLabels(
+		repo: string,
+		number: number,
+		addLabels: string[],
+		removeLabels: string[],
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('update_github_issue_labels', {
+					repo,
+					number,
+					addLabels,
+					removeLabels,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Close a GitHub issue.
+	 */
+	async closeGithubIssue(
+		repo: string,
+		number: number,
+		comment: string | null,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('close_github_issue', {
+					repo,
+					number,
+					comment,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Reopen a closed GitHub issue.
+	 */
+	async reopenGithubIssue(
+		repo: string,
+		number: number,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('reopen_github_issue', {
+					repo,
+					number,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List pull requests from a GitHub repository.
+	 */
+	async listGithubPrs(
+		repo: string,
+		state: string | null,
+		base: string | null,
+		limit: number | null,
+	): Promise<Result<GitHubPullRequest[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_github_prs', {
+					repo,
+					state,
+					base,
+					limit,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get details of a specific GitHub pull request.
+	 */
+	async getGithubPr(
+		repo: string,
+		number: number,
+	): Promise<Result<GitHubPullRequest, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_github_pr', { repo, number }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get full status of a pull request (PR + checks + reviews).
+	 */
+	async getGithubPrStatus(
+		repo: string,
+		number: number,
+	): Promise<Result<PrStatus, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_github_pr_status', {
+					repo,
+					number,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a new GitHub pull request.
+	 */
+	async createGithubPr(
+		repo: string,
+		title: string,
+		body: string | null,
+		base: string,
+		head: string | null,
+		draft: boolean,
+	): Promise<Result<GitHubPullRequest, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_github_pr', {
+					repo,
+					title,
+					body,
+					base,
+					head,
+					draft,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Merge a GitHub pull request.
+	 */
+	async mergeGithubPr(
+		repo: string,
+		number: number,
+		method: string | null,
+		deleteBranch: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('merge_github_pr', {
+					repo,
+					number,
+					method,
+					deleteBranch,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Close a GitHub pull request without merging.
+	 */
+	async closeGithubPr(
+		repo: string,
+		number: number,
+		comment: string | null,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('close_github_pr', {
+					repo,
+					number,
+					comment,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Spawn a new agent to work on an issue.
+	 *
+	 * Creates a worktree, tmux session (or Docker container if sandbox enabled),
+	 * and updates the issue with metadata.
+	 */
+	async spawnAgent(
+		repo: string,
+		issueNumber: number,
+		agentType: string,
+		repoPath: string,
+		sessionName: string | null,
+		worktreePrefix: string | null,
+		workingLabels: string[] | null,
+		useSandbox: boolean | null,
+	): Promise<Result<SpawnResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('spawn_agent', {
+					repo,
+					issueNumber,
+					agentType,
+					repoPath,
+					sessionName,
+					worktreePrefix,
+					workingLabels,
+					useSandbox,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get status of all active agents.
+	 */
+	async listAgentStatuses(): Promise<Result<AgentStatus[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_agent_statuses'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Clean up an agent's resources after work is complete.
+	 */
+	async cleanupAgent(
+		sessionName: string,
+		repoPath: string,
+		removeWorktree: boolean,
+		deleteBranch: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('cleanup_agent', {
+					sessionName,
+					repoPath,
+					removeWorktree,
+					deleteBranch,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create a PR from an agent's work.
+	 */
+	async createPrFromAgent(
+		sessionName: string,
+		title: string,
+		body: string | null,
+		draft: boolean,
+	): Promise<Result<GitHubPullRequest, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_pr_from_agent', {
+					sessionName,
+					title,
+					body,
+					draft,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Complete an agent's work with workflow automation.
+	 *
+	 * Creates PR, updates issue with link, manages labels.
+	 */
+	async completeAgentWork(
+		sessionName: string,
+		prTitle: string,
+		prBody: string | null,
+		workingLabels: string[],
+		prLabels: string[],
+		draftPr: boolean,
+	): Promise<Result<CompleteWorkResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('complete_agent_work', {
+					sessionName,
+					prTitle,
+					prBody,
+					workingLabels,
+					prLabels,
+					draftPr,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check if a PR has been merged and cleanup resources if so.
+	 */
+	async checkAndCleanupMergedPr(
+		sessionName: string,
+		repoPath: string,
+		prNumber: number,
+	): Promise<Result<boolean, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('check_and_cleanup_merged_pr', {
+					sessionName,
+					repoPath,
+					prNumber,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get current machine identifier.
+	 */
+	async getCurrentMachineId(): Promise<string> {
+		return await TAURI_INVOKE('get_current_machine_id');
+	},
+	/**
+	 * List only agents running on this machine.
+	 */
+	async listLocalAgentStatuses(): Promise<Result<AgentStatus[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_local_agent_statuses'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List agents from other machines (potentially orphaned).
+	 */
+	async listRemoteAgentStatuses(): Promise<Result<AgentStatus[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_remote_agent_statuses'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Toggle an agent type on/off.
+	 */
+	async toggleAgentEnabled(
+		agentType: string,
+		enabled: boolean,
+	): Promise<Result<string[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('toggle_agent_enabled', {
+					agentType,
+					enabled,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get list of enabled agents.
+	 */
+	async getEnabledAgents(): Promise<string[]> {
+		return await TAURI_INVOKE('get_enabled_agents');
+	},
+	/**
+	 * Set the list of enabled agents (bulk update).
+	 */
+	async setEnabledAgents(agents: string[]): Promise<string[]> {
+		return await TAURI_INVOKE('set_enabled_agents', { agents });
+	},
+	/**
+	 * Get whether sandbox mode is enabled for agent spawning.
+	 */
+	async getSandboxEnabled(): Promise<boolean> {
+		return await TAURI_INVOKE('get_sandbox_enabled');
+	},
+	/**
+	 * Set whether sandbox mode is enabled for agent spawning.
+	 */
+	async setSandboxEnabled(enabled: boolean): Promise<boolean> {
+		return await TAURI_INVOKE('set_sandbox_enabled', { enabled });
+	},
+	/**
+	 * Create a new epic issue with standardized structure
+	 */
+	async createEpic(config: EpicConfig): Promise<Result<EpicInfo, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_epic', { config }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Create multiple sub-issues for an epic in batch
+	 */
+	async createSubIssues(
+		epicNumber: number,
+		epicRepo: string,
+		epicWorkRepo: string,
+		subIssues: SubIssueConfig[],
+	): Promise<Result<SubIssueInfo[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('create_sub_issues', {
+					epicNumber,
+					epicRepo,
+					epicWorkRepo,
+					subIssues,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update epic issue progress based on sub-issue completion
+	 */
+	async updateEpicProgress(
+		epicNumber: number,
+		epicRepo: string,
+	): Promise<Result<EpicProgress, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('update_epic_progress', {
+					epicNumber,
+					epicRepo,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Spawn an agent for a GitHub issue
+	 */
+	async spawnAgentFromIssue(
+		config: SpawnAgentConfig,
+	): Promise<Result<AgentSpawnResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('spawn_agent_from_issue', { config }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Complete agent work by creating a PR
+	 */
+	async completeAgentWorkWithPr(
+		session: string,
+		prTitle: string | null,
+	): Promise<Result<AgentCompletionResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('complete_agent_work_with_pr', {
+					session,
+					prTitle,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Plan an Epic from a markdown file using AI agent
+	 */
+	async planEpicFromMarkdown(
+		config: PlanFromMarkdownConfig,
+	): Promise<Result<PlanResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('plan_epic_from_markdown', { config }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List all available Epic plan templates from docs/plans directory
+	 */
+	async listEpicPlanTemplates(): Promise<Result<PlanTemplate[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_epic_plan_templates'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Start orchestration for an epic - creates sub-issues and optionally spawns agents
+	 */
+	async startEpicOrchestration(
+		epic: EpicInfo,
+		config: StartOrchestrationConfig,
+	): Promise<Result<OrchestrationResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('start_epic_orchestration', {
+					epic,
+					config,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get status of all phases in an epic
+	 */
+	async getEpicPhaseStatus(
+		epicNumber: number,
+		epicRepo: string,
+		phases: PhaseConfig[],
+	): Promise<Result<PhaseStatus[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_epic_phase_status', {
+					epicNumber,
+					epicRepo,
+					phases,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Load an existing epic from GitHub by issue number
+	 *
+	 * Parses the epic's body to extract phases and metadata for orchestration.
+	 */
+	async loadEpic(
+		repo: string,
+		epicNumber: number,
+	): Promise<Result<EpicInfo, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('load_epic', { repo, epicNumber }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Load an existing epic with full recovery information
+	 *
+	 * Fetches the epic, all its sub-issues, and determines what work remains.
+	 * Useful for recovering/continuing orchestration on an existing epic.
+	 */
+	async loadEpicForRecovery(
+		repo: string,
+		epicNumber: number,
+	): Promise<Result<EpicRecoveryInfo, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('load_epic_for_recovery', {
+					repo,
+					epicNumber,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update the Epic issue on GitHub with current phase status.
+	 *
+	 * Call this after phases complete to keep the Epic issue body in sync.
+	 */
+	async updateEpicPhaseStatusOnGithub(
+		epicRepo: string,
+		epicNumber: number,
+		phaseStatuses: PhaseStatus[],
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('update_epic_phase_status_on_github', {
+					epicRepo,
+					epicNumber,
+					phaseStatuses,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Manually mark a phase's status on GitHub.
+	 *
+	 * Use this for phases that were completed manually (without sub-issues)
+	 * or for recovery when the Epic body status doesn't match actual state.
+	 */
+	async markEpicPhaseStatus(
+		epicRepo: string,
+		epicNumber: number,
+		phaseNumber: number,
+		newStatus: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('mark_epic_phase_status', {
+					epicRepo,
+					epicNumber,
+					phaseNumber,
+					newStatus,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get the currently active Epic state (persisted across app restarts).
+	 */
+	async getActiveEpicState(): Promise<ActiveEpicState | null> {
+		return await TAURI_INVOKE('get_active_epic_state');
+	},
+	/**
+	 * Set the active Epic from an EpicInfo (when linking an Epic).
+	 */
+	async setActiveEpicState(epicInfo: EpicInfo): Promise<ActiveEpicState> {
+		return await TAURI_INVOKE('set_active_epic_state', { epicInfo });
+	},
+	/**
+	 * Set the active Epic from recovery info (more complete data with sub-issues).
+	 */
+	async setActiveEpicFromRecovery(
+		recovery: EpicRecoveryInfo,
+	): Promise<ActiveEpicState> {
+		return await TAURI_INVOKE('set_active_epic_from_recovery', {
+			recovery,
+		});
+	},
+	/**
+	 * Clear the active Epic state. If archive is true, moves to history.
+	 */
+	async clearActiveEpicState(
+		archive: boolean,
+	): Promise<ActiveEpicState | null> {
+		return await TAURI_INVOKE('clear_active_epic_state', { archive });
+	},
+	/**
+	 * Sync the active Epic state with GitHub to get latest sub-issue status.
+	 */
+	async syncActiveEpicState(): Promise<
+		Result<ActiveEpicState | null, string>
+	> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('sync_active_epic_state'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update a sub-issue's agent assignment in the active Epic.
+	 */
+	async updateEpicSubIssueAgent(
+		issueNumber: number,
+		sessionName: string | null,
+		agentType: string | null,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('update_epic_sub_issue_agent', {
+					issueNumber,
+					sessionName,
+					agentType,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update the local repository path for the active Epic.
+	 *
+	 * This path is used when spawning agents to know where to create worktrees.
+	 */
+	async setEpicLocalRepoPath(
+		localRepoPath: string,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('set_epic_local_repo_path', {
+					localRepoPath,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Handle pipeline item completion and optionally update Epic on GitHub.
+	 *
+	 * Call this when a sub-issue is completed (PR merged, issue closed).
+	 * It syncs Epic state and optionally updates the Epic issue on GitHub
+	 * with the new phase progress.
+	 */
+	async onPipelineItemComplete(
+		issueNumber: number,
+		updateGithub: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('on_pipeline_item_complete', {
+					issueNumber,
+					updateGithub,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Merge a PR for a sub-issue that's in "Ready" state
+	 *
+	 * This command:
+	 * 1. Finds the PR associated with the sub-issue
+	 * 2. Merges the PR (squash merge by default)
+	 * 3. Syncs the Epic state to update status
+	 * 4. Returns info about whether next phase can start
+	 */
+	async mergeReadyPr(
+		issueNumber: number,
+		mergeMethod: string | null,
+		deleteBranch: boolean,
+	): Promise<Result<MergeResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('merge_ready_pr', {
+					issueNumber,
+					mergeMethod,
+					deleteBranch,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Process all "Ready" sub-issues for the active Epic
+	 *
+	 * This command finds all sub-issues with PRs (Ready state) and merges them.
+	 * After each merge, it checks if the phase is complete and can start the next phase.
+	 */
+	async processReadyPrs(
+		mergeMethod: string | null,
+		deleteBranch: boolean,
+		autoStartNextPhase: boolean,
+	): Promise<Result<ProcessReadyResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('process_ready_prs', {
+					mergeMethod,
+					deleteBranch,
+					autoStartNextPhase,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check if Docker is available and daemon is running
+	 */
+	async isDockerAvailable(): Promise<boolean> {
+		return await TAURI_INVOKE('is_docker_available');
+	},
+	/**
+	 * Spawn a sandboxed agent in a Docker container
+	 *
+	 * This creates an isolated container where the agent can run with
+	 * auto-accept permissions safely. The container has:
+	 * - The worktree mounted at /workspace
+	 * - GitHub and Anthropic credentials passed as env vars
+	 * - Resource limits applied
+	 */
+	async spawnSandbox(
+		config: SandboxConfig,
+	): Promise<Result<SandboxResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('spawn_sandbox', { config }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get status of a sandbox container
+	 */
+	async getSandboxStatus(
+		containerName: string,
+	): Promise<Result<SandboxStatus, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_sandbox_status', {
+					containerName,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get logs from a sandbox container
+	 */
+	async getSandboxLogs(
+		containerName: string,
+		tail: number | null,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('get_sandbox_logs', {
+					containerName,
+					tail,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Stop a sandbox container
+	 */
+	async stopSandbox(containerName: string): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('stop_sandbox', { containerName }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Remove a sandbox container
+	 */
+	async removeSandbox(
+		containerName: string,
+		force: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('remove_sandbox', {
+					containerName,
+					force,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List all Handy sandbox containers
+	 */
+	async listSandboxes(): Promise<Result<SandboxStatus[], string>> {
+		try {
+			return { status: 'ok', data: await TAURI_INVOKE('list_sandboxes') };
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check if devcontainer CLI is available
+	 */
+	async isDevcontainerCliAvailable(): Promise<boolean> {
+		return await TAURI_INVOKE('is_devcontainer_cli_available');
+	},
+	/**
+	 * Setup a devcontainer configuration for a worktree
+	 *
+	 * Creates a .devcontainer/devcontainer.json file with the official
+	 * Anthropic Claude Code feature configured.
+	 */
+	async setupDevcontainer(
+		worktreePath: string,
+		issueRef: string,
+		ghToken: string | null,
+		anthropicKey: string | null,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('setup_devcontainer', {
+					worktreePath,
+					issueRef,
+					ghToken,
+					anthropicKey,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Start a devcontainer for a workspace
+	 *
+	 * Uses the devcontainer CLI to build and start the container.
+	 */
+	async startDevcontainer(
+		worktreePath: string,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('start_devcontainer', {
+					worktreePath,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Execute a command inside a running devcontainer
+	 */
+	async execInDevcontainer(
+		worktreePath: string,
+		command: string,
+	): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('exec_in_devcontainer', {
+					worktreePath,
+					command,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Ensure the shared agent network exists for inter-container communication
+	 *
+	 * Creates the 'handy-agents' Docker network if it doesn't exist.
+	 * Agents on this network can communicate using container names as hostnames.
+	 */
+	async ensureAgentNetwork(): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('ensure_agent_network'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get network information for a sandboxed agent
+	 *
+	 * Returns the allocated port range and network hostname for the agent.
+	 * Use this to know which ports are available and how other agents can reach this one.
+	 */
+	async getAgentNetworkInfo(
+		issueNumber: number,
+		containerPorts: number[],
+	): Promise<AgentNetworkInfo> {
+		return await TAURI_INVOKE('get_agent_network_info', {
+			issueNumber,
+			containerPorts,
+		});
+	},
+	/**
+	 * List all containers on the agent network
+	 *
+	 * Returns container names that can be used as hostnames for inter-container communication.
+	 */
+	async listNetworkContainers(): Promise<Result<string[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_network_containers'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Assign an issue to an agent, creating worktree and tmux session.
+	 */
+	async assignIssueToAgentPipeline(
+		config: AssignIssueConfig,
+	): Promise<Result<AssignIssueResult, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('assign_issue_to_agent_pipeline', {
+					config,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Skip an issue and update its labels.
+	 */
+	async skipIssue(
+		config: SkipIssueConfig,
+	): Promise<Result<PipelineItem, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('skip_issue', { config }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * List all pipeline items, aggregating from multiple sources.
+	 */
+	async listPipelineItems(
+		workRepo: string | null,
+	): Promise<Result<PipelineItem[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('list_pipeline_items', { workRepo }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get pipeline history (completed items).
+	 */
+	async getPipelineHistory(limit: number | null): Promise<PipelineItem[]> {
+		return await TAURI_INVOKE('get_pipeline_history', { limit });
+	},
+	/**
+	 * Get pipeline summary statistics.
+	 */
+	async getPipelineSummary(): Promise<PipelineSummary> {
+		return await TAURI_INVOKE('get_pipeline_summary');
+	},
+	/**
+	 * Detect and link PRs to pipeline items.
+	 */
+	async detectAndLinkPrs(
+		workRepo: string,
+	): Promise<Result<PipelineItem[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('detect_and_link_prs', { workRepo }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Sync PR status for all pipeline items with PRs.
+	 */
+	async syncAllPrStatuses(): Promise<Result<PipelineItem[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('sync_all_pr_statuses'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Update a specific pipeline item's PR status.
+	 */
+	async updatePipelineItemPrStatus(
+		itemId: string,
+	): Promise<Result<PipelineItem | null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('update_pipeline_item_pr_status', {
+					itemId,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Get a pipeline item by ID.
+	 */
+	async getPipelineItem(itemId: string): Promise<PipelineItem | null> {
+		return await TAURI_INVOKE('get_pipeline_item', { itemId });
+	},
+	/**
+	 * Find a pipeline item by issue.
+	 */
+	async findPipelineItemByIssue(
+		repo: string,
+		issueNumber: number,
+	): Promise<PipelineItem | null> {
+		return await TAURI_INVOKE('find_pipeline_item_by_issue', {
+			repo,
+			issueNumber,
+		});
+	},
+	/**
+	 * Find a pipeline item by session name.
+	 */
+	async findPipelineItemBySession(
+		sessionName: string,
+	): Promise<PipelineItem | null> {
+		return await TAURI_INVOKE('find_pipeline_item_by_session', {
+			sessionName,
+		});
+	},
+	/**
+	 * Link a PR to a pipeline item.
+	 */
+	async linkPrToPipelineItem(
+		itemId: string,
+		prNumber: number,
+		workRepo: string,
+	): Promise<Result<PipelineItem, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('link_pr_to_pipeline_item', {
+					itemId,
+					prNumber,
+					workRepo,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Archive a completed pipeline item.
+	 */
+	async archivePipelineItem(
+		itemId: string,
+	): Promise<Result<PipelineItem | null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('archive_pipeline_item', { itemId }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Remove a pipeline item (for cleanup).
+	 */
+	async removePipelineItem(
+		itemId: string,
+	): Promise<Result<PipelineItem | null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('remove_pipeline_item', { itemId }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check all active agent sessions for PR creation.
+	 *
+	 * Returns a list of PR detection results for all active sessions.
+	 * Each result indicates whether a PR was found and if it's newly detected.
+	 */
+	async checkSessionsForPrs(): Promise<Result<PrDetectionResult[], string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('check_sessions_for_prs'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Clean up orphaned Docker containers from sandbox execution.
+	 *
+	 * Finds and removes containers that match `handy-sandbox-*` or `handy-support-sandbox-*`
+	 * but don't have a corresponding active tmux session.
+	 *
+	 * Emits `orphan-container-cleaned` events for each cleaned container (for toast notifications).
+	 */
+	async cleanupOrphanedContainers(): Promise<
+		Result<OrphanCleanupResult, string>
+	> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('cleanup_orphaned_containers'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Check the status of the Claude Code authentication volume.
+	 *
+	 * Returns information about whether the volume exists and has credentials.
+	 */
+	async checkClaudeAuthVolume(): Promise<
+		Result<ClaudeAuthVolumeStatus, string>
+	> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('check_claude_auth_volume'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	/**
+	 * Launch an interactive container for Claude Code authentication.
+	 *
+	 * Opens a new Terminal window with a container where the user can run `claude /login`.
+	 * Credentials are saved to a persistent Docker volume for future sandbox use.
+	 */
+	async launchClaudeAuthSetup(): Promise<Result<string, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('launch_claude_auth_setup'),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
 };
 
 /** user-defined events **/
@@ -983,6 +2939,196 @@ export const commands = {
 
 /** user-defined types **/
 
+/**
+ * Persisted state for an active Epic workflow
+ */
+export type ActiveEpicState = {
+	/**
+	 * Epic issue number
+	 */
+	epic_number: number;
+	/**
+	 * Tracking repository (where Epic issue lives)
+	 */
+	tracking_repo: string;
+	/**
+	 * Work repository (where code is written)
+	 */
+	work_repo: string;
+	/**
+	 * Local filesystem path to the repository (for agent spawning)
+	 */
+	local_repo_path?: string | null;
+	/**
+	 * Epic title
+	 */
+	title: string;
+	/**
+	 * Epic URL
+	 */
+	url: string;
+	/**
+	 * Phases with their tracked state
+	 */
+	phases: TrackedPhase[];
+	/**
+	 * All sub-issues for this epic
+	 */
+	sub_issues: TrackedSubIssue[];
+	/**
+	 * When this Epic was linked/loaded
+	 */
+	linked_at: string;
+	/**
+	 * Last time state was synced with GitHub
+	 */
+	last_synced_at: string | null;
+};
+/**
+ * Result of completing agent work
+ */
+export type AgentCompletionResult = {
+	/**
+	 * PR URL
+	 */
+	pr_url: string;
+	/**
+	 * Issue number
+	 */
+	issue_number: number;
+	/**
+	 * Session name
+	 */
+	session: string;
+	/**
+	 * Status
+	 */
+	status: string;
+};
+/**
+ * Metadata stored with each agent session
+ */
+export type AgentMetadata = {
+	/**
+	 * Session name (e.g., "handy-agent-42")
+	 */
+	session: string;
+	/**
+	 * GitHub issue reference (e.g., "org/repo#42")
+	 */
+	issue_ref: string | null;
+	/**
+	 * Repository being worked on
+	 */
+	repo: string | null;
+	/**
+	 * Path to the worktree
+	 */
+	worktree: string | null;
+	/**
+	 * Type of agent (e.g., "claude", "aider")
+	 */
+	agent_type: string;
+	/**
+	 * Machine identifier for multi-machine disambiguation
+	 */
+	machine_id: string;
+	/**
+	 * ISO timestamp when session started
+	 */
+	started_at: string;
+};
+/**
+ * Information about an agent's network configuration
+ */
+export type AgentNetworkInfo = {
+	/**
+	 * The Docker network name
+	 */
+	network_name: string;
+	/**
+	 * Container hostname (can be used by other containers to connect)
+	 */
+	container_hostname: string;
+	/**
+	 * Allocated host port range (base, end)
+	 */
+	host_port_range: [number, number];
+	/**
+	 * Port mappings from container port to host port
+	 */
+	port_mappings: [number, number][];
+};
+/**
+ * Result of spawning an agent
+ */
+export type AgentSpawnResult = {
+	/**
+	 * tmux session name
+	 */
+	session: string;
+	/**
+	 * Issue number
+	 */
+	issue_number: number;
+	/**
+	 * Worktree path
+	 */
+	worktree: string;
+	/**
+	 * Agent type used
+	 */
+	agent_type: string;
+	/**
+	 * Agent metadata
+	 */
+	metadata: AgentMetadata;
+};
+/**
+ * Status of an active agent.
+ */
+export type AgentStatus = {
+	/**
+	 * Session name
+	 */
+	session: string;
+	/**
+	 * Issue reference (owner/repo#number)
+	 */
+	issue_ref: string | null;
+	/**
+	 * Repository
+	 */
+	repo: string | null;
+	/**
+	 * Issue number
+	 */
+	issue_number: number | null;
+	/**
+	 * Worktree path
+	 */
+	worktree: string | null;
+	/**
+	 * Agent type
+	 */
+	agent_type: string;
+	/**
+	 * Machine ID
+	 */
+	machine_id: string;
+	/**
+	 * Started timestamp
+	 */
+	started_at: string;
+	/**
+	 * Whether session is attached
+	 */
+	is_attached: boolean;
+	/**
+	 * Whether this agent is on the current machine
+	 */
+	is_local: boolean;
+};
 export type AppSettings = {
 	bindings: Partial<{ [key in string]: ShortcutBinding }>;
 	push_to_talk: boolean;
@@ -1028,18 +3174,226 @@ export type AppSettings = {
 	enabled_agents?: string[];
 	sandbox_enabled?: boolean;
 };
+/**
+ * Configuration for assigning an issue to an agent.
+ */
+export type AssignIssueConfig = {
+	/**
+	 * Repository where the issue exists (tracking repo)
+	 */
+	tracking_repo: string;
+	/**
+	 * Repository where work will be done
+	 */
+	work_repo: string;
+	/**
+	 * Issue number to assign
+	 */
+	issue_number: number;
+	/**
+	 * Agent type to use
+	 */
+	agent_type: string;
+	/**
+	 * Local path to the work repository
+	 */
+	repo_path: string;
+	/**
+	 * Labels to add when work starts
+	 */
+	start_labels?: string[];
+	/**
+	 * Labels to remove when work starts
+	 */
+	remove_labels?: string[];
+};
+/**
+ * Result of assigning an issue to an agent.
+ */
+export type AssignIssueResult = {
+	/**
+	 * The pipeline item created
+	 */
+	pipeline_item: PipelineItem;
+	/**
+	 * The spawn result from orchestrator
+	 */
+	spawn_result: SpawnResult;
+};
 export type AudioDevice = { index: string; name: string; is_default: boolean };
 export type BindingResponse = {
 	success: boolean;
 	binding: ShortcutBinding | null;
 	error: string | null;
 };
+/**
+ * Status of the Claude Code authentication volume
+ */
+export type ClaudeAuthVolumeStatus = {
+	/**
+	 * Whether the volume exists
+	 */
+	exists: boolean;
+	/**
+	 * Whether the volume has authentication data
+	 */
+	has_auth: boolean;
+	/**
+	 * Volume name
+	 */
+	volume_name: string;
+	/**
+	 * Last authentication time (if known)
+	 */
+	last_auth: string | null;
+};
+/**
+ * Information about a cleaned up orphan container
+ */
+export type CleanedOrphanInfo = {
+	/**
+	 * Container name
+	 */
+	container_name: string;
+	/**
+	 * Issue number associated with this container (if parseable)
+	 */
+	issue_number: number | null;
+};
 export type ClipboardHandling = 'dont_modify' | 'copy_to_clipboard';
+/**
+ * Collision check result.
+ */
+export type CollisionCheck = {
+	/**
+	 * Whether any collision was detected
+	 */
+	has_collision: boolean;
+	/**
+	 * Path collision: directory already exists
+	 */
+	path_exists: boolean;
+	/**
+	 * Branch collision: branch already exists
+	 */
+	branch_exists: boolean;
+	/**
+	 * Worktree collision: worktree at path already exists
+	 */
+	worktree_exists: boolean;
+	/**
+	 * Details about the collision
+	 */
+	details: string | null;
+};
+/**
+ * Result of completing agent work.
+ */
+export type CompleteWorkResult = {
+	/**
+	 * The created pull request
+	 */
+	pull_request: GitHubPullRequest;
+	/**
+	 * Whether the issue was updated with PR link
+	 */
+	issue_updated: boolean;
+	/**
+	 * Whether working labels were removed
+	 */
+	labels_updated: boolean;
+};
 /**
  * Message in the conversation
  */
 export type ConversationMessage = { role: string; content: string };
 export type CustomSounds = { start: boolean; stop: boolean };
+/**
+ * Status of a single dependency
+ */
+export type DependencyStatus = {
+	/**
+	 * Name of the dependency
+	 */
+	name: string;
+	/**
+	 * Whether the dependency is installed
+	 */
+	installed: boolean;
+	/**
+	 * Whether the dependency is authenticated (for tools that require auth)
+	 */
+	authenticated: boolean | null;
+	/**
+	 * Username/account if authenticated
+	 */
+	auth_user: string | null;
+	/**
+	 * Authentication hint URL if not authenticated
+	 */
+	auth_hint_url: string | null;
+	/**
+	 * Version string if installed
+	 */
+	version: string | null;
+	/**
+	 * Path to the executable if installed
+	 */
+	path: string | null;
+	/**
+	 * Installation instructions if not installed
+	 */
+	install_hint: string;
+};
+/**
+ * Status of all DevOps dependencies
+ */
+export type DevOpsDependencies = {
+	/**
+	 * GitHub CLI status (required)
+	 */
+	gh: DependencyStatus;
+	/**
+	 * tmux status (required)
+	 */
+	tmux: DependencyStatus;
+	/**
+	 * Docker status (optional, enables sandboxed agents)
+	 */
+	docker: DependencyStatus;
+	/**
+	 * Claude Code CLI status
+	 */
+	claude: DependencyStatus;
+	/**
+	 * Aider CLI status
+	 */
+	aider: DependencyStatus;
+	/**
+	 * Gemini CLI status (Google AI)
+	 */
+	gemini: DependencyStatus;
+	/**
+	 * Ollama status (local LLM server)
+	 */
+	ollama: DependencyStatus;
+	/**
+	 * vLLM status (high-performance inference)
+	 */
+	vllm: DependencyStatus;
+	/**
+	 * Whether all required dependencies are installed (gh + tmux + at least one agent)
+	 */
+	all_satisfied: boolean;
+	/**
+	 * List of available agent types that are installed
+	 */
+	available_agents: string[];
+	/**
+	 * Whether sandboxed (Docker) agents are available
+	 */
+	sandbox_available: boolean;
+};
 /**
  * Embedding model info returned from sidecar
  */
@@ -1053,6 +3407,164 @@ export type EmbeddingModelInfo = {
 	is_loaded: boolean;
 };
 export type EngineType = 'Whisper' | 'Parakeet' | 'Moonshine';
+/**
+ * Configuration for creating a new epic issue
+ */
+export type EpicConfig = {
+	/**
+	 * Epic title (without [EPIC] prefix - added automatically)
+	 */
+	title: string;
+	/**
+	 * Tracking repository where Epic/Sub-issues are created (e.g., "org/Handy")
+	 */
+	repo: string;
+	/**
+	 * Work repository where code lives and agents work (e.g., "user/project")
+	 * If None, defaults to same as repo
+	 */
+	work_repo: string | null;
+	/**
+	 * Epic description/goal (1-2 sentences)
+	 */
+	goal: string;
+	/**
+	 * Success metrics (checkbox list)
+	 */
+	success_metrics: string[];
+	/**
+	 * Phases with descriptions
+	 */
+	phases: PhaseConfig[];
+	/**
+	 * Labels to add to epic (epic label added automatically)
+	 */
+	labels: string[];
+};
+/**
+ * Information about a created epic
+ */
+export type EpicInfo = {
+	/**
+	 * Epic issue number
+	 */
+	epic_number: number;
+	/**
+	 * Tracking repository (where Epic is created)
+	 */
+	repo: string;
+	/**
+	 * Work repository (where code lives)
+	 */
+	work_repo: string;
+	/**
+	 * Epic title
+	 */
+	title: string;
+	/**
+	 * GitHub issue URL
+	 */
+	url: string;
+	/**
+	 * Phases from config
+	 */
+	phases: PhaseConfig[];
+};
+/**
+ * Epic progress statistics
+ */
+export type EpicProgress = {
+	/**
+	 * Total sub-issues
+	 */
+	total: number;
+	/**
+	 * Completed sub-issues
+	 */
+	completed: number;
+	/**
+	 * Percentage complete
+	 */
+	percentage: number;
+	/**
+	 * Remaining sub-issues
+	 */
+	remaining: number;
+};
+/**
+ * Recovery information for an epic
+ */
+export type EpicRecoveryInfo = {
+	/**
+	 * The epic info
+	 */
+	epic: EpicInfo;
+	/**
+	 * The raw Epic issue body (for reading phase statuses)
+	 */
+	epic_body: string;
+	/**
+	 * Existing sub-issues for this epic
+	 */
+	sub_issues: ExistingSubIssue[];
+	/**
+	 * Progress statistics
+	 */
+	progress: EpicProgress;
+	/**
+	 * Phases that have no sub-issues yet
+	 */
+	phases_without_issues: number[];
+	/**
+	 * Sub-issues that are ready for agents (have todo label, not closed)
+	 */
+	ready_for_agents: ExistingSubIssue[];
+	/**
+	 * Sub-issues that have agents actively working
+	 */
+	in_progress: ExistingSubIssue[];
+};
+/**
+ * Information about an existing sub-issue linked to an epic
+ */
+export type ExistingSubIssue = {
+	/**
+	 * Issue number
+	 */
+	issue_number: number;
+	/**
+	 * Issue title
+	 */
+	title: string;
+	/**
+	 * Phase number (extracted from labels)
+	 */
+	phase: number | null;
+	/**
+	 * Current state (open/closed)
+	 */
+	state: string;
+	/**
+	 * Labels on the issue
+	 */
+	labels: string[];
+	/**
+	 * URL to the issue
+	 */
+	url: string;
+	/**
+	 * Whether an agent is currently working on it
+	 */
+	has_agent_working: boolean;
+	/**
+	 * PR URL if a PR has been created for this issue
+	 */
+	pr_url: string | null;
+	/**
+	 * PR number if a PR has been created
+	 */
+	pr_number: number | null;
+};
 /**
  * Output mode for filler word detection
  */
@@ -1073,6 +3585,200 @@ export type FillerOutputMode =
 	 * Remove filler words, paste cleaned text, and show coaching feedback
 	 */
 	| 'both';
+/**
+ * GitHub authentication status.
+ */
+export type GhAuthStatus = {
+	/**
+	 * Whether the user is authenticated
+	 */
+	authenticated: boolean;
+	/**
+	 * Username if authenticated
+	 */
+	username: string | null;
+	/**
+	 * Scopes available
+	 */
+	scopes: string[];
+	/**
+	 * Error message if not authenticated
+	 */
+	error: string | null;
+};
+/**
+ * A GitHub issue comment.
+ */
+export type GitHubComment = {
+	/**
+	 * Comment ID
+	 */
+	id: number;
+	/**
+	 * Comment body
+	 */
+	body: string;
+	/**
+	 * Author username
+	 */
+	author: string;
+	/**
+	 * Created timestamp
+	 */
+	created_at: string;
+};
+/**
+ * A GitHub issue.
+ */
+export type GitHubIssue = {
+	/**
+	 * Issue number
+	 */
+	number: number;
+	/**
+	 * Issue title
+	 */
+	title: string;
+	/**
+	 * Issue body/description
+	 */
+	body: string | null;
+	/**
+	 * Issue state (open, closed)
+	 */
+	state: string;
+	/**
+	 * Issue URL
+	 */
+	url: string;
+	/**
+	 * Labels on the issue
+	 */
+	labels: string[];
+	/**
+	 * Assignees
+	 */
+	assignees: string[];
+	/**
+	 * Author username
+	 */
+	author: string;
+	/**
+	 * Created timestamp
+	 */
+	created_at: string;
+	/**
+	 * Updated timestamp
+	 */
+	updated_at: string;
+	/**
+	 * Repository in owner/repo format
+	 */
+	repo: string;
+};
+/**
+ * A GitHub Pull Request.
+ */
+export type GitHubPullRequest = {
+	/**
+	 * PR number
+	 */
+	number: number;
+	/**
+	 * PR title
+	 */
+	title: string;
+	/**
+	 * PR body/description
+	 */
+	body: string | null;
+	/**
+	 * PR state (open, closed, merged)
+	 */
+	state: string;
+	/**
+	 * PR URL
+	 */
+	url: string;
+	/**
+	 * Source branch
+	 */
+	head_branch: string;
+	/**
+	 * Target branch
+	 */
+	base_branch: string;
+	/**
+	 * Is the PR a draft
+	 */
+	is_draft: boolean;
+	/**
+	 * Is the PR mergeable
+	 */
+	mergeable: boolean | null;
+	/**
+	 * Labels on the PR
+	 */
+	labels: string[];
+	/**
+	 * Author username
+	 */
+	author: string;
+	/**
+	 * Created timestamp
+	 */
+	created_at: string;
+	/**
+	 * Updated timestamp
+	 */
+	updated_at: string;
+	/**
+	 * Repository in owner/repo format
+	 */
+	repo: string;
+};
+/**
+ * Agent metadata stored in issue comments.
+ */
+export type IssueAgentMetadata = {
+	/**
+	 * Session name
+	 */
+	session: string;
+	/**
+	 * Machine ID
+	 */
+	machine_id: string;
+	/**
+	 * Worktree path
+	 */
+	worktree: string | null;
+	/**
+	 * Agent type
+	 */
+	agent_type: string;
+	/**
+	 * Started timestamp
+	 */
+	started_at: string;
+	/**
+	 * Current status
+	 */
+	status: string;
+};
+/**
+ * Parsed issue with agent metadata.
+ */
+export type IssueWithAgent = {
+	/**
+	 * The issue
+	 */
+	issue: GitHubIssue;
+	/**
+	 * Agent metadata if assigned
+	 */
+	agent: IssueAgentMetadata | null;
+};
 export type JsonValue =
 	| null
 	| boolean
@@ -1105,6 +3811,48 @@ export type MemoryStatus = {
  * User info with memory count
  */
 export type MemoryUserInfo = { user_id: string; memory_count: number };
+/**
+ * Result of merging a single PR
+ */
+export type MergeResult = {
+	/**
+	 * Issue number that was merged
+	 */
+	issue_number: number;
+	/**
+	 * PR number that was merged
+	 */
+	pr_number: number;
+	/**
+	 * PR URL
+	 */
+	pr_url: string;
+	/**
+	 * Whether the support worker was spawned successfully
+	 */
+	success: boolean;
+	/**
+	 * Error message if spawn failed
+	 */
+	error: string | null;
+	/**
+	 * Phase this issue belongs to
+	 */
+	phase: number | null;
+	/**
+	 * Support worker session name (for tracking)
+	 */
+	support_worker_session: string | null;
+	/**
+	 * Whether this phase is now complete (all issues closed)
+	 * Note: This is only accurate after the merge completes
+	 */
+	phase_complete: boolean;
+	/**
+	 * Next phase number if phase is complete and there's more work
+	 */
+	next_phase: number | null;
+};
 export type ModelInfo = {
 	id: string;
 	name: string;
@@ -1168,6 +3916,56 @@ export type OnichanModelInfo = {
  * Type of Onichan model
  */
 export type OnichanModelType = 'Llm' | 'Tts';
+/**
+ * Result of starting orchestration for an epic
+ */
+export type OrchestrationResult = {
+	/**
+	 * Epic number
+	 */
+	epic_number: number;
+	/**
+	 * Created sub-issues
+	 */
+	sub_issues: SubIssueInfo[];
+	/**
+	 * Spawned agents (for agent-assisted phases)
+	 */
+	spawned_agents: SpawnedAgentInfo[];
+	/**
+	 * Phases that were started
+	 */
+	started_phases: number[];
+	/**
+	 * Any warnings during orchestration
+	 */
+	warnings: string[];
+};
+/**
+ * Result of cleaning up orphaned containers
+ */
+export type OrphanCleanupResult = {
+	/**
+	 * Number of orphaned containers found
+	 */
+	found: number;
+	/**
+	 * Number of containers successfully removed
+	 */
+	removed: number;
+	/**
+	 * Container names that were removed
+	 */
+	removed_containers: string[];
+	/**
+	 * Detailed info about cleaned containers (includes issue numbers for toasts)
+	 */
+	cleaned_orphans: CleanedOrphanInfo[];
+	/**
+	 * Any errors encountered
+	 */
+	errors: string[];
+};
 export type OverlayPosition = 'none' | 'top' | 'bottom';
 export type PasteMethod =
 	| 'ctrl_v'
@@ -1175,12 +3973,434 @@ export type PasteMethod =
 	| 'none'
 	| 'shift_insert'
 	| 'ctrl_shift_v';
+/**
+ * Phase configuration within an epic
+ */
+export type PhaseConfig = {
+	/**
+	 * Phase name (e.g., "Foundation", "Integration Tests")
+	 */
+	name: string;
+	/**
+	 * Phase description
+	 */
+	description: string;
+	/**
+	 * Approach: "manual", "agent-assisted", or "automated"
+	 */
+	approach: string;
+	/**
+	 * Key tasks for this phase (each becomes a sub-issue)
+	 */
+	tasks?: string[];
+	/**
+	 * Files to modify (optional context for agents)
+	 */
+	files?: string[];
+	/**
+	 * Dependencies - names of phases that must complete first
+	 */
+	dependencies?: string[];
+};
+/**
+ * Get phase status for an epic (how many sub-issues complete per phase)
+ */
+export type PhaseStatus = {
+	phase_number: number;
+	phase_name: string;
+	approach: string;
+	total_issues: number;
+	completed_issues: number;
+	in_progress_issues: number;
+	status: string;
+};
+/**
+ * A pipeline item linking issue -> session -> worktree -> PR.
+ *
+ * This struct tracks the full lifecycle of an agent's work on an issue.
+ */
+export type PipelineItem = {
+	/**
+	 * Unique identifier for this pipeline item
+	 */
+	id: string;
+	/**
+	 * Repository in owner/repo format (tracking repo where issue exists)
+	 */
+	tracking_repo: string;
+	/**
+	 * Repository where work is done (may be different from tracking_repo)
+	 */
+	work_repo: string;
+	/**
+	 * Issue number being worked on
+	 */
+	issue_number: number;
+	/**
+	 * Issue title
+	 */
+	issue_title: string;
+	/**
+	 * Issue URL
+	 */
+	issue_url: string;
+	/**
+	 * Agent type (e.g., "claude", "aider")
+	 */
+	agent_type: string;
+	/**
+	 * tmux session name (if active)
+	 */
+	session_name: string | null;
+	/**
+	 * Worktree path (if created)
+	 */
+	worktree_path: string | null;
+	/**
+	 * Branch name for the work
+	 */
+	branch_name: string | null;
+	/**
+	 * Machine ID where agent is running
+	 */
+	machine_id: string | null;
+	/**
+	 * PR number (if created)
+	 */
+	pr_number: number | null;
+	/**
+	 * PR URL (if created)
+	 */
+	pr_url: string | null;
+	/**
+	 * Current PR status
+	 */
+	pr_status: PrPipelineStatus;
+	/**
+	 * Overall pipeline status
+	 */
+	status: PipelineStatus;
+	/**
+	 * When the item was created/queued
+	 */
+	created_at: string;
+	/**
+	 * When work started (agent assigned)
+	 */
+	started_at: string | null;
+	/**
+	 * When work completed (PR merged or skipped)
+	 */
+	completed_at: string | null;
+	/**
+	 * Any error message if failed
+	 */
+	error: string | null;
+};
+/**
+ * Status of a pipeline item.
+ */
+export type PipelineStatus =
+	/**
+	 * Issue is queued but not assigned
+	 */
+	| 'queued'
+	/**
+	 * Issue is assigned to an agent and work is in progress
+	 */
+	| 'in_progress'
+	/**
+	 * Agent has completed work and PR is pending
+	 */
+	| 'pr_pending'
+	/**
+	 * PR has been created and is being reviewed
+	 */
+	| 'pr_review'
+	/**
+	 * PR has been merged, work is complete
+	 */
+	| 'completed'
+	/**
+	 * Issue was skipped
+	 */
+	| 'skipped'
+	/**
+	 * Work failed or was abandoned
+	 */
+	| 'failed';
+/**
+ * Summary of pipeline items for display.
+ */
+export type PipelineSummary = {
+	/**
+	 * Total items in pipeline
+	 */
+	total: number;
+	/**
+	 * Items queued (not started)
+	 */
+	queued: number;
+	/**
+	 * Items in progress
+	 */
+	in_progress: number;
+	/**
+	 * Items with PRs pending review
+	 */
+	pr_pending: number;
+	/**
+	 * Completed items
+	 */
+	completed: number;
+	/**
+	 * Skipped items
+	 */
+	skipped: number;
+	/**
+	 * Failed items
+	 */
+	failed: number;
+};
+/**
+ * Configuration for planning an Epic from a markdown file
+ */
+export type PlanFromMarkdownConfig = {
+	/**
+	 * Path to the markdown plan file
+	 */
+	plan_file_path: string;
+	/**
+	 * Tracking repository where Epic/Sub-issues are created (e.g., "KBVE/Handy")
+	 */
+	repo: string;
+	/**
+	 * Work repository where code lives and agents work (e.g., "user/project")
+	 * If None, defaults to same as repo
+	 */
+	work_repo: string | null;
+	/**
+	 * Optional: Override epic title
+	 */
+	title_override: string | null;
+	/**
+	 * Optional: Agent to use for planning (default: claude)
+	 */
+	planning_agent: string | null;
+};
+/**
+ * Result of the planning operation
+ */
+export type PlanResult = {
+	/**
+	 * Created Epic info
+	 */
+	epic: EpicInfo;
+	/**
+	 * Created sub-issues
+	 */
+	sub_issues: SubIssueInfo[];
+	/**
+	 * Agent used for planning
+	 */
+	planning_agent: string;
+	/**
+	 * Summary of what was created
+	 */
+	summary: string;
+};
+/**
+ * Parsed plan template ready for use
+ */
+export type PlanTemplate = {
+	/**
+	 * Template identifier (filename without extension)
+	 */
+	id: string;
+	/**
+	 * Template title from frontmatter
+	 */
+	title: string;
+	/**
+	 * Template description from frontmatter
+	 */
+	description: string;
+	/**
+	 * Labels from frontmatter
+	 */
+	labels: string[];
+	/**
+	 * Repository for tracking issues (e.g., "KBVE/KBVE")
+	 */
+	tracking_repo: string | null;
+	/**
+	 * Repository for working/implementation (e.g., "KBVE/Handy")
+	 */
+	working_repo: string | null;
+	/**
+	 * Epic goal extracted from markdown
+	 */
+	goal: string;
+	/**
+	 * Success metrics extracted from markdown
+	 */
+	success_metrics: string[];
+	/**
+	 * Phases extracted from markdown
+	 */
+	phases: PhaseConfig[];
+};
 export type PostProcessProvider = {
 	id: string;
 	label: string;
 	base_url: string;
 	allow_base_url_edit?: boolean;
 	models_endpoint?: string | null;
+};
+/**
+ * PR check status.
+ */
+export type PrCheckStatus = {
+	/**
+	 * Overall status (pending, success, failure)
+	 */
+	state: string;
+	/**
+	 * Number of passing checks
+	 */
+	passing: number;
+	/**
+	 * Number of failing checks
+	 */
+	failing: number;
+	/**
+	 * Number of pending checks
+	 */
+	pending: number;
+	/**
+	 * Total number of checks
+	 */
+	total: number;
+};
+/**
+ * Result of PR detection for an agent session
+ */
+export type PrDetectionResult = {
+	/**
+	 * tmux session name
+	 */
+	session: string;
+	/**
+	 * Issue number the agent is working on
+	 */
+	issue_number: number;
+	/**
+	 * Repository (org/repo format)
+	 */
+	repo: string;
+	/**
+	 * PR URL if found
+	 */
+	pr_url: string | null;
+	/**
+	 * PR number if found
+	 */
+	pr_number: number | null;
+	/**
+	 * Branch name that was checked
+	 */
+	branch_name: string;
+	/**
+	 * Whether this is a newly detected PR (first time seeing it)
+	 */
+	is_new: boolean;
+};
+/**
+ * Status of a PR in the pipeline.
+ */
+export type PrPipelineStatus =
+	/**
+	 * No PR has been created yet
+	 */
+	| 'none'
+	/**
+	 * PR is in draft state
+	 */
+	| 'draft'
+	/**
+	 * PR is ready for review
+	 */
+	| 'ready'
+	/**
+	 * PR needs review (has reviewers assigned)
+	 */
+	| 'needs_review'
+	/**
+	 * PR has been approved
+	 */
+	| 'approved'
+	/**
+	 * PR has been merged
+	 */
+	| 'merged'
+	/**
+	 * PR was closed without merging
+	 */
+	| 'closed';
+/**
+ * PR review status.
+ */
+export type PrReviewStatus = {
+	/**
+	 * Number of approvals
+	 */
+	approved: number;
+	/**
+	 * Number of changes requested
+	 */
+	changes_requested: number;
+	/**
+	 * Number of reviews pending
+	 */
+	pending: number;
+};
+/**
+ * Full PR status including checks and reviews.
+ */
+export type PrStatus = {
+	/**
+	 * The PR
+	 */
+	pr: GitHubPullRequest;
+	/**
+	 * Check status
+	 */
+	checks: PrCheckStatus;
+	/**
+	 * Review status
+	 */
+	reviews: PrReviewStatus;
+};
+/**
+ * Result of processing all ready PRs
+ */
+export type ProcessReadyResult = {
+	/**
+	 * Individual merge results
+	 */
+	merges: MergeResult[];
+	/**
+	 * Phases that are now complete
+	 */
+	completed_phases: number[];
+	/**
+	 * Next phase to work on (if any)
+	 */
+	next_phase: number | null;
+	/**
+	 * Whether agents were auto-started for next phase
+	 */
+	agents_started: boolean;
 };
 export type PtyError =
 	| 'NotFound'
@@ -1194,6 +4414,177 @@ export type RecordingRetentionPeriod =
 	| 'weeks_2'
 	| 'months_3';
 /**
+ * A session recovered during startup
+ */
+export type RecoveredSession = {
+	metadata: AgentMetadata;
+	source: RecoverySource;
+	tmux_alive: boolean;
+	worktree_exists: boolean;
+	recommended_action: RecoveryAction;
+};
+/**
+ * Recommended action for a recovered session
+ */
+export type RecoveryAction =
+	/**
+	 * tmux alive, continue monitoring
+	 */
+	| 'Resume'
+	/**
+	 * tmux dead but work incomplete, offer restart
+	 */
+	| 'Restart'
+	/**
+	 * orphan session, offer to kill/remove
+	 */
+	| 'Cleanup'
+	/**
+	 * completed normally, nothing to do
+	 */
+	| 'None';
+/**
+ * Result of attempting to recover/restart sessions
+ */
+export type RecoveryResult = {
+	/**
+	 * Session name
+	 */
+	session: string;
+	/**
+	 * Whether recovery was successful
+	 */
+	success: boolean;
+	/**
+	 * Action that was taken
+	 */
+	action: RecoveryAction;
+	/**
+	 * Error message if recovery failed
+	 */
+	error: string | null;
+};
+/**
+ * Source of recovered session information
+ */
+export type RecoverySource =
+	/**
+	 * Found in tmux, normal operation
+	 */
+	| 'Tmux'
+	/**
+	 * Recovered from GitHub issue comment
+	 */
+	| 'GitHubIssue'
+	/**
+	 * Confirmed by both sources
+	 */
+	| 'Both';
+/**
+ * Configuration for spawning a sandboxed agent container
+ */
+export type SandboxConfig = {
+	/**
+	 * Sandbox mode - DevContainer (recommended) or DirectDocker
+	 */
+	mode: SandboxMode;
+	/**
+	 * Docker image to use (for DirectDocker mode)
+	 */
+	image: string | null;
+	/**
+	 * Working directory to mount (the worktree path)
+	 */
+	workdir: string;
+	/**
+	 * GitHub token for API access (passed as env var)
+	 */
+	gh_token: string | null;
+	/**
+	 * Anthropic API key for Claude (passed as env var)
+	 */
+	anthropic_api_key: string | null;
+	/**
+	 * Issue reference (org/repo#number)
+	 */
+	issue_ref: string;
+	/**
+	 * Agent type (claude, aider, etc.)
+	 */
+	agent_type: string;
+	/**
+	 * Whether to auto-accept all operations (safe in sandbox)
+	 */
+	auto_accept: boolean;
+	/**
+	 * Memory limit (e.g., "4g")
+	 */
+	memory_limit: string | null;
+	/**
+	 * CPU limit (e.g., "2")
+	 */
+	cpu_limit: string | null;
+	/**
+	 * Network mode: "bridge" (default), "none" (air-gapped), or "host"
+	 */
+	network_mode: string | null;
+};
+/**
+ * Sandbox mode - how to run the isolated agent
+ */
+export type SandboxMode =
+	/**
+	 * Use Dev Container (recommended) - creates .devcontainer/devcontainer.json
+	 * and uses the official Anthropic devcontainer feature
+	 */
+	| 'DevContainer'
+	/**
+	 * Use direct Docker container (simpler but less integrated)
+	 */
+	| 'DirectDocker';
+/**
+ * Result of spawning a sandboxed container
+ */
+export type SandboxResult = {
+	/**
+	 * Container ID
+	 */
+	container_id: string;
+	/**
+	 * Container name
+	 */
+	container_name: string;
+	/**
+	 * Whether the container started successfully
+	 */
+	started: boolean;
+};
+/**
+ * Status of a running sandbox container
+ */
+export type SandboxStatus = {
+	/**
+	 * Container ID
+	 */
+	container_id: string;
+	/**
+	 * Container name
+	 */
+	container_name: string;
+	/**
+	 * Whether container is running
+	 */
+	running: boolean;
+	/**
+	 * Exit code if stopped
+	 */
+	exit_code: number | null;
+	/**
+	 * Container status string
+	 */
+	status: string;
+};
+/**
  * specta-friendly mirror of `erust::supabase::Session`.
  */
 export type SessionDto = {
@@ -1204,6 +4595,22 @@ export type SessionDto = {
 	expires_at: number | null;
 	user: SupabaseUserDto;
 };
+/**
+ * Status of an agent session
+ */
+export type SessionStatus =
+	/**
+	 * Session is running and agent is active
+	 */
+	| 'Running'
+	/**
+	 * Session exists but agent process has exited
+	 */
+	| 'Stopped'
+	/**
+	 * Session was recovered from metadata (tmux or GitHub)
+	 */
+	| 'Recovered';
 export type ShortcutBinding = {
 	id: string;
 	name: string;
@@ -1220,7 +4627,198 @@ export type SidecarQuickConfig = {
 	last_discord_channel_name: string | null;
 	last_embedding_model_id: string | null;
 };
+/**
+ * Configuration for skipping an issue.
+ */
+export type SkipIssueConfig = {
+	/**
+	 * Repository where the issue exists
+	 */
+	repo: string;
+	/**
+	 * Issue number to skip
+	 */
+	issue_number: number;
+	/**
+	 * Optional reason for skipping
+	 */
+	reason: string | null;
+	/**
+	 * Labels to add (defaults to "agent-skipped")
+	 */
+	add_labels?: string[];
+	/**
+	 * Labels to remove (defaults to "agent-todo")
+	 */
+	remove_labels?: string[];
+};
 export type SoundTheme = 'marimba' | 'pop' | 'custom';
+/**
+ * Configuration for spawning an agent from a GitHub issue
+ */
+export type SpawnAgentConfig = {
+	/**
+	 * Issue reference (e.g., "org/Handy#101")
+	 */
+	issue_ref: string;
+	/**
+	 * Override agent type (if not specified in issue body)
+	 */
+	agent_type: string | null;
+	/**
+	 * Custom session name (if not auto-generated)
+	 */
+	session_name: string | null;
+	/**
+	 * Work repository (where code lives and agent works)
+	 * If None, extracts from issue body or uses issue_ref repo
+	 */
+	work_repo: string | null;
+};
+/**
+ * Result of spawning an agent.
+ */
+export type SpawnResult = {
+	/**
+	 * The issue being worked on
+	 */
+	issue: GitHubIssue;
+	/**
+	 * The created worktree
+	 */
+	worktree: WorktreeCreateResult;
+	/**
+	 * The tmux session name (or container name if sandboxed)
+	 */
+	session_name: string;
+	/**
+	 * Machine ID where agent is running
+	 */
+	machine_id: string;
+	/**
+	 * Whether agent is running in Docker sandbox
+	 */
+	is_sandboxed?: boolean;
+	/**
+	 * Container ID if sandboxed
+	 */
+	container_id: string | null;
+};
+/**
+ * Information about a spawned agent
+ */
+export type SpawnedAgentInfo = {
+	/**
+	 * Issue number the agent is working on
+	 */
+	issue_number: number;
+	/**
+	 * Session name (tmux)
+	 */
+	session_name: string;
+	/**
+	 * Worktree path
+	 */
+	worktree_path: string;
+	/**
+	 * Agent type (claude, aider, etc.)
+	 */
+	agent_type: string;
+};
+/**
+ * Configuration for starting orchestration
+ */
+export type StartOrchestrationConfig = {
+	/**
+	 * Which phases to start (1-indexed). If empty, starts Phase 1.
+	 */
+	phases: number[];
+	/**
+	 * Whether to auto-spawn agents for agent-assisted phases
+	 */
+	auto_spawn_agents: boolean;
+	/**
+	 * Default agent type for spawning
+	 */
+	default_agent_type: string;
+	/**
+	 * Local filesystem path to git repository for creating worktrees.
+	 * Must be a valid git repository path (e.g., "/Users/me/projects/MyRepo").
+	 * If empty or invalid, agent spawning will be skipped but issues will still be created.
+	 */
+	worktree_base: string;
+};
+/**
+ * Configuration for creating a sub-issue
+ */
+export type SubIssueConfig = {
+	/**
+	 * Sub-issue title (e.g., "Implement test_agent_spawning.rs")
+	 */
+	title: string;
+	/**
+	 * Phase number (1-indexed)
+	 */
+	phase: number;
+	/**
+	 * Estimated time (e.g., "6 hours", "2 days")
+	 */
+	estimated_time: string;
+	/**
+	 * Dependencies (other sub-issue titles or "None")
+	 */
+	dependencies: string;
+	/**
+	 * Goal description (1-2 sentences)
+	 */
+	goal: string;
+	/**
+	 * Detailed task breakdown (markdown)
+	 */
+	tasks: string;
+	/**
+	 * Acceptance criteria (checkbox list)
+	 */
+	acceptance_criteria: string[];
+	/**
+	 * Recommended agent type
+	 */
+	agent_type: string;
+	/**
+	 * Work repository (where agent will work)
+	 * If None, inherits from Epic
+	 */
+	work_repo: string | null;
+};
+/**
+ * Information about a created sub-issue
+ */
+export type SubIssueInfo = {
+	/**
+	 * Issue number
+	 */
+	issue_number: number;
+	/**
+	 * Issue title
+	 */
+	title: string;
+	/**
+	 * Phase number
+	 */
+	phase: number;
+	/**
+	 * Recommended agent type
+	 */
+	agent_type: string;
+	/**
+	 * Work repository (where agent will work)
+	 */
+	work_repo: string;
+	/**
+	 * GitHub issue URL
+	 */
+	url: string;
+};
 /**
  * specta-friendly mirror of `erust::supabase::SupabaseUser`.
  * erust lives outside this crate and does not derive `specta::Type`, so we
@@ -1235,6 +4833,137 @@ export type SupabaseUserDto = {
 	app_metadata?: JsonValue;
 	created_at: string | null;
 	updated_at: string | null;
+};
+/**
+ * Information about a tmux session
+ */
+export type TmuxSession = {
+	/**
+	 * Session name
+	 */
+	name: string;
+	/**
+	 * Whether the session is attached
+	 */
+	attached: boolean;
+	/**
+	 * Number of windows in the session
+	 */
+	windows: number;
+	/**
+	 * Session creation time (Unix timestamp)
+	 */
+	created: number;
+	/**
+	 * Agent metadata if this is a Handy session
+	 */
+	metadata: AgentMetadata | null;
+	/**
+	 * Current status
+	 */
+	status: SessionStatus;
+};
+/**
+ * Tracked state for a phase
+ */
+export type TrackedPhase = {
+	/**
+	 * Phase number (1-indexed)
+	 */
+	phase_number: number;
+	/**
+	 * Phase name
+	 */
+	name: string;
+	/**
+	 * Phase status
+	 */
+	status: TrackedPhaseStatus;
+	/**
+	 * Sub-issue numbers assigned to this phase
+	 */
+	sub_issues: number[];
+	/**
+	 * Count of completed sub-issues
+	 */
+	completed_count: number;
+	/**
+	 * Total sub-issues for this phase
+	 */
+	total_count: number;
+};
+/**
+ * Status of a phase within an Epic (for persisted tracking)
+ */
+export type TrackedPhaseStatus =
+	/**
+	 * Phase not started
+	 */
+	| 'not_started'
+	/**
+	 * Phase is in progress (agents working)
+	 */
+	| 'in_progress'
+	/**
+	 * Phase is ready (all sub-issues have PRs, waiting for merge)
+	 */
+	| 'ready'
+	/**
+	 * Phase is completed (all sub-issues closed)
+	 */
+	| 'completed'
+	/**
+	 * Phase was skipped
+	 */
+	| 'skipped';
+/**
+ * Tracked state for a sub-issue
+ */
+export type TrackedSubIssue = {
+	/**
+	 * Issue number
+	 */
+	issue_number: number;
+	/**
+	 * Issue title
+	 */
+	title: string;
+	/**
+	 * Phase number this belongs to
+	 */
+	phase: number | null;
+	/**
+	 * Current state (open/closed)
+	 */
+	state: string;
+	/**
+	 * Agent type assigned
+	 */
+	agent_type: string | null;
+	/**
+	 * Session name if agent is working
+	 */
+	session_name: string | null;
+	/**
+	 * tmux session name for the agent (if assigned)
+	 */
+	agent_session?: string | null;
+	/**
+	 * Whether an agent is currently working
+	 */
+	has_agent_working: boolean;
+	/**
+	 * URL to the issue
+	 */
+	url: string;
+	/**
+	 * PR URL if agent created one
+	 */
+	pr_url?: string | null;
+	/**
+	 * PR number if agent created one
+	 */
+	pr_number?: number | null;
 };
 export type ViewError = { message: string };
 /**
@@ -1265,6 +4994,52 @@ export type ViewStatus =
 	 * Task has exited (graceful shutdown or error).
 	 */
 	| 'stopped';
+/**
+ * Result of a worktree creation attempt.
+ */
+export type WorktreeCreateResult = {
+	/**
+	 * Path to the created worktree
+	 */
+	path: string;
+	/**
+	 * Branch name
+	 */
+	branch: string;
+	/**
+	 * Whether a new branch was created
+	 */
+	branch_created: boolean;
+};
+/**
+ * Information about a git worktree.
+ */
+export type WorktreeInfo = {
+	/**
+	 * Absolute path to the worktree
+	 */
+	path: string;
+	/**
+	 * Branch name checked out in this worktree
+	 */
+	branch: string | null;
+	/**
+	 * Commit SHA of HEAD
+	 */
+	head: string;
+	/**
+	 * Whether this is the main worktree
+	 */
+	is_main: boolean;
+	/**
+	 * Whether the worktree is locked
+	 */
+	is_locked: boolean;
+	/**
+	 * Whether the worktree is prunable (missing)
+	 */
+	is_prunable: boolean;
+};
 
 /** tauri-specta globals **/
 

--- a/apps/kbve/desktop-kbve/src/components/common/ToastContainer.tsx
+++ b/apps/kbve/desktop-kbve/src/components/common/ToastContainer.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { useToastStore, type Toast } from '../../stores/toastStore';
+
+function ToastItem({ toast }: { toast: Toast }) {
+	const removeToast = useToastStore((state) => state.removeToast);
+	const [progress, setProgress] = useState(100);
+
+	// Animate progress bar for auto-dismiss
+	useEffect(() => {
+		if (!toast.duration || toast.duration <= 0) return;
+
+		const duration = toast.duration;
+		const startTime = toast.createdAt;
+		const endTime = startTime + duration;
+
+		const updateProgress = () => {
+			const now = Date.now();
+			const remaining = Math.max(0, endTime - now);
+			const percent = (remaining / duration) * 100;
+			setProgress(percent);
+
+			if (percent > 0) {
+				requestAnimationFrame(updateProgress);
+			}
+		};
+
+		const animationId = requestAnimationFrame(updateProgress);
+		return () => cancelAnimationFrame(animationId);
+	}, [toast.createdAt, toast.duration]);
+
+	const getToastStyles = () => {
+		switch (toast.type) {
+			case 'success':
+				return {
+					container:
+						'bg-green-500/10 border-green-500/30 text-green-400',
+					progress: 'bg-green-500/50',
+				};
+			case 'error':
+				return {
+					container: 'bg-red-500/10 border-red-500/30 text-red-400',
+					progress: 'bg-red-500/50',
+				};
+			case 'warning':
+				return {
+					container:
+						'bg-yellow-500/10 border-yellow-500/30 text-yellow-400',
+					progress: 'bg-yellow-500/50',
+				};
+			case 'info':
+				return {
+					container:
+						'bg-blue-500/10 border-blue-500/30 text-blue-400',
+					progress: 'bg-blue-500/50',
+				};
+		}
+	};
+
+	const getIcon = () => {
+		switch (toast.type) {
+			case 'success':
+				return '✓';
+			case 'error':
+				return '✕';
+			case 'warning':
+				return '⚠';
+			case 'info':
+				return 'ℹ';
+		}
+	};
+
+	const styles = getToastStyles();
+
+	return (
+		<div
+			className={`
+        ${styles.container}
+        border rounded-lg shadow-lg
+        backdrop-blur-sm
+        min-w-[300px] max-w-[450px]
+        animate-slide-in-right
+        overflow-hidden
+        relative
+      `}>
+			<div className="flex items-start gap-3 p-3">
+				<div className="flex-shrink-0 text-lg font-bold mt-0.5">
+					{getIcon()}
+				</div>
+				<div className="flex-1 min-w-0">
+					<div className="font-medium text-sm">{toast.title}</div>
+					{toast.message && (
+						<div className="text-xs text-gray-400 mt-1 break-words">
+							{toast.message}
+						</div>
+					)}
+				</div>
+				<button
+					onClick={() => removeToast(toast.id)}
+					className="flex-shrink-0 text-gray-400 hover:text-white transition-colors text-sm"
+					aria-label="Close notification">
+					✕
+				</button>
+			</div>
+
+			{/* Progress bar for auto-dismiss */}
+			{toast.duration && toast.duration > 0 && (
+				<div className="h-0.5 w-full bg-black/20">
+					<div
+						className={`h-full ${styles.progress} transition-none`}
+						style={{ width: `${progress}%` }}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export function ToastContainer() {
+	const toasts = useToastStore((state) => state.toasts);
+
+	if (toasts.length === 0) return null;
+
+	// Sort by createdAt so oldest appears at top, newest at bottom
+	const sortedToasts = [...toasts].sort((a, b) => a.createdAt - b.createdAt);
+
+	return (
+		<div
+			className="fixed bottom-20 right-4 z-[9999] flex flex-col gap-2 pointer-events-none"
+			aria-live="polite"
+			aria-atomic="true">
+			{sortedToasts.map((toast) => (
+				<div key={toast.id} className="pointer-events-auto">
+					<ToastItem toast={toast} />
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/AgentDashboard.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/AgentDashboard.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AgentStatus } from '@/bindings';
+import { useDevOpsStore } from '@/stores/devopsStore';
+import {
+	Bot,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	Trash2,
+	GitPullRequest,
+	CircleDot,
+	FolderGit2,
+	Terminal,
+	Monitor,
+	Clock,
+	Laptop,
+	Globe,
+} from 'lucide-react';
+
+interface AgentDashboardProps {
+	onAgentSelect?: (agent: AgentStatus) => void;
+	repoPath?: string;
+}
+
+export const AgentDashboard: React.FC<AgentDashboardProps> = ({
+	onAgentSelect,
+}) => {
+	const { t } = useTranslation();
+
+	// Use Zustand store instead of component state
+	const agents = useDevOpsStore((state) => state.agents);
+	const isLoading = useDevOpsStore((state) => state.agentsLoading);
+	const error = useDevOpsStore((state) => state.agentsError);
+	const filterMode = useDevOpsStore((state) => state.agentFilterMode);
+	const currentMachineId = useDevOpsStore((state) => state.currentMachineId);
+	const cleaningUp = useDevOpsStore((state) => state.cleaningUpAgent);
+	const completingWork = useDevOpsStore((state) => state.completingWork);
+
+	const refreshAgents = useDevOpsStore((state) => state.refreshAgents);
+	const setFilterMode = useDevOpsStore((state) => state.setAgentFilterMode);
+	const cleanupAgent = useDevOpsStore((state) => state.cleanupAgent);
+	const completeAgentWork = useDevOpsStore(
+		(state) => state.completeAgentWork,
+	);
+
+	const handleCompleteWork = async (agent: AgentStatus) => {
+		if (!agent.issue_ref) {
+			return;
+		}
+
+		const prTitle = `Fix for ${agent.issue_ref}`;
+		await completeAgentWork(agent, prTitle);
+	};
+
+	// Filter agents based on filter mode
+	const filteredAgents = agents.filter((agent) => {
+		if (filterMode === 'local') return agent.is_local;
+		if (filterMode === 'remote') return !agent.is_local;
+		return true;
+	});
+
+	const handleCleanup = async (
+		agent: AgentStatus,
+		removeWorktree: boolean,
+	) => {
+		await cleanupAgent(agent, removeWorktree);
+	};
+
+	const formatDate = (dateStr: string) => {
+		if (dateStr === 'unknown') return dateStr;
+		try {
+			const date = new Date(dateStr);
+			return date.toLocaleString();
+		} catch {
+			return dateStr;
+		}
+	};
+
+	if (isLoading && agents.length === 0) {
+		return (
+			<div className="flex items-center justify-center p-8 min-h-[120px]">
+				<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center gap-2 p-4 bg-red-500/10 rounded-lg text-red-400">
+				<AlertCircle className="w-4 h-4" />
+				<span className="text-sm">{error}</span>
+				<button
+					onClick={() => refreshAgents(true)}
+					className="ml-auto p-1 hover:bg-mid-gray/20 rounded">
+					<RefreshCcw className="w-4 h-4" />
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="text-sm text-mid-gray">
+						{t('devops.orchestrator.agentCount', {
+							count: filteredAgents.length,
+						})}
+					</span>
+					{currentMachineId && (
+						<span className="text-xs text-mid-gray/50 flex items-center gap-1">
+							<Laptop className="w-3 h-3" />
+							{currentMachineId.slice(0, 12)}
+						</span>
+					)}
+				</div>
+				<div className="flex items-center gap-2">
+					{/* Filter buttons */}
+					<div className="flex items-center rounded bg-mid-gray/10 p-1">
+						<button
+							onClick={() => setFilterMode('all')}
+							className={`px-2.5 py-1.5 text-xs rounded-l transition-colors ${
+								filterMode === 'all'
+									? 'bg-logo-primary text-white'
+									: 'text-mid-gray hover:text-white'
+							}`}
+							title={t('devops.orchestrator.filterAll')}>
+							{t('devops.orchestrator.all')}
+						</button>
+						<button
+							onClick={() => setFilterMode('local')}
+							className={`px-2.5 py-1.5 text-xs transition-colors ${
+								filterMode === 'local'
+									? 'bg-logo-primary text-white'
+									: 'text-mid-gray hover:text-white'
+							}`}
+							title={t('devops.orchestrator.filterLocal')}>
+							<Laptop className="w-3 h-3" />
+						</button>
+						<button
+							onClick={() => setFilterMode('remote')}
+							className={`px-2.5 py-1.5 text-xs rounded-r transition-colors ${
+								filterMode === 'remote'
+									? 'bg-logo-primary text-white'
+									: 'text-mid-gray hover:text-white'
+							}`}
+							title={t('devops.orchestrator.filterRemote')}>
+							<Globe className="w-3 h-3" />
+						</button>
+					</div>
+					<button
+						onClick={() => refreshAgents(false)}
+						disabled={isLoading}
+						className="p-1 hover:bg-mid-gray/20 rounded transition-colors"
+						title={t('devops.refresh')}>
+						<RefreshCcw
+							className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+						/>
+					</button>
+				</div>
+			</div>
+
+			{/* Agent list */}
+			{filteredAgents.length === 0 ? (
+				<div className="flex flex-col items-center justify-center p-8 text-center min-h-[120px]">
+					<Bot className="w-12 h-12 text-mid-gray/50 mb-3" />
+					<p className="text-sm text-mid-gray">
+						{filterMode === 'all'
+							? t('devops.orchestrator.noAgents')
+							: filterMode === 'local'
+								? t('devops.orchestrator.noLocalAgents')
+								: t('devops.orchestrator.noRemoteAgents')}
+					</p>
+					<p className="text-xs text-mid-gray/70 mt-1">
+						{t('devops.orchestrator.noAgentsHint')}
+					</p>
+				</div>
+			) : (
+				<div className="flex flex-col gap-2 max-h-[400px] overflow-y-auto min-h-[120px]">
+					{filteredAgents.map((agent) => (
+						<div
+							key={agent.session}
+							className="flex flex-col rounded-lg bg-mid-gray/10 hover:bg-mid-gray/15 transition-colors">
+							{/* Agent Header */}
+							<div
+								className="flex items-start gap-3 p-4 cursor-pointer"
+								onClick={() => onAgentSelect?.(agent)}>
+								{/* Status icon */}
+								<div className="mt-1">
+									<Bot
+										className={`w-4 h-4 ${agent.is_attached ? 'text-green-400' : 'text-mid-gray'}`}
+									/>
+								</div>
+
+								{/* Content */}
+								<div className="flex-1 min-w-0">
+									<div className="flex items-center gap-2">
+										<span className="font-medium text-sm truncate">
+											{agent.session}
+										</span>
+										{agent.is_attached && (
+											<span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+												{t(
+													'devops.orchestrator.attached',
+												)}
+											</span>
+										)}
+										{agent.is_local ? (
+											<span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1">
+												<Laptop className="w-3 h-3" />
+												{t('devops.orchestrator.local')}
+											</span>
+										) : (
+											<span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 flex items-center gap-1">
+												<Globe className="w-3 h-3" />
+												{t(
+													'devops.orchestrator.remote',
+												)}
+											</span>
+										)}
+									</div>
+
+									{/* Issue info */}
+									{agent.issue_ref && (
+										<div className="mt-1 flex items-center gap-2 text-xs">
+											<CircleDot className="w-3 h-3 text-green-400" />
+											<span className="text-mid-gray">
+												{agent.issue_ref}
+											</span>
+										</div>
+									)}
+
+									{/* Metadata */}
+									<div className="mt-2 flex flex-wrap gap-3 text-xs text-mid-gray/70">
+										{agent.worktree && (
+											<span
+												className="flex items-center gap-1"
+												title={agent.worktree}>
+												<FolderGit2 className="w-3 h-3" />
+												{agent.worktree
+													.split('/')
+													.pop()}
+											</span>
+										)}
+										<span className="flex items-center gap-1">
+											<Terminal className="w-3 h-3" />
+											{agent.agent_type}
+										</span>
+										<span className="flex items-center gap-1">
+											<Monitor className="w-3 h-3" />
+											{agent.machine_id.slice(0, 12)}
+										</span>
+										<span className="flex items-center gap-1">
+											<Clock className="w-3 h-3" />
+											{formatDate(agent.started_at)}
+										</span>
+									</div>
+								</div>
+
+								{/* Actions */}
+								<div className="flex items-center gap-1">
+									{/* Complete Work button - only for local agents with issue */}
+									{agent.is_local && agent.issue_ref && (
+										<button
+											onClick={(e) => {
+												e.stopPropagation();
+												handleCompleteWork(agent);
+											}}
+											disabled={
+												completingWork === agent.session
+											}
+											className="p-1.5 hover:bg-green-500/20 rounded transition-colors text-mid-gray hover:text-green-400"
+											title={t(
+												'devops.orchestrator.completeWork',
+											)}>
+											{completingWork ===
+											agent.session ? (
+												<Loader2 className="w-4 h-4 animate-spin" />
+											) : (
+												<GitPullRequest className="w-4 h-4" />
+											)}
+										</button>
+									)}
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											handleCleanup(agent, true);
+										}}
+										disabled={
+											cleaningUp === agent.session ||
+											!agent.is_local
+										}
+										className="p-1.5 hover:bg-red-500/20 rounded transition-colors text-mid-gray hover:text-red-400 disabled:opacity-50"
+										title={
+											agent.is_local
+												? t(
+														'devops.orchestrator.cleanup',
+													)
+												: t(
+														'devops.orchestrator.remoteCannotCleanup',
+													)
+										}>
+										{cleaningUp === agent.session ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<Trash2 className="w-4 h-4" />
+										)}
+									</button>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/DependencyStatus.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/DependencyStatus.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { DependencyStatus as DependencyStatusType } from '@/bindings';
+import { toast } from '@/stores/toastStore';
+import {
+	CheckCircle2,
+	XCircle,
+	Copy,
+	AlertTriangle,
+	ExternalLink,
+	Terminal,
+	Check,
+} from 'lucide-react';
+
+interface DependencyStatusProps {
+	name: string;
+	displayName: string;
+	icon: React.ReactNode;
+	status: DependencyStatusType;
+	showToggle?: boolean;
+	isEnabled?: boolean;
+	onToggle?: (enabled: boolean) => void;
+	toggleDisabled?: boolean;
+	onLaunchAuth?: () => void;
+	launchAuthDisabled?: boolean;
+}
+
+export const DependencyStatus: React.FC<DependencyStatusProps> = ({
+	name,
+	displayName,
+	icon,
+	status,
+	showToggle = false,
+	isEnabled = false,
+	onToggle,
+	toggleDisabled = false,
+	onLaunchAuth,
+	launchAuthDisabled = false,
+}) => {
+	const { t } = useTranslation();
+	const [copiedInstall, setCopiedInstall] = React.useState(false);
+	const [copiedPath, setCopiedPath] = React.useState(false);
+
+	const copyInstallCommand = async () => {
+		try {
+			await navigator.clipboard.writeText(status.install_hint);
+			setCopiedInstall(true);
+			toast.success(
+				t('devops.dependencies.copied', 'Copied!'),
+				t(
+					'devops.dependencies.copiedInstallHint',
+					'Install command copied to clipboard',
+				),
+			);
+			setTimeout(() => setCopiedInstall(false), 2000);
+		} catch {
+			toast.error(
+				t('devops.dependencies.copyFailed', 'Copy Failed'),
+				t(
+					'devops.dependencies.copyFailedMessage',
+					'Could not copy to clipboard',
+				),
+			);
+		}
+	};
+
+	const copyPath = async () => {
+		if (!status.path) return;
+		try {
+			await navigator.clipboard.writeText(status.path);
+			setCopiedPath(true);
+			toast.success(
+				t('devops.dependencies.copied', 'Copied!'),
+				t('devops.dependencies.copiedPath', 'Path copied to clipboard'),
+			);
+			setTimeout(() => setCopiedPath(false), 2000);
+		} catch {
+			toast.error(
+				t('devops.dependencies.copyFailed', 'Copy Failed'),
+				t(
+					'devops.dependencies.copyFailedMessage',
+					'Could not copy to clipboard',
+				),
+			);
+		}
+	};
+
+	// Determine if auth is required and missing
+	const needsAuth = status.authenticated !== null;
+	const isAuthenticated = status.authenticated === true;
+	const installedButNotAuth =
+		status.installed && needsAuth && !isAuthenticated;
+
+	return (
+		<div className="flex items-start gap-3 p-4 rounded-lg bg-mid-gray/10">
+			{/* Status icon */}
+			<div className="mt-0.5">
+				{status.installed ? (
+					installedButNotAuth ? (
+						<AlertTriangle className="w-5 h-5 text-yellow-400" />
+					) : (
+						<CheckCircle2 className="w-5 h-5 text-green-400" />
+					)
+				) : (
+					<XCircle className="w-5 h-5 text-red-400" />
+				)}
+			</div>
+
+			{/* Content */}
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-2">
+					{icon}
+					<span className="font-medium">{displayName}</span>
+					<code className="text-xs px-1.5 py-0.5 rounded bg-mid-gray/20 text-mid-gray">
+						{name}
+					</code>
+				</div>
+
+				{status.installed ? (
+					<div className="mt-1 text-sm text-mid-gray">
+						<div className="flex items-center gap-2">
+							<span>{t('devops.dependencies.version')}:</span>
+							<code className="text-green-400">
+								{status.version ||
+									t('devops.dependencies.unknown')}
+							</code>
+						</div>
+						{status.path && (
+							<div className="flex items-center gap-2 mt-0.5 group">
+								<span>{t('devops.dependencies.path')}:</span>
+								<code
+									className="text-xs truncate max-w-[200px] cursor-pointer hover:text-white transition-colors"
+									title={status.path}
+									onClick={copyPath}>
+									{status.path}
+								</code>
+								<button
+									onClick={copyPath}
+									className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-mid-gray/20 transition-all"
+									title={t(
+										'devops.dependencies.copyPath',
+										'Copy path',
+									)}>
+									{copiedPath ? (
+										<Check className="w-3 h-3 text-green-400" />
+									) : (
+										<Copy className="w-3 h-3" />
+									)}
+								</button>
+							</div>
+						)}
+						{/* Show authenticated user if available */}
+						{isAuthenticated && status.auth_user && (
+							<div className="flex items-center gap-2 mt-0.5">
+								<span>
+									{t('devops.dependencies.authenticatedAs')}:
+								</span>
+								<code className="text-green-400">
+									{status.auth_user}
+								</code>
+							</div>
+						)}
+						{/* Authentication status warning */}
+						{installedButNotAuth && (
+							<div className="mt-3 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+								<p className="text-yellow-400 text-sm font-medium mb-2">
+									{t('devops.dependencies.notAuthenticated')}
+								</p>
+								<p className="text-yellow-400/80 text-xs mb-2">
+									{t('devops.dependencies.verifyInstance')}
+								</p>
+								<div className="flex items-center gap-3 mt-3">
+									{onLaunchAuth && (
+										<button
+											onClick={onLaunchAuth}
+											disabled={launchAuthDisabled}
+											className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+											<Terminal className="w-3 h-3" />
+											{t(
+												'devops.dependencies.launchAuth',
+											)}
+										</button>
+									)}
+									{status.auth_hint_url && (
+										<a
+											href={status.auth_hint_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="inline-flex items-center gap-1 text-xs text-logo-primary hover:underline">
+											<ExternalLink className="w-3 h-3" />
+											{t(
+												'devops.dependencies.followGuide',
+											)}
+										</a>
+									)}
+								</div>
+							</div>
+						)}
+					</div>
+				) : (
+					<div className="mt-2">
+						<p className="text-sm text-yellow-400 mb-2">
+							{t('devops.dependencies.notInstalled')}
+						</p>
+						<div className="flex items-center gap-2">
+							<code
+								className="flex-1 text-xs px-2 py-1.5 rounded bg-black/30 text-green-400 font-mono cursor-pointer hover:bg-black/40 transition-colors"
+								onClick={copyInstallCommand}
+								title={t(
+									'devops.dependencies.clickToCopy',
+									'Click to copy',
+								)}>
+								{status.install_hint}
+							</code>
+							<button
+								onClick={copyInstallCommand}
+								className="p-1.5 rounded hover:bg-mid-gray/20 transition-colors"
+								title={t('devops.dependencies.copyCommand')}>
+								{copiedInstall ? (
+									<Check className="w-4 h-4 text-green-400" />
+								) : (
+									<Copy className="w-4 h-4" />
+								)}
+							</button>
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Toggle switch for agents */}
+			{showToggle && (
+				<div className="flex items-center">
+					<button
+						onClick={() => onToggle?.(!isEnabled)}
+						disabled={toggleDisabled || !status.installed}
+						className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+							isEnabled && status.installed
+								? 'bg-logo-primary'
+								: 'bg-mid-gray/30'
+						} ${toggleDisabled || !status.installed ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+						title={
+							!status.installed
+								? t('devops.dependencies.installFirst')
+								: undefined
+						}>
+						<span
+							className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+								isEnabled && status.installed
+									? 'translate-x-6'
+									: 'translate-x-1'
+							}`}
+						/>
+					</button>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/DevOpsLayout.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/DevOpsLayout.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Terminal, LayoutGrid, Settings } from 'lucide-react';
+import { DevOpsSettings } from './DevOpsSettings';
+import { TmuxSessionsGrid } from './TmuxSessionsGrid';
+
+type TabId = 'settings' | 'sessions';
+
+interface Tab {
+	id: TabId;
+	labelKey: string;
+	icon: React.ReactNode;
+}
+
+const tabs: Tab[] = [
+	{
+		id: 'settings',
+		labelKey: 'devops.tabs.settings',
+		icon: <Settings className="w-4 h-4" />,
+	},
+	{
+		id: 'sessions',
+		labelKey: 'devops.tabs.sessions',
+		icon: <LayoutGrid className="w-4 h-4" />,
+	},
+];
+
+export const DevOpsLayout: React.FC = () => {
+	const { t } = useTranslation();
+	const [activeTab, setActiveTab] = useState<TabId>('settings');
+
+	const handleTabClick = (tabId: TabId) => (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setActiveTab(tabId);
+	};
+
+	return (
+		<div className="w-full max-w-4xl mx-auto">
+			{/* Header with tabs */}
+			<div className="flex items-center gap-4 pb-4 mb-4 border-b border-mid-gray/20">
+				<div className="flex items-center gap-2">
+					<Terminal className="w-5 h-5 text-logo-primary" />
+					<h1 className="text-lg font-semibold">
+						{t('devops.title')}
+					</h1>
+				</div>
+
+				{/* Tab buttons */}
+				<div className="flex items-center gap-1 ml-auto bg-mid-gray/10 rounded-lg p-1">
+					{tabs.map((tab) => (
+						<button
+							key={tab.id}
+							type="button"
+							onClick={handleTabClick(tab.id)}
+							className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+								activeTab === tab.id
+									? 'bg-logo-primary text-white'
+									: 'text-mid-gray hover:text-white hover:bg-mid-gray/20'
+							}`}>
+							{tab.icon}
+							{t(tab.labelKey)}
+						</button>
+					))}
+				</div>
+			</div>
+
+			{/* Tab content */}
+			<div className="w-full">
+				{activeTab === 'settings' && <DevOpsSettings />}
+				{activeTab === 'sessions' && <TmuxSessionsGrid />}
+			</div>
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/DevOpsSettings.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/DevOpsSettings.tsx
@@ -1,0 +1,561 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	commands,
+	DevOpsDependencies,
+	ClaudeAuthVolumeStatus,
+} from '@/bindings';
+import { SettingsGroup } from '../../ui/SettingsGroup';
+import { DependencyStatus } from './DependencyStatus';
+import { SessionManager } from './SessionManager';
+import { WorktreeManager } from './WorktreeManager';
+import { IssueQueue } from './IssueQueue';
+import { PullRequestPanel } from './PullRequestPanel';
+import { AgentDashboard } from './AgentDashboard';
+import { GenericEpicCreator } from './GenericEpicCreator';
+import { MarkdownEpicPlanner } from './MarkdownEpicPlanner';
+import {
+	initializeDevOpsStore,
+	cleanupDevOpsStore,
+} from '@/stores/devopsStore';
+import {
+	Terminal,
+	GitBranch,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	CheckCircle2,
+	Bot,
+	Sparkles,
+	Code2,
+	Server,
+	Cpu,
+	Container,
+	Key,
+} from 'lucide-react';
+
+export const DevOpsSettings: React.FC = () => {
+	const { t } = useTranslation();
+	const [dependencies, setDependencies] = useState<DevOpsDependencies | null>(
+		null,
+	);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [enabledAgents, setEnabledAgents] = useState<string[]>([]);
+	const [isTogglingAgent, setIsTogglingAgent] = useState<string | null>(null);
+	const [sandboxEnabled, setSandboxEnabled] = useState(false);
+	const [isTogglingSandbox, setIsTogglingSandbox] = useState(false);
+	const [claudeAuthVolume, setClaudeAuthVolume] =
+		useState<ClaudeAuthVolumeStatus | null>(null);
+	const [isCheckingAuthVolume, setIsCheckingAuthVolume] = useState(false);
+	const [isLaunchingAuthSetup, setIsLaunchingAuthSetup] = useState(false);
+
+	const checkClaudeAuthVolume = async () => {
+		setIsCheckingAuthVolume(true);
+		try {
+			const result = await commands.checkClaudeAuthVolume();
+			if (result.status === 'ok') {
+				setClaudeAuthVolume(result.data);
+			}
+		} catch (err) {
+			console.error('Failed to check Claude auth volume:', err);
+		} finally {
+			setIsCheckingAuthVolume(false);
+		}
+	};
+
+	const handleLaunchAuthSetup = async () => {
+		setIsLaunchingAuthSetup(true);
+		try {
+			const result = await commands.launchClaudeAuthSetup();
+			if (result.status === 'ok') {
+				// Show a message that Terminal was opened
+				// Check auth status after a delay (user needs time to complete auth)
+				setTimeout(() => {
+					checkClaudeAuthVolume();
+				}, 10000);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsLaunchingAuthSetup(false);
+		}
+	};
+
+	const checkDependencies = async () => {
+		setIsLoading(true);
+		setError(null);
+		try {
+			const result = await commands.checkDevopsDependencies();
+			if (result.status === 'ok') {
+				setDependencies(result.data);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		const loadEnabledAgents = async () => {
+			try {
+				const agents = await commands.getEnabledAgents();
+				setEnabledAgents(agents);
+			} catch (err) {
+				console.error('Failed to load enabled agents:', err);
+			}
+		};
+
+		const loadSandboxSetting = async () => {
+			try {
+				const enabled = await commands.getSandboxEnabled();
+				setSandboxEnabled(enabled);
+			} catch (err) {
+				console.error('Failed to load sandbox setting:', err);
+			}
+		};
+
+		checkDependencies();
+		loadEnabledAgents();
+		loadSandboxSetting();
+		checkClaudeAuthVolume();
+
+		// Initialize DevOps store for agents and sessions
+		initializeDevOpsStore();
+
+		// Cleanup on unmount
+		return () => {
+			cleanupDevOpsStore();
+		};
+	}, []);
+
+	const handleAgentToggle = async (agentType: string, enabled: boolean) => {
+		setIsTogglingAgent(agentType);
+		try {
+			const result = await commands.toggleAgentEnabled(
+				agentType,
+				enabled,
+			);
+			if (result.status === 'ok') {
+				setEnabledAgents(result.data);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsTogglingAgent(null);
+		}
+	};
+
+	const isAgentEnabled = (agentType: string) =>
+		enabledAgents.includes(agentType);
+
+	const handleSandboxToggle = async (enabled: boolean) => {
+		setIsTogglingSandbox(true);
+		try {
+			const result = await commands.setSandboxEnabled(enabled);
+			setSandboxEnabled(result);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsTogglingSandbox(false);
+		}
+	};
+
+	const [launchingAuth, setLaunchingAuth] = useState<string | null>(null);
+
+	const handleLaunchAuth = async (toolName: string) => {
+		setLaunchingAuth(toolName);
+		try {
+			const result = await commands.launchCliAuth(toolName);
+			if (result.status === 'ok') {
+				// Auth session launched successfully
+				// Refresh dependencies after a delay to check if user authenticated
+				setTimeout(() => {
+					checkDependencies();
+				}, 5000);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setLaunchingAuth(null);
+		}
+	};
+
+	return (
+		<div className="max-w-3xl w-full mx-auto space-y-6">
+			{/* Description and refresh */}
+			<div className="flex items-center justify-between">
+				<p className="text-sm text-mid-gray">
+					{t('devops.description')}
+				</p>
+				<button
+					onClick={checkDependencies}
+					disabled={isLoading}
+					className="flex items-center gap-1 px-2 py-1 text-sm rounded hover:bg-mid-gray/20 transition-colors disabled:opacity-50">
+					{isLoading ? (
+						<Loader2 className="w-4 h-4 animate-spin" />
+					) : (
+						<RefreshCcw className="w-4 h-4" />
+					)}
+					{t('devops.refresh')}
+				</button>
+			</div>
+
+			{/* Error state */}
+			{error && (
+				<div className="flex items-center gap-2 p-4 bg-red-500/10 rounded-lg text-red-400">
+					<AlertCircle className="w-4 h-4" />
+					<span className="text-sm">{error}</span>
+				</div>
+			)}
+
+			{/* Dependencies Section */}
+			<SettingsGroup
+				title={t('devops.dependencies.title')}
+				description={t('devops.dependencies.description')}>
+				{isLoading ? (
+					<div className="flex items-center justify-center p-4">
+						<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+					</div>
+				) : dependencies ? (
+					<div className="flex flex-col gap-3">
+						{/* Overall status */}
+						<div className="flex items-center gap-2 p-4 border-b border-mid-gray/20">
+							{dependencies.all_satisfied ? (
+								<>
+									<CheckCircle2 className="w-5 h-5 text-green-400" />
+									<span className="text-sm text-green-400">
+										{t('devops.dependencies.allSatisfied')}
+									</span>
+								</>
+							) : (
+								<>
+									<AlertCircle className="w-5 h-5 text-yellow-400" />
+									<span className="text-sm text-yellow-400">
+										{t('devops.dependencies.missing')}
+									</span>
+								</>
+							)}
+						</div>
+
+						{/* Required dependencies */}
+						<div className="text-xs text-mid-gray/70 mb-3 mt-3 px-1">
+							{t('devops.dependencies.required')}
+						</div>
+						<DependencyStatus
+							name="gh"
+							displayName="GitHub CLI"
+							icon={<GitBranch className="w-4 h-4" />}
+							status={dependencies.gh}
+							onLaunchAuth={() => handleLaunchAuth('gh')}
+							launchAuthDisabled={launchingAuth === 'gh'}
+						/>
+						<DependencyStatus
+							name="tmux"
+							displayName="tmux"
+							icon={<Terminal className="w-4 h-4" />}
+							status={dependencies.tmux}
+						/>
+
+						{/* Optional: Docker for sandboxed agents */}
+						<div className="text-xs text-mid-gray/70 mb-3 mt-5 px-1">
+							{t('devops.dependencies.optional')}
+						</div>
+						<DependencyStatus
+							name="docker"
+							displayName="Docker"
+							icon={<Container className="w-4 h-4" />}
+							status={dependencies.docker}
+						/>
+						{dependencies.sandbox_available ? (
+							<div className="ml-8 space-y-2">
+								<div className="text-xs text-green-400/70">
+									{t('devops.dependencies.sandboxAvailable')}
+								</div>
+								{/* Sandbox toggle */}
+								<div className="flex items-center justify-between bg-dark-gray/30 rounded px-3 py-2">
+									<div>
+										<div className="text-xs text-white font-medium">
+											{t(
+												'devops.sandbox.enableLabel',
+												'Run agents in Docker',
+											)}
+										</div>
+										<div className="text-[10px] text-gray-400">
+											{t(
+												'devops.sandbox.enableDescription',
+												'Isolate agents in containers for safety',
+											)}
+										</div>
+									</div>
+									<button
+										onClick={() =>
+											handleSandboxToggle(!sandboxEnabled)
+										}
+										disabled={isTogglingSandbox}
+										className={`relative w-10 h-5 rounded-full transition-colors ${
+											sandboxEnabled
+												? 'bg-green-500'
+												: 'bg-gray-600'
+										} ${isTogglingSandbox ? 'opacity-50' : ''}`}>
+										<span
+											className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${
+												sandboxEnabled
+													? 'translate-x-5'
+													: 'translate-x-0'
+											}`}
+										/>
+									</button>
+								</div>
+
+								{/* Claude Code Authentication Volume - shown when sandbox is enabled */}
+								{sandboxEnabled && (
+									<div className="mt-3 bg-dark-gray/30 rounded px-3 py-2">
+										<div className="flex items-center justify-between">
+											<div className="flex items-center gap-2">
+												<Key className="w-4 h-4 text-mid-gray" />
+												<div>
+													<div className="text-xs text-white font-medium">
+														{t(
+															'devops.sandbox.claudeAuthLabel',
+															'Claude Code Auth Volume',
+														)}
+													</div>
+													<div className="text-[10px] text-gray-400">
+														{claudeAuthVolume?.has_auth
+															? t(
+																	'devops.sandbox.claudeAuthReady',
+																	'Credentials ready for sandbox use',
+																)
+															: t(
+																	'devops.sandbox.claudeAuthNeeded',
+																	'Login required for sandbox agents',
+																)}
+													</div>
+												</div>
+											</div>
+											<div className="flex items-center gap-2">
+												{isCheckingAuthVolume ? (
+													<Loader2 className="w-4 h-4 animate-spin text-mid-gray" />
+												) : claudeAuthVolume?.has_auth ? (
+													<CheckCircle2 className="w-4 h-4 text-green-400" />
+												) : (
+													<AlertCircle className="w-4 h-4 text-yellow-400" />
+												)}
+												<button
+													onClick={
+														handleLaunchAuthSetup
+													}
+													disabled={
+														isLaunchingAuthSetup
+													}
+													className="text-[10px] px-2 py-1 bg-logo-primary/20 hover:bg-logo-primary/30 text-logo-primary rounded transition-colors disabled:opacity-50">
+													{isLaunchingAuthSetup ? (
+														<Loader2 className="w-3 h-3 animate-spin" />
+													) : claudeAuthVolume?.has_auth ? (
+														t(
+															'devops.sandbox.claudeAuthRefresh',
+															'Re-authenticate',
+														)
+													) : (
+														t(
+															'devops.sandbox.claudeAuthSetup',
+															'Setup Auth',
+														)
+													)}
+												</button>
+												<button
+													onClick={
+														checkClaudeAuthVolume
+													}
+													disabled={
+														isCheckingAuthVolume
+													}
+													className="text-[10px] px-2 py-1 bg-mid-gray/20 hover:bg-mid-gray/30 text-mid-gray rounded transition-colors disabled:opacity-50"
+													title={t(
+														'devops.sandbox.claudeAuthCheck',
+														'Check auth status',
+													)}>
+													<RefreshCcw
+														className={`w-3 h-3 ${isCheckingAuthVolume ? 'animate-spin' : ''}`}
+													/>
+												</button>
+											</div>
+										</div>
+										{claudeAuthVolume?.last_auth && (
+											<div className="text-[9px] text-gray-500 mt-1">
+												{t(
+													'devops.sandbox.claudeAuthLastAuth',
+													'Last authenticated',
+												)}
+												: {claudeAuthVolume.last_auth}
+											</div>
+										)}
+									</div>
+								)}
+							</div>
+						) : (
+							dependencies.docker.installed &&
+							!dependencies.docker.authenticated && (
+								<div className="ml-8 text-xs text-yellow-400/70">
+									{t('devops.dependencies.daemonNotRunning')}
+								</div>
+							)
+						)}
+
+						{/* AI Agents (at least one required) */}
+						<div className="text-xs text-mid-gray/70 mb-3 mt-5 px-1">
+							{t('devops.dependencies.agents')}
+						</div>
+						<DependencyStatus
+							name="claude"
+							displayName="Claude Code"
+							icon={<Bot className="w-4 h-4" />}
+							status={dependencies.claude}
+							showToggle
+							isEnabled={isAgentEnabled('claude')}
+							onToggle={(enabled) =>
+								handleAgentToggle('claude', enabled)
+							}
+							toggleDisabled={isTogglingAgent === 'claude'}
+							onLaunchAuth={() => handleLaunchAuth('claude')}
+							launchAuthDisabled={launchingAuth === 'claude'}
+						/>
+						<DependencyStatus
+							name="aider"
+							displayName="Aider"
+							icon={<Code2 className="w-4 h-4" />}
+							status={dependencies.aider}
+							showToggle
+							isEnabled={isAgentEnabled('aider')}
+							onToggle={(enabled) =>
+								handleAgentToggle('aider', enabled)
+							}
+							toggleDisabled={isTogglingAgent === 'aider'}
+						/>
+						<DependencyStatus
+							name="gemini"
+							displayName="Gemini"
+							icon={<Sparkles className="w-4 h-4" />}
+							status={dependencies.gemini}
+							showToggle
+							isEnabled={isAgentEnabled('gemini')}
+							onToggle={(enabled) =>
+								handleAgentToggle('gemini', enabled)
+							}
+							toggleDisabled={isTogglingAgent === 'gemini'}
+						/>
+
+						{/* Local LLM Servers */}
+						<div className="text-xs text-mid-gray/70 mb-3 mt-5 px-1">
+							{t('devops.dependencies.localLlm')}
+						</div>
+						<DependencyStatus
+							name="ollama"
+							displayName="Ollama"
+							icon={<Server className="w-4 h-4" />}
+							status={dependencies.ollama}
+							showToggle
+							isEnabled={isAgentEnabled('ollama')}
+							onToggle={(enabled) =>
+								handleAgentToggle('ollama', enabled)
+							}
+							toggleDisabled={isTogglingAgent === 'ollama'}
+						/>
+						<DependencyStatus
+							name="vllm"
+							displayName="vLLM"
+							icon={<Cpu className="w-4 h-4" />}
+							status={dependencies.vllm}
+							showToggle
+							isEnabled={isAgentEnabled('vllm')}
+							onToggle={(enabled) =>
+								handleAgentToggle('vllm', enabled)
+							}
+							toggleDisabled={isTogglingAgent === 'vllm'}
+						/>
+
+						{/* Enabled agents summary */}
+						{enabledAgents.length > 0 && (
+							<div className="mt-4 pt-4 px-4 border-t border-mid-gray/20 text-xs text-mid-gray">
+								{t('devops.dependencies.enabledAgents')}:{' '}
+								{enabledAgents.join(', ')}
+							</div>
+						)}
+					</div>
+				) : null}
+			</SettingsGroup>
+
+			{/* Epic Workflow Management */}
+			{dependencies?.all_satisfied && (
+				<>
+					<SettingsGroup
+						title="Epic Workflow - Predefined Plans"
+						description="Create Epic issues from predefined templates">
+						<GenericEpicCreator />
+					</SettingsGroup>
+
+					<SettingsGroup
+						title="Epic Workflow - From Markdown"
+						description="AI-assisted Epic planning: analyze markdown plans and automatically generate Epic + Sub-issues">
+						<MarkdownEpicPlanner />
+					</SettingsGroup>
+				</>
+			)}
+
+			{/* Active Agents Dashboard */}
+			{dependencies?.all_satisfied && (
+				<SettingsGroup
+					title={t('devops.orchestrator.title')}
+					description={t('devops.orchestrator.description')}>
+					<AgentDashboard />
+				</SettingsGroup>
+			)}
+
+			{/* Agent Sessions */}
+			{dependencies?.all_satisfied && (
+				<SettingsGroup
+					title={t('devops.sessions.title')}
+					description={t('devops.sessions.description')}>
+					<SessionManager onSessionsChange={checkDependencies} />
+				</SettingsGroup>
+			)}
+
+			{/* Git Worktrees */}
+			{dependencies?.all_satisfied && (
+				<SettingsGroup
+					title={t('devops.worktrees.title')}
+					description={t('devops.worktrees.description')}>
+					<WorktreeManager />
+				</SettingsGroup>
+			)}
+
+			{/* GitHub Issues */}
+			{dependencies?.gh?.installed && (
+				<SettingsGroup
+					title={t('devops.issues.title')}
+					description={t('devops.issues.description')}>
+					<IssueQueue />
+				</SettingsGroup>
+			)}
+
+			{/* GitHub Pull Requests */}
+			{dependencies?.gh?.installed && (
+				<SettingsGroup
+					title={t('devops.prs.title')}
+					description={t('devops.prs.description')}>
+					<PullRequestPanel />
+				</SettingsGroup>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/EpicCreator.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/EpicCreator.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { EpicConfig, EpicInfo, PhaseConfig } from '../../../bindings';
+
+export function EpicCreator() {
+	const [creating, setCreating] = useState(false);
+	const [result, setResult] = useState<EpicInfo | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const createCICDEpic = async () => {
+		setCreating(true);
+		setError(null);
+		setResult(null);
+
+		try {
+			const phases: PhaseConfig[] = [
+				{
+					name: 'Foundation',
+					description:
+						'Build test utilities and infrastructure (test mocks, fixtures, helpers)',
+					approach: 'manual',
+				},
+				{
+					name: 'Integration Tests',
+					description:
+						'Comprehensive integration tests for agent workflows (spawning, cleanup, PR creation, session recovery)',
+					approach: 'agent-assisted',
+				},
+				{
+					name: 'CI/CD Integration',
+					description:
+						'GitHub Actions workflow, pre-commit hooks, coverage tracking',
+					approach: 'agent-assisted',
+				},
+				{
+					name: 'Advanced Scenarios',
+					description:
+						'Multi-machine coordination, error handling, resource limits',
+					approach: 'agent-assisted',
+				},
+			];
+
+			const config: EpicConfig = {
+				title: 'CICD Testing Infrastructure',
+				repo: 'KBVE/Handy',
+				work_repo: 'KBVE/Handy',
+				goal: 'Build comprehensive testing and CI/CD infrastructure for the multi-agent DevOps system to ensure production readiness and prevent future breakage.',
+				success_metrics: [
+					'100+ total tests',
+					'>70% code coverage',
+					'CI/CD running on all PRs',
+					'Pre-commit hooks active',
+					'All phases complete',
+				],
+				phases,
+				labels: ['cicd', 'testing', 'high-priority'],
+			};
+
+			const epicInfo = await invoke<EpicInfo>('create_epic', { config });
+			setResult(epicInfo);
+			console.log('Epic created:', epicInfo);
+		} catch (err) {
+			setError(err as string);
+			console.error('Failed to create epic:', err);
+		} finally {
+			setCreating(false);
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<div>
+					<h3 className="text-sm font-medium text-white">
+						Epic Creator
+					</h3>
+					<p className="text-xs text-gray-400 mt-1">
+						Create Epic #100: CICD Testing Infrastructure
+					</p>
+				</div>
+				<button
+					onClick={createCICDEpic}
+					disabled={creating || result !== null}
+					className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors">
+					{creating
+						? 'Creating...'
+						: result
+							? 'Epic Created ✓'
+							: 'Create Epic #100'}
+				</button>
+			</div>
+
+			{error && (
+				<div className="p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">
+					<strong>Error:</strong> {error}
+				</div>
+			)}
+
+			{result && (
+				<div className="p-4 bg-green-500/10 border border-green-500/20 rounded space-y-2">
+					<div className="flex items-center gap-2">
+						<span className="text-green-400 text-lg">✓</span>
+						<span className="text-sm font-medium text-white">
+							Epic Created Successfully!
+						</span>
+					</div>
+					<div className="space-y-1 text-xs text-gray-300">
+						<div>
+							<span className="text-gray-400">Epic Number:</span>{' '}
+							<span className="font-mono text-white">
+								#{result.epic_number}
+							</span>
+						</div>
+						<div>
+							<span className="text-gray-400">Repository:</span>{' '}
+							<span className="font-mono text-white">
+								{result.repo}
+							</span>
+						</div>
+						<div>
+							<span className="text-gray-400">Phases:</span>{' '}
+							<span className="text-white">
+								{result.phases.length}
+							</span>
+						</div>
+						<div>
+							<a
+								href={result.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300 underline">
+								View on GitHub →
+							</a>
+						</div>
+					</div>
+					<div className="mt-3 pt-3 border-t border-green-500/20 text-xs text-gray-400">
+						<strong>Next steps:</strong>
+						<ol className="mt-1 ml-4 list-decimal space-y-1">
+							<li>Create sub-issue for Phase 1 implementation</li>
+							<li>Implement test utilities manually</li>
+							<li>Create sub-issues for Phase 2-4</li>
+							<li>Spawn agents for Phase 2+ tasks</li>
+						</ol>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/EpicMonitor.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/EpicMonitor.tsx
@@ -1,0 +1,614 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { invoke } from '@tauri-apps/api/core';
+import { useDevOpsStore } from '@/stores/devopsStore';
+import { toast } from '@/stores/toastStore';
+import {
+	Eye,
+	Play,
+	Square,
+	Loader2,
+	RefreshCw,
+	CheckCircle,
+	Clock,
+	CheckCheck,
+	Pause,
+	SkipForward,
+	GitPullRequest,
+	GitMerge,
+	ExternalLink,
+} from 'lucide-react';
+
+export const EpicMonitor: React.FC = () => {
+	const { t } = useTranslation();
+	const {
+		activeEpic,
+		epicLoading,
+		epicMonitor,
+		epicMonitorChecking,
+		startEpicMonitoring,
+		stopEpicMonitoring,
+		checkEpicCompletions,
+		setEpicMonitorAutoUpdate,
+		setEpicMonitorAutoStartNextPhase,
+		markPhaseStatus,
+	} = useDevOpsStore();
+
+	const [markingPhase, setMarkingPhase] = useState<number | null>(null);
+	const [mergingIssue, setMergingIssue] = useState<number | null>(null);
+	const [mergingAll, setMergingAll] = useState(false);
+
+	// Handle merging a single PR
+	const handleMergePR = async (issueNumber: number) => {
+		setMergingIssue(issueNumber);
+		try {
+			const result = await invoke<{
+				success: boolean;
+				error?: string;
+				phase_complete: boolean;
+				next_phase?: number;
+			}>('merge_ready_pr', {
+				issueNumber,
+				mergeMethod: 'squash',
+				deleteBranch: true,
+			});
+
+			if (result.success) {
+				toast.success(
+					t('devops.epicMonitor.mergePRSuccess'),
+					result.phase_complete
+						? t('devops.epicMonitor.phaseCompleteMessage', {
+								nextPhase: result.next_phase,
+							})
+						: undefined,
+				);
+				// Refresh the epic state
+				checkEpicCompletions();
+			} else {
+				toast.error(
+					t('devops.epicMonitor.mergePRFailed'),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(t('devops.epicMonitor.mergePRFailed'), String(err));
+		} finally {
+			setMergingIssue(null);
+		}
+	};
+
+	// Handle merging all ready PRs
+	const handleMergeAllReady = async () => {
+		setMergingAll(true);
+		try {
+			const result = await invoke<{
+				merges: Array<{
+					success: boolean;
+					issue_number: number;
+					error?: string;
+				}>;
+				completed_phases: number[];
+				next_phase?: number;
+			}>('process_ready_prs', {
+				mergeMethod: 'squash',
+				deleteBranch: true,
+				autoStartNextPhase: false, // For now, don't auto-start - let user decide
+			});
+
+			const successCount = result.merges.filter((m) => m.success).length;
+			const failCount = result.merges.filter((m) => !m.success).length;
+
+			if (successCount > 0) {
+				toast.success(
+					t('devops.epicMonitor.mergeAllSuccess', {
+						count: successCount,
+					}),
+					result.completed_phases.length > 0
+						? t('devops.epicMonitor.phasesCompleted', {
+								phases: result.completed_phases.join(', '),
+							})
+						: undefined,
+				);
+			}
+			if (failCount > 0) {
+				toast.warning(
+					t('devops.epicMonitor.mergeAllPartialFail', {
+						count: failCount,
+					}),
+				);
+			}
+
+			// Refresh the epic state
+			checkEpicCompletions();
+		} catch (err) {
+			toast.error(t('devops.epicMonitor.mergeAllFailed'), String(err));
+		} finally {
+			setMergingAll(false);
+		}
+	};
+
+	const handleStartMonitoring = () => {
+		startEpicMonitoring();
+		toast.info(
+			t('devops.epicMonitor.started'),
+			t('devops.epicMonitor.startedMessage'),
+		);
+	};
+
+	const handleStopMonitoring = () => {
+		stopEpicMonitoring();
+		toast.info(t('devops.epicMonitor.stopped'));
+	};
+
+	const handleMarkPhase = async (phaseNumber: number, status: string) => {
+		setMarkingPhase(phaseNumber);
+		try {
+			await markPhaseStatus(phaseNumber, status);
+			toast.success(
+				t('devops.epicMonitor.phaseUpdated'),
+				t('devops.epicMonitor.phaseUpdatedMessage', {
+					phase: phaseNumber,
+					status,
+				}),
+			);
+		} catch (err) {
+			toast.error(t('devops.epicMonitor.phaseUpdateFailed'));
+		} finally {
+			setMarkingPhase(null);
+		}
+	};
+
+	// Get phase status icon and color
+	const getPhaseStatusInfo = (status: string) => {
+		switch (status) {
+			case 'completed':
+				return {
+					icon: CheckCircle,
+					color: 'text-green-400',
+					bgColor: 'bg-green-500/10',
+				};
+			case 'ready':
+				return {
+					icon: GitPullRequest,
+					color: 'text-yellow-400',
+					bgColor: 'bg-yellow-500/10',
+				};
+			case 'in_progress':
+				return {
+					icon: Clock,
+					color: 'text-blue-400',
+					bgColor: 'bg-blue-500/10',
+				};
+			case 'skipped':
+				return {
+					icon: SkipForward,
+					color: 'text-gray-400',
+					bgColor: 'bg-gray-500/10',
+				};
+			default:
+				return {
+					icon: Pause,
+					color: 'text-mid-gray',
+					bgColor: 'bg-mid-gray/10',
+				};
+		}
+	};
+
+	// Helper to check state (GitHub returns uppercase, normalize for comparison)
+	const isOpen = (state: string) => state.toLowerCase() === 'open';
+	const isClosed = (state: string) => state.toLowerCase() === 'closed';
+
+	// Debug: Log the sub-issues to understand state
+	if (activeEpic) {
+		console.log('[EpicMonitor] sub_issues:', activeEpic.sub_issues);
+		console.log(
+			'[EpicMonitor] sub_issues details:',
+			activeEpic.sub_issues.map((s) => ({
+				issue: s.issue_number,
+				state: s.state,
+				stateLC: s.state.toLowerCase(),
+				isOpen: isOpen(s.state),
+				has_agent: s.has_agent_working,
+				pr_url: s.pr_url,
+			})),
+		);
+	}
+
+	// Count sub-issues by state
+	// In Progress: Agent is working, no PR yet
+	const inProgressCount = activeEpic
+		? activeEpic.sub_issues.filter(
+				(s) => isOpen(s.state) && s.has_agent_working && !s.pr_url,
+			).length
+		: 0;
+
+	// Ready: PR created, awaiting review/merge (work is done, ready for human review)
+	const readyCount = activeEpic
+		? activeEpic.sub_issues.filter((s) => isOpen(s.state) && s.pr_url)
+				.length
+		: 0;
+
+	// Queued: Open issues with no agent assigned and no PR (waiting to be picked up)
+	const queuedCount = activeEpic
+		? activeEpic.sub_issues.filter(
+				(s) => isOpen(s.state) && !s.has_agent_working && !s.pr_url,
+			).length
+		: 0;
+
+	// Completed: Issue is closed (PR merged)
+	const completedCount = activeEpic
+		? activeEpic.sub_issues.filter((s) => isClosed(s.state)).length
+		: 0;
+
+	// Total active agents (for header display)
+	const activeAgentCount = activeEpic
+		? activeEpic.sub_issues.filter((s) => s.has_agent_working).length
+		: 0;
+
+	if (!activeEpic) {
+		return (
+			<div className="p-4 bg-mid-gray/10 border border-mid-gray/20 rounded-lg">
+				<div className="flex items-center gap-3 text-mid-gray">
+					<Eye className="w-5 h-5" />
+					<div>
+						<p className="font-medium">
+							{t('devops.epicMonitor.title')}
+						</p>
+						<p className="text-xs">
+							{t('devops.epicMonitor.linkHint')}
+						</p>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			{/* Header with status and controls */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-3">
+					<div
+						className={`p-2 rounded-lg ${
+							epicMonitor.isMonitoring
+								? 'bg-green-500/20 text-green-400'
+								: 'bg-mid-gray/20 text-mid-gray'
+						}`}>
+						<Eye className="w-5 h-5" />
+					</div>
+					<div>
+						<h3 className="font-medium">
+							{t('devops.epicMonitor.title')}
+							{activeEpic && (
+								<span className="ml-2 text-xs text-mid-gray font-normal">
+									#{activeEpic.epic_number}
+								</span>
+							)}
+						</h3>
+						<p className="text-xs text-mid-gray">
+							{epicMonitor.isMonitoring
+								? t('devops.epicMonitor.watching')
+								: t('devops.epicMonitor.description')}
+						</p>
+					</div>
+				</div>
+
+				<div className="flex items-center gap-2">
+					{epicMonitor.isMonitoring ? (
+						<>
+							<button
+								onClick={checkEpicCompletions}
+								disabled={epicMonitorChecking}
+								className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+								title={t('devops.epicMonitor.checkNow')}>
+								{epicMonitorChecking ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<RefreshCw className="w-4 h-4" />
+								)}
+								{t('devops.epicMonitor.check')}
+							</button>
+							<button
+								onClick={handleStopMonitoring}
+								className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-400 transition-colors">
+								<Square className="w-4 h-4" />
+								{t('devops.epicMonitor.stop')}
+							</button>
+						</>
+					) : (
+						<button
+							onClick={handleStartMonitoring}
+							disabled={epicLoading}
+							className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50">
+							{epicLoading ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Play className="w-4 h-4" />
+							)}
+							{t('devops.epicMonitor.startMonitoring')}
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Status dashboard */}
+			<div className="grid grid-cols-4 gap-3">
+				{/* In Progress: Agent working, no PR yet */}
+				<div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg">
+					<div className="flex items-center gap-2 text-blue-400">
+						<Clock className="w-4 h-4" />
+						<span className="text-xs">
+							{t('devops.epicMonitor.inProgress')}
+						</span>
+					</div>
+					<p className="text-xl font-bold text-white mt-1">
+						{inProgressCount}
+					</p>
+				</div>
+
+				{/* Ready: PR created, awaiting review/merge */}
+				<div className="p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+					<div className="flex items-center gap-2 text-yellow-400">
+						<GitPullRequest className="w-4 h-4" />
+						<span className="text-xs">
+							{t('devops.epicMonitor.ready')}
+						</span>
+					</div>
+					<p className="text-xl font-bold text-white mt-1">
+						{readyCount}
+					</p>
+				</div>
+
+				{/* Completed: Issue closed (PR merged) */}
+				<div className="p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
+					<div className="flex items-center gap-2 text-green-400">
+						<CheckCircle className="w-4 h-4" />
+						<span className="text-xs">
+							{t('devops.epicMonitor.completed')}
+						</span>
+					</div>
+					<p className="text-xl font-bold text-white mt-1">
+						{completedCount}
+					</p>
+				</div>
+
+				{/* Queued: Waiting to be picked up */}
+				<div className="p-3 bg-mid-gray/10 border border-mid-gray/20 rounded-lg">
+					<div className="flex items-center gap-2 text-mid-gray">
+						<Pause className="w-4 h-4" />
+						<span className="text-xs">
+							{t('devops.epicMonitor.queued')}
+						</span>
+					</div>
+					<p className="text-xl font-bold text-white mt-1">
+						{queuedCount}
+					</p>
+				</div>
+			</div>
+
+			{/* Options */}
+			<div className="flex flex-col gap-2 p-3 bg-mid-gray/10 border border-mid-gray/20 rounded-lg">
+				<div className="flex items-center justify-between">
+					<label className="flex items-center gap-2 text-sm cursor-pointer">
+						<input
+							type="checkbox"
+							checked={epicMonitor.autoUpdateGithub}
+							onChange={(e) =>
+								setEpicMonitorAutoUpdate(e.target.checked)
+							}
+							className="rounded border-mid-gray/30 bg-mid-gray/10 text-logo-primary focus:ring-logo-primary"
+						/>
+						{t('devops.epicMonitor.autoUpdateGithub')}
+					</label>
+
+					{epicMonitor.lastCheck && (
+						<span className="text-xs text-mid-gray">
+							{t('devops.epicMonitor.lastCheck', {
+								time: epicMonitor.lastCheck.toLocaleTimeString(),
+							})}
+						</span>
+					)}
+				</div>
+
+				<label className="flex items-center gap-2 text-sm cursor-pointer">
+					<input
+						type="checkbox"
+						checked={epicMonitor.autoStartNextPhase}
+						onChange={(e) =>
+							setEpicMonitorAutoStartNextPhase(e.target.checked)
+						}
+						className="rounded border-mid-gray/30 bg-mid-gray/10 text-logo-primary focus:ring-logo-primary"
+					/>
+					{t('devops.epicMonitor.autoStartNextPhase')}
+				</label>
+			</div>
+
+			{/* Phase status list */}
+			{activeEpic.phases.length > 0 && (
+				<div className="space-y-2">
+					<h4 className="text-sm font-medium text-mid-gray">
+						{t('devops.epicMonitor.phases')}
+					</h4>
+					<div className="space-y-2">
+						{activeEpic.phases.map((phase) => {
+							const {
+								icon: StatusIcon,
+								color,
+								bgColor,
+							} = getPhaseStatusInfo(phase.status);
+							const isMarking =
+								markingPhase === phase.phase_number;
+
+							return (
+								<div
+									key={phase.phase_number}
+									className={`flex items-center justify-between p-3 rounded-lg border border-mid-gray/20 ${bgColor}`}>
+									<div className="flex items-center gap-3">
+										<StatusIcon
+											className={`w-5 h-5 ${color}`}
+										/>
+										<div>
+											<p className="text-sm font-medium text-white">
+												{t(
+													'devops.epicMonitor.phaseNumber',
+													{
+														number: phase.phase_number,
+													},
+												)}
+												: {phase.name}
+											</p>
+											<p className="text-xs text-mid-gray capitalize">
+												{phase.status.replace('_', ' ')}
+												{phase.total_count > 0 &&
+													` (${phase.completed_count}/${phase.total_count})`}
+											</p>
+										</div>
+									</div>
+
+									{/* Mark as complete button (only show if not already completed) */}
+									{phase.status !== 'completed' && (
+										<button
+											onClick={() =>
+												handleMarkPhase(
+													phase.phase_number,
+													'completed',
+												)
+											}
+											disabled={isMarking || epicLoading}
+											className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-green-500/20 hover:bg-green-500/30 text-green-400 transition-colors disabled:opacity-50"
+											title={t(
+												'devops.epicMonitor.markComplete',
+											)}>
+											{isMarking ? (
+												<Loader2 className="w-3 h-3 animate-spin" />
+											) : (
+												<CheckCheck className="w-3 h-3" />
+											)}
+											{t(
+												'devops.epicMonitor.markComplete',
+											)}
+										</button>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			)}
+
+			{/* Active agents list */}
+			{activeAgentCount > 0 && (
+				<div className="space-y-2">
+					<h4 className="text-sm font-medium text-mid-gray">
+						{t('devops.epicMonitor.activeAgents')}
+					</h4>
+					<div className="space-y-1">
+						{activeEpic.sub_issues
+							.filter((s) => s.has_agent_working)
+							.map((subIssue) => (
+								<div
+									key={subIssue.issue_number}
+									className="flex items-center gap-2 p-2 bg-mid-gray/10 rounded text-sm">
+									<div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+									<a
+										href={subIssue.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-blue-400 hover:text-blue-300">
+										#{subIssue.issue_number}
+									</a>
+									<span className="text-mid-gray">-</span>
+									<span className="text-white truncate flex-1">
+										{subIssue.title}
+									</span>
+									{subIssue.session_name && (
+										<span className="text-xs text-mid-gray bg-mid-gray/20 px-2 py-0.5 rounded">
+											{subIssue.session_name}
+										</span>
+									)}
+								</div>
+							))}
+					</div>
+				</div>
+			)}
+
+			{/* Ready PRs list - PRs that are ready to merge */}
+			{readyCount > 0 && (
+				<div className="space-y-2">
+					<div className="flex items-center justify-between">
+						<h4 className="text-sm font-medium text-mid-gray">
+							{t('devops.epicMonitor.readyPRs')}
+						</h4>
+						<button
+							onClick={handleMergeAllReady}
+							disabled={mergingAll || mergingIssue !== null}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 transition-colors disabled:opacity-50">
+							{mergingAll ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<GitMerge className="w-3 h-3" />
+							)}
+							{t('devops.epicMonitor.mergeAll')}
+						</button>
+					</div>
+					<div className="space-y-1">
+						{activeEpic.sub_issues
+							.filter((s) => isOpen(s.state) && s.pr_url)
+							.map((subIssue) => (
+								<div
+									key={subIssue.issue_number}
+									className="flex items-center gap-2 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded text-sm">
+									<GitPullRequest className="w-4 h-4 text-yellow-400" />
+									<a
+										href={subIssue.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-blue-400 hover:text-blue-300">
+										#{subIssue.issue_number}
+									</a>
+									<span className="text-mid-gray">-</span>
+									<span className="text-white truncate flex-1">
+										{subIssue.title}
+									</span>
+
+									{/* PR link */}
+									{subIssue.pr_url && (
+										<a
+											href={subIssue.pr_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="flex items-center gap-1 text-xs text-mid-gray hover:text-white"
+											title={t(
+												'devops.epicMonitor.viewPR',
+											)}>
+											<ExternalLink className="w-3 h-3" />
+											PR
+										</a>
+									)}
+
+									{/* Merge button */}
+									<button
+										onClick={() =>
+											handleMergePR(subIssue.issue_number)
+										}
+										disabled={
+											mergingIssue !== null || mergingAll
+										}
+										className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 transition-colors disabled:opacity-50"
+										title={t('devops.epicMonitor.mergePR')}>
+										{mergingIssue ===
+										subIssue.issue_number ? (
+											<Loader2 className="w-3 h-3 animate-spin" />
+										) : (
+											<GitMerge className="w-3 h-3" />
+										)}
+										{t('devops.epicMonitor.merge')}
+									</button>
+								</div>
+							))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/GenericEpicCreator.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/GenericEpicCreator.tsx
@@ -1,0 +1,1836 @@
+import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type {
+	EpicConfig,
+	EpicInfo,
+	EpicRecoveryInfo,
+	PhaseConfig,
+	StartOrchestrationConfig,
+	OrchestrationResult,
+	AssignIssueConfig,
+	AssignIssueResult,
+} from '../../../bindings';
+import { toast } from '../../../stores/toastStore';
+import { useDevOpsStore } from '../../../stores/devopsStore';
+
+interface PlanTemplate {
+	id: string;
+	title: string;
+	description: string;
+	labels: string[];
+	tracking_repo: string | null;
+	working_repo: string | null;
+	goal: string;
+	success_metrics: string[];
+	phases: PhaseConfig[];
+}
+
+interface EpicPlan {
+	title: string;
+	goal: string;
+	successMetrics: string[];
+	phases: PhaseConfig[];
+	labels: string[];
+}
+
+// Predefined epic templates
+const EPIC_TEMPLATES: Record<string, EpicPlan> = {
+	blank: {
+		title: '',
+		goal: '',
+		successMetrics: [],
+		phases: [],
+		labels: [],
+	},
+	'cicd-testing': {
+		title: 'CICD Testing Infrastructure',
+		goal: 'Build comprehensive testing and CI/CD infrastructure for the multi-agent DevOps system to ensure production readiness and prevent future breakage.',
+		successMetrics: [
+			'100+ total tests',
+			'>70% code coverage',
+			'CI/CD running on all PRs',
+			'Pre-commit hooks active',
+			'All phases complete',
+		],
+		phases: [
+			{
+				name: 'Foundation',
+				description:
+					'Build test utilities and infrastructure (test mocks, fixtures, helpers)',
+				approach: 'manual',
+			},
+			{
+				name: 'Integration Tests',
+				description:
+					'Comprehensive integration tests for agent workflows (spawning, cleanup, PR creation, session recovery)',
+				approach: 'agent-assisted',
+			},
+			{
+				name: 'CI/CD Integration',
+				description:
+					'GitHub Actions workflow, pre-commit hooks, coverage tracking',
+				approach: 'agent-assisted',
+			},
+			{
+				name: 'Advanced Scenarios',
+				description:
+					'Multi-machine coordination, error handling, resource limits',
+				approach: 'agent-assisted',
+			},
+		],
+		labels: ['cicd', 'testing', 'high-priority'],
+	},
+};
+
+type Step = 'template' | 'edit' | 'review' | 'link';
+type CreateMode = 'new' | 'link';
+
+export function GenericEpicCreator() {
+	// Get persisted Epic state from store
+	const {
+		activeEpic,
+		epicLoading,
+		setActiveEpicFromRecovery,
+		syncActiveEpic,
+		clearActiveEpic,
+	} = useDevOpsStore();
+
+	const [currentStep, setCurrentStep] = useState<Step>('template');
+	const [createMode, setCreateMode] = useState<CreateMode>('new');
+	const [selectedTemplate, setSelectedTemplate] = useState<string>('blank');
+	const [repo, setRepo] = useState<string>('KBVE/Handy');
+	const [workRepo, setWorkRepo] = useState<string>('');
+
+	// Link existing epic state
+	const [linkEpicNumber, setLinkEpicNumber] = useState<string>('');
+	const [linkRepo, setLinkRepo] = useState<string>('KBVE/Handy');
+	const [linking, setLinking] = useState(false);
+	const [recoveryInfo, setRecoveryInfo] = useState<EpicRecoveryInfo | null>(
+		null,
+	);
+
+	// Loaded templates from filesystem
+	const [templates, setTemplates] = useState<PlanTemplate[]>([
+		{
+			id: 'blank',
+			title: 'Blank',
+			description: 'Start from scratch',
+			labels: [],
+			tracking_repo: null,
+			working_repo: null,
+			goal: '',
+			success_metrics: [],
+			phases: [],
+		},
+	]);
+	const [templatesLoading, setTemplatesLoading] = useState(true);
+	const [templatesError, setTemplatesError] = useState<string | null>(null);
+
+	// Editable plan state
+	const [title, setTitle] = useState<string>('');
+	const [goal, setGoal] = useState<string>('');
+	const [successMetrics, setSuccessMetrics] = useState<string[]>([]);
+	const [phases, setPhases] = useState<PhaseConfig[]>([]);
+	const [labels, setLabels] = useState<string[]>([]);
+
+	const [creating, setCreating] = useState(false);
+	const [result, setResult] = useState<EpicInfo | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	// Orchestration state
+	const [orchestrating, setOrchestrating] = useState(false);
+	const [orchestrationResult, setOrchestrationResult] =
+		useState<OrchestrationResult | null>(null);
+	const [autoSpawnAgents, setAutoSpawnAgents] = useState(false);
+	// Initialize from persisted state if available
+	const [localRepoPath, setLocalRepoPath] = useState<string>(
+		activeEpic?.local_repo_path || '',
+	);
+	const [repoPathSuggestions, setRepoPathSuggestions] = useState<string[]>(
+		[],
+	);
+	const [spawningIssue, setSpawningIssue] = useState<number | null>(null);
+
+	// Save local repo path when it changes
+	const handleLocalRepoPathChange = async (path: string) => {
+		setLocalRepoPath(path);
+		if (path && activeEpic) {
+			try {
+				await invoke('set_epic_local_repo_path', {
+					localRepoPath: path,
+				});
+			} catch (err) {
+				console.error('Failed to save local repo path:', err);
+			}
+		}
+	};
+
+	// New metric/label/phase inputs
+	const [newMetric, setNewMetric] = useState<string>('');
+	const [newLabel, setNewLabel] = useState<string>('');
+
+	// Sync local repo path when activeEpic changes (e.g., after loading)
+	useEffect(() => {
+		if (activeEpic?.local_repo_path && !localRepoPath) {
+			setLocalRepoPath(activeEpic.local_repo_path);
+		}
+	}, [activeEpic?.local_repo_path]);
+
+	// Load templates on mount
+	useEffect(() => {
+		const loadTemplates = async () => {
+			try {
+				setTemplatesLoading(true);
+				const loadedTemplates = await invoke<PlanTemplate[]>(
+					'list_epic_plan_templates',
+				);
+				setTemplates(loadedTemplates);
+				setTemplatesError(null);
+
+				// Apply repos from first template if it has them (templates are sorted by title)
+				if (loadedTemplates.length > 0) {
+					const firstTemplate = loadedTemplates[0];
+					setSelectedTemplate(firstTemplate.id);
+					if (firstTemplate.tracking_repo) {
+						setRepo(firstTemplate.tracking_repo);
+					}
+					if (firstTemplate.working_repo) {
+						setWorkRepo(firstTemplate.working_repo);
+					}
+				}
+			} catch (err) {
+				console.error('Failed to load templates:', err);
+				setTemplatesError(err as string);
+				toast.warning(
+					'Template Loading Failed',
+					'Using fallback templates. Could not load from docs/plans/',
+					7000,
+				);
+				// Fallback to hardcoded templates if filesystem loading fails
+				const fallbackTemplates: PlanTemplate[] = [
+					{
+						id: 'blank',
+						title: 'Blank',
+						description: 'Start from scratch',
+						labels: [],
+						tracking_repo: null,
+						working_repo: null,
+						goal: '',
+						success_metrics: [],
+						phases: [],
+					},
+					{
+						id: 'cicd-testing',
+						title: EPIC_TEMPLATES['cicd-testing'].title,
+						description: 'Comprehensive testing infrastructure',
+						labels: EPIC_TEMPLATES['cicd-testing'].labels,
+						tracking_repo: null,
+						working_repo: null,
+						goal: EPIC_TEMPLATES['cicd-testing'].goal,
+						success_metrics:
+							EPIC_TEMPLATES['cicd-testing'].successMetrics,
+						phases: EPIC_TEMPLATES['cicd-testing'].phases,
+					},
+				];
+				setTemplates(fallbackTemplates);
+			} finally {
+				setTemplatesLoading(false);
+			}
+		};
+		loadTemplates();
+	}, []);
+
+	// Restore Epic state from persisted store on mount
+	useEffect(() => {
+		if (activeEpic && !result) {
+			// We have a persisted Epic but no local result yet - restore state
+			// Convert ActiveEpicState back to EpicInfo for the UI
+			const restoredEpic: EpicInfo = {
+				epic_number: activeEpic.epic_number,
+				repo: activeEpic.tracking_repo,
+				work_repo: activeEpic.work_repo,
+				title: activeEpic.title,
+				url: activeEpic.url,
+				phases: activeEpic.phases.map((p) => ({
+					name: p.name,
+					description: '', // Not stored in ActiveEpicState
+					approach: 'agent-assisted',
+				})),
+			};
+			setResult(restoredEpic);
+			setLinkRepo(activeEpic.tracking_repo);
+			setLinkEpicNumber(activeEpic.epic_number.toString());
+			setCreateMode('link');
+			setCurrentStep('link');
+
+			// Also build recovery info if we have sub-issues
+			if (activeEpic.sub_issues.length > 0) {
+				const subIssues = activeEpic.sub_issues.map((s) => ({
+					issue_number: s.issue_number,
+					title: s.title,
+					phase: s.phase ?? null,
+					state: s.state,
+					labels: [], // Not stored in TrackedSubIssue
+					has_agent_working: s.has_agent_working,
+					url: s.url,
+					pr_url: s.pr_url ?? null,
+					pr_number: s.pr_number ?? null,
+				}));
+
+				const completed = subIssues.filter(
+					(s) => s.state === 'closed',
+				).length;
+				const readyForAgents = subIssues.filter(
+					(s) => s.state === 'open' && !s.has_agent_working,
+				);
+				const inProgress = subIssues.filter((s) => s.has_agent_working);
+
+				// Calculate phases without issues
+				const phasesWithIssues = new Set(
+					subIssues
+						.map((s) => s.phase)
+						.filter((p): p is number => p !== null),
+				);
+				const allPhaseNumbers = activeEpic.phases.map(
+					(p) => p.phase_number,
+				);
+				const phasesWithoutIssues = allPhaseNumbers.filter(
+					(pn) => !phasesWithIssues.has(pn),
+				);
+
+				const restoredRecovery: EpicRecoveryInfo = {
+					epic: restoredEpic,
+					epic_body: '', // Not needed for display - only used when loading from GitHub
+					sub_issues: subIssues,
+					progress: {
+						total: subIssues.length,
+						completed,
+						percentage:
+							subIssues.length > 0
+								? Math.round(
+										(completed / subIssues.length) * 100,
+									)
+								: 0,
+						remaining: subIssues.length - completed,
+					},
+					phases_without_issues: phasesWithoutIssues,
+					ready_for_agents: readyForAgents,
+					in_progress: inProgress,
+				};
+				setRecoveryInfo(restoredRecovery);
+			}
+
+			toast.info(
+				'Epic Restored',
+				`Restored active Epic #${activeEpic.epic_number}: ${activeEpic.title}`,
+				5000,
+			);
+		}
+	}, [activeEpic, result]);
+
+	const loadTemplate = (templateId: string) => {
+		const template = templates.find((t) => t.id === templateId);
+		if (!template) return;
+
+		setTitle(template.title);
+		setGoal(template.goal);
+		setSuccessMetrics([...template.success_metrics]);
+		setPhases([...template.phases]);
+		setLabels([...template.labels]);
+		setSelectedTemplate(templateId);
+
+		// Set repos from template if specified
+		if (template.tracking_repo) {
+			setRepo(template.tracking_repo);
+		}
+		if (template.working_repo) {
+			setWorkRepo(template.working_repo);
+		}
+	};
+
+	// Update repos when template selection changes in the dropdown
+	const handleTemplateChange = (templateId: string) => {
+		setSelectedTemplate(templateId);
+		const template = templates.find((t) => t.id === templateId);
+		if (template) {
+			// Update repo fields immediately when template changes
+			if (template.tracking_repo) {
+				setRepo(template.tracking_repo);
+			}
+			if (template.working_repo) {
+				setWorkRepo(template.working_repo);
+			}
+		}
+	};
+
+	const handleTemplateSelect = () => {
+		loadTemplate(selectedTemplate);
+		setCurrentStep('edit');
+	};
+
+	const addSuccessMetric = () => {
+		if (newMetric.trim()) {
+			setSuccessMetrics([...successMetrics, newMetric.trim()]);
+			setNewMetric('');
+		}
+	};
+
+	const removeSuccessMetric = (index: number) => {
+		setSuccessMetrics(successMetrics.filter((_, i) => i !== index));
+	};
+
+	const addLabel = () => {
+		if (newLabel.trim() && !labels.includes(newLabel.trim())) {
+			setLabels([...labels, newLabel.trim()]);
+			setNewLabel('');
+		}
+	};
+
+	const removeLabel = (index: number) => {
+		setLabels(labels.filter((_, i) => i !== index));
+	};
+
+	const addPhase = () => {
+		setPhases([
+			...phases,
+			{
+				name: '',
+				description: '',
+				approach: 'manual',
+			},
+		]);
+	};
+
+	const updatePhase = (
+		index: number,
+		field: keyof PhaseConfig,
+		value: string,
+	) => {
+		const updated = [...phases];
+		updated[index] = { ...updated[index], [field]: value };
+		setPhases(updated);
+	};
+
+	const removePhase = (index: number) => {
+		setPhases(phases.filter((_, i) => i !== index));
+	};
+
+	const movePhaseUp = (index: number) => {
+		if (index > 0) {
+			const updated = [...phases];
+			[updated[index - 1], updated[index]] = [
+				updated[index],
+				updated[index - 1],
+			];
+			setPhases(updated);
+		}
+	};
+
+	const movePhaseDown = (index: number) => {
+		if (index < phases.length - 1) {
+			const updated = [...phases];
+			[updated[index], updated[index + 1]] = [
+				updated[index + 1],
+				updated[index],
+			];
+			setPhases(updated);
+		}
+	};
+
+	const handleCreateEpic = async () => {
+		setCreating(true);
+		setError(null);
+		setResult(null);
+
+		try {
+			const config: EpicConfig = {
+				title,
+				repo,
+				work_repo: workRepo.trim() || null,
+				goal,
+				success_metrics: successMetrics,
+				phases,
+				labels,
+			};
+
+			const epicInfo = await invoke<EpicInfo>('create_epic', { config });
+			setResult(epicInfo);
+			console.log('Epic created:', epicInfo);
+			toast.success(
+				'Epic Created Successfully',
+				`Epic #${epicInfo.epic_number} created in ${epicInfo.repo}`,
+				8000,
+			);
+		} catch (err) {
+			setError(err as string);
+			console.error('Failed to create epic:', err);
+			toast.error('Failed to Create Epic', err as string, 10000);
+		} finally {
+			setCreating(false);
+		}
+	};
+
+	const handleLinkEpic = async () => {
+		const epicNum = parseInt(linkEpicNumber, 10);
+		if (isNaN(epicNum) || epicNum <= 0) {
+			toast.error(
+				'Invalid Epic Number',
+				'Please enter a valid issue number',
+			);
+			return;
+		}
+
+		setLinking(true);
+		setError(null);
+
+		try {
+			// First try to load with full recovery info
+			const recovery = await invoke<EpicRecoveryInfo>(
+				'load_epic_for_recovery',
+				{
+					repo: linkRepo,
+					epicNumber: epicNum,
+				},
+			);
+
+			// Persist the Epic state to the store (survives tab switches and app restarts)
+			await setActiveEpicFromRecovery(recovery);
+
+			setRecoveryInfo(recovery);
+			setResult(recovery.epic);
+
+			toast.success(
+				'Epic Linked & Saved',
+				`Epic #${recovery.epic.epic_number} is now your active Epic. State will persist across sessions.`,
+				8000,
+			);
+		} catch (err) {
+			setError(err as string);
+			toast.error('Failed to Link Epic', err as string, 10000);
+		} finally {
+			setLinking(false);
+		}
+	};
+
+	const resetForm = (clearPersistedEpic = false) => {
+		setCurrentStep('template');
+		setCreateMode('new');
+		setSelectedTemplate('blank');
+		setTitle('');
+		setGoal('');
+		setSuccessMetrics([]);
+		setPhases([]);
+		setLabels([]);
+		setResult(null);
+		setError(null);
+		setOrchestrationResult(null);
+		setAutoSpawnAgents(false);
+		setLinkEpicNumber('');
+		setRecoveryInfo(null);
+
+		// Optionally clear the persisted Epic state
+		if (clearPersistedEpic) {
+			clearActiveEpic(true); // Archive it for history
+			toast.info('Epic Unlinked', 'The active Epic has been archived');
+		}
+	};
+
+	// Sync Epic with GitHub to get latest status
+	const handleSyncEpic = async () => {
+		if (!activeEpic) return;
+		try {
+			await syncActiveEpic();
+			toast.success(
+				'Epic Synced',
+				'Updated sub-issue status from GitHub',
+			);
+		} catch (err) {
+			toast.error('Sync Failed', err as string);
+		}
+	};
+
+	// Update Epic issue on GitHub with phase status
+	const handleUpdateEpicOnGithub = async () => {
+		if (!activeEpic) return;
+
+		try {
+			// First get phase statuses
+			const phaseStatuses = await invoke('get_epic_phase_status', {
+				epicNumber: activeEpic.epic_number,
+				epicRepo: activeEpic.tracking_repo,
+				phases: activeEpic.phases.map((p) => ({
+					name: p.name,
+					description: '',
+					approach:
+						p.status === 'completed' ? 'manual' : 'agent-assisted',
+					tasks: [],
+					files: [],
+					dependencies: [],
+				})),
+			});
+
+			// Then update the Epic issue body
+			await invoke('update_epic_phase_status_on_github', {
+				epicRepo: activeEpic.tracking_repo,
+				epicNumber: activeEpic.epic_number,
+				phaseStatuses,
+			});
+
+			toast.success(
+				'Epic Updated',
+				'Updated Epic issue on GitHub with current phase status',
+				6000,
+			);
+		} catch (err) {
+			console.error('Failed to update Epic on GitHub:', err);
+			toast.error('Update Failed', err as string, 10000);
+		}
+	};
+
+	// Spawn an agent for a specific issue
+	const handleSpawnAgentForIssue = async (
+		issueNumber: number,
+		issueTitle: string,
+	) => {
+		if (!activeEpic || !localRepoPath) {
+			toast.error(
+				'Cannot Spawn Agent',
+				'Please set the local repository path first',
+			);
+			return;
+		}
+
+		setSpawningIssue(issueNumber);
+		try {
+			const config: AssignIssueConfig = {
+				tracking_repo: activeEpic.tracking_repo,
+				work_repo: activeEpic.work_repo,
+				issue_number: issueNumber,
+				agent_type: 'claude',
+				repo_path: localRepoPath,
+				start_labels: ['staging'],
+				remove_labels: ['agent-todo'],
+			};
+
+			const result = await invoke<AssignIssueResult>(
+				'assign_issue_to_agent_pipeline',
+				{ config },
+			);
+
+			// Update the Epic state to reflect the agent assignment
+			await invoke('update_epic_sub_issue_agent', {
+				issueNumber,
+				sessionName: result.spawn_result.session_name,
+				agentType: 'claude',
+			});
+
+			// Refresh the Epic state
+			await syncActiveEpic();
+
+			toast.success(
+				'Agent Spawned',
+				`Agent working on #${issueNumber}: ${issueTitle.substring(0, 30)}...`,
+				8000,
+			);
+		} catch (err) {
+			console.error('Failed to spawn agent:', err);
+			toast.error('Failed to Spawn Agent', err as string, 10000);
+		} finally {
+			setSpawningIssue(null);
+		}
+	};
+
+	// Start orchestration - create sub-issues and spawn agents
+	const handleStartOrchestration = async (phasesToStart: number[] = [1]) => {
+		if (!result) return;
+
+		setOrchestrating(true);
+		try {
+			const config: StartOrchestrationConfig = {
+				phases: phasesToStart,
+				auto_spawn_agents: autoSpawnAgents,
+				default_agent_type: 'claude',
+				worktree_base: localRepoPath,
+			};
+
+			const orchResult = await invoke<OrchestrationResult>(
+				'start_epic_orchestration',
+				{
+					epic: result,
+					config,
+				},
+			);
+
+			setOrchestrationResult(orchResult);
+
+			if (orchResult.sub_issues.length > 0) {
+				toast.success(
+					'Orchestration Started',
+					`Created ${orchResult.sub_issues.length} sub-issues${orchResult.spawned_agents.length > 0 ? ` and spawned ${orchResult.spawned_agents.length} agents` : ''}`,
+					8000,
+				);
+			}
+
+			if (orchResult.warnings.length > 0) {
+				orchResult.warnings.forEach((warning) => {
+					toast.warning('Orchestration Warning', warning, 6000);
+				});
+			}
+		} catch (err) {
+			console.error('Failed to start orchestration:', err);
+			toast.error('Orchestration Failed', err as string, 10000);
+		} finally {
+			setOrchestrating(false);
+		}
+	};
+
+	// Success State - render first so we can return early
+	if (result) {
+		const isLinkedEpic = recoveryInfo !== null;
+		return (
+			<div className="p-4 bg-green-500/10 border border-green-500/20 rounded space-y-3">
+				<div className="flex items-center gap-2">
+					<span className="text-green-400 text-lg">✓</span>
+					<span className="text-sm font-medium text-white">
+						{isLinkedEpic
+							? 'Epic Linked Successfully!'
+							: 'Epic Created Successfully!'}
+					</span>
+				</div>
+				<div className="space-y-1 text-xs text-gray-300">
+					<div>
+						<span className="text-gray-400">Epic Number:</span>{' '}
+						<span className="font-mono text-white">
+							#{result.epic_number}
+						</span>
+					</div>
+					<div>
+						<span className="text-gray-400">Repository:</span>{' '}
+						<span className="font-mono text-white">
+							{result.repo}
+						</span>
+					</div>
+					<div>
+						<span className="text-gray-400">Work Repository:</span>{' '}
+						<span className="font-mono text-white">
+							{result.work_repo}
+						</span>
+					</div>
+					<div>
+						<span className="text-gray-400">Phases:</span>{' '}
+						<span className="text-white">
+							{result.phases.length}
+						</span>
+					</div>
+					<div>
+						<a
+							href={result.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300 underline">
+							View on GitHub →
+						</a>
+					</div>
+				</div>
+
+				{/* Recovery Info for Linked Epics */}
+				{/* Phase Status from persisted state */}
+				{activeEpic && activeEpic.phases.length > 0 && (
+					<div className="mt-3 pt-3 border-t border-green-500/20">
+						<div className="text-xs text-green-400 font-medium mb-2">
+							Phase Progress:
+						</div>
+						<div className="space-y-2">
+							{activeEpic.phases.map((phase) => {
+								const statusColors: Record<string, string> = {
+									completed: 'text-green-400 bg-green-500/20',
+									ready: 'text-yellow-400 bg-yellow-500/20',
+									in_progress: 'text-blue-400 bg-blue-500/20',
+									not_started: 'text-gray-400 bg-gray-500/20',
+									skipped: 'text-gray-500 bg-gray-500/10',
+								};
+								const statusLabels: Record<string, string> = {
+									completed: '✓ Complete',
+									ready: '🟡 Ready',
+									in_progress: '▶ In Progress',
+									not_started: '○ Not Started',
+									skipped: '⊘ Skipped',
+								};
+								const colorClass =
+									statusColors[phase.status] ||
+									statusColors.not_started;
+								const label =
+									statusLabels[phase.status] ||
+									statusLabels.not_started;
+
+								return (
+									<div
+										key={phase.phase_number}
+										className="flex items-center gap-2 text-xs">
+										<span
+											className={`px-2 py-0.5 rounded ${colorClass}`}>
+											Phase {phase.phase_number}
+										</span>
+										<span className="text-white">
+											{phase.name}
+										</span>
+										<span className="text-gray-500">—</span>
+										<span
+											className={
+												colorClass.split(' ')[0]
+											}>
+											{label}
+										</span>
+										{phase.total_count > 0 && (
+											<span className="text-gray-400">
+												({phase.completed_count}/
+												{phase.total_count} issues)
+											</span>
+										)}
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				)}
+
+				{/* Local Repo Path - needed for agent spawning */}
+				{recoveryInfo && recoveryInfo.ready_for_agents.length > 0 && (
+					<div className="mt-3 pt-3 border-t border-green-500/20">
+						<div className="text-xs text-green-400 font-medium mb-2">
+							Local Repository (for worktrees):
+						</div>
+						<div className="flex gap-2">
+							<input
+								type="text"
+								value={localRepoPath}
+								onChange={(e) =>
+									handleLocalRepoPathChange(e.target.value)
+								}
+								placeholder="/Users/me/projects/MyRepo"
+								className="flex-1 px-2 py-1.5 bg-mid-gray/20 border border-mid-gray/30 rounded text-xs text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+							/>
+							<button
+								type="button"
+								onClick={async () => {
+									try {
+										const suggestions = await invoke<
+											string[]
+										>('suggest_local_repo_path', {
+											githubRepo:
+												result?.work_repo ||
+												activeEpic?.work_repo ||
+												'',
+										});
+										setRepoPathSuggestions(suggestions);
+										if (
+											suggestions.length > 0 &&
+											!localRepoPath
+										) {
+											handleLocalRepoPathChange(
+												suggestions[0],
+											);
+										}
+									} catch (err) {
+										console.error(
+											'Failed to suggest repo path:',
+											err,
+										);
+									}
+								}}
+								className="px-2 py-1.5 bg-mid-gray/30 hover:bg-mid-gray/40 text-gray-300 text-xs rounded transition-colors">
+								Detect
+							</button>
+						</div>
+						{repoPathSuggestions.length > 1 && (
+							<div className="mt-1 flex flex-wrap gap-1">
+								{repoPathSuggestions.map((path, idx) => (
+									<button
+										key={idx}
+										type="button"
+										onClick={() =>
+											handleLocalRepoPathChange(path)
+										}
+										className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
+											localRepoPath === path
+												? 'bg-blue-500/30 text-blue-300'
+												: 'bg-mid-gray/20 text-gray-400 hover:bg-mid-gray/30'
+										}`}>
+										{path.split('/').slice(-2).join('/')}
+									</button>
+								))}
+							</div>
+						)}
+						{!localRepoPath && (
+							<p className="text-[10px] text-yellow-400/70 mt-1">
+								⚠ Set repo path to enable agent spawning
+							</p>
+						)}
+					</div>
+				)}
+
+				{recoveryInfo && (
+					<div className="mt-3 pt-3 border-t border-green-500/20">
+						<div className="text-xs text-green-400 font-medium mb-2">
+							Epic Status:
+						</div>
+						<div className="space-y-2 text-xs text-gray-300">
+							<div className="flex gap-4">
+								<div>
+									Progress:{' '}
+									<span className="text-white font-medium">
+										{recoveryInfo.progress.completed}/
+										{recoveryInfo.progress.total}
+									</span>
+									{recoveryInfo.progress.total > 0 && (
+										<span className="text-gray-400 ml-1">
+											({recoveryInfo.progress.percentage}
+											%)
+										</span>
+									)}
+								</div>
+								<div>
+									Remaining:{' '}
+									<span className="text-white">
+										{recoveryInfo.progress.remaining}
+									</span>
+								</div>
+							</div>
+
+							{recoveryInfo.in_progress.length > 0 && (
+								<div>
+									<span className="text-yellow-400">
+										In Progress (
+										{recoveryInfo.in_progress.length}):
+									</span>
+									<ul className="mt-1 ml-4 list-disc space-y-0.5">
+										{recoveryInfo.in_progress.map(
+											(issue) => (
+												<li key={issue.issue_number}>
+													<a
+														href={issue.url}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="text-blue-400 hover:text-blue-300">
+														#{issue.issue_number}
+													</a>{' '}
+													-{' '}
+													{issue.title.substring(
+														0,
+														40,
+													)}
+													...
+												</li>
+											),
+										)}
+									</ul>
+								</div>
+							)}
+
+							{recoveryInfo.ready_for_agents.length > 0 && (
+								<div>
+									<span className="text-green-400">
+										Ready for Agents (
+										{recoveryInfo.ready_for_agents.length}):
+									</span>
+									<ul className="mt-1 ml-4 space-y-1">
+										{recoveryInfo.ready_for_agents
+											.slice(0, 5)
+											.map((issue) => (
+												<li
+													key={issue.issue_number}
+													className="flex items-center gap-2">
+													<a
+														href={issue.url}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="text-blue-400 hover:text-blue-300">
+														#{issue.issue_number}
+													</a>
+													<span className="text-gray-400">
+														-
+													</span>
+													<span
+														className="text-gray-300 flex-1 truncate"
+														title={issue.title}>
+														{issue.title.substring(
+															0,
+															35,
+														)}
+														...
+													</span>
+													<button
+														onClick={() =>
+															handleSpawnAgentForIssue(
+																issue.issue_number,
+																issue.title,
+															)
+														}
+														disabled={
+															spawningIssue ===
+																issue.issue_number ||
+															!localRepoPath
+														}
+														className="px-2 py-0.5 text-[10px] bg-green-500/20 hover:bg-green-500/30 text-green-400 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+														title={
+															localRepoPath
+																? 'Spawn Claude agent for this issue'
+																: 'Set local repo path first'
+														}>
+														{spawningIssue ===
+														issue.issue_number
+															? 'Spawning...'
+															: 'Spawn'}
+													</button>
+												</li>
+											))}
+										{recoveryInfo.ready_for_agents.length >
+											5 && (
+											<li className="text-gray-500">
+												...and{' '}
+												{recoveryInfo.ready_for_agents
+													.length - 5}{' '}
+												more
+											</li>
+										)}
+									</ul>
+								</div>
+							)}
+
+							{recoveryInfo.phases_without_issues.length > 0 && (
+								<div className="text-yellow-400">
+									Phases without sub-issues:{' '}
+									{recoveryInfo.phases_without_issues.join(
+										', ',
+									)}
+								</div>
+							)}
+						</div>
+					</div>
+				)}
+
+				{/* Orchestration Result */}
+				{orchestrationResult && (
+					<div className="mt-3 pt-3 border-t border-green-500/20">
+						<div className="text-xs text-green-400 font-medium mb-2">
+							Orchestration Results:
+						</div>
+						<div className="space-y-1 text-xs text-gray-300">
+							<div>
+								Sub-issues created:{' '}
+								<span className="text-white">
+									{orchestrationResult.sub_issues.length}
+								</span>
+							</div>
+							{orchestrationResult.spawned_agents.length > 0 && (
+								<div>
+									Agents spawned:{' '}
+									<span className="text-white">
+										{
+											orchestrationResult.spawned_agents
+												.length
+										}
+									</span>
+								</div>
+							)}
+							{orchestrationResult.sub_issues.length > 0 && (
+								<div className="mt-2">
+									<span className="text-gray-400">
+										Created issues:
+									</span>
+									<ul className="mt-1 ml-4 list-disc space-y-0.5">
+										{orchestrationResult.sub_issues
+											.slice(0, 5)
+											.map((issue) => (
+												<li key={issue.issue_number}>
+													<a
+														href={issue.url}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="text-blue-400 hover:text-blue-300">
+														#{issue.issue_number}
+													</a>{' '}
+													-{' '}
+													{issue.title.substring(
+														0,
+														40,
+													)}
+													...
+												</li>
+											))}
+										{orchestrationResult.sub_issues.length >
+											5 && (
+											<li className="text-gray-500">
+												...and{' '}
+												{orchestrationResult.sub_issues
+													.length - 5}{' '}
+												more
+											</li>
+										)}
+									</ul>
+								</div>
+							)}
+						</div>
+					</div>
+				)}
+
+				{/* Start Orchestration Section */}
+				{!orchestrationResult && (
+					<div className="mt-3 pt-3 border-t border-green-500/20">
+						<div className="text-xs text-gray-400 mb-2">
+							<strong>Start Orchestration:</strong>
+							<p className="mt-1">
+								This will create sub-issues from phase tasks and
+								optionally spawn agents.
+							</p>
+						</div>
+
+						{/* Options */}
+						<div className="space-y-2 mb-3">
+							<label className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={autoSpawnAgents}
+									onChange={(e) =>
+										setAutoSpawnAgents(e.target.checked)
+									}
+									className="rounded border-mid-gray/30 bg-mid-gray/10 text-blue-500 focus:ring-blue-500"
+								/>
+								Auto-spawn agents for agent-assisted tasks
+							</label>
+
+							{autoSpawnAgents && (
+								<div className="ml-6">
+									<label className="block text-xs text-gray-400 mb-1">
+										Local Git Repository Path (for
+										worktrees)
+									</label>
+									<div className="flex gap-2">
+										<input
+											type="text"
+											value={localRepoPath}
+											onChange={(e) =>
+												handleLocalRepoPathChange(
+													e.target.value,
+												)
+											}
+											placeholder="/Users/me/projects/MyRepo"
+											className="flex-1 px-2 py-1.5 bg-mid-gray/20 border border-mid-gray/30 rounded text-xs text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+										/>
+										<button
+											type="button"
+											onClick={async () => {
+												try {
+													const suggestions =
+														await invoke<string[]>(
+															'suggest_local_repo_path',
+															{
+																githubRepo:
+																	result?.work_repo ||
+																	workRepo ||
+																	repo,
+															},
+														);
+													setRepoPathSuggestions(
+														suggestions,
+													);
+													if (
+														suggestions.length >
+															0 &&
+														!localRepoPath
+													) {
+														handleLocalRepoPathChange(
+															suggestions[0],
+														);
+													}
+												} catch (err) {
+													console.error(
+														'Failed to suggest repo path:',
+														err,
+													);
+												}
+											}}
+											className="px-2 py-1.5 bg-mid-gray/30 hover:bg-mid-gray/40 text-gray-300 text-xs rounded transition-colors">
+											Detect
+										</button>
+									</div>
+									{repoPathSuggestions.length > 1 && (
+										<div className="mt-1 flex flex-wrap gap-1">
+											{repoPathSuggestions.map(
+												(path, idx) => (
+													<button
+														key={idx}
+														type="button"
+														onClick={() =>
+															handleLocalRepoPathChange(
+																path,
+															)
+														}
+														className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
+															localRepoPath ===
+															path
+																? 'bg-blue-500/30 text-blue-300'
+																: 'bg-mid-gray/20 text-gray-400 hover:bg-mid-gray/30'
+														}`}>
+														{path
+															.split('/')
+															.slice(-2)
+															.join('/')}
+													</button>
+												),
+											)}
+										</div>
+									)}
+									<p className="text-[10px] text-gray-500 mt-1">
+										Full filesystem path to a local git repo
+										where worktrees will be created
+									</p>
+								</div>
+							)}
+						</div>
+
+						{/* Phase buttons - smart detection of next phase */}
+						{(() => {
+							// Find the next phase to work on
+							const nextPhase = activeEpic?.phases.find(
+								(p) =>
+									p.status === 'not_started' ||
+									p.status === 'in_progress',
+							);
+							const nextPhaseNum = nextPhase?.phase_number ?? 1;
+							const allCompleted = activeEpic?.phases.every(
+								(p) => p.status === 'completed',
+							);
+							const phasesNeedingWork = activeEpic?.phases
+								.filter(
+									(p) =>
+										p.status !== 'completed' &&
+										p.status !== 'skipped',
+								)
+								.map((p) => p.phase_number) ?? [1];
+
+							return (
+								<div className="flex flex-wrap gap-2">
+									{allCompleted ? (
+										<div className="text-green-400 text-xs py-1.5">
+											✓ All phases complete!
+										</div>
+									) : (
+										<>
+											<button
+												onClick={() =>
+													handleStartOrchestration([
+														nextPhaseNum,
+													])
+												}
+												disabled={orchestrating}
+												className="px-3 py-1.5 bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 text-xs rounded transition-colors disabled:opacity-50">
+												{orchestrating
+													? 'Starting...'
+													: nextPhase?.status ===
+														  'in_progress'
+														? `Continue Phase ${nextPhaseNum}`
+														: `Start Phase ${nextPhaseNum}`}
+											</button>
+											{phasesNeedingWork.length > 1 && (
+												<button
+													onClick={() =>
+														handleStartOrchestration(
+															phasesNeedingWork,
+														)
+													}
+													disabled={orchestrating}
+													className="px-3 py-1.5 bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 text-xs rounded transition-colors disabled:opacity-50">
+													{orchestrating
+														? 'Starting...'
+														: `Start Phases ${phasesNeedingWork.join(', ')}`}
+												</button>
+											)}
+										</>
+									)}
+									{/* Individual phase buttons for manual control */}
+									{result.phases.length > 1 && (
+										<div className="w-full mt-2 flex flex-wrap gap-1">
+											{result.phases.map((phase, idx) => {
+												const phaseNum = idx + 1;
+												const phaseState =
+													activeEpic?.phases.find(
+														(p) =>
+															p.phase_number ===
+															phaseNum,
+													);
+												const isComplete =
+													phaseState?.status ===
+													'completed';
+												return (
+													<button
+														key={phaseNum}
+														onClick={() =>
+															handleStartOrchestration(
+																[phaseNum],
+															)
+														}
+														disabled={
+															orchestrating ||
+															isComplete
+														}
+														className={`px-2 py-1 text-[10px] rounded transition-colors ${
+															isComplete
+																? 'bg-green-500/20 text-green-400 cursor-not-allowed'
+																: 'bg-mid-gray/20 hover:bg-mid-gray/30 text-gray-400'
+														}`}
+														title={phase.name}>
+														{isComplete
+															? `✓ P${phaseNum}`
+															: `P${phaseNum}`}
+													</button>
+												);
+											})}
+										</div>
+									)}
+								</div>
+							);
+						})()}
+					</div>
+				)}
+
+				{/* Action buttons */}
+				<div className="flex flex-wrap gap-2 mt-3">
+					{isLinkedEpic && (
+						<>
+							<button
+								onClick={handleSyncEpic}
+								disabled={epicLoading}
+								className="flex-1 px-4 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 text-sm rounded transition-colors disabled:opacity-50">
+								{epicLoading ? 'Syncing...' : 'Sync Status'}
+							</button>
+							<button
+								onClick={handleUpdateEpicOnGithub}
+								disabled={epicLoading}
+								className="flex-1 px-4 py-2 bg-green-500/20 hover:bg-green-500/30 text-green-400 text-sm rounded transition-colors disabled:opacity-50"
+								title="Update the Epic issue on GitHub with current phase status">
+								Update Epic Issue
+							</button>
+							<button
+								onClick={() => resetForm(true)}
+								className="px-4 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 text-sm rounded transition-colors">
+								Unlink
+							</button>
+						</>
+					)}
+					<button
+						onClick={() => resetForm(false)}
+						className="flex-1 px-4 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 text-white text-sm rounded transition-colors">
+						{isLinkedEpic
+							? 'Link Different Epic'
+							: 'Create Another Epic'}
+					</button>
+				</div>
+
+				{/* Persistence indicator */}
+				{activeEpic && (
+					<div className="text-xs text-green-400/70 text-center mt-2">
+						✓ Epic state is persisted and will survive app restarts
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	// Render the mode toggle for Step 1
+	const renderModeToggle = () => (
+		<div className="flex gap-2 mb-4">
+			<button
+				onClick={() => setCreateMode('new')}
+				className={`flex-1 px-3 py-2 text-sm rounded transition-colors ${
+					createMode === 'new'
+						? 'bg-blue-600 text-white'
+						: 'bg-mid-gray/20 text-gray-400 hover:bg-mid-gray/30'
+				}`}>
+				Create New Epic
+			</button>
+			<button
+				onClick={() => setCreateMode('link')}
+				className={`flex-1 px-3 py-2 text-sm rounded transition-colors ${
+					createMode === 'link'
+						? 'bg-blue-600 text-white'
+						: 'bg-mid-gray/20 text-gray-400 hover:bg-mid-gray/30'
+				}`}>
+				Link Existing Epic
+			</button>
+		</div>
+	);
+
+	// Render the Link Existing Epic form
+	const renderLinkForm = () => (
+		<div className="space-y-3">
+			<div>
+				<label className="block text-xs text-gray-400 mb-1.5">
+					Repository <span className="text-red-400">*</span>
+				</label>
+				<input
+					type="text"
+					value={linkRepo}
+					onChange={(e) => setLinkRepo(e.target.value)}
+					placeholder="org/repo"
+					className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 font-mono"
+				/>
+			</div>
+
+			<div>
+				<label className="block text-xs text-gray-400 mb-1.5">
+					Epic Issue Number <span className="text-red-400">*</span>
+				</label>
+				<input
+					type="text"
+					value={linkEpicNumber}
+					onChange={(e) =>
+						setLinkEpicNumber(e.target.value.replace(/\D/g, ''))
+					}
+					placeholder="e.g., 123"
+					className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 font-mono"
+				/>
+				<div className="mt-1 text-xs text-gray-500">
+					Enter the GitHub issue number of an existing epic to link
+					and continue orchestration
+				</div>
+			</div>
+
+			{error && (
+				<div className="p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">
+					<strong>Error:</strong> {error}
+				</div>
+			)}
+
+			<button
+				onClick={handleLinkEpic}
+				disabled={linking || !linkRepo.trim() || !linkEpicNumber.trim()}
+				className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors font-medium">
+				{linking ? 'Linking Epic...' : 'Link Epic'}
+			</button>
+		</div>
+	);
+
+	// Render the Create New Epic template selection form
+	const renderNewEpicForm = () => {
+		const selectedTemplateData = templates.find(
+			(t) => t.id === selectedTemplate,
+		);
+
+		return (
+			<div className="space-y-3">
+				{templatesLoading && (
+					<div className="text-xs text-gray-400 py-2">
+						Loading templates...
+					</div>
+				)}
+
+				{templatesError && (
+					<div className="text-xs text-yellow-400 py-2">
+						Note: Using fallback templates (could not load from
+						docs/plans/)
+					</div>
+				)}
+
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Choose Template
+					</label>
+					<select
+						value={selectedTemplate}
+						onChange={(e) => handleTemplateChange(e.target.value)}
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500"
+						disabled={templatesLoading}>
+						{templates.map((template) => (
+							<option key={template.id} value={template.id}>
+								{template.title || 'Blank (Start from scratch)'}{' '}
+								{template.description &&
+									`- ${template.description}`}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Tracking Repository{' '}
+						<span className="text-gray-500">
+							(where Epic/Sub-issues are created)
+						</span>
+					</label>
+					<input
+						type="text"
+						value={repo}
+						onChange={(e) => setRepo(e.target.value)}
+						placeholder="org/repo"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 font-mono"
+					/>
+				</div>
+
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Work Repository{' '}
+						<span className="text-gray-500">
+							(optional - where code lives and agents work)
+						</span>
+					</label>
+					<input
+						type="text"
+						value={workRepo}
+						onChange={(e) => setWorkRepo(e.target.value)}
+						placeholder="Leave empty to use tracking repo"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 font-mono"
+					/>
+					<div className="mt-1 text-xs text-gray-500">
+						If your issues are tracked in one repo but code lives in
+						another
+					</div>
+				</div>
+
+				{selectedTemplate !== 'blank' && selectedTemplateData && (
+					<div className="p-3 bg-mid-gray/5 border border-mid-gray/10 rounded space-y-2">
+						<div className="text-xs">
+							<div className="text-gray-400">
+								Template Preview:
+							</div>
+							<div className="text-gray-300 mt-1">
+								{selectedTemplateData.goal}
+							</div>
+						</div>
+						<div className="text-xs">
+							<div className="text-gray-400">
+								Phases: {selectedTemplateData.phases.length} |
+								Metrics:{' '}
+								{selectedTemplateData.success_metrics.length}
+							</div>
+						</div>
+					</div>
+				)}
+
+				<button
+					onClick={handleTemplateSelect}
+					disabled={!repo.trim()}
+					className="w-full mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors font-medium">
+					Next: Edit Plan →
+				</button>
+			</div>
+		);
+	};
+
+	// Main wizard - use single container with hidden sections to avoid DOM unmounting issues
+	// This prevents OverlayScrollbars from breaking when steps change
+	return (
+		<div className="space-y-4">
+			{/* Step 1: Template Selection or Link Existing */}
+			<div className={currentStep === 'template' ? '' : 'hidden'}>
+				{renderModeToggle()}
+				{createMode === 'link' ? renderLinkForm() : renderNewEpicForm()}
+			</div>
+
+			{/* Step 2: Edit Plan */}
+			<div
+				className={
+					currentStep === 'edit'
+						? 'space-y-4 max-h-[600px] overflow-y-auto pr-2'
+						: 'hidden'
+				}>
+				{/* Title */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Epic Title <span className="text-red-400">*</span>
+					</label>
+					<input
+						type="text"
+						value={title}
+						onChange={(e) => setTitle(e.target.value)}
+						placeholder="e.g., CICD Testing Infrastructure"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500"
+					/>
+				</div>
+
+				{/* Goal */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Goal <span className="text-red-400">*</span>
+					</label>
+					<textarea
+						value={goal}
+						onChange={(e) => setGoal(e.target.value)}
+						placeholder="1-2 sentence description of what this Epic aims to achieve"
+						rows={3}
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 resize-none"
+					/>
+				</div>
+
+				{/* Success Metrics */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Success Metrics
+					</label>
+					<div className="space-y-2">
+						{successMetrics.map((metric, index) => (
+							<div
+								key={index}
+								className="flex items-center gap-2">
+								<span className="text-xs text-gray-400">□</span>
+								<span className="flex-1 text-sm text-gray-300">
+									{metric}
+								</span>
+								<button
+									onClick={() => removeSuccessMetric(index)}
+									className="text-xs text-red-400 hover:text-red-300">
+									Remove
+								</button>
+							</div>
+						))}
+						<div className="flex gap-2">
+							<input
+								type="text"
+								value={newMetric}
+								onChange={(e) => setNewMetric(e.target.value)}
+								onKeyPress={(e) =>
+									e.key === 'Enter' && addSuccessMetric()
+								}
+								placeholder="Add success metric..."
+								className="flex-1 px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500"
+							/>
+							<button
+								onClick={addSuccessMetric}
+								className="px-3 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 text-white text-sm rounded transition-colors">
+								Add
+							</button>
+						</div>
+					</div>
+				</div>
+
+				{/* Phases */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Phases <span className="text-red-400">*</span>
+					</label>
+					<div className="space-y-3">
+						{phases.map((phase, index) => (
+							<div
+								key={index}
+								className="p-3 bg-mid-gray/5 border border-mid-gray/10 rounded space-y-2">
+								<div className="flex items-center justify-between">
+									<span className="text-xs text-gray-400">
+										Phase {index + 1}
+									</span>
+									<div className="flex gap-1">
+										<button
+											onClick={() => movePhaseUp(index)}
+											disabled={index === 0}
+											className="text-xs text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed">
+											↑
+										</button>
+										<button
+											onClick={() => movePhaseDown(index)}
+											disabled={
+												index === phases.length - 1
+											}
+											className="text-xs text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed">
+											↓
+										</button>
+										<button
+											onClick={() => removePhase(index)}
+											className="text-xs text-red-400 hover:text-red-300 ml-2">
+											Remove
+										</button>
+									</div>
+								</div>
+								<input
+									type="text"
+									value={phase.name}
+									onChange={(e) =>
+										updatePhase(
+											index,
+											'name',
+											e.target.value,
+										)
+									}
+									placeholder="Phase name"
+									className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500"
+								/>
+								<textarea
+									value={phase.description}
+									onChange={(e) =>
+										updatePhase(
+											index,
+											'description',
+											e.target.value,
+										)
+									}
+									placeholder="Phase description"
+									rows={2}
+									className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 resize-none"
+								/>
+								<select
+									value={phase.approach}
+									onChange={(e) =>
+										updatePhase(
+											index,
+											'approach',
+											e.target.value,
+										)
+									}
+									className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500">
+									<option value="manual">Manual</option>
+									<option value="agent-assisted">
+										Agent-Assisted
+									</option>
+									<option value="automated">Automated</option>
+								</select>
+							</div>
+						))}
+						<button
+							onClick={addPhase}
+							className="w-full px-3 py-2 bg-mid-gray/10 hover:bg-mid-gray/20 border border-dashed border-mid-gray/30 rounded text-sm text-gray-400 hover:text-white transition-colors">
+							+ Add Phase
+						</button>
+					</div>
+				</div>
+
+				{/* Labels */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Labels
+					</label>
+					<div className="flex flex-wrap gap-2 mb-2">
+						{labels.map((label, index) => (
+							<div
+								key={index}
+								className="flex items-center gap-1 px-2 py-1 bg-blue-500/20 border border-blue-500/30 rounded text-xs text-blue-300">
+								{label}
+								<button
+									onClick={() => removeLabel(index)}
+									className="text-blue-400 hover:text-blue-200">
+									×
+								</button>
+							</div>
+						))}
+					</div>
+					<div className="flex gap-2">
+						<input
+							type="text"
+							value={newLabel}
+							onChange={(e) => setNewLabel(e.target.value)}
+							onKeyPress={(e) => e.key === 'Enter' && addLabel()}
+							placeholder="Add label..."
+							className="flex-1 px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500"
+						/>
+						<button
+							onClick={addLabel}
+							className="px-3 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 text-white text-sm rounded transition-colors">
+							Add
+						</button>
+					</div>
+				</div>
+
+				{/* Navigation */}
+				<div className="flex gap-2 pt-4 border-t border-mid-gray/20">
+					<button
+						onClick={() => setCurrentStep('template')}
+						className="flex-1 px-4 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 text-white text-sm rounded transition-colors">
+						← Back
+					</button>
+					<button
+						onClick={() => setCurrentStep('review')}
+						disabled={
+							!title.trim() || !goal.trim() || phases.length === 0
+						}
+						className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors font-medium">
+						Review Plan →
+					</button>
+				</div>
+			</div>
+
+			{/* Step 3: Review & Create */}
+			<div
+				className={
+					currentStep === 'review'
+						? 'space-y-4 max-h-[600px] overflow-y-auto pr-2'
+						: 'hidden'
+				}>
+				<div className="p-4 bg-mid-gray/5 border border-mid-gray/10 rounded space-y-3">
+					<div>
+						<div className="text-xs text-gray-400">Title</div>
+						<div className="text-sm text-white font-medium">
+							[EPIC] {title}
+						</div>
+					</div>
+					<div>
+						<div className="text-xs text-gray-400">Repository</div>
+						<div className="text-sm text-white font-mono">
+							{repo}
+						</div>
+					</div>
+					<div>
+						<div className="text-xs text-gray-400">Goal</div>
+						<div className="text-sm text-gray-300">{goal}</div>
+					</div>
+					{successMetrics.length > 0 && (
+						<div>
+							<div className="text-xs text-gray-400 mb-1">
+								Success Metrics
+							</div>
+							{successMetrics.map((metric, i) => (
+								<div key={i} className="text-sm text-gray-300">
+									□ {metric}
+								</div>
+							))}
+						</div>
+					)}
+					<div>
+						<div className="text-xs text-gray-400 mb-1">
+							Phases ({phases.length})
+						</div>
+						{phases.map((phase, i) => (
+							<div key={i} className="text-sm text-gray-300 mb-1">
+								{i + 1}. <strong>{phase.name}</strong> (
+								{phase.approach})
+							</div>
+						))}
+					</div>
+					{labels.length > 0 && (
+						<div>
+							<div className="text-xs text-gray-400 mb-1">
+								Labels
+							</div>
+							<div className="flex flex-wrap gap-1">
+								{labels.map((label, i) => (
+									<span
+										key={i}
+										className="px-2 py-1 bg-blue-500/20 border border-blue-500/30 rounded text-xs text-blue-300">
+										{label}
+									</span>
+								))}
+							</div>
+						</div>
+					)}
+				</div>
+
+				{error && (
+					<div className="p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">
+						<strong>Error:</strong> {error}
+					</div>
+				)}
+
+				<div className="flex gap-2 pt-4 border-t border-mid-gray/20">
+					<button
+						onClick={() => setCurrentStep('edit')}
+						disabled={creating}
+						className="flex-1 px-4 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 disabled:opacity-50 text-white text-sm rounded transition-colors">
+						← Edit
+					</button>
+					<button
+						onClick={handleCreateEpic}
+						disabled={creating}
+						className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors font-medium">
+						{creating ? 'Creating Epic...' : 'Create Epic ✓'}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/IssueQueue.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/IssueQueue.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { commands, GitHubIssue, GhAuthStatus } from '@/bindings';
+import {
+	CircleDot,
+	ExternalLink,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	CheckCircle2,
+	Tag,
+	User,
+	Clock,
+	LogIn,
+	Bot,
+} from 'lucide-react';
+
+interface IssueQueueProps {
+	hubRepo?: string;
+	repoPath?: string;
+	onIssueSelect?: (issue: GitHubIssue) => void;
+	onAgentSpawned?: () => void;
+}
+
+export const IssueQueue: React.FC<IssueQueueProps> = ({
+	hubRepo,
+	repoPath,
+	onIssueSelect,
+	onAgentSpawned,
+}) => {
+	const { t } = useTranslation();
+	const [authStatus, setAuthStatus] = useState<GhAuthStatus | null>(null);
+	const [issues, setIssues] = useState<GitHubIssue[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [repoInput, setRepoInput] = useState(hubRepo || '');
+	const [activeRepo, setActiveRepo] = useState(hubRepo || '');
+	const [showRepoInput, setShowRepoInput] = useState(!hubRepo);
+	const [spawningIssue, setSpawningIssue] = useState<number | null>(null);
+
+	const checkAuth = useCallback(async () => {
+		try {
+			const status = await commands.checkGhAuth();
+			setAuthStatus(status);
+			return status.authenticated;
+		} catch (err) {
+			setAuthStatus({
+				authenticated: false,
+				username: null,
+				scopes: [],
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return false;
+		}
+	}, []);
+
+	const loadIssues = useCallback(async () => {
+		if (!activeRepo) {
+			setIssues([]);
+			setIsLoading(false);
+			return;
+		}
+
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const isAuthed = await checkAuth();
+			if (!isAuthed) {
+				setIsLoading(false);
+				return;
+			}
+
+			const result = await commands.listGithubIssues(
+				activeRepo,
+				'open',
+				null, // all labels
+				50, // limit
+			);
+			if (result.status === 'ok') {
+				setIssues(result.data);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsLoading(false);
+		}
+	}, [activeRepo, checkAuth]);
+
+	useEffect(() => {
+		loadIssues();
+	}, [loadIssues]);
+
+	const handleSetRepo = () => {
+		if (repoInput.trim()) {
+			setActiveRepo(repoInput.trim());
+			setShowRepoInput(false);
+		}
+	};
+
+	const formatDate = (dateStr: string) => {
+		try {
+			const date = new Date(dateStr);
+			return date.toLocaleDateString();
+		} catch {
+			return dateStr;
+		}
+	};
+
+	const handleSpawnAgent = async (issue: GitHubIssue) => {
+		if (!repoPath) {
+			setError(t('devops.orchestrator.noRepoPath'));
+			return;
+		}
+
+		setSpawningIssue(issue.number);
+		setError(null);
+
+		try {
+			await commands.spawnAgent(
+				activeRepo,
+				issue.number,
+				'claude', // Default agent type
+				repoPath,
+				null, // Auto-generate session name
+				null, // Default prefix
+				['agent-working'], // Add working label
+				false, // No sandbox
+			);
+			onAgentSpawned?.();
+			await loadIssues(); // Refresh to show updated labels
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setSpawningIssue(null);
+		}
+	};
+
+	// Not authenticated
+	if (authStatus && !authStatus.authenticated) {
+		return (
+			<div className="flex flex-col items-center justify-center p-8 text-center">
+				<LogIn className="w-12 h-12 text-mid-gray/50 mb-3" />
+				<p className="text-sm text-mid-gray mb-2">
+					{t('devops.issues.notAuthenticated')}
+				</p>
+				<p className="text-xs text-mid-gray/70 mb-4">
+					{t('devops.issues.notAuthenticatedHint')}
+				</p>
+				<code className="text-xs bg-mid-gray/20 px-3 py-2 rounded">
+					{t('devops.issues.authCommand')}
+				</code>
+			</div>
+		);
+	}
+
+	// No repo configured
+	if (!activeRepo || showRepoInput) {
+		return (
+			<div className="flex flex-col gap-3">
+				<p className="text-sm text-mid-gray">
+					{t('devops.issues.configureRepo')}
+				</p>
+				<div className="flex gap-2">
+					<input
+						type="text"
+						value={repoInput}
+						onChange={(e) => setRepoInput(e.target.value)}
+						placeholder={t('devops.issues.repoPlaceholder')}
+						className="flex-1 px-3 py-2 rounded bg-mid-gray/10 border border-mid-gray/20 text-sm focus:outline-none focus:border-logo-primary"
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' && repoInput.trim()) {
+								handleSetRepo();
+							}
+						}}
+					/>
+					<button
+						onClick={handleSetRepo}
+						disabled={!repoInput.trim()}
+						className="px-3 py-2 rounded bg-logo-primary hover:bg-logo-primary/90 disabled:opacity-50 text-sm">
+						{t('devops.issues.setRepo')}
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center p-8">
+				<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center gap-2 p-3 bg-red-500/10 rounded-lg text-red-400">
+				<AlertCircle className="w-4 h-4" />
+				<span className="text-sm">{error}</span>
+				<button
+					onClick={loadIssues}
+					className="ml-auto p-1 hover:bg-mid-gray/20 rounded">
+					<RefreshCcw className="w-4 h-4" />
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="text-sm text-mid-gray">
+						{t('devops.issues.count', { count: issues.length })}
+					</span>
+					<button
+						onClick={() => setShowRepoInput(true)}
+						className="text-xs text-mid-gray/70 hover:text-mid-gray"
+						title={activeRepo}>
+						({activeRepo})
+					</button>
+				</div>
+				<button
+					onClick={loadIssues}
+					disabled={isLoading}
+					className="p-1 hover:bg-mid-gray/20 rounded transition-colors"
+					title={t('devops.refresh')}>
+					<RefreshCcw
+						className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+					/>
+				</button>
+			</div>
+
+			{/* Auth status */}
+			{authStatus?.username && (
+				<div className="flex items-center gap-2 text-xs text-green-400">
+					<CheckCircle2 className="w-3 h-3" />
+					<span>
+						{t('devops.issues.authenticatedAs', {
+							user: authStatus.username,
+						})}
+					</span>
+				</div>
+			)}
+
+			{/* Issue list */}
+			{issues.length === 0 ? (
+				<div className="flex flex-col items-center justify-center p-8 text-center">
+					<CircleDot className="w-12 h-12 text-mid-gray/50 mb-3" />
+					<p className="text-sm text-mid-gray">
+						{t('devops.issues.noIssues')}
+					</p>
+					<p className="text-xs text-mid-gray/70 mt-1">
+						{t('devops.issues.noIssuesHint')}
+					</p>
+				</div>
+			) : (
+				<div className="flex flex-col gap-2 max-h-[400px] overflow-y-auto">
+					{issues.map((issue) => (
+						<div
+							key={`${issue.repo}-${issue.number}`}
+							className="flex items-start gap-3 p-3 rounded-lg bg-mid-gray/10 hover:bg-mid-gray/15 transition-colors cursor-pointer"
+							onClick={() => onIssueSelect?.(issue)}>
+							{/* Status icon */}
+							<div className="mt-1">
+								<CircleDot
+									className={`w-4 h-4 ${
+										issue.state === 'open'
+											? 'text-green-400'
+											: 'text-purple-400'
+									}`}
+								/>
+							</div>
+
+							{/* Content */}
+							<div className="flex-1 min-w-0">
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-mid-gray/70">
+										#{issue.number}
+									</span>
+									<span className="font-medium text-sm truncate">
+										{issue.title}
+									</span>
+								</div>
+
+								<div className="mt-1 flex flex-wrap gap-2">
+									{issue.labels.slice(0, 3).map((label) => (
+										<span
+											key={label}
+											className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-mid-gray/20">
+											<Tag className="w-3 h-3" />
+											{label}
+										</span>
+									))}
+									{issue.labels.length > 3 && (
+										<span className="text-xs text-mid-gray/70">
+											+{issue.labels.length - 3}
+										</span>
+									)}
+								</div>
+
+								<div className="mt-1 flex items-center gap-3 text-xs text-mid-gray/70">
+									<span className="flex items-center gap-1">
+										<User className="w-3 h-3" />
+										{issue.author}
+									</span>
+									<span className="flex items-center gap-1">
+										<Clock className="w-3 h-3" />
+										{formatDate(issue.created_at)}
+									</span>
+								</div>
+							</div>
+
+							{/* Actions */}
+							<div className="flex items-center gap-1">
+								{repoPath && (
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											handleSpawnAgent(issue);
+										}}
+										disabled={
+											spawningIssue === issue.number
+										}
+										className="p-1.5 hover:bg-green-500/20 rounded transition-colors text-mid-gray hover:text-green-400"
+										title={t(
+											'devops.orchestrator.spawnAgent',
+										)}>
+										{spawningIssue === issue.number ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<Bot className="w-4 h-4" />
+										)}
+									</button>
+								)}
+								<a
+									href={issue.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={(e) => e.stopPropagation()}
+									className="p-1.5 hover:bg-mid-gray/20 rounded transition-colors text-mid-gray"
+									title={t('devops.issues.openInGitHub')}>
+									<ExternalLink className="w-4 h-4" />
+								</a>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/MarkdownEpicPlanner.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/MarkdownEpicPlanner.tsx
@@ -1,0 +1,304 @@
+import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { commands } from '@/bindings';
+import type { PlanFromMarkdownConfig, PlanResult } from '../../../bindings';
+
+export function MarkdownEpicPlanner() {
+	const [planFilePath, setPlanFilePath] = useState<string>('');
+	const [repo, setRepo] = useState<string>('KBVE/Handy');
+	const [workRepo, setWorkRepo] = useState<string>('');
+	const [titleOverride, setTitleOverride] = useState<string>('');
+	const [agentType, setAgentType] = useState<string>('');
+	const [enabledAgents, setEnabledAgents] = useState<string[]>([]);
+	const [planning, setPlanning] = useState(false);
+	const [result, setResult] = useState<PlanResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	// Load enabled agents on mount
+	useEffect(() => {
+		const loadAgents = async () => {
+			try {
+				const agents = await commands.getEnabledAgents();
+				setEnabledAgents(agents);
+				if (agents.length > 0 && !agentType) {
+					setAgentType(agents[0]); // Default to first enabled agent
+				}
+			} catch (err) {
+				console.error('Failed to load enabled agents:', err);
+			}
+		};
+		loadAgents();
+	}, []);
+
+	const planEpic = async () => {
+		if (!planFilePath.trim()) {
+			setError('Please select a markdown file');
+			return;
+		}
+
+		setPlanning(true);
+		setError(null);
+		setResult(null);
+
+		try {
+			const config: PlanFromMarkdownConfig = {
+				plan_file_path: planFilePath,
+				repo,
+				work_repo: workRepo.trim() || null,
+				title_override: titleOverride.trim() || null,
+				planning_agent: agentType || null,
+			};
+
+			const planResult = await invoke<PlanResult>(
+				'plan_epic_from_markdown',
+				{
+					config,
+				},
+			);
+			setResult(planResult);
+			console.log('Epic planned:', planResult);
+		} catch (err) {
+			setError(err as string);
+			console.error('Failed to plan epic:', err);
+		} finally {
+			setPlanning(false);
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			<div className="space-y-3">
+				{/* File Path Input */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Markdown Plan File Path
+					</label>
+					<input
+						type="text"
+						value={planFilePath}
+						onChange={(e) => setPlanFilePath(e.target.value)}
+						disabled={planning || result !== null}
+						placeholder="/path/to/plan.md"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed font-mono"
+					/>
+					<div className="mt-1 text-xs text-gray-500">
+						Example: ~/.claude/plans/my-project-plan.md
+					</div>
+				</div>
+
+				{/* Repository */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Tracking Repository{' '}
+						<span className="text-gray-500">
+							(where Epic/Sub-issues are created)
+						</span>
+					</label>
+					<input
+						type="text"
+						value={repo}
+						onChange={(e) => setRepo(e.target.value)}
+						disabled={planning || result !== null}
+						placeholder="org/repo"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed font-mono"
+					/>
+				</div>
+
+				{/* Work Repository */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Work Repository{' '}
+						<span className="text-gray-500">
+							(optional - where code lives and agents work)
+						</span>
+					</label>
+					<input
+						type="text"
+						value={workRepo}
+						onChange={(e) => setWorkRepo(e.target.value)}
+						disabled={planning || result !== null}
+						placeholder="Leave empty to use tracking repo"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed font-mono"
+					/>
+				</div>
+
+				{/* Title Override (Optional) */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Epic Title Override{' '}
+						<span className="text-gray-500">(optional)</span>
+					</label>
+					<input
+						type="text"
+						value={titleOverride}
+						onChange={(e) => setTitleOverride(e.target.value)}
+						disabled={planning || result !== null}
+						placeholder="Leave empty to extract from plan"
+						className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+					/>
+				</div>
+
+				{/* Agent Type */}
+				<div>
+					<label className="block text-xs text-gray-400 mb-1.5">
+						Planning Agent{' '}
+						{enabledAgents.length === 0 && (
+							<span className="text-yellow-400">
+								(No agents enabled)
+							</span>
+						)}
+					</label>
+					{enabledAgents.length > 0 ? (
+						<select
+							value={agentType}
+							onChange={(e) => setAgentType(e.target.value)}
+							disabled={planning || result !== null}
+							className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed">
+							{enabledAgents.map((agent) => (
+								<option key={agent} value={agent}>
+									{agent}
+								</option>
+							))}
+						</select>
+					) : (
+						<div className="w-full px-3 py-2 bg-mid-gray/10 border border-mid-gray/20 rounded text-sm text-gray-500">
+							Enable at least one agent in the "AI Coding Agents"
+							section above
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Plan Button */}
+			<button
+				onClick={planEpic}
+				disabled={
+					planning ||
+					result !== null ||
+					!planFilePath.trim() ||
+					!repo.trim()
+				}
+				className="w-full px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded transition-colors font-medium">
+				{planning
+					? 'Planning Epic...'
+					: result
+						? 'Epic Planned ✓'
+						: 'Plan Epic from Markdown'}
+			</button>
+
+			{/* Error Display */}
+			{error && (
+				<div className="p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400 space-y-1">
+					<strong>Error:</strong>
+					<pre className="mt-2 text-xs whitespace-pre-wrap">
+						{error}
+					</pre>
+				</div>
+			)}
+
+			{/* Success Display */}
+			{result && (
+				<div className="p-4 bg-green-500/10 border border-green-500/20 rounded space-y-3">
+					<div className="flex items-center gap-2">
+						<span className="text-green-400 text-lg">✓</span>
+						<span className="text-sm font-medium text-white">
+							Epic Planned Successfully!
+						</span>
+					</div>
+
+					<div className="space-y-1 text-xs text-gray-300">
+						<div>
+							<span className="text-gray-400">Summary:</span>{' '}
+							<span className="text-white">{result.summary}</span>
+						</div>
+						<div>
+							<span className="text-gray-400">Epic Number:</span>{' '}
+							<span className="font-mono text-white">
+								#{result.epic.epic_number}
+							</span>
+						</div>
+						<div>
+							<span className="text-gray-400">Repository:</span>{' '}
+							<span className="font-mono text-white">
+								{result.epic.repo}
+							</span>
+						</div>
+						<div>
+							<span className="text-gray-400">
+								Sub-issues Created:
+							</span>{' '}
+							<span className="text-white">
+								{result.sub_issues.length}
+							</span>
+						</div>
+						<div>
+							<span className="text-gray-400">
+								Planning Agent:
+							</span>{' '}
+							<span className="text-white">
+								{result.planning_agent}
+							</span>
+						</div>
+					</div>
+
+					<div className="mt-2">
+						<a
+							href={result.epic.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300 underline text-sm">
+							View Epic on GitHub →
+						</a>
+					</div>
+
+					{/* Sub-issues List */}
+					{result.sub_issues.length > 0 && (
+						<div className="mt-3 pt-3 border-t border-green-500/20">
+							<div className="text-xs text-gray-400 mb-2">
+								<strong>Created Sub-issues:</strong>
+							</div>
+							<div className="space-y-1 max-h-40 overflow-y-auto">
+								{result.sub_issues.map((issue) => (
+									<div
+										key={issue.issue_number}
+										className="text-xs text-gray-300 flex items-start gap-2">
+										<span className="font-mono text-gray-400">
+											#{issue.issue_number}
+										</span>
+										<a
+											href={issue.url}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-blue-400 hover:text-blue-300 underline flex-1">
+											{issue.title}
+										</a>
+									</div>
+								))}
+							</div>
+						</div>
+					)}
+
+					<div className="mt-3 pt-3 border-t border-green-500/20 text-xs text-gray-400">
+						<strong>Next steps:</strong>
+						<ol className="mt-1 ml-4 list-decimal space-y-1">
+							<li>Review Epic and sub-issues on GitHub</li>
+							<li>Implement manual phases</li>
+							<li>Spawn agents for agent-assisted phases</li>
+						</ol>
+					</div>
+
+					<button
+						onClick={() => {
+							setResult(null);
+							setPlanFilePath('');
+							setWorkRepo('');
+							setTitleOverride('');
+						}}
+						className="w-full mt-3 px-4 py-2 bg-mid-gray/20 hover:bg-mid-gray/30 text-white text-sm rounded transition-colors">
+						Plan Another Epic
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/PullRequestPanel.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/PullRequestPanel.tsx
@@ -1,0 +1,509 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	commands,
+	GitHubPullRequest,
+	PrStatus,
+	GhAuthStatus,
+} from '@/bindings';
+import {
+	GitPullRequest,
+	ExternalLink,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	CheckCircle2,
+	XCircle,
+	Clock,
+	GitMerge,
+	Tag,
+	User,
+	LogIn,
+	ChevronDown,
+	ChevronUp,
+} from 'lucide-react';
+
+interface PullRequestPanelProps {
+	hubRepo?: string;
+	onPrSelect?: (pr: GitHubPullRequest) => void;
+}
+
+export const PullRequestPanel: React.FC<PullRequestPanelProps> = ({
+	hubRepo,
+	onPrSelect,
+}) => {
+	const { t } = useTranslation();
+	const [authStatus, setAuthStatus] = useState<GhAuthStatus | null>(null);
+	const [prs, setPrs] = useState<GitHubPullRequest[]>([]);
+	const [prStatuses, setPrStatuses] = useState<Record<number, PrStatus>>({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [repoInput, setRepoInput] = useState(hubRepo || '');
+	const [activeRepo, setActiveRepo] = useState(hubRepo || '');
+	const [showRepoInput, setShowRepoInput] = useState(!hubRepo);
+	const [expandedPr, setExpandedPr] = useState<number | null>(null);
+
+	const checkAuth = useCallback(async () => {
+		try {
+			const status = await commands.checkGhAuth();
+			setAuthStatus(status);
+			return status.authenticated;
+		} catch (err) {
+			setAuthStatus({
+				authenticated: false,
+				username: null,
+				scopes: [],
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return false;
+		}
+	}, []);
+
+	const loadPrs = useCallback(async () => {
+		if (!activeRepo) {
+			setPrs([]);
+			setIsLoading(false);
+			return;
+		}
+
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const isAuthed = await checkAuth();
+			if (!isAuthed) {
+				setIsLoading(false);
+				return;
+			}
+
+			const result = await commands.listGithubPrs(
+				activeRepo,
+				'open',
+				null, // all base branches
+				50, // limit
+			);
+			if (result.status === 'ok') {
+				setPrs(result.data);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsLoading(false);
+		}
+	}, [activeRepo, checkAuth]);
+
+	const loadPrStatus = useCallback(
+		async (prNumber: number) => {
+			if (!activeRepo) return;
+			try {
+				const result = await commands.getGithubPrStatus(
+					activeRepo,
+					prNumber,
+				);
+				if (result.status === 'ok') {
+					setPrStatuses((prev) => ({
+						...prev,
+						[prNumber]: result.data,
+					}));
+				}
+			} catch (err) {
+				console.error('Failed to load PR status:', err);
+			}
+		},
+		[activeRepo],
+	);
+
+	useEffect(() => {
+		loadPrs();
+	}, [loadPrs]);
+
+	const handleSetRepo = () => {
+		if (repoInput.trim()) {
+			setActiveRepo(repoInput.trim());
+			setShowRepoInput(false);
+		}
+	};
+
+	const handleExpandPr = (prNumber: number) => {
+		if (expandedPr === prNumber) {
+			setExpandedPr(null);
+		} else {
+			setExpandedPr(prNumber);
+			if (!prStatuses[prNumber]) {
+				loadPrStatus(prNumber);
+			}
+		}
+	};
+
+	const formatDate = (dateStr: string) => {
+		try {
+			const date = new Date(dateStr);
+			return date.toLocaleDateString();
+		} catch {
+			return dateStr;
+		}
+	};
+
+	const getCheckStatusIcon = (state: string) => {
+		switch (state) {
+			case 'success':
+				return <CheckCircle2 className="w-4 h-4 text-green-400" />;
+			case 'failure':
+				return <XCircle className="w-4 h-4 text-red-400" />;
+			case 'pending':
+				return <Clock className="w-4 h-4 text-yellow-400" />;
+			default:
+				return <AlertCircle className="w-4 h-4 text-mid-gray" />;
+		}
+	};
+
+	// Not authenticated
+	if (authStatus && !authStatus.authenticated) {
+		return (
+			<div className="flex flex-col items-center justify-center p-8 text-center">
+				<LogIn className="w-12 h-12 text-mid-gray/50 mb-3" />
+				<p className="text-sm text-mid-gray mb-2">
+					{t('devops.prs.notAuthenticated')}
+				</p>
+				<p className="text-xs text-mid-gray/70 mb-4">
+					{t('devops.prs.notAuthenticatedHint')}
+				</p>
+				<code className="text-xs bg-mid-gray/20 px-3 py-2 rounded">
+					{t('devops.prs.authCommand')}
+				</code>
+			</div>
+		);
+	}
+
+	// No repo configured
+	if (!activeRepo || showRepoInput) {
+		return (
+			<div className="flex flex-col gap-3">
+				<p className="text-sm text-mid-gray">
+					{t('devops.prs.configureRepo')}
+				</p>
+				<div className="flex gap-2">
+					<input
+						type="text"
+						value={repoInput}
+						onChange={(e) => setRepoInput(e.target.value)}
+						placeholder={t('devops.prs.repoPlaceholder')}
+						className="flex-1 px-3 py-2 rounded bg-mid-gray/10 border border-mid-gray/20 text-sm focus:outline-none focus:border-logo-primary"
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' && repoInput.trim()) {
+								handleSetRepo();
+							}
+						}}
+					/>
+					<button
+						onClick={handleSetRepo}
+						disabled={!repoInput.trim()}
+						className="px-3 py-2 rounded bg-logo-primary hover:bg-logo-primary/90 disabled:opacity-50 text-sm">
+						{t('devops.prs.setRepo')}
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center p-8">
+				<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center gap-2 p-3 bg-red-500/10 rounded-lg text-red-400">
+				<AlertCircle className="w-4 h-4" />
+				<span className="text-sm">{error}</span>
+				<button
+					onClick={loadPrs}
+					className="ml-auto p-1 hover:bg-mid-gray/20 rounded">
+					<RefreshCcw className="w-4 h-4" />
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="text-sm text-mid-gray">
+						{t('devops.prs.count', { count: prs.length })}
+					</span>
+					<button
+						onClick={() => setShowRepoInput(true)}
+						className="text-xs text-mid-gray/70 hover:text-mid-gray"
+						title={activeRepo}>
+						({activeRepo})
+					</button>
+				</div>
+				<button
+					onClick={loadPrs}
+					disabled={isLoading}
+					className="p-1 hover:bg-mid-gray/20 rounded transition-colors"
+					title={t('devops.refresh')}>
+					<RefreshCcw
+						className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+					/>
+				</button>
+			</div>
+
+			{/* Auth status */}
+			{authStatus?.username && (
+				<div className="flex items-center gap-2 text-xs text-green-400">
+					<CheckCircle2 className="w-3 h-3" />
+					<span>
+						{t('devops.prs.authenticatedAs', {
+							user: authStatus.username,
+						})}
+					</span>
+				</div>
+			)}
+
+			{/* PR list */}
+			{prs.length === 0 ? (
+				<div className="flex flex-col items-center justify-center p-8 text-center">
+					<GitPullRequest className="w-12 h-12 text-mid-gray/50 mb-3" />
+					<p className="text-sm text-mid-gray">
+						{t('devops.prs.noPrs')}
+					</p>
+					<p className="text-xs text-mid-gray/70 mt-1">
+						{t('devops.prs.noPrsHint')}
+					</p>
+				</div>
+			) : (
+				<div className="flex flex-col gap-2 max-h-[400px] overflow-y-auto">
+					{prs.map((pr) => (
+						<div
+							key={`${pr.repo}-${pr.number}`}
+							className="flex flex-col rounded-lg bg-mid-gray/10 hover:bg-mid-gray/15 transition-colors">
+							{/* PR Header */}
+							<div
+								className="flex items-start gap-3 p-3 cursor-pointer"
+								onClick={() => onPrSelect?.(pr)}>
+								{/* Status icon */}
+								<div className="mt-1">
+									{pr.state === 'MERGED' ? (
+										<GitMerge className="w-4 h-4 text-purple-400" />
+									) : pr.is_draft ? (
+										<GitPullRequest className="w-4 h-4 text-mid-gray" />
+									) : (
+										<GitPullRequest className="w-4 h-4 text-green-400" />
+									)}
+								</div>
+
+								{/* Content */}
+								<div className="flex-1 min-w-0">
+									<div className="flex items-center gap-2">
+										<span className="text-xs text-mid-gray/70">
+											#{pr.number}
+										</span>
+										<span className="font-medium text-sm truncate">
+											{pr.title}
+										</span>
+										{pr.is_draft && (
+											<span className="text-xs px-1.5 py-0.5 rounded bg-mid-gray/30 text-mid-gray">
+												{t('devops.prs.draft')}
+											</span>
+										)}
+									</div>
+
+									<div className="mt-1 flex flex-wrap gap-2">
+										{/* Branch info */}
+										<span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
+											{pr.head_branch} → {pr.base_branch}
+										</span>
+										{pr.labels.slice(0, 2).map((label) => (
+											<span
+												key={label}
+												className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-mid-gray/20">
+												<Tag className="w-3 h-3" />
+												{label}
+											</span>
+										))}
+										{pr.labels.length > 2 && (
+											<span className="text-xs text-mid-gray/70">
+												+{pr.labels.length - 2}
+											</span>
+										)}
+									</div>
+
+									<div className="mt-1 flex items-center gap-3 text-xs text-mid-gray/70">
+										<span className="flex items-center gap-1">
+											<User className="w-3 h-3" />
+											{pr.author}
+										</span>
+										<span className="flex items-center gap-1">
+											<Clock className="w-3 h-3" />
+											{formatDate(pr.created_at)}
+										</span>
+									</div>
+								</div>
+
+								{/* Actions */}
+								<div className="flex items-center gap-1">
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											handleExpandPr(pr.number);
+										}}
+										className="p-1.5 hover:bg-mid-gray/20 rounded transition-colors text-mid-gray"
+										title={t('devops.prs.showStatus')}>
+										{expandedPr === pr.number ? (
+											<ChevronUp className="w-4 h-4" />
+										) : (
+											<ChevronDown className="w-4 h-4" />
+										)}
+									</button>
+									<a
+										href={pr.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={(e) => e.stopPropagation()}
+										className="p-1.5 hover:bg-mid-gray/20 rounded transition-colors text-mid-gray"
+										title={t('devops.prs.openInGitHub')}>
+										<ExternalLink className="w-4 h-4" />
+									</a>
+								</div>
+							</div>
+
+							{/* Expanded status */}
+							{expandedPr === pr.number && (
+								<div className="px-3 pb-3 pt-0 border-t border-mid-gray/20 mt-1">
+									{prStatuses[pr.number] ? (
+										<div className="flex flex-col gap-2 mt-2">
+											{/* Checks status */}
+											<div className="flex items-center gap-2">
+												{getCheckStatusIcon(
+													prStatuses[pr.number].checks
+														.state,
+												)}
+												<span className="text-xs">
+													{t('devops.prs.checks')}:{' '}
+													{
+														prStatuses[pr.number]
+															.checks.passing
+													}
+													/
+													{
+														prStatuses[pr.number]
+															.checks.total
+													}{' '}
+													{t('devops.prs.passing')}
+													{prStatuses[pr.number]
+														.checks.failing > 0 && (
+														<span className="text-red-400">
+															{' '}
+															(
+															{
+																prStatuses[
+																	pr.number
+																].checks.failing
+															}{' '}
+															{t(
+																'devops.prs.failing',
+															)}
+															)
+														</span>
+													)}
+													{prStatuses[pr.number]
+														.checks.pending > 0 && (
+														<span className="text-yellow-400">
+															{' '}
+															(
+															{
+																prStatuses[
+																	pr.number
+																].checks.pending
+															}{' '}
+															{t(
+																'devops.prs.pending',
+															)}
+															)
+														</span>
+													)}
+												</span>
+											</div>
+
+											{/* Reviews status */}
+											<div className="flex items-center gap-2">
+												{prStatuses[pr.number].reviews
+													.approved > 0 ? (
+													<CheckCircle2 className="w-4 h-4 text-green-400" />
+												) : prStatuses[pr.number]
+														.reviews
+														.changes_requested >
+												  0 ? (
+													<XCircle className="w-4 h-4 text-red-400" />
+												) : (
+													<Clock className="w-4 h-4 text-mid-gray" />
+												)}
+												<span className="text-xs">
+													{t('devops.prs.reviews')}:{' '}
+													{
+														prStatuses[pr.number]
+															.reviews.approved
+													}{' '}
+													{t('devops.prs.approved')}
+													{prStatuses[pr.number]
+														.reviews
+														.changes_requested >
+														0 && (
+														<span className="text-red-400">
+															,{' '}
+															{
+																prStatuses[
+																	pr.number
+																].reviews
+																	.changes_requested
+															}{' '}
+															{t(
+																'devops.prs.changesRequested',
+															)}
+														</span>
+													)}
+												</span>
+											</div>
+
+											{/* Mergeable status */}
+											{pr.mergeable !== null && (
+												<div className="flex items-center gap-2">
+													{pr.mergeable ? (
+														<CheckCircle2 className="w-4 h-4 text-green-400" />
+													) : (
+														<XCircle className="w-4 h-4 text-red-400" />
+													)}
+													<span className="text-xs">
+														{pr.mergeable
+															? t(
+																	'devops.prs.mergeable',
+																)
+															: t(
+																	'devops.prs.notMergeable',
+																)}
+													</span>
+												</div>
+											)}
+										</div>
+									) : (
+										<div className="flex items-center justify-center py-2">
+											<Loader2 className="w-4 h-4 animate-spin text-mid-gray" />
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/SessionManager.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/SessionManager.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDevOpsStore } from '@/stores/devopsStore';
+import {
+	Terminal,
+	Play,
+	Square,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	Clock,
+	Trash2,
+	RotateCcw,
+	GitBranch,
+} from 'lucide-react';
+
+interface SessionManagerProps {
+	onSessionsChange?: () => void;
+}
+
+export const SessionManager: React.FC<SessionManagerProps> = ({
+	onSessionsChange,
+}) => {
+	const { t } = useTranslation();
+
+	// Use Zustand store instead of component state
+	const sessions = useDevOpsStore((state) => state.sessions);
+	const recoveredSessions = useDevOpsStore(
+		(state) => state.recoveredSessions,
+	);
+	const isLoading = useDevOpsStore((state) => state.sessionsLoading);
+	const isTmuxRunning = useDevOpsStore((state) => state.isTmuxRunning);
+	const error = useDevOpsStore((state) => state.sessionsError);
+	const killingSession = useDevOpsStore((state) => state.killingSession);
+
+	const refreshSessions = useDevOpsStore((state) => state.refreshSessions);
+	const killSessionAction = useDevOpsStore((state) => state.killSession);
+
+	const handleKillSession = async (sessionName: string) => {
+		await killSessionAction(sessionName);
+		onSessionsChange?.();
+	};
+
+	const formatTimestamp = (timestamp: string) => {
+		try {
+			const date = new Date(timestamp);
+			return date.toLocaleString();
+		} catch {
+			return timestamp;
+		}
+	};
+
+	const getStatusIcon = (status: string) => {
+		switch (status) {
+			case 'Running':
+				return <Play className="w-4 h-4 text-green-400" />;
+			case 'Stopped':
+				return <Square className="w-4 h-4 text-yellow-400" />;
+			default:
+				return <AlertCircle className="w-4 h-4 text-gray-400" />;
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center p-8 min-h-[120px]">
+				<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	if (!isTmuxRunning) {
+		return (
+			<div className="flex flex-col items-center justify-center p-8 text-center min-h-[120px]">
+				<Terminal className="w-12 h-12 text-mid-gray/50 mb-3" />
+				<p className="text-sm text-mid-gray mb-2">
+					{t('devops.sessions.tmuxNotRunning')}
+				</p>
+				<p className="text-xs text-mid-gray/70">
+					{t('devops.sessions.tmuxNotRunningHint')}
+				</p>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center gap-2 p-4 bg-red-500/10 rounded-lg text-red-400">
+				<AlertCircle className="w-4 h-4" />
+				<span className="text-sm">{error}</span>
+				<button
+					onClick={() => refreshSessions(true)}
+					className="ml-auto p-1 hover:bg-mid-gray/20 rounded">
+					<RefreshCcw className="w-4 h-4" />
+				</button>
+			</div>
+		);
+	}
+
+	if (sessions.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center p-8 text-center min-h-[120px]">
+				<Terminal className="w-12 h-12 text-mid-gray/50 mb-3" />
+				<p className="text-sm text-mid-gray">
+					{t('devops.sessions.noSessions')}
+				</p>
+				<p className="text-xs text-mid-gray/70 mt-1">
+					{t('devops.sessions.noSessionsHint')}
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Header with refresh */}
+			<div className="flex items-center justify-between">
+				<span className="text-sm text-mid-gray">
+					{t('devops.sessions.activeCount', {
+						count: sessions.length,
+					})}
+				</span>
+				<button
+					onClick={() => refreshSessions(false)}
+					disabled={isLoading}
+					className="p-1 hover:bg-mid-gray/20 rounded transition-colors"
+					title={t('devops.refresh')}>
+					<RefreshCcw
+						className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+					/>
+				</button>
+			</div>
+
+			{/* Session list */}
+			<div className="flex flex-col gap-2 min-h-[120px]">
+				{sessions.map((session) => (
+					<div
+						key={session.name}
+						className="flex items-start gap-3 p-4 rounded-lg bg-mid-gray/10 hover:bg-mid-gray/15 transition-colors">
+						{/* Status icon */}
+						<div className="mt-1">
+							{getStatusIcon(session.status)}
+						</div>
+
+						{/* Content */}
+						<div className="flex-1 min-w-0">
+							<div className="flex items-center gap-2">
+								<code className="font-medium text-sm">
+									{session.name}
+								</code>
+								{session.attached && (
+									<span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+										{t('devops.sessions.attached')}
+									</span>
+								)}
+							</div>
+
+							{session.metadata && (
+								<div className="mt-1 text-xs text-mid-gray space-y-0.5">
+									{session.metadata.issue_ref && (
+										<div className="flex items-center gap-1">
+											<GitBranch className="w-3 h-3" />
+											<span>
+												{session.metadata.issue_ref}
+											</span>
+										</div>
+									)}
+									{session.metadata.agent_type && (
+										<div className="flex items-center gap-1">
+											<Terminal className="w-3 h-3" />
+											<span>
+												{session.metadata.agent_type}
+											</span>
+										</div>
+									)}
+									{session.metadata.started_at && (
+										<div className="flex items-center gap-1">
+											<Clock className="w-3 h-3" />
+											<span>
+												{formatTimestamp(
+													session.metadata.started_at,
+												)}
+											</span>
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+
+						{/* Actions */}
+						<div className="flex items-center gap-1">
+							<button
+								onClick={() => handleKillSession(session.name)}
+								disabled={killingSession === session.name}
+								className="p-1.5 hover:bg-red-500/20 rounded transition-colors text-red-400"
+								title={t('devops.sessions.kill')}>
+								{killingSession === session.name ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<Trash2 className="w-4 h-4" />
+								)}
+							</button>
+						</div>
+					</div>
+				))}
+			</div>
+
+			{/* Recovery suggestions */}
+			{recoveredSessions.some((s) => s.recommended_action !== 'None') && (
+				<div className="mt-4 pt-4 border-t border-mid-gray/20">
+					<h4 className="text-sm font-medium mb-3">
+						{t('devops.sessions.recoveryTitle')}
+					</h4>
+					<div className="flex flex-col gap-2">
+						{recoveredSessions
+							.filter((s) => s.recommended_action !== 'None')
+							.map((session) => (
+								<div
+									key={session.metadata.session}
+									className="flex items-center gap-2 p-3 rounded bg-yellow-500/10 text-sm">
+									<RotateCcw className="w-4 h-4 text-yellow-400" />
+									<span className="flex-1">
+										{session.metadata.session}:{' '}
+										{t(
+											`devops.sessions.action.${session.recommended_action.toLowerCase()}`,
+										)}
+									</span>
+								</div>
+							))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/SupportWorker.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/SupportWorker.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { commands } from '@/bindings';
+import { useDevOpsStore } from '@/stores/devopsStore';
+import { toast } from '@/stores/toastStore';
+import {
+	Headphones,
+	Play,
+	Square,
+	Loader2,
+	ExternalLink,
+	Send,
+} from 'lucide-react';
+
+const SUPPORT_SESSION_NAME = 'handy-agent-support-worker';
+
+export const SupportWorker: React.FC = () => {
+	const { t } = useTranslation();
+	const [isStarting, setIsStarting] = useState(false);
+	const [isStopping, setIsStopping] = useState(false);
+	const [output, setOutput] = useState<string>('');
+	const [loadingOutput, setLoadingOutput] = useState(false);
+	const [inputMessage, setInputMessage] = useState('');
+	const [isSending, setIsSending] = useState(false);
+
+	const sessions = useDevOpsStore((state) => state.sessions);
+	const refreshSessions = useDevOpsStore((state) => state.refreshSessions);
+
+	// Check if support worker session exists
+	const supportSession = sessions.find(
+		(s) => s.name === SUPPORT_SESSION_NAME,
+	);
+	const isRunning = !!supportSession;
+
+	// Fetch output when session is running
+	useEffect(() => {
+		if (!isRunning) {
+			setOutput('');
+			return;
+		}
+
+		let isMounted = true;
+
+		const fetchOutput = async () => {
+			if (!isMounted) return;
+			setLoadingOutput(true);
+			try {
+				const result = await commands.getTmuxSessionOutput(
+					SUPPORT_SESSION_NAME,
+					50,
+				);
+				if (result.status === 'ok' && isMounted) {
+					setOutput(result.data);
+				}
+			} catch {
+				// Silently fail
+			} finally {
+				if (isMounted) {
+					setLoadingOutput(false);
+				}
+			}
+		};
+
+		fetchOutput();
+		const interval = setInterval(fetchOutput, 3000);
+		return () => {
+			isMounted = false;
+			clearInterval(interval);
+		};
+	}, [isRunning]);
+
+	const handleStart = async () => {
+		setIsStarting(true);
+		try {
+			// Ensure tmux server is running first
+			const masterResult = await commands.ensureMasterTmuxSession();
+			if (masterResult.status === 'error') {
+				toast.error(
+					t(
+						'devops.supportWorker.error.masterSession',
+						'Failed to start tmux',
+					),
+					masterResult.error,
+				);
+				return;
+			}
+
+			// Create a tmux session with claude as the agent
+			const result = await commands.createTmuxSession(
+				SUPPORT_SESSION_NAME,
+				null, // working_dir - use current
+				null, // issue_ref
+				null, // repo
+				'claude', // agent_type
+			);
+
+			if (result.status === 'ok') {
+				// Send the initial command to start claude
+				await commands.sendTmuxCommand(SUPPORT_SESSION_NAME, 'claude');
+				// Refresh sessions to pick up the new one
+				await refreshSessions(false);
+				toast.success(
+					t(
+						'devops.supportWorker.success.started',
+						'Support Worker Started',
+					),
+					t(
+						'devops.supportWorker.success.startedMessage',
+						'Claude agent is now running',
+					),
+				);
+			} else {
+				toast.error(
+					t(
+						'devops.supportWorker.error.create',
+						'Failed to create session',
+					),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(
+				t('devops.supportWorker.error.start', 'Failed to start'),
+				err instanceof Error ? err.message : String(err),
+			);
+		} finally {
+			setIsStarting(false);
+		}
+	};
+
+	const handleStop = async () => {
+		setIsStopping(true);
+		try {
+			const result = await commands.killTmuxSession(SUPPORT_SESSION_NAME);
+			if (result.status === 'ok') {
+				await refreshSessions(false);
+				toast.success(
+					t(
+						'devops.supportWorker.success.stopped',
+						'Support Worker Stopped',
+					),
+				);
+			} else {
+				toast.error(
+					t(
+						'devops.supportWorker.error.stop',
+						'Failed to stop session',
+					),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(
+				t('devops.supportWorker.error.stop', 'Failed to stop'),
+				err instanceof Error ? err.message : String(err),
+			);
+		} finally {
+			setIsStopping(false);
+		}
+	};
+
+	const handleOpenInTerminal = async () => {
+		try {
+			await commands.attachTmuxSession(SUPPORT_SESSION_NAME);
+		} catch (err) {
+			toast.error(
+				t('devops.supportWorker.error.attach', 'Failed to attach'),
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	};
+
+	const handleSendMessage = async () => {
+		if (!inputMessage.trim() || isSending) return;
+
+		setIsSending(true);
+		try {
+			await commands.sendTmuxCommand(
+				SUPPORT_SESSION_NAME,
+				inputMessage.trim(),
+			);
+			setInputMessage('');
+		} catch (err) {
+			toast.error(
+				t('devops.supportWorker.error.send', 'Failed to send message'),
+				err instanceof Error ? err.message : String(err),
+			);
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			{/* Header with status and controls */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-3">
+					<div
+						className={`p-2 rounded-lg ${isRunning ? 'bg-green-500/20 text-green-400' : 'bg-mid-gray/20 text-mid-gray'}`}>
+						<Headphones className="w-5 h-5" />
+					</div>
+					<div>
+						<h3 className="font-medium">
+							{t('devops.supportWorker.title', 'Support Worker')}
+						</h3>
+						<p className="text-xs text-mid-gray">
+							{isRunning
+								? t(
+										'devops.supportWorker.running',
+										'Agent is running',
+									)
+								: t(
+										'devops.supportWorker.stopped',
+										'Agent is stopped',
+									)}
+						</p>
+					</div>
+				</div>
+
+				<div className="flex items-center gap-2">
+					{isRunning ? (
+						<>
+							<button
+								onClick={handleOpenInTerminal}
+								className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors"
+								title={t('devops.sessions.openTerminal')}>
+								<ExternalLink className="w-4 h-4" />
+								{t('devops.supportWorker.attach', 'Attach')}
+							</button>
+							<button
+								onClick={handleStop}
+								disabled={isStopping}
+								className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-400 transition-colors disabled:opacity-50">
+								{isStopping ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<Square className="w-4 h-4" />
+								)}
+								{t('devops.supportWorker.stop', 'Stop')}
+							</button>
+						</>
+					) : (
+						<button
+							onClick={handleStart}
+							disabled={isStarting}
+							className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50">
+							{isStarting ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Play className="w-4 h-4" />
+							)}
+							{t(
+								'devops.supportWorker.start',
+								'Start Support Worker',
+							)}
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Output preview and input when running */}
+			{isRunning && (
+				<div className="border border-mid-gray/20 rounded-lg overflow-hidden">
+					{/* Output area */}
+					<div className="bg-black/40 p-3 max-h-[200px] overflow-auto">
+						{loadingOutput && !output ? (
+							<div className="flex items-center justify-center py-4">
+								<Loader2 className="w-5 h-5 animate-spin text-mid-gray" />
+							</div>
+						) : (
+							<div className="text-xs font-mono text-green-400/80 whitespace-pre-wrap break-all">
+								{output || t('devops.sessions.noOutput')}
+							</div>
+						)}
+					</div>
+
+					{/* Send message input */}
+					<div className="flex items-center gap-2 p-3 bg-mid-gray/10 border-t border-mid-gray/20">
+						<input
+							type="text"
+							value={inputMessage}
+							onChange={(e) => setInputMessage(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' && !e.shiftKey) {
+									e.preventDefault();
+									handleSendMessage();
+								}
+							}}
+							placeholder={t(
+								'devops.supportWorker.inputPlaceholder',
+								'Send a message to the support worker...',
+							)}
+							className="flex-1 px-3 py-2 text-sm bg-background border border-mid-gray/30 rounded-lg focus:outline-none focus:border-logo-primary/50 placeholder:text-mid-gray/50 text-white"
+							disabled={isSending}
+						/>
+						<button
+							onClick={handleSendMessage}
+							disabled={isSending || !inputMessage.trim()}
+							className="flex items-center justify-center p-2 rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+							type="button"
+							title={t('devops.sessions.send')}>
+							{isSending ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Send className="w-4 h-4" />
+							)}
+						</button>
+					</div>
+				</div>
+			)}
+
+			{/* Description when not running */}
+			{!isRunning && (
+				<p className="text-sm text-mid-gray/70">
+					{t(
+						'devops.supportWorker.description',
+						'Start a general-purpose Claude agent for support tasks, quick questions, or testing. This worker runs in a tmux session and can be used for any ad-hoc assistance.',
+					)}
+				</p>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/TmuxSessionsGrid.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/TmuxSessionsGrid.tsx
@@ -1,0 +1,1009 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { commands, TmuxSession } from '@/bindings';
+import { useDevOpsStore } from '@/stores/devopsStore';
+import { toast } from '@/stores/toastStore';
+import {
+	Terminal,
+	Play,
+	Square,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	Clock,
+	Trash2,
+	GitBranch,
+	Bot,
+	Maximize2,
+	Minimize2,
+	ExternalLink,
+	X,
+	Send,
+	Headphones,
+	CornerDownLeft,
+	XCircle,
+	ArrowUp,
+	ArrowDown,
+	Delete,
+	RotateCcw,
+	AlertTriangle,
+} from 'lucide-react';
+import { EpicMonitor } from './EpicMonitor';
+
+const SUPPORT_SESSION_NAME = 'handy-agent-support-worker';
+
+interface SessionCardProps {
+	session: TmuxSession;
+	onKill: (name: string) => void;
+	isKilling: boolean;
+	onExpand: () => void;
+	onRestart: (name: string) => void;
+	isRestarting: boolean;
+}
+
+const SessionCard: React.FC<SessionCardProps> = ({
+	session,
+	onKill,
+	isKilling,
+	onExpand,
+	onRestart,
+	isRestarting,
+}) => {
+	const { t } = useTranslation();
+	const [output, setOutput] = useState<string>('');
+	const [loadingOutput, setLoadingOutput] = useState(false);
+
+	useEffect(() => {
+		const fetchOutput = async () => {
+			setLoadingOutput(true);
+			try {
+				const result = await commands.getTmuxSessionOutput(
+					session.name,
+					20,
+				);
+				if (result.status === 'ok') {
+					setOutput(result.data);
+				}
+			} catch {
+				// Silently fail - output preview is optional
+			} finally {
+				setLoadingOutput(false);
+			}
+		};
+
+		fetchOutput();
+		// Refresh output every 5 seconds
+		const interval = setInterval(fetchOutput, 5000);
+		return () => clearInterval(interval);
+	}, [session.name]);
+
+	const getStatusColor = (status: string) => {
+		switch (status) {
+			case 'Running':
+				return 'text-green-400 bg-green-500/20';
+			case 'Stopped':
+				return 'text-yellow-400 bg-yellow-500/20';
+			default:
+				return 'text-gray-400 bg-gray-500/20';
+		}
+	};
+
+	const getAgentIcon = (agentType?: string) => {
+		switch (agentType) {
+			case 'claude':
+				return <Bot className="w-4 h-4" />;
+			default:
+				return <Terminal className="w-4 h-4" />;
+		}
+	};
+
+	const formatTimestamp = (timestamp: string) => {
+		try {
+			const date = new Date(timestamp);
+			return date.toLocaleTimeString([], {
+				hour: '2-digit',
+				minute: '2-digit',
+			});
+		} catch {
+			return timestamp;
+		}
+	};
+
+	const handleOpenInTerminal = async () => {
+		try {
+			await commands.attachTmuxSession(session.name);
+		} catch (err) {
+			console.error('Failed to attach to session:', err);
+		}
+	};
+
+	return (
+		<div className="flex flex-col bg-mid-gray/10 rounded-xl border border-mid-gray/20 overflow-hidden hover:border-logo-primary/50 transition-colors">
+			{/* Header */}
+			<div className="flex items-center gap-3 p-4 border-b border-mid-gray/20">
+				<div
+					className={`p-2 rounded-lg ${getStatusColor(session.status)}`}>
+					{session.status === 'Running' ? (
+						<Play className="w-4 h-4" />
+					) : (
+						<Square className="w-4 h-4" />
+					)}
+				</div>
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-2">
+						<code className="font-medium text-sm truncate">
+							{session.name}
+						</code>
+						{session.attached && (
+							<span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 shrink-0">
+								{t('devops.sessions.attached')}
+							</span>
+						)}
+					</div>
+					{session.metadata?.agent_type && (
+						<div className="flex items-center gap-1 text-xs text-mid-gray mt-0.5">
+							{getAgentIcon(session.metadata.agent_type)}
+							<span>{session.metadata.agent_type}</span>
+						</div>
+					)}
+				</div>
+				<button
+					onClick={onExpand}
+					className="p-1.5 rounded hover:bg-mid-gray/20 transition-colors"
+					title={t('devops.sessions.expand')}>
+					<Maximize2 className="w-4 h-4 text-mid-gray" />
+				</button>
+			</div>
+
+			{/* Metadata */}
+			{session.metadata && (
+				<div className="px-4 py-2 text-xs text-mid-gray border-b border-mid-gray/10 space-y-1">
+					{session.metadata.issue_ref && (
+						<div className="flex items-center gap-1.5">
+							<GitBranch className="w-3 h-3" />
+							<span className="truncate">
+								{session.metadata.issue_ref}
+							</span>
+						</div>
+					)}
+					{session.metadata.started_at && (
+						<div className="flex items-center gap-1.5">
+							<Clock className="w-3 h-3" />
+							<span>
+								{formatTimestamp(session.metadata.started_at)}
+							</span>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Output preview */}
+			<div
+				className="flex-1 p-3 bg-black/30 min-h-[120px] max-h-[200px] overflow-hidden relative cursor-pointer hover:bg-black/40 transition-colors"
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onExpand();
+				}}
+				role="button"
+				tabIndex={0}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						onExpand();
+					}
+				}}>
+				{loadingOutput && !output ? (
+					<div className="flex items-center justify-center h-full pointer-events-none">
+						<Loader2 className="w-4 h-4 animate-spin text-mid-gray" />
+					</div>
+				) : (
+					<pre className="text-xs font-mono text-green-400/80 whitespace-pre-wrap break-all overflow-hidden pointer-events-none select-none">
+						{output || t('devops.sessions.noOutput')}
+					</pre>
+				)}
+				{/* Gradient fade at bottom */}
+				<div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-black/50 to-transparent pointer-events-none" />
+			</div>
+
+			{/* Actions */}
+			<div className="flex items-center gap-2 p-3 border-t border-mid-gray/20">
+				<button
+					onClick={handleOpenInTerminal}
+					className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-logo-primary/20 hover:bg-logo-primary/30 text-logo-primary transition-colors">
+					<ExternalLink className="w-3 h-3" />
+					{t('devops.sessions.openTerminal')}
+				</button>
+				{/* Show restart button for stopped sessions with issue metadata */}
+				{session.status === 'Stopped' &&
+					session.metadata?.issue_ref && (
+						<button
+							onClick={() => onRestart(session.name)}
+							disabled={isRestarting}
+							className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 transition-colors disabled:opacity-50"
+							title={t(
+								'devops.sessions.restartAgent',
+								'Restart the agent in this session',
+							)}>
+							{isRestarting ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<RotateCcw className="w-3 h-3" />
+							)}
+							{t('devops.sessions.restart', 'Restart')}
+						</button>
+					)}
+				<button
+					onClick={() => onKill(session.name)}
+					disabled={isKilling}
+					className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-red-500/20 hover:bg-red-500/30 text-red-400 transition-colors disabled:opacity-50">
+					{isKilling ? (
+						<Loader2 className="w-3 h-3 animate-spin" />
+					) : (
+						<Trash2 className="w-3 h-3" />
+					)}
+					{t('devops.sessions.kill')}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+interface ExpandedSessionViewProps {
+	sessionName: string;
+	onClose: () => void;
+	onKill: (name: string) => void;
+	isKilling: boolean;
+	onRestart: (name: string) => void;
+	isRestarting: boolean;
+}
+
+const ExpandedSessionView: React.FC<ExpandedSessionViewProps> = ({
+	sessionName,
+	onClose,
+	onKill,
+	isKilling,
+	onRestart,
+	isRestarting,
+}) => {
+	const { t } = useTranslation();
+	const [output, setOutput] = useState<string>('');
+	const [loadingOutput, setLoadingOutput] = useState(true);
+	const [inputMessage, setInputMessage] = useState('');
+	const [isSending, setIsSending] = useState(false);
+	const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+	// Get the current session data from the store to keep it fresh
+	const sessions = useDevOpsStore((state) => state.sessions);
+	const session = useMemo(
+		() => sessions.find((s) => s.name === sessionName),
+		[sessions, sessionName],
+	);
+
+	const handleSendMessage = async () => {
+		if (!inputMessage.trim() || isSending) return;
+
+		setIsSending(true);
+		try {
+			await commands.sendTmuxCommand(sessionName, inputMessage.trim());
+			setInputMessage('');
+		} catch (err) {
+			console.error('Failed to send message:', err);
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	const handleSendKeys = async (keys: string) => {
+		if (isSending) return;
+		setIsSending(true);
+		try {
+			await commands.sendTmuxKeys(sessionName, keys);
+		} catch (err) {
+			console.error('Failed to send keys:', err);
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	useEffect(() => {
+		let isMounted = true;
+
+		const fetchOutput = async () => {
+			if (!isMounted) return;
+			try {
+				// Fetch more lines for expanded view
+				const result = await commands.getTmuxSessionOutput(
+					sessionName,
+					100,
+				);
+				if (result.status === 'ok' && isMounted) {
+					setOutput(result.data);
+					setLastUpdated(new Date());
+				}
+			} catch {
+				// Silently fail
+			} finally {
+				if (isMounted) {
+					setLoadingOutput(false);
+				}
+			}
+		};
+
+		fetchOutput();
+		// Refresh output every 2 seconds for expanded view
+		const interval = setInterval(fetchOutput, 2000);
+		return () => {
+			isMounted = false;
+			clearInterval(interval);
+		};
+	}, [sessionName]);
+
+	const getStatusColor = (status: string) => {
+		switch (status) {
+			case 'Running':
+				return 'text-green-400 bg-green-500/20';
+			case 'Stopped':
+				return 'text-yellow-400 bg-yellow-500/20';
+			default:
+				return 'text-gray-400 bg-gray-500/20';
+		}
+	};
+
+	const getAgentIcon = (agentType?: string) => {
+		switch (agentType) {
+			case 'claude':
+				return <Bot className="w-5 h-5" />;
+			default:
+				return <Terminal className="w-5 h-5" />;
+		}
+	};
+
+	const formatTimestamp = (timestamp: string) => {
+		try {
+			const date = new Date(timestamp);
+			return date.toLocaleString();
+		} catch {
+			return timestamp;
+		}
+	};
+
+	const formatRelativeTime = (date: Date) => {
+		const seconds = Math.floor(
+			(new Date().getTime() - date.getTime()) / 1000,
+		);
+		if (seconds < 5) return t('devops.sessions.justNow', 'just now');
+		if (seconds < 60)
+			return t('devops.sessions.secondsAgo', '{{count}}s ago', {
+				count: seconds,
+			});
+		const minutes = Math.floor(seconds / 60);
+		return t('devops.sessions.minutesAgo', '{{count}}m ago', {
+			count: minutes,
+		});
+	};
+
+	const handleOpenInTerminal = async () => {
+		try {
+			await commands.attachTmuxSession(sessionName);
+		} catch (err) {
+			console.error('Failed to attach to session:', err);
+		}
+	};
+
+	// Close on escape key
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				onClose();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [onClose]);
+
+	// If session no longer exists, close the modal
+	useEffect(() => {
+		if (!session) {
+			onClose();
+		}
+	}, [session, onClose]);
+
+	// Don't render if session doesn't exist
+	if (!session) {
+		return null;
+	}
+
+	return (
+		<div
+			className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-6"
+			onClick={onClose}>
+			<div
+				className="bg-background border border-mid-gray/30 rounded-xl w-full max-w-4xl max-h-[90vh] flex flex-col overflow-hidden shadow-2xl"
+				onClick={(e) => e.stopPropagation()}>
+				{/* Header */}
+				<div className="flex items-center gap-4 p-4 border-b border-mid-gray/20">
+					<div
+						className={`p-2 rounded-lg ${getStatusColor(session.status)}`}>
+						{session.status === 'Running' ? (
+							<Play className="w-5 h-5" />
+						) : (
+							<Square className="w-5 h-5" />
+						)}
+					</div>
+					<div className="flex-1 min-w-0">
+						<div className="flex items-center gap-2">
+							<code className="font-semibold text-lg">
+								{session.name}
+							</code>
+							{session.attached && (
+								<span className="text-xs px-2 py-1 rounded bg-green-500/20 text-green-400">
+									{t('devops.sessions.attached')}
+								</span>
+							)}
+						</div>
+						{session.metadata?.agent_type && (
+							<div className="flex items-center gap-1.5 text-sm text-mid-gray mt-1">
+								{getAgentIcon(session.metadata.agent_type)}
+								<span>{session.metadata.agent_type}</span>
+							</div>
+						)}
+					</div>
+					<button
+						onClick={onClose}
+						className="p-2 rounded-lg hover:bg-mid-gray/20 transition-colors"
+						type="button">
+						<X className="w-5 h-5" />
+					</button>
+				</div>
+
+				{/* Metadata bar */}
+				<div className="flex items-center gap-6 px-4 py-3 bg-mid-gray/5 border-b border-mid-gray/10 text-sm text-mid-gray">
+					{session.metadata?.issue_ref && (
+						<div className="flex items-center gap-2">
+							<GitBranch className="w-4 h-4" />
+							<span>{session.metadata.issue_ref}</span>
+						</div>
+					)}
+					{session.metadata?.started_at && (
+						<div className="flex items-center gap-2">
+							<Clock className="w-4 h-4" />
+							<span
+								title={t(
+									'devops.sessions.startedAt',
+									'Started at',
+								)}>
+								{formatTimestamp(session.metadata.started_at)}
+							</span>
+						</div>
+					)}
+					{session.metadata?.worktree && (
+						<div className="flex items-center gap-2 truncate">
+							<Terminal className="w-4 h-4 shrink-0" />
+							<span className="truncate">
+								{session.metadata.worktree}
+							</span>
+						</div>
+					)}
+					{/* Last updated indicator */}
+					<div className="flex items-center gap-2 ml-auto">
+						<RefreshCcw
+							className={`w-3 h-3 ${loadingOutput ? 'animate-spin' : ''}`}
+						/>
+						<span className="text-xs">
+							{lastUpdated
+								? formatRelativeTime(lastUpdated)
+								: t('devops.sessions.updating', 'updating...')}
+						</span>
+					</div>
+				</div>
+
+				{/* Output area - scrollable */}
+				<div className="flex-1 overflow-auto bg-black/40 p-4 min-h-[200px] max-h-[50vh]">
+					{loadingOutput && !output ? (
+						<div className="flex items-center justify-center h-full">
+							<Loader2 className="w-6 h-6 animate-spin text-mid-gray" />
+						</div>
+					) : (
+						<div className="text-sm font-mono text-green-400/90 whitespace-pre-wrap break-words">
+							{output || t('devops.sessions.noOutput')}
+						</div>
+					)}
+				</div>
+
+				{/* Send message input */}
+				<div className="flex flex-col gap-2 px-4 py-3 bg-mid-gray/10 border-t border-mid-gray/20 shrink-0">
+					{/* Quick action buttons */}
+					<div className="flex items-center gap-1.5">
+						<span className="text-xs text-mid-gray/70 mr-1">
+							{t('devops.sessions.quickKeys', 'Quick keys:')}
+						</span>
+						<button
+							onClick={() => handleSendKeys('Enter')}
+							disabled={isSending}
+							className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+							type="button"
+							title="Enter">
+							<CornerDownLeft className="w-3 h-3" />
+							Enter
+						</button>
+						<button
+							onClick={() => handleSendKeys('C-c')}
+							disabled={isSending}
+							className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-red-500/20 hover:bg-red-500/30 text-red-400 transition-colors disabled:opacity-50"
+							type="button"
+							title="Ctrl+C (Cancel)">
+							<XCircle className="w-3 h-3" />
+							Ctrl+C
+						</button>
+						<button
+							onClick={() => handleSendKeys('Escape')}
+							disabled={isSending}
+							className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+							type="button"
+							title="Escape">
+							Esc
+						</button>
+						<button
+							onClick={() => handleSendKeys('Up')}
+							disabled={isSending}
+							className="flex items-center justify-center p-1 text-xs rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+							type="button"
+							title="Up Arrow">
+							<ArrowUp className="w-3 h-3" />
+						</button>
+						<button
+							onClick={() => handleSendKeys('Down')}
+							disabled={isSending}
+							className="flex items-center justify-center p-1 text-xs rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+							type="button"
+							title="Down Arrow">
+							<ArrowDown className="w-3 h-3" />
+						</button>
+						<button
+							onClick={() => handleSendKeys('BSpace')}
+							disabled={isSending}
+							className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors disabled:opacity-50"
+							type="button"
+							title="Backspace">
+							<Delete className="w-3 h-3" />
+						</button>
+					</div>
+					{/* Input row */}
+					<div className="flex items-center gap-2">
+						<input
+							type="text"
+							value={inputMessage}
+							onChange={(e) => setInputMessage(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' && !e.shiftKey) {
+									e.preventDefault();
+									handleSendMessage();
+								}
+							}}
+							placeholder={t('devops.sessions.sendPlaceholder')}
+							className="flex-1 px-3 py-2 text-sm bg-background border border-mid-gray/30 rounded-lg focus:outline-none focus:border-logo-primary/50 placeholder:text-mid-gray/50 text-white"
+							disabled={isSending}
+						/>
+						<button
+							onClick={handleSendMessage}
+							disabled={isSending || !inputMessage.trim()}
+							className="flex items-center justify-center p-2.5 rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+							type="button"
+							title={t('devops.sessions.send')}>
+							{isSending ? (
+								<Loader2 className="w-5 h-5 animate-spin" />
+							) : (
+								<Send className="w-5 h-5" />
+							)}
+						</button>
+					</div>
+				</div>
+
+				{/* Actions */}
+				<div className="flex items-center justify-between gap-4 p-4 border-t border-mid-gray/20">
+					<div className="flex items-center gap-2">
+						<button
+							onClick={handleOpenInTerminal}
+							className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors"
+							type="button">
+							<ExternalLink className="w-4 h-4" />
+							{t('devops.sessions.openTerminal')}
+						</button>
+						{/* Show restart button for stopped sessions with issue metadata */}
+						{session.status === 'Stopped' &&
+							session.metadata?.issue_ref && (
+								<button
+									onClick={() => onRestart(session.name)}
+									disabled={isRestarting}
+									className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 transition-colors disabled:opacity-50"
+									type="button"
+									title={t(
+										'devops.sessions.restartAgent',
+										'Restart the agent in this session',
+									)}>
+									{isRestarting ? (
+										<Loader2 className="w-4 h-4 animate-spin" />
+									) : (
+										<RotateCcw className="w-4 h-4" />
+									)}
+									{t('devops.sessions.restart', 'Restart')}
+								</button>
+							)}
+					</div>
+					<div className="flex items-center gap-2">
+						<button
+							onClick={onClose}
+							className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors"
+							type="button">
+							<Minimize2 className="w-4 h-4" />
+							{t('devops.sessions.collapse')}
+						</button>
+						<button
+							onClick={() => onKill(session.name)}
+							disabled={isKilling}
+							className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-400 transition-colors disabled:opacity-50"
+							type="button">
+							{isKilling ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Trash2 className="w-4 h-4" />
+							)}
+							{t('devops.sessions.kill')}
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const TmuxSessionsGrid: React.FC = () => {
+	const { t } = useTranslation();
+	const [expandedSessionName, setExpandedSessionName] = useState<
+		string | null
+	>(null);
+	const [isStartingSupportWorker, setIsStartingSupportWorker] =
+		useState(false);
+	const [restartingSession, setRestartingSession] = useState<string | null>(
+		null,
+	);
+
+	const sessions = useDevOpsStore((state) => state.sessions);
+	const isLoading = useDevOpsStore((state) => state.sessionsLoading);
+	const isTmuxRunning = useDevOpsStore((state) => state.isTmuxRunning);
+	const error = useDevOpsStore((state) => state.sessionsError);
+	const killingSession = useDevOpsStore((state) => state.killingSession);
+
+	const refreshSessions = useDevOpsStore((state) => state.refreshSessions);
+	const killSession = useDevOpsStore((state) => state.killSession);
+
+	// Count stopped sessions that can be restarted
+	const stoppedSessions = sessions.filter(
+		(s) => s.status === 'Stopped' && s.metadata?.issue_ref,
+	);
+
+	// Handler for restarting an agent in a session
+	const handleRestartAgent = async (sessionName: string) => {
+		setRestartingSession(sessionName);
+		try {
+			const result = await commands.restartAgentInSession(sessionName);
+			if (result.status === 'ok') {
+				toast.success(
+					t('devops.sessions.restartSuccess', 'Agent Restarted'),
+					t(
+						'devops.sessions.restartSuccessMessage',
+						'The agent has been restarted in session {{session}}',
+						{ session: sessionName },
+					),
+				);
+				// Refresh to update status
+				await refreshSessions(false);
+			} else {
+				toast.error(
+					t('devops.sessions.restartError', 'Failed to Restart'),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(
+				t('devops.sessions.restartError', 'Failed to Restart'),
+				err instanceof Error ? err.message : String(err),
+			);
+		} finally {
+			setRestartingSession(null);
+		}
+	};
+
+	// Handler for recovering all stopped sessions
+	const handleRecoverAll = async () => {
+		try {
+			const result = await commands.recoverAllAgentSessions(true, false);
+			if (result.status === 'ok') {
+				const succeeded = result.data.filter((r) => r.success).length;
+				const failed = result.data.filter((r) => !r.success).length;
+				if (succeeded > 0) {
+					toast.success(
+						t(
+							'devops.sessions.recoverySuccess',
+							'Recovery Complete',
+						),
+						t(
+							'devops.sessions.recoverySuccessMessage',
+							'Restarted {{count}} agent(s)',
+							{ count: succeeded },
+						),
+					);
+				}
+				if (failed > 0) {
+					toast.warning(
+						t('devops.sessions.recoveryPartial', 'Some Failed'),
+						t(
+							'devops.sessions.recoveryPartialMessage',
+							'{{count}} agent(s) could not be restarted',
+							{ count: failed },
+						),
+					);
+				}
+				await refreshSessions(false);
+			} else {
+				toast.error(
+					t('devops.sessions.recoveryError', 'Recovery Failed'),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(
+				t('devops.sessions.recoveryError', 'Recovery Failed'),
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	};
+
+	// Check if support worker is running
+	const supportWorkerSession = sessions.find(
+		(s) => s.name === SUPPORT_SESSION_NAME,
+	);
+	const isSupportWorkerRunning = !!supportWorkerSession;
+
+	const handleStartSupportWorker = async () => {
+		setIsStartingSupportWorker(true);
+		try {
+			// Ensure tmux server is running first
+			const masterResult = await commands.ensureMasterTmuxSession();
+			if (masterResult.status === 'error') {
+				toast.error(
+					t(
+						'devops.supportWorker.error.masterSession',
+						'Failed to start tmux',
+					),
+					masterResult.error,
+				);
+				return;
+			}
+
+			// Create a tmux session with claude as the agent
+			const result = await commands.createTmuxSession(
+				SUPPORT_SESSION_NAME,
+				null, // working_dir - use current
+				null, // issue_ref
+				null, // repo
+				'claude', // agent_type
+			);
+
+			if (result.status === 'ok') {
+				// Send the initial command to start claude
+				await commands.sendTmuxCommand(SUPPORT_SESSION_NAME, 'claude');
+				// Refresh sessions to pick up the new one
+				await refreshSessions(false);
+				toast.success(
+					t(
+						'devops.supportWorker.success.started',
+						'Support Worker Started',
+					),
+					t(
+						'devops.supportWorker.success.startedMessage',
+						'Claude agent is now running',
+					),
+				);
+			} else {
+				toast.error(
+					t(
+						'devops.supportWorker.error.create',
+						'Failed to create session',
+					),
+					result.error,
+				);
+			}
+		} catch (err) {
+			toast.error(
+				t('devops.supportWorker.error.start', 'Failed to start'),
+				err instanceof Error ? err.message : String(err),
+			);
+		} finally {
+			setIsStartingSupportWorker(false);
+		}
+	};
+
+	// tmux not running
+	if (!isTmuxRunning && !isLoading) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16 text-center">
+				<Terminal className="w-16 h-16 text-mid-gray/30 mb-4" />
+				<p className="text-lg text-mid-gray mb-2">
+					{t('devops.sessions.tmuxNotRunning')}
+				</p>
+				<p className="text-sm text-mid-gray/70 max-w-md">
+					{t('devops.sessions.tmuxNotRunningHint')}
+				</p>
+			</div>
+		);
+	}
+
+	// Loading state
+	if (isLoading && sessions.length === 0) {
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Loader2 className="w-8 h-8 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	// Error state
+	if (error) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16 text-center">
+				<AlertCircle className="w-12 h-12 text-red-400 mb-4" />
+				<p className="text-red-400 mb-4">{error}</p>
+				<button
+					onClick={() => refreshSessions(true)}
+					className="flex items-center gap-2 px-4 py-2 rounded bg-mid-gray/20 hover:bg-mid-gray/30 transition-colors">
+					<RefreshCcw className="w-4 h-4" />
+					{t('devops.refresh')}
+				</button>
+			</div>
+		);
+	}
+
+	// No sessions
+	if (sessions.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16 text-center">
+				<Terminal className="w-16 h-16 text-mid-gray/30 mb-4" />
+				<p className="text-lg text-mid-gray mb-2">
+					{t('devops.sessions.noSessions')}
+				</p>
+				<p className="text-sm text-mid-gray/70 max-w-md mb-6">
+					{t('devops.sessions.noSessionsHint')}
+				</p>
+				<button
+					onClick={handleStartSupportWorker}
+					disabled={isStartingSupportWorker}
+					className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50">
+					{isStartingSupportWorker ? (
+						<Loader2 className="w-4 h-4 animate-spin" />
+					) : (
+						<Headphones className="w-4 h-4" />
+					)}
+					{t('devops.supportWorker.start', 'Start Support Worker')}
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<div className="space-y-4">
+				{/* Recovery banner for stopped sessions */}
+				{stoppedSessions.length > 0 && (
+					<div className="flex items-center gap-3 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+						<AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0" />
+						<div className="flex-1">
+							<p className="text-sm text-yellow-400 font-medium">
+								{t(
+									'devops.sessions.stoppedAgents',
+									'{{count}} stopped agent(s) detected',
+									{ count: stoppedSessions.length },
+								)}
+							</p>
+							<p className="text-xs text-yellow-400/70">
+								{t(
+									'devops.sessions.stoppedAgentsHint',
+									'These sessions have agents that stopped. You can restart them to continue work.',
+								)}
+							</p>
+						</div>
+						<button
+							onClick={handleRecoverAll}
+							disabled={restartingSession !== null}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 transition-colors disabled:opacity-50">
+							{restartingSession !== null ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<RotateCcw className="w-4 h-4" />
+							)}
+							{t('devops.sessions.restartAll', 'Restart All')}
+						</button>
+					</div>
+				)}
+
+				{/* Epic Monitor - Supervisor for sub-agents */}
+				<EpicMonitor />
+
+				{/* Header */}
+				<div className="flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<span className="text-sm text-mid-gray">
+							{t('devops.sessions.activeCount', {
+								count: sessions.length,
+							})}
+						</span>
+						{isLoading && (
+							<Loader2 className="w-4 h-4 animate-spin text-mid-gray" />
+						)}
+					</div>
+					<div className="flex items-center gap-2">
+						{!isSupportWorkerRunning && (
+							<button
+								onClick={handleStartSupportWorker}
+								disabled={isStartingSupportWorker}
+								className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-logo-primary hover:bg-logo-primary/80 text-white transition-colors disabled:opacity-50">
+								{isStartingSupportWorker ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<Headphones className="w-4 h-4" />
+								)}
+								{t(
+									'devops.supportWorker.start',
+									'Start Support Worker',
+								)}
+							</button>
+						)}
+						<button
+							onClick={() => refreshSessions(false)}
+							disabled={isLoading}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded hover:bg-mid-gray/20 transition-colors disabled:opacity-50">
+							<RefreshCcw
+								className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+							/>
+							{t('devops.refresh')}
+						</button>
+					</div>
+				</div>
+
+				{/* Bento grid */}
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					{sessions.map((session) => (
+						<SessionCard
+							key={session.name}
+							session={session}
+							onKill={killSession}
+							isKilling={killingSession === session.name}
+							onExpand={() =>
+								setExpandedSessionName(session.name)
+							}
+							onRestart={handleRestartAgent}
+							isRestarting={restartingSession === session.name}
+						/>
+					))}
+				</div>
+			</div>
+
+			{/* Expanded session modal */}
+			{expandedSessionName && (
+				<ExpandedSessionView
+					key={expandedSessionName}
+					sessionName={expandedSessionName}
+					onClose={() => setExpandedSessionName(null)}
+					onKill={(name) => {
+						killSession(name);
+						setExpandedSessionName(null);
+					}}
+					isKilling={killingSession === expandedSessionName}
+					onRestart={handleRestartAgent}
+					isRestarting={restartingSession === expandedSessionName}
+				/>
+			)}
+		</>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/WorktreeManager.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/WorktreeManager.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { commands, WorktreeInfo } from '@/bindings';
+import {
+	GitBranch,
+	FolderGit2,
+	Plus,
+	Trash2,
+	RefreshCcw,
+	Loader2,
+	AlertCircle,
+	FolderOpen,
+	X,
+} from 'lucide-react';
+
+interface WorktreeManagerProps {
+	repoPath?: string;
+	onWorktreeChange?: () => void;
+}
+
+export const WorktreeManager: React.FC<WorktreeManagerProps> = ({
+	repoPath,
+	onWorktreeChange,
+}) => {
+	const { t } = useTranslation();
+	const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [removingWorktree, setRemovingWorktree] = useState<string | null>(
+		null,
+	);
+	const [showCreateDialog, setShowCreateDialog] = useState(false);
+	const [currentRepoPath, setCurrentRepoPath] = useState<string | null>(null);
+
+	// Create dialog state
+	const [newWorktreeName, setNewWorktreeName] = useState('');
+	const [isCreating, setIsCreating] = useState(false);
+	const [createError, setCreateError] = useState<string | null>(null);
+
+	const detectRepoPath = useCallback(async () => {
+		if (repoPath) {
+			setCurrentRepoPath(repoPath);
+			return repoPath;
+		}
+
+		// Try to get repo root from current working directory
+		try {
+			const result = await commands.getGitRepoRoot('.');
+			if (result.status === 'ok') {
+				setCurrentRepoPath(result.data);
+				return result.data;
+			}
+			// Not in a git repo
+			setCurrentRepoPath(null);
+			return null;
+		} catch {
+			// Not in a git repo
+			setCurrentRepoPath(null);
+			return null;
+		}
+	}, [repoPath]);
+
+	const loadWorktrees = useCallback(async () => {
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const detectedPath = await detectRepoPath();
+			if (!detectedPath) {
+				setWorktrees([]);
+				setIsLoading(false);
+				return;
+			}
+
+			const result = await commands.listGitWorktrees(detectedPath);
+			if (result.status === 'ok') {
+				setWorktrees(result.data);
+			} else {
+				setError(result.error);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsLoading(false);
+		}
+	}, [detectRepoPath]);
+
+	useEffect(() => {
+		loadWorktrees();
+	}, [loadWorktrees]);
+
+	const handleRemoveWorktree = async (
+		worktreePath: string,
+		branch?: string,
+	) => {
+		if (!currentRepoPath) return;
+
+		setRemovingWorktree(worktreePath);
+		try {
+			await commands.removeGitWorktree(
+				currentRepoPath,
+				worktreePath,
+				false, // force
+				branch ? true : false, // delete branch if it exists
+			);
+			await loadWorktrees();
+			onWorktreeChange?.();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setRemovingWorktree(null);
+		}
+	};
+
+	const handleCreateWorktree = async () => {
+		if (!currentRepoPath || !newWorktreeName.trim()) return;
+
+		setIsCreating(true);
+		setCreateError(null);
+
+		try {
+			await commands.createGitWorktree(
+				currentRepoPath,
+				newWorktreeName.trim(),
+				null, // prefix (use default)
+				null, // base_path (use default)
+				null, // base_branch (use default)
+			);
+			await loadWorktrees();
+			onWorktreeChange?.();
+			setShowCreateDialog(false);
+			setNewWorktreeName('');
+		} catch (err) {
+			setCreateError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsCreating(false);
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center p-8">
+				<Loader2 className="w-6 h-6 animate-spin text-logo-primary" />
+			</div>
+		);
+	}
+
+	if (!currentRepoPath) {
+		return (
+			<div className="flex flex-col items-center justify-center p-8 text-center">
+				<FolderGit2 className="w-12 h-12 text-mid-gray/50 mb-3" />
+				<p className="text-sm text-mid-gray">
+					{t('devops.worktrees.notInRepo')}
+				</p>
+				<p className="text-xs text-mid-gray/70 mt-1">
+					{t('devops.worktrees.notInRepoHint')}
+				</p>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center gap-2 p-3 bg-red-500/10 rounded-lg text-red-400">
+				<AlertCircle className="w-4 h-4" />
+				<span className="text-sm">{error}</span>
+				<button
+					onClick={loadWorktrees}
+					className="ml-auto p-1 hover:bg-mid-gray/20 rounded">
+					<RefreshCcw className="w-4 h-4" />
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Header with actions */}
+			<div className="flex items-center justify-between">
+				<span className="text-sm text-mid-gray">
+					{t('devops.worktrees.count', { count: worktrees.length })}
+				</span>
+				<div className="flex items-center gap-2">
+					<button
+						onClick={() => setShowCreateDialog(true)}
+						className="flex items-center gap-1 px-2 py-1 text-sm rounded bg-logo-primary/20 hover:bg-logo-primary/30 transition-colors text-logo-primary">
+						<Plus className="w-4 h-4" />
+						{t('devops.worktrees.create')}
+					</button>
+					<button
+						onClick={loadWorktrees}
+						disabled={isLoading}
+						className="p-1 hover:bg-mid-gray/20 rounded transition-colors"
+						title={t('devops.refresh')}>
+						<RefreshCcw
+							className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+						/>
+					</button>
+				</div>
+			</div>
+
+			{/* Create Dialog */}
+			{showCreateDialog && (
+				<div className="p-3 rounded-lg bg-mid-gray/10 border border-mid-gray/20">
+					<div className="flex items-center justify-between mb-3">
+						<span className="text-sm font-medium">
+							{t('devops.worktrees.createTitle')}
+						</span>
+						<button
+							onClick={() => {
+								setShowCreateDialog(false);
+								setNewWorktreeName('');
+								setCreateError(null);
+							}}
+							className="p-1 hover:bg-mid-gray/20 rounded">
+							<X className="w-4 h-4" />
+						</button>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<input
+							type="text"
+							value={newWorktreeName}
+							onChange={(e) => setNewWorktreeName(e.target.value)}
+							placeholder={t('devops.worktrees.namePlaceholder')}
+							className="px-3 py-2 rounded bg-mid-gray/10 border border-mid-gray/20 text-sm focus:outline-none focus:border-logo-primary"
+							onKeyDown={(e) => {
+								if (
+									e.key === 'Enter' &&
+									newWorktreeName.trim()
+								) {
+									handleCreateWorktree();
+								}
+							}}
+						/>
+
+						{createError && (
+							<div className="flex items-center gap-2 text-red-400 text-xs">
+								<AlertCircle className="w-3 h-3" />
+								{createError}
+							</div>
+						)}
+
+						<button
+							onClick={handleCreateWorktree}
+							disabled={!newWorktreeName.trim() || isCreating}
+							className="flex items-center justify-center gap-2 px-3 py-2 rounded bg-logo-primary hover:bg-logo-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm">
+							{isCreating ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Plus className="w-4 h-4" />
+							)}
+							{t('devops.worktrees.createButton')}
+						</button>
+					</div>
+				</div>
+			)}
+
+			{/* Worktree list */}
+			{worktrees.length === 0 ? (
+				<div className="flex flex-col items-center justify-center p-8 text-center">
+					<FolderGit2 className="w-12 h-12 text-mid-gray/50 mb-3" />
+					<p className="text-sm text-mid-gray">
+						{t('devops.worktrees.noWorktrees')}
+					</p>
+					<p className="text-xs text-mid-gray/70 mt-1">
+						{t('devops.worktrees.noWorktreesHint')}
+					</p>
+				</div>
+			) : (
+				<div className="flex flex-col gap-2">
+					{worktrees.map((worktree) => (
+						<div
+							key={worktree.path}
+							className="flex items-start gap-3 p-3 rounded-lg bg-mid-gray/10 hover:bg-mid-gray/15 transition-colors">
+							{/* Icon */}
+							<div className="mt-1">
+								{worktree.is_main ? (
+									<FolderGit2 className="w-4 h-4 text-logo-primary" />
+								) : (
+									<FolderOpen className="w-4 h-4 text-blue-400" />
+								)}
+							</div>
+
+							{/* Content */}
+							<div className="flex-1 min-w-0">
+								<div className="flex items-center gap-2">
+									<code className="font-medium text-sm truncate">
+										{worktree.path.split('/').pop() ||
+											worktree.path}
+									</code>
+									{worktree.is_main && (
+										<span className="text-xs px-1.5 py-0.5 rounded bg-logo-primary/20 text-logo-primary">
+											{t('devops.worktrees.main')}
+										</span>
+									)}
+									{worktree.is_locked && (
+										<span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
+											{t('devops.worktrees.locked')}
+										</span>
+									)}
+									{worktree.is_prunable && (
+										<span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">
+											{t('devops.worktrees.prunable')}
+										</span>
+									)}
+								</div>
+
+								<div className="mt-1 text-xs text-mid-gray space-y-0.5">
+									{worktree.branch && (
+										<div className="flex items-center gap-1">
+											<GitBranch className="w-3 h-3" />
+											<span>{worktree.branch}</span>
+										</div>
+									)}
+									<div className="flex items-center gap-1 truncate">
+										<FolderOpen className="w-3 h-3 shrink-0" />
+										<span
+											className="truncate"
+											title={worktree.path}>
+											{worktree.path}
+										</span>
+									</div>
+								</div>
+							</div>
+
+							{/* Actions */}
+							{!worktree.is_main && (
+								<div className="flex items-center gap-1">
+									<button
+										onClick={() =>
+											handleRemoveWorktree(
+												worktree.path,
+												worktree.branch ?? undefined,
+											)
+										}
+										disabled={
+											removingWorktree === worktree.path
+										}
+										className="p-1.5 hover:bg-red-500/20 rounded transition-colors text-red-400"
+										title={t('devops.worktrees.remove')}>
+										{removingWorktree === worktree.path ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<Trash2 className="w-4 h-4" />
+										)}
+									</button>
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/components/ui/SettingsGroup.tsx
+++ b/apps/kbve/desktop-kbve/src/components/ui/SettingsGroup.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface SettingsGroupProps {
+	title?: string;
+	description?: string;
+	children: React.ReactNode;
+}
+
+export const SettingsGroup: React.FC<SettingsGroupProps> = ({
+	title,
+	description,
+	children,
+}) => {
+	return (
+		<div className="space-y-2">
+			{title && (
+				<div className="px-4">
+					<h2 className="text-xs font-medium text-mid-gray uppercase tracking-wide">
+						{title}
+					</h2>
+					{description && (
+						<p className="text-xs text-mid-gray mt-1">
+							{description}
+						</p>
+					)}
+				</div>
+			)}
+			<div className="bg-background border border-mid-gray/20 rounded-lg overflow-visible">
+				<div className="divide-y divide-mid-gray/20">{children}</div>
+			</div>
+		</div>
+	);
+};

--- a/apps/kbve/desktop-kbve/src/i18n/en.json
+++ b/apps/kbve/desktop-kbve/src/i18n/en.json
@@ -1,0 +1,1094 @@
+{
+	"auth": {
+		"signIn": {
+			"title": "Welcome to Handy",
+			"description": "Sign in to sync your settings and access cloud features",
+			"github": "Sign in with GitHub",
+			"discord": "Sign in with Discord",
+			"twitch": "Sign in with Twitch",
+			"hint": "Your data is stored securely and never shared",
+			"cancel": "Cancel sign in"
+		},
+		"signOut": "Sign Out",
+		"ghost": {
+			"title": "Ghost Mode",
+			"subtitle": "Completely Offline",
+			"description": "Run entirely offline with no network connections. Perfect for privacy-focused users or air-gapped systems.",
+			"badge": {
+				"private": "100% Private",
+				"offline": "No Internet"
+			}
+		},
+		"guest": {
+			"title": "Guest Mode",
+			"subtitle": "Anonymous Access",
+			"description": "Use cloud features anonymously without creating an account. Some features may be limited.",
+			"badge": {
+				"anonymous": "Anonymous",
+				"cloud": "Cloud Enabled"
+			}
+		},
+		"or": "or",
+		"profile": {
+			"title": "Your Profile",
+			"avatar": "Profile picture",
+			"anonymous": "Anonymous User",
+			"via": "via",
+			"viewProfile": "View Profile",
+			"email": "Email",
+			"userId": "User ID",
+			"provider": "Sign-in Provider",
+			"unknown": "Unknown",
+			"syncInfo": "Your settings and preferences will sync across devices when you sign in on other computers."
+		}
+	},
+	"tray": {
+		"settings": "Settings...",
+		"checkUpdates": "Check for Updates...",
+		"quit": "Quit",
+		"cancel": "Cancel"
+	},
+	"sidebar": {
+		"general": "General",
+		"coach": "Coach",
+		"coaching": "Coaching",
+		"live": "Live",
+		"onichan": "Onichan",
+		"discord": "Discord",
+		"memory": "Memory",
+		"credentials": "Credentials",
+		"devops": "DevOps",
+		"advanced": "Advanced",
+		"postProcessing": "Post Process",
+		"history": "History",
+		"debug": "Debug",
+		"about": "About"
+	},
+	"onboarding": {
+		"subtitle": "To get started, choose a transcription model",
+		"vadSubtitle": "First, let's set up voice detection",
+		"vad": {
+			"title": "Voice Activity Detection",
+			"description": "This small model detects when you're speaking and helps improve transcription accuracy.",
+			"download": "Download Voice Detection Model",
+			"downloading": "Downloading... {{progress}}%",
+			"ready": "Voice detection is ready!",
+			"continue": "Continue",
+			"size": "~1.8 MB download"
+		},
+		"recommended": "Recommended",
+		"download": "Download",
+		"downloading": "Downloading...",
+		"modelCard": {
+			"accuracy": "accuracy",
+			"speed": "speed"
+		},
+		"models": {
+			"small": {
+				"name": "Whisper Small",
+				"description": "Fast and fairly accurate."
+			},
+			"medium": {
+				"name": "Whisper Medium",
+				"description": "Good accuracy, medium speed"
+			},
+			"turbo": {
+				"name": "Whisper Turbo",
+				"description": "Balanced accuracy and speed."
+			},
+			"large": {
+				"name": "Whisper Large",
+				"description": "Good accuracy, but slow."
+			},
+			"parakeet-tdt-0.6b-v2": {
+				"name": "Parakeet V2",
+				"description": "English only. The best model for English speakers."
+			},
+			"parakeet-tdt-0.6b-v3": {
+				"name": "Parakeet V3",
+				"description": "Fast and accurate"
+			},
+			"moonshine-base": {
+				"name": "Moonshine Base",
+				"description": "Very fast, English only. Handles accents well."
+			}
+		},
+		"errors": {
+			"loadModels": "Failed to load available models",
+			"downloadModel": "Failed to download model: {{error}}",
+			"vadDownload": "Failed to download voice detection model: {{error}}"
+		}
+	},
+	"modelSelector": {
+		"welcome": "Welcome to Handy!",
+		"downloadPrompt": "Download a model below to get started with transcription.",
+		"availableModels": "Available Models",
+		"downloadModels": "Download Models",
+		"chooseModel": "Choose a Model",
+		"active": "Active",
+		"download": "Download",
+		"downloadSize": "Download size",
+		"noModelsAvailable": "No models available",
+		"extracting": "Extracting {{modelName}}...",
+		"extractingMultiple": "Extracting {{count}} models...",
+		"extractingGeneric": "Extracting...",
+		"downloading": "Downloading {{percentage}}%",
+		"downloadingMultiple": "Downloading {{count}} models...",
+		"modelReady": "Model Ready",
+		"loading": "Loading {{modelName}}...",
+		"loadingGeneric": "Loading...",
+		"modelError": "Model Error",
+		"modelUnloaded": "Model Unloaded",
+		"noModelDownloadRequired": "No Model - Download Required",
+		"deleteModel": "Delete {{modelName}}"
+	},
+	"settings": {
+		"general": {
+			"title": "General",
+			"shortcut": {
+				"title": "Handy Shortcuts",
+				"description": "Configure keyboard shortcuts to trigger speech-to-text recording",
+				"loading": "Loading shortcuts...",
+				"none": "No shortcuts configured",
+				"notFound": "Shortcut not found",
+				"pressKeys": "Press keys...",
+				"bindings": {
+					"transcribe": {
+						"name": "Transcribe",
+						"description": "Converts your speech into text."
+					},
+					"cancel": {
+						"name": "Cancel",
+						"description": "Cancels the current recording."
+					}
+				},
+				"errors": {
+					"restore": "Failed to restore original shortcut",
+					"set": "Failed to set shortcut: {{error}}",
+					"reset": "Failed to reset shortcut to original value"
+				}
+			},
+			"language": {
+				"title": "Language",
+				"description": "Select the language for speech recognition. Auto will automatically determine the language, while selecting a specific language can improve accuracy for that language.",
+				"descriptionUnsupported": "Parakeet model automatically detects the language. No manual selection is needed.",
+				"searchPlaceholder": "Search languages...",
+				"noResults": "No languages found",
+				"auto": "Auto"
+			},
+			"pushToTalk": {
+				"label": "Push To Talk",
+				"description": "Hold to record, release to stop"
+			}
+		},
+		"sound": {
+			"title": "Sound",
+			"microphone": {
+				"title": "Microphone",
+				"description": "Select your preferred microphone device",
+				"placeholder": "Select microphone...",
+				"loading": "Loading..."
+			},
+			"audioFeedback": {
+				"label": "Audio Feedback",
+				"description": "Play sound when recording starts and stops"
+			},
+			"outputDevice": {
+				"title": "Output Device",
+				"description": "Select your preferred audio output device for feedback sounds",
+				"placeholder": "Select output device...",
+				"loading": "Loading..."
+			},
+			"volume": {
+				"title": "Volume",
+				"description": "Adjust the volume of audio feedback sounds"
+			}
+		},
+		"advanced": {
+			"title": "Advanced",
+			"startHidden": {
+				"label": "Start Hidden",
+				"description": "Launch to system tray without opening the window."
+			},
+			"autostart": {
+				"label": "Launch on Startup",
+				"description": "Automatically start Handy when you log in to your computer."
+			},
+			"overlay": {
+				"title": "Overlay Position",
+				"description": "Display visual feedback overlay during recording and transcription. On Linux 'None' is recommended.",
+				"options": {
+					"none": "None",
+					"bottom": "Bottom",
+					"top": "Top"
+				}
+			},
+			"pasteMethod": {
+				"title": "Paste Method",
+				"description": "Choose how text is inserted. Direct: simulates typing via system input. None: skips paste, only updates history/clipboard.",
+				"options": {
+					"clipboard": "Clipboard ({{modifier}}+V)",
+					"clipboardCtrlShiftV": "Clipboard (Ctrl+Shift+V)",
+					"clipboardShiftInsert": "Clipboard (Shift+Insert)",
+					"direct": "Direct",
+					"none": "None"
+				}
+			},
+			"clipboardHandling": {
+				"title": "Clipboard Handling",
+				"description": "Don't Modify Clipboard preserves your current clipboard contents after transcription. Copy to Clipboard leaves the transcription result in your clipboard after pasting.",
+				"options": {
+					"dontModify": "Don't Modify Clipboard",
+					"copyToClipboard": "Copy to Clipboard"
+				}
+			},
+			"translateToEnglish": {
+				"label": "Translate to English",
+				"description": "Automatically translate speech from other languages to English during transcription.",
+				"descriptionUnsupported": "Translation is not supported by the {{model}} model."
+			},
+			"modelUnload": {
+				"title": "Unload Model",
+				"description": "Automatically free GPU/CPU memory when the model hasn't been used for the specified time",
+				"options": {
+					"never": "Never",
+					"immediately": "Immediately",
+					"min2": "After 2 minutes",
+					"min5": "After 5 minutes",
+					"min10": "After 10 minutes",
+					"min15": "After 15 minutes",
+					"hour1": "After 1 hour",
+					"sec5": "After 5 seconds (Debug)"
+				}
+			},
+			"customWords": {
+				"title": "Custom Words",
+				"description": "Add words that are often misheard or misspelled during transcription. The system will automatically correct similar-sounding words to match your list.",
+				"placeholder": "Add a word",
+				"add": "Add",
+				"remove": "Remove {{word}}"
+			},
+			"privacy": {
+				"title": "Privacy"
+			},
+			"resetApp": {
+				"title": "Reset App",
+				"description": "Delete all data including models, recordings, history, and settings. The app will restart fresh with onboarding.",
+				"button": "Reset All Data",
+				"confirmTitle": "Are you sure?",
+				"confirmDescription": "This will permanently delete all your data including downloaded models, recordings, transcription history, and settings. This action cannot be undone. The app will restart after reset.",
+				"confirmButton": "Yes, Reset Everything",
+				"resetting": "Resetting..."
+			}
+		},
+		"postProcessing": {
+			"title": "Post Process",
+			"disabledNotice": "Post processing is currently disabled. Enable it in Debug settings to configure.",
+			"api": {
+				"title": "API (OpenAI Compatible)",
+				"provider": {
+					"title": "Provider",
+					"description": "Select an OpenAI-compatible provider."
+				},
+				"appleIntelligence": {
+					"title": "Apple Intelligence",
+					"description": "Runs fully on-device. No API key or network access is required.",
+					"requirements": "Requires an Apple Silicon Mac running macOS Tahoe (26.0) or later. Apple Intelligence must be enabled in System Settings.",
+					"unavailable": "Apple Intelligence is not available on this device. Requires an Apple Silicon Mac running macOS Tahoe (26.0) or later with Apple Intelligence enabled in System Settings."
+				},
+				"baseUrl": {
+					"title": "Base URL",
+					"description": "API base URL for the selected provider. Only the custom provider can be edited.",
+					"placeholder": "https://api.openai.com/v1"
+				},
+				"apiKey": {
+					"title": "API Key",
+					"description": "API key for the selected provider.",
+					"placeholder": "sk-..."
+				},
+				"model": {
+					"title": "Model",
+					"descriptionApple": "Provide an optional numeric token limit or keep the default on-device preset.",
+					"descriptionCustom": "Provide the model identifier expected by your custom endpoint.",
+					"descriptionDefault": "Choose a model exposed by the selected provider.",
+					"placeholderApple": "Apple Intelligence",
+					"placeholderWithOptions": "Search or select a model",
+					"placeholderNoOptions": "Type a model name",
+					"refreshModels": "Refresh models"
+				}
+			},
+			"prompts": {
+				"title": "Prompt",
+				"selectedPrompt": {
+					"title": "Selected Prompt",
+					"description": "Select a template for refining transcriptions or create a new one. Use ${output} inside the prompt text to reference the captured transcript."
+				},
+				"noPrompts": "No prompts available",
+				"selectPrompt": "Select a prompt",
+				"createNew": "Create New Prompt",
+				"promptLabel": "Prompt Label",
+				"promptLabelPlaceholder": "Enter prompt name",
+				"promptInstructions": "Prompt Instructions",
+				"promptInstructionsPlaceholder": "Write the instructions to run after transcription. Example: Improve grammar and clarity for the following text: ${output}",
+				"promptTip": "Tip: Use <code>${output}</code> to insert the transcribed text in your prompt.",
+				"updatePrompt": "Update Prompt",
+				"deletePrompt": "Delete Prompt",
+				"createPrompt": "Create Prompt",
+				"cancel": "Cancel",
+				"selectToEdit": "Select a prompt above to view and edit its details.",
+				"createFirst": "Click 'Create New Prompt' above to create your first post-processing prompt."
+			}
+		},
+		"history": {
+			"title": "History",
+			"openFolder": "Open Recordings Folder",
+			"loading": "Loading history...",
+			"empty": "No transcriptions yet. Start recording to build your history!",
+			"copyToClipboard": "Copy transcription to clipboard",
+			"save": "Save transcription",
+			"unsave": "Remove from saved",
+			"delete": "Delete entry",
+			"deleteError": "Failed to delete entry. Please try again."
+		},
+		"debug": {
+			"title": "Debug",
+			"logDirectory": {
+				"title": "Log Directory",
+				"description": "Location where log files are stored"
+			},
+			"logLevel": {
+				"title": "Log Level",
+				"description": "Set the verbosity of logging"
+			},
+			"updateChecks": {
+				"label": "Check for Updates",
+				"description": "Automatically check for new versions of Handy"
+			},
+			"soundTheme": {
+				"label": "Sound Theme",
+				"description": "Choose a sound theme for recording start and stop feedback"
+			},
+			"wordCorrectionThreshold": {
+				"title": "Word Correction Threshold",
+				"description": "Sensitivity for custom word corrections"
+			},
+			"historyLimit": {
+				"title": "History Limit",
+				"description": "Maximum number of history entries to keep",
+				"entries": "entries"
+			},
+			"recordingRetention": {
+				"title": "Auto-Delete Recordings",
+				"description": "Automatically delete old recordings to save space",
+				"never": "Never",
+				"preserveLimit": "Keep latest {{count}}",
+				"days3": "After 3 days",
+				"weeks2": "After 2 weeks",
+				"months3": "After 3 months",
+				"placeholder": "Select retention period..."
+			},
+			"alwaysOnMicrophone": {
+				"label": "Always-On Microphone",
+				"description": "Keep microphone active for faster response"
+			},
+			"clamshellMicrophone": {
+				"title": "Clamshell Microphone",
+				"description": "Microphone to use when laptop lid is closed"
+			},
+			"postProcessingToggle": {
+				"label": "Post Processing",
+				"description": "Enable AI-powered text refinement after transcription"
+			},
+			"muteWhileRecording": {
+				"label": "Mute While Recording",
+				"description": "Mute system audio during recording"
+			},
+			"appendTrailingSpace": {
+				"label": "Append Trailing Space",
+				"description": "Add a space after pasted transcription"
+			},
+			"paths": {
+				"appData": "App Data:",
+				"models": "Models:",
+				"settings": "Settings:"
+			}
+		},
+		"about": {
+			"title": "About",
+			"version": {
+				"title": "Version",
+				"description": "Current version of Handy"
+			},
+			"appDataDirectory": {
+				"title": "App Data Directory",
+				"description": "Location where Handy stores its data"
+			},
+			"sourceCode": {
+				"title": "Source Code",
+				"description": "View source code and contribute",
+				"button": "View on GitHub"
+			},
+			"supportDevelopment": {
+				"title": "Support Development",
+				"description": "Help us continue building Handy",
+				"button": "Donate"
+			},
+			"acknowledgments": {
+				"title": "Acknowledgments",
+				"whisper": {
+					"title": "Whisper.cpp",
+					"description": "High-performance inference of OpenAI's Whisper automatic speech recognition model",
+					"details": "Handy uses Whisper.cpp for fast, local speech-to-text processing. Thanks to the amazing work by Georgi Gerganov and contributors."
+				}
+			}
+		}
+	},
+	"footer": {
+		"signIn": "Sign In",
+		"downloadingModel": "Downloading {{model}}...",
+		"checkingUpdates": "Checking for updates...",
+		"updateAvailable": "Update available: {{version}}",
+		"updateAvailableShort": "Update available",
+		"upToDate": "Up to date",
+		"downloadUpdate": "Download Update",
+		"restart": "Restart",
+		"updateCheckingDisabled": "Update Checking Disabled",
+		"downloading": "Downloading... {{progress}}%",
+		"installing": "Installing...",
+		"preparing": "Preparing...",
+		"checkForUpdates": "Check for updates",
+		"sidecar": {
+			"llm": "LLM",
+			"tts": "TTS",
+			"discord": "Discord",
+			"memory": "Memory",
+			"online": "{{name}}: Online",
+			"offline": "{{name}}: Offline",
+			"loading": "{{name}}: Loading..."
+		},
+		"popover": {
+			"status": "Status",
+			"model": "Model",
+			"loaded": "Loaded",
+			"notLoaded": "Not Loaded",
+			"running": "Running",
+			"stopped": "Stopped",
+			"yes": "Yes",
+			"no": "No",
+			"connected": "Connected",
+			"inVoice": "In Voice",
+			"server": "Server",
+			"channel": "Channel",
+			"sidecar": "Sidecar",
+			"embeddingModel": "Embedding Model",
+			"memories": "Memories",
+			"llmDescription": "Local language model for AI responses in Onichan mode.",
+			"ttsDescription": "Text-to-speech engine for voice responses.",
+			"discordDescription": "Discord bot for voice channel integration.",
+			"memoryDescription": "Long-term memory storage for conversation context.",
+			"start": "Start",
+			"stop": "Stop",
+			"starting": "Starting...",
+			"stopping": "Stopping...",
+			"notConfigured": "Not configured"
+		},
+		"devops": {
+			"title": "DevOps",
+			"tmuxServer": "tmux Server",
+			"running": "Running",
+			"stopped": "Stopped",
+			"totalAgents": "Total Agents",
+			"localAgents": "Local",
+			"remoteAgents": "Remote",
+			"machineId": "Machine ID",
+			"description": "Multi-agent orchestration system for automated code development."
+		}
+	},
+	"common": {
+		"loading": "Loading...",
+		"save": "Save",
+		"cancel": "Cancel",
+		"reset": "Reset",
+		"add": "Add",
+		"remove": "Remove",
+		"delete": "Delete",
+		"edit": "Edit",
+		"create": "Create",
+		"update": "Update",
+		"close": "Close",
+		"open": "Open",
+		"default": "Default",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"on": "On",
+		"off": "Off",
+		"yes": "Yes",
+		"no": "No",
+		"noOptionsFound": "No options found"
+	},
+	"accessibility": {
+		"permissionsRequired": "Accessibility Permissions Required",
+		"permissionsDescription": "Handy needs accessibility permissions to type transcribed text.",
+		"openSettings": "Open System Settings",
+		"dismiss": "Dismiss"
+	},
+	"errors": {
+		"loadDirectory": "Error loading directory: {{error}}"
+	},
+	"appLanguage": {
+		"title": "Application Language",
+		"description": "Change the language of the Handy interface"
+	},
+	"overlay": {
+		"transcribing": "Transcribing..."
+	},
+	"coaching": {
+		"title": "Settings",
+		"settingsToggle": "Show coaching settings",
+		"fillerDetection": {
+			"label": "Filler Word Detection",
+			"description": "Detect and analyze filler words like 'um', 'uh', 'like' in your speech"
+		},
+		"outputMode": {
+			"label": "Output Mode",
+			"description": "Choose what happens after filler words are detected",
+			"coachingOnly": "Coaching Only (don't paste)",
+			"pasteCleaned": "Paste Cleaned Text",
+			"pasteOriginal": "Paste Original + Show Feedback",
+			"both": "Paste Cleaned + Show Feedback"
+		},
+		"showOverlay": {
+			"label": "Show Filler Stats",
+			"description": "Display filler word statistics after each transcription"
+		},
+		"customWords": {
+			"title": "Custom Filler Words",
+			"description": "Add your own filler words or phrases to detect in addition to the defaults",
+			"placeholder": "Add a filler word",
+			"add": "Add",
+			"remove": "Remove {{word}}"
+		},
+		"stats": {
+			"fillerCount": "Filler Words",
+			"percentage": "of speech",
+			"topFillers": "Most Used",
+			"improvement": "Improvement"
+		},
+		"tips": {
+			"title": "Tips to Reduce Filler Words",
+			"pause": "Pause instead of filling silence",
+			"slow": "Slow down your speaking pace",
+			"practice": "Practice with shorter recordings"
+		}
+	},
+	"live": {
+		"title": "Live Coaching",
+		"status": {
+			"idle": "Ready",
+			"recording": "Recording",
+			"transcribing": "Transcribing...",
+			"complete": "Complete"
+		},
+		"trafficLight": {
+			"idle": "Press your shortcut to start",
+			"green": "Great flow!",
+			"yellow": "Some filler words detected",
+			"red": "Too many filler words"
+		},
+		"stats": {
+			"fillerWords": "Filler Words",
+			"totalWords": "Total Words",
+			"fillerPercentage": "Filler %"
+		},
+		"transcription": {
+			"title": "Transcription"
+		},
+		"breakdown": {
+			"title": "Filler Word Breakdown"
+		},
+		"fillerWord": "Filler word",
+		"instructions": {
+			"title": "Ready for Live Coaching",
+			"description": "Use your recording shortcut to start. Your speech will be analyzed in real-time for filler words."
+		}
+	},
+	"onichan": {
+		"tabs": {
+			"core": "Core",
+			"chat": "Chat",
+			"discord": "Discord",
+			"models": "Models"
+		},
+		"core": {
+			"description": "Quick-start all services with one click",
+			"startAll": "Start All",
+			"stopAll": "Stop All",
+			"start": "Start",
+			"stop": "Stop",
+			"starting": "Starting...",
+			"running": "Running",
+			"ready": "Ready to start",
+			"notConfigured": "Not configured",
+			"noConfig": "No services configured yet",
+			"noConfigHint": "Use the Models and Discord tabs to set up services first",
+			"llm": "Language Model",
+			"tts": "Text-to-Speech",
+			"discord": "Discord Voice",
+			"memory": "Memory"
+		},
+		"title": "Onichan Voice Assistant",
+		"enable": "Enable",
+		"disable": "Disable",
+		"status": {
+			"idle": "Ready to listen",
+			"listening": "Listening...",
+			"thinking": "Thinking...",
+			"speaking": "Speaking..."
+		},
+		"instructions": "Use your recording shortcut to speak. Onichan will respond when you stop.",
+		"instructionsContinuous": "Just start speaking. Onichan is listening and will respond when you pause.",
+		"continuousListening": "Continuous listening active - just start talking",
+		"silenceThreshold": {
+			"label": "Pause Duration",
+			"description": "Time to wait before responding",
+			"min": "0.5s",
+			"max": "5s",
+			"value": "{{value}}s"
+		},
+		"volume": {
+			"label": "TTS Volume",
+			"description": "Speech output volume",
+			"min": "0%",
+			"max": "100%"
+		},
+		"liveTranscription": "You said",
+		"listeningPlaceholder": "Listening...",
+		"processingPlaceholder": "Processing...",
+		"conversation": "Conversation",
+		"clearHistory": "Clear conversation",
+		"setupTitle": "Voice Assistant",
+		"setupDescription": "Enable Onichan to have voice conversations. Download and load a local LLM model below, or configure a cloud provider in Post Process settings.",
+		"mode": {
+			"label": "Processing Mode",
+			"local": "Local",
+			"cloud": "Cloud",
+			"localWarning": "Load a Language Model below to enable Local mode. TTS uses your system voices automatically.",
+			"cloudInfo": "Uses your configured Post Process API provider. Make sure you have an API key set in Post Process settings."
+		},
+		"models": {
+			"llmTitle": "Language Model (LLM)",
+			"llmDescription": "Download and load a local language model for AI responses.",
+			"ttsTitle": "Text-to-Speech (TTS)",
+			"ttsDescription": "Select a voice for spoken responses. In Local mode, uses your system's built-in voices.",
+			"ttsNote": "In Local mode, voices are mapped to system TTS (macOS say, Windows SAPI). In Cloud mode, uses OpenAI TTS.",
+			"active": "Active",
+			"available": "Available",
+			"notDownloaded": "Download",
+			"load": "Load model",
+			"unload": "Unload model",
+			"unloadButton": "Unload",
+			"download": "Download model",
+			"downloadButton": "Download",
+			"delete": "Delete model",
+			"clickToLoad": "Click to load",
+			"loading": "Loading...",
+			"loadingTooltip": "Loading model into memory, this may take a moment",
+			"downloading": "Downloading..."
+		},
+		"tooltips": {
+			"enableDisabled": "Load a Language Model below before enabling Local mode",
+			"enableReady": "Click to enable voice assistant",
+			"disableActive": "Click to disable voice assistant",
+			"modeLocal": "Process locally using downloaded models. No internet required.",
+			"modeCloud": "Process using cloud API. Requires API key in Post Process settings."
+		}
+	},
+	"discord": {
+		"title": "Discord Bot",
+		"botConfiguration": "Bot Configuration",
+		"description": "Connect KBVE to your Discord server to use voice coaching in voice channels.",
+		"botToken": {
+			"label": "Bot Token",
+			"placeholder": "Enter your Discord bot token",
+			"save": "Save",
+			"clear": "Clear",
+			"saved": "Token saved securely",
+			"hint": "Get your bot token from the Discord Developer Portal",
+			"securityNote": "Your token is stored securely and never displayed in full"
+		},
+		"status": {
+			"connected": "Connected to voice channel",
+			"disconnected": "Not connected",
+			"connecting": "Connecting to Discord...",
+			"fetchingServers": "Fetching servers...",
+			"waitingForServers": "Waiting for server list (attempt {{attempt}}/{{max}})...",
+			"noServersFound": "No servers found. Make sure the bot is in at least one server.",
+			"botOnline": "Bot is online",
+			"botOffline": "Bot is offline - click refresh or reconnect"
+		},
+		"connection": {
+			"title": "Voice Channel"
+		},
+		"guild": {
+			"label": "Server",
+			"placeholder": "Select a server...",
+			"loading": "Loading servers...",
+			"refresh": "Refresh server list",
+			"noServersHint": "No servers found. Click refresh or make sure the bot has been invited to your server."
+		},
+		"channel": {
+			"label": "Voice Channel",
+			"placeholder": "Select a voice channel..."
+		},
+		"connect": "Connect to Voice",
+		"connecting": "Connecting...",
+		"reconnect": "Reconnect",
+		"disconnect": "Disconnect",
+		"controls": {
+			"title": "Voice Controls",
+			"description": "You're connected to Discord voice. KBVE will listen and provide coaching feedback."
+		},
+		"setup": {
+			"title": "Discord Integration",
+			"description": "Set up a Discord bot to use voice coaching in voice channels.",
+			"step1": "Go to Discord Developer Portal and create a new application",
+			"step2": "Create a bot and copy the bot token",
+			"step3": "Invite the bot to your server with Voice permissions",
+			"step4": "Paste the bot token above to get started"
+		},
+		"errors": {
+			"tokenRequired": "Bot token is required",
+			"selectChannel": "Please select a server and voice channel"
+		},
+		"models": {
+			"llmTitle": "Language Model (LLM)",
+			"llmDescription": "Select a language model for generating responses in Discord voice chat.",
+			"llmRequired": "Load a language model to enable AI responses in voice chat.",
+			"ttsTitle": "Text-to-Speech (TTS)",
+			"ttsDescription": "Select a TTS model for speaking responses in Discord voice chat.",
+			"ttsRequired": "Load a TTS model to enable voice responses."
+		},
+		"conversation": {
+			"title": "Voice Assistant",
+			"label": "Discord Conversation Mode",
+			"description": "Enable continuous listening in Discord voice. The bot will transcribe what users say, generate AI responses, and speak back to the channel.",
+			"start": "Start Listening",
+			"stop": "Stop Listening",
+			"hint": "Make sure you have a transcription model and TTS loaded. The bot will respond to anyone speaking in the voice channel.",
+			"status": {
+				"active": "Listening for voice...",
+				"listening": "Listening for speech...",
+				"transcribing": "Transcribing...",
+				"thinking": "Generating response...",
+				"speaking": "Speaking response..."
+			}
+		}
+	},
+	"memory": {
+		"title": "Long-Term Memory",
+		"status": {
+			"title": "Status",
+			"refresh": "Refresh status",
+			"sidecarRunning": "Memory sidecar is running",
+			"sidecarStopped": "Memory sidecar is not running",
+			"modelLoaded": "Embedding model loaded",
+			"modelNotLoaded": "Embedding model not loaded",
+			"memoryCount": "{{count}} memories stored",
+			"info": "Memories are stored when you use Onichan or Discord voice chat. The embedding model downloads automatically on first use.",
+			"startButton": "Start Memory Service",
+			"starting": "Starting...",
+			"stopButton": "Stop Memory Service",
+			"stopping": "Stopping..."
+		},
+		"model": {
+			"title": "Embedding Model",
+			"description": "Select an embedding model for semantic memory search. Larger models are more accurate but use more resources.",
+			"active": "Active",
+			"available": "Available",
+			"notDownloaded": "Download",
+			"loading": "Loading...",
+			"clickToLoad": "Click to load this model",
+			"downloadAndLoad": "Download and load this model",
+			"downloadButton": "Download",
+			"loadFirst": "Start the memory sidecar to see available models",
+			"note": "Models are downloaded from HuggingFace on first use. Changing models doesn't affect stored memories.",
+			"sizeAndDim": "{{size}} MB • {{dim}} dim"
+		},
+		"browser": {
+			"title": "Memory Browser",
+			"search": "Search memories semantically...",
+			"searchButton": "Search",
+			"searchHint": "Enter a search query to find relevant memories",
+			"noResults": "No memories found matching your query",
+			"clearAll": "Clear All Memories",
+			"userId": "User: {{id}}...",
+			"similarity": "{{percent}}% match",
+			"browseRecent": "Browse Recent",
+			"browseRecentHint": "Browse recent memories without search",
+			"filters": "Filters",
+			"filterByUser": "Filter by User",
+			"filterByType": "Filter by Type",
+			"allUsers": "All Users",
+			"allTypes": "All Types",
+			"userMessages": "User Messages",
+			"botResponses": "Bot Responses",
+			"recentFirst": "Recent First",
+			"relevanceFirst": "Relevance First",
+			"sortBy": "Sort",
+			"userCount": "{{count}} memories",
+			"userOption": "{{id}}... ({{count}} memories)",
+			"loadMore": "Load More",
+			"showingCount": "Showing {{count}} of {{total}} memories",
+			"recencyBadge": "Recent",
+			"semanticSearch": "Semantic Search",
+			"chronological": "Chronological",
+			"viewMode": "View"
+		},
+		"dangerZone": {
+			"title": "Danger Zone",
+			"clearDescription": "Permanently delete all stored memories. This cannot be undone.",
+			"cancel": "Cancel",
+			"confirm": "Yes, Delete All"
+		},
+		"empty": {
+			"title": "No Memories Yet",
+			"description": "Memories will be stored automatically when you use Onichan or Discord voice chat."
+		}
+	},
+	"devops": {
+		"title": "DevOps",
+		"description": "Manage coding agents and multi-repo workflows. Requires debug mode enabled.",
+		"refresh": "Refresh",
+		"tabs": {
+			"settings": "Settings",
+			"sessions": "Sessions"
+		},
+		"dependencies": {
+			"title": "Dependencies",
+			"description": "Required CLI tools for DevOps features",
+			"allSatisfied": "All dependencies installed",
+			"missing": "Some dependencies missing",
+			"version": "Version",
+			"path": "Path",
+			"unknown": "unknown",
+			"notInstalled": "Not installed. Run the command below to install:",
+			"copyCommand": "Copy install command",
+			"required": "Required",
+			"agents": "AI Coding Agents (at least one required)",
+			"localLlm": "Local LLM Servers (optional)",
+			"availableAgents": "Available agents",
+			"enabledAgents": "Enabled agents",
+			"installFirst": "Install this tool first to enable it",
+			"authenticatedAs": "Authenticated as",
+			"notAuthenticated": "Not authenticated",
+			"verifyInstance": "You need to verify your instance before using this tool.",
+			"launchAuth": "Launch Authentication",
+			"followGuide": "Follow the authentication guide",
+			"optional": "Optional (enables sandboxed agents)",
+			"sandboxAvailable": "✓ Docker daemon running - sandboxed agents available",
+			"copied": "Copied!",
+			"copiedInstallHint": "Install command copied to clipboard",
+			"copiedPath": "Path copied to clipboard",
+			"copyFailed": "Copy Failed",
+			"copyFailedMessage": "Could not copy to clipboard",
+			"clickToCopy": "Click to copy",
+			"daemonNotRunning": "Docker installed but daemon not running",
+			"daemonNotRunningHint": "Start Docker Desktop to enable sandboxed agents"
+		},
+		"supportWorker": {
+			"sectionTitle": "Support Worker",
+			"sectionDescription": "A general-purpose helper agent for quick tasks and testing",
+			"title": "Support Worker",
+			"running": "Agent is running",
+			"stopped": "Agent is stopped",
+			"start": "Start Support Worker",
+			"stop": "Stop",
+			"attach": "Attach",
+			"description": "Start a general-purpose Claude agent for support tasks, quick questions, or testing. This worker runs in a tmux session and can be used for any ad-hoc assistance.",
+			"inputPlaceholder": "Send a message to the support worker..."
+		},
+		"sessions": {
+			"title": "Agent Sessions",
+			"description": "Manage tmux sessions running coding agents",
+			"comingSoon": "Agent session management coming soon. This will allow you to spawn and monitor multiple coding agents working in parallel.",
+			"tmuxNotRunning": "tmux is not currently running",
+			"tmuxNotRunningHint": "Start a tmux session to manage coding agents",
+			"noSessions": "No active sessions",
+			"noSessionsHint": "Sessions will appear here when you start coding agents",
+			"activeCount": "{{count}} active session(s)",
+			"attached": "Attached",
+			"kill": "Kill",
+			"openTerminal": "Open in Terminal",
+			"noOutput": "No output yet...",
+			"expand": "Expand session",
+			"collapse": "Collapse",
+			"send": "Send message",
+			"sendPlaceholder": "Type a message to send to the agent...",
+			"quickKeys": "Quick keys:",
+			"startedAt": "Started at",
+			"updating": "updating...",
+			"justNow": "just now",
+			"secondsAgo": "{{count}}s ago",
+			"minutesAgo": "{{count}}m ago",
+			"recoveryTitle": "Recovery Suggestions",
+			"action": {
+				"resume": "Session can be resumed",
+				"cleanup": "Session needs cleanup",
+				"recreate": "Session should be recreated"
+			}
+		},
+		"epicMonitor": {
+			"title": "Epic Monitor",
+			"linkHint": "Link an Epic to enable monitoring",
+			"watching": "Watching for completions...",
+			"description": "Supervisor for Epic sub-agents",
+			"startMonitoring": "Start Monitoring",
+			"stop": "Stop",
+			"check": "Check",
+			"checkNow": "Check now",
+			"started": "Epic Monitor Started",
+			"startedMessage": "Checking every 30s",
+			"stopped": "Epic Monitor Stopped",
+			"inProgress": "In Progress",
+			"ready": "Ready (PR)",
+			"completed": "Completed",
+			"queued": "Queued",
+			"autoUpdateGithub": "Auto-update Epic issue on GitHub when sub-issues complete",
+			"autoStartNextPhase": "Auto-merge ready PRs and start next phase",
+			"lastCheck": "Last check: {{time}}",
+			"activeAgents": "Active Agents",
+			"phases": "Phases",
+			"phaseNumber": "Phase {{number}}",
+			"markComplete": "Mark Complete",
+			"phaseUpdated": "Phase Updated",
+			"phaseUpdatedMessage": "Phase {{phase}} marked as {{status}}",
+			"phaseUpdateFailed": "Failed to update phase status",
+			"readyPRs": "Ready PRs",
+			"mergeAll": "Merge All",
+			"merge": "Merge",
+			"mergePR": "Merge this PR",
+			"viewPR": "View PR on GitHub",
+			"mergePRSuccess": "PR Merged Successfully",
+			"mergePRFailed": "Failed to merge PR",
+			"phaseCompleteMessage": "Phase complete! Next phase: {{nextPhase}}",
+			"mergeAllSuccess": "Merged {{count}} PR(s)",
+			"mergeAllPartialFail": "{{count}} PR(s) failed to merge",
+			"mergeAllFailed": "Failed to process PRs",
+			"phasesCompleted": "Completed phases: {{phases}}"
+		},
+		"worktrees": {
+			"title": "Git Worktrees",
+			"description": "Isolated development environments for parallel agent work",
+			"count": "{{count}} worktree(s)",
+			"create": "New",
+			"createTitle": "Create Worktree",
+			"createButton": "Create Worktree",
+			"namePlaceholder": "Enter worktree name (e.g., fix-bug-123)",
+			"remove": "Remove worktree",
+			"main": "Main",
+			"locked": "Locked",
+			"prunable": "Prunable",
+			"notInRepo": "Not in a git repository",
+			"notInRepoHint": "Open a git repository to manage worktrees",
+			"noWorktrees": "No worktrees",
+			"noWorktreesHint": "Create a worktree to start parallel development"
+		},
+		"issues": {
+			"title": "GitHub Issues",
+			"description": "Task queue from GitHub issues for agent assignment",
+			"count": "{{count}} issue(s)",
+			"configureRepo": "Configure a repository to load issues from",
+			"repoPlaceholder": "owner/repo (e.g., KBVE/kbve)",
+			"setRepo": "Set",
+			"notAuthenticated": "GitHub CLI not authenticated",
+			"notAuthenticatedHint": "Run the following command to authenticate:",
+			"authCommand": "gh auth login",
+			"authenticatedAs": "Authenticated as {{user}}",
+			"noIssues": "No open issues",
+			"noIssuesHint": "Create issues in the repository to see them here",
+			"openInGitHub": "Open in GitHub"
+		},
+		"prs": {
+			"title": "Pull Requests",
+			"description": "Monitor and manage pull requests created by agents",
+			"count": "{{count}} PR(s)",
+			"configureRepo": "Configure a repository to load pull requests from",
+			"repoPlaceholder": "owner/repo (e.g., KBVE/kbve)",
+			"setRepo": "Set",
+			"notAuthenticated": "GitHub CLI not authenticated",
+			"notAuthenticatedHint": "Run the following command to authenticate:",
+			"authCommand": "gh auth login",
+			"authenticatedAs": "Authenticated as {{user}}",
+			"noPrs": "No open pull requests",
+			"noPrsHint": "PRs created by agents will appear here",
+			"openInGitHub": "Open in GitHub",
+			"showStatus": "Show status",
+			"draft": "Draft",
+			"checks": "Checks",
+			"reviews": "Reviews",
+			"passing": "passing",
+			"failing": "failing",
+			"pending": "pending",
+			"approved": "approved",
+			"changesRequested": "changes requested",
+			"mergeable": "Ready to merge",
+			"notMergeable": "Not mergeable"
+		},
+		"orchestrator": {
+			"title": "Active Agents",
+			"description": "Dashboard showing all running coding agents and their status",
+			"agentCount": "{{count}} active agent(s)",
+			"noAgents": "No active agents",
+			"noLocalAgents": "No local agents",
+			"noRemoteAgents": "No remote agents",
+			"noAgentsHint": "Spawn an agent from an issue to see it here",
+			"spawnAgent": "Spawn agent on this issue",
+			"attached": "Attached",
+			"local": "Local",
+			"remote": "Remote",
+			"all": "All",
+			"filterAll": "Show all agents",
+			"filterLocal": "Show only local agents",
+			"filterRemote": "Show only remote agents",
+			"cleanup": "Stop agent and cleanup resources",
+			"remoteCannotCleanup": "Cannot cleanup remote agent from this machine",
+			"completeWork": "Create PR and complete agent work",
+			"noIssueRef": "Agent has no associated issue",
+			"noRepoPath": "No repository path configured. Open a git repository first."
+		}
+	},
+	"credentials": {
+		"discord": {
+			"title": "Discord Bot Token",
+			"heading": "Discord Integration",
+			"description": "Your Discord bot token is stored securely. Configure or update it in the Discord settings tab.",
+			"configured": "Discord bot token is configured",
+			"notConfigured": "Discord bot token not configured",
+			"manageHint": "Go to the Discord tab to update or clear your token.",
+			"setupHint": "Go to the Discord tab to set up your bot token."
+		},
+		"supabase": {
+			"title": "Supabase Configuration",
+			"heading": "Supabase Backend",
+			"description": "Configure your Supabase project for user authentication and cloud sync features.",
+			"urlLabel": "Supabase URL",
+			"urlPlaceholder": "https://your-project.supabase.co",
+			"urlHint": "Find this in your Supabase project settings under API",
+			"keyLabel": "Supabase Anon Key",
+			"keyPlaceholder": "Enter your Supabase anon/public key",
+			"keyHint": "The public anonymous key from your Supabase project settings",
+			"save": "Save",
+			"clear": "Clear",
+			"keySaved": "Anon key saved securely",
+			"configured": "Supabase is configured",
+			"readyHint": "Your Supabase credentials are ready for authentication."
+		},
+		"errors": {
+			"keyRequired": "Anon key is required"
+		},
+		"info": {
+			"title": "Secure Credential Storage",
+			"description": "All credentials are stored securely on your device. API keys are never displayed in full after being saved."
+		}
+	}
+}

--- a/apps/kbve/desktop-kbve/src/i18n/react-i18next.ts
+++ b/apps/kbve/desktop-kbve/src/i18n/react-i18next.ts
@@ -1,0 +1,37 @@
+import en from './en.json';
+
+type Dict = { [key: string]: string | Dict };
+
+type TOptions = { defaultValue?: string } & Record<string, unknown>;
+
+function lookup(key: string): string | undefined {
+	let node: string | Dict | undefined = en as Dict;
+	for (const part of key.split('.')) {
+		if (typeof node !== 'object' || node === undefined) return undefined;
+		node = node[part];
+	}
+	return typeof node === 'string' ? node : undefined;
+}
+
+function interpolate(template: string, vars: Record<string, unknown>): string {
+	return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+		vars[name] !== undefined ? String(vars[name]) : `{{${name}}}`,
+	);
+}
+
+export function t(
+	key: string,
+	defaultValueOrOptions?: string | TOptions,
+	maybeOptions?: TOptions,
+): string {
+	const opts: TOptions | undefined =
+		typeof defaultValueOrOptions === 'string'
+			? { defaultValue: defaultValueOrOptions, ...maybeOptions }
+			: defaultValueOrOptions;
+	const raw = lookup(key) ?? opts?.defaultValue ?? key;
+	return opts ? interpolate(raw, opts) : raw;
+}
+
+export function useTranslation() {
+	return { t, i18n: { language: 'en' } };
+}

--- a/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
+++ b/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
@@ -1,0 +1,1001 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import {
+	commands,
+	AgentStatus,
+	TmuxSession,
+	RecoveredSession,
+	ActiveEpicState,
+	EpicInfo,
+	EpicRecoveryInfo,
+} from '@/bindings';
+
+import { toast } from '@/stores/toastStore';
+
+// Event payload for PR creation
+interface AgentPrCreatedEvent {
+	session: string;
+	issue_number: number;
+	pr_url: string;
+	pr_number: number | null;
+	repo: string;
+}
+
+// Event payload for orphan container cleanup
+interface OrphanContainerCleanedEvent {
+	container_name: string;
+	issue_number: number | null;
+}
+
+// Epic Monitor state for supervisor functionality
+export interface EpicMonitorState {
+	isMonitoring: boolean;
+	lastCheck: Date | null;
+	completedSinceStart: number;
+	autoUpdateGithub: boolean;
+	autoStartNextPhase: boolean;
+}
+
+interface DevOpsStore {
+	// Agent state
+	agents: AgentStatus[];
+	agentsLoading: boolean;
+	agentsError: string | null;
+
+	// Tmux session state
+	sessions: TmuxSession[];
+	recoveredSessions: RecoveredSession[];
+	sessionsLoading: boolean;
+	sessionsError: string | null;
+	isTmuxRunning: boolean;
+
+	// Epic state (persisted across tab switches and app restarts)
+	activeEpic: ActiveEpicState | null;
+	epicLoading: boolean;
+	epicError: string | null;
+
+	// Epic Monitor state (supervisor for sub-agents)
+	epicMonitor: EpicMonitorState;
+	epicMonitorChecking: boolean;
+
+	// Current machine ID
+	currentMachineId: string;
+
+	// Filter state
+	agentFilterMode: 'all' | 'local' | 'remote';
+
+	// Loading states for individual operations
+	killingSession: string | null;
+	cleaningUpAgent: string | null;
+	completingWork: string | null;
+
+	// Actions
+	initialize: () => Promise<void>;
+	cleanup: () => void;
+
+	// Agent actions
+	refreshAgents: (showLoading?: boolean) => Promise<void>;
+	setAgentFilterMode: (mode: 'all' | 'local' | 'remote') => void;
+	cleanupAgent: (
+		agent: AgentStatus,
+		removeWorktree: boolean,
+	) => Promise<void>;
+	completeAgentWork: (agent: AgentStatus, prTitle: string) => Promise<void>;
+
+	// Session actions
+	refreshSessions: (showLoading?: boolean) => Promise<void>;
+	killSession: (sessionName: string) => Promise<void>;
+
+	// Epic actions
+	loadActiveEpic: () => Promise<void>;
+	setActiveEpic: (epic: EpicInfo) => Promise<void>;
+	setActiveEpicFromRecovery: (recovery: EpicRecoveryInfo) => Promise<void>;
+	syncActiveEpic: () => Promise<void>;
+	clearActiveEpic: (archive?: boolean) => Promise<void>;
+	markPhaseStatus: (phaseNumber: number, status: string) => Promise<void>;
+
+	// Epic Monitor actions
+	startEpicMonitoring: () => void;
+	stopEpicMonitoring: () => void;
+	checkEpicCompletions: () => Promise<void>;
+	setEpicMonitorAutoUpdate: (enabled: boolean) => void;
+	setEpicMonitorAutoStartNextPhase: (enabled: boolean) => void;
+	incrementCompletedCount: (count?: number) => void;
+
+	// Internal setters
+	setAgents: (agents: AgentStatus[]) => void;
+	setAgentsLoading: (loading: boolean) => void;
+	setAgentsError: (error: string | null) => void;
+	setSessions: (sessions: TmuxSession[]) => void;
+	setRecoveredSessions: (sessions: RecoveredSession[]) => void;
+	setSessionsLoading: (loading: boolean) => void;
+	setSessionsError: (error: string | null) => void;
+	setIsTmuxRunning: (running: boolean) => void;
+
+	// Interval IDs for cleanup
+	_agentRefreshInterval: number | null;
+	_sessionRefreshInterval: number | null;
+	_epicMonitorInterval: number | null;
+	_orphanCleanupInterval: number | null;
+	_prEventUnlisten: UnlistenFn | null;
+	_orphanEventUnlisten: UnlistenFn | null;
+	_previousSubIssueStates: Map<number, string>;
+	_mergeWorkersSpawned: Set<number>; // Track issues with merge workers already spawned
+	_setAgentRefreshInterval: (id: number | null) => void;
+	_setSessionRefreshInterval: (id: number | null) => void;
+	_setEpicMonitorInterval: (id: number | null) => void;
+	_setOrphanCleanupInterval: (id: number | null) => void;
+}
+
+export const useDevOpsStore = create<DevOpsStore>()(
+	subscribeWithSelector((set, get) => ({
+		// Initial state
+		agents: [],
+		agentsLoading: true,
+		agentsError: null,
+
+		sessions: [],
+		recoveredSessions: [],
+		sessionsLoading: true,
+		sessionsError: null,
+		isTmuxRunning: false,
+
+		// Epic state (persisted via tauri-plugin-store)
+		activeEpic: null,
+		epicLoading: false,
+		epicError: null,
+
+		// Epic Monitor state
+		epicMonitor: {
+			isMonitoring: false,
+			lastCheck: null,
+			completedSinceStart: 0,
+			autoUpdateGithub: true,
+			autoStartNextPhase: false, // Default to false for safety
+		},
+		epicMonitorChecking: false,
+
+		currentMachineId: '',
+
+		agentFilterMode: 'all',
+
+		killingSession: null,
+		cleaningUpAgent: null,
+		completingWork: null,
+
+		_agentRefreshInterval: null,
+		_sessionRefreshInterval: null,
+		_epicMonitorInterval: null,
+		_orphanCleanupInterval: null,
+		_prEventUnlisten: null,
+		_orphanEventUnlisten: null,
+		_previousSubIssueStates: new Map(),
+		_mergeWorkersSpawned: new Set(),
+
+		// Internal setters
+		setAgents: (agents) => set({ agents }),
+		setAgentsLoading: (agentsLoading) => set({ agentsLoading }),
+		setAgentsError: (agentsError) => set({ agentsError }),
+		setSessions: (sessions) => set({ sessions }),
+		setRecoveredSessions: (recoveredSessions) => set({ recoveredSessions }),
+		setSessionsLoading: (sessionsLoading) => set({ sessionsLoading }),
+		setSessionsError: (sessionsError) => set({ sessionsError }),
+		setIsTmuxRunning: (isTmuxRunning) => set({ isTmuxRunning }),
+		setAgentFilterMode: (agentFilterMode) => set({ agentFilterMode }),
+		_setAgentRefreshInterval: (id) => set({ _agentRefreshInterval: id }),
+		_setSessionRefreshInterval: (id) =>
+			set({ _sessionRefreshInterval: id }),
+		_setOrphanCleanupInterval: (id) => set({ _orphanCleanupInterval: id }),
+		_setEpicMonitorInterval: (id) => set({ _epicMonitorInterval: id }),
+
+		// Refresh agents from backend
+		refreshAgents: async (showLoading = false) => {
+			const startState = get();
+
+			if (showLoading && !startState.agentsLoading) {
+				set({ agentsLoading: true });
+			}
+
+			try {
+				const result = await commands.listAgentStatuses();
+				const currentState = get();
+
+				if (result.status === 'ok') {
+					// Only update if data actually changed
+					const dataChanged =
+						JSON.stringify(currentState.agents) !==
+						JSON.stringify(result.data);
+					if (dataChanged) {
+						set({ agents: result.data });
+					}
+
+					// Clear error only if there was one
+					if (currentState.agentsError !== null) {
+						set({ agentsError: null });
+					}
+				} else {
+					// Only set error if it changed
+					if (currentState.agentsError !== result.error) {
+						set({ agentsError: result.error });
+					}
+				}
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				const currentState = get();
+				if (currentState.agentsError !== errorMsg) {
+					set({ agentsError: errorMsg });
+				}
+			} finally {
+				if (showLoading) {
+					const finalState = get();
+					if (finalState.agentsLoading) {
+						set({ agentsLoading: false });
+					}
+				}
+			}
+		},
+
+		// Refresh tmux sessions from backend
+		refreshSessions: async (showLoading = false) => {
+			const startState = get();
+
+			if (showLoading && !startState.sessionsLoading) {
+				set({ sessionsLoading: true });
+			}
+
+			try {
+				const running = await commands.isTmuxRunning();
+				const currentState = get();
+
+				// Only update if changed
+				if (currentState.isTmuxRunning !== running) {
+					set({ isTmuxRunning: running });
+				}
+
+				if (running) {
+					const [sessionResult, recoveredResult] = await Promise.all([
+						commands.listTmuxSessions(),
+						commands.recoverTmuxSessions(),
+					]);
+
+					const afterFetchState = get();
+
+					if (sessionResult.status === 'ok') {
+						const sessionsChanged =
+							JSON.stringify(afterFetchState.sessions) !==
+							JSON.stringify(sessionResult.data);
+						if (sessionsChanged) {
+							set({ sessions: sessionResult.data });
+						}
+					}
+
+					if (recoveredResult.status === 'ok') {
+						const recoveredChanged =
+							JSON.stringify(
+								afterFetchState.recoveredSessions,
+							) !== JSON.stringify(recoveredResult.data);
+						if (recoveredChanged) {
+							set({ recoveredSessions: recoveredResult.data });
+						}
+					}
+
+					// Clear error if it was set
+					const finalState = get();
+					if (finalState.sessionsError !== null) {
+						set({ sessionsError: null });
+					}
+				} else {
+					// Only update if not already empty
+					const emptyState = get();
+					if (
+						emptyState.sessions.length > 0 ||
+						emptyState.recoveredSessions.length > 0
+					) {
+						set({ sessions: [], recoveredSessions: [] });
+					}
+				}
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				const errorState = get();
+				if (errorState.sessionsError !== errorMsg) {
+					set({ sessionsError: errorMsg });
+				}
+			} finally {
+				if (showLoading) {
+					const finalState = get();
+					if (finalState.sessionsLoading) {
+						set({ sessionsLoading: false });
+					}
+				}
+			}
+		},
+
+		// Kill a tmux session
+		killSession: async (sessionName: string) => {
+			set({ killingSession: sessionName });
+			try {
+				await commands.killTmuxSession(sessionName);
+				await get().refreshSessions(false);
+			} catch (err) {
+				set({
+					sessionsError:
+						err instanceof Error ? err.message : String(err),
+				});
+			} finally {
+				set({ killingSession: null });
+			}
+		},
+
+		// Cleanup an agent
+		cleanupAgent: async (agent: AgentStatus, removeWorktree: boolean) => {
+			if (!agent.worktree) {
+				set({ agentsError: 'Agent has no associated worktree' });
+				return;
+			}
+
+			set({ cleaningUpAgent: agent.session });
+			try {
+				const repoRootResult = await commands.getGitRepoRoot(
+					agent.worktree,
+				);
+				if (repoRootResult.status === 'error') {
+					set({ agentsError: repoRootResult.error });
+					return;
+				}
+
+				const cleanupResult = await commands.cleanupAgent(
+					agent.session,
+					repoRootResult.data,
+					removeWorktree,
+					removeWorktree,
+				);
+
+				if (cleanupResult.status === 'error') {
+					set({ agentsError: cleanupResult.error });
+					return;
+				}
+
+				await get().refreshAgents(false);
+			} catch (err) {
+				set({
+					agentsError:
+						err instanceof Error ? err.message : String(err),
+				});
+			} finally {
+				set({ cleaningUpAgent: null });
+			}
+		},
+
+		// Complete agent work (create PR)
+		completeAgentWork: async (agent: AgentStatus, prTitle: string) => {
+			if (!agent.issue_ref) {
+				set({ agentsError: 'Agent has no issue reference' });
+				return;
+			}
+
+			set({ completingWork: agent.session });
+			set({ agentsError: null });
+
+			try {
+				await commands.completeAgentWork(
+					agent.session,
+					prTitle,
+					null,
+					['agent-working'],
+					['needs-review'],
+					false,
+				);
+				await get().refreshAgents(false);
+			} catch (err) {
+				set({
+					agentsError:
+						err instanceof Error ? err.message : String(err),
+				});
+			} finally {
+				set({ completingWork: null });
+			}
+		},
+
+		// Load active Epic from persistent storage
+		loadActiveEpic: async () => {
+			set({ epicLoading: true, epicError: null });
+			try {
+				const epic = await commands.getActiveEpicState();
+				set({ activeEpic: epic ?? null });
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to load active Epic:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Set active Epic from EpicInfo (when linking a new Epic)
+		setActiveEpic: async (epic: EpicInfo) => {
+			set({ epicLoading: true, epicError: null });
+			try {
+				const activeEpic = await commands.setActiveEpicState(epic);
+				set({ activeEpic });
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to set active Epic:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Set active Epic from recovery info (when recovering an Epic)
+		setActiveEpicFromRecovery: async (recovery: EpicRecoveryInfo) => {
+			set({ epicLoading: true, epicError: null });
+			try {
+				const activeEpic =
+					await commands.setActiveEpicFromRecovery(recovery);
+				set({ activeEpic });
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to set active Epic from recovery:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Sync active Epic state with GitHub (get latest sub-issue status)
+		syncActiveEpic: async () => {
+			const currentEpic = get().activeEpic;
+			if (!currentEpic) return;
+
+			set({ epicLoading: true, epicError: null });
+			try {
+				const result = await commands.syncActiveEpicState();
+				if (result.status === 'ok' && result.data) {
+					set({ activeEpic: result.data });
+				} else if (result.status === 'error') {
+					set({ epicError: result.error });
+				}
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to sync active Epic:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Clear active Epic (optionally archive it)
+		clearActiveEpic: async (archive = false) => {
+			set({ epicLoading: true, epicError: null });
+			try {
+				await commands.clearActiveEpicState(archive);
+				set({ activeEpic: null });
+				// Also stop monitoring when Epic is cleared
+				get().stopEpicMonitoring();
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to clear active Epic:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Mark a phase status (e.g., mark as completed for manual phases)
+		markPhaseStatus: async (phaseNumber: number, status: string) => {
+			const { activeEpic, syncActiveEpic } = get();
+			if (!activeEpic) {
+				console.error('No active Epic to mark phase status');
+				return;
+			}
+
+			set({ epicLoading: true, epicError: null });
+			try {
+				const result = await commands.markEpicPhaseStatus(
+					activeEpic.tracking_repo,
+					activeEpic.epic_number,
+					phaseNumber,
+					status,
+				);
+				if (result.status === 'error') {
+					set({ epicError: result.error });
+					return;
+				}
+				// Sync to get the updated state
+				await syncActiveEpic();
+			} catch (err) {
+				const errorMsg =
+					err instanceof Error ? err.message : String(err);
+				set({ epicError: errorMsg });
+				console.error('Failed to mark phase status:', err);
+			} finally {
+				set({ epicLoading: false });
+			}
+		},
+
+		// Start Epic monitoring (supervisor mode)
+		startEpicMonitoring: () => {
+			const { activeEpic, _epicMonitorInterval, checkEpicCompletions } =
+				get();
+			if (!activeEpic || _epicMonitorInterval !== null) return;
+
+			// Initialize previous states from current sub-issues
+			const previousStates = new Map<number, string>();
+			for (const subIssue of activeEpic.sub_issues) {
+				previousStates.set(subIssue.issue_number, subIssue.state);
+			}
+
+			set({
+				_previousSubIssueStates: previousStates,
+				epicMonitor: {
+					...get().epicMonitor,
+					isMonitoring: true,
+					completedSinceStart: 0,
+				},
+			});
+
+			// Do an immediate check
+			checkEpicCompletions();
+
+			// Start polling interval (30 seconds)
+			const intervalId = window.setInterval(checkEpicCompletions, 30000);
+			get()._setEpicMonitorInterval(intervalId);
+		},
+
+		// Stop Epic monitoring
+		stopEpicMonitoring: () => {
+			const { _epicMonitorInterval, _setEpicMonitorInterval } = get();
+
+			if (_epicMonitorInterval !== null) {
+				clearInterval(_epicMonitorInterval);
+				_setEpicMonitorInterval(null);
+			}
+
+			set({
+				epicMonitor: {
+					...get().epicMonitor,
+					isMonitoring: false,
+				},
+			});
+		},
+
+		// Check for Epic completions
+		checkEpicCompletions: async () => {
+			const {
+				activeEpic,
+				epicMonitor,
+				_previousSubIssueStates,
+				syncActiveEpic,
+			} = get();
+			if (!activeEpic) return;
+
+			set({ epicMonitorChecking: true });
+			try {
+				// Check active sessions for PR creation (new feature)
+				try {
+					const prCheckResult = await commands.checkSessionsForPrs();
+					if (prCheckResult.status === 'ok') {
+						const prResults = prCheckResult.data;
+						for (const result of prResults) {
+							if (result.is_new && result.pr_url) {
+								console.log(
+									`[Epic Monitor] New PR detected for #${result.issue_number}: ${result.pr_url}`,
+								);
+								// The backend already updated the Epic state, just log for now
+								// A future enhancement could show a toast notification here
+							}
+						}
+					}
+				} catch (err) {
+					console.warn('PR check failed (non-critical):', err);
+				}
+
+				// Sync with GitHub to get latest status
+				await syncActiveEpic();
+
+				// Get the updated state
+				const updatedEpic = get().activeEpic;
+				if (!updatedEpic) return;
+
+				// Auto-spawn merge workers for phases that are "Ready"
+				// A phase is "Ready" when all open sub-issues have PRs
+				const { _mergeWorkersSpawned } = get();
+
+				if (epicMonitor.autoStartNextPhase) {
+					const readyPhases = updatedEpic.phases.filter(
+						(p) => p.status === 'ready',
+					);
+
+					for (const phase of readyPhases) {
+						// Find all open sub-issues in this phase that have PRs but no merge worker yet
+						const readySubIssues = updatedEpic.sub_issues.filter(
+							(s) =>
+								s.phase === phase.phase_number &&
+								s.state.toLowerCase() === 'open' &&
+								s.pr_url &&
+								s.pr_number &&
+								!s.has_agent_working && // No agent currently working on it
+								!_mergeWorkersSpawned.has(s.issue_number), // Haven't already spawned a worker
+						);
+
+						for (const subIssue of readySubIssues) {
+							console.log(
+								`[Epic Monitor] Auto-spawning merge worker for PR #${subIssue.pr_number} (issue #${subIssue.issue_number})`,
+							);
+
+							try {
+								const mergeResult = await commands.mergeReadyPr(
+									subIssue.issue_number,
+									'squash', // Default to squash merge
+									true, // Delete branch after merge
+								);
+
+								if (
+									mergeResult.status === 'ok' &&
+									mergeResult.data.success
+								) {
+									console.log(
+										`[Epic Monitor] Merge worker spawned: ${mergeResult.data.support_worker_session}`,
+									);
+									// Track that we've spawned a worker for this issue
+									_mergeWorkersSpawned.add(
+										subIssue.issue_number,
+									);
+								} else {
+									console.error(
+										`[Epic Monitor] Failed to spawn merge worker for #${subIssue.issue_number}:`,
+										mergeResult.status === 'error'
+											? mergeResult.error
+											: mergeResult.data.error,
+									);
+								}
+							} catch (err) {
+								console.error(
+									`[Epic Monitor] Error spawning merge worker:`,
+									err,
+								);
+							}
+						}
+					}
+				}
+
+				// Clean up tracking for closed issues
+				for (const subIssue of updatedEpic.sub_issues) {
+					if (subIssue.state.toLowerCase() === 'closed') {
+						_mergeWorkersSpawned.delete(subIssue.issue_number);
+					}
+				}
+
+				// Check each sub-issue for state changes
+				let newCompletions = 0;
+				for (const subIssue of updatedEpic.sub_issues) {
+					const previousState = _previousSubIssueStates.get(
+						subIssue.issue_number,
+					);
+
+					// If state changed to closed, it's completed
+					if (
+						previousState &&
+						previousState !== 'closed' &&
+						subIssue.state === 'closed'
+					) {
+						newCompletions++;
+
+						// Call the completion handler if auto-update is enabled
+						if (epicMonitor.autoUpdateGithub) {
+							try {
+								await commands.onPipelineItemComplete(
+									subIssue.issue_number,
+									true,
+								);
+							} catch (err) {
+								console.error(
+									'Failed to handle completion:',
+									err,
+								);
+							}
+						}
+					}
+
+					// Update the reference
+					_previousSubIssueStates.set(
+						subIssue.issue_number,
+						subIssue.state,
+					);
+				}
+
+				if (newCompletions > 0) {
+					set({
+						epicMonitor: {
+							...get().epicMonitor,
+							completedSinceStart:
+								get().epicMonitor.completedSinceStart +
+								newCompletions,
+						},
+					});
+
+					// Check if we should auto-start the next phase
+					if (
+						epicMonitor.autoStartNextPhase &&
+						updatedEpic.local_repo_path
+					) {
+						// Check if any phase just completed
+						const completedPhase = updatedEpic.phases.find(
+							(p) =>
+								p.status === 'completed' && p.total_count > 0,
+						);
+
+						// Find the next phase that's not started yet
+						const nextPhase = updatedEpic.phases.find(
+							(p) => p.status === 'not_started',
+						);
+
+						if (completedPhase && nextPhase) {
+							console.log(
+								`[Epic Monitor] Phase ${completedPhase.phase_number} completed, auto-starting phase ${nextPhase.phase_number}`,
+							);
+
+							// Start orchestration for the next phase
+							try {
+								const epicInfo = {
+									epic_number: updatedEpic.epic_number,
+									repo: updatedEpic.tracking_repo,
+									work_repo: updatedEpic.work_repo,
+									title: updatedEpic.title,
+									url: updatedEpic.url,
+									phases: updatedEpic.phases.map((p) => ({
+										name: p.name,
+										description: '',
+										approach: 'agent-assisted',
+										tasks: [],
+										files: [],
+										dependencies: [],
+									})),
+								};
+								const startConfig = {
+									phases: [nextPhase.phase_number],
+									auto_spawn_agents: true,
+									default_agent_type: 'claude',
+									worktree_base: updatedEpic.local_repo_path,
+								};
+								const startResult =
+									await commands.startEpicOrchestration(
+										epicInfo,
+										startConfig,
+									);
+
+								if (startResult.status === 'ok') {
+									console.log(
+										`[Epic Monitor] Auto-started phase ${nextPhase.phase_number}:`,
+										startResult.data,
+									);
+								} else {
+									console.error(
+										`[Epic Monitor] Failed to auto-start phase ${nextPhase.phase_number}:`,
+										startResult.error,
+									);
+								}
+							} catch (err) {
+								console.error(
+									'[Epic Monitor] Auto-start error:',
+									err,
+								);
+							}
+						}
+					}
+				}
+
+				set({
+					epicMonitor: {
+						...get().epicMonitor,
+						lastCheck: new Date(),
+					},
+				});
+			} catch (err) {
+				console.error('Monitor check failed:', err);
+			} finally {
+				set({ epicMonitorChecking: false });
+			}
+		},
+
+		// Toggle auto-update GitHub setting
+		setEpicMonitorAutoUpdate: (enabled: boolean) => {
+			set({
+				epicMonitor: {
+					...get().epicMonitor,
+					autoUpdateGithub: enabled,
+				},
+			});
+		},
+
+		// Toggle auto-start next phase setting
+		setEpicMonitorAutoStartNextPhase: (enabled: boolean) => {
+			set({
+				epicMonitor: {
+					...get().epicMonitor,
+					autoStartNextPhase: enabled,
+				},
+			});
+		},
+
+		// Increment completed count (for external use)
+		incrementCompletedCount: (count = 1) => {
+			set({
+				epicMonitor: {
+					...get().epicMonitor,
+					completedSinceStart:
+						get().epicMonitor.completedSinceStart + count,
+				},
+			});
+		},
+
+		// Initialize store and start polling
+		initialize: async () => {
+			const {
+				refreshAgents,
+				refreshSessions,
+				loadActiveEpic,
+				syncActiveEpic,
+				incrementCompletedCount,
+				_setAgentRefreshInterval,
+				_setSessionRefreshInterval,
+				_setOrphanCleanupInterval,
+			} = get();
+
+			// Load current machine ID
+			try {
+				const machineId = await commands.getCurrentMachineId();
+				set({ currentMachineId: machineId });
+			} catch (err) {
+				console.error('Failed to get machine ID:', err);
+			}
+
+			// Initial load with loading state (including persisted Epic state)
+			await Promise.all([
+				refreshAgents(true),
+				refreshSessions(true),
+				loadActiveEpic(),
+			]);
+
+			// Set up event listener for real-time PR detection
+			const prUnlisten = await listen<AgentPrCreatedEvent>(
+				'agent-pr-created',
+				(event) => {
+					const { issue_number, pr_url, session } = event.payload;
+					console.log(
+						`[DevOps] PR created for #${issue_number}: ${pr_url} (session: ${session})`,
+					);
+
+					// Sync Epic state to get updated PR info
+					syncActiveEpic();
+
+					// Increment completion counter
+					incrementCompletedCount(1);
+				},
+			);
+			set({ _prEventUnlisten: prUnlisten });
+
+			// Set up event listener for orphan container cleanup (for toast notifications)
+			const orphanUnlisten = await listen<OrphanContainerCleanedEvent>(
+				'orphan-container-cleaned',
+				(event) => {
+					const { container_name, issue_number } = event.payload;
+					const issueText = issue_number
+						? `#${issue_number}`
+						: container_name;
+					console.log(
+						`[DevOps] Cleaned up orphan container: ${container_name} (issue: ${issueText})`,
+					);
+
+					// Show toast notification
+					toast.info(
+						'Orphan Container Cleaned',
+						`Removed container for ${issueText}`,
+					);
+				},
+			);
+			set({ _orphanEventUnlisten: orphanUnlisten });
+
+			// Set up polling intervals
+			// Agents: 12 seconds (staggered from sessions)
+			const agentInterval = window.setInterval(
+				() => refreshAgents(false),
+				12000,
+			);
+			_setAgentRefreshInterval(agentInterval);
+
+			// Sessions: 10 seconds
+			const sessionInterval = window.setInterval(
+				() => refreshSessions(false),
+				10000,
+			);
+			_setSessionRefreshInterval(sessionInterval);
+
+			// Orphan container cleanup: 60 seconds
+			// This runs periodically to clean up Docker containers that were left behind
+			const orphanCleanupInterval = window.setInterval(async () => {
+				try {
+					await commands.cleanupOrphanedContainers();
+					// Toasts are shown via the orphan-container-cleaned event listener
+				} catch (err) {
+					// Silent failure - orphan cleanup is non-critical
+					console.debug(
+						'Orphan cleanup check failed (non-critical):',
+						err,
+					);
+				}
+			}, 60000);
+			_setOrphanCleanupInterval(orphanCleanupInterval);
+
+			// Run initial orphan cleanup
+			commands.cleanupOrphanedContainers().catch((err) => {
+				console.debug(
+					'Initial orphan cleanup failed (non-critical):',
+					err,
+				);
+			});
+		},
+
+		// Cleanup intervals and event listeners
+		cleanup: () => {
+			const {
+				_agentRefreshInterval,
+				_sessionRefreshInterval,
+				_epicMonitorInterval,
+				_orphanCleanupInterval,
+				_prEventUnlisten,
+				_orphanEventUnlisten,
+			} = get();
+
+			if (_agentRefreshInterval !== null) {
+				clearInterval(_agentRefreshInterval);
+				set({ _agentRefreshInterval: null });
+			}
+
+			if (_sessionRefreshInterval !== null) {
+				clearInterval(_sessionRefreshInterval);
+				set({ _sessionRefreshInterval: null });
+			}
+
+			if (_epicMonitorInterval !== null) {
+				clearInterval(_epicMonitorInterval);
+				set({ _epicMonitorInterval: null });
+			}
+
+			if (_orphanCleanupInterval !== null) {
+				clearInterval(_orphanCleanupInterval);
+				set({ _orphanCleanupInterval: null });
+			}
+
+			if (_prEventUnlisten !== null) {
+				_prEventUnlisten();
+				set({ _prEventUnlisten: null });
+			}
+
+			if (_orphanEventUnlisten !== null) {
+				_orphanEventUnlisten();
+				set({ _orphanEventUnlisten: null });
+			}
+		},
+	})),
+);
+
+// Hook for initializing the store (call once when DevOps settings are mounted)
+export const initializeDevOpsStore = () => {
+	const { initialize } = useDevOpsStore.getState();
+	initialize();
+};
+
+// Hook for cleanup (call when DevOps settings are unmounted)
+export const cleanupDevOpsStore = () => {
+	const { cleanup } = useDevOpsStore.getState();
+	cleanup();
+};

--- a/apps/kbve/desktop-kbve/src/stores/toastStore.ts
+++ b/apps/kbve/desktop-kbve/src/stores/toastStore.ts
@@ -1,0 +1,130 @@
+import { create } from 'zustand';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+	id: string;
+	type: ToastType;
+	title: string;
+	message?: string;
+	duration?: number; // milliseconds, 0 = persistent
+	createdAt: number;
+}
+
+interface ToastStore {
+	toasts: Toast[];
+	addToast: (toast: Omit<Toast, 'id' | 'createdAt'>) => string;
+	removeToast: (id: string) => void;
+	clearAll: () => void;
+}
+
+// Configuration
+const MAX_VISIBLE_TOASTS = 3;
+const DEFAULT_DURATION = 6000; // 6 seconds default
+const DURATION_BY_TYPE: Record<ToastType, number> = {
+	success: 5000,
+	info: 6000,
+	warning: 7000,
+	error: 8000, // errors stay longer
+};
+
+let toastCounter = 0;
+
+export const useToastStore = create<ToastStore>((set) => ({
+	toasts: [],
+
+	addToast: (toast) => {
+		const id = `toast-${Date.now()}-${toastCounter++}`;
+		const duration =
+			toast.duration ?? DURATION_BY_TYPE[toast.type] ?? DEFAULT_DURATION;
+
+		const newToast: Toast = {
+			id,
+			createdAt: Date.now(),
+			duration,
+			...toast,
+		};
+
+		set((state) => {
+			let updatedToasts = [...state.toasts, newToast];
+
+			// If we exceed max visible, remove the oldest ones
+			if (updatedToasts.length > MAX_VISIBLE_TOASTS) {
+				// Sort by createdAt and keep only the newest MAX_VISIBLE_TOASTS
+				updatedToasts = updatedToasts
+					.sort((a, b) => b.createdAt - a.createdAt)
+					.slice(0, MAX_VISIBLE_TOASTS);
+			}
+
+			return { toasts: updatedToasts };
+		});
+
+		// Auto-remove after duration (if not persistent)
+		if (duration > 0) {
+			setTimeout(() => {
+				set((state) => ({
+					toasts: state.toasts.filter((t) => t.id !== id),
+				}));
+			}, duration);
+		}
+
+		return id;
+	},
+
+	removeToast: (id) =>
+		set((state) => ({
+			toasts: state.toasts.filter((t) => t.id !== id),
+		})),
+
+	clearAll: () => set({ toasts: [] }),
+}));
+
+// Global toast helper - can be called from anywhere without hooks
+export const toast = {
+	/**
+	 * Show a success toast (auto-dismisses in 5s)
+	 */
+	success: (title: string, message?: string, duration?: number): string =>
+		useToastStore
+			.getState()
+			.addToast({ type: 'success', title, message, duration }),
+
+	/**
+	 * Show an error toast (auto-dismisses in 8s)
+	 */
+	error: (title: string, message?: string, duration?: number): string =>
+		useToastStore
+			.getState()
+			.addToast({ type: 'error', title, message, duration }),
+
+	/**
+	 * Show a warning toast (auto-dismisses in 7s)
+	 */
+	warning: (title: string, message?: string, duration?: number): string =>
+		useToastStore
+			.getState()
+			.addToast({ type: 'warning', title, message, duration }),
+
+	/**
+	 * Show an info toast (auto-dismisses in 6s)
+	 */
+	info: (title: string, message?: string, duration?: number): string =>
+		useToastStore
+			.getState()
+			.addToast({ type: 'info', title, message, duration }),
+
+	/**
+	 * Remove a specific toast by ID
+	 */
+	dismiss: (id: string): void => useToastStore.getState().removeToast(id),
+
+	/**
+	 * Clear all toasts
+	 */
+	clear: (): void => useToastStore.getState().clearAll(),
+};
+
+// Make toast available globally for easy access
+if (typeof window !== 'undefined') {
+	(window as unknown as { toast: typeof toast }).toast = toast;
+}

--- a/apps/kbve/desktop-kbve/src/views/devops.tsx
+++ b/apps/kbve/desktop-kbve/src/views/devops.tsx
@@ -1,0 +1,5 @@
+import { DevOpsLayout } from '../components/settings/devops/DevOpsLayout';
+
+export function DevOpsView() {
+	return <DevOpsLayout />;
+}

--- a/apps/kbve/desktop-kbve/src/views/index.ts
+++ b/apps/kbve/desktop-kbve/src/views/index.ts
@@ -14,6 +14,7 @@ import { AudioView } from './audio';
 import { ModelsView } from './models';
 import { ShortcutsView } from './shortcuts';
 import { OnichanView } from './onichan';
+import { DevOpsView } from './devops';
 import { AboutView } from './about';
 import { ProfileView } from './profile';
 import { TerminalView } from './terminal';
@@ -56,6 +57,12 @@ export function initViews() {
 		label: 'Onichan',
 		icon: createElement(IconUser),
 		component: OnichanView,
+	});
+	registerView({
+		id: 'devops',
+		label: 'DevOps',
+		icon: createElement(IconTerminal),
+		component: DevOpsView,
 	});
 	registerView({
 		id: 'profile',

--- a/apps/kbve/desktop-kbve/tsconfig.json
+++ b/apps/kbve/desktop-kbve/tsconfig.json
@@ -16,7 +16,8 @@
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
 		"paths": {
-			"@/*": ["./src/*"]
+			"@/*": ["./src/*"],
+			"react-i18next": ["./src/i18n/react-i18next.ts"]
 		}
 	},
 	"include": ["src"]

--- a/apps/kbve/desktop-kbve/vite.config.ts
+++ b/apps/kbve/desktop-kbve/vite.config.ts
@@ -11,6 +11,12 @@ const packagesDir = resolve(root, '../../../packages/npm');
 
 export default defineConfig({
 	plugins: [react(), tailwindcss(), kbveRnTauri({ packagesDir })],
+	resolve: {
+		alias: {
+			'@': resolve(root, 'src'),
+			'react-i18next': resolve(root, 'src/i18n/react-i18next.ts'),
+		},
+	},
 	clearScreen: false,
 	server: {
 		port: 1421,


### PR DESCRIPTION
Ports the deferred DevOps pillar from kbve/handy into desktop-kbve.

## Backend
- `src-tauri/src/devops/`: dependency detection (gh/tmux/docker), tmux session management, git worktrees, GitHub issues/PRs, Docker sandbox (installs `@anthropic-ai/claude-code`, persistent auth volume), devcontainer support, epic planner + orchestrator (issue → worktree → tmux → claude → PR), pipeline state tracking.
- `commands/devops.rs` wired through tauri-specta (~110 commands), `ensure_master_session` on setup.
- New deps: `gray_matter` (epic markdown frontmatter), `hostname` (machine id).

## Frontend
- 14 devops components + `devopsStore`/`toastStore` (zustand), ToastContainer mounted in App.
- New DevOps sidebar view wrapping `DevOpsLayout` (Settings / Sessions tabs).
- `react-i18next` shimmed via vite/tsconfig alias to a local EN-only `t()` (upstream components unmodified where possible, eases re-sync); `lucide-react` added.
- Tailwind 4 `@theme inline` block maps Handy token names (mid-gray, logo-primary, …) onto the desktop-kbve palette.

`cargo check` clean, `tsc` clean (pre-existing `@kbve/rn` worktree resolution noise unchanged), vite build + nx test pass.