### PR TITLE
fix(arpg-web): discord Activity bundle crashed on bare exports reference

### DIFF
--- a/apps/agones/arpg/web/vite.config.ts
+++ b/apps/agones/arpg/web/vite.config.ts
@@ -224,7 +224,9 @@ export default defineConfig(({ mode }) => {
 				rollupOptions: {
 					output: {
 						inlineDynamicImports: true,
-						exports: 'named' as const,
+						exports: discord
+							? ('none' as const)
+							: ('named' as const),
 						// Discord only: content-hashed, immutable URL per build
 						// (see hashDiscordBundle). The embed bundle keeps its
 						// stable name — kbve.com loads it by fixed URL.

--- a/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx
@@ -13,7 +13,7 @@ tags:
 key: arpg_web
 pipeline: docker
 app_name: arpg-web
-version: "0.1.29"
+version: "0.1.30"
 source_path: apps/agones/arpg
 version_toml: apps/agones/arpg/web/version.toml
 version_source: apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx


### PR DESCRIPTION
## Problem
The Discord Activity froze on the static boot screen ("Entering the dungeon… / Connecting to Discord.") with console error `Uncaught ReferenceError: exports is not defined`.

The served discord IIFE bundle opens with:
```js
!function(){Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});...
```
rolldown emits the ESM `Symbol.toStringTag` marker even though the discord entry (`src/embed/discord.tsx`) exports nothing, so the IIFE wrapper has no `exports` parameter — the bundle dies at eval before any boot code (or its error UI) runs. Surfaced by the module-graph reshuffle from the laser subpath split (#15092); the direct site and the embed bundle (`ArpgEmbed` has real exports → wrapper gets the param) are unaffected.

## Fix
`output.exports: 'none'` for the discord build only. Rebuilt wrapper starts `!function(){var e=...` — verified `node --check` passes, client id, `/.proxy/` paths, and URL mappings all intact. Bumps arpg-web MDX to 0.1.30 to ship the rebuild (post-publish sync handles version.toml).

Docs: apps/kbve/astro-kbve/src/content/docs/project/arpg-web.mdx