### PR TITLE
feat(dashboard): add IDE to staff sidebar, restore VM power controls

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/dashboardNav.ts
@@ -96,6 +96,11 @@ export const DASHBOARD_NAV: DashboardNavEntry[] = [
 				icon: 'server',
 			},
 			{
+				label: 'IDE',
+				href: '/dashboard/ide/',
+				icon: 'terminal',
+			},
+			{
 				label: 'ClickHouse',
 				href: '/dashboard/clickhouse/',
 				icon: 'database',

--- a/apps/kbve/astro-kbve/src/components/rnweb/ReactVMDashRN.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/ReactVMDashRN.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StreamView, createVMStream, vmLens } from '@kbve/rn/dash';
+import { StreamView, createVMStream, createVMLens } from '@kbve/rn/dash';
 import { initSupa, getSupa } from '@/lib/supa';
 import { DASH_PROXY_BASE } from './dashProxyBase';
 
@@ -16,14 +16,13 @@ async function getToken(): Promise<string | null> {
 }
 
 export default function ReactVMDashRN() {
-	const store = useMemo(
-		() => createVMStream({ getToken, baseUrl: DASH_PROXY_BASE }),
-		[],
-	);
+	const opts = useMemo(() => ({ getToken, baseUrl: DASH_PROXY_BASE }), []);
+	const store = useMemo(() => createVMStream(opts), [opts]);
+	const lens = useMemo(() => createVMLens(opts), [opts]);
 	return (
 		<StreamView
 			store={store}
-			lens={vmLens}
+			lens={lens}
 			layout="rows"
 			searchPlaceholder="filter by VM name / namespace / status"
 		/>

--- a/packages/npm/rn/src/dash/StreamView.tsx
+++ b/packages/npm/rn/src/dash/StreamView.tsx
@@ -48,19 +48,22 @@ const StreamRow = memo(
 			);
 		}
 		const render = layout === 'cards' && lens.card ? lens.card : lens.row;
+		const actions = lens.actions?.filter(
+			(a) => !a.enabled || a.enabled(row.item),
+		);
 		return (
 			<View>
 				<Pressable onPress={() => onToggle(row.key)}>
 					{render(row.item, row.expanded)}
 				</Pressable>
-				{row.expanded && (lens.detail || lens.actions?.length) ? (
+				{row.expanded && (lens.detail || actions?.length) ? (
 					<View style={styles.detail}>
 						{lens.detail ? lens.detail(row.item) : null}
-						{lens.actions?.length ? (
+						{actions?.length ? (
 							<ActionBar
 								store={store}
 								item={row.item}
-								actions={lens.actions}
+								actions={actions}
 							/>
 						) : null}
 					</View>

--- a/packages/npm/rn/src/dash/adapters/vm.tsx
+++ b/packages/npm/rn/src/dash/adapters/vm.tsx
@@ -3,7 +3,7 @@ import { Badge, Stack, Surface, Text, tokens } from '../_ui';
 import type { BadgeTone } from '../_ui';
 import { createStreamSource } from '../createStreamSource';
 import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
-import type { StreamLens, StreamStore } from '../types';
+import type { StreamAction, StreamLens, StreamStore } from '../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -410,6 +410,92 @@ export const vmLens: StreamLens<VMItem> = {
 		</Stack>
 	),
 };
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export type VMAction = 'start' | 'stop' | 'restart';
+
+/** VM is mid-transition — no action should be offered. */
+function isTransitioning(phase: VMPhase): boolean {
+	return (
+		phase === 'Starting' || phase === 'Stopping' || phase === 'Migrating'
+	);
+}
+
+export function canStart(it: VMItem): boolean {
+	return !isTransitioning(it.phase) && it.phase !== 'Running';
+}
+
+export function canStop(it: VMItem): boolean {
+	return !isTransitioning(it.phase) && it.phase === 'Running';
+}
+
+export function canRestart(it: VMItem): boolean {
+	return !isTransitioning(it.phase) && it.phase === 'Running';
+}
+
+async function vmMutate(
+	opts: VMStreamOptions,
+	item: VMItem,
+	action: VMAction,
+): Promise<void> {
+	const { getToken, baseUrl = '', namespace = 'angelscript' } = opts;
+	const token = await getToken();
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+	};
+	if (token) headers['Authorization'] = `Bearer ${token}`;
+
+	const res = await dashFetch(
+		`${baseUrl}/dashboard/vm/proxy/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${encodeURIComponent(item.name)}/${action}`,
+		{
+			method: 'PUT',
+			headers,
+			body:
+				action === 'start' ? '{}' : JSON.stringify({ gracePeriod: 30 }),
+			label: `vm:${action}`,
+		},
+	);
+
+	if (res.status === 403)
+		throw dashHttpError(res, `vm:${action}`, 'Manage permission required');
+	if (!res.ok) throw dashHttpError(res, `vm:${action}`);
+}
+
+export function vmActions(opts: VMStreamOptions): StreamAction<VMItem>[] {
+	return [
+		{
+			id: 'start',
+			label: 'Start',
+			enabled: canStart,
+			run: (it) => vmMutate(opts, it, 'start'),
+		},
+		{
+			id: 'stop',
+			label: 'Stop',
+			destructive: true,
+			enabled: canStop,
+			run: (it) => vmMutate(opts, it, 'stop'),
+		},
+		{
+			id: 'restart',
+			label: 'Restart',
+			destructive: true,
+			enabled: canRestart,
+			run: (it) => vmMutate(opts, it, 'restart'),
+		},
+	];
+}
+
+/** Full VM lens with token-bound actions (preferred over the view-only `vmLens`). */
+export function createVMLens(opts: VMStreamOptions): StreamLens<VMItem> {
+	return {
+		...vmLens,
+		actions: vmActions(opts),
+	};
+}
 
 function Fact({ label, value }: { label: string; value: string }) {
 	return (

--- a/packages/npm/rn/src/dash/types.ts
+++ b/packages/npm/rn/src/dash/types.ts
@@ -157,6 +157,8 @@ export interface StreamAction<TItem> {
 	label: string;
 	/** Requires a two-tap inline confirm before running. */
 	destructive?: boolean;
+	/** Hides the action for items it cannot apply to. Shown when omitted. */
+	enabled?: (item: TItem) => boolean;
 	/** The raw mutation; the store wraps it with busy/error/refresh handling. */
 	run: (item: TItem) => Promise<void>;
 }


### PR DESCRIPTION
Two unrelated dashboard gaps, both surfaced while auditing components.

## 1. `/dashboard/ide/` missing from the staff sidebar

The page exists, but there are two nav configs and the IDE entry only landed in one:

- `navigation/dashboardMenu.ts` — has it (drives the header dropdown)
- `dashboard/dashboardNav.ts` — did **not** have it (feeds the Starlight sidebar via `sectionNav.ts`)

Added to the Infrastructure group next to Virtual Machines.

## 2. `/dashboard/vm/` had no power controls

Regression from the rn-dash migration. The page renders via `StreamView` + `vmLens`, and `StreamView` fully supports row actions (`StreamAction` in `dash/types.ts`, used by `adapters/argo.tsx`) — but `adapters/vm.tsx` never defined an `actions` array. The page was read-only for every VM, not just Windows.

The start/stop/restart logic was never lost; it still lives in `astro-kbve/src/components/dashboard/vmService.ts` (still used by the IDE, Kasm and Deploy panels) — it just wasn't on the VM page's path anymore.

Added to the rn dash kit:

- `vmMutate` → `PUT /dashboard/vm/proxy/apis/subresources.kubevirt.io/v1/namespaces/{ns}/virtualmachines/{name}/{action}`, same proxy path and `gracePeriod: 30` body the old service used
- `canStart` / `canStop` / `canRestart` guards, all excluding transitional phases (Starting/Stopping/Migrating)
- `vmActions()` and `createVMLens()`, mirroring the existing `argoActions()` / `createArgoLens()` pattern
- `StreamAction.enabled?: (item) => boolean` so actions hide on items they can't apply to; `StreamView` filters on it

Stop and restart are `destructive: true` for the two-tap confirm — a Windows VM restart has previously caused etcd contention, so a single tap felt wrong.

## Verification

- `rn:typecheck` — 22 errors, byte-identical file set to baseline (all pre-existing: `ClusterChartsPanel`, `adapters/rows`, `markets/*`). Zero in the touched files.
- `rn:test` — 47 files / 217 tests pass
- `astro-kbve:test` — 38 files / 320 tests pass, including `dashboardNav.test.ts`
- `astro-kbve:build` — exit 0. IDE sidebar link renders on 173 pages (was 134), present on `/dashboard/vm/`. `subresources.kubevirt.io` ships in the `ReactVMDashRN` bundle.

## Not verified

The action calls themselves were not exercised against a live cluster — the proxy is server-side at kbve.com and the dev integration just forwards `req.method`. Path, method and body match what `vmService.ts` already does in production, but a real start/stop against a VM is worth a manual check after deploy.