### PR TITLE
fix(desktop-kbve): script full DevOpsDependencies shape in devops e2e mock

### DIFF
--- a/apps/kbve/desktop-kbve/src/views/devops.e2e.test.tsx
+++ b/apps/kbve/desktop-kbve/src/views/devops.e2e.test.tsx
@@ -10,10 +10,28 @@ import {
 	__invokeCalls,
 } from '../__mocks__/tauri-api-core';
 import { DevOpsView } from './devops';
+import type { DependencyStatus } from '../bindings';
 
 // Handlers return the RAW invoke payload; the generated bindings wrap it
 // into { status: 'ok', data } and turn non-Error throws into
 // { status: 'error', error }.
+function dep(
+	name: string,
+	overrides: Partial<DependencyStatus> = {},
+): DependencyStatus {
+	return {
+		name,
+		installed: false,
+		authenticated: null,
+		auth_user: null,
+		auth_hint_url: null,
+		version: null,
+		path: null,
+		install_hint: `install ${name}`,
+		...overrides,
+	};
+}
+
 function scriptBackend(overrides: Record<string, unknown> = {}) {
 	__setInvokeHandler((cmd) => {
 		if (cmd in overrides) return overrides[cmd];
@@ -25,13 +43,21 @@ function scriptBackend(overrides: Record<string, unknown> = {}) {
 				return null;
 			case 'check_devops_dependencies':
 				return {
-					gh: {
+					gh: dep('gh', {
 						installed: true,
 						version: '2.0',
 						authenticated: true,
-					},
-					tmux: { installed: true, version: '3.4' },
-					docker: { installed: false, version: null },
+					}),
+					tmux: dep('tmux', { installed: true, version: '3.4' }),
+					docker: dep('docker'),
+					claude: dep('claude'),
+					aider: dep('aider'),
+					gemini: dep('gemini'),
+					ollama: dep('ollama'),
+					vllm: dep('vllm'),
+					all_satisfied: false,
+					available_agents: [],
+					sandbox_available: false,
 				};
 			case 'get_enabled_agents':
 				return ['claude'];


### PR DESCRIPTION
## Why

`nx run desktop-kbve:test` exits non-zero on dev even though all 75 tests pass. The `check_devops_dependencies` mock in `devops.e2e.test.tsx` only scripts `gh/tmux/docker`, but `DevOpsSettings` now renders `DependencyStatus` for `claude/aider/gemini/ollama/vllm` as well. Each missing entry crashes at `DependencyStatus.tsx:89` (`status.authenticated` on `undefined`) as an uncaught async exception — 3 errors, vitest fails the run.

## What

- `dep()` helper builds a complete `DependencyStatus` from the generated bindings type
- Mock now returns the full `DevOpsDependencies` shape: all 8 tools plus `all_satisfied`, `available_agents`, `sandbox_available`

## Verified

- `nx run desktop-kbve:test --skip-nx-cache` — 10 files, 75 tests, 0 errors, green
- `nx run desktop-kbve:lint --skip-nx-cache` — green
