### PR TITLE
fix(desktop-kbve): install app-local pnpm deps before nx test/build

### DIFF
--- a/apps/kbve/desktop-kbve/project.json
+++ b/apps/kbve/desktop-kbve/project.json
@@ -31,6 +31,7 @@
 		},
 		"build": {
 			"executor": "nx:run-commands",
+			"dependsOn": ["install-deps"],
 			"options": {
 				"commands": [
 					"export PATH=\"$HOME/.cargo/bin:$PATH\" && pnpm build"
@@ -38,8 +39,17 @@
 				"cwd": "apps/kbve/desktop-kbve"
 			}
 		},
+		"install-deps": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": ["CI=true pnpm install --frozen-lockfile"],
+				"cwd": "apps/kbve/desktop-kbve"
+			}
+		},
 		"test": {
 			"executor": "nx:run-commands",
+			"dependsOn": ["install-deps"],
 			"options": {
 				"commands": ["npx vitest run --config vitest.config.ts"],
 				"cwd": "apps/kbve/desktop-kbve"


### PR DESCRIPTION
## Why

Closes #15518. The Dev→Main validation job failed on `desktop-kbve:test` with `Failed to resolve import \"zustand\"` in every store test. desktop-kbve is its own pnpm workspace (own `pnpm-lock.yaml` inside the app dir, zero entries in the root lockfile), so the root `pnpm install` CI performs never installs its dependencies. Any runner that hasn't manually installed in `apps/kbve/desktop-kbve` fails the same way — local runs only passed because we had.

## What

New `install-deps` nx target (`CI=true pnpm install --frozen-lockfile` in the app dir, cache disabled) with `dependsOn` from `test` and `build`. Any `nx run desktop-kbve:test` now self-provisions — CI, fresh clones, worktrees alike. No workflow changes needed.

## Verified

- App lockfile passes `--frozen-lockfile` cleanly
- `nx run desktop-kbve:test --skip-nx-cache` runs `install-deps` first, then 75/75 tests pass