### PR TITLE
feat(astro-kbve): rail item icons, bento the last arcade sections, arcade SEO

### DIFF
--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeFeatureBoard.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeFeatureBoard.astro
@@ -1,0 +1,54 @@
+---
+import { iconMarkup } from '../icons/Icon';
+import type { IconName } from '../icons/Icon';
+
+export interface FeatureItem {
+	title: string;
+	icon: IconName;
+	/** Rendered as HTML so entries can carry inline links. */
+	body: string;
+	/** Optional bullet list rendered under the body. */
+	list?: string[];
+}
+
+export interface Props {
+	items: FeatureItem[];
+	columns?: 2 | 3;
+}
+
+const { items, columns = 2 } = Astro.props;
+---
+
+<div class:list={['bento-board', `bento-board--cols-${columns}`]}>
+	{
+		items.map((item) => (
+			<div class="bento-cell bento-featurecard">
+				<h3 class="bento-featurecard__title">{item.title}</h3>
+				<span
+					class="bento-icon-tile"
+					set:html={iconMarkup(item.icon, { size: 18 })}
+				/>
+				<div class="bento-featurecard__body">
+					<p set:html={item.body} />
+					{item.list && (
+						<ul class="bento-list">
+							{item.list.map((li) => (
+								<li set:html={li} />
+							))}
+						</ul>
+					)}
+				</div>
+			</div>
+		))
+	}
+</div>
+
+<style>
+	.bento-featurecard__body p {
+		margin: 0;
+	}
+
+	.bento-featurecard__body :global(a) {
+		color: var(--bento-accent, var(--sl-color-text-accent));
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeJsonLd.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeJsonLd.astro
@@ -1,0 +1,70 @@
+---
+import { ARCADE_GAMES } from './arcadeGames';
+
+const SITE = 'https://kbve.com';
+const HUB = `${SITE}/arcade/`;
+
+/**
+ * Catalog structured data for the hub. Each playable title is a VideoGame
+ * node; `soon` entries are omitted because they have no page to land on and
+ * an ItemList pointing at anchors dilutes the collection.
+ */
+const playable = ARCADE_GAMES.filter(
+	(game) => game.status !== 'soon' && game.href !== '/arcade/',
+);
+
+const itemList = {
+	'@context': 'https://schema.org',
+	'@type': 'ItemList',
+	name: 'KBVE Arcade games',
+	description:
+		'Browser games built by KBVE — card games, tactics, tower defense, action RPGs and an endless runner, all playable without an install.',
+	url: HUB,
+	numberOfItems: playable.length,
+	itemListElement: playable.map((game, i) => ({
+		'@type': 'ListItem',
+		position: i + 1,
+		item: {
+			'@type': 'VideoGame',
+			name: game.title,
+			url: `${SITE}${game.href}`,
+			description: game.description,
+			genre: game.tags,
+			applicationCategory: 'Game',
+			gamePlatform: 'Web browser',
+			operatingSystem: 'Any',
+			playMode: 'SinglePlayer',
+			isAccessibleForFree: true,
+			publisher: { '@type': 'Organization', name: 'KBVE', url: SITE },
+			offers: {
+				'@type': 'Offer',
+				price: '0',
+				priceCurrency: 'USD',
+				availability: 'https://schema.org/InStock',
+			},
+		},
+	})),
+};
+
+const collection = {
+	'@context': 'https://schema.org',
+	'@type': 'CollectionPage',
+	name: 'KBVE Arcade',
+	url: HUB,
+	description:
+		'Free browser games from KBVE — no install, no account. Blackjack, roguelite Klondike, turn-based tactics, tower defense, a WebGL action RPG, a WebGPU isometric prototype and an endless runner.',
+	isPartOf: { '@type': 'WebSite', name: 'KBVE', url: SITE },
+	about: { '@type': 'Thing', name: 'Browser games' },
+};
+---
+
+<script
+	type="application/ld+json"
+	is:inline
+	set:html={JSON.stringify(collection)}
+/>
+<script
+	type="application/ld+json"
+	is:inline
+	set:html={JSON.stringify(itemList)}
+/>

--- a/apps/kbve/astro-kbve/src/components/arcade/arcadeGames.ts
+++ b/apps/kbve/astro-kbve/src/components/arcade/arcadeGames.ts
@@ -2,6 +2,8 @@ export type ArcadeStatus = 'live' | 'beta' | 'soon';
 
 export interface ArcadeGame {
 	slug: string;
+	/** Registry glyph used by the section rail (see @kbve/rn/icons). */
+	navIcon: string;
 	title: string;
 	href: string;
 	description: string;
@@ -24,6 +26,7 @@ export const ARCADE_STATUS_LABEL: Record<ArcadeStatus, string> = {
 export const ARCADE_GAMES: ArcadeGame[] = [
 	{
 		slug: 'tactics',
+		navIcon: 'kanban',
 		title: 'Frontline Grid',
 		href: '/arcade/tactics/',
 		description:
@@ -35,6 +38,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'blackjack',
+		navIcon: 'gem',
 		title: 'Blackjack',
 		href: '/arcade/blackjack/',
 		description:
@@ -46,6 +50,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'solitaire',
+		navIcon: 'layers',
 		title: 'Solitaire',
 		href: '/arcade/solitaire/',
 		description:
@@ -57,6 +62,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'towerdefense',
+		navIcon: 'shield',
 		title: 'Tower Defense',
 		href: '/arcade/towerdefense/',
 		description:
@@ -68,6 +74,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'runner',
+		navIcon: 'zap',
 		title: 'Endless Runner',
 		href: '/arcade/runner/',
 		description:
@@ -79,6 +86,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'arpg',
+		navIcon: 'gamepad',
 		title: 'ARPG',
 		href: '/arcade/arpg/',
 		description:
@@ -90,6 +98,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'rareicon',
+		navIcon: 'sparkles',
 		title: 'RareIcon (WebGL)',
 		href: '/arcade/rareicon/',
 		description:
@@ -101,6 +110,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'isometric',
+		navIcon: 'cube',
 		title: 'Isometric',
 		href: '/arcade/isometric/',
 		description:
@@ -112,6 +122,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'ruffle',
+		navIcon: 'play',
 		title: 'Ruffle Flash player',
 		href: '/arcade/',
 		description:
@@ -123,6 +134,7 @@ export const ARCADE_GAMES: ArcadeGame[] = [
 	},
 	{
 		slug: 'more',
+		navIcon: 'star',
 		title: 'More first-party titles',
 		href: '/arcade/',
 		description:

--- a/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
+++ b/apps/kbve/astro-kbve/src/components/arcade/arcadeNav.ts
@@ -36,6 +36,7 @@ export const buildArcadeNav = (): DashboardNavGroup[] =>
 		).map<DashboardNavItem>((game) => ({
 			label: game.title,
 			href: game.href,
+			icon: game.navIcon,
 			copy: game.description,
 		}));
 		if (!items.length) return [];

--- a/apps/kbve/astro-kbve/src/components/dashboard/starlightNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/starlightNav.ts
@@ -114,12 +114,14 @@ const isNavGroup = (entry: DashboardNavEntry): entry is DashboardNavGroup =>
 const toStarlightLink = (
 	item: DashboardNavItem,
 	pathname: string,
-): StarlightLink => ({
-	type: 'link',
-	label: item.label,
-	href: item.href,
-	isCurrent: normalize(item.href) === normalize(pathname),
-});
+): StarlightLink =>
+	({
+		type: 'link',
+		label: item.label,
+		href: item.href,
+		icon: item.icon,
+		isCurrent: normalize(item.href) === normalize(pathname),
+	}) as StarlightLink;
 
 /**
  * Map a hand-authored nav module onto Starlight's sidebar shape so the route

--- a/apps/kbve/astro-kbve/src/components/navigation/KbveSidebarSublist.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/KbveSidebarSublist.astro
@@ -2,6 +2,7 @@
 import KbveSidebarSublist from './KbveSidebarSublist.astro';
 import { sidebarIconForLabel } from './sidebarIcons';
 import { iconMarkup } from '../icons/Icon';
+import type { IconName } from '../icons/Icon';
 import { ICONS } from '@kbve/rn/icons';
 
 interface Props {
@@ -17,6 +18,21 @@ const slugify = (label: string) =>
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, '-')
 		.replace(/^-+|-+$/g, '');
+
+/**
+ * Nav modules predate the shared icon registry, so `icon` is either a registry
+ * name or a raw SVG path `d` (DASHBOARD_NAV and friends still use paths).
+ * Feeding a path to `iconMarkup` throws, so resolve the form first.
+ */
+const iconFor = (icon: string | undefined): string | null => {
+	if (!icon) return null;
+	if (icon in ICONS)
+		return iconMarkup(icon as IconName, { strokeWidth: 1.6 });
+	if (/^[Mm][\s\d.,-]/.test(icon)) {
+		return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="${icon}" /></svg>`;
+	}
+	return null;
+};
 
 const firstHref = (entry: any): string | null => {
 	if (entry?.type === 'link') return entry.href ?? null;
@@ -39,6 +55,12 @@ const firstHref = (entry: any): string | null => {
 							data-kbve-link
 							aria-current={entry.isCurrent ? 'page' : undefined}
 							{...entry.attrs}>
+							{iconFor(entry.icon) && (
+								<span
+									data-kbve-item-icon
+									set:html={iconFor(entry.icon)}
+								/>
+							)}
 							<span data-kbve-label>{entry.label}</span>
 							{entry.badge && (
 								<span
@@ -61,7 +83,7 @@ const firstHref = (entry: any): string | null => {
 			const glyph = !entry.icon
 				? sidebarIconForLabel(entry.label)
 				: entry.icon in ICONS
-					? iconMarkup(entry.icon, { strokeWidth: 1.6 })
+					? iconFor(entry.icon)
 					: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="${entry.icon}" /></svg>`;
 			return (
 				<li data-kbve-item>

--- a/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
@@ -1,8 +1,9 @@
 ---
 title: Arcade
 description: |
-    KBVE Arcade — the home for our in-browser games. Card games, action
-    RPGs, endless runners, and (soon) classic Flash titles via Ruffle.
+    Play free browser games from KBVE — blackjack, roguelite Klondike
+    solitaire, turn-based tactics, tower defense, a WebGL action RPG and an
+    endless runner. No install, no account, no paywall.
 template: splash
 tableOfContents: false
 unsplash: 1688413399498-e35ed74b554f
@@ -16,13 +17,56 @@ tags:
     - browser-games
     - flash
     - ruffle
+    - free-games
+    - html5-games
+    - webgl
+ogTitle: 'KBVE Arcade — free browser games, no install'
+ogDescription: |
+    Eight browser games built in-house: blackjack, roguelite Klondike, turn-based
+    tactics, tower defense, a WebGL action RPG, a WebGPU isometric prototype and
+    an endless runner. Free, no account required.
+twitterTitle: 'KBVE Arcade — free browser games, no install'
+twitterDescription: |
+    Eight browser games built in-house. Free, no account, playable on desktop
+    and touch.
+jsonld:
+    breadcrumb:
+        - name: Home
+          path: /
+        - name: Gaming
+          path: /gaming/
+        - name: Arcade
+          path: /arcade/
+    faq:
+        - question: Are the KBVE Arcade games free?
+          answer: |
+              Yes. Every game is free to play with no account and no install.
+              Ads support the site; nothing is paywalled.
+        - question: Do the games work on mobile?
+          answer: |
+              Yes. Drag, tap and gesture support are first-class, and the canvas
+              scales to the screen. Landscape gives the same view as desktop.
+        - question: What do I need to install to play?
+          answer: |
+              Nothing. Every title runs in the browser via WebAssembly, WebGL or
+              WebGPU — no plugin, no download, no Adobe runtime.
+        - question: Which games are available right now?
+          answer: |
+              Frontline Grid, Blackjack, Solitaire, Tower Defense and Endless
+              Runner are live. ARPG, RareIcon and the isometric prototype are in
+              beta, and a Ruffle-based Flash player is in progress.
+        - question: Is the arcade open source?
+          answer: |
+              Most of it, yes. The games live in the public KBVE monorepo at
+              github.com/KBVE/kbve, and issues or pull requests are welcome.
 editUrl: false
 lastUpdated: false
 prev: false
 next: false
 ---
 
-import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
+import ArcadeFeatureBoard from '@/components/arcade/ArcadeFeatureBoard.astro';
+import ArcadeJsonLd from '@/components/arcade/ArcadeJsonLd.astro';
 import BentoShell from '@/components/hero/BentoShell.astro';
 import {
 	ArcadeHero,
@@ -36,6 +80,8 @@ import {
 } from '@/components/arcade/arcadeGames';
 
 import Adsense from '@/components/ads/Adsense.astro';
+
+<ArcadeJsonLd />
 
 <ArcadeTooltipController client:only="react" />
 
@@ -80,51 +126,67 @@ fan-favorite classics and grow from there.
 	{ARCADE_UPCOMING.map((game) => <ArcadeGameCard {...game} />)}
 </ArcadeGameGrid>
 
-<CardGrid>
-	<Card title="Mobile-friendly" icon="seti:lock">
-		Every game we ship plays on touch — drag, tap, and gesture support are
-		first-class. Rotate your phone to landscape and the same canvas you play
-		on desktop fits the screen.
-	</Card>
-	<Card title="Open source" icon="github">
-		Most of the arcade lives in the public KBVE monorepo. PRs and bug
-		reports welcome — see
-		[github.com/KBVE/kbve](https://github.com/KBVE/kbve).
-	</Card>
-</CardGrid>
+<ArcadeFeatureBoard
+	items={[
+		{
+			title: 'Mobile-friendly',
+			icon: 'gamepad',
+			body: 'Every game we ship plays on touch — drag, tap, and gesture support are first-class. Rotate your phone to landscape and the same canvas you play on desktop fits the screen.',
+		},
+		{
+			title: 'Open source',
+			icon: 'gitFork',
+			body: 'Most of the arcade lives in the public KBVE monorepo. PRs and bug reports welcome — see <a href="https://github.com/KBVE/kbve">github.com/KBVE/kbve</a>.',
+		},
+	]}
+/>
 
 </BentoShell>
 
 <BentoShell id="built" eyebrow="Under the hood" heading="How it's built">
 
-The arcade is part of [kbve.com](https://kbve.com), a static Astro
-Starlight site. Each game embeds via a `client:only` React island so
-the heavy runtime (Phaser, Bevy/WASM, R3F) is only fetched when you
-actually open the game's page — the rest of the site stays light.
+<ArcadeFeatureBoard
+	columns={3}
+	items={[
+		{
+			title: 'Static Astro site',
+			icon: 'zap',
+			body: 'The arcade is part of <a href="https://kbve.com">kbve.com</a>, a static Astro Starlight site. Every page ships prerendered HTML.',
+		},
+		{
+			title: 'Islands per game',
+			icon: 'layers',
+			body: 'Each game embeds via a <code>client:only</code> island, so the heavy runtime — Phaser, Bevy/WASM, R3F — is only fetched when you open that game. First load pulls the bundle once; later visits reuse it.',
+		},
+		{
+			title: 'Controls cheatsheet',
+			icon: 'terminal',
+			body: 'Patterns shared across the arcade:',
+			list: [
+				'<strong>Drag</strong> with mouse or finger to move cards and units.',
+				'<strong>Tap / double-click</strong> a card to send it home.',
+				'<strong>Click stock / deck</strong> to draw.',
+				'<strong>Theater</strong> and <strong>Fullscreen</strong> buttons sit up top.',
+				'Shortcuts where applicable: <code>N</code> new game, <code>Z</code> undo.',
+			],
+		},
+	]}
+/>
 
-<Aside type="tip" title="Performance">
-	First-load on a brand-new game page kicks off a one-time bundle download.
-	Subsequent navigations inside the arcade share cached assets and feel
-	near-instant.
-</Aside>
-
-### Controls cheatsheet
-
-A few common patterns across the arcade:
-
-- **Drag** with the mouse or finger to move cards / units.
-- **Tap / double-click** a card to send it home (e.g. solitaire
-  foundation).
-- **Click stock / deck** to draw.
-- Most pages support a **Theater** button (focus mode) and a
-  **Fullscreen** button up top.
-- Keyboard shortcuts where applicable: `N` = new game, `Z` = undo.
-
-<Aside type="note" title="Spot a bug?">
-	The arcade is under active development — if a game misbehaves, please [open
-	an issue](https://github.com/KBVE/kbve/issues) with the title and your
-	browser/device. We move fast on player feedback.
-</Aside>
+<ArcadeFeatureBoard
+	items={[
+		{
+			title: 'Spot a bug?',
+			icon: 'warn',
+			body: 'The arcade is under active development. If a game misbehaves, <a href="https://github.com/KBVE/kbve/issues">open an issue</a> with the title and your browser or device — we move fast on player feedback.',
+		},
+		{
+			title: 'Free to play',
+			icon: 'sparkles',
+			body: 'No account, no install, no paywall. Ads keep the lights on; everything else is on the house.',
+		},
+	]}
+/>
 
 </BentoShell>
 

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -1240,6 +1240,33 @@ body:has([data-kbve-section])
 	[data-kbve-link][aria-current='page'] [data-kbve-label] {
 		color: var(--sl-color-accent-high);
 	}
+	/* Leaf-row glyph: smaller and unboxed, so it reads as a marker beside the
+	   label rather than competing with the group tiles. */
+	[data-kbve-item-icon] {
+		flex: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1rem;
+		height: 1rem;
+		color: var(--sl-color-gray-4);
+	}
+
+	[data-kbve-item-icon] svg {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	[data-kbve-link]:hover [data-kbve-item-icon],
+	[data-kbve-link][aria-current='page'] [data-kbve-item-icon] {
+		color: var(--sl-color-accent-high);
+	}
+
+	[data-kbve-rail='collapsed'] [data-kbve-item-icon] {
+		display: none;
+	}
+
 	[data-kbve-label] {
 		flex: 1 1 auto;
 		min-width: 0;


### PR DESCRIPTION
Three items off the `/arcade/` review.

## 1. Rail icons

Icons only ever rendered on group headers, so the eight games sat as bare text — that is what "not displaying proper icons" was.

- `arcadeGames` gains a `navIcon` per title from the shared registry in `@kbve/rn/icons` (`kanban`, `gem`, `layers`, `shield`, `zap`, `gamepad`, `sparkles`, `cube`)
- leaf glyphs render at 1rem, unboxed, so they read as markers instead of competing with the group tiles, and hide when the rail collapses

`KbveSidebarSublist` now resolves **either** form of `icon`: a registry key, or the raw SVG path `d` that `DASHBOARD_NAV` and the older section navs still carry. That guard is load-bearing — passing a path into `iconMarkup` indexes `ICONS` with it and throws on `.map`:

```
[ERROR] TypeError: Cannot read properties of undefined (reading 'map')
    at iconMarkup … at KbveSidebarSublist
[build] Caught error rendering /dashboard/market/
```

Side benefit: the dashboard rail's 27 path-form item icons now render too, where before they were dropped.

## 2. Last non-bento sections on the hub

The `Mobile-friendly` / `Open source` `CardGrid` and the entire "How it's built" block — two `<Aside>`s, an `###` heading and a markdown list — are replaced by a new `ArcadeFeatureBoard` composing `.bento-board` / `.bento-featurecard` / `.bento-icon-tile` / `.bento-list`.

The Starlight `Aside` and `CardGrid` imports are gone from the page, so the hub is bento end to end.

## 3. SEO

- `ArcadeJsonLd.astro` emits `CollectionPage` + an `ItemList` of `VideoGame` nodes generated from `ARCADE_GAMES` — genre from tags, `gamePlatform`, `isAccessibleForFree` and a zero-price `Offer` each. Follows the existing `MCItemJsonLd` house pattern.
- description rewritten to lead with what people actually search ("free browser games", the titles) rather than the internal framing; `ogTitle`/`ogDescription`/`twitterTitle`/`twitterDescription` overrides; `free-games`, `html5-games`, `webgl` tags
- `jsonld.breadcrumb` (Home › Gaming › Arcade) and a five-entry `jsonld.faq`, which `Head.astro` turns into a `FAQPage`

## Verified

Full build: astro exit **0**, zero `[ERROR]` lines, **7567 pages**, 83 top-level output dirs. The three JSON-LD blocks parse:

```
#1 @graph: Organization, WebSite, WebPage, BreadcrumbList, FAQPage
   breadcrumb: Home > Gaming > Arcade
   faq: 5 questions
#2 CollectionPage
#3 ItemList  items=8  first=Frontline Grid  genre=["Tactics","Strategy","React"]
```

`/arcade/`, `/stock/`, `/dashboard/`, `/dashboard/market/`, `/npcdb/` and `/journal/05-10/` all 200. Screenshotted the rail and the converted sections.

## Not from this branch

`dev` already pins the content column to a 4rem strip and lets the expanded rail overlay it:

```css
@media (min-width: 50rem) {
  :root:has(body [data-kbve-section]) { --sl-content-inline-start: 4rem; }
}
```

Measured on `/arcade/`: sidebar 300px, content padding 64px. Since the rail defaults to expanded, a first-time visitor at 1440px has the hero's left ~236px sitting under it. Flagging rather than changing — it is a deliberate layout decision, but the default state currently hides content.