### PR TITLE
feat(desktop-kbve): tmux control-mode notification bus, push session updates to UI

### DIFF
--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/actor.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/actor.rs
@@ -6,6 +6,7 @@ use tokio::process::Command;
 use tokio::sync::{mpsc, watch};
 use tokio::time::MissedTickBehavior;
 
+use super::control::{self, Notification};
 use super::detector::hysteresis::Smoother;
 use super::detector::{AgentActivity, DetectContext, DetectorRegistry};
 use super::tmux::{self, AgentMetadata, SessionStatus, TmuxSession};
@@ -67,12 +68,36 @@ async fn run(
     let mut tick = tokio::time::interval(REFRESH_INTERVAL);
     tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+    let (_control_guard, mut notif_rx) = match control::ensure_monitor_session().await {
+        Ok(()) => match control::spawn_control_client() {
+            Ok((guard, rx)) => (Some(guard), Some(rx)),
+            Err(e) => {
+                log::warn!("tmux control client unavailable, polling only: {}", e);
+                (None, None)
+            }
+        },
+        Err(e) => {
+            log::warn!("tmux monitor session unavailable, polling only: {}", e);
+            (None, None)
+        }
+    };
+
     loop {
         tokio::select! {
             cmd = cmd_rx.recv() => {
                 match cmd {
                     Some(ActorCommand::Refresh) => {}
                     None => break,
+                }
+            }
+            notif = recv_notification(&mut notif_rx) => {
+                match notif {
+                    Some(Notification::Exit) | None => {
+                        log::warn!("tmux control client exited, polling only");
+                        notif_rx = None;
+                        continue;
+                    }
+                    Some(_) => {}
                 }
             }
             _ = tick.tick() => {}
@@ -86,6 +111,15 @@ async fn run(
             let _ = snapshot_tx.send(Some(sessions.clone()));
             let _ = app.emit("devops-sessions-updated", &sessions);
         }
+    }
+}
+
+async fn recv_notification(
+    rx: &mut Option<mpsc::UnboundedReceiver<Notification>>,
+) -> Option<Notification> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
     }
 }
 

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/control.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/control.rs
@@ -1,0 +1,204 @@
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+
+use super::tmux;
+
+pub const MONITOR_SESSION: &str = "__handy_monitor";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Notification {
+    SessionsChanged,
+    SessionChanged,
+    SessionRenamed,
+    SessionClosed,
+    SessionWindowChanged,
+    WindowAdd,
+    WindowClose,
+    WindowRenamed,
+    Exit,
+}
+
+#[derive(Debug, Default)]
+pub struct ControlParser {
+    in_block: bool,
+}
+
+impl ControlParser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn parse_line(&mut self, line: &str) -> Option<Notification> {
+        if self.in_block {
+            if line.starts_with("%end") || line.starts_with("%error") {
+                self.in_block = false;
+            }
+            return None;
+        }
+        if line.starts_with("%begin") {
+            self.in_block = true;
+            return None;
+        }
+
+        let word = line.split_whitespace().next()?;
+        match word {
+            "%sessions-changed" => Some(Notification::SessionsChanged),
+            "%session-changed" => Some(Notification::SessionChanged),
+            "%session-renamed" => Some(Notification::SessionRenamed),
+            "%session-closed" => Some(Notification::SessionClosed),
+            "%session-window-changed" => Some(Notification::SessionWindowChanged),
+            "%window-add" => Some(Notification::WindowAdd),
+            "%window-close" => Some(Notification::WindowClose),
+            "%window-renamed" => Some(Notification::WindowRenamed),
+            "%exit" => Some(Notification::Exit),
+            _ => None,
+        }
+    }
+}
+
+pub struct ControlClientGuard {
+    child: Child,
+}
+
+impl Drop for ControlClientGuard {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+pub async fn ensure_monitor_session() -> Result<(), String> {
+    let output = Command::new("tmux")
+        .args([
+            "-L",
+            tmux::SOCKET_NAME,
+            "new-session",
+            "-d",
+            "-s",
+            MONITOR_SESSION,
+        ])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to create monitor session: {}", e))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("already exists") || stderr.contains("duplicate session") {
+        return Ok(());
+    }
+    Err(format!("Failed to create monitor session: {}", stderr))
+}
+
+pub fn spawn_control_client(
+) -> Result<(ControlClientGuard, mpsc::UnboundedReceiver<Notification>), String> {
+    let mut child = Command::new("tmux")
+        .args([
+            "-L",
+            tmux::SOCKET_NAME,
+            "-C",
+            "attach-session",
+            "-t",
+            MONITOR_SESSION,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn tmux control client: {}", e))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "No stdout on tmux control client".to_string())?;
+
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    tauri::async_runtime::spawn(async move {
+        let mut parser = ControlParser::new();
+        let mut lines = BufReader::new(stdout).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if let Some(notif) = parser.parse_line(&line) {
+                        let is_exit = notif == Notification::Exit;
+                        if tx.send(notif).is_err() || is_exit {
+                            break;
+                        }
+                    }
+                }
+                Ok(None) | Err(_) => {
+                    let _ = tx.send(Notification::Exit);
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok((ControlClientGuard { child }, rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_notifications_parse() {
+        let mut p = ControlParser::new();
+        assert_eq!(
+            p.parse_line("%sessions-changed"),
+            Some(Notification::SessionsChanged)
+        );
+        assert_eq!(
+            p.parse_line("%session-changed $3 handy-agent-42"),
+            Some(Notification::SessionChanged)
+        );
+        assert_eq!(
+            p.parse_line("%session-closed $3"),
+            Some(Notification::SessionClosed)
+        );
+        assert_eq!(
+            p.parse_line("%window-renamed @1 build"),
+            Some(Notification::WindowRenamed)
+        );
+        assert_eq!(p.parse_line("%exit"), Some(Notification::Exit));
+    }
+
+    #[test]
+    fn output_and_unknown_lines_are_ignored() {
+        let mut p = ControlParser::new();
+        assert_eq!(p.parse_line("%output %5 hello\\033[31m"), None);
+        assert_eq!(p.parse_line("%layout-change @1 abcd"), None);
+        assert_eq!(p.parse_line(""), None);
+        assert_eq!(p.parse_line("plain text"), None);
+    }
+
+    #[test]
+    fn command_block_interior_is_swallowed() {
+        let mut p = ControlParser::new();
+        assert_eq!(p.parse_line("%begin 1622 1 0"), None);
+        assert_eq!(p.parse_line("%sessions-changed"), None);
+        assert_eq!(p.parse_line("some output"), None);
+        assert_eq!(p.parse_line("%end 1622 1 0"), None);
+        assert_eq!(
+            p.parse_line("%sessions-changed"),
+            Some(Notification::SessionsChanged)
+        );
+    }
+
+    #[test]
+    fn error_block_terminates_too() {
+        let mut p = ControlParser::new();
+        assert_eq!(p.parse_line("%begin 1622 1 0"), None);
+        assert_eq!(p.parse_line("%error 1622 1 0"), None);
+        assert_eq!(
+            p.parse_line("%session-closed $1"),
+            Some(Notification::SessionClosed)
+        );
+    }
+}

--- a/apps/kbve/desktop-kbve/src-tauri/src/devops/mod.rs
+++ b/apps/kbve/desktop-kbve/src-tauri/src/devops/mod.rs
@@ -10,6 +10,7 @@
 //! - Pipeline state tracking
 
 pub mod actor;
+pub mod control;
 mod dependencies;
 pub mod detector;
 pub mod docker;

--- a/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
+++ b/apps/kbve/desktop-kbve/src/stores/devopsStore.ts
@@ -120,6 +120,7 @@ interface DevOpsStore {
 	_orphanCleanupInterval: number | null;
 	_prEventUnlisten: UnlistenFn | null;
 	_orphanEventUnlisten: UnlistenFn | null;
+	_sessionsEventUnlisten: UnlistenFn | null;
 	_previousSubIssueStates: Map<number, string>;
 	_mergeWorkersSpawned: Set<number>; // Track issues with merge workers already spawned
 	_setAgentRefreshInterval: (id: number | null) => void;
@@ -170,6 +171,7 @@ export const useDevOpsStore = create<DevOpsStore>()(
 		_orphanCleanupInterval: null,
 		_prEventUnlisten: null,
 		_orphanEventUnlisten: null,
+		_sessionsEventUnlisten: null,
 		_previousSubIssueStates: new Map(),
 		_mergeWorkersSpawned: new Set(),
 
@@ -909,6 +911,23 @@ export const useDevOpsStore = create<DevOpsStore>()(
 			);
 			set({ _orphanEventUnlisten: orphanUnlisten });
 
+			const sessionsUnlisten = await listen<TmuxSession[]>(
+				'devops-sessions-updated',
+				(event) => {
+					const current = get();
+					const changed =
+						JSON.stringify(current.sessions) !==
+						JSON.stringify(event.payload);
+					if (changed) {
+						set({ sessions: event.payload });
+					}
+					if (!current.isTmuxRunning && event.payload.length > 0) {
+						set({ isTmuxRunning: true });
+					}
+				},
+			);
+			set({ _sessionsEventUnlisten: sessionsUnlisten });
+
 			// Set up polling intervals
 			// Agents: 12 seconds (staggered from sessions)
 			const agentInterval = window.setInterval(
@@ -917,10 +936,10 @@ export const useDevOpsStore = create<DevOpsStore>()(
 			);
 			_setAgentRefreshInterval(agentInterval);
 
-			// Sessions: 10 seconds
+			// Sessions fallback: 30 seconds; live state arrives via devops-sessions-updated
 			const sessionInterval = window.setInterval(
 				() => refreshSessions(false),
-				10000,
+				30000,
 			);
 			_setSessionRefreshInterval(sessionInterval);
 
@@ -958,6 +977,7 @@ export const useDevOpsStore = create<DevOpsStore>()(
 				_orphanCleanupInterval,
 				_prEventUnlisten,
 				_orphanEventUnlisten,
+				_sessionsEventUnlisten,
 			} = get();
 
 			if (_agentRefreshInterval !== null) {
@@ -988,6 +1008,11 @@ export const useDevOpsStore = create<DevOpsStore>()(
 			if (_orphanEventUnlisten !== null) {
 				_orphanEventUnlisten();
 				set({ _orphanEventUnlisten: null });
+			}
+
+			if (_sessionsEventUnlisten !== null) {
+				_sessionsEventUnlisten();
+				set({ _sessionsEventUnlisten: null });
 			}
 		},
 	})),


### PR DESCRIPTION
## Why

Phase 2 of the bosun adoption ([#15514](https://github.com/KBVE/kbve/pull/15514) was Phase 1). Session lifecycle changes (create/kill/rename) currently surface only when a poll tick happens to run — the frontend polled every 10s. bosun's pattern: attach a `tmux -C` control-mode client to a dedicated dummy session and use it purely as a notification bus.

## What

**`devops/control.rs`**:
- `ensure_monitor_session` — idempotent `__handy_monitor` dummy session (double-underscore prefix keeps it out of the `handy-` listing filter)
- `spawn_control_client` — `tmux -L handy -C attach-session -t __handy_monitor` with piped stdin held open (verified live: notifications do NOT flow with `/dev/null` stdin), reader task feeding an unbounded mpsc
- `ControlParser` — line parser for the 8 session/window lifecycle notifications plus `%exit`; `%begin`/`%end`/`%error` command-block interiors swallowed; `%output` and unknown lines (incl. `%unlinked-window-*`) ignored

**Actor integration**: new `select!` branch on the notification stream triggers an immediate refresh; on `%exit` or channel close the branch degrades permanently to `std::future::pending()` and the 2s poll tick carries on (no reconnect, bosun's model). Guard kills the control client on drop.

**Frontend (`devopsStore`)**: subscribes to `devops-sessions-updated` and applies pushed snapshots directly; session polling demoted from 10s to a 30s fallback (still refreshes recovery info + tmux liveness).

## Verified

- Live smoke against tmux 3.6a: create/kill emit `%sessions-changed`, rename emits `%session-renamed`, monitor-session shell `%output` noise correctly ignored
- `cargo test` — 100 passed (4 new parser tests); clippy clean
- `nx run desktop-kbve:test` — 75 passed; lint clean