### PR TITLE
fix(rn): resolve no-empty-function lint errors blocking dev→main

### DIFF
--- a/packages/npm/rn/src/auth/executor.ts
+++ b/packages/npm/rn/src/auth/executor.ts
@@ -22,7 +22,7 @@ const PROVIDER_SCOPES: Record<OAuthProvider, string> = {
 
 export function createSupabaseAuthExecutor(
 	client: SupabaseClient,
-	_oauthUrl?: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+	_oauthUrl?: string,
 ): EffectExecutor<AuthEffect, AuthEvent> {
 	const redirectTo = makeRedirectUri({
 		scheme: 'kbve',

--- a/packages/npm/rn/src/dash/__tests__/dashFetch.test.ts
+++ b/packages/npm/rn/src/dash/__tests__/dashFetch.test.ts
@@ -4,7 +4,7 @@ import { dashFetch, dashJson, dashHttpError } from '../dashFetch';
 describe('dashFetch', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
-		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
 	});
 
 	it('returns the response on success', async () => {
@@ -40,7 +40,7 @@ describe('dashFetch', () => {
 describe('dashJson', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
-		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
 	});
 
 	it('parses valid JSON', async () => {


### PR DESCRIPTION
Closes #15504.

`rn:lint` failed the Validate Dev→Main PR job on #15501 with two `@typescript-eslint/no-empty-function` errors in `packages/npm/rn/src/dash/__tests__/dashFetch.test.ts` (console.error stubs `() => {}`).

- Stubs now `mockImplementation(() => undefined)` — same behavior, rule-clean.
- `src/auth/executor.ts`: removed unused `eslint-disable-line @typescript-eslint/no-unused-vars` (the `_` prefix already exempts the param).

Verified: `nx run rn:lint --skip-nx-cache` → 0 errors, 54 pre-existing warnings.