### PR TITLE
fix(astro-kbve): correct OSRS chart hover mapping on wide layouts

### DIFF
--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSCharts.tsx
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSCharts.tsx
@@ -285,8 +285,17 @@ function formatTime(timestamp: number, timeRange: TimeRangeOption): string {
 }
 
 interface TooltipData {
+	/** Anchor in viewBox user units, for marks drawn inside the SVG. */
 	x: number;
 	y: number;
+	/** Same anchor in CSS pixels relative to the chart container, for the
+	 * absolutely-positioned tooltip. The two differ whenever the rendered
+	 * element is not exactly `width` x `height` CSS pixels, which is almost
+	 * always — the SVG is width:100% inside a fixed-height box. */
+	clientX: number;
+	clientY: number;
+	/** Rendered width of the SVG box in CSS pixels, for clamping. */
+	boxWidth: number;
 	point: TimeSeriesPoint;
 	index: number;
 }
@@ -439,7 +448,24 @@ function LineChart({
 
 			const svg = e.currentTarget;
 			const rect = svg.getBoundingClientRect();
-			const x = ((e.clientX - rect.left) / rect.width) * width;
+
+			// The viewBox does NOT map linearly onto the element box. With the
+			// default preserveAspectRatio (xMidYMid meet) the drawing is scaled
+			// uniformly and centred, so once the box aspect diverges from
+			// width:height the content is letterboxed and a naive
+			// (clientX - rect.left) / rect.width mapping picks up an offset
+			// that grows toward the edges. getScreenCTM() carries the real
+			// transform, so inverting it is exact under any aspect ratio.
+			const ctm = svg.getScreenCTM();
+			let x: number;
+			if (ctm) {
+				const pt = new DOMPoint(e.clientX, e.clientY).matrixTransform(
+					ctm.inverse(),
+				);
+				x = pt.x;
+			} else {
+				x = ((e.clientX - rect.left) / rect.width) * width;
+			}
 
 			// Find closest data point
 			const targetTime =
@@ -466,9 +492,25 @@ function LineChart({
 						? yScale(closest.avgLowPrice)
 						: height / 2;
 
+			// Project the anchor back into CSS pixels so the tooltip, which is
+			// a sibling DOM node rather than an SVG child, lands on the point
+			// it describes instead of at raw viewBox coordinates.
+			let clientX = (pointX / width) * rect.width;
+			let clientY = (pointY / height) * rect.height;
+			if (ctm) {
+				const screenPt = new DOMPoint(pointX, pointY).matrixTransform(
+					ctm,
+				);
+				clientX = screenPt.x - rect.left;
+				clientY = screenPt.y - rect.top;
+			}
+
 			onHover({
 				x: pointX,
 				y: pointY,
+				clientX,
+				clientY,
+				boxWidth: rect.width,
 				point: closest,
 				index: closestIndex,
 			});
@@ -1001,13 +1043,24 @@ export default function OSRSCharts({
 		fetchData();
 	}, [fetchData]);
 
-	// Calculate tooltip position (keep it inside bounds)
+	// Calculate tooltip position (keep it inside bounds).
+	// Clamped against the measured box rather than the old hardcoded 500,
+	// which was a pixel guess at a 700-unit viewBox and so pinned the tooltip
+	// mid-chart on wide layouts while overflowing narrow ones. Flips to the
+	// left of the cursor when it would otherwise run off the right edge.
 	const tooltipStyle = useMemo(() => {
 		if (!tooltip) return {};
+		// minWidth 150 + 0.75rem padding each side + 1px borders.
+		const TOOLTIP_WIDTH = 176;
+		const GAP = 15;
+		const flip = tooltip.clientX + GAP + TOOLTIP_WIDTH > tooltip.boxWidth;
+		const left = flip
+			? Math.max(tooltip.clientX - GAP - TOOLTIP_WIDTH, 0)
+			: tooltip.clientX + GAP;
 		return {
 			...styles.tooltip,
-			left: Math.min(tooltip.x + 15, 500),
-			top: Math.max(tooltip.y - 100, 10),
+			left,
+			top: Math.max(tooltip.clientY - 100, 10),
 		};
 	}, [tooltip]);
 


### PR DESCRIPTION
Reported on https://kbve.com/osrs/blue-wizard-hat-g/ — the price history graph doesn't scale right and hovering shifts.

## Cause

`OSRSCharts.tsx` renders the SVG with `viewBox="0 0 700 280"` and the **default** `preserveAspectRatio` (`xMidYMid meet`), inside a container that is `width: 100%` with a fixed `height: 320px`. So the drawing is scaled uniformly and centred, and the viewBox does not span the element box.

Hover mapping assumed it did:

```js
const rect = svg.getBoundingClientRect();
const x = ((e.clientX - rect.left) / rect.width) * width;
```

That is only correct while the box aspect matches 700:280. Measured across widths at the fixed 320px height:

```
box  700x320   letterbox=0px     max hover error   0.0 units
box  800x320   letterbox=0px     max hover error   0.0 units
box 1000x320   letterbox=100px   max hover error  70.0 units (10.0% of chart)
box 1200x320   letterbox=200px   max hover error 116.7 units (16.7% of chart)
```

Past 800px the content letterboxes horizontally and the mapping gains an offset that is **zero at the centre and grows toward the edges** — hence "shifts at a certain point" rather than a uniform offset. Under 800px there is no horizontal letterbox, which is why this never appeared on mobile.

## Fix

**Hover** inverts `getScreenCTM()`, which carries the actual transform and stays exact under any `preserveAspectRatio` or container size, with the previous arithmetic kept as a fallback when no CTM is available.

**Tooltip** was a second, compounding bug. It is a sibling DOM node rather than an SVG child, so it consumed viewBox units directly as CSS pixels:

```js
left: Math.min(tooltip.x + 15, 500),
top:  Math.max(tooltip.y - 100, 10),
```

`tooltip.x` ranges 0–700 in viewBox units while `left` is CSS pixels in a `width:100%` container, so the tooltip drifted from its own data point by an amount that scaled with container width. The hardcoded `500` was a pixel guess at a 700-unit coordinate — it pinned the tooltip mid-chart on wide layouts and overflowed narrow ones.

The anchor is now projected back into container-relative pixels through the same CTM and clamped against the measured box, flipping to the left of the cursor near the right edge instead of running off it.

## Scope

Hover and tooltip positioning only. The `meet` letterboxing itself is left alone — it preserves the chart's aspect ratio, and switching to `preserveAspectRatio="none"` would stretch strokes and axis labels non-uniformly. `VolumeChart` shares the viewBox pattern but has no hover handler, so it is unaffected.

## Verification

The error model above was computed directly from the `meet` scaling rule, and it reproduces the reported symptom: correct in the middle of the chart, increasingly wrong toward the edges, desktop only.

**Not verified in a browser** — the worktree has no `node_modules` and the main-tree copy needed for a dev server was blocked. CI is the gate. Worth checking on preview at a wide viewport (>800px chart width) that the crosshair follows the cursor at both edges and the tooltip sits beside the point it describes.

## Related

- #15295 sitemap chain · #15297 homepage entity clarity · #15298 baked GE prices · #15319 related-items link guard · #15331 generator collapse guard