### PR TITLE
fix(astro-kbve): drop unowned social handles from sameAs and twitter meta

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -215,20 +215,6 @@ export default defineConfig({
 					},
 				},
 				{
-					tag: 'meta',
-					attrs: {
-						name: 'twitter:site',
-						content: '@kbve',
-					},
-				},
-				{
-					tag: 'meta',
-					attrs: {
-						name: 'twitter:creator',
-						content: '@kbve',
-					},
-				},
-				{
 					tag: 'link',
 					attrs: {
 						rel: 'preconnect',

--- a/apps/kbve/astro-kbve/src/lib/seo.ts
+++ b/apps/kbve/astro-kbve/src/lib/seo.ts
@@ -24,8 +24,6 @@ export const seo = createSeo({
 		'https://discord.gg/kbve',
 		'https://www.youtube.com/@kbve',
 		'https://twitch.tv/kbve',
-		'https://x.com/kbve',
-		'https://bsky.app/profile/kbve.com',
 	],
 });
 


### PR DESCRIPTION
Follow-up to #15379 — that PR merged before this commit was pushed.

- Removes x.com/kbve and bsky.app/profile/kbve.com from Organization `sameAs` (not owned)
- Removes site-wide `twitter:site`/`twitter:creator` @kbve meta from astro.config.mjs (same unowned handle)
- Twitch stays as twitch.tv/kbve