### PR TITLE
feat(desktop-kbve): persist agent voice, backend announce hooks, unit + e2e tests

### DIFF
--- a/apps/kbve/desktop-kbve/package.json
+++ b/apps/kbve/desktop-kbve/package.json
@@ -28,6 +28,7 @@
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.1.3",
+		"@testing-library/react": "^16.3.2",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^4.0.0",

--- a/apps/kbve/desktop-kbve/pnpm-lock.yaml
+++ b/apps/kbve/desktop-kbve/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.3
         version: 4.2.2(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -599,6 +602,28 @@ packages:
   '@tauri-apps/plugin-store@2.4.2':
     resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -651,6 +676,17 @@ packages:
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -688,9 +724,16 @@ packages:
       supports-color:
         optional: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
@@ -844,6 +887,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -891,6 +938,10 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -898,6 +949,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-native-web@0.21.2:
     resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
@@ -1407,6 +1461,29 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -1468,6 +1545,14 @@ snapshots:
 
   '@xterm/xterm@5.5.0': {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   asap@2.0.6: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -1500,7 +1585,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   electron-to-chromium@1.5.321: {}
 
@@ -1640,6 +1729,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1672,6 +1763,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -1680,6 +1777,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-native-web@0.21.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/apps/kbve/desktop-kbve/pnpm-workspace.yaml
+++ b/apps/kbve/desktop-kbve/pnpm-workspace.yaml
@@ -2,5 +2,8 @@ packages:
     - '.'
     - '../../../packages/npm/tauri'
 
+allowBuilds:
+    esbuild: true
+
 onlyBuiltDependencies:
     - esbuild

--- a/apps/kbve/desktop-kbve/src-tauri/src/agent_voice.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/agent_voice.rs
@@ -2,15 +2,17 @@
 //!
 //! Routes announcement text through the `VoiceEngine`: into the connected
 //! Discord voice channel when the bot is in one, otherwise onto the local
-//! output device. Disabled by default; toggled from the DevOps view.
+//! output device. Disabled by default; toggled from the DevOps view and
+//! persisted in settings.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use log::{info, warn};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 use crate::discord::DiscordManager;
+use crate::settings::{get_settings, write_settings};
 use crate::voice::VoiceEngine;
 
 pub struct AgentVoiceManager {
@@ -26,16 +28,20 @@ impl AgentVoiceManager {
         voice: Arc<dyn VoiceEngine>,
         discord: Arc<DiscordManager>,
     ) -> Self {
+        let enabled = get_settings(app_handle).agent_voice_enabled;
         Self {
             app_handle: app_handle.clone(),
             voice,
             discord,
-            enabled: AtomicBool::new(false),
+            enabled: AtomicBool::new(enabled),
         }
     }
 
     pub fn set_enabled(&self, enabled: bool) {
         self.enabled.store(enabled, Ordering::SeqCst);
+        let mut settings = get_settings(&self.app_handle);
+        settings.agent_voice_enabled = enabled;
+        write_settings(&self.app_handle, settings);
         info!("Agent voice announcements enabled: {}", enabled);
     }
 
@@ -43,12 +49,20 @@ impl AgentVoiceManager {
         self.enabled.load(Ordering::SeqCst)
     }
 
-    /// Speak an announcement. No-op unless enabled; falls back from Discord
-    /// voice to local playback; never fails the caller's workflow.
-    pub fn announce(&self, text: &str) {
+    /// Speak an announcement without blocking the caller. No-op unless
+    /// enabled; never fails the caller's workflow.
+    pub fn announce(self: &Arc<Self>, text: &str) {
         if !self.is_enabled() {
             return;
         }
+        let this = self.clone();
+        let text = text.to_string();
+        std::thread::spawn(move || this.announce_blocking(&text));
+    }
+
+    /// Synthesize and play: Discord voice channel when connected, local
+    /// output device otherwise.
+    fn announce_blocking(&self, text: &str) {
         let _ = self.app_handle.emit("agent-voice-announcement", text);
         if !self.voice.tts_ready() {
             warn!("Agent voice announcement skipped, TTS model not loaded");
@@ -69,5 +83,13 @@ impl AgentVoiceManager {
         if let Err(e) = self.voice.speak_local(text, 1.0) {
             warn!("Agent voice local playback failed: {}", e);
         }
+    }
+}
+
+/// Announce via the managed `AgentVoiceManager`, if initialized. For use
+/// inside commands that only have an `AppHandle`.
+pub fn announce_from_app(app: &AppHandle, text: &str) {
+    if let Some(manager) = app.try_state::<Arc<AgentVoiceManager>>() {
+        manager.announce(text);
     }
 }

--- a/apps/kbve/desktop-kbve/src-tauri/src/commands/devops.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/commands/devops.rs
@@ -870,9 +870,15 @@ pub async fn update_epic_progress(
 #[tauri::command]
 #[specta::specta]
 pub async fn spawn_agent_from_issue(
+    app: AppHandle,
     config: crate::devops::operations::SpawnAgentConfig,
 ) -> Result<crate::devops::operations::AgentSpawnResult, String> {
-    crate::devops::operations::spawn_agent_from_issue(config).await
+    let issue_ref = config.issue_ref.clone();
+    let result = crate::devops::operations::spawn_agent_from_issue(config).await;
+    if result.is_ok() {
+        crate::agent_voice::announce_from_app(&app, &format!("Agent spawned on {}", issue_ref));
+    }
+    result
 }
 
 /// Complete agent work by creating a PR
@@ -1103,7 +1109,16 @@ pub async fn on_pipeline_item_complete(
     issue_number: u32,
     update_github: bool,
 ) -> Result<(), String> {
-    crate::devops::orchestration::on_pipeline_item_complete(&app, issue_number, update_github).await
+    let result =
+        crate::devops::orchestration::on_pipeline_item_complete(&app, issue_number, update_github)
+            .await;
+    if result.is_ok() {
+        crate::agent_voice::announce_from_app(
+            &app,
+            &format!("Issue {} completed its pipeline", issue_number),
+        );
+    }
+    result
 }
 
 /// Merge a PR for a sub-issue that's in "Ready" state
@@ -1121,13 +1136,20 @@ pub async fn merge_ready_pr(
     merge_method: Option<String>,
     delete_branch: bool,
 ) -> Result<crate::devops::orchestration::MergeResult, String> {
-    crate::devops::orchestration::merge_ready_pr(
+    let result = crate::devops::orchestration::merge_ready_pr(
         &app,
         issue_number,
         merge_method.as_deref(),
         delete_branch,
     )
-    .await
+    .await;
+    if result.is_ok() {
+        crate::agent_voice::announce_from_app(
+            &app,
+            &format!("Pull request for issue {} merged", issue_number),
+        );
+    }
+    result
 }
 
 /// Process all "Ready" sub-issues for the active Epic

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan_parser.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/operations/plan_parser.rs
@@ -305,10 +305,14 @@ fn extract_phases(markdown: &str) -> Result<Vec<PhaseConfig>, String> {
             in_tasks = false;
             in_files = false;
             in_deps = true;
-            // Check for inline "None"
+            // Inline value: "None" clears, anything else is a single dependency;
+            // no inline value means a list follows.
             let dep_value = trimmed.trim_start_matches("**Dependencies**:").trim();
             if dep_value.eq_ignore_ascii_case("none") {
                 current_deps.clear();
+                in_deps = false;
+            } else if !dep_value.is_empty() {
+                current_deps.push(dep_value.to_string());
                 in_deps = false;
             }
             continue;

--- a/apps/kbve/desktop-kbve/src-tauri/src/settings.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/settings.rs
@@ -329,6 +329,9 @@ pub struct AppSettings {
     // DevOps sandbox mode - run agents in Docker containers
     #[serde(default = "default_sandbox_enabled")]
     pub sandbox_enabled: bool,
+    // Spoken agent feedback (Discord voice or local playback)
+    #[serde(default)]
+    pub agent_voice_enabled: bool,
 }
 
 fn default_model() -> String {
@@ -656,6 +659,7 @@ pub fn get_default_settings() -> AppSettings {
         onichan_silence_threshold: default_onichan_silence_threshold(),
         enabled_agents: default_enabled_agents(),
         sandbox_enabled: default_sandbox_enabled(),
+        agent_voice_enabled: false,
     }
 }
 

--- a/apps/kbve/desktop-kbve/src-tauri/src/voice_commands.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/voice_commands.rs
@@ -72,3 +72,43 @@ pub fn execute(command: VoiceCommand) -> String {
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kind(text: &str) -> Option<&'static str> {
+        parse(text).map(|c| match c {
+            VoiceCommand::AgentStatus => "agents",
+            VoiceCommand::SessionStatus => "sessions",
+        })
+    }
+
+    #[test]
+    fn parses_agent_status_phrases() {
+        assert_eq!(kind("agent status please"), Some("agents"));
+        assert_eq!(kind("Onichan, what's the AGENT REPORT?"), Some("agents"));
+        assert_eq!(kind("hey chan, list agents"), Some("agents"));
+        assert_eq!(kind("could you list the agents"), Some("agents"));
+    }
+
+    #[test]
+    fn parses_session_status_phrases() {
+        assert_eq!(kind("session status"), Some("sessions"));
+        assert_eq!(kind("List Sessions now"), Some("sessions"));
+        assert_eq!(kind("list the sessions for me"), Some("sessions"));
+    }
+
+    #[test]
+    fn ignores_normal_conversation() {
+        assert_eq!(kind("hey onichan how are you today"), None);
+        assert_eq!(kind("tell me about rust lifetimes"), None);
+        assert_eq!(kind("what's on the agenda"), None);
+        assert_eq!(kind(""), None);
+    }
+
+    #[test]
+    fn agent_status_wins_over_session_words() {
+        assert_eq!(kind("agent status and session things"), Some("agents"));
+    }
+}

--- a/apps/kbve/desktop-kbve/src/App.tsx
+++ b/apps/kbve/desktop-kbve/src/App.tsx
@@ -7,6 +7,8 @@ import { getView } from './engine';
 import { useAuthStore } from './stores/auth';
 import { SignIn } from './components/SignIn';
 import { ToastContainer } from './components/common/ToastContainer';
+import { listen } from '@tauri-apps/api/event';
+import { toast } from './stores/toastStore';
 
 export default function App() {
 	const phase = useAuthStore((s) => s.phase);
@@ -14,6 +16,16 @@ export default function App() {
 
 	useEffect(() => {
 		void useAuthStore.getState().init();
+	}, []);
+
+	// Surface spoken agent announcements as toasts too.
+	useEffect(() => {
+		const unlisten = listen<string>('agent-voice-announcement', (event) => {
+			toast.info('Agent voice', event.payload);
+		});
+		return () => {
+			void unlisten.then((fn) => fn());
+		};
 	}, []);
 
 	// Hold the shell back until a stored session has had its chance to restore,

--- a/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-core.ts
+++ b/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-core.ts
@@ -1,4 +1,23 @@
 // Mock for @tauri-apps/api/core — used in tests and CI where Tauri is not available.
-export async function invoke(_cmd: string, _args?: unknown): Promise<unknown> {
-	return undefined;
+// Tests can register a per-command handler to script backend responses and
+// assert on the calls the frontend made.
+
+type InvokeHandler = (cmd: string, args?: unknown) => unknown;
+
+let handler: InvokeHandler = () => undefined;
+
+export const __invokeCalls: Array<{ cmd: string; args?: unknown }> = [];
+
+export function __setInvokeHandler(fn: InvokeHandler): void {
+	handler = fn;
+}
+
+export function __resetInvokeMock(): void {
+	handler = () => undefined;
+	__invokeCalls.length = 0;
+}
+
+export async function invoke(cmd: string, args?: unknown): Promise<unknown> {
+	__invokeCalls.push({ cmd, args });
+	return handler(cmd, args);
 }

--- a/apps/kbve/desktop-kbve/src/bindings.ts
+++ b/apps/kbve/desktop-kbve/src/bindings.ts
@@ -3367,6 +3367,7 @@ export type AppSettings = {
 	onichan_silence_threshold?: number;
 	enabled_agents?: string[];
 	sandbox_enabled?: boolean;
+	agent_voice_enabled?: boolean;
 };
 /**
  * Configuration for assigning an issue to an agent.

--- a/apps/kbve/desktop-kbve/src/i18n/react-i18next.test.ts
+++ b/apps/kbve/desktop-kbve/src/i18n/react-i18next.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { t, useTranslation } from './react-i18next';
+
+describe('react-i18next shim', () => {
+	it('resolves known keys from the EN catalog', () => {
+		expect(t('devops.title')).not.toBe('devops.title');
+	});
+
+	it('falls back to the key for unknown paths', () => {
+		expect(t('no.such.key.anywhere')).toBe('no.such.key.anywhere');
+	});
+
+	it('uses the string default value form', () => {
+		expect(t('no.such.key', 'fallback text')).toBe('fallback text');
+	});
+
+	it('uses defaultValue from the options form', () => {
+		expect(t('no.such.key', { defaultValue: 'opt fallback' })).toBe(
+			'opt fallback',
+		);
+	});
+
+	it('interpolates variables in the 3-argument form', () => {
+		expect(t('no.such.key', '{{count}}s ago', { count: 42 })).toBe(
+			'42s ago',
+		);
+	});
+
+	it('leaves unknown placeholders intact', () => {
+		expect(t('no.such.key', 'hello {{name}}', {})).toBe('hello {{name}}');
+	});
+
+	it('useTranslation returns the same t', () => {
+		const { t: hookT } = useTranslation();
+		expect(hookT('no.such.key', 'x')).toBe('x');
+	});
+});

--- a/apps/kbve/desktop-kbve/src/stores/devopsStore.test.ts
+++ b/apps/kbve/desktop-kbve/src/stores/devopsStore.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+	__setInvokeHandler,
+	__resetInvokeMock,
+	__invokeCalls,
+} from '../__mocks__/tauri-api-core';
+import { useDevOpsStore } from './devopsStore';
+
+const AGENT = {
+	session: 'agent-issue-7',
+	issue_ref: 'kbve/kbve#7',
+	repo: 'kbve/kbve',
+	issue_number: 7,
+	worktree: '/tmp/wt',
+	agent_type: 'claude',
+	machine_id: 'mac-1',
+	started_at: '2026-01-01T00:00:00Z',
+	is_attached: false,
+	is_local: true,
+};
+
+describe('DevOps Store', () => {
+	beforeEach(() => {
+		__resetInvokeMock();
+		useDevOpsStore.setState({
+			agents: [],
+			agentsError: null,
+			agentsLoading: false,
+			sessions: [],
+			recoveredSessions: [],
+			isTmuxRunning: false,
+			sessionsError: null,
+			completingWork: null,
+		});
+	});
+
+	it('setAgentFilterMode updates the filter', () => {
+		useDevOpsStore.getState().setAgentFilterMode('remote');
+		expect(useDevOpsStore.getState().agentFilterMode).toBe('remote');
+	});
+
+	it('refreshAgents stores agents on ok result', async () => {
+		__setInvokeHandler((cmd) => {
+			if (cmd === 'list_agent_statuses') return [AGENT];
+			return undefined;
+		});
+		await useDevOpsStore.getState().refreshAgents();
+		const state = useDevOpsStore.getState();
+		expect(state.agents).toHaveLength(1);
+		expect(state.agents[0].session).toBe('agent-issue-7');
+		expect(state.agentsError).toBeNull();
+	});
+
+	it('refreshAgents surfaces backend errors', async () => {
+		__setInvokeHandler((cmd) => {
+			if (cmd === 'list_agent_statuses') {
+				// Non-Error throw is what the generated bindings turn into
+				// a { status: 'error' } result.
+				throw 'gh not authenticated';
+			}
+			return undefined;
+		});
+		await useDevOpsStore.getState().refreshAgents();
+		expect(useDevOpsStore.getState().agentsError).toBe(
+			'gh not authenticated',
+		);
+	});
+
+	it('refreshSessions clears sessions when tmux is not running', async () => {
+		useDevOpsStore.setState({
+			sessions: [
+				{ name: 'stale', attached: false, status: 'Running' },
+			] as never,
+			isTmuxRunning: true,
+		});
+		__setInvokeHandler((cmd) =>
+			cmd === 'is_tmux_running' ? false : undefined,
+		);
+		await useDevOpsStore.getState().refreshSessions();
+		const state = useDevOpsStore.getState();
+		expect(state.isTmuxRunning).toBe(false);
+		expect(state.sessions).toHaveLength(0);
+	});
+
+	it('completeAgentWork announces the pull request by voice', async () => {
+		__setInvokeHandler((cmd) => {
+			if (cmd === 'list_agent_statuses') return [];
+			return undefined;
+		});
+		await useDevOpsStore
+			.getState()
+			.completeAgentWork(AGENT as never, 'Fix for kbve/kbve#7');
+		const announce = __invokeCalls.find(
+			(c) => c.cmd === 'agent_voice_announce',
+		);
+		expect(announce).toBeDefined();
+		expect(String((announce?.args as { text: string }).text)).toContain(
+			'kbve/kbve#7',
+		);
+	});
+
+	it('completeAgentWork refuses agents without an issue ref', async () => {
+		await useDevOpsStore
+			.getState()
+			.completeAgentWork({ ...AGENT, issue_ref: null } as never, 'title');
+		expect(useDevOpsStore.getState().agentsError).toBe(
+			'Agent has no issue reference',
+		);
+		expect(__invokeCalls).toHaveLength(0);
+	});
+});

--- a/apps/kbve/desktop-kbve/src/stores/toastStore.test.ts
+++ b/apps/kbve/desktop-kbve/src/stores/toastStore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import { useToastStore, toast } from './toastStore';
+
+describe('Toast Store', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('adds a toast with type defaults', () => {
+		const id = toast.success('Done');
+		const toasts = useToastStore.getState().toasts;
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].id).toBe(id);
+		expect(toasts[0].type).toBe('success');
+		expect(toasts[0].duration).toBe(5000);
+	});
+
+	it('auto-dismisses after the duration', () => {
+		toast.info('Heads up');
+		expect(useToastStore.getState().toasts).toHaveLength(1);
+		vi.advanceTimersByTime(6001);
+		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+
+	it('keeps only the newest three toasts', () => {
+		toast.info('one');
+		vi.advanceTimersByTime(1);
+		toast.info('two');
+		vi.advanceTimersByTime(1);
+		toast.info('three');
+		vi.advanceTimersByTime(1);
+		toast.info('four');
+		const titles = useToastStore.getState().toasts.map((t) => t.title);
+		expect(titles).toHaveLength(3);
+		expect(titles).not.toContain('one');
+	});
+
+	it('removes a toast by id and clears all', () => {
+		const id = toast.error('boom');
+		toast.warning('careful');
+		toast.dismiss(id);
+		expect(
+			useToastStore.getState().toasts.find((t) => t.id === id),
+		).toBeUndefined();
+		toast.clear();
+		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+
+	it('persistent toast (duration 0) never auto-dismisses', () => {
+		toast.info('sticky', undefined, 0);
+		vi.advanceTimersByTime(60_000);
+		expect(useToastStore.getState().toasts).toHaveLength(1);
+	});
+});

--- a/apps/kbve/desktop-kbve/src/stores/toastStore.ts
+++ b/apps/kbve/desktop-kbve/src/stores/toastStore.ts
@@ -39,10 +39,10 @@ export const useToastStore = create<ToastStore>((set) => ({
 			toast.duration ?? DURATION_BY_TYPE[toast.type] ?? DEFAULT_DURATION;
 
 		const newToast: Toast = {
+			...toast,
 			id,
 			createdAt: Date.now(),
 			duration,
-			...toast,
 		};
 
 		set((state) => {

--- a/apps/kbve/desktop-kbve/src/views/devops.e2e.test.tsx
+++ b/apps/kbve/desktop-kbve/src/views/devops.e2e.test.tsx
@@ -1,0 +1,100 @@
+// End-to-end style test: renders the real DevOps view through the real
+// generated bindings, with only the Tauri invoke boundary scripted.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import {
+	__setInvokeHandler,
+	__resetInvokeMock,
+	__invokeCalls,
+} from '../__mocks__/tauri-api-core';
+import { DevOpsView } from './devops';
+
+// Handlers return the RAW invoke payload; the generated bindings wrap it
+// into { status: 'ok', data } and turn non-Error throws into
+// { status: 'error', error }.
+function scriptBackend(overrides: Record<string, unknown> = {}) {
+	__setInvokeHandler((cmd) => {
+		if (cmd in overrides) return overrides[cmd];
+		switch (cmd) {
+			case 'agent_voice_is_enabled':
+				return false;
+			case 'agent_voice_set_enabled':
+			case 'agent_voice_announce':
+				return null;
+			case 'check_devops_dependencies':
+				return {
+					gh: {
+						installed: true,
+						version: '2.0',
+						authenticated: true,
+					},
+					tmux: { installed: true, version: '3.4' },
+					docker: { installed: false, version: null },
+				};
+			case 'get_enabled_agents':
+				return ['claude'];
+			case 'get_sandbox_enabled':
+				return false;
+			case 'check_claude_auth_volume':
+				return false;
+			case 'is_tmux_running':
+				return false;
+			case 'list_agent_statuses':
+			case 'list_tmux_sessions':
+			case 'recover_tmux_sessions':
+			case 'list_pipeline_items':
+				return [];
+			case 'get_active_epic_state':
+				return null;
+			case 'get_current_machine_id':
+				return 'test-machine';
+			default:
+				// Anything unscripted exercises the components' error paths.
+				throw `unscripted: ${cmd}`;
+		}
+	});
+}
+
+describe('DevOps view (e2e-style)', () => {
+	beforeEach(() => {
+		__resetInvokeMock();
+		scriptBackend();
+	});
+
+	it('renders the voice announcements card and the devops layout', async () => {
+		render(<DevOpsView />);
+		expect(screen.getByText('Voice announcements')).toBeDefined();
+		await waitFor(() => {
+			expect(
+				__invokeCalls.some((c) => c.cmd === 'agent_voice_is_enabled'),
+			).toBe(true);
+		});
+	});
+
+	it('toggling voice announcements calls the backend', async () => {
+		const { container } = render(<DevOpsView />);
+		const toggle = container.querySelector('button');
+		expect(toggle).not.toBeNull();
+		fireEvent.click(toggle as HTMLButtonElement);
+		await waitFor(() => {
+			const call = __invokeCalls.find(
+				(c) => c.cmd === 'agent_voice_set_enabled',
+			);
+			expect(call).toBeDefined();
+			expect((call?.args as { enabled: boolean }).enabled).toBe(true);
+		});
+	});
+
+	it('reflects a backend-enabled toggle on mount', async () => {
+		__resetInvokeMock();
+		scriptBackend({ agent_voice_is_enabled: true });
+		render(<DevOpsView />);
+		await waitFor(() => {
+			expect(
+				__invokeCalls.some((c) => c.cmd === 'agent_voice_is_enabled'),
+			).toBe(true);
+		});
+	});
+});

--- a/apps/kbve/desktop-kbve/vitest.config.ts
+++ b/apps/kbve/desktop-kbve/vitest.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
 				__dirname,
 				'src/__mocks__/tauri-api-event.ts',
 			),
+			'react-i18next': path.resolve(
+				__dirname,
+				'src/i18n/react-i18next.ts',
+			),
+			'@': path.resolve(__dirname, 'src'),
 		},
 	},
 });


### PR DESCRIPTION
Follow-up to #15461: deeper wiring plus real test coverage for the voice/devops stack.

## Wiring
- `agent_voice_enabled` persisted in settings (serde default false); AgentVoiceManager restores it on boot and writes on toggle.
- `announce()` no longer blocks callers — synthesis/playback moved to a background thread; `announce_from_app(&AppHandle, text)` helper for command bodies.
- Backend announce hooks on the epic orchestration path (frontend hooks from #15461 only covered manual UI actions): `spawn_agent_from_issue`, `on_pipeline_item_complete`, `merge_ready_pr`.
- `agent-voice-announcement` events now surface as toasts in the app shell.

## Fixes found by the new tests
- `plan_parser`: inline `**Dependencies**: Phase 1 complete` was silently dropped (only list form and "None" handled) — ported test from Handy failed; parser fixed.
- `toastStore`: spread order clobbered the computed per-type duration with `undefined`, killing the progress bar; fixed.
- App-level `pnpm-workspace.yaml` gets a valid `allowBuilds: esbuild: true` so pnpm 11 stops injecting its broken placeholder template and vitest's dep verification passes.

## Tests (75 passing, was 61 backend / 47 frontend)
- Rust: `voice_commands::parse` coverage (phrase matching, negatives, precedence). Full `cargo test` now green — the devops-port PRs only ran `cargo check`.
- Vitest units: i18n shim (lookup/fallback/both defaultValue forms/interpolation), toastStore (defaults, auto-dismiss, max-visible, persistent), devopsStore (filter, refresh ok/error, tmux-down clearing, voice announce on PR completion, no-issue guard).
- E2E-style: `devops.e2e.test.tsx` renders the real DevOps view through the real generated bindings with only the Tauri `invoke` boundary scripted (upgraded mock supports per-test handlers + call assertions). Verifies voice toggle round-trip against the backend contract. Note: true webdriver e2e via tauri-driver is Linux/Windows only — jsdom-through-bindings is the deepest cut available on macOS.

`cargo test` 62/62, vitest 75/75, tsc clean, vite build passes.