### PR TITLE
fix(reel): report the real stream failure and stop reconnect flicker

### DIFF
--- a/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
+++ b/apps/kbve/astro-kbve/src/components/media/AstroReelPlayer.astro
@@ -105,6 +105,27 @@ import ReactReelDiagnostics from '@/components/media/ReactReelDiagnostics';
 		font-size: 0.875rem;
 	}
 
+	:global(.reel-player__badge) {
+		position: absolute;
+		top: 0.75rem;
+		left: 0.75rem;
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		max-width: min(90%, 32rem);
+		padding: 0.35rem 0.6rem;
+		border-radius: 0.4rem;
+		background: rgba(17, 24, 39, 0.82);
+		color: #e5e7eb;
+		font-size: 0.8125rem;
+		line-height: 1.3;
+		pointer-events: none;
+	}
+
+	:global(.reel-player__badge--warn) {
+		color: #fbbf24;
+	}
+
 	:global(.reel-player__meta) {
 		color: #9ca3af;
 		font-size: 0.8125rem;

--- a/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
+++ b/apps/kbve/astro-kbve/src/components/media/ReactReelPlayer.tsx
@@ -90,6 +90,11 @@ export default function ReactReelPlayer() {
 		state === 'reconnecting';
 	const playing = state === 'raw' || state === 'hls';
 	const reconnecting = state === 'reconnecting';
+	// Reconnects keep the video on screen: swapping in a full-stage overlay for
+	// every retry is what made a flapping stream flicker. The badge reports what
+	// is happening without tearing the picture down.
+	const overlay = !playing && !reconnecting;
+	const badge = playing || reconnecting ? status?.message : null;
 
 	return (
 		<div className={`reel-player${theater ? ' reel-player--theater' : ''}`}>
@@ -110,20 +115,24 @@ export default function ReactReelPlayer() {
 						{theater ? '✕ Exit' : '⛶ Theater'}
 					</button>
 				)}
-				{!playing && (
+				{badge && (
+					<div
+						className={`reel-player__badge${reconnecting ? ' reel-player__badge--warn' : ''}`}>
+						<span>{badge}</span>
+						{reconnecting && status?.attempt && status?.max ? (
+							<span>{`· ${status.attempt}/${status.max}`}</span>
+						) : null}
+					</div>
+				)}
+				{overlay && (
 					<div className="reel-player__overlay">
 						<p>{STATE_LABEL[state] ?? state}</p>
 						{name && <p className="reel-player__meta">{name}</p>}
-						{reconnecting && (
-							<p className="reel-player__meta">
-								{status?.message ?? 'Stream interrupted'}
-								{status?.attempt && status?.max
-									? ` · attempt ${status.attempt}/${status.max}`
-									: ''}
-							</p>
-						)}
 						{state === 'error' && error && (
 							<p className="reel-player__error">{error}</p>
+						)}
+						{state !== 'error' && status?.message && (
+							<p className="reel-player__meta">{status.message}</p>
 						)}
 						{!selectedId && (
 							<p className="reel-player__meta">

--- a/apps/kbve/astro-kbve/src/components/media/reelService.ts
+++ b/apps/kbve/astro-kbve/src/components/media/reelService.ts
@@ -153,14 +153,33 @@ const MAX_POLLS = 25;
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 5000;
 const MAX_RESURRECTS = 30;
+// Reconnects that never reach playback, counted inside one window: a stream
+// that flaps this fast is broken at the source, not recovering.
+const MAX_THRASH = 4;
+const RESURRECT_WINDOW_MS = 60000;
 
 let mediaTokenCache: { token: string; expiresAtMs: number } | null = null;
 
-async function mediaToken(force = false): Promise<string | null> {
+// Why a token could not be minted. Only a real 401/403 means the viewer isn't
+// signed in — every other failure (proxy 502, reel restart, offline) used to be
+// reported as "sign in to watch", which sent signed-in users chasing an auth
+// problem that didn't exist.
+export interface MediaTokenResult {
+	token: string | null;
+	code: ReelStreamErrorCode;
+	message: string;
+}
+
+async function mediaToken(force = false): Promise<MediaTokenResult> {
+	const ok = (token: string): MediaTokenResult => ({
+		token,
+		code: 'unknown',
+		message: '',
+	});
 	const dev = import.meta.env.PUBLIC_REEL_TOKEN as string | undefined;
-	if (dev) return dev;
+	if (dev) return ok(dev);
 	if (!force && mediaTokenCache && mediaTokenCache.expiresAtMs > Date.now()) {
-		return mediaTokenCache.token;
+		return ok(mediaTokenCache.token);
 	}
 	try {
 		const res = await authedApiFetch<{ token: string; exp: number }>(
@@ -170,10 +189,30 @@ async function mediaToken(force = false): Promise<string | null> {
 			token: res.token,
 			expiresAtMs: Date.now() + Math.max(0, res.exp - 30) * 1000,
 		};
-		return res.token;
-	} catch {
+		return ok(res.token);
+	} catch (e) {
+		const status = e instanceof ApiError ? e.status : 0;
+		if (status === 401 || status === 403) {
+			mediaTokenCache = null;
+			return {
+				token: null,
+				code: 'sign-in',
+				message: 'sign in to watch',
+			};
+		}
+		// Transient: keep a still-valid cached token so playback survives a
+		// blip instead of tearing down over a failed refresh.
+		if (mediaTokenCache && mediaTokenCache.expiresAtMs > Date.now()) {
+			return ok(mediaTokenCache.token);
+		}
 		mediaTokenCache = null;
-		return null;
+		return {
+			token: null,
+			code: 'network',
+			message: status
+				? `reel access service returned ${status} — retrying`
+				: 'cannot reach the reel access service — retrying',
+		};
 	}
 }
 
@@ -389,6 +428,8 @@ export class ReelPlayer {
 	private recover: (() => void) | null = null;
 	private lastPos = 0;
 	private resurrects = 0;
+	private thrash = 0;
+	private lastResurrectAt = 0;
 	private currentId: string | null = null;
 
 	private emit(
@@ -420,6 +461,8 @@ export class ReelPlayer {
 		const gen = ++this.generation;
 		this.teardown();
 		this.resurrects = 0;
+		this.thrash = 0;
+		this.lastResurrectAt = 0;
 		this.currentId = id;
 		this.video = video;
 		$reelError.set(null);
@@ -428,12 +471,13 @@ export class ReelPlayer {
 		$reelState.set('loading');
 		this.emit('loading', 'Loading…');
 
-		const token = await mediaToken();
+		const minted = await mediaToken();
 		if (this.generation !== gen) return;
-		if (!token) {
-			this.fail('sign in to watch', 'sign-in');
+		if (!minted.token) {
+			this.fail(minted.message, minted.code);
 			return;
 		}
+		const token = minted.token;
 
 		try {
 			const detail = await authedApiFetch<ReelDetail>(
@@ -727,8 +771,8 @@ export class ReelPlayer {
 			if (this.tokenTimer) clearInterval(this.tokenTimer);
 			this.tokenTimer = setInterval(() => {
 				if (this.generation !== gen) return;
-				void mediaToken().then((t) => {
-					if (t && this.generation === gen) liveToken = t;
+				void mediaToken().then((r) => {
+					if (r.token && this.generation === gen) liveToken = r.token;
 				});
 			}, 60000);
 			// Recovery ladder: don't fail on the first fatal error. Resume loading
@@ -754,6 +798,7 @@ export class ReelPlayer {
 				mediaRetries = 0;
 				starveRetries = 0;
 				this.resurrects = 0;
+				this.thrash = 0;
 			});
 			hls.on(Hls.Events.ERROR, (_evt, data) => {
 				if (!data.fatal) return;
@@ -779,9 +824,9 @@ export class ReelPlayer {
 							? 'token-expired'
 							: 'network';
 						if (netRetries++ < MAX_RECOVER) {
-							void mediaToken(true).then((t) => {
+							void mediaToken(true).then((r) => {
 								if (this.generation !== gen) return;
-								if (t) liveToken = t;
+								if (r.token) liveToken = r.token;
 								setTimeout(() => {
 									if (this.generation === gen) hls.startLoad();
 								}, 1000);
@@ -917,6 +962,11 @@ export class ReelPlayer {
 		this.teardown();
 	}
 
+	// A reconnect that never buffers a fragment is a loop, not a recovery: each
+	// cycle tears the media element down and rebuilds it, which the viewer sees
+	// as flicker. Reconnect attempts that produce no playback back off, and a
+	// burst of them inside one short window stops with the server's own reason
+	// rather than flapping until the attempt budget runs out.
 	private async resurrect(
 		video: HTMLVideoElement,
 		id: string,
@@ -925,8 +975,20 @@ export class ReelPlayer {
 		reason: string,
 	): Promise<void> {
 		if (this.generation !== gen) return;
+		const now = Date.now();
+		if (now - this.lastResurrectAt > RESURRECT_WINDOW_MS) this.thrash = 0;
+		this.lastResurrectAt = now;
+		if (++this.thrash > MAX_THRASH) {
+			const why = await this.streamFailureReason(id);
+			this.fail(
+				why ?? 'stream keeps dropping — the source may be unplayable',
+				code,
+			);
+			return;
+		}
 		if (this.resurrects++ >= MAX_RESURRECTS) {
-			this.fail('stream ended — could not recover', code);
+			const why = await this.streamFailureReason(id);
+			this.fail(why ?? 'stream ended — could not recover', code);
 			return;
 		}
 		const attempt = this.resurrects;
@@ -947,15 +1009,47 @@ export class ReelPlayer {
 			this.hls = null;
 		}
 		if (this.video) this.video.onerror = null;
-		const token = await mediaToken(true);
+		const minted = await mediaToken(true);
 		if (this.generation !== gen) return;
-		if (!token) {
-			this.fail('sign in to watch', 'sign-in');
+		if (!minted.token) {
+			this.fail(minted.message, minted.code);
 			return;
 		}
-		await new Promise((r) => setTimeout(r, 1500));
+		// Back off with each consecutive attempt that hasn't reached playback.
+		await new Promise((r) =>
+			setTimeout(r, backoffMs(Math.min(this.thrash, 4) - 1)),
+		);
 		if (this.generation !== gen) return;
-		await this.probe(video, id, token, 0, gen);
+		await this.probe(video, id, minted.token, 0, gen);
+	}
+
+	// Ask the server why playback keeps failing so the viewer sees the actual
+	// cause (encoder died, torrent failed, entry reaped) instead of a generic
+	// "could not recover".
+	private async streamFailureReason(id: string): Promise<string | null> {
+		try {
+			const d = await authedApiFetch<ReelDetail>(
+				`${REEL_PATH}/torrents/${encodeURIComponent(id)}`,
+			);
+			if (!d) return null;
+			if (d.state === 'Failed') {
+				return typeof d.error === 'string' && d.error
+					? `download failed: ${d.error}`
+					: 'this reel failed to download';
+			}
+			if (d.state === 'Reaped') {
+				return 'this reel expired and was removed — re-add it to watch';
+			}
+			if (d.hls === 'Failed') {
+				const why = d.hls_error;
+				return typeof why === 'string' && why
+					? `the stream encoder failed: ${why}`
+					: 'the stream encoder failed — try Transcode from the console';
+			}
+			return null;
+		} catch {
+			return null;
+		}
 	}
 
 	stop(reset = true): void {

--- a/apps/kube/reel/README.md
+++ b/apps/kube/reel/README.md
@@ -1,0 +1,33 @@
+# reel — deployment notes
+
+## VPN port forwarding stays OFF
+
+`VPN_PORT_FORWARDING` on the gluetun container must remain `'off'`. It has been
+enabled and reverted three times (#14797 → #14871, #14872 → #14883, #15075 →
+#15496); each attempt cost days of "downloads keep stalling" debugging.
+
+**Why it cannot work here:** ProtonVPN's NAT-PMP hands back a *fresh* external
+port on every renewal (~45–90s) instead of honouring the held mapping. gluetun
+treats the renewal as failed and restarts port forwarding, which rebuilds
+iptables and flushes conntrack — killing every live BitTorrent peer. Downloads
+burst inside one renewal window, then flatline with peers stuck `connecting`.
+librqbit cannot hot-rebind its listen socket, so reel cannot follow the rotating
+port either.
+
+This is universal Proton behaviour, not a bad server: pinning
+`SERVER_CITIES: Frankfurt` (#14872) showed identical rotation. "Observe mode"
+(`REEL_BT_PORT_WATCH_RESTART: false`, #15075) does not help — the peer wipe is
+gluetun's firewall rebuild, which happens whether or not reel reacts.
+
+Restoring inbound peers requires a VPN provider that issues a **static**
+forwarded port. The provider is fixed, so treat inbound as unavailable and tune
+outbound only (librqbit `peer_opts`, trackers/DHT).
+
+**Diagnosing a suspected relapse:**
+
+```sh
+kubectl -n reel logs <pod> -c gluetun | grep 'port forwarding.*starting'
+```
+
+Repeated hits every 45–90s means port forwarding is live again. Cross-check
+`port_rotations` on `GET /status`.


### PR DESCRIPTION
Found while debugging a live stall: the player was hiding what was actually wrong.

## 1. "Sign in to watch" while signed in

`mediaToken()` caught **every** error and returned null, and the only caller behaviour for null was `fail('sign in to watch', 'sign-in')`. A proxy 502, a reel pod restart, or a dropped request all rendered as an auth problem.

Now the mint returns a typed result: only 401/403 is `sign-in`; anything else reports the real condition (`reel access service returned 502 — retrying`) and, if a cached token is still valid, playback keeps using it instead of tearing down over a failed refresh.

## 2. Flicker on Play

A reconnect that never reaches playback destroyed and rebuilt the media element every ~1.5s — visually, flicker. Fixes:

- reconnect attempts back off (1s → 5s cap) instead of a fixed 1.5s
- **thrash guard**: more than 4 reconnects inside 60s without a buffered fragment stops the loop
- on stopping, the player asks the server *why* and shows it — `download failed: …`, `the stream encoder failed: …`, `this reel expired and was removed` — instead of "could not recover"
- counters reset on `FRAG_BUFFERED`, so genuine long-session recoveries are unaffected

## 3. No visible UI errors

Reconnecting swapped the video for a full-stage overlay, so status flashed by with the flicker and never persisted. Now the video stays mounted and a corner badge carries the status (with attempt count); the overlay is reserved for non-playing states and always renders a reason.

## 4. Port-forwarding tripwire

`apps/kube/reel/README.md` documents why `VPN_PORT_FORWARDING` stays off — enabled and reverted three times now (#14797→#14871, #14872→#14883, #15075→#15496) — with the one-line log check to confirm a relapse.

Frontend + docs only, no reel image change, so no version bump. `astro check`: 0 errors in media components (26 repo-wide pre-existing). Pairs with #15496 (turns the port forwarding back off). Docs: [reel](https://kbve.com/project/reel/)