### PR TITLE
fix(axum-kbve): 301 /services to /service/

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -101,6 +101,8 @@ const PERMANENT_REDIRECTS: &[(&str, &str)] = &[
     ("/profile/market/", "/dashboard/market/"),
     ("/dashboard/rows", "/dashboard/gameops/rows/"),
     ("/dashboard/rows/", "/dashboard/gameops/rows/"),
+    ("/services", "/service/"),
+    ("/services/", "/service/"),
 ];
 
 async fn lang_strip_root() -> Redirect {


### PR DESCRIPTION
Adds `/services` and `/services/` to the `PERMANENT_REDIRECTS` table in `transport/https.rs`, both pointing at `/service/` (https://kbve.com/service/).

No version bump: `api.mdx` is at 1.0.277 with version.toml at 1.0.276 — a publish is already in flight, this rides it.

Verified: `cargo test -p axum-kbve permanent_redirect` (table uniqueness + trailing-slash tests) green; no conflicting `/services` route elsewhere in the router.