### PR TITLE
feat(desktop-kbve): unified VoiceEngine + spoken agent feedback loop

### DIFF
--- a/apps/kbve/desktop-kbve/src-tauri/src/agent_voice.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/agent_voice.rs
@@ -1,0 +1,73 @@
+//! Spoken feedback for DevOps agent activity.
+//!
+//! Routes announcement text through the `VoiceEngine`: into the connected
+//! Discord voice channel when the bot is in one, otherwise onto the local
+//! output device. Disabled by default; toggled from the DevOps view.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use log::{info, warn};
+use tauri::{AppHandle, Emitter};
+
+use crate::discord::DiscordManager;
+use crate::voice::VoiceEngine;
+
+pub struct AgentVoiceManager {
+    app_handle: AppHandle,
+    voice: Arc<dyn VoiceEngine>,
+    discord: Arc<DiscordManager>,
+    enabled: AtomicBool,
+}
+
+impl AgentVoiceManager {
+    pub fn new(
+        app_handle: &AppHandle,
+        voice: Arc<dyn VoiceEngine>,
+        discord: Arc<DiscordManager>,
+    ) -> Self {
+        Self {
+            app_handle: app_handle.clone(),
+            voice,
+            discord,
+            enabled: AtomicBool::new(false),
+        }
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::SeqCst);
+        info!("Agent voice announcements enabled: {}", enabled);
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    /// Speak an announcement. No-op unless enabled; falls back from Discord
+    /// voice to local playback; never fails the caller's workflow.
+    pub fn announce(&self, text: &str) {
+        if !self.is_enabled() {
+            return;
+        }
+        let _ = self.app_handle.emit("agent-voice-announcement", text);
+        if !self.voice.tts_ready() {
+            warn!("Agent voice announcement skipped, TTS model not loaded");
+            return;
+        }
+        let in_voice = self.discord.status().in_voice;
+        if in_voice {
+            match self.voice.synthesize(text) {
+                Ok(audio) => {
+                    if let Err(e) = self.discord.play_audio(&audio.base64, audio.sample_rate) {
+                        warn!("Agent voice Discord playback failed: {}", e);
+                    }
+                    return;
+                }
+                Err(e) => warn!("Agent voice synthesis failed: {}", e),
+            }
+        }
+        if let Err(e) = self.voice.speak_local(text, 1.0) {
+            warn!("Agent voice local playback failed: {}", e);
+        }
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/agent_voice.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/agent_voice.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::agent_voice::AgentVoiceManager;
+
+#[tauri::command]
+#[specta::specta]
+pub fn agent_voice_set_enabled(
+    enabled: bool,
+    manager: State<'_, Arc<AgentVoiceManager>>,
+) -> Result<(), String> {
+    manager.set_enabled(enabled);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn agent_voice_is_enabled(manager: State<'_, Arc<AgentVoiceManager>>) -> bool {
+    manager.is_enabled()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn agent_voice_announce(
+    text: String,
+    manager: State<'_, Arc<AgentVoiceManager>>,
+) -> Result<(), String> {
+    manager.announce(&text);
+    Ok(())
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_voice;
 pub mod audio;
 pub mod devops;
 pub mod discord;

--- a/apps/kbve/desktop-kbve/src-tauri/src/discord_conversation.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/discord_conversation.rs
@@ -567,13 +567,16 @@ async fn process_transcription_result(
         return Ok(());
     }
 
-    // Process with LLM
     let _ = app_handle.emit("discord-conversation-state", "thinking");
 
-    // Set the current user for memory association
-    onichan_manager.set_current_user(Some(user_id.to_string()));
-
-    let response = onichan_manager.process_input(text.to_string()).await?;
+    // Spoken DevOps queries short-circuit the LLM; everything else goes to Onichan
+    let response = if let Some(command) = crate::voice_commands::parse(&text) {
+        crate::voice_commands::execute(command)
+    } else {
+        // Set the current user for memory association
+        onichan_manager.set_current_user(Some(user_id.to_string()));
+        onichan_manager.process_input(text.to_string()).await?
+    };
 
     info!("LLM response for {}: {}", user_id, response);
 

--- a/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod agent_voice;
 pub mod audio_feedback;
 pub mod audio_toolkit;
 pub mod auth;
@@ -26,6 +27,8 @@ pub mod tray_i18n;
 pub mod utils;
 pub mod vad_model;
 mod views;
+pub mod voice;
+pub mod voice_commands;
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -221,6 +224,10 @@ fn specta_builder() -> Builder<tauri::Wry> {
         // onichan: sidecar quick-config
         commands::sidecar_config::get_sidecar_quick_config,
         commands::sidecar_config::set_sidecar_quick_config_field,
+        // agent voice: spoken devops feedback
+        commands::agent_voice::agent_voice_set_enabled,
+        commands::agent_voice::agent_voice_is_enabled,
+        commands::agent_voice::agent_voice_announce,
         // discord: voice bot + conversation
         commands::discord::discord_has_token,
         commands::discord::discord_get_token,
@@ -536,6 +543,18 @@ pub fn run() {
                 ));
             discord_conversation_manager.set_memory_manager(memory_manager.clone());
 
+            // Unified voice engine + spoken agent feedback.
+            let voice_engine: Arc<dyn voice::VoiceEngine> =
+                Arc::new(voice::PairedVoiceEngine::new(
+                    transcription_manager.clone(),
+                    local_tts_manager.clone(),
+                ));
+            let agent_voice_manager = Arc::new(agent_voice::AgentVoiceManager::new(
+                &dict_handle,
+                voice_engine.clone(),
+                discord_manager.clone(),
+            ));
+
             app.manage(onichan_manager);
             app.manage(onichan_model_manager);
             app.manage(local_llm_manager);
@@ -544,6 +563,8 @@ pub fn run() {
             app.manage(onichan_conversation_manager);
             app.manage(discord_manager);
             app.manage(discord_conversation_manager);
+            app.manage(voice_engine);
+            app.manage(agent_voice_manager);
 
             // System tray reflecting recording state (idle/recording/transcribing).
             let initial_theme = tray::get_current_theme(&dict_handle);

--- a/apps/kbve/desktop-kbve/src-tauri/src/voice.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/voice.rs
@@ -1,0 +1,70 @@
+//! Unified voice interface over the STT and TTS engines.
+//!
+//! Everything that talks (agent announcements, Discord replies) or listens
+//! (voice commands) should go through `VoiceEngine` rather than the concrete
+//! managers, so a future duplex speech model (single model doing both
+//! directions) can replace `PairedVoiceEngine` without touching callers.
+
+use std::sync::Arc;
+
+use crate::local_tts::LocalTtsManager;
+use crate::managers::transcription::TranscriptionManager;
+
+/// Synthesized speech: base64-encoded 16-bit PCM mono samples + sample rate.
+pub struct SynthesizedAudio {
+    pub base64: String,
+    pub sample_rate: u32,
+}
+
+pub trait VoiceEngine: Send + Sync {
+    /// Transcribe 16 kHz mono f32 samples to text.
+    fn transcribe(&self, samples: Vec<f32>) -> Result<String, String>;
+
+    /// Synthesize text to audio for streaming (e.g. into Discord voice).
+    fn synthesize(&self, text: &str) -> Result<SynthesizedAudio, String>;
+
+    /// Speak text on the local output device.
+    fn speak_local(&self, text: &str, volume: f32) -> Result<(), String>;
+
+    fn stt_ready(&self) -> bool;
+    fn tts_ready(&self) -> bool;
+}
+
+/// Today's implementation: separate STT (whisper/parakeet, in-process) and
+/// TTS (piper sidecar) models behind the one interface.
+pub struct PairedVoiceEngine {
+    stt: Arc<TranscriptionManager>,
+    tts: Arc<LocalTtsManager>,
+}
+
+impl PairedVoiceEngine {
+    pub fn new(stt: Arc<TranscriptionManager>, tts: Arc<LocalTtsManager>) -> Self {
+        Self { stt, tts }
+    }
+}
+
+impl VoiceEngine for PairedVoiceEngine {
+    fn transcribe(&self, samples: Vec<f32>) -> Result<String, String> {
+        self.stt.transcribe(samples).map_err(|e| e.to_string())
+    }
+
+    fn synthesize(&self, text: &str) -> Result<SynthesizedAudio, String> {
+        let (base64, sample_rate) = self.tts.synthesize(text)?;
+        Ok(SynthesizedAudio {
+            base64,
+            sample_rate,
+        })
+    }
+
+    fn speak_local(&self, text: &str, volume: f32) -> Result<(), String> {
+        self.tts.speak(text, volume)
+    }
+
+    fn stt_ready(&self) -> bool {
+        true
+    }
+
+    fn tts_ready(&self) -> bool {
+        self.tts.is_loaded()
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/voice_commands.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/voice_commands.rs
@@ -1,0 +1,74 @@
+//! Spoken DevOps queries.
+//!
+//! Deterministic keyword matching over Discord voice transcripts. Read-only
+//! operations only — anything that mutates state (spawn, kill, merge) stays
+//! behind the UI.
+
+use crate::devops::orchestrator;
+use crate::devops::tmux;
+
+pub enum VoiceCommand {
+    AgentStatus,
+    SessionStatus,
+}
+
+/// Match a transcript against the known spoken commands.
+pub fn parse(text: &str) -> Option<VoiceCommand> {
+    let t = text.to_lowercase();
+    let mentions = |words: &[&str]| words.iter().any(|w| t.contains(w));
+    if mentions(&[
+        "agent status",
+        "agent report",
+        "list agents",
+        "list the agents",
+    ]) {
+        return Some(VoiceCommand::AgentStatus);
+    }
+    if mentions(&["session status", "list sessions", "list the sessions"]) {
+        return Some(VoiceCommand::SessionStatus);
+    }
+    None
+}
+
+/// Execute a voice command and return the sentence to speak back.
+pub fn execute(command: VoiceCommand) -> String {
+    match command {
+        VoiceCommand::AgentStatus => match orchestrator::list_agent_statuses() {
+            Ok(agents) if agents.is_empty() => "No coding agents are running.".to_string(),
+            Ok(agents) => {
+                let mut parts: Vec<String> = Vec::new();
+                for agent in agents.iter().take(5) {
+                    let issue = agent
+                        .issue_ref
+                        .clone()
+                        .unwrap_or_else(|| "no issue".to_string());
+                    parts.push(format!("{} working on {}", agent.agent_type, issue));
+                }
+                let mut summary = format!(
+                    "{} agent{} running: {}.",
+                    agents.len(),
+                    if agents.len() == 1 { "" } else { "s" },
+                    parts.join(", ")
+                );
+                if agents.len() > 5 {
+                    summary.push_str(" And more.");
+                }
+                summary
+            }
+            Err(e) => format!("I could not list the agents: {}", e),
+        },
+        VoiceCommand::SessionStatus => match tmux::list_sessions() {
+            Ok(sessions) if sessions.is_empty() => "No tmux sessions are running.".to_string(),
+            Ok(sessions) => {
+                let names: Vec<String> = sessions.iter().take(8).map(|s| s.name.clone()).collect();
+                format!(
+                    "{} session{}: {}.",
+                    sessions.len(),
+                    if sessions.len() == 1 { "" } else { "s" },
+                    names.join(", ")
+                )
+            }
+            Err(e) => format!("I could not list the sessions: {}", e),
+        },
+    }
+}

--- a/apps/kbve/desktop-kbve/src/bindings.ts
+++ b/apps/kbve/desktop-kbve/src/bindings.ts
@@ -975,6 +975,35 @@ export const commands = {
 			else return { status: 'error', error: e as any };
 		}
 	},
+	async agentVoiceSetEnabled(
+		enabled: boolean,
+	): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('agent_voice_set_enabled', {
+					enabled,
+				}),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
+	async agentVoiceIsEnabled(): Promise<boolean> {
+		return await TAURI_INVOKE('agent_voice_is_enabled');
+	},
+	async agentVoiceAnnounce(text: string): Promise<Result<null, string>> {
+		try {
+			return {
+				status: 'ok',
+				data: await TAURI_INVOKE('agent_voice_announce', { text }),
+			};
+		} catch (e) {
+			if (e instanceof Error) throw e;
+			else return { status: 'error', error: e as any };
+		}
+	},
 	/**
 	 * Check if a Discord bot token is configured (without returning the actual token)
 	 */

--- a/apps/kbve/desktop-kbve/src/components/settings/devops/IssueQueue.tsx
+++ b/apps/kbve/desktop-kbve/src/components/settings/devops/IssueQueue.tsx
@@ -129,6 +129,11 @@ export const IssueQueue: React.FC<IssueQueueProps> = ({
 				['agent-working'], // Add working label
 				false, // No sandbox
 			);
+			void commands
+				.agentVoiceAnnounce(
+					`Claude agent spawned on issue ${issue.number}`,
+				)
+				.catch(() => {});
 			onAgentSpawned?.();
 			await loadIssues(); // Refresh to show updated labels
 		} catch (err) {

--- a/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
+++ b/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
@@ -388,6 +388,11 @@ export const useDevOpsStore = create<DevOpsStore>()(
 					['needs-review'],
 					false,
 				);
+				void commands
+					.agentVoiceAnnounce(
+						`Pull request created for ${agent.issue_ref}`,
+					)
+					.catch(() => {});
 				await get().refreshAgents(false);
 			} catch (err) {
 				set({

--- a/apps/kbve/desktop-kbve/src/views/devops.tsx
+++ b/apps/kbve/desktop-kbve/src/views/devops.tsx
@@ -1,5 +1,38 @@
+import { useEffect, useState } from 'react';
 import { DevOpsLayout } from '../components/settings/devops/DevOpsLayout';
+import { SettingsCard } from '../components/SettingsCard';
+import { SettingsRow } from '../components/SettingsRow';
+import { ToggleSwitch } from '../components/ToggleSwitch';
+import { commands } from '../bindings';
 
 export function DevOpsView() {
-	return <DevOpsLayout />;
+	const [voiceEnabled, setVoiceEnabled] = useState(false);
+
+	useEffect(() => {
+		void commands
+			.agentVoiceIsEnabled()
+			.then(setVoiceEnabled)
+			.catch(() => {});
+	}, []);
+
+	const toggleVoice = (checked: boolean) => {
+		setVoiceEnabled(checked);
+		void commands.agentVoiceSetEnabled(checked).catch(() => {});
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<SettingsCard title="Agent voice">
+				<SettingsRow
+					label="Voice announcements"
+					description="Speak agent events (spawns, pull requests) into the connected Discord voice channel, or locally when not connected. Requires a loaded TTS model.">
+					<ToggleSwitch
+						checked={voiceEnabled}
+						onChange={toggleVoice}
+					/>
+				</SettingsRow>
+			</SettingsCard>
+			<DevOpsLayout />
+		</div>
+	);
 }


### PR DESCRIPTION
Phase F of the Handy migration: glue between the DevOps pillar (#15458) and the Discord voice pillar (#15459).

## VoiceEngine (`voice.rs`)
One interface over both speech directions — `transcribe`, `synthesize`, `speak_local` — implemented today by `PairedVoiceEngine` (whisper/parakeet STT + piper TTS). A future duplex speech model (single model doing STT and TTS) replaces this one impl without touching callers.

## Spoken agent feedback (`agent_voice.rs`)
`AgentVoiceManager.announce(text)`: synthesizes through the VoiceEngine and plays into the connected Discord voice channel, falling back to the local output device. Off by default; toggled from a new "Agent voice" card in the DevOps view. Frontend fires announcements on agent spawn (IssueQueue) and PR creation (devopsStore.completeAgentWork); also exposed as `agent_voice_announce` for anything else. Emits `agent-voice-announcement` for UI logging.

## Spoken DevOps queries (`voice_commands.rs`)
Deterministic keyword matching in the Discord conversation loop, after the wake-word gate and before the LLM: "agent status" / "list agents" and "session status" / "list sessions" answer from `orchestrator::list_agent_statuses()` / `tmux::list_sessions()` by voice. Read-only only — mutating operations stay behind the UI.

Full loop now: speak in Discord → STT → spawn/monitor Claude Code agents from the DevOps view → agent milestones spoken back into the channel.

`cargo check` clean, tsc/vite/nx test pass.