### PR TITLE
fix(reel): disable VPN port forwarding again — observe-mode still wipes peers

### DIFF
--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -44,11 +44,7 @@ spec:
                       - { name: WIREGUARD_MTU, value: '1320' }
                       - { name: SERVER_COUNTRIES, value: 'Germany' }
                       - { name: SERVER_CITIES, value: 'Frankfurt' }
-                      - { name: VPN_PORT_FORWARDING, value: 'on' }
-                      - {
-                            name: VPN_PORT_FORWARDING_STATUS_FILE,
-                            value: '/tmp/gluetun/forwarded_port',
-                        }
+                      - { name: VPN_PORT_FORWARDING, value: 'off' }
                   volumeMounts:
                       - { name: gluetun-run, mountPath: /tmp/gluetun }
                 - name: reel
@@ -70,11 +66,6 @@ spec:
                         }
                       - { name: REEL_LOG_JSON, value: 'true' }
                       - { name: REEL_ENCODE_THREADS, value: '16' }
-                      - {
-                            name: REEL_BT_PORT_FILE,
-                            value: '/tmp/gluetun/forwarded_port',
-                        }
-                      - { name: REEL_BT_PORT_WATCH_RESTART, value: 'false' }
                   envFrom:
                       - secretRef: { name: reel-api }
                   ports:

--- a/apps/kube/reel/manifest/reel.yaml
+++ b/apps/kube/reel/manifest/reel.yaml
@@ -44,6 +44,9 @@ spec:
                       - { name: WIREGUARD_MTU, value: '1320' }
                       - { name: SERVER_COUNTRIES, value: 'Germany' }
                       - { name: SERVER_CITIES, value: 'Frankfurt' }
+                      # Stays 'off' — Proton rotates the NAT-PMP port every
+                      # 45-90s and gluetun's renewal rebuilds iptables, wiping
+                      # every peer. Enabled and reverted 3x; see ../README.md.
                       - { name: VPN_PORT_FORWARDING, value: 'off' }
                   volumeMounts:
                       - { name: gluetun-run, mountPath: /tmp/gluetun }


### PR DESCRIPTION
## Problem (live, today)

Streaming a 7GB leech stalled hard at 2.5GB: download burst at ~100Mbps for ~60s, then flatlined at 0 with ~110 peers stuck `connecting` and `peers_live` decaying — the live-HLS encoder starved and the stream froze.

gluetun logs show `[port forwarding] starting` + firewall rebuild every 45–90s. That's the #14871/#14883 ProtonVPN NAT-PMP sawtooth: each renewal rebuilds iptables → flushes conntrack → wipes every live peer. A download only survives inside a single renewal window.

## Cause

#15075 re-enabled `VPN_PORT_FORWARDING` in "observe mode" (count rotations, never restart reel). Observation assumed the harm came from reel reacting to rotation — but the wipe is gluetun's own firewall rebuild, present regardless. Counter verdict: **3750 rotations at ~47/hour**, still rotating on every renewal on the pinned Frankfurt exit.

## Fix (kube-only, no version bump)

- `VPN_PORT_FORWARDING: 'off'` explicit (wins over the sealed `reel-gluetun` env)
- drop `VPN_PORT_FORWARDING_STATUS_FILE` + `REEL_BT_PORT_FILE` + `REEL_BT_PORT_WATCH_RESTART` — reel binds its random outbound port immediately, no port-file wait
- Frankfurt pin kept for stable exit

Same end-state as #14883, which remains the settled answer until a provider with a static forwarded port. Docs: [reel](https://kbve.com/project/reel/)