### PR TITLE
fix(edge): boot-path hardening, env allowlist gaps, structured logging

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.48"
+version: "0.1.49"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/deno.json
+++ b/apps/kbve/edge/deno.json
@@ -6,10 +6,6 @@
     ],
     "strict": true
   },
-  "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2",
-    "@clickhouse/client-web": "npm:@clickhouse/client-web@1.8.1"
-  },
   "fmt": {
     "useTabs": false,
     "lineWidth": 80,

--- a/apps/kbve/edge/deno.lock
+++ b/apps/kbve/edge/deno.lock
@@ -1,7 +1,8 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@clickhouse/client-web@1.8.1": "1.8.1"
+    "npm:@clickhouse/client-web@1.8.1": "1.8.1",
+    "npm:@supabase/supabase-js@2.112.1": "2.112.1"
   },
   "npm": {
     "@clickhouse/client-common@1.8.1": {
@@ -12,10 +13,58 @@
       "dependencies": [
         "@clickhouse/client-common"
       ]
+    },
+    "@supabase/auth-js@2.112.1": {
+      "integrity": "sha512-TBacB69YXSYYFFet9ISgNC2jsPExFPIWngmzeLHAWrp/xvKWfYIyhh0nyvDLryi8WP6KoexkXO9kRF6Y9oBUTA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.112.1": {
+      "integrity": "sha512-t5L8qBpRC2ZswHD4A7DNL/sNpFLEeflaYaZVe5dCWvAD82pm2WOysU8EKgiJub3doxo/QU8RuDvYFlRyRk8ghw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.5": {
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
+    },
+    "@supabase/postgrest-js@2.112.1": {
+      "integrity": "sha512-oX42JgoVT8bP73/XYE1+kQdj6/Ql1j6lD6zpCoL8aq1B0uhZsz4FSoT+cBJB3pi4aPZEA0Ntkid6w7uzuAH5jQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.112.1": {
+      "integrity": "sha512-jp5TgXXTb1m2rqF6kiirOhVnvAoFHrjj7ZHOzWRa+SL+Am0BbcMcQr6FyHkJJS1ngw0TAL2DeymfGgKkSanN0A==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.112.1": {
+      "integrity": "sha512-FHKAQTw4KUV9nF3bnOLvZvjB3bkmtl6ltavlJfdJKdabvqMtQQ2iyBliFyp2dSHMCn9qA8c6WoZoRkgV5nxAmg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.112.1": {
+      "integrity": "sha512-KooEPqALZNkQCr1PBhbEImnPm6Ko6TKWiOrj3UxQki74g2KWlXGleQgEudUwRAKZs5U1ilSssO0TpxgVOspihQ==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     }
-  },
-  "redirects": {
-    "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.108.2"
   },
   "remote": {
     "https://deno.land/std@0.168.0/async/abortable.ts": "80b2ac399f142cc528f95a037a7d0e653296352d95c681e284533765961de409",
@@ -105,11 +154,18 @@
     "https://deno.land/x/jose@v4.14.4/util/decode_jwt.ts": "704e28d29feeadfa331259caae66951b5d4c62b0c6ee23c62f70b47db978cd1a",
     "https://deno.land/x/jose@v4.14.4/util/decode_protected_header.ts": "546eac15dd97d267373cb3d8d9a94ad03481f1328c4457560ffde9a5a595ebe8",
     "https://deno.land/x/jose@v4.14.4/util/errors.ts": "107a41f79bd8a226c836080f617809cd148e00112fdadc0e15c3a6079da02f5d",
-    "https://esm.sh/@supabase/supabase-js@2.108.2": "7fbe17c4ef67b80d388cef1f0a0c7ecb28b2b1c3c4110875925a4bc82ff28e13"
-  },
-  "workspace": {
-    "dependencies": [
-      "npm:@clickhouse/client-web@1.8.1"
-    ]
+    "https://deno.land/x/zod@v3.23.8/ZodError.ts": "528da200fbe995157b9ae91498b103c4ef482217a5c086249507ac850bd78f52",
+    "https://deno.land/x/zod@v3.23.8/errors.ts": "5285922d2be9700cc0c70c95e4858952b07ae193aa0224be3cbd5cd5567eabef",
+    "https://deno.land/x/zod@v3.23.8/external.ts": "a6cfbd61e9e097d5f42f8a7ed6f92f93f51ff927d29c9fbaec04f03cbce130fe",
+    "https://deno.land/x/zod@v3.23.8/helpers/enumUtil.ts": "54efc393cc9860e687d8b81ff52e980def00fa67377ad0bf8b3104f8a5bf698c",
+    "https://deno.land/x/zod@v3.23.8/helpers/errorUtil.ts": "7a77328240be7b847af6de9189963bd9f79cab32bbc61502a9db4fe6683e2ea7",
+    "https://deno.land/x/zod@v3.23.8/helpers/parseUtil.ts": "c14814d167cc286972b6e094df88d7d982572a08424b7cd50f862036b6fcaa77",
+    "https://deno.land/x/zod@v3.23.8/helpers/partialUtil.ts": "998c2fe79795257d4d1cf10361e74492f3b7d852f61057c7c08ac0a46488b7e7",
+    "https://deno.land/x/zod@v3.23.8/helpers/typeAliases.ts": "0fda31a063c6736fc3cf9090dd94865c811dfff4f3cb8707b932bf937c6f2c3e",
+    "https://deno.land/x/zod@v3.23.8/helpers/util.ts": "30c273131661ca5dc973f2cfb196fa23caf3a43e224cdde7a683b72e101a31fc",
+    "https://deno.land/x/zod@v3.23.8/index.ts": "d27aabd973613985574bc31f39e45cb5d856aa122ef094a9f38a463b8ef1a268",
+    "https://deno.land/x/zod@v3.23.8/locales/en.ts": "a7a25cd23563ccb5e0eed214d9b31846305ddbcdb9c5c8f508b108943366ab4c",
+    "https://deno.land/x/zod@v3.23.8/mod.ts": "ec6e2b1255c1a350b80188f97bd0a6bac45801bb46fc48f50b9763aa66046039",
+    "https://deno.land/x/zod@v3.23.8/types.ts": "1b172c90782b1eaa837100ebb6abd726d79d6c1ec336350c8e851e0fd706bf5c"
   }
 }

--- a/apps/kbve/edge/functions/_shared/supabase.ts
+++ b/apps/kbve/edge/functions/_shared/supabase.ts
@@ -1,10 +1,11 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2.112.1";
 import {
   createRemoteJWKSet,
   decodeProtectedHeader,
   jwtVerify,
 } from "https://deno.land/x/jose@v4.14.4/index.ts";
 import { corsHeaders } from "./cors.ts";
+import { logError } from "./logging.ts";
 
 // ---------------------------------------------------------------------------
 // Shared Supabase utilities for all edge function modules
@@ -171,7 +172,7 @@ export async function checkStaffPermissions(
   const client = createUserClient(token);
   const { data, error } = await client.rpc("staff_permissions");
   if (error) {
-    console.error("staff_permissions RPC error:", error.message);
+    logError("supabase.staff_permissions", error.message);
     return 0;
   }
   return typeof data === "number" ? data : 0;

--- a/apps/kbve/edge/functions/_shared/validators.ts
+++ b/apps/kbve/edge/functions/_shared/validators.ts
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------
 
 import { jsonResponse } from "./supabase.ts";
+import { logError } from "./logging.ts";
 import {
   ILLEGAL_CHARS_RE,
   MAX_URL_LENGTH,
@@ -149,7 +150,10 @@ export function safeRpcError(
   context: string,
   status = 400,
 ): Response {
-  console.error(`${context}:`, error.message, error.code ?? "", error.hint ?? "");
+  logError(context, error.message, {
+    code: error.code,
+    hint: error.hint,
+  });
   return jsonResponse(
     {
       error: "Operation failed. Please try again or contact support.",

--- a/apps/kbve/edge/functions/discord-bootstrap/index.ts
+++ b/apps/kbve/edge/functions/discord-bootstrap/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { logError, logWarn } from "../_shared/logging.ts";
 import {
   enforceBodySizeLimit,
   requireJsonContentType,
@@ -88,7 +89,7 @@ serve(async (req) => {
     }
     userId = claims.sub;
   } catch (e) {
-    console.error("discord-bootstrap: auth failed:", e);
+    logError("discord-bootstrap.auth", e);
     return jsonResponse({ error: "Authentication failed" }, 401);
   }
 
@@ -124,7 +125,9 @@ serve(async (req) => {
       );
     }
     if (!meRes.ok) {
-      console.error("discord-bootstrap: /users/@me failed:", meRes.status);
+      logError("discord-bootstrap.users_me", "/users/@me failed", {
+        status: meRes.status,
+      });
       return jsonResponse(
         { error: "Failed to verify Discord identity" },
         502,
@@ -139,7 +142,7 @@ serve(async (req) => {
     }
     discordUserId = me.id;
   } catch (e) {
-    console.error("discord-bootstrap: /users/@me threw:", e);
+    logError("discord-bootstrap.users_me", e);
     return jsonResponse({ error: "Failed to call Discord" }, 502);
   }
 
@@ -153,13 +156,11 @@ serve(async (req) => {
       { p_user_id: userId },
     );
     if (error) {
-      console.error(
-        "discord-bootstrap: proxy_service_get_discord_provider_id failed:",
-        error.message,
-        error.code,
-        error.details,
-        error.hint,
-      );
+      logError("discord-bootstrap.get_discord_provider_id", error.message, {
+        code: error.code,
+        details: error.details,
+        hint: error.hint,
+      });
       return jsonResponse(
         {
           error: "Failed to verify linked Discord identity",
@@ -177,10 +178,11 @@ serve(async (req) => {
       );
     }
     if (linkedProviderId !== discordUserId) {
-      console.warn(
-        "discord-bootstrap: provider_id mismatch",
-        { expected: linkedProviderId, got: discordUserId, userId },
-      );
+      logWarn("discord-bootstrap.provider_id_mismatch", {
+        expected: linkedProviderId,
+        got: discordUserId,
+        userId,
+      });
       return jsonResponse(
         {
           error:
@@ -210,10 +212,9 @@ serve(async (req) => {
       );
     }
     if (!gRes.ok) {
-      console.error(
-        "discord-bootstrap: /users/@me/guilds failed:",
-        gRes.status,
-      );
+      logError("discord-bootstrap.users_me_guilds", "/users/@me/guilds failed", {
+        status: gRes.status,
+      });
       return jsonResponse(
         { error: "Failed to fetch Discord guilds" },
         502,
@@ -234,7 +235,7 @@ serve(async (req) => {
       )
       .map((g) => g.id);
   } catch (e) {
-    console.error("discord-bootstrap: /users/@me/guilds threw:", e);
+    logError("discord-bootstrap.users_me_guilds", e);
     return jsonResponse({ error: "Failed to call Discord" }, 502);
   }
 
@@ -250,10 +251,7 @@ serve(async (req) => {
     },
   );
   if (rpcError) {
-    console.error(
-      "discord-bootstrap: service_upsert RPC failed:",
-      rpcError.message,
-    );
+    logError("discord-bootstrap.service_upsert", rpcError.message);
     // SQLSTATE 22023 = validation failure from the RPC; map to 400.
     const status = rpcError.code === "22023" ? 400 : 500;
     return jsonResponse(

--- a/apps/kbve/edge/functions/discord-bot/index.ts
+++ b/apps/kbve/edge/functions/discord-bot/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
 import {
   enforceBodySizeLimit,
   requireJsonContentType,
@@ -32,7 +33,7 @@ async function getBotToken(): Promise<string | null> {
     secret_id: BOT_TOKEN_VAULT_ID,
   });
   if (error) {
-    console.error("discord-bot: vault lookup failed:", error.message);
+    logError("discord-bot.vault_lookup", error.message);
     return null;
   }
   const row = Array.isArray(data) ? data[0] : data;
@@ -133,10 +134,10 @@ async function handleIsMember(serverId: string): Promise<Response> {
       joined_at: (body as { joined_at?: string } | null)?.joined_at ?? null,
     });
   }
-  console.error(
-    "discord-bot: unexpected /members status",
-    { status, body },
-  );
+  logError("discord-bot.members_status", "unexpected /members status", {
+    status,
+    body,
+  });
   return jsonResponse({ error: "Discord API error", status }, 502);
 }
 
@@ -205,10 +206,10 @@ async function handleListForumChannels(serverId: string): Promise<Response> {
     return jsonResponse({ error: "Discord rate limited" }, 429);
   }
   if (status < 200 || status >= 300 || !Array.isArray(body)) {
-    console.error(
-      "discord-bot: unexpected /channels status",
-      { status, body },
-    );
+    logError("discord-bot.channels_status", "unexpected /channels status", {
+      status,
+      body,
+    });
     return jsonResponse({ error: "Discord API error", status }, 502);
   }
   const channels = (body as Array<{
@@ -259,7 +260,7 @@ serve(async (req) => {
     const denied = requireUserToken(claims);
     if (denied) return denied;
   } catch (e) {
-    console.error("discord-bot: auth failed:", e);
+    logError("discord-bot.auth", e);
     return jsonResponse({ error: "Authentication failed" }, 401);
   }
 
@@ -306,7 +307,7 @@ serve(async (req) => {
       );
   }
   } catch (e) {
-    console.error("discord-bot: unhandled error:", e);
+    logError("discord-bot.unhandled", e);
     return jsonResponse({ error: "Internal error" }, 500);
   }
 });

--- a/apps/kbve/edge/functions/gh-admin/index.ts
+++ b/apps/kbve/edge/functions/gh-admin/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
 import {
   enforceBodySizeLimit,
   requireJsonContentType,
@@ -70,10 +71,7 @@ async function fetchGuildSecret(
     p_service: service,
   });
   if (error) {
-    console.error(
-      `gh-admin: vault lookup failed for ${service}:`,
-      error.message,
-    );
+    logError("gh-admin.vault_lookup", error.message, { service });
     return null;
   }
   if (!data || typeof data !== "string") return null;
@@ -104,7 +102,7 @@ function isRepoAllowed(allowlist: string[], owner: string, repo: string) {
 }
 
 async function githubCallback(
-  method: "GET" | "POST" | "DELETE",
+  method: "GET" | "POST" | "PATCH" | "DELETE",
   path: string,
   pat: string,
   body?: unknown,
@@ -257,7 +255,7 @@ async function upsertGuildSecret(
     },
   );
   if (error) {
-    console.error("gh-admin: service_set_guild_token failed", error.message);
+    logError("gh-admin.set_guild_token", error.message);
     return { ok: false, error: error.message };
   }
   const row = (Array.isArray(data) ? data[0] : data) as
@@ -756,10 +754,7 @@ async function handleEventStats(serverId: string): Promise<Response> {
     if (errCode === "GH006") {
       return jsonResponse({ error: error.message }, 413);
     }
-    console.error(
-      "gh-admin: service_get_guild_event_stats failed",
-      error.message,
-    );
+    logError("gh-admin.event_stats", error.message);
     return jsonResponse({ error: "stats lookup failed" }, 500);
   }
   const row = (Array.isArray(data) ? data[0] : data) ?? {};
@@ -794,10 +789,7 @@ async function handleEventFailed(
     if (errCode === "GH006") {
       return jsonResponse({ error: error.message }, 413);
     }
-    console.error(
-      "gh-admin: service_get_recent_failed_events failed",
-      error.message,
-    );
+    logError("gh-admin.event_failed", error.message);
     return jsonResponse({ error: "failed-events lookup failed" }, 500);
   }
   return jsonResponse({ events: Array.isArray(data) ? data : [] });
@@ -831,10 +823,7 @@ async function handleEventPending(
     if (errCode === "GH006") {
       return jsonResponse({ error: error.message }, 413);
     }
-    console.error(
-      "gh-admin: service_get_recent_pending_events failed",
-      error.message,
-    );
+    logError("gh-admin.event_pending", error.message);
     return jsonResponse({ error: "pending-events lookup failed" }, 500);
   }
   return jsonResponse({ events: Array.isArray(data) ? data : [] });
@@ -876,7 +865,7 @@ async function handleEventRequeue(
     if (errCode === "GH006") {
       return jsonResponse({ error: message }, 413);
     }
-    console.error("gh-admin: service_requeue_event failed", message);
+    logError("gh-admin.event_requeue", message);
     return jsonResponse({ error: "requeue failed" }, 500);
   }
   const row = (Array.isArray(data) ? data[0] : data) as
@@ -907,7 +896,7 @@ serve(async (req) => {
     const denied = requireUserToken(claims);
     if (denied) return denied;
   } catch (e) {
-    console.error("gh-admin: auth failed:", e);
+    logError("gh-admin.auth", e);
     return jsonResponse({ error: "Authentication failed" }, 401);
   }
 
@@ -1063,7 +1052,7 @@ serve(async (req) => {
       );
   }
   } catch (e) {
-    console.error("gh-admin: unhandled error:", e);
+    logError("gh-admin.unhandled", e);
     return jsonResponse({ error: "Internal error" }, 500);
   }
 });

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { logError } from "../_shared/logging.ts";
 import {
   createServiceClient,
   extractToken,
@@ -257,7 +258,7 @@ serve(async (req) => {
     { p_server_id: guildId, p_service: VAULT_GITHUB_SERVICE },
   );
   if (tokenErr) {
-    console.error("gh-backfill: vault lookup failed:", tokenErr.message);
+    logError("gh-backfill.vault_lookup", tokenErr.message);
     return jsonResponse({ error: "Failed to resolve GitHub token from vault" }, 500);
   }
   if (!githubToken || typeof githubToken !== "string") {
@@ -295,7 +296,7 @@ serve(async (req) => {
       result = await fetchPage(githubToken, body.owner, body.repo, state, perPage, page);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error("gh-backfill fetch error:", msg);
+      logError("gh-backfill.fetch", msg);
       return jsonResponse({ error: "GitHub fetch failed" }, 502);
     }
 
@@ -326,9 +327,11 @@ serve(async (req) => {
         p_closed_at: issue.closed_at ?? null,
       });
       if (error) {
-        console.error(
-          `gh.upsert_issue failed for ${body.owner}/${body.repo}#${issue.number}: ${error.message}`,
-        );
+        logError("gh-backfill.upsert_issue", error.message, {
+          owner: body.owner,
+          repo: body.repo,
+          number: issue.number,
+        });
         continue;
       }
       upserted++;
@@ -352,7 +355,7 @@ serve(async (req) => {
     200,
   );
   } catch (e) {
-    console.error("gh-backfill: unhandled error:", e);
+    logError("gh-backfill.unhandled", e);
     return jsonResponse({ error: "Internal error" }, 500);
   }
 });

--- a/apps/kbve/edge/functions/gh-webhook/index.ts
+++ b/apps/kbve/edge/functions/gh-webhook/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 import { createServiceClient, jsonResponse } from "../_shared/supabase.ts";
 import { enforceBodySizeLimit } from "../_shared/validators.ts";
+import { logError, logWarn } from "../_shared/logging.ts";
 
 const ALLOWED_EVENTS = new Set([
   "issues",
@@ -81,10 +82,10 @@ async function resolveAllowlist(
       p_service: "github_repos",
     });
     if (error) {
-      console.warn(
-        "gh-webhook: github_repos lookup failed; falling back to env",
-        error.message,
-      );
+      logWarn("gh-webhook.github_repos_lookup", {
+        fallback: "env",
+        error: error.message,
+      });
       return ALLOWED_REPOS;
     }
     if (typeof data !== "string") return ALLOWED_REPOS;
@@ -95,7 +96,10 @@ async function resolveAllowlist(
     if (list.length === 0) return ALLOWED_REPOS;
     return new Set(list.map((r) => r.trim().toLowerCase()));
   } catch (e) {
-    console.warn("gh-webhook: parse error on github_repos; env fallback", e);
+    logWarn("gh-webhook.github_repos_parse", {
+      fallback: "env",
+      error: e instanceof Error ? e.message : String(e),
+    });
     return ALLOWED_REPOS;
   }
 }
@@ -205,24 +209,18 @@ serve(async (req) => {
     { p_server_id: guildId, p_service: VAULT_WEBHOOK_SERVICE },
   );
   if (secretErr) {
-    console.error(
-      "gh-webhook: vault lookup failed",
-      { guild: guildId, error: secretErr.message },
-    );
+    logError("gh-webhook.vault_lookup", secretErr.message, { guild: guildId });
     return jsonResponse({ error: "Failed to resolve webhook secret" }, 500);
   }
   if (!secret || typeof secret !== "string") {
-    console.warn(
-      "gh-webhook: no webhook secret registered for guild",
-      { guild: guildId },
-    );
+    logWarn("gh-webhook.no_webhook_secret", { guild: guildId });
     return jsonResponse({ error: "webhook not configured for guild" }, 404);
   }
 
   const rawBody = await req.text();
 
   if (!(await verifySignature(secret, signature, rawBody))) {
-    console.warn("gh-webhook: signature verification failed", {
+    logWarn("gh-webhook.signature_verification", {
       delivery: deliveryId,
       event: githubEvent,
       guild: guildId,
@@ -288,7 +286,7 @@ serve(async (req) => {
     .schema("gh")
     .rpc("upsert_issue", upsertParams);
   if (upsertErr) {
-    console.error("gh.upsert_issue failed:", upsertErr.message);
+    logError("gh-webhook.upsert_issue", upsertErr.message);
     return jsonResponse({ error: "upsert failed" }, 500);
   }
 
@@ -303,7 +301,7 @@ serve(async (req) => {
     p_github_delivery_id: deliveryId,
   });
   if (eventErr) {
-    console.error("gh.record_event failed:", eventErr.message);
+    logError("gh-webhook.record_event", eventErr.message);
   }
 
   return jsonResponse(

--- a/apps/kbve/edge/functions/guild-vault/_shared.ts
+++ b/apps/kbve/edge/functions/guild-vault/_shared.ts
@@ -9,6 +9,7 @@ export {
 } from "../_shared/supabase.ts";
 
 import { jsonResponse } from "../_shared/supabase.ts";
+import { logError, logWarn } from "../_shared/logging.ts";
 import {
   SERVICE_RE,
   SNOWFLAKE_RE,
@@ -264,10 +265,9 @@ export async function verifyGuildOwnership(
     }
 
     if (res.status === 429) {
-      console.warn(
-        "Discord API rate limited. Retry after:",
-        res.headers.get("retry-after"),
-      );
+      logWarn("guild-vault.discord_rate_limited", {
+        retry_after: res.headers.get("retry-after"),
+      });
       return jsonResponse(
         { error: "Discord API rate limited. Please try again later." },
         429,
@@ -275,7 +275,10 @@ export async function verifyGuildOwnership(
     }
 
     if (!res.ok) {
-      console.error(`Discord API error: ${res.status} ${res.statusText}`);
+      logError("guild-vault.discord_api", "Discord API error", {
+        status: res.status,
+        status_text: res.statusText,
+      });
       return jsonResponse(
         { error: "Failed to verify Discord guild ownership" },
         502,
@@ -298,7 +301,7 @@ export async function verifyGuildOwnership(
 
     return null;
   } catch (err) {
-    console.error("Discord guild ownership verification error:", err);
+    logError("guild-vault.ownership_verification", err);
     return jsonResponse(
       { error: "Failed to verify Discord guild ownership" },
       502,

--- a/apps/kbve/edge/functions/irc/_shared.ts
+++ b/apps/kbve/edge/functions/irc/_shared.ts
@@ -88,8 +88,6 @@ export async function withIrcConnection<T>(
     async read(timeoutMs = IRC_TIMEOUT_MS): Promise<string[]> {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        // Use Deno.conn with a short read timeout
-        conn.setReadDeadline?.(new Date(Math.min(Date.now() + 500, deadline)));
         try {
           const n = await conn.read(buf);
           if (n === null) break;
@@ -113,7 +111,6 @@ export async function withIrcConnection<T>(
       const deadline = Date.now() + timeoutMs;
       const collected: string[] = [];
       while (Date.now() < deadline) {
-        conn.setReadDeadline?.(new Date(Math.min(Date.now() + 500, deadline)));
         try {
           const n = await conn.read(buf);
           if (n === null) break;

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -1,5 +1,5 @@
 /// <reference path="../types.d.ts" />
-import { serve } from "https://deno.land/std@0.131.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import * as jose from "https://deno.land/x/jose@v4.14.4/index.ts";
 import { validateJwtSecret } from "../_shared/env.ts";
 import { logError, logInfo } from "../_shared/logging.ts";
@@ -182,8 +182,18 @@ serve(async (req: Request) => {
     argo: ["ARGOCD_UPSTREAM_URL", "ARGOCD_AUTH_TOKEN"],
     "discord-bootstrap": [],
     "discord-bot": ["DISCORD_BOT_CLIENT_ID"],
-    "gh-admin": [],
+    "gh-admin": ["WEBHOOK_PUBLIC_BASE"],
+    "gh-backfill": ["GH_BACKFILL_DEFAULT_GUILD_ID"],
+    "gh-webhook": ["GH_WEBHOOK_ALLOWED_REPOS"],
     "guild-vault": [],
+    mc: [
+      "MC_RCON_LOBBY_HOST",
+      "MC_RCON_LOBBY_PORT",
+      "MC_RCON_LOBBY_PASSWORD",
+      "MC_RCON_SURVIVAL_HOST",
+      "MC_RCON_SURVIVAL_PORT",
+      "MC_RCON_SURVIVAL_PASSWORD",
+    ],
     "user-vault": [],
     "vault-reader": [],
     meme: [],

--- a/apps/kbve/edge/functions/mc/admin.ts
+++ b/apps/kbve/edge/functions/mc/admin.ts
@@ -59,7 +59,7 @@ async function readRconPacket(
   // Read until we have at least 4 bytes for the length prefix
   let buffer = new Uint8Array(0);
 
-  function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  function concat(a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer> {
     const result = new Uint8Array(a.length + b.length);
     result.set(a);
     result.set(b, a.length);

--- a/apps/kbve/edge/functions/ows/character.ts
+++ b/apps/kbve/edge/functions/ows/character.ts
@@ -6,6 +6,7 @@ import {
   validateUuid,
   type OwsRequest,
 } from "./_shared.ts";
+import { logError } from "../_shared/logging.ts";
 
 export const CHARACTER_ACTIONS = [
   "unstuck",
@@ -115,7 +116,7 @@ async function unstuck(req: OwsRequest): Promise<Response> {
     .eq("characterid", character.characterid);
 
   if (updateErr) {
-    console.error("unstuck update error:", updateErr.message);
+    logError("ows.character.unstuck_update", updateErr.message);
     return jsonResponse({ error: "Failed to update character position" }, 500);
   }
 
@@ -128,7 +129,7 @@ async function unstuck(req: OwsRequest): Promise<Response> {
     .eq("characterid", character.characterid);
 
   if (clearErr) {
-    console.error("unstuck clear map instance error:", clearErr.message);
+    logError("ows.character.unstuck_clear_map_instance", clearErr.message);
   }
 
   return jsonResponse({
@@ -213,7 +214,7 @@ async function resetStats(req: OwsRequest): Promise<Response> {
     .eq("characterid", character.characterid);
 
   if (updateErr) {
-    console.error("reset_stats error:", updateErr.message);
+    logError("ows.character.reset_stats", updateErr.message);
     return jsonResponse({ error: "Failed to reset character stats" }, 500);
   }
 
@@ -335,7 +336,7 @@ async function list(req: OwsRequest): Promise<Response> {
   );
 
   if (charErr) {
-    console.error("list error:", charErr.message);
+    logError("ows.character.list", charErr.message);
     return jsonResponse({ error: "Failed to list characters" }, 500);
   }
 
@@ -442,7 +443,7 @@ async function create(req: OwsRequest): Promise<Response> {
     .single();
 
   if (insertErr || !newChar) {
-    console.error("create character error:", insertErr?.message);
+    logError("ows.character.create", insertErr?.message);
     return jsonResponse({ error: "Failed to create character" }, 500);
   }
 
@@ -468,7 +469,7 @@ async function create(req: OwsRequest): Promise<Response> {
       .insert(customRows);
 
     if (customErr) {
-      console.error("create custom data error:", customErr.message);
+      logError("ows.character.create_custom_data", customErr.message);
       // Non-fatal — character exists, custom data can be added later
     }
   }
@@ -545,7 +546,7 @@ async function remove(req: OwsRequest): Promise<Response> {
     }
     const { count, error } = await query;
     if (error) {
-      console.error(`delete ${table} error:`, error.message);
+      logError("ows.character.delete", error.message, { table });
     }
     deleted[table] = count ?? 0;
   }
@@ -569,7 +570,9 @@ async function remove(req: OwsRequest): Promise<Response> {
       .in("charabilitybarid", barIds);
 
     if (barAbilErr) {
-      console.error("delete charabilitybarabilities error:", barAbilErr.message);
+      logError("ows.character.delete", barAbilErr.message, {
+        table: "charabilitybarabilities",
+      });
     }
     deleted["charabilitybarabilities"] = barAbilCount ?? 0;
   }
@@ -592,7 +595,9 @@ async function remove(req: OwsRequest): Promise<Response> {
       .in("charinventoryid", invIds);
 
     if (invItemErr) {
-      console.error("delete charinventoryitems error:", invItemErr.message);
+      logError("ows.character.delete", invItemErr.message, {
+        table: "charinventoryitems",
+      });
     }
     deleted["charinventoryitems"] = invItemCount ?? 0;
   }
@@ -673,7 +678,7 @@ async function setAdmin(req: OwsRequest): Promise<Response> {
     .eq("characterid", character.characterid);
 
   if (updateErr) {
-    console.error("set_admin error:", updateErr.message);
+    logError("ows.character.set_admin", updateErr.message);
     return jsonResponse({ error: "Failed to update admin flags" }, 500);
   }
 

--- a/apps/kbve/edge/functions/ows/firecracker.ts
+++ b/apps/kbve/edge/functions/ows/firecracker.ts
@@ -1,6 +1,7 @@
 import { jsonResponse } from "../_shared/supabase.ts";
 import { requireServiceRole } from "../_shared/supabase.ts";
 import type { OwsRequest } from "./_shared.ts";
+import { logError } from "../_shared/logging.ts";
 
 // ---------------------------------------------------------------------------
 // Firecracker MicroVM — OWS Admin Submodule
@@ -50,7 +51,7 @@ export async function handleFirecracker(
       try {
         return await fcFetch("/health");
       } catch (err) {
-        console.error("firecracker status error:", err);
+        logError("ows.firecracker.status", err);
         return jsonResponse(
           {
             status: "unreachable",
@@ -87,7 +88,7 @@ export async function handleFirecracker(
           }),
         });
       } catch (err) {
-        console.error("firecracker create error:", err);
+        logError("ows.firecracker.create", err);
         return jsonResponse(
           { error: "Failed to create VM — firecracker-ctl unreachable" },
           503,
@@ -99,7 +100,7 @@ export async function handleFirecracker(
       try {
         return await fcFetch("/vm");
       } catch (err) {
-        console.error("firecracker list error:", err);
+        logError("ows.firecracker.list", err);
         return jsonResponse(
           { error: "Failed to list VMs — firecracker-ctl unreachable" },
           503,
@@ -116,7 +117,7 @@ export async function handleFirecracker(
       try {
         return await fcFetch(`/vm/${vm_id}`, { method: "DELETE" });
       } catch (err) {
-        console.error("firecracker destroy error:", err);
+        logError("ows.firecracker.destroy", err);
         return jsonResponse(
           { error: "Failed to destroy VM — firecracker-ctl unreachable" },
           503,

--- a/apps/kbve/edge/functions/ows/index.ts
+++ b/apps/kbve/edge/functions/ows/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
+import { logError } from "../_shared/logging.ts";
 import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
 import { CHARACTER_ACTIONS, handleCharacter } from "./character.ts";
 import { FIRECRACKER_ACTIONS, handleFirecracker } from "./firecracker.ts";
@@ -94,7 +95,7 @@ serve(async (req) => {
 
     return mod.handler({ token, claims, body, action });
   } catch (err) {
-    console.error("ows error:", err);
+    logError("ows.unhandled", err);
     const rawMessage = err instanceof Error
       ? err.message
       : "Internal server error";

--- a/apps/kbve/edge/functions/ows/maintenance.ts
+++ b/apps/kbve/edge/functions/ows/maintenance.ts
@@ -5,6 +5,7 @@ import {
   validateUuid,
   type OwsRequest,
 } from "./_shared.ts";
+import { logError } from "../_shared/logging.ts";
 
 export const MAINTENANCE_ACTIONS = [
   "cleanup_worldservers",
@@ -58,7 +59,7 @@ async function cleanupWorldServers(req: OwsRequest): Promise<Response> {
     .order("worldserverid", { ascending: true });
 
   if (fetchErr) {
-    console.error("cleanup_worldservers fetch error:", fetchErr.message);
+    logError("ows.maintenance.cleanup_worldservers_fetch", fetchErr.message);
     return jsonResponse({ error: "Failed to fetch world servers" }, 500);
   }
 
@@ -82,7 +83,7 @@ async function cleanupWorldServers(req: OwsRequest): Promise<Response> {
       .in("worldserverid", duplicateIds);
 
     if (delErr) {
-      console.error("cleanup_worldservers delete error:", delErr.message);
+      logError("ows.maintenance.cleanup_worldservers_delete", delErr.message);
       return jsonResponse({ error: "Failed to delete duplicate servers" }, 500);
     }
     deleted = count ?? duplicateIds.length;
@@ -100,7 +101,10 @@ async function cleanupWorldServers(req: OwsRequest): Promise<Response> {
     .eq("worldserverid", keepId);
 
   if (activateErr) {
-    console.error("cleanup_worldservers activate error:", activateErr.message);
+    logError(
+      "ows.maintenance.cleanup_worldservers_activate",
+      activateErr.message,
+    );
   }
 
   return jsonResponse({
@@ -136,7 +140,7 @@ async function cleanupMapInstances(req: OwsRequest): Promise<Response> {
     .lt("lastupdatefromserver", oneHourAgo);
 
   if (delErr) {
-    console.error("cleanup_map_instances error:", delErr.message);
+    logError("ows.maintenance.cleanup_map_instances", delErr.message);
     return jsonResponse({ error: "Failed to clean map instances" }, 500);
   }
 

--- a/apps/kbve/edge/functions/types.d.ts
+++ b/apps/kbve/edge/functions/types.d.ts
@@ -30,27 +30,8 @@ declare namespace EdgeRuntime {
 }
 
 // Module declarations for Deno imports
-declare module "https://deno.land/std@0.131.0/http/server.ts" {
-  export function serve(
-    handler: (request: Request) => Response | Promise<Response>,
-  ): void;
-}
-
 declare module "https://deno.land/std@0.168.0/http/server.ts" {
   export function serve(
     handler: (request: Request) => Response | Promise<Response>,
   ): void;
-}
-
-declare module "https://deno.land/x/jose@v4.14.4/index.ts" {
-  import type { JWTPayload } from "jose";
-  export function jwtVerify(
-    jwt: string,
-    key: Uint8Array,
-    options?: { algorithms?: string[] },
-  ): Promise<{ payload: JWTPayload & Record<string, unknown> }>;
-}
-
-declare module "https://esm.sh/@supabase/supabase-js@2" {
-  export { createClient } from "@supabase/supabase-js";
 }

--- a/apps/kbve/edge/functions/vault-reader/index.ts
+++ b/apps/kbve/edge/functions/vault-reader/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2.112.1";
 import { jwtVerify } from "https://deno.land/x/jose@v4.14.4/index.ts";
 import { corsHeaders, preflight, withCors } from "../_shared/cors.ts";
 import { logError } from "../_shared/logging.ts";

--- a/apps/kbve/edge/project.json
+++ b/apps/kbve/edge/project.json
@@ -114,6 +114,13 @@
 				"parallel": false
 			}
 		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["bash apps/kbve/edge/scripts/check.sh"],
+				"parallel": false
+			}
+		},
 		"e2e": {
 			"executor": "nx:run-commands",
 			"cache": false,

--- a/apps/kbve/edge/scripts/check.sh
+++ b/apps/kbve/edge/scripts/check.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+
+bad=$(perl -ne 'print "$ARGV:$.: $_" if /^\s*(?:import|export)[^"'\''"]*from\s*["'\''](?!\.{1,2}\/|npm:|jsr:|node:|https?:\/\/)/; close ARGV if eof' $(find functions -name "*.ts" ! -name "*.d.ts") || true)
+if [ -n "$bad" ]; then
+  echo "Bare import specifiers found — user workers boot with importMapPath null, so these crash at runtime:"
+  echo "$bad"
+  exit 1
+fi
+
+stubbed=0
+if [ ! -f functions/_shared/manifest.ts ]; then
+  stubbed=1
+  printf 'export const VERSION = "0.0.0";\nexport const FUNCTIONS: { name: string; label: string; description: string }[] = [];\n' \
+    > functions/_shared/manifest.ts
+fi
+trap '[ "$stubbed" = 1 ] && rm -f functions/_shared/manifest.ts' EXIT
+
+for entry in functions/*/index.ts; do
+  deno check "$entry"
+done


### PR DESCRIPTION
Stacked on #15426 (includes its commit; rebases clean once it merges).

## Boot-path hardening
- **Pin `@supabase/supabase-js` to `npm:…@2.112.1`** in `_shared/supabase.ts` + `vault-reader`. Previously `https://esm.sh/@supabase/supabase-js@2` — unpinned major on a third-party CDN, imported by nearly every function. One esm.sh outage (already happened once, 2026-05-08, killed `logs`) would boot-kill the whole fleet.
- **Remove dead `deno.json` imports map** — never copied into the image and workers boot with `importMapPath: null`, so it never applied. Its presence is what caused the `logs` outage fixed in #15426.
- **New `scripts/check.sh` + `edge:check` nx target**: fails on any bare import specifier under `functions/` and runs `deno check` on every entrypoint (stubs the docker-baked `manifest.ts` locally). Recurrence guard.

## FUNCTION_ENV allowlist gaps (silent live breakage)
`main/index.ts` withholds any env not allowlisted per function:
- `mc`: RCON `MC_RCON_{LOBBY,SURVIVAL}_{HOST,PORT,PASSWORD}` were withheld → `getServerConfig` returned null → RCON admin commands silently dead.
- `gh-admin`: `WEBHOOK_PUBLIC_BASE` withheld → fell back to internal `SUPABASE_URL` (Kong :8000) → wrong expected webhook URL in hook list/rotate reconciliation.
- `gh-backfill`: `GH_BACKFILL_DEFAULT_GUILD_ID` withheld — its own 400 message tells operators to set it, but setting it did nothing.
- `gh-webhook`: `GH_WEBHOOK_ALLOWED_REPOS` env fallback withheld (vault path primary).

## Structured logging
All 56 raw `console.*` calls migrated to `_shared/logging.ts` (`logError`/`logWarn`) so Vector → ClickHouse gets single-line JSON instead of unparseable multi-arg output. Dot-scoped contexts (`gh-webhook.upsert_issue`, `ows.character.create`, …), postgrest `code`/`hint` moved into fields.

## Latent bugs surfaced by real types
The esm.sh/jose type shims in `types.d.ts` were masking type checking; removing them surfaced:
- `gh-admin`: `githubCallback` method union missing `"PATCH"` (used by hook-secret rotate).
- `irc`: `conn.setReadDeadline?.()` — API that has never existed in Deno; always a no-op. Deleted (no behavior change).
- `mc`: `Uint8Array<ArrayBuffer>` generic in RCON packet reader.
- `main`: std unified 0.131.0 → 0.168.0.

## Version
Edge MDX 0.1.48 → 0.1.49 (post-publish atom PR syncs version.toml + manifests).

Deliberately NOT included: rate-limit expansion to the 9 uncovered functions (client-visible behavior change — separate discussion).